### PR TITLE
Support /v1/responses API and openai agents sdk

### DIFF
--- a/dto/openai_responses.go
+++ b/dto/openai_responses.go
@@ -1,46 +1,11 @@
 package dto
 
-type OpenAIResponsesOutput struct {
-	Type    string `json:"type"`
-	ID      string `json:"id"`
-	Status  string `json:"status"`
-	Role    string `json:"role"`
-	Content []struct {
-		Type        string `json:"type"`
-		Text        string `json:"text"`
-		Annotations []any  `json:"annotations"`
-	} `json:"content"`
-}
-
 type OpenAIResponsesResponse struct {
-	ID                 string                  `json:"id"`
-	Object             string                  `json:"object"`
-	CreatedAt          int64                   `json:"created_at"`
-	Status             string                  `json:"status"`
-	Error              *OpenAIError            `json:"error,omitempty"`
-	IncompleteDetails  *any                    `json:"incomplete_details,omitempty"`
-	Instructions       *any                    `json:"instructions,omitempty"`
-	MaxOutputTokens    *int                    `json:"max_output_tokens,omitempty"`
-	Model              string                  `json:"model"`
-	Output             []OpenAIResponsesOutput `json:"output"`
-	ParallelToolCalls  bool                    `json:"parallel_tool_calls"`
-	PreviousResponseID *string                 `json:"previous_response_id,omitempty"`
-	Reasoning          struct {
-		Effort          *string `json:"effort,omitempty"`
-		GenerateSummary *bool   `json:"generate_summary,omitempty"`
-	} `json:"reasoning"`
-	Store       bool    `json:"store"`
-	Temperature float64 `json:"temperature"`
-	Text        struct {
-		Format struct {
-			Type string `json:"type"`
-		} `json:"format"`
-	} `json:"text"`
-	ToolChoice string  `json:"tool_choice"`
-	Tools      []any   `json:"tools"`
-	TopP       float64 `json:"top_p"`
-	Truncation string  `json:"truncation"`
-	Usage      struct {
+	ID        string `json:"id"`
+	Object    string `json:"object"`
+	CreatedAt int64  `json:"created_at"`
+	Status    string `json:"status"`
+	Usage     struct {
 		InputTokens        int `json:"input_tokens"`
 		InputTokensDetails struct {
 			CachedTokens int `json:"cached_tokens"`
@@ -51,6 +16,5 @@ type OpenAIResponsesResponse struct {
 		} `json:"output_tokens_details"`
 		TotalTokens int `json:"total_tokens"`
 	} `json:"usage"`
-	User     *string        `json:"user,omitempty"`
 	Metadata map[string]any `json:"metadata"`
 }

--- a/dto/openai_responses.go
+++ b/dto/openai_responses.go
@@ -1,0 +1,56 @@
+package dto
+
+type OpenAIResponsesOutput struct {
+	Type    string `json:"type"`
+	ID      string `json:"id"`
+	Status  string `json:"status"`
+	Role    string `json:"role"`
+	Content []struct {
+		Type        string `json:"type"`
+		Text        string `json:"text"`
+		Annotations []any  `json:"annotations"`
+	} `json:"content"`
+}
+
+type OpenAIResponsesResponse struct {
+	ID                 string                  `json:"id"`
+	Object             string                  `json:"object"`
+	CreatedAt          int64                   `json:"created_at"`
+	Status             string                  `json:"status"`
+	Error              *OpenAIError            `json:"error,omitempty"`
+	IncompleteDetails  *any                    `json:"incomplete_details,omitempty"`
+	Instructions       *any                    `json:"instructions,omitempty"`
+	MaxOutputTokens    *int                    `json:"max_output_tokens,omitempty"`
+	Model              string                  `json:"model"`
+	Output             []OpenAIResponsesOutput `json:"output"`
+	ParallelToolCalls  bool                    `json:"parallel_tool_calls"`
+	PreviousResponseID *string                 `json:"previous_response_id,omitempty"`
+	Reasoning          struct {
+		Effort          *string `json:"effort,omitempty"`
+		GenerateSummary *bool   `json:"generate_summary,omitempty"`
+	} `json:"reasoning"`
+	Store       bool    `json:"store"`
+	Temperature float64 `json:"temperature"`
+	Text        struct {
+		Format struct {
+			Type string `json:"type"`
+		} `json:"format"`
+	} `json:"text"`
+	ToolChoice string  `json:"tool_choice"`
+	Tools      []any   `json:"tools"`
+	TopP       float64 `json:"top_p"`
+	Truncation string  `json:"truncation"`
+	Usage      struct {
+		InputTokens        int `json:"input_tokens"`
+		InputTokensDetails struct {
+			CachedTokens int `json:"cached_tokens"`
+		} `json:"input_tokens_details"`
+		OutputTokens        int `json:"output_tokens"`
+		OutputTokensDetails struct {
+			ReasoningTokens int `json:"reasoning_tokens"`
+		} `json:"output_tokens_details"`
+		TotalTokens int `json:"total_tokens"`
+	} `json:"usage"`
+	User     *string        `json:"user,omitempty"`
+	Metadata map[string]any `json:"metadata"`
+}

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -263,6 +263,8 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycom
 		err, usage = OpenaiTTSHandler(c, resp, info)
 	case constant.RelayModeRerank:
 		err, usage = common_handler.RerankHandler(c, info, resp)
+	case constant.RelayModeResponses:
+		err, usage = OpenaiResponsesHandler(c, info)
 	default:
 		if info.IsStream {
 			err, usage = OaiStreamHandler(c, resp, info)

--- a/relay/constant/relay_mode.go
+++ b/relay/constant/relay_mode.go
@@ -13,6 +13,7 @@ const (
 	RelayModeModerations
 	RelayModeImagesGenerations
 	RelayModeEdits
+	RelayModeResponses
 
 	RelayModeMidjourneyImagine
 	RelayModeMidjourneyDescribe
@@ -58,6 +59,8 @@ func Path2RelayMode(path string) int {
 		relayMode = RelayModeImagesGenerations
 	} else if strings.HasPrefix(path, "/v1/edits") {
 		relayMode = RelayModeEdits
+	} else if strings.HasPrefix(path, "/v1/responses") {
+		relayMode = RelayModeResponses
 	} else if strings.HasPrefix(path, "/v1/audio/speech") {
 		relayMode = RelayModeAudioSpeech
 	} else if strings.HasPrefix(path, "/v1/audio/transcriptions") {

--- a/relay/relay-text.go
+++ b/relay/relay-text.go
@@ -64,6 +64,12 @@ func getAndValidateTextRequest(c *gin.Context, relayInfo *relaycommon.RelayInfo)
 		if textRequest.Instruction == "" {
 			return nil, errors.New("field instruction is required")
 		}
+	case relayconstant.RelayModeResponses:
+		if textRequest.Input == nil || textRequest.Input == "" {
+			return nil, errors.New("field input is required")
+		}
+		// 为 responses 模式强制开启透传请求
+		c.Set("pass_through_request", true)
 	}
 	relayInfo.IsStream = textRequest.Stream
 	return textRequest, nil
@@ -153,7 +159,9 @@ func TextHelper(c *gin.Context) (openaiErr *dto.OpenAIErrorWithStatusCode) {
 	adaptor.Init(relayInfo)
 	var requestBody io.Reader
 
-	if model_setting.GetGlobalSettings().PassThroughRequestEnabled {
+	passThrough, exists := c.Get("pass_through_request")
+	passThroughEnabled := exists && passThrough.(bool)
+	if passThroughEnabled || model_setting.GetGlobalSettings().PassThroughRequestEnabled {
 		body, err := common.GetRequestBody(c)
 		if err != nil {
 			return service.OpenAIErrorWrapperLocal(err, "get_request_body_failed", http.StatusInternalServerError)
@@ -220,6 +228,8 @@ func getPromptTokens(textRequest *dto.GeneralOpenAIRequest, info *relaycommon.Re
 		promptTokens, err = service.CountTokenInput(textRequest.Input, textRequest.Model)
 	case relayconstant.RelayModeEmbeddings:
 		promptTokens, err = service.CountTokenInput(textRequest.Input, textRequest.Model)
+	case relayconstant.RelayModeResponses:
+		promptTokens, err = service.CountTokenInput(textRequest.Input, textRequest.Model)
 	default:
 		err = errors.New("unknown relay mode")
 		promptTokens = 0
@@ -239,6 +249,8 @@ func checkRequestSensitive(textRequest *dto.GeneralOpenAIRequest, info *relaycom
 	case relayconstant.RelayModeModerations:
 		words, err = service.CheckSensitiveInput(textRequest.Input)
 	case relayconstant.RelayModeEmbeddings:
+		words, err = service.CheckSensitiveInput(textRequest.Input)
+	case relayconstant.RelayModeResponses:
 		words, err = service.CheckSensitiveInput(textRequest.Input)
 	}
 	return words, err

--- a/router/relay-router.go
+++ b/router/relay-router.go
@@ -47,6 +47,7 @@ func SetRelayRouter(router *gin.Engine) {
 		httpRouter.POST("/audio/transcriptions", controller.Relay)
 		httpRouter.POST("/audio/translations", controller.Relay)
 		httpRouter.POST("/audio/speech", controller.Relay)
+		httpRouter.POST("/responses", controller.Relay)
 		httpRouter.GET("/files", controller.RelayNotImplemented)
 		httpRouter.POST("/files", controller.RelayNotImplemented)
 		httpRouter.DELETE("/files/:id", controller.RelayNotImplemented)


### PR DESCRIPTION
Fixes #885 

Documentation for Agents SDK: https://openai.github.io/openai-agents-python/
Documentation for /v1/responses API: https://platform.openai.com/docs/api-reference/responses

I know nothing about go, I just implemented this feature using Cursor. So feel free to give feedback on this pull request.

Examples Usage:

```python
from agents import Agent, Runner, set_default_openai_client, set_tracing_disabled
from openai import AsyncOpenAI

# Disable tracing
set_tracing_disabled(True)

# Configure custom OpenAI client
custom_client = AsyncOpenAI(
    base_url="http://localhost:3000/v1",
    api_key="xxxxx"
)
set_default_openai_client(custom_client)

agent = Agent(name="Assistant", instructions="You are a helpful assistant")

result = Runner.run_sync(agent, "Write a haiku about recursion in programming.")
print(result.final_output)
```