### PR TITLE
fix: update getAndValidImageRequest function in relay/relay-image.go to support grok-2-image model

### DIFF
--- a/relay/relay-image.go
+++ b/relay/relay-image.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"io"
 	"net/http"
 	"one-api/common"
@@ -16,6 +15,8 @@ import (
 	"one-api/service"
 	"one-api/setting"
 	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 func getAndValidImageRequest(c *gin.Context, info *relaycommon.RelayInfo) (*dto.ImageRequest, error) {
@@ -38,6 +39,10 @@ func getAndValidImageRequest(c *gin.Context, info *relaycommon.RelayInfo) (*dto.
 	}
 	if imageRequest.Model == "" {
 		imageRequest.Model = "dall-e-2"
+	}
+	// x.ai grok-2-image not support size, quality or style
+	if imageRequest.Size == "empty" {
+		imageRequest.Size = ""
 	}
 
 	// Not "256x256", "512x512", or "1024x1024"


### PR DESCRIPTION
2025.4.9 grok-2-image: quality, size or style are not supported by xAI API at the moment.

I modified the getAndValidImageRequest function in the relay/relay-image.go file. I added a condition to change the size to an empty string if it is set to "empty". This change is to support the grok-2-image model.

Here's an example of usage:

~~~json
{
    "model": "grok-2-image",
    "prompt": "A cat in a tree",
    "response_format": "url",
    "size": "empty",
    "n": 1
}
~~~