### PR TITLE
.env文件配置DEBUG=true等参数不起作用的fix

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -1,8 +1,8 @@
 package common
 
 import (
-	"os"
-	"strconv"
+	//"os"
+	//"strconv"
 	"sync"
 	"time"
 
@@ -63,8 +63,8 @@ var EmailDomainWhitelist = []string{
 	"foxmail.com",
 }
 
-var DebugEnabled = os.Getenv("DEBUG") == "true"
-var MemoryCacheEnabled = os.Getenv("MEMORY_CACHE_ENABLED") == "true"
+var DebugEnabled bool
+var MemoryCacheEnabled bool
 
 var LogConsumeEnabled = true
 
@@ -103,22 +103,22 @@ var RetryTimes = 0
 
 //var RootUserEmail = ""
 
-var IsMasterNode = os.Getenv("NODE_TYPE") != "slave"
+var IsMasterNode bool
 
-var requestInterval, _ = strconv.Atoi(os.Getenv("POLLING_INTERVAL"))
-var RequestInterval = time.Duration(requestInterval) * time.Second
+var requestInterval int
+var RequestInterval time.Duration
 
-var SyncFrequency = GetEnvOrDefault("SYNC_FREQUENCY", 60) // unit is second
+var SyncFrequency int // unit is second
 
 var BatchUpdateEnabled = false
-var BatchUpdateInterval = GetEnvOrDefault("BATCH_UPDATE_INTERVAL", 5)
+var BatchUpdateInterval int
 
-var RelayTimeout = GetEnvOrDefault("RELAY_TIMEOUT", 0) // unit is second
+var RelayTimeout int // unit is second
 
-var GeminiSafetySetting = GetEnvOrDefaultString("GEMINI_SAFETY_SETTING", "BLOCK_NONE")
+var GeminiSafetySetting string
 
 // https://docs.cohere.com/docs/safety-modes Type; NONE/CONTEXTUAL/STRICT
-var CohereSafetySetting = GetEnvOrDefaultString("COHERE_SAFETY_SETTING", "NONE")
+var CohereSafetySetting string
 
 const (
 	RequestIdKey = "X-Oneapi-Request-Id"
@@ -145,13 +145,13 @@ var (
 // All duration's unit is seconds
 // Shouldn't larger then RateLimitKeyExpirationDuration
 var (
-	GlobalApiRateLimitEnable   = GetEnvOrDefaultBool("GLOBAL_API_RATE_LIMIT_ENABLE", true)
-	GlobalApiRateLimitNum      = GetEnvOrDefault("GLOBAL_API_RATE_LIMIT", 180)
-	GlobalApiRateLimitDuration = int64(GetEnvOrDefault("GLOBAL_API_RATE_LIMIT_DURATION", 180))
+	GlobalApiRateLimitEnable   bool
+	GlobalApiRateLimitNum      int
+	GlobalApiRateLimitDuration int64
 
-	GlobalWebRateLimitEnable   = GetEnvOrDefaultBool("GLOBAL_WEB_RATE_LIMIT_ENABLE", true)
-	GlobalWebRateLimitNum      = GetEnvOrDefault("GLOBAL_WEB_RATE_LIMIT", 60)
-	GlobalWebRateLimitDuration = int64(GetEnvOrDefault("GLOBAL_WEB_RATE_LIMIT_DURATION", 180))
+	GlobalWebRateLimitEnable   bool
+	GlobalWebRateLimitNum      int
+	GlobalWebRateLimitDuration int64
 
 	UploadRateLimitNum            = 10
 	UploadRateLimitDuration int64 = 60

--- a/common/init.go
+++ b/common/init.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
+	"time"
 )
 
 var (
@@ -66,4 +68,31 @@ func LoadEnv() {
 			}
 		}
 	}
+
+	// Initialize variables from constants.go that were using environment variables
+	DebugEnabled = os.Getenv("DEBUG") == "true"
+	MemoryCacheEnabled = os.Getenv("MEMORY_CACHE_ENABLED") == "true"
+	IsMasterNode = os.Getenv("NODE_TYPE") != "slave"
+	
+	// Parse requestInterval and set RequestInterval
+	requestInterval, _ = strconv.Atoi(os.Getenv("POLLING_INTERVAL"))
+	RequestInterval = time.Duration(requestInterval) * time.Second
+	
+	// Initialize variables with GetEnvOrDefault
+	SyncFrequency = GetEnvOrDefault("SYNC_FREQUENCY", 60)
+	BatchUpdateInterval = GetEnvOrDefault("BATCH_UPDATE_INTERVAL", 5)
+	RelayTimeout = GetEnvOrDefault("RELAY_TIMEOUT", 0)
+	
+	// Initialize string variables with GetEnvOrDefaultString
+	GeminiSafetySetting = GetEnvOrDefaultString("GEMINI_SAFETY_SETTING", "BLOCK_NONE")
+	CohereSafetySetting = GetEnvOrDefaultString("COHERE_SAFETY_SETTING", "NONE")
+	
+	// Initialize rate limit variables
+	GlobalApiRateLimitEnable = GetEnvOrDefaultBool("GLOBAL_API_RATE_LIMIT_ENABLE", true)
+	GlobalApiRateLimitNum = GetEnvOrDefault("GLOBAL_API_RATE_LIMIT", 180)
+	GlobalApiRateLimitDuration = int64(GetEnvOrDefault("GLOBAL_API_RATE_LIMIT_DURATION", 180))
+	
+	GlobalWebRateLimitEnable = GetEnvOrDefaultBool("GLOBAL_WEB_RATE_LIMIT_ENABLE", true)
+	GlobalWebRateLimitNum = GetEnvOrDefault("GLOBAL_WEB_RATE_LIMIT", 60)
+	GlobalWebRateLimitDuration = int64(GetEnvOrDefault("GLOBAL_WEB_RATE_LIMIT_DURATION", 180))
 }

--- a/constant/env.go
+++ b/constant/env.go
@@ -4,32 +4,39 @@ import (
 	"one-api/common"
 )
 
-var StreamingTimeout = common.GetEnvOrDefault("STREAMING_TIMEOUT", 60)
-var DifyDebug = common.GetEnvOrDefaultBool("DIFY_DEBUG", true)
-
-var MaxFileDownloadMB = common.GetEnvOrDefault("MAX_FILE_DOWNLOAD_MB", 20)
-
-// ForceStreamOption 覆盖请求参数，强制返回usage信息
-var ForceStreamOption = common.GetEnvOrDefaultBool("FORCE_STREAM_OPTION", true)
-
-var GetMediaToken = common.GetEnvOrDefaultBool("GET_MEDIA_TOKEN", true)
-
-var GetMediaTokenNotStream = common.GetEnvOrDefaultBool("GET_MEDIA_TOKEN_NOT_STREAM", true)
-
-var UpdateTask = common.GetEnvOrDefaultBool("UPDATE_TASK", true)
-
-var AzureDefaultAPIVersion = common.GetEnvOrDefaultString("AZURE_DEFAULT_API_VERSION", "2024-12-01-preview")
+var StreamingTimeout int
+var DifyDebug bool
+var MaxFileDownloadMB int
+var ForceStreamOption bool
+var GetMediaToken bool
+var GetMediaTokenNotStream bool
+var UpdateTask bool
+var AzureDefaultAPIVersion string
+var GeminiVisionMaxImageNum int
+var NotifyLimitCount int
+var NotificationLimitDurationMinute int
+var GenerateDefaultToken bool
 
 //var GeminiModelMap = map[string]string{
 //	"gemini-1.0-pro": "v1",
 //}
 
-var GeminiVisionMaxImageNum = common.GetEnvOrDefault("GEMINI_VISION_MAX_IMAGE_NUM", 16)
-
-var NotifyLimitCount = common.GetEnvOrDefault("NOTIFY_LIMIT_COUNT", 2)
-var NotificationLimitDurationMinute = common.GetEnvOrDefault("NOTIFICATION_LIMIT_DURATION_MINUTE", 10)
-
 func InitEnv() {
+	StreamingTimeout = common.GetEnvOrDefault("STREAMING_TIMEOUT", 60)
+	DifyDebug = common.GetEnvOrDefaultBool("DIFY_DEBUG", true)
+	MaxFileDownloadMB = common.GetEnvOrDefault("MAX_FILE_DOWNLOAD_MB", 20)
+	// ForceStreamOption 覆盖请求参数，强制返回usage信息
+	ForceStreamOption = common.GetEnvOrDefaultBool("FORCE_STREAM_OPTION", true)
+	GetMediaToken = common.GetEnvOrDefaultBool("GET_MEDIA_TOKEN", true)
+	GetMediaTokenNotStream = common.GetEnvOrDefaultBool("GET_MEDIA_TOKEN_NOT_STREAM", true)
+	UpdateTask = common.GetEnvOrDefaultBool("UPDATE_TASK", true)
+	AzureDefaultAPIVersion = common.GetEnvOrDefaultString("AZURE_DEFAULT_API_VERSION", "2024-12-01-preview")
+	GeminiVisionMaxImageNum = common.GetEnvOrDefault("GEMINI_VISION_MAX_IMAGE_NUM", 16)
+	NotifyLimitCount = common.GetEnvOrDefault("NOTIFY_LIMIT_COUNT", 2)
+	NotificationLimitDurationMinute = common.GetEnvOrDefault("NOTIFICATION_LIMIT_DURATION_MINUTE", 10)
+	// GenerateDefaultToken 是否生成初始令牌，默认关闭。
+	GenerateDefaultToken = common.GetEnvOrDefaultBool("GENERATE_DEFAULT_TOKEN", false)
+
 	//modelVersionMapStr := strings.TrimSpace(os.Getenv("GEMINI_MODEL_MAP"))
 	//if modelVersionMapStr == "" {
 	//	return
@@ -43,6 +50,3 @@ func InitEnv() {
 	//	}
 	//}
 }
-
-// GenerateDefaultToken 是否生成初始令牌，默认关闭。
-var GenerateDefaultToken = common.GetEnvOrDefaultBool("GENERATE_DEFAULT_TOKEN", false)

--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,7 @@
     "react-turnstile": "^1.0.5",
     "semantic-ui-offline": "^2.5.0",
     "semantic-ui-react": "^2.1.3",
-    "sse": "github:mpetazzoni/sse.js",
+    "sse": "https://github.com/mpetazzoni/sse.js",
     "i18next": "^23.16.8",
     "react-i18next": "^13.0.0",
     "i18next-browser-languagedetector": "^7.2.0"


### PR DESCRIPTION
主要修改点：
1、把common/instants.go里的从Getenv获取的参数，放到init.go的LoadEnv函数里获取
2、把constant/env.go里的从Getenv获取的参数，放到env.go的InitEnv函数里获取。
上述改动主要是避免.env文件配置参数不起作用的情况

看代码DEBUG参数是在common/constants.go里的DebugEnabled = os.Getenv("DEBUG") == "true"获取
但是common包初始化的时候，.env文件还没有读进来，这时获取不到环境变量

对应的issue：.env文件配置DEBUG=true不起作用 #951
