### PR TITLE
fix: ensure SSE ping packets are sent before upstream response

### DIFF
--- a/relay/relay-text.go
+++ b/relay/relay-text.go
@@ -192,7 +192,16 @@ func TextHelper(c *gin.Context) (openaiErr *dto.OpenAIErrorWithStatusCode) {
 	}
 
 	var httpResp *http.Response
-	resp, err := adaptor.DoRequest(c, relayInfo, requestBody)
+	var resp any
+
+	if relayInfo.IsStream {
+		// Streaming requests can use SSE ping to keep alive and avoid connection timeout
+		// The judgment of whether ping is enabled will be made within the function
+		resp, err = helper.DoStreamRequestWithPinger(adaptor.DoRequest, c, relayInfo, requestBody)
+	} else {
+		resp, err = adaptor.DoRequest(c, relayInfo, requestBody)
+	}
+
 	if err != nil {
 		return service.OpenAIErrorWrapper(err, "do_request_failed", http.StatusInternalServerError)
 	}


### PR DESCRIPTION
These changes ensures SSE ping packets are sent before receiving a response from the upstream. The previous implementation did not send ping packets until after the upstream response, rendering the feature ineffective.

Fixes #971 

**Before:**
HTTP 524/504/502 error when using CDN service and the upstream didn't respond within 60/100 seconds

**Now:**
Works without issue since the SSE ping option was enabled.

**Screenshot:**
A simulated response with the first chunk of the response received after 180 seconds.
![Screenshot](https://github.com/user-attachments/assets/e45ec625-b76c-4844-8ae7-7fe3beab7f5b)


