### PR TITLE
fix: gemini response json schema

### DIFF
--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -391,6 +391,7 @@ func removeAdditionalPropertiesWithDepth(schema interface{}, depth int) interfac
 	}
 	// 删除所有的title字段
 	delete(v, "title")
+	delete(v, "$schema")
 	// 如果type不为object和array，则直接返回
 	if typeVal, exists := v["type"]; !exists || (typeVal != "object" && typeVal != "array") {
 		return schema


### PR DESCRIPTION
If the `json_schema` is generated using OpenAI's Zod helper function `zodResponseFormat`, it will contain `$schema` property, which will cause the request to fail.
```
Error: 400 Invalid JSON payload received. Unknown name "$schema" at 'generation_config.response_schema': Cannot find field. 
```