### PR TITLE
添加DALL-E图像生成请求中的Background和Moderation字段

### DIFF
--- a/dto/dalle.go
+++ b/dto/dalle.go
@@ -12,6 +12,8 @@ type ImageRequest struct {
 	Style          string          `json:"style,omitempty"`
 	User           string          `json:"user,omitempty"`
 	ExtraFields    json.RawMessage `json:"extra_fields,omitempty"`
+	Background     string          `json:"background,omitempty"`
+	Moderation     string          `json:"moderation,omitempty"`
 }
 
 type ImageResponse struct {


### PR DESCRIPTION
在ImageRequest结构中添加了两个新字段：Background和Moderation，用于支持更多的图像生成配置选项。