### PR TITLE
fix: restrict redemptionCount and MinTopUp to positive integers only

### DIFF
--- a/web/src/components/SystemSetting.js
+++ b/web/src/components/SystemSetting.js
@@ -649,6 +649,8 @@ const SystemSetting = () => {
                         field='MinTopUp'
                         label='最低充值美元数量'
                         placeholder='例如：2，就是最低充值2$'
+                        min={1}
+                        precision={0}
                       />
                     </Col>
                   </Row>

--- a/web/src/pages/TopUp/index.js
+++ b/web/src/pages/TopUp/index.js
@@ -280,15 +280,17 @@ const TopUp = () => {
               <div style={{ marginTop: 20 }}>
                 <Divider>{t('在线充值')}</Divider>
                 <Form>
-                  <Form.Input
+                  <Form.InputNumber
+                    style={{ width: '100%' }}
                     disabled={!enableOnlineTopUp}
                     field={'redemptionCount'}
                     label={t('实付金额：') + ' ' + renderAmount()}
                     placeholder={
                       t('充值数量，最低 ') + renderQuotaWithAmount(minTopUp)
                     }
+                    min={1}
+                    precision={0}
                     name='redemptionCount'
-                    type={'number'}
                     value={topUpCount}
                     onChange={async (value) => {
                       if (value < 1) {


### PR DESCRIPTION
充值字段服务端是int类型, 前端却可以输入小数和负数,限制一下