### PR TITLE
fix: if default model is not exist, set the first one as default

### DIFF
--- a/web/src/pages/Playground/Playground.js
+++ b/web/src/pages/Playground/Playground.js
@@ -64,8 +64,9 @@ const Playground = () => {
     },
   ];
 
+  const defaultModel = 'gpt-4o-mini';
   const [inputs, setInputs] = useState({
-    model: 'gpt-4o-mini',
+    model: defaultModel,
     group: '',
     max_tokens: 0,
     temperature: 0,
@@ -108,6 +109,11 @@ const Playground = () => {
         value: model,
       }));
       setModels(localModelOptions);
+      // if default model is not in the list, set the first one as default
+      const hasDefault = localModelOptions.some(option => option.value === defaultModel);
+      if (!hasDefault && localModelOptions.length > 0) {
+        setInputs((inputs) => ({ ...inputs, model: localModelOptions[0].value }));
+      }
     } else {
       showError(t(message));
     }


### PR DESCRIPTION
修复playground默认模型不存在时, 取模型列表第一个兜底, 保证对话可用