### PR TITLE
feat: 渠道编辑页增加复制所有模型功能

### DIFF
--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -408,6 +408,7 @@
   "填入基础模型": "Fill in the basic model",
   "填入所有模型": "Fill in all models",
   "清除所有模型": "Clear all models",
+  "复制所有模型": "Copy all models",
   "密钥": "Key",
   "请输入密钥": "Please enter the key",
   "批量创建": "Batch Create",

--- a/web/src/pages/Channel/EditChannel.js
+++ b/web/src/pages/Channel/EditChannel.js
@@ -29,6 +29,7 @@ import {
 } from '@douyinfe/semi-ui';
 import { getChannelModels, loadChannelModels } from '../../components/utils.js';
 import { IconHelpCircle } from '@douyinfe/semi-icons';
+import { copy } from '../../helpers';
 
 const MODEL_MAPPING_EXAMPLE = {
   'gpt-3.5-turbo': 'gpt-3.5-turbo-0125',
@@ -873,7 +874,7 @@ const EditChannel = (props) => {
             optionList={modelOptions}
           />
           <div style={{ lineHeight: '40px', marginBottom: '12px' }}>
-            <Space>
+            <Space wrap={true}>
               <Button
                 type='primary'
                 onClick={() => {
@@ -911,6 +912,14 @@ const EditChannel = (props) => {
                 }}
               >
                 {t('清除所有模型')}
+              </Button>
+              <Button
+                type='tertiary'
+                onClick={() => {
+                  copy(inputs.models.join(','));
+                }}
+              >
+                {t('复制所有模型')}
               </Button>
             </Space>
             <Input


### PR DESCRIPTION
在渠道编辑页“清除所有模型”按钮后新增“复制所有模型”按钮，用于复制该渠道（英文逗号分隔的）所有模型名。

On the channel editing page, a "Copy all models" button has been added after the "Clear all models" button, used to copy all model names in this channel (separated by comma).