### PR TITLE
Add support for claude-neptune.

### DIFF
--- a/relay/channel/claude/adaptor.go
+++ b/relay/channel/claude/adaptor.go
@@ -38,7 +38,7 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 }
 
 func (a *Adaptor) Init(info *relaycommon.RelayInfo) {
-	if strings.HasPrefix(info.UpstreamModelName, "claude-3") {
+	if strings.HasPrefix(info.UpstreamModelName, "claude-3") || strings.HasPrefix(info.UpstreamModelName, "claude-neptune") {
 		a.RequestMode = RequestModeMessage
 	} else {
 		a.RequestMode = RequestModeCompletion


### PR DESCRIPTION
claude-neptune must send requests using the Message endpoint, otherwise it will prompt that "claude-neptune" is not supported on this API. Please use the Messages API instead.
![image](https://github.com/user-attachments/assets/7c8a10d0-2738-487e-b00e-67166c9239b1)
