### PR TITLE
feat: Implement user daily check-in feature

### DIFF
--- a/model/option.go
+++ b/model/option.go
@@ -128,6 +128,7 @@ func InitOptionMap() {
 	for k, v := range modelConfigs {
 		common.OptionMap[k] = v
 	}
+	common.OptionMap["checkin.reward_amount"] = strconv.Itoa(operation_setting.GetCheckinSetting().RewardAmount)
 
 	common.OptionMapRWMutex.Unlock()
 	loadOptionsFromDatabase()

--- a/model/user.go
+++ b/model/user.go
@@ -7,6 +7,7 @@ import (
 	"one-api/common"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/bytedance/gopkg/util/gopool"
 	"gorm.io/gorm"
@@ -41,6 +42,7 @@ type User struct {
 	DeletedAt        gorm.DeletedAt `gorm:"index"`
 	LinuxDOId        string         `json:"linux_do_id" gorm:"column:linux_do_id;index"`
 	Setting          string         `json:"setting" gorm:"type:text;column:setting"`
+	LastCheckinAt    *time.Time     `json:"last_checkin_at,omitempty" gorm:"index"`
 }
 
 func (user *User) ToBaseUser() *UserBase {

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -60,6 +60,7 @@ func SetApiRouter(router *gin.Engine) {
 				selfRoute.POST("/amount", controller.RequestAmount)
 				selfRoute.POST("/aff_transfer", controller.TransferAffQuota)
 				selfRoute.PUT("/setting", controller.UpdateUserSetting)
+			selfRoute.POST("/checkin", controller.UserCheckin)
 			}
 
 			adminRoute := userRoute.Group("/")

--- a/setting/operation_setting/checkin_setting.go
+++ b/setting/operation_setting/checkin_setting.go
@@ -1,0 +1,21 @@
+package operation_setting
+
+import (
+	"github.com/songquanpeng/one-api/common/config"
+)
+
+type CheckinSetting struct {
+	RewardAmount int `json:"reward_amount"`
+}
+
+var checkinSetting = CheckinSetting{
+	RewardAmount: 100, // Default reward amount
+}
+
+func init() {
+	config.GlobalConfig.Register("checkin", &checkinSetting)
+}
+
+func GetCheckinSetting() *CheckinSetting {
+	return &checkinSetting
+}

--- a/web/src/components/SystemSetting.js
+++ b/web/src/components/SystemSetting.js
@@ -73,6 +73,7 @@ const SystemSetting = () => {
     LinuxDOOAuthEnabled: '',
     LinuxDOClientId: '',
     LinuxDOClientSecret: '',
+    'checkin.reward_amount': 100, // Default value, will be overwritten by API on load
   });
 
   const [originInputs, setOriginInputs] = useState({});
@@ -118,6 +119,9 @@ const SystemSetting = () => {
           case 'Price':
           case 'MinTopUp':
             item.value = parseFloat(item.value);
+            break;
+          case 'checkin.reward_amount':
+            item.value = parseInt(item.value, 10); // Or parseFloat if decimals were intended
             break;
           default:
             break;
@@ -1127,6 +1131,38 @@ const SystemSetting = () => {
               >
                 <p>您确定要取消密码登录功能吗？这可能会影响用户的登录方式。</p>
               </Modal>
+
+              <Card>
+                <Form.Section text='签到设置'>
+                  <Form.InputNumber
+                    field='checkin.reward_amount'
+                    label='每日签到奖励额度'
+                    placeholder='例如：100 (设置为0则禁用签到奖励)'
+                    min={0} // Ensure non-negative
+                    style={{ width: '100%' }}
+                  />
+                  <Button
+                    onClick={async () => {
+                      if (
+                        inputs['checkin.reward_amount'] === undefined ||
+                        inputs['checkin.reward_amount'] < 0
+                      ) {
+                        showError('签到奖励额度不能小于0');
+                        return;
+                      }
+                      await updateOptions([
+                        {
+                          key: 'checkin.reward_amount',
+                          value: inputs['checkin.reward_amount'].toString(),
+                        },
+                      ]);
+                    }}
+                    style={{ marginTop: 10 }}
+                  >
+                    保存签到设置
+                  </Button>
+                </Form.Section>
+              </Card>
             </div>
           )}
         </Form>


### PR DESCRIPTION
This commit introduces a new daily check-in feature that allows users to receive a configurable amount of quota once per day.

Key changes include:

Backend:
- Added `CheckinSetting` to `setting/operation_setting/checkin_setting.go` for admin-configurable reward amount, defaulting to 100. Integrated with global config and options system.
- Modified `model/user.go` to include `LastCheckinAt (*time.Time)` field in the `User` struct to track the last check-in time.
- Created a new API endpoint `POST /api/user/checkin` in `controller/user.go` and `router/api-router.go`. This endpoint handles:
    - Retrieving reward settings.
    - Checking if you have already checked in today (UTC based).
    - Increasing your quota.
    - Updating your `LastCheckinAt` timestamp.
    - Logging the check-in event.
- Ensured GORM's auto-migration handles the new `LastCheckinAt` database field.

Frontend:
- Added an admin interface in `web/src/components/SystemSetting.js` under a new "签到设置" card for administrators to set the "每日签到奖励额度".
- Added a user-facing check-in UI in `web/src/pages/TopUp/index.js`:
    - Includes a "每日签到" button.
    - Displays loading states.
    - Shows success/error messages from the API.
    - Disables the button after a successful check-in for the day.
    - Fetches initial check-in status on page load to update UI accordingly.
    - Refreshes your quota display on successful check-in.