### PR TITLE
feat: log user msg info

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@
 # 调试相关配置
 # 启用pprof
 # ENABLE_PPROF=true
+# 记录输出日志
+RESPONSE_LOG_ENABLED=true
 
 # 数据库相关配置
 # 数据库连接字符串

--- a/common/constants.go
+++ b/common/constants.go
@@ -69,6 +69,7 @@ var EmailLoginAuthServerList = []string{
 
 var DebugEnabled bool
 var MemoryCacheEnabled bool
+var ResponseLogEnabled bool
 
 var LogConsumeEnabled = true
 

--- a/common/gin-writer.go
+++ b/common/gin-writer.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"bytes"
+	"github.com/gin-gonic/gin"
+	"io"
+	"strings"
+)
+
+const KeyResponseWriter = "key_response_Writer"
+
+func checkWrapWriter(c *gin.Context) bool {
+	if !ResponseLogEnabled {
+		return false
+	}
+	if !strings.Contains(c.Request.Header.Get("Content-Type"), "application/json") {
+		return false
+	}
+	return true
+}
+
+type BodyLogWriter struct {
+	gin.ResponseWriter
+	body *bytes.Buffer
+}
+
+func (w BodyLogWriter) Write(b []byte) (int, error) {
+	w.body.Write(b)
+	return w.ResponseWriter.Write(b)
+}
+func (w BodyLogWriter) String() string {
+	return w.body.String()
+}
+func (w BodyLogWriter) Bytes() []byte {
+	return w.body.Bytes()
+}
+func WrapWriter(c *gin.Context) *gin.Context {
+	if !checkWrapWriter(c) {
+		return c
+	}
+	requestBody, _ := GetRequestBody(c)
+	c.Request.Body = io.NopCloser(bytes.NewBuffer(requestBody))
+	w := BodyLogWriter{
+		ResponseWriter: c.Writer,
+		body:           bytes.NewBufferString(""),
+	}
+	c.Writer = w
+	c.Set(KeyResponseWriter, w)
+	return c
+}

--- a/common/init.go
+++ b/common/init.go
@@ -72,6 +72,7 @@ func LoadEnv() {
 	// Initialize variables from constants.go that were using environment variables
 	DebugEnabled = os.Getenv("DEBUG") == "true"
 	MemoryCacheEnabled = os.Getenv("MEMORY_CACHE_ENABLED") == "true"
+	ResponseLogEnabled = os.Getenv("RESPONSE_LOG_ENABLED") == "true"
 	IsMasterNode = os.Getenv("NODE_TYPE") != "slave"
 
 	// Parse requestInterval and set RequestInterval

--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -125,6 +125,8 @@ func testChannel(channel *model.Channel, testModel string) (err error, openAIErr
 	}
 	requestBody := bytes.NewBuffer(jsonData)
 	c.Request.Body = io.NopCloser(requestBody)
+	c.Set(common.KeyRequestBody, requestBody.Bytes())
+	c = common.WrapWriter(c)
 	resp, err := adaptor.DoRequest(c, info, requestBody)
 	if err != nil {
 		return err, nil

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -1,9 +1,18 @@
 package middleware
 
 import (
+	"bytes"
+	"compress/gzip"
 	"fmt"
-	"github.com/gin-gonic/gin"
+	"io"
 	"one-api/common"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	maxSize = 1024
 )
 
 func SetUpLogger(server *gin.Engine) {
@@ -12,7 +21,8 @@ func SetUpLogger(server *gin.Engine) {
 		if param.Keys != nil {
 			requestID = param.Keys[common.RequestIdKey].(string)
 		}
-		return fmt.Sprintf("[GIN] %s | %s | %3d | %13v | %15s | %7s %s\n",
+
+		logStr := fmt.Sprintf("[GIN] %s | %s | %3d | %13v | %15s | %7s %s\n",
 			param.TimeStamp.Format("2006/01/02 - 15:04:05"),
 			requestID,
 			param.StatusCode,
@@ -21,5 +31,59 @@ func SetUpLogger(server *gin.Engine) {
 			param.Method,
 			param.Path,
 		)
+
+		logStr += requestLog(param)
+		logStr += responseLog(param)
+
+		return logStr
 	}))
+
+	// add a middleware to log the response body when gin detail enabled
+	server.Use(func(c *gin.Context) {
+		c = common.WrapWriter(c)
+		c.Next()
+	})
+}
+
+func requestLog(param gin.LogFormatterParams) string {
+	if !common.DebugEnabled || param.Request.Body == nil {
+		return ""
+	}
+
+	requestBody, ok := param.Keys[common.KeyRequestBody]
+	if !ok {
+		return ""
+	}
+	bodyBytes, ok := requestBody.([]byte)
+	if !ok {
+		return ""
+	}
+	if len(bodyBytes) > maxSize {
+		bodyBytes = append(bodyBytes[:maxSize], []byte("...")...)
+	}
+	return fmt.Sprintf("Req: %s\n", string(bodyBytes))
+}
+
+func responseLog(param gin.LogFormatterParams) string {
+	if !common.DebugEnabled {
+		return ""
+	}
+	blw, ok := param.Keys[common.KeyResponseWriter].(common.BodyLogWriter)
+	if !ok {
+		return ""
+	}
+	body := blw.String()
+	// decompressed gzip response body
+	if strings.Contains(param.Request.Header.Get("Accept-Encoding"), "gzip") {
+		if reader, err := gzip.NewReader(bytes.NewReader([]byte(body))); err == nil {
+			if decompressed, err := io.ReadAll(reader); err == nil {
+				body = string(decompressed)
+			}
+		}
+	}
+
+	if len(body) > maxSize {
+		body = string(body[:maxSize]) + "..."
+	}
+	return fmt.Sprintf("Res: %s\n", body)
 }

--- a/model/log.go
+++ b/model/log.go
@@ -127,6 +127,7 @@ func RecordConsumeLog(c *gin.Context, userId int, channelId int, promptTokens in
 		return
 	}
 	username := c.GetString("username")
+	other["msg_info"] = GetMsgInfo(c)
 	otherStr := common.MapToJsonStr(other)
 	log := &Log{
 		UserId:           userId,

--- a/model/msg_info.go
+++ b/model/msg_info.go
@@ -1,0 +1,123 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"one-api/common"
+	"one-api/dto"
+	"one-api/relay/constant"
+	"strings"
+)
+
+func GetMsgInfo(c *gin.Context) map[string]any {
+	var err error
+	msgInfo := make(map[string]any)
+	openAiRequest := dto.GeneralOpenAIRequest{}
+	if err = common.UnmarshalBodyReusable(c, &openAiRequest); err == nil {
+		messages := openAiRequest.Messages
+		if len(messages) > 0 {
+			msgInfo["msg_input"] = messages[len(messages)-1].Content
+		} else if inputs := openAiRequest.Input; inputs != nil {
+			if inputList, ok := inputs.([]any); ok {
+				if len(inputList) > 0 {
+					msgInfo["msg_input"] = inputList[0]
+				}
+			} else {
+				msgInfo["msg_input"] = inputs
+			}
+		}
+	}
+	msgInfo["msg_output"] = GetMsgOutput(c)
+	return msgInfo
+}
+
+type Content interface {
+	StringContent() string
+}
+type ResponseContent[T Content] struct {
+	Choices []T `json:"choices"`
+}
+
+func (m *ResponseContent[T]) StringContent() string {
+	if len(m.Choices) > 0 {
+		return m.Choices[0].StringContent()
+	}
+	return ""
+}
+
+type Delta struct {
+	dto.Message `json:"delta"`
+}
+
+func (m Delta) StringContent() string {
+	return m.Message.StringContent()
+}
+
+type Message struct {
+	dto.Message `json:"message"`
+}
+
+func (m Message) StringContent() string {
+	return m.Message.StringContent()
+}
+func newResponseContent[T Content](data []byte) (res ResponseContent[T], err error) {
+	err = json.Unmarshal(data, &res)
+	return
+}
+func getResponseContentStr[T Content](data []byte) (res string, err error) {
+	var response ResponseContent[T]
+	response, err = newResponseContent[T](data)
+	if err != nil {
+		return
+	}
+	res = response.StringContent()
+	return
+}
+func GetMsgOutput(c *gin.Context) (output string) {
+	var err error
+	responseBody, ok := c.Get(common.KeyResponseWriter)
+	if !ok {
+		return
+	}
+	blw, ok := responseBody.(common.BodyLogWriter)
+	if !ok {
+		return
+	}
+	output = blw.String()
+	if len(output) == 0 {
+		return
+	}
+	relayMode := constant.Path2RelayMode(c.Request.URL.Path)
+	switch relayMode {
+	case constant.RelayModeChatCompletions:
+		firstData := output[0]
+		switch firstData {
+		case '{':
+			if output, err = getResponseContentStr[Message]([]byte(output)); err != nil {
+				common.LogWarn(c, fmt.Sprintf("unmarshal response failed: %s", err.Error()))
+				return
+			}
+		case 'd':
+			resSlice := strings.Split(output, "\n")
+			var streamResBuilder strings.Builder
+			for _, r := range resSlice {
+				r = strings.TrimPrefix(r, "data:")
+				r = strings.TrimSpace(r)
+				if r == "" || r == "[DONE]" {
+					continue
+				}
+				deltaContent, err := getResponseContentStr[Delta]([]byte(r))
+				if err != nil {
+					common.LogWarn(c, fmt.Sprintf("unmarshal stream response failed: %s", err.Error()))
+					continue
+				}
+				streamResBuilder.WriteString(deltaContent)
+			}
+			output = streamResBuilder.String()
+		}
+	//case constant.RelayModeEmbeddings:
+	default:
+	}
+	return
+}

--- a/web/src/components/LogsTable.js
+++ b/web/src/components/LogsTable.js
@@ -1013,6 +1013,20 @@ const LogsTable = () => {
           key: t('计费过程'),
           value: content,
         });
+        let msgInput = other?.msg_info?.msg_input;
+        let msgOutput = other?.msg_info?.msg_output;
+        if (msgInput) {
+          expandDataLocal.push({
+            key: t('用户输入'),
+            value: msgInput,
+          });
+        }
+        if (msgOutput) {
+          expandDataLocal.push({
+            key: t('模型输出'),
+            value: msgOutput,
+          });
+        }
         if (other?.reasoning_effort) {
           expandDataLocal.push({
             key: t('Reasoning Effort'),


### PR DESCRIPTION
模型日志增加用户输入和模型输出的显示
通过RESPONSE_LOG_ENABLED开关配置
启用多读取一次res body略微影响性能
不启用不影响性能
![image](https://github.com/user-attachments/assets/e74002d3-54bc-4311-9350-48017e80b654)

