### PR TITLE
feat: 火山引擎增加文生图

### DIFF
--- a/dto/dalle.go
+++ b/dto/dalle.go
@@ -15,6 +15,7 @@ type ImageRequest struct {
 	Background     string          `json:"background,omitempty"`
 	Moderation     string          `json:"moderation,omitempty"`
 	OutputFormat   string          `json:"output_format,omitempty"`
+	Watermark      *bool           `json:"watermark,omitempty"`
 }
 
 type ImageResponse struct {

--- a/relay/relay-image.go
+++ b/relay/relay-image.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"one-api/relay/constant"
 )
 
 func getAndValidImageRequest(c *gin.Context, info *relaycommon.RelayInfo) (*dto.ImageRequest, error) {
@@ -40,6 +41,11 @@ func getAndValidImageRequest(c *gin.Context, info *relaycommon.RelayInfo) (*dto.
 			if imageRequest.Quality == "" {
 				imageRequest.Quality = "standard"
 			}
+		}
+
+		if info.ApiType == constant.APITypeVolcEngine {
+			watermark := formData.Has("watermark")
+			imageRequest.Watermark = &watermark
 		}
 	default:
 		err := common.UnmarshalBodyReusable(c, imageRequest)


### PR DESCRIPTION
增加火山引擎渠道下的, 文生图模型<doubao-seedream-3.0-t2i>的支持, 并增加参数 watermark 来控制是否增加水印