### PR TITLE
fix: keep BatchDelete and TagMode enabled status

### DIFF
--- a/web/src/components/ChannelsTable.js
+++ b/web/src/components/ChannelsTable.js
@@ -888,9 +888,13 @@ const ChannelsTable = () => {
     const localIdSort = localStorage.getItem('id-sort') === 'true';
     const localPageSize =
       parseInt(localStorage.getItem('page-size')) || ITEMS_PER_PAGE;
+    const localEnableTagMode = localStorage.getItem('enable-tag-mode') === 'true';
+    const localEnableBatchDelete = localStorage.getItem('enable-batch-delete') === 'true';
     setIdSort(localIdSort);
     setPageSize(localPageSize);
-    loadChannels(0, localPageSize, localIdSort, enableTagMode)
+    setEnableTagMode(localEnableTagMode);
+    setEnableBatchDelete(localEnableBatchDelete);
+    loadChannels(0, localPageSize, localIdSort, localEnableTagMode)
       .then()
       .catch((reason) => {
         showError(reason);
@@ -1486,10 +1490,12 @@ const ChannelsTable = () => {
             {t('开启批量操作')}
           </Typography.Text>
           <Switch
+            checked={enableBatchDelete}
             label={t('开启批量操作')}
             uncheckedText={t('关')}
             aria-label={t('是否开启批量操作')}
             onChange={(v) => {
+              localStorage.setItem('enable-batch-delete', v + '');
               setEnableBatchDelete(v);
             }}
           />
@@ -1553,6 +1559,7 @@ const ChannelsTable = () => {
             uncheckedText={t('关')}
             aria-label={t('是否启用标签聚合')}
             onChange={(v) => {
+              localStorage.setItem('enable-tag-mode', v + '');
               setEnableTagMode(v);
               loadChannels(0, pageSize, idSort, v);
             }}


### PR DESCRIPTION
渠道管理界面, '使用ID排序'状态会保存到localStorage, 刷新页面可以记住, 
'开启批量操作'和'标签聚合模式'状态没有保存,刷新页面状态会失效,
使用和'使用ID排序'一样的逻辑保存到localStorage里解决了