### PR TITLE
fix: ali parameter.enable_thinking must be set to false for non-strea…

### DIFF
--- a/relay/channel/ali/adaptor.go
+++ b/relay/channel/ali/adaptor.go
@@ -57,6 +57,12 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 	if request == nil {
 		return nil, errors.New("request is nil")
 	}
+
+	// fix: ali parameter.enable_thinking must be set to false for non-streaming calls
+	if !info.IsStream {
+		request.EnableThinking = false
+	}
+
 	switch info.RelayMode {
 	default:
 		aliReq := requestOpenAI2Ali(*request)


### PR DESCRIPTION
qwen3非流模型默认调用会报: parameter.enable_thinking must be set to false for non-streaming calls
需要客户端主动传参enable_thinking:false
对客户端不友好, 服务兼容当非流模型时默认设置enable_thinking=false