### PR TITLE
fix: ali FetchUpstreamModels url

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -119,8 +119,11 @@ func FetchUpstreamModels(c *gin.Context) {
 		baseURL = channel.GetBaseURL()
 	}
 	url := fmt.Sprintf("%s/v1/models", baseURL)
-	if channel.Type == common.ChannelTypeGemini {
+	switch channel.Type {
+	case common.ChannelTypeGemini:
 		url = fmt.Sprintf("%s/v1beta/openai/models", baseURL)
+	case common.ChannelTypeAli:
+		url = fmt.Sprintf("%s/compatible-mode/v1/models", baseURL)
 	}
 	body, err := GetResponseBody("GET", url, channel, GetAuthHeader(channel.Key))
 	if err != nil {


### PR DESCRIPTION
阿里获取模型列表url需要加上`/compatible-mode`
自测通过, 详见: https://bailian.console.aliyun.com/?utm_content=se_1021228191&gclid=Cj0KCQjwotDBBhCQARIsAG5pinNBVh9oMBwfcxMx_YMzByBdEAwAvwzYHAg_IhaExHhkl5---naskwcaAiBSEALw_wcB&tab=api#/api/?type=model&url=https%3A%2F%2Fhelp.aliyun.com%2Fdocument_detail%2F2833609.html