### PR TITLE
Fix: Ensure OpenAI SDK extra_body fields can correctly merge into request

### DIFF
--- a/relay/relay-text.go
+++ b/relay/relay-text.go
@@ -194,7 +194,7 @@ func TextHelper(c *gin.Context) (openaiErr *dto.OpenAIErrorWithStatusCode) {
 			if err := json.Unmarshal(body, &topLevel); err == nil {
 				fieldsToCollect := []string{
 					"guided_choice", "guided_json", "guided_regex", "guided_grammar",
-					"guided_decoding_backend", "structural_tag", "enable_thinking"
+					"guided_decoding_backend", "structural_tag", "enable_thinking",
 				}
 				convertedMap := make(map[string]interface{})
 				json.Unmarshal(jsonData, &convertedMap)

--- a/relay/relay-text.go
+++ b/relay/relay-text.go
@@ -188,6 +188,29 @@ func TextHelper(c *gin.Context) (openaiErr *dto.OpenAIErrorWithStatusCode) {
 			return service.OpenAIErrorWrapperLocal(err, "json_marshal_failed", http.StatusInternalServerError)
 		}
 
+		body, err := common.GetRequestBody(c)
+		if err == nil {
+			var topLevel map[string]interface{}
+			if err := json.Unmarshal(body, &topLevel); err == nil {
+				fieldsToCollect := []string{
+					"guided_choice", "guided_json", "guided_regex", "guided_grammar",
+					"guided_decoding_backend", "structural_tag",
+				}
+				convertedMap := make(map[string]interface{})
+				json.Unmarshal(jsonData, &convertedMap)
+
+				for _, field := range fieldsToCollect {
+					if val, ok := topLevel[field]; ok {
+						convertedMap[field] = val
+					}
+				}
+				jsonData, err = json.Marshal(convertedMap)
+				if err != nil {
+					return service.OpenAIErrorWrapperLocal(err, "merge_sdk_fields_failed", http.StatusInternalServerError)
+				}
+			}
+		}
+
 		// apply param override
 		if len(relayInfo.ParamOverride) > 0 {
 			reqMap := make(map[string]interface{})

--- a/relay/relay-text.go
+++ b/relay/relay-text.go
@@ -194,7 +194,7 @@ func TextHelper(c *gin.Context) (openaiErr *dto.OpenAIErrorWithStatusCode) {
 			if err := json.Unmarshal(body, &topLevel); err == nil {
 				fieldsToCollect := []string{
 					"guided_choice", "guided_json", "guided_regex", "guided_grammar",
-					"guided_decoding_backend", "structural_tag",
+					"guided_decoding_backend", "structural_tag", "enable_thinking"
 				}
 				convertedMap := make(map[string]interface{})
 				json.Unmarshal(jsonData, &convertedMap)


### PR DESCRIPTION

### 🔧 Description:

This PR fixes an issue where requests using the `extra_body` parameter with the OpenAI Python SDK do not function as intended.

⚠️ The OpenAI SDK **automatically merges `extra_body` fields into the top-level JSON payload**. As a result, on the backend, the `ExtraBody` field in our request struct remains empty, and the extra parameters (such as `guided_choice`, `guided_json`, etc.) are ignored.

This behavior is **identical to using the `requests` to send these parameters at the root of the payload**, which is also a valid and common way users interact with the API.

Previously, we relied on the presence of `ExtraBody` in the parsed request struct, which remains empty in this case, leading to missing parameters when forwarding the request upstream.

---

### ✅ Fix:

* When passthrough is disabled, we now scan the top-level request payload for keys that are typically expected in `extra_body`.
* These fields are then explicitly merged back into the outgoing request to the model server.
* This preserves the original logic and avoids breaking passthrough mode.

---

### 💡 Why this matters:

Without this patch, SDK users (and native `requests` users sending `guided_*` or `response_format` directly in the root) will experience confusing failures, where valid parameters are silently dropped. This fix ensures full compatibility with both SDK usage patterns and manual requests.
