### PR TITLE
refactor: simplify SQL query by removing redundant database check

### DIFF
--- a/model/ability.go
+++ b/model/ability.go
@@ -98,11 +98,7 @@ func GetRandomSatisfiedChannel(group string, model string, retry int) (*Channel,
 
 	var err error = nil
 	channelQuery := getChannelQuery(group, model, retry)
-	if common.UsingSQLite || common.UsingPostgreSQL {
-		err = channelQuery.Order("weight DESC").Find(&abilities).Error
-	} else {
-		err = channelQuery.Order("weight DESC").Find(&abilities).Error
-	}
+	err = channelQuery.Order("weight DESC").Find(&abilities).Error
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
两个sql是完全一样的, 没必要使用if判断, 合并为一行即可