### PR TITLE
修复Gemini原生格式的inline_data

### DIFF
--- a/relay/channel/gemini/dto.go
+++ b/relay/channel/gemini/dto.go
@@ -18,7 +18,7 @@ func (c *GeminiThinkingConfig) SetThinkingBudget(budget int) {
 }
 
 type GeminiInlineData struct {
-	MimeType string `json:"mimeType"`
+	MimeType string `json:"mime_type"`
 	Data     string `json:"data"`
 }
 
@@ -55,7 +55,7 @@ type GeminiFileData struct {
 type GeminiPart struct {
 	Text                string                         `json:"text,omitempty"`
 	Thought             bool                           `json:"thought,omitempty"`
-	InlineData          *GeminiInlineData              `json:"inlineData,omitempty"`
+	InlineData          *GeminiInlineData              `json:"inline_data,omitempty"`
 	FunctionCall        *FunctionCall                  `json:"functionCall,omitempty"`
 	FunctionResponse    *FunctionResponse              `json:"functionResponse,omitempty"`
 	FileData            *GeminiFileData                `json:"fileData,omitempty"`


### PR DESCRIPTION
修复 JSON 结构体标签 (struct tag) 与实际请求中的 JSON 键名不匹配导致的原生Gemini丢图。已测试未影响openai格式传图