### PR TITLE
fix: login page hide sider

### DIFF
--- a/web/src/components/PageLayout.js
+++ b/web/src/components/PageLayout.js
@@ -102,7 +102,7 @@ const PageLayout = () => {
           flexDirection: 'column',
         }}
       >
-        {styleState.showSider && (
+        {userState.user && styleState.showSider && (
           <Sider
             style={{
               position: 'fixed',
@@ -123,7 +123,7 @@ const PageLayout = () => {
           style={{
             marginLeft: styleState.isMobile
               ? '0'
-              : styleState.showSider
+              : userState.user && styleState.showSider
                 ? styleState.siderCollapsed
                   ? '60px'
                   : '200px'


### PR DESCRIPTION
登录页面不应该显示左边菜单栏
修改前:
![image](https://github.com/user-attachments/assets/1786c7e3-6683-46b7-8102-6da737a3001d)
修改后:
![image](https://github.com/user-attachments/assets/d4c13477-5848-4215-9e2e-1aa5f6c280f8)
