### PR TITLE
fix: Rename and refactor RedisHDelObj to RedisDelKey

### DIFF
--- a/common/redis.go
+++ b/common/redis.go
@@ -97,7 +97,7 @@ func RedisHDelObj(key string) error {
 		SysLog(fmt.Sprintf("Redis HDEL: key=%s", key))
 	}
 	ctx := context.Background()
-	return RDB.HDel(ctx, key).Err()
+	return RDB.Del(ctx, key).Err()
 }
 
 func RedisHSetObj(key string, obj interface{}, expiration time.Duration) error {

--- a/common/redis.go
+++ b/common/redis.go
@@ -92,9 +92,9 @@ func RedisDel(key string) error {
 	return RDB.Del(ctx, key).Err()
 }
 
-func RedisHDelObj(key string) error {
+func RedisDelKey(key string) error {
 	if DebugEnabled {
-		SysLog(fmt.Sprintf("Redis HDEL: key=%s", key))
+		SysLog(fmt.Sprintf("Redis DEL Key: key=%s", key))
 	}
 	ctx := context.Background()
 	return RDB.Del(ctx, key).Err()

--- a/model/token_cache.go
+++ b/model/token_cache.go
@@ -19,7 +19,7 @@ func cacheSetToken(token Token) error {
 
 func cacheDeleteToken(key string) error {
 	key = common.GenerateHMAC(key)
-	err := common.RedisHDelObj(fmt.Sprintf("token:%s", key))
+	err := common.RedisDelKey(fmt.Sprintf("token:%s", key))
 	if err != nil {
 		return err
 	}

--- a/model/user_cache.go
+++ b/model/user_cache.go
@@ -3,10 +3,11 @@ package model
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"one-api/common"
 	"one-api/constant"
 	"time"
+
+	"github.com/gin-gonic/gin"
 
 	"github.com/bytedance/gopkg/util/gopool"
 )
@@ -57,7 +58,7 @@ func invalidateUserCache(userId int) error {
 	if !common.RedisEnabled {
 		return nil
 	}
-	return common.RedisHDelObj(getUserCacheKey(userId))
+	return common.RedisDelKey(getUserCacheKey(userId))
 }
 
 // updateUserCache updates all user cache fields using hash


### PR DESCRIPTION
Change the implementation of RedisHDelObj to use the Del command instead of HDel, and update all references accordingly.
The legacy implementation throws an `ERR wrong number of arguments for 'hdel' command` error when a user account is  deleted.