### PR TITLE
Fix: Correctly relay FunctionResponse content for Gemini API

### DIFF
--- a/relay/channel/gemini/dto.go
+++ b/relay/channel/gemini/dto.go
@@ -27,14 +27,14 @@ type FunctionCall struct {
 	Arguments    any    `json:"args"`
 }
 
-type GeminiFunctionResponseContent struct {
-	Name    string `json:"name"`
-	Content any    `json:"content"`
-}
+// type GeminiFunctionResponseContent struct {
+// 	Name    string `json:"name"`
+// 	Content any    `json:"content"`
+// }
 
 type FunctionResponse struct {
-	Name     string                        `json:"name"`
-	Response GeminiFunctionResponseContent `json:"response"`
+	Name     string                 `json:"name"`
+	Response map[string]interface{} `json:"response"`
 }
 
 type GeminiPartExecutableCode struct {


### PR DESCRIPTION
修复了FunctionResponse.Response内部字段丢失的问题，参考
https://ai.google.dev/api/caching?hl=zh-cn#FunctionResponse，response应当是一个自由的object。

已测试未影响openai2gemini的tool message