### PR TITLE
fix: balance unit sync

### DIFF
--- a/web/src/components/table/ChannelsTable.js
+++ b/web/src/components/table/ChannelsTable.js
@@ -6,7 +6,7 @@ import {
   showSuccess,
   timestamp2string,
   renderGroup,
-  renderNumberWithPoint,
+  renderQuotaWithAmount,
   renderQuota
 } from '../../helpers/index.js';
 
@@ -328,7 +328,7 @@ const ChannelsTable = () => {
                     {renderQuota(record.used_quota)}
                   </Tag>
                 </Tooltip>
-                <Tooltip content={t('剩余额度') + record.balance + t('，点击更新')}>
+                <Tooltip content={t('剩余额度$') + record.balance + t('，点击更新')}>
                   <Tag
                     color='white'
                     type='ghost'
@@ -336,7 +336,7 @@ const ChannelsTable = () => {
                     shape='circle'
                     onClick={() => updateChannelBalance(record)}
                   >
-                    ${renderNumberWithPoint(record.balance)}
+                    {renderQuotaWithAmount(record.balance)}
                   </Tag>
                 </Tooltip>
               </Space>

--- a/web/src/helpers/render.js
+++ b/web/src/helpers/render.js
@@ -764,7 +764,7 @@ export function renderQuotaWithAmount(amount) {
   if (displayInCurrency) {
     return '$' + amount;
   } else {
-    return renderUnitWithQuota(amount);
+    return renderNumber(renderUnitWithQuota(amount));
   }
 }
 


### PR DESCRIPTION
渠道剩余额度目前显示固定为货币单位
修复为根据后台设置显示为$或token