### PR TITLE
fix(mistral): adjust condition for assistant content with tool call

### DIFF
--- a/relay/channel/mistral/text.go
+++ b/relay/channel/mistral/text.go
@@ -47,7 +47,7 @@ func requestOpenAI2Mistral(request *dto.GeneralOpenAIRequest) *dto.GeneralOpenAI
 		}
 
 		mediaMessages := message.ParseContent()
-		if message.Role == "assistant" && message.ToolCalls != nil && message.Content != "null" {
+		if message.Role == "assistant" && message.ToolCalls != nil && message.Content == "" {
 			mediaMessages = []dto.MediaContent{}
 		}
 		for j, mediaMessage := range mediaMessages {


### PR DESCRIPTION
旧的逻辑会导致在处理带有工具调用且content不为空的 assistant 消息时丢弃content