### PR TITLE
refactor: remove redundant return

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -85,7 +85,6 @@ func GetAllChannels(c *gin.Context) {
 		"message": "",
 		"data":    channelData,
 	})
-	return
 }
 
 func FetchUpstreamModels(c *gin.Context) {
@@ -215,7 +214,6 @@ func SearchChannels(c *gin.Context) {
 		"message": "",
 		"data":    channelData,
 	})
-	return
 }
 
 func GetChannel(c *gin.Context) {
@@ -240,7 +238,6 @@ func GetChannel(c *gin.Context) {
 		"message": "",
 		"data":    channel,
 	})
-	return
 }
 
 func AddChannel(c *gin.Context) {
@@ -309,7 +306,6 @@ func AddChannel(c *gin.Context) {
 		"success": true,
 		"message": "",
 	})
-	return
 }
 
 func DeleteChannel(c *gin.Context) {
@@ -327,7 +323,6 @@ func DeleteChannel(c *gin.Context) {
 		"success": true,
 		"message": "",
 	})
-	return
 }
 
 func DeleteDisabledChannel(c *gin.Context) {
@@ -344,7 +339,6 @@ func DeleteDisabledChannel(c *gin.Context) {
 		"message": "",
 		"data":    rows,
 	})
-	return
 }
 
 type ChannelTag struct {
@@ -379,7 +373,6 @@ func DisableTagChannels(c *gin.Context) {
 		"success": true,
 		"message": "",
 	})
-	return
 }
 
 func EnableTagChannels(c *gin.Context) {
@@ -404,7 +397,6 @@ func EnableTagChannels(c *gin.Context) {
 		"success": true,
 		"message": "",
 	})
-	return
 }
 
 func EditTagChannels(c *gin.Context) {
@@ -436,7 +428,6 @@ func EditTagChannels(c *gin.Context) {
 		"success": true,
 		"message": "",
 	})
-	return
 }
 
 type ChannelBatch struct {
@@ -467,7 +458,6 @@ func DeleteChannelBatch(c *gin.Context) {
 		"message": "",
 		"data":    len(channelBatch.Ids),
 	})
-	return
 }
 
 func UpdateChannel(c *gin.Context) {
@@ -514,7 +504,6 @@ func UpdateChannel(c *gin.Context) {
 		"message": "",
 		"data":    channel,
 	})
-	return
 }
 
 func FetchModels(c *gin.Context) {
@@ -621,7 +610,6 @@ func BatchSetChannelTag(c *gin.Context) {
 		"message": "",
 		"data":    len(channelBatch.Ids),
 	})
-	return
 }
 
 func GetTagModels(c *gin.Context) {
@@ -662,5 +650,4 @@ func GetTagModels(c *gin.Context) {
 		"message": "",
 		"data":    longestModels,
 	})
-	return
 }


### PR DESCRIPTION
移除多余的return

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code clarity and consistency in channel-related operations. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->