### PR TITLE
feat: add user display name tooltips

### DIFF
--- a/web/src/components/table/LogsTable.js
+++ b/web/src/components/table/LogsTable.js
@@ -398,7 +398,14 @@ const LogsTable = () => {
             >
               {typeof text === 'string' && text.slice(0, 1)}
             </Avatar>
-            {text}
+            <Tooltip content={record.display_name || t('无显示名称')} position='top'>
+              <span
+                onClick={() => showUserInfo(record.user_id)}
+                style={{ cursor: 'pointer' }}
+              >
+                {text}
+              </span>
+            </Tooltip>
           </div>
         ) : (
           <></>

--- a/web/src/components/table/UsersTable.js
+++ b/web/src/components/table/UsersTable.js
@@ -26,6 +26,7 @@ import {
   Space,
   Table,
   Tag,
+  Tooltip,
   Typography
 } from '@douyinfe/semi-ui';
 import {
@@ -110,6 +111,16 @@ const UsersTable = () => {
     {
       title: t('用户名'),
       dataIndex: 'username',
+      render: (text, record) => {
+        if (record.display_name) {
+          return (
+            <Tooltip content={record.display_name} position='top'>
+              <span>{text}</span>
+            </Tooltip>
+          );
+        }
+        return text;
+      },
     },
     {
       title: t('分组'),


### PR DESCRIPTION
用户列表和日志列表增加显示名称tips, 方便查看管理
使用日志:
![image](https://github.com/user-attachments/assets/7b8307bb-ee7a-4a27-8957-9caaf9116356)
用户管理:
![image](https://github.com/user-attachments/assets/c3d90038-5db1-4bf1-9db1-238281674b6b)
