### PR TITLE
feat(Gemini): 支持通过模型名称后缀动态设置思考预算

### DIFF
--- a/relay/channel/gemini/adaptor.go
+++ b/relay/channel/gemini/adaptor.go
@@ -72,8 +72,11 @@ func (a *Adaptor) Init(info *relaycommon.RelayInfo) {
 func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 
 	if model_setting.GetGeminiSettings().ThinkingAdapterEnabled {
-		// suffix -thinking and -nothinking
-		if strings.HasSuffix(info.OriginModelName, "-thinking") {
+		// 新增逻辑：处理 -thinking-<budget> 格式
+		if strings.Contains(info.OriginModelName, "-thinking-") {
+			parts := strings.Split(info.UpstreamModelName, "-thinking-")
+			info.UpstreamModelName = parts[0]
+		} else if strings.HasSuffix(info.OriginModelName, "-thinking") { // 旧的适配
 			info.UpstreamModelName = strings.TrimSuffix(info.UpstreamModelName, "-thinking")
 		} else if strings.HasSuffix(info.OriginModelName, "-nothinking") {
 			info.UpstreamModelName = strings.TrimSuffix(info.UpstreamModelName, "-nothinking")

--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -60,8 +60,8 @@ func CovertGemini2OpenAI(textRequest dto.GeneralOpenAIRequest, info *relaycommon
 	if model_setting.GetGeminiSettings().ThinkingAdapterEnabled {
 		// 新增逻辑：处理 -thinking-<budget> 格式
 		if strings.Contains(info.OriginModelName, "-thinking-") {
-			parts := strings.Split(info.OriginModelName, "-thinking-")
-			if len(parts) == 2 {
+			parts := strings.SplitN(info.OriginModelName, "-thinking-", 2)
+			if len(parts) == 2 && parts[1] != "" {
 				if budgetTokens, err := strconv.Atoi(parts[1]); err == nil {
 					// 从模型名称成功解析预算
 					isNew25Pro := strings.HasPrefix(info.OriginModelName, "gemini-2.5-pro") &&

--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -12,6 +12,7 @@ import (
 	"one-api/relay/helper"
 	"one-api/service"
 	"one-api/setting/model_setting"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -57,7 +58,40 @@ func CovertGemini2OpenAI(textRequest dto.GeneralOpenAIRequest, info *relaycommon
 	}
 
 	if model_setting.GetGeminiSettings().ThinkingAdapterEnabled {
-		if strings.HasSuffix(info.OriginModelName, "-thinking") {
+		// 新增逻辑：处理 -thinking-<budget> 格式
+		if strings.Contains(info.OriginModelName, "-thinking-") {
+			parts := strings.Split(info.OriginModelName, "-thinking-")
+			if len(parts) == 2 {
+				if budgetTokens, err := strconv.Atoi(parts[1]); err == nil {
+					// 从模型名称成功解析预算
+					isNew25Pro := strings.HasPrefix(info.OriginModelName, "gemini-2.5-pro") &&
+						!strings.HasPrefix(info.OriginModelName, "gemini-2.5-pro-preview-05-06") &&
+						!strings.HasPrefix(info.OriginModelName, "gemini-2.5-pro-preview-03-25")
+
+					if isNew25Pro {
+						// 新的2.5pro模型：ThinkingBudget范围为128-32768
+						if budgetTokens < 128 {
+							budgetTokens = 128
+						} else if budgetTokens > 32768 {
+							budgetTokens = 32768
+						}
+					} else {
+						// 其他模型：ThinkingBudget范围为0-24576
+						if budgetTokens < 0 {
+							budgetTokens = 0
+						} else if budgetTokens > 24576 {
+							budgetTokens = 24576
+						}
+					}
+
+					geminiRequest.GenerationConfig.ThinkingConfig = &GeminiThinkingConfig{
+						ThinkingBudget:  common.GetPointer(budgetTokens),
+						IncludeThoughts: true,
+					}
+				}
+				// 如果解析失败，则不设置ThinkingConfig，静默处理
+			}
+		} else if strings.HasSuffix(info.OriginModelName, "-thinking") { // 保留旧逻辑以兼容
 			// 硬编码不支持 ThinkingBudget 的旧模型
 			unsupportedModels := []string{
 				"gemini-2.5-pro-preview-05-06",

--- a/setting/operation_setting/model-ratio.go
+++ b/setting/operation_setting/model-ratio.go
@@ -142,6 +142,11 @@ var defaultModelRatio = map[string]float64{
 	"gemini-2.5-flash-preview-04-17":            0.075,
 	"gemini-2.5-flash-preview-04-17-thinking":   0.075,
 	"gemini-2.5-flash-preview-04-17-nothinking": 0.075,
+	"gemini-2.5-flash-preview-05-20":            0.075,
+	"gemini-2.5-flash-preview-05-20-thinking":   0.075,
+	"gemini-2.5-flash-preview-05-20-nothinking": 0.075,
+	"gemini-2.5-flash-thinking-*":               0.075, // 用于为后续所有2.5 flash thinking 模型设置默认倍率
+	"gemini-2.5-pro-thinking-*":                 0.625, // 用于为后续所有2.5 pro thinking 模型设置默认倍率
 	"text-embedding-004":                        0.001,
 	"chatglm_turbo":                             0.3572,     // ￥0.005 / 1k tokens
 	"chatglm_pro":                               0.7143,     // ￥0.01 / 1k tokens
@@ -345,7 +350,12 @@ func UpdateModelRatioByJSONString(jsonStr string) error {
 func GetModelRatio(name string) (float64, bool) {
 	modelRatioMapMutex.RLock()
 	defer modelRatioMapMutex.RUnlock()
-
+	if strings.HasPrefix(name, "gemini-2.5-flash") && strings.Contains(name, "-thinking-") {
+		name = "gemini-2.5-flash-thinking-*"
+	}
+	if strings.HasPrefix(name, "gemini-2.5-pro") && strings.Contains(name, "-thinking-") {
+		name = "gemini-2.5-pro-thinking-*"
+	}
 	if strings.HasPrefix(name, "gpt-4-gizmo") {
 		name = "gpt-4-gizmo-*"
 	}
@@ -470,9 +480,9 @@ func getHardcodedCompletionModelRatio(name string) (float64, bool) {
 			return 4, true
 		} else if strings.HasPrefix(name, "gemini-2.0") {
 			return 4, true
-		} else if strings.HasPrefix(name, "gemini-2.5-pro-preview") {
+		} else if strings.HasPrefix(name, "gemini-2.5-pro") { // 移除preview来增加兼容性，这里假设正式版的倍率和preview一致
 			return 8, true
-		} else if strings.HasPrefix(name, "gemini-2.5-flash-preview") {
+		} else if strings.HasPrefix(name, "gemini-2.5-flash") { // 同上
 			if strings.HasSuffix(name, "-nothinking") {
 				return 4, false
 			} else {

--- a/web/src/pages/Setting/Model/SettingGeminiModel.js
+++ b/web/src/pages/Setting/Model/SettingGeminiModel.js
@@ -173,7 +173,8 @@ export default function SettingGeminiModel(props) {
                 <Text>
                   {t(
                     "和Claude不同，默认情况下Gemini的思考模型会自动决定要不要思考，就算不开启适配模型也可以正常使用，" +
-                    "如果您需要计费，推荐设置无后缀模型价格按思考价格设置"
+                    "如果您需要计费，推荐设置无后缀模型价格按思考价格设置。" +
+                    "支持使用 gemini-2.5-pro-preview-06-05-thinking-128 格式来精确传递思考预算。"
                   )}
                 </Text>
               </Col>
@@ -183,7 +184,7 @@ export default function SettingGeminiModel(props) {
                 <Form.Switch
                   label={t('启用Gemini思考后缀适配')}
                   field={'gemini.thinking_adapter_enabled'}
-                  extraText={"适配-thinking和-nothinking后缀"}
+                  extraText={"适配-thinking、-thinking-预算数字和-nothinking后缀"}
                   onChange={(value) =>
                     setInputs({
                       ...inputs,
@@ -205,7 +206,7 @@ export default function SettingGeminiModel(props) {
             <Row>
               <Col xs={24} sm={12} md={8} lg={8} xl={8}>
                 <Form.InputNumber
-                  label={t('请求模型带-thinking后缀的BudgetTokens数（超出24576的部分将被忽略）')}
+                  label={t('思考预算/MaxToken的比值（超出24576或32678的预算将被忽略）')}
                   field={'gemini.thinking_adapter_budget_tokens_percentage'}
                   initValue={''}
                   extraText={t('0.1-1之间的小数')}


### PR DESCRIPTION
### 概览

close https://github.com/QuantumNous/new-api/issues/1183
本次更新为 Gemini 渠道引入了一项增强功能，允许用户通过在模型名称后添加特定后缀来动态指定 `Thinking Budget`。此前的 `-thinking` 后缀仅能开启/关闭思考功能，而新的格式 `...-thinking-<budget>` 提供了更精细的控制能力。

为配合此功能，后端 Relay 逻辑、计费倍率系统和前端设置页面均已进行相应适配。

### 主要变更

#### 1. 后端 Relay 逻辑更新 (`relay/channel/gemini/`)

- **新增模型名称解析逻辑**:
  - 在 `adaptor.go` 和 `relay-gemini.go` 中，增加了对 `model-name-thinking-<budget>` 格式的识别。
  - 系统会从模型名称中解析出 `<budget>` 数值，并将其作为 `ThinkingConfig.ThinkingBudget` 参数传递给 Google Gemini API。

- **向后兼容**:
  - 保留了对原有 `-thinking` 和 `-nothinking` 后缀的支持，确保旧的配置可以继续正常工作。

#### 2. 模型计费倍率适配 (`setting/operation_setting/model-ratio.go`)

- **引入通配符计费规则**:
  - 为了给所有 `...-thinking-<budget>` 格式的模型统一定价，新增了两个通配符模型倍率：
    - `gemini-2.5-flash-thinking-*`
    - `gemini-2.5-pro-thinking-*`
  - `GetModelRatio` 函数已更新，当遇到符合新格式的模型名称时，会匹配到对应的通配符规则进行计费。

- **兼容性提升**:
  - 将 `getHardcodedCompletionModelRatio` 中的模型前缀检查从 `gemini-2.5-pro-preview` 和 `gemini-2.5-flash-preview` 分别简化为 `gemini-2.5-pro` 和 `gemini-2.5-flash`，以更好地兼容未来发布的正式版模型。

#### 3. 前端 UI/UX 优化 (`web/src/pages/Setting/Model/SettingGeminiModel.js`)

- **更新设置说明**:
  - 在 `设置` -> `模型` -> `Gemini` 部分，更新了关于思考模型适配的说明文本，明确告知用户现在可以使用 `-thinking-<budget>` 格式来精确控制思考预算。
  - 调整了部分标签和提示文本，使其更清晰易懂。

### 如何使用

1.  确保在 **设置 -> 模型 -> Gemini** 中已开启 **“启用Gemini思考后缀适配”** 开关。
2.  在进行 API 请求时，将模型名称设置为 `[原始模型名称]-thinking-[预算值]` 的格式。

**示例**:
若要使用 `gemini-2.5-pro-preview-06-05` 模型并设置 `1024` tokens 的思考预算，请在 API 请求中将 `model` 参数设置为：
`gemini-2.5-pro-preview-06-05-thinking-1024`

系统将自动解析该名称，正确调用上游模型 `gemini-2.5-pro-preview-06-05`，并附带 `{ "thinking_config": { "thinking_budget": 1024 } }` 的配置。

### 向后兼容性

此变更为**非破坏性更新**，完全向后兼容。
- 使用旧的 `-thinking` 或 `-nothinking` 后缀的请求将继续按原有逻辑工作。
- 未使用任何相关后缀的请求不受任何影响。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying Gemini model thinking budgets using the "-thinking-<budget>" suffix in model names.
- **Improvements**
  - Enhanced model ratio handling for new Gemini model variants, including wildcard support for future models.
  - UI text updated to clearly explain the new thinking budget suffix format and its usage in settings.
- **Bug Fixes**
  - Improved normalization and compatibility for Gemini model ratio calculations, ensuring accurate handling for both preview and official releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->