### PR TITLE
feat: openrouter format for claude request

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"one-api/common"
 	"one-api/dto"
+	"one-api/relay/channel/openrouter"
 	relaycommon "one-api/relay/common"
 	"one-api/relay/helper"
 	"one-api/service"
@@ -120,6 +121,21 @@ func RequestOpenAI2ClaudeMessage(textRequest dto.GeneralOpenAIRequest) (*dto.Cla
 		claudeRequest.TopP = 0
 		claudeRequest.Temperature = common.GetPointer[float64](1.0)
 		claudeRequest.Model = strings.TrimSuffix(textRequest.Model, "-thinking")
+	}
+
+	if textRequest.Reasoning != nil {
+		var reasoning openrouter.RequestReasoning
+		if err := json.Unmarshal(textRequest.Reasoning, &reasoning); err != nil {
+			return nil, err
+		}
+
+		budgetTokens := reasoning.MaxTokens
+		if budgetTokens > 0 {
+			claudeRequest.Thinking = &dto.Thinking{
+				Type:         "enabled",
+				BudgetTokens: budgetTokens,
+			}
+		}
 	}
 
 	if textRequest.Stop != nil {


### PR DESCRIPTION
之前的 PR: #1112 
#983 实现了 openrouter 的 reasoning 字段透传和 `/messages -> openrouter`，没有实现 `/chat/completions -> claude`
这个 pr 支持 openrouter 格式请求 `"reasoning": {"max_tokens": 16000}` ，转换成 ClaudeRequest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for processing an optional "Reasoning" field in relevant requests, enabling enhanced handling of reasoning-related parameters when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->