### PR TITLE
Fix: optimize Redis expiration handling and refactor cache duration retrieval

### DIFF
--- a/common/redis.go
+++ b/common/redis.go
@@ -141,7 +141,11 @@ func RedisHSetObj(key string, obj interface{}, expiration time.Duration) error {
 
 	txn := RDB.TxPipeline()
 	txn.HSet(ctx, key, data)
-	txn.Expire(ctx, key, expiration)
+
+	// 只有在 expiration 大于 0 时才设置过期时间
+	if expiration > 0 {
+		txn.Expire(ctx, key, expiration)
+	}
 
 	_, err := txn.Exec(ctx)
 	if err != nil {

--- a/constant/cache_key.go
+++ b/constant/cache_key.go
@@ -2,12 +2,10 @@ package constant
 
 import "one-api/common"
 
-var (
-	TokenCacheSeconds         = common.SyncFrequency
-	UserId2GroupCacheSeconds  = common.SyncFrequency
-	UserId2QuotaCacheSeconds  = common.SyncFrequency
-	UserId2StatusCacheSeconds = common.SyncFrequency
-)
+// 使用函数来避免初始化顺序带来的赋值问题
+func RedisKeyCacheSeconds() int {
+	return common.SyncFrequency
+}
 
 // Cache keys
 const (

--- a/model/token_cache.go
+++ b/model/token_cache.go
@@ -10,7 +10,7 @@ import (
 func cacheSetToken(token Token) error {
 	key := common.GenerateHMAC(token.Key)
 	token.Clean()
-	err := common.RedisHSetObj(fmt.Sprintf("token:%s", key), &token, time.Duration(constant.TokenCacheSeconds)*time.Second)
+	err := common.RedisHSetObj(fmt.Sprintf("token:%s", key), &token, time.Duration(constant.RedisKeyCacheSeconds())*time.Second)
 	if err != nil {
 		return err
 	}

--- a/model/user_cache.go
+++ b/model/user_cache.go
@@ -70,7 +70,7 @@ func updateUserCache(user User) error {
 	return common.RedisHSetObj(
 		getUserCacheKey(user.Id),
 		user.ToBaseUser(),
-		time.Duration(constant.UserId2QuotaCacheSeconds)*time.Second,
+		time.Duration(constant.RedisKeyCacheSeconds())*time.Second,
 	)
 }
 


### PR DESCRIPTION
Ensure expiration is only set in Redis if greater than 0 and replace direct constant usage with a function to retrieve cache duration to fix a package initialization order bug where constants were evaluated before environment variables were loaded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Unified cache expiration settings by replacing multiple constants with a single function to determine Redis key expiration time.
  - Adjusted internal logic to only set Redis key expiration when the duration is greater than zero.

- **Chores**
  - Improved maintainability by consolidating cache expiration configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->