### PR TITLE
fix: playground write user context to check acceptUnsetRatio

### DIFF
--- a/controller/playground.go
+++ b/controller/playground.go
@@ -66,5 +66,14 @@ func Playground(c *gin.Context) {
 	}
 	middleware.SetupContextForSelectedChannel(c, channel, playgroundRequest.Model)
 	c.Set(constant.ContextKeyRequestStartTime, time.Now())
+
+	// Write user context to ensure acceptUnsetRatio is available
+	userId := c.GetInt("id")
+	userCache, err := model.GetUserCache(userId)
+	if err != nil {
+		openaiErr = service.OpenAIErrorWrapperLocal(err, "get_user_cache_failed", http.StatusInternalServerError)
+		return
+	}
+	userCache.WriteContext(c)
 	Relay(c)
 }


### PR DESCRIPTION
用户设置`接受未设置价格模型`
渠道测试和API请求会生效
playgroud请求未生效
原因是playground没有取到user.Setting
修复后测试正常