### PR TITLE
fix: Gemini & Vertex empty content error

### DIFF
--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -374,7 +374,9 @@ func CovertGemini2OpenAI(textRequest dto.GeneralOpenAIRequest, info *relaycommon
 		if content.Role == "assistant" {
 			content.Role = "model"
 		}
-		geminiRequest.Contents = append(geminiRequest.Contents, content)
+		if len(content.Parts) > 0 {
+			geminiRequest.Contents = append(geminiRequest.Contents, content)
+		}
 	}
 
 	if len(system_content) > 0 {


### PR DESCRIPTION
# **PR 报告：修复 Gemini/Vertex 因消息内容为空导致的请求失败问题**

## 一、问题描述

**问题现象：**
当 API 请求中 `messages` 数组包含 `content` 字段为空的条目时，向 Gemini 及 Vertex 渠道发送的请求会失败，上游服务返回 `400 Bad Request` 错误。

**复现步骤:**
```bash
curl -X POST http://127.0.0.1:3000/v1/chat/completions \
-H "Content-Type: application/json" \
-H "Authorization: Bearer sk-123456" \
-d '{
    "model": "gemini-pro",
    "messages": [
        {
            "role": "user",
            "content": "hello"
        },
        {
            "role": "user",
            "content": "" 
        }
    ]
}'
```

**上游错误响应 (Error Response):**
```json
{
    "error": {
        "message": "Unable to submit request because it must include at least one parts field...",
        "code": 400
    }
}
```

**背景：**
此问题在多个客户端（如 SillyTavern, Cherry Studio 等）中都有出现，推测可能与上游服务（Google）近期对 API 请求参数校验规则的调整有关（因为最近才收到比较多的反馈）。

---

## 二、根本原因分析

在请求转换过程中，项目将 OpenAI 格式的 `messages` 转换为 Gemini 格式。当遇到 `content` 为空的 `message` 时，会生成一个 `parts` 字段为 `null` 的 `content` 对象。

**转换后错误的请求体片段：**
```json
{
  "contents": [
    {
      "role": "user",
      "parts": [{ "text": "hello" }]
    },
    {
      "role": "user",
      "parts": null  // 此处为问题根源
    }
  ]
}
```
根据 Gemini API 的规范，`parts` 字段必须是一个包含至少一个有效元素的数组，`null` 值或空数组均不被接受，从而导致请求校验失败。

---

## 三、解决方案

在将消息转换为 Gemini 格式的 `contents` 数组时，增加一道过滤逻辑：**如果一个 `message` 对象转换后的 `parts` 数组为空，则直接跳过该消息**，不将其添加到最终的 `contents` 数组中。

**代码实现：**
在 `relay/channel/gemini/relay-gemini.go` 文件约 377 行处，增加对 `parts` 数组长度的判断。
```go
// 代码示例
if len(content.Parts) > 0 {
    // 只有当 parts 不为空时，才将此 content 添加到请求体中
    geminiRequest.Contents = append(geminiRequest.Contents, content)
}
```
此修改可以从根本上避免生成不符合上游规范的请求体。

---

## 四、测试与验证

已在本地环境完成以下场景的回归测试，确保修复方案的正确性，且未引入新的问题：

- ✅ **核心功能**：成功处理包含空消息的请求，不再报错。
- ✅ **多模态**：图片和文本混合输入功能正常。
- ❌ **纯图片**：只有图片没有文字的场景，上游报错400。经验证不是此pr影响，目前正式版本仍然有此问题。
- ✅ **多渠道兼容性**：
    - ✅ Google AI Studio
    - ✅ Vertex AI
    - ✅ Vertex Express Mode(快速模式)
- ✅ **功能完整性**：
    - ✅ 流式与非流式输出
    - ✅ 长上下文（>200k）处理
    - ✅ 长时间（>5m）请求
- ✅ **MCP**：支持正常。

除了本地自测之外，也正在邀请我站内的用户进行更大范围的用户场景测试，也许1，2天后会更新多场景测试结果。此修复对于提升 Gemini 渠道的稳定性至关重要，建议合并。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message handling to prevent empty messages from appearing in requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->