### PR TITLE
fix: unique channel models

### DIFF
--- a/controller/model.go
+++ b/controller/model.go
@@ -17,6 +17,7 @@ import (
 	"one-api/setting"
 
 	"github.com/gin-gonic/gin"
+	"github.com/samber/lo"
 )
 
 // https://platform.openai.com/docs/api-reference/models/list
@@ -121,6 +122,9 @@ func init() {
 			Parent:     nil,
 		})
 	}
+	openAIModels = lo.UniqBy(openAIModels, func(m dto.OpenAIModels) string {
+		return m.Id
+	})
 	openAIModelsMap = make(map[string]dto.OpenAIModels)
 	for _, aiModel := range openAIModels {
 		openAIModelsMap[aiModel.Id] = aiModel


### PR DESCRIPTION
初始化时就去重模型列表
避免客户端显示重复的模型名

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved model list reliability by ensuring duplicate models are removed from the available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->