### PR TITLE
fix: unique channel models

### DIFF
--- a/controller/model.go
+++ b/controller/model.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"github.com/samber/lo"
 	"net/http"
 	"one-api/common"
 	"one-api/constant"
@@ -136,6 +137,9 @@ func init() {
 		adaptor.Init(meta)
 		channelId2Models[i] = adaptor.GetModelList()
 	}
+	openAIModels = lo.UniqBy(openAIModels, func(m dto.OpenAIModels) string {
+		return m.Id
+	})
 }
 
 func ListModels(c *gin.Context) {


### PR DESCRIPTION
初始化时就去重模型列表
避免客户端显示重复的模型名

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where duplicate models could appear in the list of available models. Only unique models are now shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->