### PR TITLE
fix: admin user edit admin

### DIFF
--- a/web/src/components/table/UsersTable.js
+++ b/web/src/components/table/UsersTable.js
@@ -296,9 +296,15 @@ const UsersTable = () => {
               type='tertiary'
               size="small"
               className="!rounded-full"
-              onClick={() => {
-                setEditingUser(record);
-                setShowEditUser(true);
+              onClick={async () => {
+                const res = await API.get(`/api/user/${record.id}`);
+                const { success, message } = res.data;
+                if (success) {
+                  setEditingUser(record);
+                  setShowEditUser(true);
+                } else {
+                  showError(message);
+                }
               }}
             >
               {t('编辑')}


### PR DESCRIPTION
管理员编辑同样的管理员级别的用户时, 后端权限会拦住, 
但前端会表现错误,  依旧会弹出编辑框, 而内容是自己的信息
![image](https://github.com/user-attachments/assets/ca3d4a7a-60db-4d8f-833c-38bf2aca6770)


最好的修复方案是, api请求从弹出框里面改到外面, 但这样修改逻辑较大
目前使用最小改动方案修复, 在弹出前请求一次, 如果api返回正常才弹出编辑界面, 使编辑表现正常
