### PR TITLE
fix(playground): skip keep-alive heartbeats to prevent JSON parse errors

### DIFF
--- a/web/src/hooks/useApiRequest.js
+++ b/web/src/hooks/useApiRequest.js
@@ -258,6 +258,13 @@ export const useApiRequest = (
         return;
       }
 
+      // sse.js transforms keep-alive comments like ": PING" into an empty
+      // string, which is not valid JSON. We can safely ignore such messages.
+      if (typeof e.data !== 'string' || !e.data.startsWith('{')) {
+        console.debug('Skipping keep-alive / non-JSON SSE message:', JSON.stringify(e.data, null, 2));
+        return;
+      }
+
       try {
         const payload = JSON.parse(e.data);
         responseData += e.data + '\n';


### PR DESCRIPTION
**Fixed**: Playground throws the error “解析响应数据时发生错误” when SSE keep-alive is enabled.

**Steps to reproduce**
1. Enable SSE keep-alive and set the interval to 1
2. Send any message in Playground