### PR TITLE
fix: 修复使用gemini-balance作为上游时，测试gemini2.5pro模型时出现的错误问题

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -199,7 +199,7 @@ func buildTestRequest(model string) *dto.GeneralOpenAIRequest {
 			testRequest.MaxTokens = 50
 		}
 	} else if strings.Contains(model, "gemini") {
-		testRequest.MaxTokens = 300
+		testRequest.MaxTokens = 3000
 	} else {
 		testRequest.MaxTokens = 10
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the maximum token limit for "gemini" models in test requests, allowing for longer completions during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->