### PR TITLE
feat: jimeng apiKey format to use `|` delimiter

### DIFF
--- a/relay/channel/task/jimeng/adaptor.go
+++ b/relay/channel/task/jimeng/adaptor.go
@@ -77,8 +77,8 @@ func (a *TaskAdaptor) Init(info *relaycommon.TaskRelayInfo) {
 	a.ChannelType = info.ChannelType
 	a.baseURL = info.BaseUrl
 
-	// apiKey format: "access_key,secret_key"
-	keyParts := strings.Split(info.ApiKey, ",")
+	// apiKey format: "access_key|secret_key"
+	keyParts := strings.Split(info.ApiKey, "|")
 	if len(keyParts) == 2 {
 		a.accessKey = strings.TrimSpace(keyParts[0])
 		a.secretKey = strings.TrimSpace(keyParts[1])
@@ -192,9 +192,9 @@ func (a *TaskAdaptor) FetchTask(baseUrl, key string, body map[string]any) (*http
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 
-	keyParts := strings.Split(key, ",")
+	keyParts := strings.Split(key, "|")
 	if len(keyParts) != 2 {
-		return nil, fmt.Errorf("invalid api key format for jimeng: expected 'ak,sk'")
+		return nil, fmt.Errorf("invalid api key format for jimeng: expected 'ak|sk'")
 	}
 	accessKey := strings.TrimSpace(keyParts[0])
 	secretKey := strings.TrimSpace(keyParts[1])

--- a/web/src/pages/Channel/EditChannel.js
+++ b/web/src/pages/Channel/EditChannel.js
@@ -67,6 +67,8 @@ function type2secretPrompt(type) {
       return '按照如下格式输入：Ak|Sk|Region';
     case 50:
       return '按照如下格式输入: AccessKey|SecretKey';
+    case 51:
+      return '按照如下格式输入: Access Key ID|Secret Access Key';
     default:
       return '请输入渠道对应的鉴权密钥';
   }


### PR DESCRIPTION
增加即梦渠道的Access Key ID 和 Secret Access Key使用 `|` 分隔的提示,保持和其他渠道格式一致