### PR TITLE
fix: usage cost(any) to support claude and gemini

### DIFF
--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -182,7 +182,7 @@ type Usage struct {
 	OutputTokens           int                `json:"output_tokens"`
 	InputTokensDetails     *InputTokenDetails `json:"input_tokens_details"`
 	// OpenRouter Params
-	Cost float64 `json:"cost,omitempty"`
+	Cost any `json:"cost,omitempty"`
 }
 
 type InputTokenDetails struct {

--- a/service/quota.go
+++ b/service/quota.go
@@ -326,7 +326,7 @@ func CalcOpenRouterCacheCreateTokens(usage dto.Usage, priceData helper.PriceData
 	promptCacheReadPrice := quotaPrice * priceData.CacheRatio
 	completionPrice := quotaPrice * priceData.CompletionRatio
 
-	cost := usage.Cost
+	cost, _ := usage.Cost.(float64)
 	totalPromptTokens := float64(usage.PromptTokens)
 	completionTokens := float64(usage.CompletionTokens)
 	promptCacheReadTokens := float64(usage.PromptTokensDetails.CachedTokens)


### PR DESCRIPTION
usage给OpenRouter增加了 Cost float64
但是 claude3.7和gemini2.0经测试返回的是:   "cost":{"jobId":"","fastCost":0,"relaxCost":0,"feeCost":0,"costAt":"0001-01-01T00:00:00Z"}
这会导致流模式的返回token计算失败, 以及非流模型的对话失败