### PR TITLE
fix : Ensure stream: false is serialized in requests

### DIFF
--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -24,7 +24,7 @@ type GeneralOpenAIRequest struct {
 	Prompt              any               `json:"prompt,omitempty"`
 	Prefix              any               `json:"prefix,omitempty"`
 	Suffix              any               `json:"suffix,omitempty"`
-	Stream              bool              `json:"stream,omitempty"`
+	Stream              bool              `json:"stream"`
 	StreamOptions       *StreamOptions    `json:"stream_options,omitempty"`
 	MaxTokens           uint              `json:"max_tokens,omitempty"`
 	MaxCompletionTokens uint              `json:"max_completion_tokens,omitempty"`


### PR DESCRIPTION
渠道类型为OPENAI的情况下，我在点击模型测试，测试渠道模型的时候，如下图
<img width="931" height="274" alt="image" src="https://github.com/user-attachments/assets/039bf56b-6572-4f7b-8857-c9d54ac0399f" />
报了反序列化的错，debug发现代码在构造openai请求参数并序列化请求为json的时候，由于GeneralOpenAIRequest的Stream为false，反序列化后会丢失该字段，部分渠道stream=false的时候会按流式返回，导致对于返回结果反序列化解析失败

因此最好取消Stream的json tag omitempty内容，对于stream=false的也应序列化到json
