### PR TITLE
fix: disable ping in native Gemini mode

### DIFF
--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -223,7 +223,7 @@ func doRequest(c *gin.Context, req *http.Request, info *common.RelayInfo) (*http
 		helper.SetEventStreamHeaders(c)
 		// 处理流式请求的 ping 保活
 		generalSettings := operation_setting.GetGeneralSetting()
-		if generalSettings.PingIntervalEnabled {
+		if generalSettings.PingIntervalEnabled && !info.DisablePing {
 			pingInterval := time.Duration(generalSettings.PingIntervalSeconds) * time.Second
 			stopPinger = startPingKeepAlive(c, pingInterval)
 			// 使用defer确保在任何情况下都能停止ping goroutine

--- a/relay/channel/gemini/adaptor.go
+++ b/relay/channel/gemini/adaptor.go
@@ -171,6 +171,7 @@ func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, request
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
 	if info.RelayMode == constant.RelayModeGemini {
 		if info.IsStream {
+			info.DisablePing = true
 			return GeminiTextGenerationStreamHandler(c, info, resp)
 		} else {
 			return GeminiTextGenerationHandler(c, info, resp)

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -88,6 +88,7 @@ type RelayInfo struct {
 	BaseUrl              string
 	SupportStreamOptions bool
 	ShouldIncludeUsage   bool
+	DisablePing          bool // 是否禁止向下游发送自定义 Ping
 	IsModelMapped        bool
 	ClientWs             *websocket.Conn
 	TargetWs             *websocket.Conn

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -54,7 +54,7 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	)
 
 	generalSettings := operation_setting.GetGeneralSetting()
-	pingEnabled := generalSettings.PingIntervalEnabled
+	pingEnabled := generalSettings.PingIntervalEnabled && !info.DisablePing
 	pingInterval := time.Duration(generalSettings.PingIntervalSeconds) * time.Second
 	if pingInterval <= 0 {
 		pingInterval = DefaultPingInterval


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

在Gemini原生模式中禁用了Ping保活，以避免客户端标准SDK的解析异常。
参见 https://github.com/googleapis/js-genai/blob/main/src/_api_client.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to disable ping keep-alive messages on a per-request basis, even if the global setting is enabled.

* **Bug Fixes**
  * Improved control over ping behavior for Gemini streaming responses to prevent unnecessary pings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->