### PR TITLE
fix: ali embedding support base64

### DIFF
--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -48,6 +48,19 @@ type OpenAIEmbeddingResponse struct {
 	Usage  `json:"usage"`
 }
 
+type FlexibleEmbeddingResponseItem struct {
+	Object    string `json:"object"`
+	Index     int    `json:"index"`
+	Embedding any    `json:"embedding"`
+}
+
+type FlexibleEmbeddingResponse struct {
+	Object string                          `json:"object"`
+	Data   []FlexibleEmbeddingResponseItem `json:"data"`
+	Model  string                          `json:"model"`
+	Usage  `json:"usage"`
+}
+
 type ChatCompletionsStreamResponseChoice struct {
 	Delta        ChatCompletionsStreamResponseChoiceDelta `json:"delta,omitempty"`
 	Logprobs     *any                                     `json:"logprobs"`

--- a/relay/channel/ali/text.go
+++ b/relay/channel/ali/text.go
@@ -40,7 +40,7 @@ func embeddingRequestOpenAI2Ali(request dto.EmbeddingRequest) *AliEmbeddingReque
 }
 
 func aliEmbeddingHandler(c *gin.Context, resp *http.Response) (*types.NewAPIError, *dto.Usage) {
-	var fullTextResponse dto.OpenAIEmbeddingResponse
+	var fullTextResponse dto.FlexibleEmbeddingResponse
 	err := json.NewDecoder(resp.Body).Decode(&fullTextResponse)
 	if err != nil {
 		return types.NewError(err, types.ErrorCodeBadResponseBody), nil


### PR DESCRIPTION
支持阿里embedding请求格式encoding_format为base64的返回格式