### PR TITLE
fix: improve gemini nothinking handler

### DIFF
--- a/relay/gemini_handler.go
+++ b/relay/gemini_handler.go
@@ -80,7 +80,7 @@ func getGeminiInputTokens(req *gemini.GeminiChatRequest, info *relaycommon.Relay
 
 func isNoThinkingRequest(req *gemini.GeminiChatRequest) bool {
 	if req.GenerationConfig.ThinkingConfig != nil && req.GenerationConfig.ThinkingConfig.ThinkingBudget != nil {
-		return *req.GenerationConfig.ThinkingConfig.ThinkingBudget <= 0
+		return *req.GenerationConfig.ThinkingConfig.ThinkingBudget == 0
 	}
 	return false
 }


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

部分客户端遵循Gemini文档将思考预算设置为-1来自动决定预算，这会导致模型在计费时被new-api误判为nothinking。本次修复将判断条件修改为等于0来解决这一问题。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of requests by refining the criteria for identifying "no thinking" requests. Only requests with a budget of exactly zero are now classified this way, ensuring more accurate processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->