### PR TITLE
fix: page query param is p

### DIFF
--- a/common/page_info.go
+++ b/common/page_info.go
@@ -41,7 +41,7 @@ func (p *PageInfo) SetItems(items any) {
 func GetPageQuery(c *gin.Context) *PageInfo {
 	pageInfo := &PageInfo{}
 	// 手动获取并处理每个参数
-	if page, err := strconv.Atoi(c.Query("page")); err == nil {
+	if page, err := strconv.Atoi(c.Query("p")); err == nil {
 		pageInfo.Page = page
 	}
 	if pageSize, err := strconv.Atoi(c.Query("page_size")); err == nil {


### PR DESCRIPTION
修复前端所有页面无法翻页的问题
前端翻页变量已统一统一传`p`