### PR TITLE
feat: support ExtraBody for extra openAI req

### DIFF
--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -2,6 +2,7 @@ package dto
 
 import (
 	"encoding/json"
+	"maps"
 	"one-api/common"
 	"strings"
 )
@@ -71,6 +72,30 @@ func (r *GeneralOpenAIRequest) ToMap() map[string]any {
 	data, _ := common.Marshal(r)
 	_ = common.Unmarshal(data, &result)
 	return result
+}
+
+func (r *GeneralOpenAIRequest) MarshalJSON() ([]byte, error) {
+	type Alias GeneralOpenAIRequest
+	base := (*Alias)(r)
+	data, err := json.Marshal(base)
+	if err != nil {
+		return nil, err
+	}
+	if len(r.ExtraBody) == 0 {
+		return data, nil
+	}
+
+	// parse extraBody to request
+	var result map[string]any
+	if err = json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	var extraBodyMap map[string]any
+	if err = json.Unmarshal(r.ExtraBody, &extraBodyMap); err != nil {
+		return nil, err
+	}
+	maps.Copy(result, extraBodyMap)
+	return json.Marshal(result)
 }
 
 type ToolCallRequest struct {


### PR DESCRIPTION
支持第三方模型额外参数通过extraBody传递
例如`qwen-mt`系列模型需要额外传递翻译参数: `"translation_options": { "source_lang": "auto", "target_lang": "English" } `
请求
```
{
  "model": "qwen-mt-turbo",
  "messages": [
    {
      "role": "user",
      "content": "你好，请介绍一下自己"
    }
  ],
"extra_body":{
  "translation_options": { "source_lang": "auto", "target_lang": "English" }
},
  "temperature": 0.7,
  "stream": false
}
```
返回:
```
{
  "choices": [
    {
      "message": {
        "content": "Hello, please introduce yourself.",
        "role": "assistant"
      },
      "finish_reason": "stop",
      "index": 0,
      "logprobs": null
    }
  ],
  "object": "chat.completion",
  "usage": {
    "prompt_tokens": 25,
    "completion_tokens": 6,
    "total_tokens": 31
  },
  "created": 1753423192,
  "system_fingerprint": null,
  "model": "qwen-mt-turbo",
  "id": "chatcmpl-b7ce56a1-e1c9-9f18-8e01-f4c7b1dba180"
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced request customization by allowing dynamic addition or override of fields when exporting data to JSON.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->