### PR TITLE
模型请求速率限制，增加对请求次数最大值的限制

### DIFF
--- a/setting/rate_limit.go
+++ b/setting/rate_limit.go
@@ -58,6 +58,9 @@ func CheckModelRequestRateLimitGroup(jsonStr string) error {
 		if limits[0] < 0 || limits[1] < 1 {
 			return fmt.Errorf("group %s has negative rate limit values: [%d, %d]", group, limits[0], limits[1])
 		}
+		if limits[0] > 2147483647 || limits[1] > 2147483647 {
+			return fmt.Errorf("group %s [%d, %d] has max rate limits value 2147483647", group, limits[0], limits[1])
+		}
 	}
 
 	return nil

--- a/setting/rate_limit.go
+++ b/setting/rate_limit.go
@@ -3,6 +3,7 @@ package setting
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"one-api/common"
 	"sync"
 )
@@ -58,7 +59,7 @@ func CheckModelRequestRateLimitGroup(jsonStr string) error {
 		if limits[0] < 0 || limits[1] < 1 {
 			return fmt.Errorf("group %s has negative rate limit values: [%d, %d]", group, limits[0], limits[1])
 		}
-		if limits[0] > 2147483647 || limits[1] > 2147483647 {
+		if limits[0] > math.MaxInt32 || limits[1] > math.MaxInt32 {
 			return fmt.Errorf("group %s [%d, %d] has max rate limits value 2147483647", group, limits[0], limits[1])
 		}
 	}

--- a/web/src/pages/Setting/RateLimit/SettingsRequestRateLimit.js
+++ b/web/src/pages/Setting/RateLimit/SettingsRequestRateLimit.js
@@ -128,6 +128,7 @@ export default function RequestRateLimit(props) {
                   label={t('用户每周期最多请求次数')}
                   step={1}
                   min={0}
+                  max={2147483647}
                   suffix={t('次')}
                   extraText={t('包括失败请求的次数，0代表不限制')}
                   field={'ModelRequestRateLimitCount'}
@@ -144,6 +145,7 @@ export default function RequestRateLimit(props) {
                   label={t('用户每周期最多请求完成次数')}
                   step={1}
                   min={1}
+                  max={2147483647}
                   suffix={t('次')}
                   extraText={t('只包括请求成功的次数')}
                   field={'ModelRequestRateLimitSuccessCount'}
@@ -180,6 +182,7 @@ export default function RequestRateLimit(props) {
                         <li>{t('使用 JSON 对象格式，格式为：{"组名": [最多请求次数, 最多请求完成次数]}')}</li>
                       <li>{t('示例：{"default": [200, 100], "vip": [0, 1000]}。')}</li>
                       <li>{t('[最多请求次数]必须大于等于0，[最多请求完成次数]必须大于等于1。')}</li>
+                        <li>{t('[最多请求次数]和[最多请求完成次数]的最大值为2147483647。')}</li>
                         <li>{t('分组速率配置优先级高于全局速率限制。')}</li>
                         <li>{t('限制周期统一使用上方配置的“限制周期”值。')}</li>
                       </ul>

--- a/web/src/pages/Setting/RateLimit/SettingsRequestRateLimit.js
+++ b/web/src/pages/Setting/RateLimit/SettingsRequestRateLimit.js
@@ -128,7 +128,7 @@ export default function RequestRateLimit(props) {
                   label={t('用户每周期最多请求次数')}
                   step={1}
                   min={0}
-                  max={2147483647}
+                  max={100000}
                   suffix={t('次')}
                   extraText={t('包括失败请求的次数，0代表不限制')}
                   field={'ModelRequestRateLimitCount'}
@@ -145,7 +145,7 @@ export default function RequestRateLimit(props) {
                   label={t('用户每周期最多请求完成次数')}
                   step={1}
                   min={1}
-                  max={2147483647}
+                  max={100000}
                   suffix={t('次')}
                   extraText={t('只包括请求成功的次数')}
                   field={'ModelRequestRateLimitSuccessCount'}


### PR DESCRIPTION
对用户每周期最多请求次数和用户每周期最多请求完成次数增加最大值限制在2147483647内

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an upper limit of 2,147,483,647 for user request limits per period in the rate limit settings.
  * Enforced a maximum input value of 100,000 for user request counts in the rate limit configuration UI.

* **Documentation**
  * Updated user guidance to clarify the new maximum value constraint for rate limit inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->