### PR TITLE
feat: add multi-key management

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -53,12 +53,12 @@ type Channel struct {
 }
 
 type ChannelInfo struct {
-	IsMultiKey             bool                  `json:"is_multi_key"`              // 是否多Key模式
-	MultiKeySize           int                   `json:"multi_key_size"`            // 多Key模式下的Key数量
-	MultiKeyStatusList     map[int]int           `json:"multi_key_status_list"`     // key状态列表，key index -> status
-	MultiKeyDisabledReason map[int]string        `json:"multi_key_disabled_reason"` // key禁用原因列表，key index -> reason
-	MultiKeyDisabledTime   map[int]int64         `json:"multi_key_disabled_time"`   // key禁用时间列表，key index -> time
-	MultiKeyPollingIndex   int                   `json:"multi_key_polling_index"`   // 多Key模式下轮询的key索引
+	IsMultiKey             bool                  `json:"is_multi_key"`                        // 是否多Key模式
+	MultiKeySize           int                   `json:"multi_key_size"`                      // 多Key模式下的Key数量
+	MultiKeyStatusList     map[int]int           `json:"multi_key_status_list"`               // key状态列表，key index -> status
+	MultiKeyDisabledReason map[int]string        `json:"multi_key_disabled_reason,omitempty"` // key禁用原因列表，key index -> reason
+	MultiKeyDisabledTime   map[int]int64         `json:"multi_key_disabled_time,omitempty"`   // key禁用时间列表，key index -> time
+	MultiKeyPollingIndex   int                   `json:"multi_key_polling_index"`             // 多Key模式下轮询的key索引
 	MultiKeyMode           constant.MultiKeyMode `json:"multi_key_mode"`
 }
 

--- a/model/channel_cache.go
+++ b/model/channel_cache.go
@@ -70,7 +70,7 @@ func InitChannelCache() {
 	//channelsIDM = newChannelId2channel
 	for i, channel := range newChannelId2channel {
 		if channel.ChannelInfo.IsMultiKey {
-			channel.Keys = channel.getKeys()
+			channel.Keys = channel.GetKeys()
 			if channel.ChannelInfo.MultiKeyMode == constant.MultiKeyModePolling {
 				if oldChannel, ok := channelsIDM[i]; ok {
 					// 存在旧的渠道，如果是多key且轮询，保留轮询索引信息

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -120,6 +120,7 @@ func SetApiRouter(router *gin.Engine) {
 			channelRoute.POST("/batch/tag", controller.BatchSetChannelTag)
 			channelRoute.GET("/tag/models", controller.GetTagModels)
 			channelRoute.POST("/copy/:id", controller.CopyChannel)
+			channelRoute.POST("/multi_key/manage", controller.ManageMultiKeys)
 		}
 		tokenRoute := apiRouter.Group("/token")
 		tokenRoute.Use(middleware.UserAuth())

--- a/web/src/components/table/channels/ChannelsColumnDefs.js
+++ b/web/src/components/table/channels/ChannelsColumnDefs.js
@@ -210,7 +210,9 @@ export const getChannelsColumns = ({
   copySelectedChannel,
   refresh,
   activePage,
-  channels
+  channels,
+  setShowMultiKeyManageModal,
+  setCurrentMultiKeyChannel
 }) => {
   return [
     {
@@ -503,47 +505,7 @@ export const getChannelsColumns = ({
                 />
               </SplitButtonGroup>
 
-              {record.channel_info?.is_multi_key ? (
-                <SplitButtonGroup
-                  aria-label={t('多密钥渠道操作项目组')}
-                >
-                  {
-                    record.status === 1 ? (
-                      <Button
-                        type='danger'
-                        size="small"
-                        onClick={() => manageChannel(record.id, 'disable', record)}
-                      >
-                        {t('禁用')}
-                      </Button>
-                    ) : (
-                      <Button
-                        size="small"
-                        onClick={() => manageChannel(record.id, 'enable', record)}
-                      >
-                        {t('启用')}
-                      </Button>
-                    )
-                  }
-                  <Dropdown
-                    trigger='click'
-                    position='bottomRight'
-                    menu={[
-                      {
-                        node: 'item',
-                        name: t('启用全部密钥'),
-                        onClick: () => manageChannel(record.id, 'enable_all', record),
-                      }
-                    ]}
-                  >
-                    <Button
-                      type='tertiary'
-                      size="small"
-                      icon={<IconTreeTriangleDown />}
-                    />
-                  </Dropdown>
-                </SplitButtonGroup>
-              ) : (
+              {
                 record.status === 1 ? (
                   <Button
                     type='danger'
@@ -560,18 +522,55 @@ export const getChannelsColumns = ({
                     {t('启用')}
                   </Button>
                 )
-              )}
+              }
 
-              <Button
-                type='tertiary'
-                size="small"
-                onClick={() => {
-                  setEditingChannel(record);
-                  setShowEdit(true);
-                }}
-              >
-                {t('编辑')}
-              </Button>
+              {record.channel_info?.is_multi_key ? (
+                <SplitButtonGroup
+                  aria-label={t('多密钥渠道操作项目组')}
+                >
+                  <Button
+                    type='tertiary'
+                    size="small"
+                    onClick={() => {
+                      setEditingChannel(record);
+                      setShowEdit(true);
+                    }}
+                  >
+                    {t('编辑')}
+                  </Button>
+                  <Dropdown
+                    trigger='click'
+                    position='bottomRight'
+                    menu={[
+                      {
+                        node: 'item',
+                        name: t('多key管理'),
+                        onClick: () => {
+                          setCurrentMultiKeyChannel(record);
+                          setShowMultiKeyManageModal(true);
+                        },
+                      }
+                    ]}
+                  >
+                    <Button
+                      type='tertiary'
+                      size="small"
+                      icon={<IconTreeTriangleDown />}
+                    />
+                  </Dropdown>
+                </SplitButtonGroup>
+              ) : (
+                <Button
+                  type='tertiary'
+                  size="small"
+                  onClick={() => {
+                    setEditingChannel(record);
+                    setShowEdit(true);
+                  }}
+                >
+                  {t('编辑')}
+                </Button>
+              )}
 
               <Dropdown
                 trigger='click'

--- a/web/src/components/table/channels/ChannelsTable.jsx
+++ b/web/src/components/table/channels/ChannelsTable.jsx
@@ -57,6 +57,9 @@ const ChannelsTable = (channelsData) => {
     setEditingTag,
     copySelectedChannel,
     refresh,
+    // Multi-key management
+    setShowMultiKeyManageModal,
+    setCurrentMultiKeyChannel,
   } = channelsData;
 
   // Get all columns
@@ -79,6 +82,8 @@ const ChannelsTable = (channelsData) => {
       refresh,
       activePage,
       channels,
+      setShowMultiKeyManageModal,
+      setCurrentMultiKeyChannel,
     });
   }, [
     t,
@@ -98,6 +103,8 @@ const ChannelsTable = (channelsData) => {
     refresh,
     activePage,
     channels,
+    setShowMultiKeyManageModal,
+    setCurrentMultiKeyChannel,
   ]);
 
   // Filter columns based on visibility settings

--- a/web/src/components/table/channels/index.jsx
+++ b/web/src/components/table/channels/index.jsx
@@ -30,6 +30,7 @@ import ModelTestModal from './modals/ModelTestModal.jsx';
 import ColumnSelectorModal from './modals/ColumnSelectorModal.jsx';
 import EditChannelModal from './modals/EditChannelModal.jsx';
 import EditTagModal from './modals/EditTagModal.jsx';
+import MultiKeyManageModal from './modals/MultiKeyManageModal.jsx';
 import { createCardProPagination } from '../../../helpers/utils';
 
 const ChannelsPage = () => {
@@ -54,6 +55,12 @@ const ChannelsPage = () => {
       />
       <BatchTagModal {...channelsData} />
       <ModelTestModal {...channelsData} />
+      <MultiKeyManageModal
+        visible={channelsData.showMultiKeyManageModal}
+        onCancel={() => channelsData.setShowMultiKeyManageModal(false)}
+        channel={channelsData.currentMultiKeyChannel}
+        onRefresh={channelsData.refresh}
+      />
 
       {/* Main Content */}
       <CardPro

--- a/web/src/components/table/channels/modals/MultiKeyManageModal.jsx
+++ b/web/src/components/table/channels/modals/MultiKeyManageModal.jsx
@@ -428,7 +428,7 @@ const MultiKeyManageModal = ({
                     >
                       <Select.Option value={50}>50</Select.Option>
                       <Select.Option value={100}>100</Select.Option>
-                      <Select.Option value={200}>500</Select.Option>
+                      <Select.Option value={500}>500</Select.Option>
                       <Select.Option value={1000}>1000</Select.Option>
                     </Select>
                     

--- a/web/src/components/table/channels/modals/MultiKeyManageModal.jsx
+++ b/web/src/components/table/channels/modals/MultiKeyManageModal.jsx
@@ -1,0 +1,372 @@
+/*
+Copyright (C) 2025 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Modal,
+  Button,
+  Table,
+  Tag,
+  Typography,
+  Space,
+  Tooltip,
+  Popconfirm,
+  Empty,
+  Spin,
+  Banner
+} from '@douyinfe/semi-ui';
+import { 
+  IconRefresh,
+  IconDelete,
+  IconClose,
+  IconSave,
+  IconSetting
+} from '@douyinfe/semi-icons';
+import { API, showError, showSuccess, timestamp2string } from '../../../../helpers/index.js';
+
+const { Text, Title } = Typography;
+
+const MultiKeyManageModal = ({
+  visible,
+  onCancel,
+  channel,
+  onRefresh
+}) => {
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState(false);
+  const [keyStatusList, setKeyStatusList] = useState([]);
+  const [operationLoading, setOperationLoading] = useState({});
+
+  // Load key status data
+  const loadKeyStatus = async () => {
+    if (!channel?.id) return;
+    
+    setLoading(true);
+    try {
+      const res = await API.post('/api/channel/multi_key/manage', {
+        channel_id: channel.id,
+        action: 'get_key_status'
+      });
+      
+      if (res.data.success) {
+        setKeyStatusList(res.data.data.keys || []);
+      } else {
+        showError(res.data.message);
+      }
+    } catch (error) {
+      showError(t('获取密钥状态失败'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Disable a specific key
+  const handleDisableKey = async (keyIndex) => {
+    const operationId = `disable_${keyIndex}`;
+    setOperationLoading(prev => ({ ...prev, [operationId]: true }));
+    
+    try {
+      const res = await API.post('/api/channel/multi_key/manage', {
+        channel_id: channel.id,
+        action: 'disable_key',
+        key_index: keyIndex
+      });
+      
+      if (res.data.success) {
+        showSuccess(t('密钥已禁用'));
+        await loadKeyStatus(); // Reload data
+        onRefresh && onRefresh(); // Refresh parent component
+      } else {
+        showError(res.data.message);
+      }
+    } catch (error) {
+      showError(t('禁用密钥失败'));
+    } finally {
+      setOperationLoading(prev => ({ ...prev, [operationId]: false }));
+    }
+  };
+
+  // Enable a specific key
+  const handleEnableKey = async (keyIndex) => {
+    const operationId = `enable_${keyIndex}`;
+    setOperationLoading(prev => ({ ...prev, [operationId]: true }));
+    
+    try {
+      const res = await API.post('/api/channel/multi_key/manage', {
+        channel_id: channel.id,
+        action: 'enable_key',
+        key_index: keyIndex
+      });
+      
+      if (res.data.success) {
+        showSuccess(t('密钥已启用'));
+        await loadKeyStatus(); // Reload data
+        onRefresh && onRefresh(); // Refresh parent component
+      } else {
+        showError(res.data.message);
+      }
+    } catch (error) {
+      showError(t('启用密钥失败'));
+    } finally {
+      setOperationLoading(prev => ({ ...prev, [operationId]: false }));
+    }
+  };
+
+  // Delete all disabled keys
+  const handleDeleteDisabledKeys = async () => {
+    setOperationLoading(prev => ({ ...prev, delete_disabled: true }));
+    
+    try {
+      const res = await API.post('/api/channel/multi_key/manage', {
+        channel_id: channel.id,
+        action: 'delete_disabled_keys'
+      });
+      
+      if (res.data.success) {
+        showSuccess(res.data.message);
+        await loadKeyStatus(); // Reload data
+        onRefresh && onRefresh(); // Refresh parent component
+      } else {
+        showError(res.data.message);
+      }
+    } catch (error) {
+      showError(t('删除禁用密钥失败'));
+    } finally {
+      setOperationLoading(prev => ({ ...prev, delete_disabled: false }));
+    }
+  };
+
+  // Effect to load data when modal opens
+  useEffect(() => {
+    if (visible && channel?.id) {
+      loadKeyStatus();
+    }
+  }, [visible, channel?.id]);
+
+  // Get status tag component
+  const renderStatusTag = (status) => {
+    switch (status) {
+      case 1:
+        return <Tag color='green' shape='circle'>{t('已启用')}</Tag>;
+      case 2:
+        return <Tag color='red' shape='circle'>{t('已禁用')}</Tag>;
+      case 3:
+        return <Tag color='orange' shape='circle'>{t('自动禁用')}</Tag>;
+      default:
+        return <Tag color='grey' shape='circle'>{t('未知状态')}</Tag>;
+    }
+  };
+
+  // Table columns definition
+  const columns = [
+    {
+      title: t('索引'),
+      dataIndex: 'index',
+      render: (text) => `#${text}`,
+    },
+    {
+      title: t('密钥预览'),
+      dataIndex: 'key_preview',
+      render: (text) => (
+        <Text code style={{ fontSize: '12px' }}>
+          {text}
+        </Text>
+      ),
+    },
+    {
+      title: t('状态'),
+      dataIndex: 'status',
+      width: 100,
+      render: (status) => renderStatusTag(status),
+    },
+    {
+      title: t('禁用原因'),
+      dataIndex: 'reason',
+      width: 220,
+      render: (reason, record) => {
+        if (record.status === 1 || !reason) {
+          return <Text type='quaternary'>-</Text>;
+        }
+        return (
+          <Tooltip content={reason}>
+            <Text style={{ maxWidth: '200px', display: 'block' }} ellipsis>
+              {reason}
+            </Text>
+          </Tooltip>
+        );
+      },
+    },
+    {
+      title: t('禁用时间'),
+      dataIndex: 'disabled_time',
+      width: 150,
+      render: (time, record) => {
+        if (record.status === 1 || !time) {
+          return <Text type='quaternary'>-</Text>;
+        }
+        return (
+          <Tooltip content={timestamp2string(time)}>
+            <Text style={{ fontSize: '12px' }}>
+              {timestamp2string(time)}
+            </Text>
+          </Tooltip>
+        );
+      },
+    },
+    {
+      title: t('操作'),
+      key: 'action',
+      width: 120,
+      render: (_, record) => (
+        <Space>
+          {record.status === 1 ? (
+            <Popconfirm
+              title={t('确定要禁用此密钥吗？')}
+              content={t('禁用后该密钥将不再被使用')}
+              onConfirm={() => handleDisableKey(record.index)}
+            >
+              <Button
+                type='danger'
+                size='small'
+                loading={operationLoading[`disable_${record.index}`]}
+              >
+                {t('禁用')}
+              </Button>
+            </Popconfirm>
+          ) : (
+            <Popconfirm
+              title={t('确定要启用此密钥吗？')}
+              content={t('启用后该密钥将重新被使用')}
+              onConfirm={() => handleEnableKey(record.index)}
+            >
+              <Button
+                type='primary'
+                size='small'
+                loading={operationLoading[`enable_${record.index}`]}
+              >
+                {t('启用')}
+              </Button>
+            </Popconfirm>
+          )}
+        </Space>
+      ),
+    },
+  ];
+
+  // Calculate statistics
+  const enabledCount = keyStatusList.filter(key => key.status === 1).length;
+  const manualDisabledCount = keyStatusList.filter(key => key.status === 2).length;
+  const autoDisabledCount = keyStatusList.filter(key => key.status === 3).length;
+  const totalCount = keyStatusList.length;
+
+  return (
+    <Modal
+      title={
+        <Space>
+          <IconSetting />
+          <span>{t('多密钥管理')} - {channel?.name}</span>
+        </Space>
+      }
+      visible={visible}
+      onCancel={onCancel}
+      width={800}
+      height={600}
+      footer={
+        <Space>
+          <Button onClick={onCancel}>{t('关闭')}</Button>
+          <Button
+            icon={<IconRefresh />}
+            onClick={loadKeyStatus}
+            loading={loading}
+          >
+            {t('刷新')}
+          </Button>
+          {autoDisabledCount > 0 && (
+            <Popconfirm
+              title={t('确定要删除所有已自动禁用的密钥吗？')}
+              content={t('此操作不可撤销，将永久删除已自动禁用的密钥')}
+              onConfirm={handleDeleteDisabledKeys}
+            >
+              <Button
+                type='danger'
+                icon={<IconDelete />}
+                loading={operationLoading.delete_disabled}
+              >
+                {t('删除自动禁用密钥')}
+              </Button>
+            </Popconfirm>
+          )}
+        </Space>
+      }
+    >
+      <div style={{ padding: '16px 0' }}>
+        {/* Statistics Banner */}
+        <Banner
+          type='info'
+          style={{ marginBottom: '16px' }}
+          description={
+            <div>
+              <Text>
+                {t('总共 {{total}} 个密钥，{{enabled}} 个已启用，{{manual}} 个手动禁用，{{auto}} 个自动禁用', {
+                  total: totalCount,
+                  enabled: enabledCount,
+                  manual: manualDisabledCount,
+                  auto: autoDisabledCount
+                })}
+              </Text>
+              {channel?.channel_info?.multi_key_mode && (
+                <div style={{ marginTop: '4px' }}>
+                  <Text type='quaternary' style={{ fontSize: '12px' }}>
+                    {t('多密钥模式')}: {channel.channel_info.multi_key_mode === 'random' ? t('随机') : t('轮询')}
+                  </Text>
+                </div>
+              )}
+            </div>
+          }
+        />
+
+        {/* Key Status Table */}
+        <Spin spinning={loading}>
+          {keyStatusList.length > 0 ? (
+            <Table
+              columns={columns}
+              dataSource={keyStatusList}
+              pagination={false}
+              size='small'
+              bordered
+              rowKey='index'
+              style={{ maxHeight: '400px', overflow: 'auto' }}
+            />
+          ) : (
+            !loading && (
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                title={t('暂无密钥数据')}
+                description={t('请检查渠道配置或刷新重试')}
+              />
+            )
+          )}
+        </Spin>
+      </div>
+    </Modal>
+  );
+};
+
+export default MultiKeyManageModal; 

--- a/web/src/hooks/channels/useChannelsData.js
+++ b/web/src/hooks/channels/useChannelsData.js
@@ -83,6 +83,10 @@ export const useChannelsData = () => {
   const [isProcessingQueue, setIsProcessingQueue] = useState(false);
   const [modelTablePage, setModelTablePage] = useState(1);
 
+  // Multi-key management states
+  const [showMultiKeyManageModal, setShowMultiKeyManageModal] = useState(false);
+  const [currentMultiKeyChannel, setCurrentMultiKeyChannel] = useState(null);
+
   // Refs
   const requestCounter = useRef(0);
   const allSelectingRef = useRef(false);
@@ -884,6 +888,12 @@ export const useChannelsData = () => {
     modelTablePage,
     setModelTablePage,
     allSelectingRef,
+
+    // Multi-key management states
+    showMultiKeyManageModal,
+    setShowMultiKeyManageModal,
+    currentMultiKeyChannel,
+    setCurrentMultiKeyChannel,
 
     // Form
     formApi,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-key management modal for channels, allowing users to view, enable, disable, and delete keys with detailed status, reasons, and timestamps.
  * Introduced a dedicated API endpoint for managing keys in multi-key channels, supporting actions like status viewing, enabling/disabling keys, and bulk deletion of auto-disabled keys.

* **Improvements**
  * Updated channel table controls for clearer enable/disable and edit actions, and added direct access to multi-key management for applicable channels.

* **Bug Fixes**
  * Ensured channel information resets key disable reasons and timestamps appropriately in API responses.

* **User Interface**
  * Enhanced the channel management table and modals for improved multi-key channel operations and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->