### PR TITLE
fix：修复添加模型倍率时的输入框锁定

### DIFF
--- a/web/src/pages/Setting/Ratio/ModelSettingsVisualEditor.js
+++ b/web/src/pages/Setting/Ratio/ModelSettingsVisualEditor.js
@@ -44,6 +44,7 @@ export default function ModelSettingsVisualEditor(props) {
   const { t } = useTranslation();
   const [models, setModels] = useState([]);
   const [visible, setVisible] = useState(false);
+  const [isEditMode, setIsEditMode] = useState(false);
   const [currentModel, setCurrentModel] = useState(null);
   const [searchText, setSearchText] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
@@ -386,9 +387,11 @@ export default function ModelSettingsVisualEditor(props) {
     setCurrentModel(null);
     setPricingMode('per-token');
     setPricingSubMode('ratio');
+    setIsEditMode(false);
   };
 
   const editModel = (record) => {
+    setIsEditMode(true);
     // Determine which pricing mode to use based on the model's current configuration
     let initialPricingMode = 'per-token';
     let initialPricingSubMode = 'ratio';
@@ -500,13 +503,7 @@ export default function ModelSettingsVisualEditor(props) {
       </Space>
 
       <Modal
-        title={
-          currentModel &&
-            currentModel.name &&
-            models.some((model) => model.name === currentModel.name)
-            ? t('编辑模型')
-            : t('添加模型')
-        }
+        title={isEditMode ? t('编辑模型') : t('添加模型')}
         visible={visible}
         onCancel={() => {
           resetModalState();
@@ -562,11 +559,7 @@ export default function ModelSettingsVisualEditor(props) {
             label={t('模型名称')}
             placeholder='strawberry'
             required
-            disabled={
-              currentModel &&
-              currentModel.name &&
-              models.some((model) => model.name === currentModel.name)
-            }
+            disabled={isEditMode}
             onChange={(value) =>
               setCurrentModel((prev) => ({ ...prev, name: value }))
             }


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

close https://github.com/QuantumNous/new-api/issues/1456

在模型倍率的可视化编辑器中，当用户添加一个新模型，并且输入的模型名称与一个已存在的模型名称前缀相同时，模型名称的输入框会被错误地禁用，导致用户无法完成输入。

此修改通过引入一个明确的 `isEditMode` 状态来区分“添加”和“编辑”模式，确保只有在编辑现有模型时输入框才会被禁用，从而解决了该问题。

<img width="537" height="699" alt="修复后的示例" src="https://github.com/user-attachments/assets/9137b994-d098-42fb-92a7-03361b35b2d0" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the modal’s edit and add mode handling for model settings, resulting in clearer modal titles and more intuitive input field behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->