### PR TITLE
feat: add support for claude-opus-4-1 model and update ratios

### DIFF
--- a/relay/channel/aws/constants.go
+++ b/relay/channel/aws/constants.go
@@ -13,6 +13,7 @@ var awsModelIDMap = map[string]string{
 	"claude-3-7-sonnet-20250219": "anthropic.claude-3-7-sonnet-20250219-v1:0",
 	"claude-sonnet-4-20250514":   "anthropic.claude-sonnet-4-20250514-v1:0",
 	"claude-opus-4-20250514":     "anthropic.claude-opus-4-20250514-v1:0",
+	"claude-opus-4-1-20250805":   "anthropic.claude-opus-4-1-20250805-v1:0",
 }
 
 var awsModelCanCrossRegionMap = map[string]map[string]bool{
@@ -52,6 +53,9 @@ var awsModelCanCrossRegionMap = map[string]map[string]bool{
 		"eu": true,
 	},
 	"anthropic.claude-opus-4-20250514-v1:0": {
+		"us": true,
+	},
+	"anthropic.claude-opus-4-1-20250805-v1:0": {
 		"us": true,
 	},
 }

--- a/relay/channel/claude/constants.go
+++ b/relay/channel/claude/constants.go
@@ -17,6 +17,8 @@ var ModelList = []string{
 	"claude-sonnet-4-20250514-thinking",
 	"claude-opus-4-20250514",
 	"claude-opus-4-20250514-thinking",
+	"claude-opus-4-1-20250805",
+	"claude-opus-4-1-20250805-thinking",
 }
 
 var ChannelName = "claude"

--- a/relay/channel/vertex/adaptor.go
+++ b/relay/channel/vertex/adaptor.go
@@ -35,6 +35,7 @@ var claudeModelMap = map[string]string{
 	"claude-3-7-sonnet-20250219": "claude-3-7-sonnet@20250219",
 	"claude-sonnet-4-20250514":   "claude-sonnet-4@20250514",
 	"claude-opus-4-20250514":     "claude-opus-4@20250514",
+	"claude-opus-4-1-20250805":   "claude-opus-4-1@20250805",
 }
 
 const anthropicVersion = "vertex-2023-10-16"

--- a/setting/ratio_setting/cache_ratio.go
+++ b/setting/ratio_setting/cache_ratio.go
@@ -40,6 +40,8 @@ var defaultCacheRatio = map[string]float64{
 	"claude-sonnet-4-20250514-thinking":   0.1,
 	"claude-opus-4-20250514":              0.1,
 	"claude-opus-4-20250514-thinking":     0.1,
+	"claude-opus-4-1-20250805":            0.1,
+	"claude-opus-4-1-20250805-thinking":   0.1,
 }
 
 var defaultCreateCacheRatio = map[string]float64{
@@ -55,6 +57,8 @@ var defaultCreateCacheRatio = map[string]float64{
 	"claude-sonnet-4-20250514-thinking":   1.25,
 	"claude-opus-4-20250514":              1.25,
 	"claude-opus-4-20250514-thinking":     1.25,
+	"claude-opus-4-1-20250805":            1.25,
+	"claude-opus-4-1-20250805-thinking":   1.25,
 }
 
 //var defaultCreateCacheRatio = map[string]float64{}

--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -118,6 +118,7 @@ var defaultModelRatio = map[string]float64{
 	"claude-sonnet-4-20250514":                  1.5,
 	"claude-3-opus-20240229":                    7.5, // $15 / 1M tokens
 	"claude-opus-4-20250514":                    7.5,
+	"claude-opus-4-1-20250805":                  7.5,
 	"ERNIE-4.0-8K":                              0.120 * RMB,
 	"ERNIE-3.5-8K":                              0.012 * RMB,
 	"ERNIE-3.5-8K-0205":                         0.024 * RMB,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the new models "claude-opus-4-1-20250805" and "claude-opus-4-1-20250805-thinking" across relevant model lists and mappings.
* **Chores**
  * Updated internal model mappings and default ratio settings to include the newly supported models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->