### PR TITLE
Fix/gemini-fetch-models

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -36,28 +36,9 @@ type OpenAIModel struct {
 	Parent string `json:"parent"`
 }
 
-type GoogleOpenAICompatibleModels []struct {
-	Name                       string   `json:"name"`
-	Version                    string   `json:"version"`
-	DisplayName                string   `json:"displayName"`
-	Description                string   `json:"description,omitempty"`
-	InputTokenLimit            int      `json:"inputTokenLimit"`
-	OutputTokenLimit           int      `json:"outputTokenLimit"`
-	SupportedGenerationMethods []string `json:"supportedGenerationMethods"`
-	Temperature                float64  `json:"temperature,omitempty"`
-	TopP                       float64  `json:"topP,omitempty"`
-	TopK                       int      `json:"topK,omitempty"`
-	MaxTemperature             int      `json:"maxTemperature,omitempty"`
-}
-
 type OpenAIModelsResponse struct {
 	Data    []OpenAIModel `json:"data"`
 	Success bool          `json:"success"`
-}
-
-type GoogleOpenAICompatibleResponse struct {
-	Models        []GoogleOpenAICompatibleModels `json:"models"`
-	NextPageToken string                         `json:"nextPageToken"`
 }
 
 func parseStatusFilter(statusParam string) int {
@@ -203,7 +184,7 @@ func FetchUpstreamModels(c *gin.Context) {
 	switch channel.Type {
 	case constant.ChannelTypeGemini:
 		// curl https://example.com/v1beta/models?key=$GEMINI_API_KEY
-		url = fmt.Sprintf("%s/v1beta/openai/models?key=%s", baseURL, channel.Key)
+		url = fmt.Sprintf("%s/v1beta/openai/models", baseURL) // Remember key in url since we need to use AuthHeader
 	case constant.ChannelTypeAli:
 		url = fmt.Sprintf("%s/compatible-mode/v1/models", baseURL)
 	default:
@@ -213,7 +194,7 @@ func FetchUpstreamModels(c *gin.Context) {
 	// 获取响应体 - 根据渠道类型决定是否添加 AuthHeader
 	var body []byte
 	if channel.Type == constant.ChannelTypeGemini {
-		body, err = GetResponseBody("GET", url, channel, nil) // I don't know why, but Gemini requires no AuthHeader
+		body, err = GetResponseBody("GET", url, channel, GetAuthHeader(channel.Key)) // Use AuthHeader since Gemini now forces it
 	} else {
 		body, err = GetResponseBody("GET", url, channel, GetAuthHeader(channel.Key))
 	}
@@ -223,34 +204,12 @@ func FetchUpstreamModels(c *gin.Context) {
 	}
 
 	var result OpenAIModelsResponse
-	var parseSuccess bool
-
-	// 适配特殊格式
-	switch channel.Type {
-	case constant.ChannelTypeGemini:
-		var googleResult GoogleOpenAICompatibleResponse
-		if err = json.Unmarshal(body, &googleResult); err == nil {
-			// 转换Google格式到OpenAI格式
-			for _, model := range googleResult.Models {
-				for _, gModel := range model {
-					result.Data = append(result.Data, OpenAIModel{
-						ID: gModel.Name,
-					})
-				}
-			}
-			parseSuccess = true
-		}
-	}
-
-	// 如果解析失败，尝试OpenAI格式
-	if !parseSuccess {
-		if err = json.Unmarshal(body, &result); err != nil {
-			c.JSON(http.StatusOK, gin.H{
-				"success": false,
-				"message": fmt.Sprintf("解析响应失败: %s", err.Error()),
-			})
-			return
-		}
+	if err = json.Unmarshal(body, &result); err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": fmt.Sprintf("解析响应失败: %s", err.Error()),
+		})
+		return
 	}
 
 	var ids []string

--- a/controller/channel.go
+++ b/controller/channel.go
@@ -193,10 +193,11 @@ func FetchUpstreamModels(c *gin.Context) {
 
 	// 获取响应体 - 根据渠道类型决定是否添加 AuthHeader
 	var body []byte
+	key := strings.Split(channel.Key, "\n")[0]
 	if channel.Type == constant.ChannelTypeGemini {
-		body, err = GetResponseBody("GET", url, channel, GetAuthHeader(channel.Key)) // Use AuthHeader since Gemini now forces it
+		body, err = GetResponseBody("GET", url, channel, GetAuthHeader(key)) // Use AuthHeader since Gemini now forces it
 	} else {
-		body, err = GetResponseBody("GET", url, channel, GetAuthHeader(channel.Key))
+		body, err = GetResponseBody("GET", url, channel, GetAuthHeader(key))
 	}
 	if err != nil {
 		common.ApiError(c, err)


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

- Gemini的openai models端点目前返回与OpenAI一致的结构，移除了多余的解析尝试；

- 在URL中使用key无效，改为使用Authheader;

- 适配了多key情况下的模型列表获取。使用第一个key。未实现错误回退机制。
