### PR TITLE
feat: enable thinking mode on ali thinking model

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -275,7 +275,7 @@ func testChannel(channel *model.Channel, testModel string) testResult {
 		Quota:            quota,
 		Content:          "模型测试",
 		UseTimeSeconds:   int(consumedTime),
-		IsStream:         false,
+		IsStream:         info.IsStream,
 		Group:            info.UsingGroup,
 		Other:            other,
 	})

--- a/relay/channel/ali/adaptor.go
+++ b/relay/channel/ali/adaptor.go
@@ -3,6 +3,7 @@ package ali
 import (
 	"errors"
 	"fmt"
+	"github.com/gin-gonic/gin"
 	"io"
 	"net/http"
 	"one-api/dto"
@@ -11,8 +12,7 @@ import (
 	relaycommon "one-api/relay/common"
 	"one-api/relay/constant"
 	"one-api/types"
-
-	"github.com/gin-gonic/gin"
+	"strings"
 )
 
 type Adaptor struct {
@@ -65,7 +65,13 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 	if request == nil {
 		return nil, errors.New("request is nil")
 	}
-
+	// docs: https://bailian.console.aliyun.com/?tab=api#/api/?type=model&url=2712216
+	// fix: InternalError.Algo.InvalidParameter: The value of the enable_thinking parameter is restricted to True.
+	if strings.Contains(request.Model, "thinking") {
+		request.EnableThinking = true
+		request.Stream = true
+		info.IsStream = true
+	}
 	// fix: ali parameter.enable_thinking must be set to false for non-streaming calls
 	if !info.IsStream {
 		request.EnableThinking = false

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -225,6 +225,9 @@ func GenRelayInfo(c *gin.Context) *RelayInfo {
 	userId := common.GetContextKeyInt(c, constant.ContextKeyUserId)
 	tokenUnlimited := common.GetContextKeyBool(c, constant.ContextKeyTokenUnlimited)
 	startTime := common.GetContextKeyTime(c, constant.ContextKeyRequestStartTime)
+	if startTime.IsZero() {
+		startTime = time.Now()
+	}
 	// firstResponseTime = time.Now() - 1 second
 
 	apiType, _ := common.ChannelType2APIType(channelType)


### PR DESCRIPTION
渠道测试支持qwen3-thinking模型
docs: https://bailian.console.aliyun.com/?tab=api#/api/?type=model&url=2712216
qwen3-thinking需要EnableThinking, 并且支持流模式
否则报错: InternalError.Algo.InvalidParameter: The value of the enable_thinking parameter is restricted to True.

修复前:
<img width="1854" height="822" alt="image" src="https://github.com/user-attachments/assets/c7d56281-6919-41eb-a6e2-8ad110b75b33" />
修复后:
<img width="1846" height="966" alt="image" src="https://github.com/user-attachments/assets/82ce1090-571e-4028-929a-2c913523132f" />
