### PR TITLE
fix: 修复通配符处理对判断可用渠道的破坏

### DIFF
--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -657,8 +657,15 @@ func GetCompletionRatioCopy() map[string]float64 {
 
 // 转换模型名，减少渠道必须配置各种带参数模型
 func FormatMatchingModelName(name string) string {
-	name = handleThinkingBudgetModel(name, "gemini-2.5-flash", "gemini-2.5-flash-thinking-*")
-	name = handleThinkingBudgetModel(name, "gemini-2.5-pro", "gemini-2.5-pro-thinking-*")
+
+	if strings.HasPrefix(name, "gemini-2.5-flash-lite") {
+		name = handleThinkingBudgetModel(name, "gemini-2.5-flash-lite", "gemini-2.5-flash-lite-thinking-*")
+	} else if strings.HasPrefix(name, "gemini-2.5-flash") {
+		name = handleThinkingBudgetModel(name, "gemini-2.5-flash", "gemini-2.5-flash-thinking-*")
+	} else if strings.HasPrefix(name, "gemini-2.5-pro") {
+		name = handleThinkingBudgetModel(name, "gemini-2.5-pro", "gemini-2.5-pro-thinking-*")
+	}
+
 	if strings.HasPrefix(name, "gpt-4-gizmo") {
 		name = "gpt-4-gizmo-*"
 	}

--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -150,6 +150,7 @@ var defaultModelRatio = map[string]float64{
 	"gemini-2.5-flash-preview-05-20-nothinking": 0.075,
 	"gemini-2.5-flash-thinking-*":               0.075, // 用于为后续所有2.5 flash thinking budget 模型设置默认倍率
 	"gemini-2.5-pro-thinking-*":                 0.625, // 用于为后续所有2.5 pro thinking budget 模型设置默认倍率
+	"gemini-2.5-flash-lite-preview-thinking-*":  0.05,
 	"gemini-2.5-flash-lite-preview-06-17":       0.05,
 	"gemini-2.5-flash":                          0.15,
 	"text-embedding-004":                        0.001,
@@ -503,9 +504,6 @@ func getHardcodedCompletionModelRatio(name string) (float64, bool) {
 				return 3.5 / 0.15, false
 			}
 			if strings.HasPrefix(name, "gemini-2.5-flash-lite") {
-				if strings.HasPrefix(name, "gemini-2.5-flash-lite-preview") {
-					return 4, false
-				}
 				return 4, false
 			}
 			return 2.5 / 0.3, true


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

- 先检查模型原名，再检查格式化的通配符名称
- 增加了gemini-2.5-flash-lite的通配符模型名以及定价
- 推荐后续使用通配符模型名，避免添加多个后缀的模型

### 修复效果
仅配置精确模型名
<img width="586" height="217" alt="6c8dcf9efe85913d8772b0c8490ca1e5" src="https://github.com/user-attachments/assets/4e57b796-2063-462e-94e2-c070397816a4" />
调用成功
<img width="991" height="102" alt="482dc03f34852c909ff742f6a98ae76a" src="https://github.com/user-attachments/assets/50a2aa2b-8c19-40aa-bd37-76e287202151" />

配置通配符模型名
<img width="606" height="246" alt="98640b6803ca22fa1247383d80410872" src="https://github.com/user-attachments/assets/a96e5901-e6d4-454e-aa73-5177c495f867" />

调用-12345成功
<img width="993" height="107" alt="a2bde01e9f2ecccba51799a9dede9069" src="https://github.com/user-attachments/assets/acf0033d-64df-4f7d-9def-0b292a414559" />
