### PR TITLE
fix: ensure last message is sent successfully

### DIFF
--- a/relay/channel/openai/helper.go
+++ b/relay/channel/openai/helper.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"encoding/json"
 	"errors"
+	"github.com/samber/lo"
 	"net/http"
 	"one-api/common"
 	"one-api/dto"
@@ -186,7 +187,9 @@ func handleLastResponse(lastStreamData string, responseId *string, createAt *int
 		*containStreamUsage = true
 		*usage = lastStreamResponse.Usage
 		if !info.ShouldIncludeUsage {
-			*shouldSendLastResp = false
+			*shouldSendLastResp = lo.SomeBy(lastStreamResponse.Choices, func(choice dto.ChatCompletionsStreamResponseChoice) bool {
+				return choice.Delta.GetContentString() != "" || choice.Delta.GetReasoningContent() != ""
+			})
 		}
 	}
 


### PR DESCRIPTION
修复gemini丢失消息的问题
gemini会在最后一条统计信息中夹带内容
<img width="3558" height="292" alt="image" src="https://github.com/user-attachments/assets/a500bfa8-2609-4407-8557-dab61315b7e7" />
