### PR TITLE
feat: sync gpt-5 model ratio and support new reasoning effort

### DIFF
--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -35,6 +35,21 @@ type Adaptor struct {
 	ResponseFormat string
 }
 
+// parseReasoningEffortFromModelSuffix 从模型名称中解析推理级别
+// support OAI models: o1-mini/o3-mini/o4-mini/o1/o3 etc...
+// minimal effort only available in gpt-5
+func parseReasoningEffortFromModelSuffix(model string) (string, string) {
+	effortSuffixes := []string{"-high", "-minimal", "-low", "-medium"}
+	for _, suffix := range effortSuffixes {
+		if strings.HasSuffix(model, suffix) {
+			effort := strings.TrimPrefix(suffix, "-")
+			originModel := strings.TrimSuffix(model, suffix)
+			return effort, originModel
+		}
+	}
+	return "", model
+}
+
 func (a *Adaptor) ConvertGeminiRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeminiChatRequest) (any, error) {
 	// 使用 service.GeminiToOpenAIRequest 转换请求格式
 	openaiRequest, err := service.GeminiToOpenAIRequest(request, info)
@@ -197,16 +212,14 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 			request.MaxTokens = 0
 		}
 		request.Temperature = nil
-		if strings.HasSuffix(request.Model, "-high") {
-			request.ReasoningEffort = "high"
-			request.Model = strings.TrimSuffix(request.Model, "-high")
-		} else if strings.HasSuffix(request.Model, "-low") {
-			request.ReasoningEffort = "low"
-			request.Model = strings.TrimSuffix(request.Model, "-low")
-		} else if strings.HasSuffix(request.Model, "-medium") {
-			request.ReasoningEffort = "medium"
-			request.Model = strings.TrimSuffix(request.Model, "-medium")
+
+		// 转换模型推理力度后缀
+		effort, originModel := parseReasoningEffortFromModelSuffix(request.Model)
+		if effort != "" {
+			request.ReasoningEffort = effort
+			request.Model = originModel
 		}
+
 		info.ReasoningEffort = request.ReasoningEffort
 		info.UpstreamModelName = request.Model
 
@@ -423,16 +436,11 @@ func detectImageMimeType(filename string) string {
 }
 
 func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {
-	// 模型后缀转换 reasoning effort
-	if strings.HasSuffix(request.Model, "-high") {
-		request.Reasoning.Effort = "high"
-		request.Model = strings.TrimSuffix(request.Model, "-high")
-	} else if strings.HasSuffix(request.Model, "-low") {
-		request.Reasoning.Effort = "low"
-		request.Model = strings.TrimSuffix(request.Model, "-low")
-	} else if strings.HasSuffix(request.Model, "-medium") {
-		request.Reasoning.Effort = "medium"
-		request.Model = strings.TrimSuffix(request.Model, "-medium")
+	//  转换模型推理力度后缀
+	effort, originModel := parseReasoningEffortFromModelSuffix(request.Model)
+	if effort != "" {
+		request.Reasoning.Effort = effort
+		request.Model = originModel
 	}
 	return request, nil
 }

--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -449,6 +449,10 @@ func getHardcodedCompletionModelRatio(name string) (float64, bool) {
 			}
 			return 4, true
 		}
+		// gpt-5 匹配
+		if strings.HasPrefix(name, "gpt-5") {
+			return 8, true
+		}
 		// gpt-4.5-preview匹配
 		if strings.HasPrefix(name, "gpt-4.5-preview") {
 			return 2, true


### PR DESCRIPTION
支持 GPT-5 模型补全倍率: 8
新增 minimal reasoning effort (仅 gpt5 系列可用)

官方文档：
>Minimal reasoning effort  最小推理工作量
The reasoning.effort parameter controls how many reasoning tokens the model generates before producing a response. Earlier reasoning models like o3 supported only low, medium, and high: low favored speed and fewer tokens, while high favored more thorough reasoning.
reasoning.effort 参数控制模型在生成响应之前生成多少推理令牌。像 o3 这样的早期推理模型仅支持 low 、 medium 和 high ： low 倾向于速度和更少的令牌，而 high 倾向于更彻底的推理。

>The new minimal setting produces very few reasoning tokens for cases where you need the fastest possible time-to-first-token. We often see better performance when the model can produce a few tokens when needed versus none. The default is medium.
新的 minimal 设置在您需要最快的首次令牌时间的情况下，会生成非常少的推理令牌。我们经常发现，当模型可以在需要时生成少量令牌而不是不生成时，性能会更好。默认值为 medium 。

>The minimal setting performs especially well in coding and instruction following scenarios, adhering closely to given directions. However, it may require prompting to act more proactively. To improve the model's reasoning quality, even at minimal effort, encourage it to “think” or outline its steps before answering.
minimal 设置在编码和指令遵循场景中表现尤为出色，能严格遵循给定的方向。然而，它可能需要提示才能更主动地行动。为了提高模型的推理质量，即使付出最小的努力，也可以鼓励它在回答前“思考”或概述其步骤。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of model names with reasoning effort suffixes, ensuring consistent processing and display.
  * Added support for detecting "gpt-5" model names and applying a specific ratio setting automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->