### PR TITLE
feats:replace GLM-4v authentication headers to support customize api key

### DIFF
--- a/relay/channel/zhipu_4v/adaptor.go
+++ b/relay/channel/zhipu_4v/adaptor.go
@@ -54,8 +54,7 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 
 func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *relaycommon.RelayInfo) error {
 	channel.SetupApiRequestHeader(info, c, req)
-	token := getZhipuToken(info.ApiKey)
-	req.Set("Authorization", token)
+	req.Set("Authorization", "Bearer "+info.ApiKey)
 	return nil
 }
 

--- a/relay/channel/zhipu_4v/relay-zhipu_v4.go
+++ b/relay/channel/zhipu_4v/relay-zhipu_v4.go
@@ -1,68 +1,9 @@
 package zhipu_4v
 
 import (
-	"github.com/golang-jwt/jwt"
-	"one-api/common"
 	"one-api/dto"
 	"strings"
-	"sync"
-	"time"
 )
-
-// https://open.bigmodel.cn/doc/api#chatglm_std
-// chatglm_std, chatglm_lite
-// https://open.bigmodel.cn/api/paas/v3/model-api/chatglm_std/invoke
-// https://open.bigmodel.cn/api/paas/v3/model-api/chatglm_std/sse-invoke
-
-var zhipuTokens sync.Map
-var expSeconds int64 = 24 * 3600
-
-func getZhipuToken(apikey string) string {
-	data, ok := zhipuTokens.Load(apikey)
-	if ok {
-		tokenData := data.(tokenData)
-		if time.Now().Before(tokenData.ExpiryTime) {
-			return tokenData.Token
-		}
-	}
-
-	split := strings.Split(apikey, ".")
-	if len(split) != 2 {
-		common.SysError("invalid zhipu key: " + apikey)
-		return ""
-	}
-
-	id := split[0]
-	secret := split[1]
-
-	expMillis := time.Now().Add(time.Duration(expSeconds)*time.Second).UnixNano() / 1e6
-	expiryTime := time.Now().Add(time.Duration(expSeconds) * time.Second)
-
-	timestamp := time.Now().UnixNano() / 1e6
-
-	payload := jwt.MapClaims{
-		"api_key":   id,
-		"exp":       expMillis,
-		"timestamp": timestamp,
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, payload)
-
-	token.Header["alg"] = "HS256"
-	token.Header["sign_type"] = "SIGN"
-
-	tokenString, err := token.SignedString([]byte(secret))
-	if err != nil {
-		return ""
-	}
-
-	zhipuTokens.Store(apikey, tokenData{
-		Token:      tokenString,
-		ExpiryTime: expiryTime,
-	})
-
-	return tokenString
-}
 
 func requestOpenAI2Zhipu(request dto.GeneralOpenAIRequest) *dto.GeneralOpenAIRequest {
 	messages := make([]dto.Message, 0, len(request.Messages))


### PR DESCRIPTION
According to the official documentation (https://docs.bigmodel.cn/cn/guide/develop/http/introduction), JWT generation is not required, so it has been replaced with a more compatible approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified authentication by using the API key directly in the authorization header, removing the previous token generation and caching process.

* **Chores**
  * Cleaned up code by removing obsolete token-related logic and dependencies.

* **Chores**
  * Streamlined the Docker image build workflow to target Docker Hub exclusively, removing multi-registry support and related permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->