### PR TITLE
feat: 支持原生Gemini Embedding格式

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -42,7 +42,11 @@ func relayHandler(c *gin.Context, relayMode int) *types.NewAPIError {
 	case relayconstant.RelayModeResponses:
 		err = relay.ResponsesHelper(c)
 	case relayconstant.RelayModeGemini:
-		err = relay.GeminiHelper(c)
+		if strings.Contains(c.Request.URL.Path, "embed") {
+			err = relay.GeminiEmbeddingHandler(c)
+		} else {
+			err = relay.GeminiHelper(c)
+		}
 	default:
 		err = relay.TextHelper(c)
 	}

--- a/dto/gemini.go
+++ b/dto/gemini.go
@@ -210,14 +210,23 @@ type GeminiImagePrediction struct {
 
 // Embedding related structs
 type GeminiEmbeddingRequest struct {
+	Model                string            `json:"model,omitempty"`
 	Content              GeminiChatContent `json:"content"`
 	TaskType             string            `json:"taskType,omitempty"`
 	Title                string            `json:"title,omitempty"`
 	OutputDimensionality int               `json:"outputDimensionality,omitempty"`
 }
 
+type GeminiBatchEmbeddingRequest struct {
+	Requests []GeminiEmbeddingRequest `json:"requests"`
+}
+
 type GeminiEmbeddingResponse struct {
 	Embedding ContentEmbedding `json:"embedding"`
+}
+
+type GeminiBatchEmbeddingResponse struct {
+	Embeddings []ContentEmbedding `json:"embeddings"`
 }
 
 type ContentEmbedding struct {

--- a/dto/gemini.go
+++ b/dto/gemini.go
@@ -218,7 +218,7 @@ type GeminiEmbeddingRequest struct {
 }
 
 type GeminiBatchEmbeddingRequest struct {
-	Requests []GeminiEmbeddingRequest `json:"requests"`
+	Requests []*GeminiEmbeddingRequest `json:"requests"`
 }
 
 type GeminiEmbeddingResponse struct {
@@ -226,7 +226,7 @@ type GeminiEmbeddingResponse struct {
 }
 
 type GeminiBatchEmbeddingResponse struct {
-	Embeddings []ContentEmbedding `json:"embeddings"`
+	Embeddings []*ContentEmbedding `json:"embeddings"`
 }
 
 type ContentEmbedding struct {

--- a/relay/channel/gemini/adaptor.go
+++ b/relay/channel/gemini/adaptor.go
@@ -115,7 +115,7 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 		strings.HasPrefix(info.UpstreamModelName, "embedding") ||
 		strings.HasPrefix(info.UpstreamModelName, "gemini-embedding") {
 		action := "embedContent"
-		if info.IsGeminiBatchEmbdding {
+		if info.IsGeminiBatchEmbedding {
 			action = "batchEmbedContents"
 		}
 		return fmt.Sprintf("%s/%s/models/%s:%s", info.BaseUrl, version, info.UpstreamModelName, action), nil
@@ -199,7 +199,8 @@ func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, request
 
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
 	if info.RelayMode == constant.RelayModeGemini {
-		if strings.Contains(info.RequestURLPath, "embed") {
+		if strings.HasSuffix(info.RequestURLPath, ":embedContent") ||
+			strings.HasSuffix(info.RequestURLPath, ":batchEmbedContents") {
 			return NativeGeminiEmbeddingHandler(c, resp, info)
 		}
 		if info.IsStream {

--- a/relay/channel/gemini/relay-gemini-native.go
+++ b/relay/channel/gemini/relay-gemini-native.go
@@ -81,7 +81,7 @@ func NativeGeminiEmbeddingHandler(c *gin.Context, resp *http.Response, info *rel
 		TotalTokens:  info.PromptTokens,
 	}
 
-	if info.IsGeminiBatchEmbdding {
+	if info.IsGeminiBatchEmbedding {
 		var geminiResponse dto.GeminiBatchEmbeddingResponse
 		err = common.Unmarshal(responseBody, &geminiResponse)
 		if err != nil {

--- a/relay/channel/gemini/relay-gemini-native.go
+++ b/relay/channel/gemini/relay-gemini-native.go
@@ -1,7 +1,6 @@
 package gemini
 
 import (
-	"github.com/pkg/errors"
 	"io"
 	"net/http"
 	"one-api/common"
@@ -11,6 +10,8 @@ import (
 	"one-api/service"
 	"one-api/types"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/gin-gonic/gin"
 )
@@ -61,6 +62,42 @@ func GeminiTextGenerationHandler(c *gin.Context, info *relaycommon.RelayInfo, re
 	common.IOCopyBytesGracefully(c, resp, jsonResponse)
 
 	return &usage, nil
+}
+
+func NativeGeminiEmbeddingHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (*dto.Usage, *types.NewAPIError) {
+	defer common.CloseResponseBodyGracefully(resp)
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+
+	if common.DebugEnabled {
+		println(string(responseBody))
+	}
+
+	usage := &dto.Usage{
+		PromptTokens: info.PromptTokens,
+		TotalTokens:  info.PromptTokens,
+	}
+
+	if info.IsGeminiBatchEmbdding {
+		var geminiResponse dto.GeminiBatchEmbeddingResponse
+		err = common.Unmarshal(responseBody, &geminiResponse)
+		if err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+	} else {
+		var geminiResponse dto.GeminiEmbeddingResponse
+		err = common.Unmarshal(responseBody, &geminiResponse)
+		if err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+	}
+
+	common.IOCopyBytesGracefully(c, resp, responseBody)
+
+	return usage, nil
 }
 
 func GeminiTextGenerationStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -74,13 +74,14 @@ type RelayInfo struct {
 	FirstResponseTime    time.Time
 	isFirstResponse      bool
 	//SendLastReasoningResponse bool
-	ApiType           int
-	IsStream          bool
-	IsPlayground      bool
-	UsePrice          bool
-	RelayMode         int
-	UpstreamModelName string
-	OriginModelName   string
+	ApiType               int
+	IsStream              bool
+	IsGeminiBatchEmbdding bool
+	IsPlayground          bool
+	UsePrice              bool
+	RelayMode             int
+	UpstreamModelName     string
+	OriginModelName       string
 	//RecodeModelName      string
 	RequestURLPath       string
 	ApiVersion           string

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -74,14 +74,14 @@ type RelayInfo struct {
 	FirstResponseTime    time.Time
 	isFirstResponse      bool
 	//SendLastReasoningResponse bool
-	ApiType               int
-	IsStream              bool
-	IsGeminiBatchEmbdding bool
-	IsPlayground          bool
-	UsePrice              bool
-	RelayMode             int
-	UpstreamModelName     string
-	OriginModelName       string
+	ApiType                int
+	IsStream               bool
+	IsGeminiBatchEmbedding bool
+	IsPlayground           bool
+	UsePrice               bool
+	RelayMode              int
+	UpstreamModelName      string
+	OriginModelName        string
 	//RecodeModelName      string
 	RequestURLPath       string
 	ApiVersion           string

--- a/relay/gemini_handler.go
+++ b/relay/gemini_handler.go
@@ -264,3 +264,105 @@ func GeminiHelper(c *gin.Context) (newAPIError *types.NewAPIError) {
 	postConsumeQuota(c, relayInfo, usage.(*dto.Usage), preConsumedQuota, userQuota, priceData, "")
 	return nil
 }
+
+func GeminiEmbeddingHandler(c *gin.Context) (newAPIError *types.NewAPIError) {
+	relayInfo := relaycommon.GenRelayInfoGemini(c)
+
+	isBatch := strings.HasSuffix(c.Request.URL.Path, "batchEmbedContents")
+	relayInfo.IsGeminiBatchEmbdding = isBatch
+
+	var promptTokens int
+	var req any
+	var err error
+	var inputTexts []string
+
+	if isBatch {
+		batchRequest := &dto.GeminiBatchEmbeddingRequest{}
+		err = common.UnmarshalBodyReusable(c, batchRequest)
+		if err != nil {
+			return types.NewError(err, types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
+		}
+		req = batchRequest
+		for _, r := range batchRequest.Requests {
+			for _, part := range r.Content.Parts {
+				if part.Text != "" {
+					inputTexts = append(inputTexts, part.Text)
+				}
+			}
+		}
+	} else {
+		singleRequest := &dto.GeminiEmbeddingRequest{}
+		err = common.UnmarshalBodyReusable(c, singleRequest)
+		if err != nil {
+			return types.NewError(err, types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
+		}
+		req = singleRequest
+		for _, part := range singleRequest.Content.Parts {
+			if part.Text != "" {
+				inputTexts = append(inputTexts, part.Text)
+			}
+		}
+	}
+	promptTokens = service.CountTokenInput(strings.Join(inputTexts, "\n"), relayInfo.UpstreamModelName)
+	relayInfo.SetPromptTokens(promptTokens)
+	c.Set("prompt_tokens", promptTokens)
+
+	err = helper.ModelMappedHelper(c, relayInfo, req)
+	if err != nil {
+		return types.NewError(err, types.ErrorCodeChannelModelMappedError, types.ErrOptionWithSkipRetry())
+	}
+
+	priceData, err := helper.ModelPriceHelper(c, relayInfo, relayInfo.PromptTokens, 0)
+	if err != nil {
+		return types.NewError(err, types.ErrorCodeModelPriceError, types.ErrOptionWithSkipRetry())
+	}
+
+	preConsumedQuota, userQuota, newAPIError := preConsumeQuota(c, priceData.ShouldPreConsumedQuota, relayInfo)
+	if newAPIError != nil {
+		return newAPIError
+	}
+	defer func() {
+		if newAPIError != nil {
+			returnPreConsumedQuota(c, relayInfo, userQuota, preConsumedQuota)
+		}
+	}()
+
+	adaptor := GetAdaptor(relayInfo.ApiType)
+	if adaptor == nil {
+		return types.NewError(fmt.Errorf("invalid api type: %d", relayInfo.ApiType), types.ErrorCodeInvalidApiType, types.ErrOptionWithSkipRetry())
+	}
+	adaptor.Init(relayInfo)
+
+	var requestBody io.Reader
+	jsonData, err := common.Marshal(req)
+	if err != nil {
+		return types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
+	}
+	requestBody = bytes.NewReader(jsonData)
+
+	resp, err := adaptor.DoRequest(c, relayInfo, requestBody)
+	if err != nil {
+		common.LogError(c, "Do gemini request failed: "+err.Error())
+		return types.NewOpenAIError(err, types.ErrorCodeDoRequestFailed, http.StatusInternalServerError)
+	}
+
+	statusCodeMappingStr := c.GetString("status_code_mapping")
+	var httpResp *http.Response
+	if resp != nil {
+		httpResp = resp.(*http.Response)
+		if httpResp.StatusCode != http.StatusOK {
+			newAPIError = service.RelayErrorHandler(httpResp, false)
+			service.ResetStatusCode(newAPIError, statusCodeMappingStr)
+			return newAPIError
+		}
+	}
+
+	usage, openaiErr := adaptor.DoResponse(c, resp.(*http.Response), relayInfo)
+	if openaiErr != nil {
+		service.ResetStatusCode(openaiErr, statusCodeMappingStr)
+		return openaiErr
+	}
+
+	postConsumeQuota(c, relayInfo, usage.(*dto.Usage), preConsumedQuota, userQuota, priceData, "")
+	return nil
+}

--- a/relay/gemini_handler.go
+++ b/relay/gemini_handler.go
@@ -269,7 +269,7 @@ func GeminiEmbeddingHandler(c *gin.Context) (newAPIError *types.NewAPIError) {
 	relayInfo := relaycommon.GenRelayInfoGemini(c)
 
 	isBatch := strings.HasSuffix(c.Request.URL.Path, "batchEmbedContents")
-	relayInfo.IsGeminiBatchEmbdding = isBatch
+	relayInfo.IsGeminiBatchEmbedding = isBatch
 
 	var promptTokens int
 	var req any
@@ -337,6 +337,19 @@ func GeminiEmbeddingHandler(c *gin.Context) (newAPIError *types.NewAPIError) {
 	jsonData, err := common.Marshal(req)
 	if err != nil {
 		return types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
+	}
+
+	// apply param override
+	if len(relayInfo.ParamOverride) > 0 {
+		reqMap := make(map[string]interface{})
+		_ = common.Unmarshal(jsonData, &reqMap)
+		for key, value := range relayInfo.ParamOverride {
+			reqMap[key] = value
+		}
+		jsonData, err = common.Marshal(reqMap)
+		if err != nil {
+			return types.NewError(err, types.ErrorCodeChannelParamOverrideInvalid, types.ErrOptionWithSkipRetry())
+		}
 	}
 	requestBody = bytes.NewReader(jsonData)
 


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [x] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

- close https://github.com/QuantumNous/new-api/pull/1368#issuecomment-3162226399

- 支持了Gemini原生格式的Embedding，方便下游统一接入与测试

### **重要提示**
- Gemini**不返回**Embedding的统计信息（无论原生还是OpenAI兼容格式），token数是new-api本地计算得到的


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for Gemini embedding requests, including single and batch embedding operations.
  * Introduced new endpoints and handlers to process embedding requests and responses.
  * Added an optional model selection field for embedding requests.

* **Improvements**
  * Enhanced request handling to distinguish embedding types based on URL path.
  * Improved response processing for Gemini embedding to handle batch and single responses accurately.
  * Added quota pre-consumption and usage tracking for embedding requests.

* **Bug Fixes**
  * Refined error handling and status code management for Gemini embedding responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->