### PR TITLE
feat: add jimeng video official api

### DIFF
--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -174,7 +174,9 @@ func getModelRequest(c *gin.Context) (*ModelRequest, bool, error) {
 			relayMode = relayconstant.RelayModeVideoFetchByID
 			shouldSelectChannel = false
 		}
-		c.Set("relay_mode", relayMode)
+		if _, ok := c.Get("relay_mode"); !ok {
+			c.Set("relay_mode", relayMode)
+		}
 	} else if strings.HasPrefix(c.Request.URL.Path, "/v1beta/models/") || strings.HasPrefix(c.Request.URL.Path, "/v1/models/") {
 		// Gemini API 路径处理: /v1beta/models/gemini-2.0-flash:generateContent
 		relayMode := relayconstant.RelayModeGemini

--- a/middleware/jimeng_adapter.go
+++ b/middleware/jimeng_adapter.go
@@ -1,0 +1,66 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/gin-gonic/gin"
+	"io"
+	"net/http"
+	"one-api/common"
+	"one-api/constant"
+	relayconstant "one-api/relay/constant"
+)
+
+func JimengRequestConvert() func(c *gin.Context) {
+	return func(c *gin.Context) {
+		action := c.Query("Action")
+		if action == "" {
+			abortWithOpenAiMessage(c, http.StatusBadRequest, "Action query parameter is required")
+			return
+		}
+
+		// Handle Jimeng official API request
+		var originalReq map[string]interface{}
+		if err := common.UnmarshalBodyReusable(c, &originalReq); err != nil {
+			abortWithOpenAiMessage(c, http.StatusBadRequest, "Invalid request body")
+			return
+		}
+		model, _ := originalReq["req_key"].(string)
+		prompt, _ := originalReq["prompt"].(string)
+
+		unifiedReq := map[string]interface{}{
+			"model":    model,
+			"prompt":   prompt,
+			"metadata": originalReq,
+		}
+
+		jsonData, err := json.Marshal(unifiedReq)
+		if err != nil {
+			abortWithOpenAiMessage(c, http.StatusInternalServerError, "Failed to marshal request body")
+			return
+		}
+
+		// Update request body
+		c.Request.Body = io.NopCloser(bytes.NewBuffer(jsonData))
+		c.Set(common.KeyRequestBody, jsonData)
+
+		if image, ok := originalReq["image"]; !ok || image == "" {
+			c.Set("action", constant.TaskActionTextGenerate)
+		}
+
+		c.Request.URL.Path = "/v1/video/generations"
+
+		if action == "CVSync2AsyncGetResult" {
+			taskId, ok := originalReq["task_id"].(string)
+			if !ok || taskId == "" {
+				abortWithOpenAiMessage(c, http.StatusBadRequest, "task_id is required for CVSync2AsyncGetResult")
+				return
+			}
+			c.Request.URL.Path = "/v1/video/generations/" + taskId
+			c.Request.Method = http.MethodGet
+			c.Set("task_id", taskId)
+			c.Set("relay_mode", relayconstant.RelayModeVideoFetchByID)
+		}
+		c.Next()
+	}
+}

--- a/relay/relay_task.go
+++ b/relay/relay_task.go
@@ -258,6 +258,9 @@ func sunoFetchByIDRespBodyBuilder(c *gin.Context) (respBody []byte, taskResp *dt
 
 func videoFetchByIDRespBodyBuilder(c *gin.Context) (respBody []byte, taskResp *dto.TaskError) {
 	taskId := c.Param("task_id")
+	if taskId == "" {
+		taskId = c.GetString("task_id")
+	}
 	userId := c.GetInt("id")
 
 	originTask, exist, err := model.GetByTaskId(userId, taskId)

--- a/router/video-router.go
+++ b/router/video-router.go
@@ -23,4 +23,12 @@ func SetVideoRouter(router *gin.Engine) {
 		klingV1Router.GET("/videos/text2video/:task_id", controller.RelayTask)
 		klingV1Router.GET("/videos/image2video/:task_id", controller.RelayTask)
 	}
+
+	// Jimeng official API routes - direct mapping to official API format
+	jimengOfficialGroup := router.Group("jimeng")
+	jimengOfficialGroup.Use(middleware.JimengRequestConvert(), middleware.TokenAuth(), middleware.Distribute())
+	{
+		// Maps to: /?Action=CVSync2AsyncSubmitTask&Version=2022-08-31 and /?Action=CVSync2AsyncGetResult&Version=2022-08-31
+		jimengOfficialGroup.POST("/", controller.RelayTask)
+	}
 }


### PR DESCRIPTION
增加即梦官方接口
1. 生图请求示例:
url= 'https://xxx/jimeng/?Action=CVSync2AsyncSubmitTask&Version=2022-08-31' 
json {
  "aspect_ratio": "16:9",
  "prompt": "一只猫在花园里弹钢琴",
  "req_key": "jimeng_vgfm_t2v_l20",
  "seed": -1
}
<img width="2278" height="1066" alt="image" src="https://github.com/user-attachments/assets/f623bf70-e12b-4b55-9c1d-48b4dfdd95e5" />

2.  查询示例:
url = 'https://xxx/jimeng/?Action=CVSync2AsyncGetResult&Version=2022-08-31'
json {
  "task_id": "10874234309578611716"
}
<img width="2766" height="1322" alt="image" src="https://github.com/user-attachments/assets/5e7353b7-6b0f-441e-a98c-be131e476eea" />
 3. 任务日志:
 
<img width="2808" height="342" alt="image" src="https://github.com/user-attachments/assets/d2df69b9-9f67-48af-95b7-f9c73997df5c" />
