### PR TITLE
docs(web_api): 修复 Markdown 表格格式

### DIFF
--- a/docs/api/web_api.md
+++ b/docs/api/web_api.md
@@ -62,6 +62,8 @@
 | GET  | /api/user/groups | 公开 | 列出所有分组（无鉴权版） |
 
 ### 5.2 用户自身操作 (需登录)
+| 方法 | 路径 | 鉴权 | 说明 |
+|------|------|------|------|
 | GET | /api/user/self/groups | 用户 | 获取自己所在分组 |
 | GET | /api/user/self | 用户 | 获取个人资料 |
 | GET | /api/user/models | 用户 | 获取模型可见性 |


### PR DESCRIPTION
修复因 web_api.md 中 5.2 节 Markdown 表格格式缺失导致渲染失败

修改前：
<img width="1080" height="178" alt="image" src="https://github.com/user-attachments/assets/4411b686-e090-4c44-a467-25adce8c44b8" />

修改后：
<img width="542" height="487" alt="image" src="https://github.com/user-attachments/assets/78192352-34c6-4cdc-b7a6-33f7f791fabf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Fixed table formatting in Web API docs (section 5.2 用户自身操作).
  * Added table header and separator to comply with Markdown syntax for correct rendering.
  * Clarifies columns: 方法 (method), 路径 (path), 鉴权 (auth), 说明 (description).
  * Improves readability and consistency; no content or semantics changed.
  * Ensures consistent display across different documentation viewers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->