### PR TITLE
fix(adaptor): missing first text delta while convert OpenAI to Claude

### DIFF
--- a/service/convert.go
+++ b/service/convert.go
@@ -248,9 +248,10 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 				},
 			})
 			claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
-				Type: "content_block_delta",
+				Index: &info.ClaudeConvertInfo.Index,
+				Type:  "content_block_delta",
 				Delta: &dto.ClaudeMediaMessage{
-					Type: "text",
+					Type: "text_delta",
 					Text: common.GetPointer[string](openAIResponse.Choices[0].Delta.GetContentString()),
 				},
 			})


### PR DESCRIPTION
While converting OpenAI to Claude format, the first text delta has been wrongly converted.
This PR fix the problem by adding missing `Index` and changing the message type to `text_delta`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamed content updates now include block-level indexing, improving ordering and handling of multi-part responses in real time.
  * Standardized the event type for partial text updates in streaming to ensure clearer, more consistent incremental updates. Non-streaming behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->