### PR TITLE
refactor(topup): remove unnecessary mutex lock for top-up request handler

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -11,7 +11,6 @@ import (
 	"one-api/setting"
 	"strconv"
 	"strings"
-	"sync"
 
 	"one-api/constant"
 
@@ -817,11 +816,7 @@ type topUpRequest struct {
 	Key string `json:"key"`
 }
 
-var topUpLock = sync.Mutex{}
-
 func TopUp(c *gin.Context) {
-	topUpLock.Lock()
-	defer topUpLock.Unlock()
 	req := topUpRequest{}
 	err := c.ShouldBindJSON(&req)
 	if err != nil {


### PR DESCRIPTION
### Fix: Remove Global Lock for Top-Up Redemption to Improve Concurrency

#### Background

Previously, the **TopUp** API endpoint relied on a global `sync.Mutex` to prevent concurrent redemption of top-up codes. While effective in ensuring exclusivity, this approach introduced severe performance bottlenecks and occasional deadlocks. Since all requests were serialized, users attempting to redeem different codes simultaneously were unnecessarily blocked.

#### Changes

* **Removed** the global `topUpLock` mutex from the **TopUp** controller.
* **Switched** to database-level guarantees: rely solely on database transactions and `FOR UPDATE` row-level locking in `model.Redeem` to ensure each code can only be redeemed once.
* **Cleaned up** unused imports.

#### Benefits

* **Improved concurrency:** Users can redeem different codes in parallel without contention.
* **No deadlocks:** Eliminating the global lock removes the risk of system-wide blocking.
* **Data integrity preserved:** Row-level locks and transactions still guarantee one-time redemption.
* **Rate limiting intact:** Enforcement remains via the `CriticalRateLimit` middleware.

#### Testing

* Verified that multiple users can redeem codes concurrently without blocking or deadlocks.
* Confirmed that a single code cannot be redeemed more than once, even under heavy concurrent load.
* All existing test cases pass successfully.

#### Summary

This change significantly enhances both **user experience** and **system scalability** for top-up code redemption by eliminating unnecessary global locking while preserving data safety and rate-limiting guarantees.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined the account top-up flow to reduce contention and improve responsiveness under concurrent usage.
  - No changes to the user interface, inputs/outputs, or public APIs.
  - Behavior remains consistent; users should experience smoother performance during peak activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->