### PR TITLE
feat: adapt Volcengine adaptor for deepseek3.1 with thinking mode

### DIFF
--- a/relay/channel/volcengine/adaptor.go
+++ b/relay/channel/volcengine/adaptor.go
@@ -2,6 +2,7 @@ package volcengine
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -213,6 +214,12 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *rel
 func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeneralOpenAIRequest) (any, error) {
 	if request == nil {
 		return nil, errors.New("request is nil")
+	}
+	// 适配 方舟deepseek混合模型 的 thinking 后缀
+	if strings.HasSuffix(info.UpstreamModelName, "-thinking") && strings.HasPrefix(info.UpstreamModelName, "deepseek") {
+		info.UpstreamModelName = strings.TrimSuffix(info.UpstreamModelName, "-thinking")
+		request.Model = info.UpstreamModelName
+		request.THINKING = json.RawMessage(`{"type": "enabled"}`)
 	}
 	return request, nil
 }


### PR DESCRIPTION
ref: https://github.com/QuantumNous/new-api/issues/1638

适配火山方舟 Deepseek 3.1 思考后缀
模型名称为 deepseek-v3-1-250821-thinking 将会启用思考功能
<img width="1402" height="759" alt="image" src="https://github.com/user-attachments/assets/ea151287-815b-46a1-ae99-1d8b4f516438" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic "thinking" mode for DeepSeek hybrid models: selecting a model with the “-thinking” suffix now transparently routes to the correct underlying model and enables the thinking behavior without extra configuration.

* **Chores**
  * Internal handling updated to recognize “-thinking” model variants while preserving existing behavior for all other models; no API or settings changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->