### PR TITLE
fix: prevent loop auto-migrate with bool default false

### DIFF
--- a/model/twofa.go
+++ b/model/twofa.go
@@ -16,7 +16,7 @@ type TwoFA struct {
 	Id             int            `json:"id" gorm:"primaryKey"`
 	UserId         int            `json:"user_id" gorm:"unique;not null;index"`
 	Secret         string         `json:"-" gorm:"type:varchar(255);not null"` // TOTP密钥，不返回给前端
-	IsEnabled      bool           `json:"is_enabled" gorm:"default:false"`
+	IsEnabled      bool           `json:"is_enabled"`
 	FailedAttempts int            `json:"failed_attempts" gorm:"default:0"`
 	LockedUntil    *time.Time     `json:"locked_until,omitempty"`
 	LastUsedAt     *time.Time     `json:"last_used_at,omitempty"`
@@ -30,7 +30,7 @@ type TwoFABackupCode struct {
 	Id        int            `json:"id" gorm:"primaryKey"`
 	UserId    int            `json:"user_id" gorm:"not null;index"`
 	CodeHash  string         `json:"-" gorm:"type:varchar(255);not null"` // 备用码哈希
-	IsUsed    bool           `json:"is_used" gorm:"default:false"`
+	IsUsed    bool           `json:"is_used"`
 	UsedAt    *time.Time     `json:"used_at,omitempty"`
 	CreatedAt time.Time      `json:"created_at"`
 	DeletedAt gorm.DeletedAt `json:"-" gorm:"index"`


### PR DESCRIPTION
mysql bool类型实际为tinyint 
默认值设置为false不会成功
会导致每次重启autoMigrate重复执行 `ALTER TABLE `two_fa_backup_codes` MODIFY COLUMN `is_used` boolean DEFAULT false`