### PR TITLE
feat: add channel remark #1710

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -47,6 +47,7 @@ type Channel struct {
 	Setting           *string `json:"setting" gorm:"type:text"` // 渠道额外设置
 	ParamOverride     *string `json:"param_override" gorm:"type:text"`
 	HeaderOverride    *string `json:"header_override" gorm:"type:text"`
+	Remark            string  `json:"remark,omitempty" gorm:"type:varchar(255)" validate:"max=255"`
 	// add after v0.8.5
 	ChannelInfo ChannelInfo `json:"channel_info" gorm:"type:json"`
 

--- a/web/src/components/table/channels/ChannelsColumnDefs.jsx
+++ b/web/src/components/table/channels/ChannelsColumnDefs.jsx
@@ -35,6 +35,8 @@ import {
   renderQuota,
   getChannelIcon,
   renderQuotaWithAmount,
+  showSuccess,
+  showError,
 } from '../../../helpers';
 import { CHANNEL_OPTIONS } from '../../../constants';
 import { IconTreeTriangleDown, IconMore } from '@douyinfe/semi-icons';
@@ -216,6 +218,39 @@ export const getChannelsColumns = ({
       key: COLUMN_KEYS.NAME,
       title: t('名称'),
       dataIndex: 'name',
+      render: (text, record, index) => {
+        if (record.remark && record.remark.trim() !== '') {
+          return (
+            <Tooltip
+              content={
+                <div className='flex flex-col gap-2 max-w-xs'>
+                  <div className='text-sm'>{record.remark}</div>
+                  <Button
+                    size='small'
+                    type='primary'
+                    theme='outline'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      navigator.clipboard.writeText(record.remark).then(() => {
+                        showSuccess(t('复制成功'));
+                      }).catch(() => {
+                        showError(t('复制失败'));
+                      });
+                    }}
+                  >
+                    {t('复制')}
+                  </Button>
+                </div>
+              }
+              trigger='hover'
+              position='topLeft'
+            >
+              <span>{text}</span>
+            </Tooltip>
+          );
+        }
+        return text;
+      },
     },
     {
       key: COLUMN_KEYS.GROUP,

--- a/web/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/src/components/table/channels/modals/EditChannelModal.jsx
@@ -1993,6 +1993,14 @@ const EditChannelModal = (props) => {
                     showClear
                     onChange={(value) => handleInputChange('tag', value)}
                   />
+                  <Form.TextArea
+                    field='remark'
+                    label={t('备注')}
+                    placeholder={t('请输入备注（仅管理员可见）')}
+                    maxLength={255}
+                    showClear
+                    onChange={(value) => handleInputChange('remark', value)}
+                  />
 
                   <Row gutter={12}>
                     <Col span={12}>


### PR DESCRIPTION
<img width="1230" height="1056" alt="image" src="https://github.com/user-attachments/assets/1351ec54-3c05-4aeb-967e-4e3a9fa63148" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channels now support an optional remark (up to 255 characters, omitted if empty).
  * Edit Channel modal includes a Remark field with clear button and character limit; saved on create/update. Remark is visible to admins only.
  * In the Channels table, names display a tooltip with the remark when available, plus a Copy action. Users receive success/error notifications when copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->