### PR TITLE
openai v1/models 完全兼容 解决接入trae时候的字段校验

### DIFF
--- a/controller/model.go
+++ b/controller/model.go
@@ -174,6 +174,7 @@ func ListModels(c *gin.Context) {
 	c.JSON(200, gin.H{
 		"success": true,
 		"data":    userOpenAiModels,
+		"object":  "list",
 	})
 }
 


### PR DESCRIPTION
自建自签名证书+hosts 修改 api.openai.com 的地址
接入 trae IDE 后报错
增加models接口缺少的字段后成功接入