### PR TITLE
fix: ensure the BuiltInTools entry exists before incrementing CallCount

### DIFF
--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -48,7 +48,12 @@ func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 	}
 	// 解析 Tools 用量
 	for _, tool := range responsesResponse.Tools {
-		info.ResponsesUsageInfo.BuiltInTools[common.Interface2String(tool["type"])].CallCount++
+		buildToolinfo, ok := info.ResponsesUsageInfo.BuiltInTools[common.Interface2String(tool["type"])]
+		if !ok {
+			logger.LogError(c, fmt.Sprintf("BuiltInTools not found for tool type: %v", tool["type"]))
+			continue
+		}
+		buildToolinfo.CallCount++
 	}
 	return &usage, nil
 }
@@ -72,7 +77,7 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 			sendResponsesStreamData(c, streamResponse, data)
 			switch streamResponse.Type {
 			case "response.completed":
-				if streamResponse.Response.Usage != nil {
+				if streamResponse.Response != nil && streamResponse.Response.Usage != nil {
 					if streamResponse.Response.Usage.InputTokens != 0 {
 						usage.PromptTokens = streamResponse.Response.Usage.InputTokens
 					}

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -46,10 +46,13 @@ func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 			usage.PromptTokensDetails.CachedTokens = responsesResponse.Usage.InputTokensDetails.CachedTokens
 		}
 	}
+	if info == nil || info.ResponsesUsageInfo == nil || info.ResponsesUsageInfo.BuiltInTools == nil {
+		return &usage, nil
+	}
 	// 解析 Tools 用量
 	for _, tool := range responsesResponse.Tools {
 		buildToolinfo, ok := info.ResponsesUsageInfo.BuiltInTools[common.Interface2String(tool["type"])]
-		if !ok {
+		if !ok || buildToolinfo == nil {
 			logger.LogError(c, fmt.Sprintf("BuiltInTools not found for tool type: %v", tool["type"]))
 			continue
 		}


### PR DESCRIPTION
Fix: #1748 
在操作前进行检查，解决因为工具值无法转换，或者异常结构导致返回空值，在空值上操作导致程序panic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rare crashes during streaming by guarding against missing response usage data.
  * Improved stability when calling built-in tools by safely handling unknown or absent tool entries.
  * Enhanced error logging for unsupported tool scenarios without interrupting requests.
  * Reduced nil-pointer risks in completion events for more reliable response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->