### PR TITLE
feat: 改进Claude响应转OpenAI响应

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -32,7 +32,7 @@ func stopReasonClaude2OpenAI(reason string) string {
 	case "end_turn":
 		return "stop"
 	case "max_tokens":
-		return "max_tokens"
+		return "length"
 	case "tool_use":
 		return "tool_calls"
 	default:
@@ -426,7 +426,10 @@ func StreamResponseClaude2OpenAI(reqMode int, claudeResponse *dto.ClaudeResponse
 			choice.Delta.Role = "assistant"
 		} else if claudeResponse.Type == "content_block_start" {
 			if claudeResponse.ContentBlock != nil {
-				//choice.Delta.SetContentString(claudeResponse.ContentBlock.Text)
+				// 如果是文本块，尽可能发送首段文本（若存在）
+				if claudeResponse.ContentBlock.Type == "text" && claudeResponse.ContentBlock.Text != nil {
+					choice.Delta.SetContentString(*claudeResponse.ContentBlock.Text)
+				}
 				if claudeResponse.ContentBlock.Type == "tool_use" {
 					tools = append(tools, dto.ToolCallResponse{
 						Index: common.GetPointer(fcIdx),


### PR DESCRIPTION
- 映射 claude stop reason "max_tokens" 为 openai 的 finish_reason "length"
- 流模式起始块发送首段文本

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected finish reason mapping for token limits to report “length” (improves OpenAI-compatible client behavior).
  * Improved streaming to only emit initial content when a valid text block is available, reducing empty or misleading first tokens.
* **Refactor**
  * Streamlined content handling for more predictable text vs. tool-call streaming without changing public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->