### PR TITLE
fix：Account Management Status

### DIFF
--- a/web/src/components/settings/personal/cards/AccountManagement.jsx
+++ b/web/src/components/settings/personal/cards/AccountManagement.jsx
@@ -165,9 +165,10 @@ const AccountManagement = ({
                         {t('微信')}
                       </div>
                       <div className='text-sm text-gray-500 truncate'>
-                        {userState.user && userState.user.wechat_id !== ''
-                          ? t('已绑定')
-                          : t('未绑定')}
+                        {renderAccountInfo(
+                          userState.user?.wechat_id,
+                          t('微信 ID'),
+                        )}
                       </div>
                     </div>
                   </div>
@@ -179,7 +180,7 @@ const AccountManagement = ({
                       disabled={!status.wechat_login}
                       onClick={() => setShowWeChatBindModal(true)}
                     >
-                      {userState.user && userState.user.wechat_id !== ''
+                      {userState.user && userState.user?.wechat_id
                         ? t('修改绑定')
                         : status.wechat_login
                           ? t('绑定')
@@ -298,7 +299,7 @@ const AccountManagement = ({
                   </div>
                   <div className='flex-shrink-0'>
                     {status.telegram_oauth ? (
-                      userState.user.telegram_id !== '' ? (
+                      userState.user?.telegram_id ? (
                         <Button disabled={true} size='small'>
                           {t('已绑定')}
                         </Button>


### PR DESCRIPTION
修复状态提示，避免出现未配置微信但显示已绑定状态

<img width="650" height="306" alt="image" src="https://github.com/user-attachments/assets/1bed1f50-9fa7-438d-80e6-d70b3f74d04d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WeChat and Telegram bindings now display the linked ID (truncated) with a hover label; shows “未绑定” when not linked.
* **Improvements**
  * Unified account binding display across services for a more consistent experience.
  * Clearer button labels that switch between “绑定”, “修改绑定”, and “未启用” based on status.
* **Bug Fixes**
  * Improved resilience to missing user data, reducing chances of display errors when account info hasn’t loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->