### PR TITLE
feat: add thousand separators to token display in dashboard

### DIFF
--- a/web/src/hooks/dashboard/useDashboardStats.jsx
+++ b/web/src/hooks/dashboard/useDashboardStats.jsx
@@ -102,7 +102,7 @@ export const useDashboardStats = (
           },
           {
             title: t('统计Tokens'),
-            value: isNaN(consumeTokens) ? 0 : consumeTokens,
+            value: isNaN(consumeTokens) ? 0 : consumeTokens.toLocaleString(),
             icon: <IconTextStroked />,
             avatarColor: 'pink',
             trendData: trendData.tokens,


### PR DESCRIPTION
<img width="322" height="167" alt="image" src="https://github.com/user-attachments/assets/30cb5982-419f-450c-a927-0ca6775cbbdc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved readability of the Dashboard’s Resource Usage stats. “Token Usage” values now use locale-aware formatting (e.g., 1,234,567) for clearer presentation across regions.
  * Non-numeric values are gracefully shown as 0 to avoid confusing displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->