### PR TITLE
即梦支持多图生视频

### DIFF
--- a/relay/channel/task/jimeng/adaptor.go
+++ b/relay/channel/task/jimeng/adaptor.go
@@ -318,11 +318,11 @@ func (a *TaskAdaptor) convertToRequestPayload(req *relaycommon.TaskSubmitReq) (*
 	}
 
 	// Handle one-of image_urls or binary_data_base64
-	if req.Image != "" {
-		if strings.HasPrefix(req.Image, "http") {
-			r.ImageUrls = []string{req.Image}
+	if req.HasImage() {
+		if strings.HasPrefix(req.Images[0], "http") {
+			r.ImageUrls = req.Images
 		} else {
-			r.BinaryDataBase64 = []string{req.Image}
+			r.BinaryDataBase64 = req.Images
 		}
 	}
 	metadata := req.Metadata

--- a/relay/channel/task/jimeng/adaptor.go
+++ b/relay/channel/task/jimeng/adaptor.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 
-	"one-api/common"
 	"one-api/constant"
 	"one-api/dto"
 	"one-api/relay/channel"
@@ -89,22 +88,7 @@ func (a *TaskAdaptor) Init(info *relaycommon.RelayInfo) {
 // ValidateRequestAndSetAction parses body, validates fields and sets default action.
 func (a *TaskAdaptor) ValidateRequestAndSetAction(c *gin.Context, info *relaycommon.RelayInfo) (taskErr *dto.TaskError) {
 	// Accept only POST /v1/video/generations as "generate" action.
-	action := constant.TaskActionGenerate
-	info.Action = action
-
-	req := relaycommon.TaskSubmitReq{}
-	if err := common.UnmarshalBodyReusable(c, &req); err != nil {
-		taskErr = service.TaskErrorWrapperLocal(err, "invalid_request", http.StatusBadRequest)
-		return
-	}
-	if strings.TrimSpace(req.Prompt) == "" {
-		taskErr = service.TaskErrorWrapperLocal(fmt.Errorf("prompt is required"), "invalid_request", http.StatusBadRequest)
-		return
-	}
-
-	// Store into context for later usage
-	c.Set("task_request", req)
-	return nil
+	return relaycommon.ValidateBasicTaskRequest(c, info, constant.TaskActionGenerate)
 }
 
 // BuildRequestURL constructs the upstream URL.

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -481,6 +481,7 @@ type TaskSubmitReq struct {
 	Model    string                 `json:"model,omitempty"`
 	Mode     string                 `json:"mode,omitempty"`
 	Image    string                 `json:"image,omitempty"`
+	Images   []string               `json:"images,omitempty"`
 	Size     string                 `json:"size,omitempty"`
 	Duration int                    `json:"duration,omitempty"`
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
@@ -490,8 +491,8 @@ func (t TaskSubmitReq) GetPrompt() string {
 	return t.Prompt
 }
 
-func (t TaskSubmitReq) GetImage() string {
-	return t.Image
+func (t TaskSubmitReq) HasImage() bool {
+	return len(t.Images) > 0
 }
 
 type TaskInfo struct {

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -486,6 +486,14 @@ type TaskSubmitReq struct {
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
+func (t TaskSubmitReq) GetPrompt() string {
+	return t.Prompt
+}
+
+func (t TaskSubmitReq) GetImage() string {
+	return t.Image
+}
+
 type TaskInfo struct {
 	Code     int    `json:"code"`
 	TaskID   string `json:"task_id"`

--- a/relay/common/relay_utils.go
+++ b/relay/common/relay_utils.go
@@ -2,11 +2,22 @@ package common
 
 import (
 	"fmt"
+	"net/http"
+	"one-api/common"
 	"one-api/constant"
+	"one-api/dto"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 )
+
+type HasPrompt interface {
+	GetPrompt() string
+}
+
+type HasImage interface {
+	GetImage() string
+}
 
 func GetFullRequestURL(baseURL string, requestURL string, channelType int) string {
 	fullRequestURL := fmt.Sprintf("%s%s", baseURL, requestURL)
@@ -29,4 +40,68 @@ func GetAPIVersion(c *gin.Context) string {
 		apiVersion = c.GetString("api_version")
 	}
 	return apiVersion
+}
+
+func createTaskError(err error, code string, statusCode int, localError bool) *dto.TaskError {
+	return &dto.TaskError{
+		Code:       code,
+		Message:    err.Error(),
+		StatusCode: statusCode,
+		LocalError: localError,
+		Error:      err,
+	}
+}
+
+func storeTaskRequest(c *gin.Context, info *RelayInfo, action string, requestObj interface{}) {
+	info.Action = action
+	c.Set("task_request", requestObj)
+}
+
+func validatePrompt(prompt string) *dto.TaskError {
+	if strings.TrimSpace(prompt) == "" {
+		return createTaskError(fmt.Errorf("prompt is required"), "invalid_request", http.StatusBadRequest, true)
+	}
+	return nil
+}
+
+func ValidateBasicTaskRequest(c *gin.Context, info *RelayInfo, action string) *dto.TaskError {
+	var req TaskSubmitReq
+	if err := common.UnmarshalBodyReusable(c, &req); err != nil {
+		return createTaskError(err, "invalid_request", http.StatusBadRequest, true)
+	}
+
+	if taskErr := validatePrompt(req.Prompt); taskErr != nil {
+		return taskErr
+	}
+
+	storeTaskRequest(c, info, action, req)
+	return nil
+}
+
+func ValidateTaskRequestWithImage(c *gin.Context, info *RelayInfo, requestObj interface{}) *dto.TaskError {
+	hasPrompt, ok := requestObj.(HasPrompt)
+	if !ok {
+		return createTaskError(fmt.Errorf("request must have prompt"), "invalid_request", http.StatusBadRequest, true)
+	}
+
+	if taskErr := validatePrompt(hasPrompt.GetPrompt()); taskErr != nil {
+		return taskErr
+	}
+
+	action := constant.TaskActionTextGenerate
+	if hasImage, ok := requestObj.(HasImage); ok && strings.TrimSpace(hasImage.GetImage()) != "" {
+		action = constant.TaskActionGenerate
+	}
+
+	storeTaskRequest(c, info, action, requestObj)
+	return nil
+}
+
+func ValidateTaskRequestWithImageBinding(c *gin.Context, info *RelayInfo) *dto.TaskError {
+	var req TaskSubmitReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		return createTaskError(err, "invalid_request_body", http.StatusBadRequest, false)
+	}
+
+	return ValidateTaskRequestWithImage(c, info, req)
 }

--- a/relay/common/relay_utils.go
+++ b/relay/common/relay_utils.go
@@ -16,7 +16,7 @@ type HasPrompt interface {
 }
 
 type HasImage interface {
-	GetImage() string
+	HasImage() bool
 }
 
 func GetFullRequestURL(baseURL string, requestURL string, channelType int) string {
@@ -74,6 +74,11 @@ func ValidateBasicTaskRequest(c *gin.Context, info *RelayInfo, action string) *d
 		return taskErr
 	}
 
+	if len(req.Images) == 0 && strings.TrimSpace(req.Image) != "" {
+		// 兼容单图上传
+		req.Images = []string{req.Image}
+	}
+
 	storeTaskRequest(c, info, action, req)
 	return nil
 }
@@ -89,7 +94,7 @@ func ValidateTaskRequestWithImage(c *gin.Context, info *RelayInfo, requestObj in
 	}
 
 	action := constant.TaskActionTextGenerate
-	if hasImage, ok := requestObj.(HasImage); ok && strings.TrimSpace(hasImage.GetImage()) != "" {
+	if hasImage, ok := requestObj.(HasImage); ok && hasImage.HasImage() {
 		action = constant.TaskActionGenerate
 	}
 


### PR DESCRIPTION
1. 视频统一taskSubmitReq请求参数
2. 增加images, 支持多图生视频

即梦多图请求示例:
`/v1/video/generations`
```
{
  "model": "jimeng_vgfm_t2v_l20",
  "prompt": "一个穿着宇航服的宇航员在月球上行走",
  "images": ["https://xxx1","https://xxx2"],
  "metadata": {
    "desc": "原厂字段"
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for submitting multiple images; single-image requests remain compatible.
  * Expanded Kling task options, including image tail, negative prompt, dynamic masks, and camera control.
* Bug Fixes
  * Correct routing for text-only tasks when no images are provided.
  * More consistent validation and clearer errors for missing prompts.
* Refactor
  * Unified request validation across task channels for consistent behavior.
  * Standardized defaults (e.g., mode, duration, model) and metadata merging across providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->