### PR TITLE
fix: VolcEngine渠道-图片生成 API-渠道测试报错

### DIFF
--- a/relay/channel/volcengine/adaptor.go
+++ b/relay/channel/volcengine/adaptor.go
@@ -41,6 +41,8 @@ func (a *Adaptor) ConvertAudioRequest(c *gin.Context, info *relaycommon.RelayInf
 
 func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.ImageRequest) (any, error) {
 	switch info.RelayMode {
+	case constant.RelayModeImagesGenerations:
+		return request, nil
 	case constant.RelayModeImagesEdits:
 
 		var requestBody bytes.Buffer

--- a/relay/channel/volcengine/constants.go
+++ b/relay/channel/volcengine/constants.go
@@ -8,6 +8,7 @@ var ModelList = []string{
 	"Doubao-lite-32k",
 	"Doubao-lite-4k",
 	"Doubao-embedding",
+	"doubao-seedream-4-0-250828",
 }
 
 var ChannelName = "volcengine"


### PR DESCRIPTION
## 例行检查
[//]: # (方框内删除已有的空格，填 x 号)
- [x] 我已确认目前没有类似 issue
- [x] 我已确认我已升级到最新版本
- [x] 我已完整查看过项目 README，尤其是常见问题部分
- [x] 我理解并愿意跟进此 issue，协助测试和提供反馈 
- [x] 我理解并认可上述内容，并理解项目维护者精力有限，**不遵循规则的 issue 可能会被无视或直接关闭**

## 问题描述
**VolcEngine渠道 图片生成 API（Seedream 4.0 API）渠道测试报错**

## 复现步骤
<img width="750" height="990" alt="image" src="https://github.com/user-attachments/assets/943ed87e-d5d3-420f-bff1-2df7d7f15a91" />
<img width="1920" height="952" alt="image" src="https://github.com/user-attachments/assets/975fca10-8a69-411b-956c-f9733aae64f2" />

**错误：The service encountered an unexpected internal error. Request id: 021758005348475c0aff847c202c3af808452f8823ee7ffd559cc**

返回值
```json
{
    "message": "The service encountered an unexpected internal error. Request id: 0217580045706792691491f6517da846ef8026349228d886e1346",
    "success": false,
    "time": 0
}
````
<img width="1920" height="926" alt="image" src="https://github.com/user-attachments/assets/1a25bc3a-7efb-4828-8550-449771382ac8" />

**错误：The service encountered an unexpected internal error. Request id: 021758005377607c0aff847c202c3af808452f8823ee7ffad2668** 

## 预期结果
- 调用该模型成功（修复前后均正常）
- 不指定模型测试成功（使用渠道配置的第一个模型）
- 指定模型测试成功

## 相关截图
**渠道测试成功**
<img width="1920" height="989" alt="image" src="https://github.com/user-attachments/assets/c088ce55-aa0f-43f6-8a63-2f2362141c80" />
<img width="1920" height="989" alt="image" src="https://github.com/user-attachments/assets/dd03d671-5601-4c03-9452-5c7a30e0d18f" />
**模型调用成功**
<img width="1392" height="926" alt="image" src="https://github.com/user-attachments/assets/afc424c5-18db-40c1-b972-c49dae8bdabc" />

## 改动影响面

✅无影响的功能
- **聊天模型**：继续使用 `/v1/chat/completions` 路径，完全不受影响
- **Embedding 模型**：继续使用 `/v1/embeddings` 路径，逻辑保持不变
- **其他渠道类型**：只有 VolcEngine 且包含 "seedream" 的模型才会触发新逻辑
- **VolcEngine 非图像模型**：如 Doubao-pro-128k 等聊天模型按原有逻辑处理

✅新增功能
- **VolcEngine 图像生成模型支持**：新增对 Seedream 系列模型的完整支持
- **智能模型识别**：系统能自动识别图像生成模型并使用正确的 API
- **优化的测试性能**：使用简短 prompt "cat" 提升测试速度

✅向后兼容性
- 所有现有 API 接口保持不变
- 现有测试用例不受影响
- 现有配置和数据完全兼容

## 注意事项
1. **模型识别**：只有模型名称包含 "seedream" 的才会被识别为图像生成模型
2. **渠道类型**：只有 VolcEngine 渠道类型才支持此功能
3. **API 兼容性**：完全兼容 OpenAI 图像生成 API 格式
4. **测试优化**：测试时使用简短 prompt 以提高速度，实际使用时可以使用复杂 prompt

## 参考文档
volcengine 图片生成 API（Seedream 4.0 API）
https://www.volcengine.com/docs/82379/1541523
https://www.volcengine.com/docs/82379/1330310


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for VolcEngine Seedream image generation with automatic routing to the correct endpoint.
  * Expanded request handling to support both image generation and embeddings, selecting the proper path automatically.
  * Applies a sensible default prompt for image generation when none is provided.
  * Added new supported model: "doubao-seedream-4-0-250828".

* **Bug Fixes**
  * Ensured updated request paths are reliably applied to outgoing HTTP requests for accurate routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->