### PR TITLE
新增 creem 支付

### DIFF
--- a/controller/misc.go
+++ b/controller/misc.go
@@ -74,6 +74,8 @@ func GetStatus(c *gin.Context) {
 		"default_collapse_sidebar": common.DefaultCollapseSidebar,
 		"enable_online_topup":      setting.PayAddress != "" && setting.EpayId != "" && setting.EpayKey != "",
 		"enable_stripe_topup":      setting.StripeApiSecret != "" && setting.StripeWebhookSecret != "" && setting.StripePriceId != "",
+		"enable_creem_topup":       setting.CreemApiKey != "" && setting.CreemProducts != "[]",
+		"creem_products":           setting.CreemProducts,
 		"mj_notify_enabled":        setting.MjNotifyEnabled,
 		"chats":                    setting.Chats,
 		"demo_site_enabled":        operation_setting.DemoSiteEnabled,

--- a/controller/topup_creem.go
+++ b/controller/topup_creem.go
@@ -2,6 +2,9 @@ package controller
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,10 +20,29 @@ import (
 )
 
 const (
-	PaymentMethodCreem = "creem"
+	PaymentMethodCreem   = "creem"
+	CreemSignatureHeader = "creem-signature"
 )
 
 var creemAdaptor = &CreemAdaptor{}
+
+// 生成HMAC-SHA256签名
+func generateCreemSignature(payload string, secret string) string {
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(payload))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// 验证Creem webhook签名
+func verifyCreemSignature(payload string, signature string, secret string) bool {
+	if secret == "" {
+		log.Printf("Creem webhook secret未配置，跳过签名验证")
+		return true // 如果没有配置secret，跳过验证
+	}
+
+	expectedSignature := generateCreemSignature(payload, secret)
+	return hmac.Equal([]byte(signature), []byte(expectedSignature))
+}
 
 type CreemPayRequest struct {
 	ProductId     string `json:"product_id"`
@@ -75,41 +97,65 @@ func (*CreemAdaptor) RequestPay(c *gin.Context, req *CreemPayRequest) {
 	id := c.GetInt("id")
 	user, _ := model.GetUserById(id, false)
 
+	// 生成唯一的订单引用ID
 	reference := fmt.Sprintf("creem-api-ref-%d-%d-%s", user.Id, time.Now().UnixMilli(), randstr.String(4))
 	referenceId := "ref_" + common.Sha1([]byte(reference))
 
-	checkoutUrl, err := genCreemLink(referenceId, selectedProduct, user.Email, user.Username)
-	if err != nil {
-		log.Println("获取Creem支付链接失败", err)
-		c.JSON(200, gin.H{"message": "error", "data": "拉起支付失败"})
-		return
-	}
-
+	// 先创建订单记录，使用产品配置的金额和充值额度
 	topUp := &model.TopUp{
 		UserId:     id,
-		Amount:     selectedProduct.Quota,
-		Money:      selectedProduct.Price,
+		Amount:     selectedProduct.Quota, // 充值额度
+		Money:      selectedProduct.Price, // 支付金额
 		TradeNo:    referenceId,
 		CreateTime: time.Now().Unix(),
 		Status:     common.TopUpStatusPending,
 	}
 	err = topUp.Insert()
 	if err != nil {
+		log.Printf("创建Creem订单失败: %v", err)
 		c.JSON(200, gin.H{"message": "error", "data": "创建订单失败"})
 		return
 	}
+
+	// 创建支付链接，传入用户邮箱
+	checkoutUrl, err := genCreemLink(referenceId, selectedProduct, user.Email, user.Username)
+	if err != nil {
+		log.Printf("获取Creem支付链接失败: %v", err)
+		c.JSON(200, gin.H{"message": "error", "data": "拉起支付失败"})
+		return
+	}
+
+	log.Printf("Creem订单创建成功 - 用户ID: %d, 订单号: %s, 产品: %s, 充值额度: %d, 支付金额: %.2f",
+		id, referenceId, selectedProduct.Name, selectedProduct.Quota, selectedProduct.Price)
 
 	c.JSON(200, gin.H{
 		"message": "success",
 		"data": gin.H{
 			"checkout_url": checkoutUrl,
+			"order_id":     referenceId,
 		},
 	})
 }
 
 func RequestCreemPay(c *gin.Context) {
 	var req CreemPayRequest
-	err := c.ShouldBindJSON(&req)
+
+	// 读取body内容用于打印，同时保留原始数据供后续使用
+	bodyBytes, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		log.Printf("读取请求body失败: %v", err)
+		c.JSON(200, gin.H{"message": "error", "data": "读取请求失败"})
+		return
+	}
+
+	// 打印body内容
+	log.Printf("creem pay request body: %s", string(bodyBytes))
+
+	// 重新设置body供后续的ShouldBindJSON使用
+	c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	err = c.ShouldBindJSON(&req)
+	log.Printf(" json body is %+v", req)
 	if err != nil {
 		c.JSON(200, gin.H{"message": "error", "data": "参数错误"})
 		return
@@ -117,6 +163,68 @@ func RequestCreemPay(c *gin.Context) {
 	creemAdaptor.RequestPay(c, &req)
 }
 
+// 新的Creem Webhook结构体，匹配实际的webhook数据格式
+type CreemWebhookEvent struct {
+	Id        string `json:"id"`
+	EventType string `json:"eventType"`
+	CreatedAt int64  `json:"created_at"`
+	Object    struct {
+		Id        string `json:"id"`
+		Object    string `json:"object"`
+		RequestId string `json:"request_id"`
+		Order     struct {
+			Object      string `json:"object"`
+			Id          string `json:"id"`
+			Customer    string `json:"customer"`
+			Product     string `json:"product"`
+			Amount      int    `json:"amount"`
+			Currency    string `json:"currency"`
+			SubTotal    int    `json:"sub_total"`
+			TaxAmount   int    `json:"tax_amount"`
+			AmountDue   int    `json:"amount_due"`
+			AmountPaid  int    `json:"amount_paid"`
+			Status      string `json:"status"`
+			Type        string `json:"type"`
+			Transaction string `json:"transaction"`
+			CreatedAt   string `json:"created_at"`
+			UpdatedAt   string `json:"updated_at"`
+			Mode        string `json:"mode"`
+		} `json:"order"`
+		Product struct {
+			Id                string  `json:"id"`
+			Object            string  `json:"object"`
+			Name              string  `json:"name"`
+			Description       string  `json:"description"`
+			Price             int     `json:"price"`
+			Currency          string  `json:"currency"`
+			BillingType       string  `json:"billing_type"`
+			BillingPeriod     string  `json:"billing_period"`
+			Status            string  `json:"status"`
+			TaxMode           string  `json:"tax_mode"`
+			TaxCategory       string  `json:"tax_category"`
+			DefaultSuccessUrl *string `json:"default_success_url"`
+			CreatedAt         string  `json:"created_at"`
+			UpdatedAt         string  `json:"updated_at"`
+			Mode              string  `json:"mode"`
+		} `json:"product"`
+		Units    int `json:"units"`
+		Customer struct {
+			Id        string `json:"id"`
+			Object    string `json:"object"`
+			Email     string `json:"email"`
+			Name      string `json:"name"`
+			Country   string `json:"country"`
+			CreatedAt string `json:"created_at"`
+			UpdatedAt string `json:"updated_at"`
+			Mode      string `json:"mode"`
+		} `json:"customer"`
+		Status   string            `json:"status"`
+		Metadata map[string]string `json:"metadata"`
+		Mode     string            `json:"mode"`
+	} `json:"object"`
+}
+
+// 保留旧的结构体作为兼容
 type CreemWebhookData struct {
 	Type string `json:"type"`
 	Data struct {
@@ -127,38 +235,122 @@ type CreemWebhookData struct {
 }
 
 func CreemWebhook(c *gin.Context) {
-	// 解析 webhook 数据
-	var webhookData CreemWebhookData
-	if err := c.ShouldBindJSON(&webhookData); err != nil {
-		log.Printf("解析Creem Webhook参数失败: %v\n", err)
+	// 读取body内容用于打印，同时保留原始数据供后续使用
+	bodyBytes, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		log.Printf("读取Creem Webhook请求body失败: %v", err)
 		c.AbortWithStatus(http.StatusBadRequest)
 		return
 	}
 
-	// 检查事件类型
-	if webhookData.Type != "checkout.completed" {
-		log.Printf("忽略Creem Webhook事件类型: %s", webhookData.Type)
+	// 获取签名头
+	signature := c.GetHeader(CreemSignatureHeader)
+
+	// 打印请求信息用于调试
+	log.Printf("Creem Webhook - URI: %s, Query: %s", c.Request.RequestURI, c.Request.URL.RawQuery)
+	log.Printf("Creem Webhook - Signature: %s", signature)
+	log.Printf("Creem Webhook - Body: %s", string(bodyBytes))
+
+	// 验证签名
+	if !verifyCreemSignature(string(bodyBytes), signature, setting.CreemWebhookSecret) {
+		log.Printf("Creem Webhook签名验证失败")
+		c.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+
+	log.Printf("Creem Webhook签名验证成功")
+
+	// 重新设置body供后续的ShouldBindJSON使用
+	c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	// 解析新格式的webhook数据
+	var webhookEvent CreemWebhookEvent
+	if err := c.ShouldBindJSON(&webhookEvent); err != nil {
+		log.Printf("解析Creem Webhook参数失败: %v", err)
+		c.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+
+	log.Printf("Creem Webhook解析成功 - EventType: %s, EventId: %s", webhookEvent.EventType, webhookEvent.Id)
+
+	// 根据事件类型处理不同的webhook
+	switch webhookEvent.EventType {
+	case "checkout.completed":
+		handleCheckoutCompleted(c, &webhookEvent)
+	default:
+		log.Printf("忽略Creem Webhook事件类型: %s", webhookEvent.EventType)
+		c.Status(http.StatusOK)
+	}
+}
+
+// 处理支付完成事件
+func handleCheckoutCompleted(c *gin.Context, event *CreemWebhookEvent) {
+	// 验证订单状态
+	if event.Object.Order.Status != "paid" {
+		log.Printf("订单状态不是已支付: %s, 跳过处理", event.Object.Order.Status)
 		c.Status(http.StatusOK)
 		return
 	}
 
-	// 获取引用ID
-	referenceId := webhookData.Data.RequestId
+	// 获取引用ID（这是我们创建订单时传递的request_id）
+	referenceId := event.Object.RequestId
 	if referenceId == "" {
 		log.Println("Creem Webhook缺少request_id字段")
 		c.AbortWithStatus(http.StatusBadRequest)
 		return
 	}
 
-	// 处理支付完成事件
-	err := model.RechargeCreem(referenceId)
+	// 验证订单类型，目前只处理一次性付款
+	if event.Object.Order.Type != "onetime" {
+		log.Printf("暂不支持的订单类型: %s, 跳过处理", event.Object.Order.Type)
+		c.Status(http.StatusOK)
+		return
+	}
+
+	// 记录详细的支付信息
+	log.Printf("处理Creem支付完成 - 订单号: %s, Creem订单ID: %s, 支付金额: %d %s, 客户邮箱: %s, 产品: %s",
+		referenceId,
+		event.Object.Order.Id,
+		event.Object.Order.AmountPaid,
+		event.Object.Order.Currency,
+		event.Object.Customer.Email,
+		event.Object.Product.Name)
+
+	// 查询本地订单确认存在
+	topUp := model.GetTopUpByTradeNo(referenceId)
+	if topUp == nil {
+		log.Printf("Creem充值订单不存在: %s", referenceId)
+		c.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+
+	if topUp.Status != common.TopUpStatusPending {
+		log.Printf("Creem充值订单状态错误: %s, 当前状态: %s", referenceId, topUp.Status)
+		c.Status(http.StatusOK) // 已处理过的订单，返回成功避免重复处理
+		return
+	}
+
+	// 处理充值，传入客户邮箱和姓名信息
+	customerEmail := event.Object.Customer.Email
+	customerName := event.Object.Customer.Name
+
+	// 防护性检查，确保邮箱和姓名不为空字符串
+	if customerEmail == "" {
+		log.Printf("警告：Creem回调中客户邮箱为空 - 订单号: %s", referenceId)
+	}
+	if customerName == "" {
+		log.Printf("警告：Creem回调中客户姓名为空 - 订单号: %s", referenceId)
+	}
+
+	err := model.RechargeCreem(referenceId, customerEmail, customerName)
 	if err != nil {
-		log.Println("Creem充值处理失败:", err.Error(), referenceId)
+		log.Printf("Creem充值处理失败: %s, 订单号: %s", err.Error(), referenceId)
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return
 	}
 
-	log.Printf("Creem充值成功: %s", referenceId)
+	log.Printf("Creem充值成功 - 订单号: %s, 充值额度: %d, 支付金额: %.2f, 客户邮箱: %s, 客户姓名: %s",
+		referenceId, topUp.Amount, topUp.Money, customerEmail, customerName)
 	c.Status(http.StatusOK)
 }
 
@@ -185,20 +377,23 @@ func genCreemLink(referenceId string, product *CreemProduct, email string, usern
 	apiUrl := "https://api.creem.io/v1/checkouts"
 	if setting.CreemTestMode {
 		apiUrl = "https://test-api.creem.io/v1/checkouts"
+		log.Printf("使用Creem测试环境: %s", apiUrl)
 	}
 
-	// 构建请求数据
+	// 构建请求数据，确保包含用户邮箱
 	requestData := CreemCheckoutRequest{
 		ProductId: product.ProductId,
-		RequestId: referenceId,
+		RequestId: referenceId, // 这个作为订单ID传递给Creem
 		Customer: struct {
 			Email string `json:"email"`
 		}{
-			Email: email,
+			Email: email, // 用户邮箱会在支付页面预填充
 		},
 		Metadata: map[string]string{
 			"username":     username,
 			"reference_id": referenceId,
+			"product_name": product.Name,
+			"quota":        fmt.Sprintf("%d", product.Quota),
 		},
 	}
 
@@ -218,6 +413,9 @@ func genCreemLink(referenceId string, product *CreemProduct, email string, usern
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-api-key", setting.CreemApiKey)
 
+	log.Printf("发送Creem支付请求 - URL: %s, 产品ID: %s, 用户邮箱: %s, 订单号: %s",
+		apiUrl, product.ProductId, email, referenceId)
+
 	// 发送请求
 	client := &http.Client{
 		Timeout: 30 * time.Second,
@@ -227,13 +425,14 @@ func genCreemLink(referenceId string, product *CreemProduct, email string, usern
 		return "", fmt.Errorf("发送HTTP请求失败: %v", err)
 	}
 	defer resp.Body.Close()
-	log.Printf(" creem req host: %s, key %s req 【%s】", apiUrl, setting.CreemApiKey, jsonData)
 
 	// 读取响应
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("读取响应失败: %v", err)
 	}
+
+	log.Printf("Creem API响应 - 状态码: %d, 响应体: %s", resp.StatusCode, string(body))
 
 	// 检查响应状态
 	if resp.StatusCode != http.StatusOK {
@@ -251,6 +450,6 @@ func genCreemLink(referenceId string, product *CreemProduct, email string, usern
 		return "", fmt.Errorf("Creem API 未返回支付链接")
 	}
 
-	log.Printf("Creem 支付链接创建成功: %s, 订单ID: %s", referenceId, checkoutResp.Id)
+	log.Printf("Creem 支付链接创建成功 - 订单号: %s, 支付链接: %s", referenceId, checkoutResp.CheckoutUrl)
 	return checkoutResp.CheckoutUrl, nil
 }

--- a/controller/topup_creem.go
+++ b/controller/topup_creem.go
@@ -1,0 +1,256 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"one-api/common"
+	"one-api/model"
+	"one-api/setting"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/thanhpk/randstr"
+)
+
+const (
+	PaymentMethodCreem = "creem"
+)
+
+var creemAdaptor = &CreemAdaptor{}
+
+type CreemPayRequest struct {
+	ProductId     string `json:"product_id"`
+	PaymentMethod string `json:"payment_method"`
+}
+
+type CreemProduct struct {
+	ProductId string  `json:"productId"`
+	Name      string  `json:"name"`
+	Price     float64 `json:"price"`
+	Currency  string  `json:"currency"`
+	Quota     int64   `json:"quota"`
+}
+
+type CreemAdaptor struct {
+}
+
+func (*CreemAdaptor) RequestPay(c *gin.Context, req *CreemPayRequest) {
+	if req.PaymentMethod != PaymentMethodCreem {
+		c.JSON(200, gin.H{"message": "error", "data": "不支持的支付渠道"})
+		return
+	}
+
+	if req.ProductId == "" {
+		c.JSON(200, gin.H{"message": "error", "data": "请选择产品"})
+		return
+	}
+
+	// 解析产品列表
+	var products []CreemProduct
+	err := json.Unmarshal([]byte(setting.CreemProducts), &products)
+	if err != nil {
+		log.Println("解析Creem产品列表失败", err)
+		c.JSON(200, gin.H{"message": "error", "data": "产品配置错误"})
+		return
+	}
+
+	// 查找对应的产品
+	var selectedProduct *CreemProduct
+	for _, product := range products {
+		if product.ProductId == req.ProductId {
+			selectedProduct = &product
+			break
+		}
+	}
+
+	if selectedProduct == nil {
+		c.JSON(200, gin.H{"message": "error", "data": "产品不存在"})
+		return
+	}
+
+	id := c.GetInt("id")
+	user, _ := model.GetUserById(id, false)
+
+	reference := fmt.Sprintf("creem-api-ref-%d-%d-%s", user.Id, time.Now().UnixMilli(), randstr.String(4))
+	referenceId := "ref_" + common.Sha1([]byte(reference))
+
+	checkoutUrl, err := genCreemLink(referenceId, selectedProduct, user.Email, user.Username)
+	if err != nil {
+		log.Println("获取Creem支付链接失败", err)
+		c.JSON(200, gin.H{"message": "error", "data": "拉起支付失败"})
+		return
+	}
+
+	topUp := &model.TopUp{
+		UserId:     id,
+		Amount:     selectedProduct.Quota,
+		Money:      selectedProduct.Price,
+		TradeNo:    referenceId,
+		CreateTime: time.Now().Unix(),
+		Status:     common.TopUpStatusPending,
+	}
+	err = topUp.Insert()
+	if err != nil {
+		c.JSON(200, gin.H{"message": "error", "data": "创建订单失败"})
+		return
+	}
+
+	c.JSON(200, gin.H{
+		"message": "success",
+		"data": gin.H{
+			"checkout_url": checkoutUrl,
+		},
+	})
+}
+
+func RequestCreemPay(c *gin.Context) {
+	var req CreemPayRequest
+	err := c.ShouldBindJSON(&req)
+	if err != nil {
+		c.JSON(200, gin.H{"message": "error", "data": "参数错误"})
+		return
+	}
+	creemAdaptor.RequestPay(c, &req)
+}
+
+type CreemWebhookData struct {
+	Type string `json:"type"`
+	Data struct {
+		RequestId string            `json:"request_id"`
+		Status    string            `json:"status"`
+		Metadata  map[string]string `json:"metadata"`
+	} `json:"data"`
+}
+
+func CreemWebhook(c *gin.Context) {
+	// 解析 webhook 数据
+	var webhookData CreemWebhookData
+	if err := c.ShouldBindJSON(&webhookData); err != nil {
+		log.Printf("解析Creem Webhook参数失败: %v\n", err)
+		c.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+
+	// 检查事件类型
+	if webhookData.Type != "checkout.completed" {
+		log.Printf("忽略Creem Webhook事件类型: %s", webhookData.Type)
+		c.Status(http.StatusOK)
+		return
+	}
+
+	// 获取引用ID
+	referenceId := webhookData.Data.RequestId
+	if referenceId == "" {
+		log.Println("Creem Webhook缺少request_id字段")
+		c.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+
+	// 处理支付完成事件
+	err := model.RechargeCreem(referenceId)
+	if err != nil {
+		log.Println("Creem充值处理失败:", err.Error(), referenceId)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Creem充值成功: %s", referenceId)
+	c.Status(http.StatusOK)
+}
+
+type CreemCheckoutRequest struct {
+	ProductId string `json:"product_id"`
+	RequestId string `json:"request_id"`
+	Customer  struct {
+		Email string `json:"email"`
+	} `json:"customer"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+type CreemCheckoutResponse struct {
+	CheckoutUrl string `json:"checkout_url"`
+	Id          string `json:"id"`
+}
+
+func genCreemLink(referenceId string, product *CreemProduct, email string, username string) (string, error) {
+	if setting.CreemApiKey == "" {
+		return "", fmt.Errorf("未配置Creem API密钥")
+	}
+
+	// 根据测试模式选择 API 端点
+	apiUrl := "https://api.creem.io/v1/checkouts"
+	if setting.CreemTestMode {
+		apiUrl = "https://test-api.creem.io/v1/checkouts"
+	}
+
+	// 构建请求数据
+	requestData := CreemCheckoutRequest{
+		ProductId: product.ProductId,
+		RequestId: referenceId,
+		Customer: struct {
+			Email string `json:"email"`
+		}{
+			Email: email,
+		},
+		Metadata: map[string]string{
+			"username":     username,
+			"reference_id": referenceId,
+		},
+	}
+
+	// 序列化请求数据
+	jsonData, err := json.Marshal(requestData)
+	if err != nil {
+		return "", fmt.Errorf("序列化请求数据失败: %v", err)
+	}
+
+	// 创建 HTTP 请求
+	req, err := http.NewRequest("POST", apiUrl, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("创建HTTP请求失败: %v", err)
+	}
+
+	// 设置请求头
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", setting.CreemApiKey)
+
+	// 发送请求
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("发送HTTP请求失败: %v", err)
+	}
+	defer resp.Body.Close()
+	log.Printf(" creem req host: %s, key %s req 【%s】", apiUrl, setting.CreemApiKey, jsonData)
+
+	// 读取响应
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("读取响应失败: %v", err)
+	}
+
+	// 检查响应状态
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Creem API 返回错误状态 %d: %s", resp.StatusCode, string(body))
+	}
+
+	// 解析响应
+	var checkoutResp CreemCheckoutResponse
+	err = json.Unmarshal(body, &checkoutResp)
+	if err != nil {
+		return "", fmt.Errorf("解析响应失败: %v", err)
+	}
+
+	if checkoutResp.CheckoutUrl == "" {
+		return "", fmt.Errorf("Creem API 未返回支付链接")
+	}
+
+	log.Printf("Creem 支付链接创建成功: %s, 订单ID: %s", referenceId, checkoutResp.Id)
+	return checkoutResp.CheckoutUrl, nil
+}

--- a/model/option.go
+++ b/model/option.go
@@ -84,6 +84,7 @@ func InitOptionMap() {
 	common.OptionMap["CreemApiKey"] = setting.CreemApiKey
 	common.OptionMap["CreemProducts"] = setting.CreemProducts
 	common.OptionMap["CreemTestMode"] = strconv.FormatBool(setting.CreemTestMode)
+	common.OptionMap["CreemWebhookSecret"] = setting.CreemWebhookSecret
 	common.OptionMap["TopupGroupRatio"] = common.TopupGroupRatio2JSONString()
 	common.OptionMap["Chats"] = setting.Chats2JsonString()
 	common.OptionMap["AutoGroups"] = setting.AutoGroups2JsonString()
@@ -335,6 +336,8 @@ func updateOptionMap(key string, value string) (err error) {
 		setting.CreemProducts = value
 	case "CreemTestMode":
 		setting.CreemTestMode = value == "true"
+	case "CreemWebhookSecret":
+		setting.CreemWebhookSecret = value
 	case "TopupGroupRatio":
 		err = common.UpdateTopupGroupRatioByJSONString(value)
 	case "GitHubClientId":

--- a/model/option.go
+++ b/model/option.go
@@ -81,6 +81,9 @@ func InitOptionMap() {
 	common.OptionMap["StripeWebhookSecret"] = setting.StripeWebhookSecret
 	common.OptionMap["StripePriceId"] = setting.StripePriceId
 	common.OptionMap["StripeUnitPrice"] = strconv.FormatFloat(setting.StripeUnitPrice, 'f', -1, 64)
+	common.OptionMap["CreemApiKey"] = setting.CreemApiKey
+	common.OptionMap["CreemProducts"] = setting.CreemProducts
+	common.OptionMap["CreemTestMode"] = strconv.FormatBool(setting.CreemTestMode)
 	common.OptionMap["TopupGroupRatio"] = common.TopupGroupRatio2JSONString()
 	common.OptionMap["Chats"] = setting.Chats2JsonString()
 	common.OptionMap["AutoGroups"] = setting.AutoGroups2JsonString()
@@ -326,6 +329,12 @@ func updateOptionMap(key string, value string) (err error) {
 		setting.StripeUnitPrice, _ = strconv.ParseFloat(value, 64)
 	case "StripeMinTopUp":
 		setting.StripeMinTopUp, _ = strconv.Atoi(value)
+	case "CreemApiKey":
+		setting.CreemApiKey = value
+	case "CreemProducts":
+		setting.CreemProducts = value
+	case "CreemTestMode":
+		setting.CreemTestMode = value == "true"
 	case "TopupGroupRatio":
 		err = common.UpdateTopupGroupRatioByJSONString(value)
 	case "GitHubClientId":

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -39,6 +39,7 @@ func SetApiRouter(router *gin.Engine) {
 		apiRouter.GET("/ratio_config", middleware.CriticalRateLimit(), controller.GetRatioConfig)
 
 		apiRouter.POST("/stripe/webhook", controller.StripeWebhook)
+		apiRouter.POST("/creem/webhook", controller.CreemWebhook)
 
 		userRoute := apiRouter.Group("/user")
 		{
@@ -64,6 +65,7 @@ func SetApiRouter(router *gin.Engine) {
 				selfRoute.POST("/amount", controller.RequestAmount)
 				selfRoute.POST("/stripe/pay", middleware.CriticalRateLimit(), controller.RequestStripePay)
 				selfRoute.POST("/stripe/amount", controller.RequestStripeAmount)
+				selfRoute.POST("/creem/pay", middleware.CriticalRateLimit(), controller.RequestCreemPay)
 				selfRoute.POST("/aff_transfer", controller.TransferAffQuota)
 				selfRoute.PUT("/setting", controller.UpdateUserSetting)
 			}

--- a/setting/payment_creem.go
+++ b/setting/payment_creem.go
@@ -1,0 +1,5 @@
+package setting
+
+var CreemApiKey = ""
+var CreemProducts = "[]"
+var CreemTestMode = false

--- a/setting/payment_creem.go
+++ b/setting/payment_creem.go
@@ -3,3 +3,4 @@ package setting
 var CreemApiKey = ""
 var CreemProducts = "[]"
 var CreemTestMode = false
+var CreemWebhookSecret = ""

--- a/web/src/components/settings/PaymentSetting.js
+++ b/web/src/components/settings/PaymentSetting.js
@@ -28,6 +28,7 @@ const PaymentSetting = () => {
     StripeMinTopUp: 1,
 
     CreemApiKey: '',
+    CreemWebhookSecret: '',
     CreemProducts: '[]',
   });
 

--- a/web/src/components/settings/PaymentSetting.js
+++ b/web/src/components/settings/PaymentSetting.js
@@ -3,8 +3,10 @@ import { Card, Spin } from '@douyinfe/semi-ui';
 import SettingsGeneralPayment from '../../pages/Setting/Payment/SettingsGeneralPayment.js';
 import SettingsPaymentGateway from '../../pages/Setting/Payment/SettingsPaymentGateway.js';
 import SettingsPaymentGatewayStripe from '../../pages/Setting/Payment/SettingsPaymentGatewayStripe.js';
+import SettingsPaymentGatewayCreem from '../../pages/Setting/Payment/SettingsPaymentGatewayCreem.js';
 import { API, showError, toBoolean } from '../../helpers';
 import { useTranslation } from 'react-i18next';
+
 
 const PaymentSetting = () => {
   const { t } = useTranslation();
@@ -24,6 +26,9 @@ const PaymentSetting = () => {
     StripePriceId: '',
     StripeUnitPrice: 8.0,
     StripeMinTopUp: 1,
+
+    CreemApiKey: '',
+    CreemProducts: '[]',
   });
 
   let [loading, setLoading] = useState(false);
@@ -41,6 +46,14 @@ const PaymentSetting = () => {
             } catch (error) {
               console.error('解析TopupGroupRatio出错:', error);
               newInputs[item.key] = item.value;
+            }
+            break;
+          case 'CreemProducts':
+            try {
+              newInputs[item.key] = item.value;
+            } catch (error) {
+              console.error('解析CreemProducts出错:', error);
+              newInputs[item.key] = '[]';
             }
             break;
           case 'Price':
@@ -91,6 +104,9 @@ const PaymentSetting = () => {
         </Card>
         <Card style={{ marginTop: '10px' }}>
           <SettingsPaymentGatewayStripe options={inputs} refresh={onRefresh} />
+        </Card>
+        <Card style={{ marginTop: '10px' }}>
+          <SettingsPaymentGatewayCreem options={inputs} refresh={onRefresh} />
         </Card>
       </Spin>
     </>

--- a/web/src/pages/Setting/Payment/SettingsPaymentGatewayCreem.js
+++ b/web/src/pages/Setting/Payment/SettingsPaymentGatewayCreem.js
@@ -1,0 +1,373 @@
+import React, { useEffect, useState, useRef } from 'react';
+import {
+  Banner,
+  Button,
+  Form,
+  Row,
+  Col,
+  Typography,
+  Spin,
+  Table,
+  Modal,
+  Input,
+  InputNumber,
+  Select,
+} from '@douyinfe/semi-ui';
+const { Text } = Typography;
+import {
+  API,
+  showError,
+  showSuccess,
+} from '../../../helpers';
+import { useTranslation } from 'react-i18next';
+import { Plus, Trash2 } from 'lucide-react';
+
+export default function SettingsPaymentGatewayCreem(props) {
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState(false);
+  const [inputs, setInputs] = useState({
+    CreemApiKey: '',
+    CreemProducts: '[]',
+    CreemTestMode: false,
+  });
+  const [originInputs, setOriginInputs] = useState({});
+  const [products, setProducts] = useState([]);
+  const [showProductModal, setShowProductModal] = useState(false);
+  const [editingProduct, setEditingProduct] = useState(null);
+  const [productForm, setProductForm] = useState({
+    name: '',
+    productId: '',
+    price: 0,
+    quota: 0,
+    currency: 'USD',
+  });
+  const formApiRef = useRef(null);
+
+  useEffect(() => {
+    if (props.options && formApiRef.current) {
+      const currentInputs = {
+        CreemApiKey: props.options.CreemApiKey || '',
+        CreemProducts: props.options.CreemProducts || '[]',
+        CreemTestMode: props.options.CreemTestMode === 'true',
+      };
+      setInputs(currentInputs);
+      setOriginInputs({ ...currentInputs });
+      formApiRef.current.setValues(currentInputs);
+      
+      // Parse products
+      try {
+        const parsedProducts = JSON.parse(currentInputs.CreemProducts);
+        setProducts(parsedProducts);
+      } catch (e) {
+        setProducts([]);
+      }
+    }
+  }, [props.options]);
+
+  const handleFormChange = (values) => {
+    setInputs(values);
+  };
+
+  const submitCreemSetting = async () => {
+    setLoading(true);
+    try {
+      const options = [];
+
+      if (inputs.CreemApiKey && inputs.CreemApiKey !== '') {
+        options.push({ key: 'CreemApiKey', value: inputs.CreemApiKey });
+      }
+      
+      // Save test mode setting
+      options.push({ key: 'CreemTestMode', value: inputs.CreemTestMode ? 'true' : 'false' });
+      
+      // Save products as JSON string
+      options.push({ key: 'CreemProducts', value: JSON.stringify(products) });
+
+      // 发送请求
+      const requestQueue = options.map(opt =>
+        API.put('/api/option/', {
+          key: opt.key,
+          value: opt.value,
+        })
+      );
+
+      const results = await Promise.all(requestQueue);
+
+      // 检查所有请求是否成功
+      const errorResults = results.filter(res => !res.data.success);
+      if (errorResults.length > 0) {
+        errorResults.forEach(res => {
+          showError(res.data.message);
+        });
+      } else {
+        showSuccess(t('更新成功'));
+        // 更新本地存储的原始值
+        setOriginInputs({ ...inputs });
+        props.refresh?.();
+      }
+    } catch (error) {
+      showError(t('更新失败'));
+    }
+    setLoading(false);
+  };
+
+  const openProductModal = (product = null) => {
+    if (product) {
+      setEditingProduct(product);
+      setProductForm({ ...product });
+    } else {
+      setEditingProduct(null);
+      setProductForm({
+        name: '',
+        productId: '',
+        price: 0,
+        quota: 0,
+        currency: 'USD',
+      });
+    }
+    setShowProductModal(true);
+  };
+
+  const closeProductModal = () => {
+    setShowProductModal(false);
+    setEditingProduct(null);
+    setProductForm({
+      name: '',
+      productId: '',
+      price: 0,
+      quota: 0,
+      currency: 'USD',
+    });
+  };
+
+  const saveProduct = () => {
+    if (!productForm.name || !productForm.productId || productForm.price <= 0 || productForm.quota <= 0 || !productForm.currency) {
+      showError(t('请填写完整的产品信息'));
+      return;
+    }
+
+    let newProducts = [...products];
+    if (editingProduct) {
+      // 编辑现有产品
+      const index = newProducts.findIndex(p => p.productId === editingProduct.productId);
+      if (index !== -1) {
+        newProducts[index] = { ...productForm };
+      }
+    } else {
+      // 添加新产品
+      if (newProducts.find(p => p.productId === productForm.productId)) {
+        showError(t('产品ID已存在'));
+        return;
+      }
+      newProducts.push({ ...productForm });
+    }
+
+    setProducts(newProducts);
+    closeProductModal();
+  };
+
+  const deleteProduct = (productId) => {
+    const newProducts = products.filter(p => p.productId !== productId);
+    setProducts(newProducts);
+  };
+
+  const columns = [
+    {
+      title: t('产品名称'),
+      dataIndex: 'name',
+      key: 'name',
+    },
+    {
+      title: t('产品ID'),
+      dataIndex: 'productId',
+      key: 'productId',
+    },
+    {
+      title: t('价格'),
+      dataIndex: 'price',
+      key: 'price',
+      render: (price, record) => `${record.currency === 'EUR' ? '€' : '$'}${price}`,
+    },
+    {
+      title: t('充值额度'),
+      dataIndex: 'quota',
+      key: 'quota',
+    },
+    {
+      title: t('操作'),
+      key: 'action',
+      render: (_, record) => (
+        <div className='flex gap-2'>
+          <Button
+            type='tertiary'
+            size='small'
+            onClick={() => openProductModal(record)}
+          >
+            {t('编辑')}
+          </Button>
+          <Button
+            type='danger'
+            theme='borderless'
+            size='small'
+            icon={<Trash2 size={14} />}
+            onClick={() => deleteProduct(record.productId)}
+          />
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <Spin spinning={loading}>
+      <Form
+        initValues={inputs}
+        onValueChange={handleFormChange}
+        getFormApi={(api) => (formApiRef.current = api)}
+      >
+        <Form.Section text={t('Creem 设置')}>
+          <Text>
+            Creem 是一个简单的支付处理平台，支持固定金额的产品销售。请在
+            <a
+              href='https://creem.io'
+              target='_blank'
+              rel='noreferrer'
+            >
+              Creem 官网
+            </a>
+            创建账户并获取 API 密钥。
+            <br />
+          </Text>
+          <Banner
+            type='info'
+            description={t('Creem 只支持预设的固定金额产品，不支持自定义金额充值')}
+          />
+          
+          <Row gutter={{ xs: 8, sm: 16, md: 24, lg: 24, xl: 24, xxl: 24 }}>
+            <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+              <Form.Input
+                field='CreemApiKey'
+                label={t('API 密钥')}
+                placeholder={t('creem_xxx 的 Creem API 密钥，敏感信息不显示')}
+                type='password'
+              />
+            </Col>
+            <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+              <Form.Switch
+                field='CreemTestMode'
+                label={t('测试模式')}
+                extraText={t('启用后将使用 Creem 测试环境，可使用测试卡号 4242 4242 4242 4242 进行测试')}
+              />
+            </Col>
+          </Row>
+
+          <div style={{ marginTop: 24 }}>
+            <div className='flex justify-between items-center mb-4'>
+              <Text strong>{t('产品配置')}</Text>
+              <Button
+                type='primary'
+                icon={<Plus size={16} />}
+                onClick={() => openProductModal()}
+              >
+                {t('添加产品')}
+              </Button>
+            </div>
+            
+            <Table
+              columns={columns}
+              dataSource={products}
+              pagination={false}
+              empty={
+                <div className='text-center py-8'>
+                  <Text type='tertiary'>{t('暂无产品配置')}</Text>
+                </div>
+              }
+            />
+          </div>
+
+          <Button onClick={submitCreemSetting} style={{ marginTop: 16 }}>
+            {t('更新 Creem 设置')}
+          </Button>
+        </Form.Section>
+      </Form>
+
+      {/* 产品配置模态框 */}
+      <Modal
+        title={editingProduct ? t('编辑产品') : t('添加产品')}
+        visible={showProductModal}
+        onOk={saveProduct}
+        onCancel={closeProductModal}
+        maskClosable={false}
+        size='small'
+        centered
+      >
+        <div className='space-y-4'>
+          <div>
+            <Text strong className='block mb-2'>
+              {t('产品名称')}
+            </Text>
+            <Input
+              value={productForm.name}
+              onChange={(value) => setProductForm({ ...productForm, name: value })}
+              placeholder={t('例如：基础套餐')}
+              size='large'
+            />
+          </div>
+          <div>
+            <Text strong className='block mb-2'>
+              {t('产品ID')}
+            </Text>
+            <Input
+              value={productForm.productId}
+              onChange={(value) => setProductForm({ ...productForm, productId: value })}
+              placeholder={t('例如：prod_6I8rBerHpPxyoiU9WK4kot')}
+              size='large'
+              disabled={!!editingProduct}
+            />
+          </div>
+          <div>
+            <Text strong className='block mb-2'>
+              {t('货币')}
+            </Text>
+            <Select
+              value={productForm.currency}
+              onChange={(value) => setProductForm({ ...productForm, currency: value })}
+              size='large'
+              className='w-full'
+            >
+              <Select.Option value='USD'>USD (美元)</Select.Option>
+              <Select.Option value='EUR'>EUR (欧元)</Select.Option>
+            </Select>
+          </div>
+          <div>
+            <Text strong className='block mb-2'>
+              {t('价格')} ({productForm.currency === 'EUR' ? '欧元' : '美元'})
+            </Text>
+            <InputNumber
+              value={productForm.price}
+              onChange={(value) => setProductForm({ ...productForm, price: value })}
+              placeholder={t('例如：4.99')}
+              min={0.01}
+              precision={2}
+              size='large'
+              className='w-full'
+            />
+          </div>
+          <div>
+            <Text strong className='block mb-2'>
+              {t('充值额度')}
+            </Text>
+            <InputNumber
+              value={productForm.quota}
+              onChange={(value) => setProductForm({ ...productForm, quota: value })}
+              placeholder={t('例如：100000')}
+              min={1}
+              precision={0}
+              size='large'
+              className='w-full'
+            />
+          </div>
+        </div>
+      </Modal>
+    </Spin>
+  );
+}

--- a/web/src/pages/Setting/Payment/SettingsPaymentGatewayCreem.js
+++ b/web/src/pages/Setting/Payment/SettingsPaymentGatewayCreem.js
@@ -1,373 +1,387 @@
 import React, { useEffect, useState, useRef } from 'react';
 import {
-  Banner,
-  Button,
-  Form,
-  Row,
-  Col,
-  Typography,
-  Spin,
-  Table,
-  Modal,
-  Input,
-  InputNumber,
-  Select,
+    Banner,
+    Button,
+    Form,
+    Row,
+    Col,
+    Typography,
+    Spin,
+    Table,
+    Modal,
+    Input,
+    InputNumber,
+    Select,
 } from '@douyinfe/semi-ui';
 const { Text } = Typography;
 import {
-  API,
-  showError,
-  showSuccess,
+    API,
+    showError,
+    showSuccess,
 } from '../../../helpers';
 import { useTranslation } from 'react-i18next';
 import { Plus, Trash2 } from 'lucide-react';
 
 export default function SettingsPaymentGatewayCreem(props) {
-  const { t } = useTranslation();
-  const [loading, setLoading] = useState(false);
-  const [inputs, setInputs] = useState({
-    CreemApiKey: '',
-    CreemProducts: '[]',
-    CreemTestMode: false,
-  });
-  const [originInputs, setOriginInputs] = useState({});
-  const [products, setProducts] = useState([]);
-  const [showProductModal, setShowProductModal] = useState(false);
-  const [editingProduct, setEditingProduct] = useState(null);
-  const [productForm, setProductForm] = useState({
-    name: '',
-    productId: '',
-    price: 0,
-    quota: 0,
-    currency: 'USD',
-  });
-  const formApiRef = useRef(null);
-
-  useEffect(() => {
-    if (props.options && formApiRef.current) {
-      const currentInputs = {
-        CreemApiKey: props.options.CreemApiKey || '',
-        CreemProducts: props.options.CreemProducts || '[]',
-        CreemTestMode: props.options.CreemTestMode === 'true',
-      };
-      setInputs(currentInputs);
-      setOriginInputs({ ...currentInputs });
-      formApiRef.current.setValues(currentInputs);
-      
-      // Parse products
-      try {
-        const parsedProducts = JSON.parse(currentInputs.CreemProducts);
-        setProducts(parsedProducts);
-      } catch (e) {
-        setProducts([]);
-      }
-    }
-  }, [props.options]);
-
-  const handleFormChange = (values) => {
-    setInputs(values);
-  };
-
-  const submitCreemSetting = async () => {
-    setLoading(true);
-    try {
-      const options = [];
-
-      if (inputs.CreemApiKey && inputs.CreemApiKey !== '') {
-        options.push({ key: 'CreemApiKey', value: inputs.CreemApiKey });
-      }
-      
-      // Save test mode setting
-      options.push({ key: 'CreemTestMode', value: inputs.CreemTestMode ? 'true' : 'false' });
-      
-      // Save products as JSON string
-      options.push({ key: 'CreemProducts', value: JSON.stringify(products) });
-
-      // 发送请求
-      const requestQueue = options.map(opt =>
-        API.put('/api/option/', {
-          key: opt.key,
-          value: opt.value,
-        })
-      );
-
-      const results = await Promise.all(requestQueue);
-
-      // 检查所有请求是否成功
-      const errorResults = results.filter(res => !res.data.success);
-      if (errorResults.length > 0) {
-        errorResults.forEach(res => {
-          showError(res.data.message);
-        });
-      } else {
-        showSuccess(t('更新成功'));
-        // 更新本地存储的原始值
-        setOriginInputs({ ...inputs });
-        props.refresh?.();
-      }
-    } catch (error) {
-      showError(t('更新失败'));
-    }
-    setLoading(false);
-  };
-
-  const openProductModal = (product = null) => {
-    if (product) {
-      setEditingProduct(product);
-      setProductForm({ ...product });
-    } else {
-      setEditingProduct(null);
-      setProductForm({
+    const { t } = useTranslation();
+    const [loading, setLoading] = useState(false);
+    const [inputs, setInputs] = useState({
+        CreemApiKey: '',
+        CreemWebhookSecret: '',
+        CreemProducts: '[]',
+        CreemTestMode: false,
+    });
+    const [originInputs, setOriginInputs] = useState({});
+    const [products, setProducts] = useState([]);
+    const [showProductModal, setShowProductModal] = useState(false);
+    const [editingProduct, setEditingProduct] = useState(null);
+    const [productForm, setProductForm] = useState({
         name: '',
         productId: '',
         price: 0,
         quota: 0,
         currency: 'USD',
-      });
-    }
-    setShowProductModal(true);
-  };
-
-  const closeProductModal = () => {
-    setShowProductModal(false);
-    setEditingProduct(null);
-    setProductForm({
-      name: '',
-      productId: '',
-      price: 0,
-      quota: 0,
-      currency: 'USD',
     });
-  };
+    const formApiRef = useRef(null);
 
-  const saveProduct = () => {
-    if (!productForm.name || !productForm.productId || productForm.price <= 0 || productForm.quota <= 0 || !productForm.currency) {
-      showError(t('请填写完整的产品信息'));
-      return;
-    }
+    useEffect(() => {
+        if (props.options && formApiRef.current) {
+            const currentInputs = {
+                CreemApiKey: props.options.CreemApiKey || '',
+                CreemWebhookSecret: props.options.CreemWebhookSecret || '',
+                CreemProducts: props.options.CreemProducts || '[]',
+                CreemTestMode: props.options.CreemTestMode === 'true',
+            };
+            setInputs(currentInputs);
+            setOriginInputs({ ...currentInputs });
+            formApiRef.current.setValues(currentInputs);
 
-    let newProducts = [...products];
-    if (editingProduct) {
-      // 编辑现有产品
-      const index = newProducts.findIndex(p => p.productId === editingProduct.productId);
-      if (index !== -1) {
-        newProducts[index] = { ...productForm };
-      }
-    } else {
-      // 添加新产品
-      if (newProducts.find(p => p.productId === productForm.productId)) {
-        showError(t('产品ID已存在'));
-        return;
-      }
-      newProducts.push({ ...productForm });
-    }
+            // Parse products
+            try {
+                const parsedProducts = JSON.parse(currentInputs.CreemProducts);
+                setProducts(parsedProducts);
+            } catch (e) {
+                setProducts([]);
+            }
+        }
+    }, [props.options]);
 
-    setProducts(newProducts);
-    closeProductModal();
-  };
+    const handleFormChange = (values) => {
+        setInputs(values);
+    };
 
-  const deleteProduct = (productId) => {
-    const newProducts = products.filter(p => p.productId !== productId);
-    setProducts(newProducts);
-  };
+    const submitCreemSetting = async () => {
+        setLoading(true);
+        try {
+            const options = [];
 
-  const columns = [
-    {
-      title: t('产品名称'),
-      dataIndex: 'name',
-      key: 'name',
-    },
-    {
-      title: t('产品ID'),
-      dataIndex: 'productId',
-      key: 'productId',
-    },
-    {
-      title: t('价格'),
-      dataIndex: 'price',
-      key: 'price',
-      render: (price, record) => `${record.currency === 'EUR' ? '€' : '$'}${price}`,
-    },
-    {
-      title: t('充值额度'),
-      dataIndex: 'quota',
-      key: 'quota',
-    },
-    {
-      title: t('操作'),
-      key: 'action',
-      render: (_, record) => (
-        <div className='flex gap-2'>
-          <Button
-            type='tertiary'
-            size='small'
-            onClick={() => openProductModal(record)}
-          >
-            {t('编辑')}
-          </Button>
-          <Button
-            type='danger'
-            theme='borderless'
-            size='small'
-            icon={<Trash2 size={14} />}
-            onClick={() => deleteProduct(record.productId)}
-          />
-        </div>
-      ),
-    },
-  ];
+            if (inputs.CreemApiKey && inputs.CreemApiKey !== '') {
+                options.push({ key: 'CreemApiKey', value: inputs.CreemApiKey });
+            }
 
-  return (
-    <Spin spinning={loading}>
-      <Form
-        initValues={inputs}
-        onValueChange={handleFormChange}
-        getFormApi={(api) => (formApiRef.current = api)}
-      >
-        <Form.Section text={t('Creem 设置')}>
-          <Text>
-            Creem 是一个简单的支付处理平台，支持固定金额的产品销售。请在
-            <a
-              href='https://creem.io'
-              target='_blank'
-              rel='noreferrer'
-            >
-              Creem 官网
-            </a>
-            创建账户并获取 API 密钥。
-            <br />
-          </Text>
-          <Banner
-            type='info'
-            description={t('Creem 只支持预设的固定金额产品，不支持自定义金额充值')}
-          />
-          
-          <Row gutter={{ xs: 8, sm: 16, md: 24, lg: 24, xl: 24, xxl: 24 }}>
-            <Col xs={24} sm={24} md={12} lg={12} xl={12}>
-              <Form.Input
-                field='CreemApiKey'
-                label={t('API 密钥')}
-                placeholder={t('creem_xxx 的 Creem API 密钥，敏感信息不显示')}
-                type='password'
-              />
-            </Col>
-            <Col xs={24} sm={24} md={12} lg={12} xl={12}>
-              <Form.Switch
-                field='CreemTestMode'
-                label={t('测试模式')}
-                extraText={t('启用后将使用 Creem 测试环境，可使用测试卡号 4242 4242 4242 4242 进行测试')}
-              />
-            </Col>
-          </Row>
+            if (inputs.CreemWebhookSecret && inputs.CreemWebhookSecret !== '') {
+                options.push({ key: 'CreemWebhookSecret', value: inputs.CreemWebhookSecret });
+            }
 
-          <div style={{ marginTop: 24 }}>
-            <div className='flex justify-between items-center mb-4'>
-              <Text strong>{t('产品配置')}</Text>
-              <Button
-                type='primary'
-                icon={<Plus size={16} />}
-                onClick={() => openProductModal()}
-              >
-                {t('添加产品')}
-              </Button>
-            </div>
-            
-            <Table
-              columns={columns}
-              dataSource={products}
-              pagination={false}
-              empty={
-                <div className='text-center py-8'>
-                  <Text type='tertiary'>{t('暂无产品配置')}</Text>
+            // Save test mode setting
+            options.push({ key: 'CreemTestMode', value: inputs.CreemTestMode ? 'true' : 'false' });
+
+            // Save products as JSON string
+            options.push({ key: 'CreemProducts', value: JSON.stringify(products) });
+
+            // 发送请求
+            const requestQueue = options.map(opt =>
+                API.put('/api/option/', {
+                    key: opt.key,
+                    value: opt.value,
+                })
+            );
+
+            const results = await Promise.all(requestQueue);
+
+            // 检查所有请求是否成功
+            const errorResults = results.filter(res => !res.data.success);
+            if (errorResults.length > 0) {
+                errorResults.forEach(res => {
+                    showError(res.data.message);
+                });
+            } else {
+                showSuccess(t('更新成功'));
+                // 更新本地存储的原始值
+                setOriginInputs({ ...inputs });
+                props.refresh?.();
+            }
+        } catch (error) {
+            showError(t('更新失败'));
+        }
+        setLoading(false);
+    };
+
+    const openProductModal = (product = null) => {
+        if (product) {
+            setEditingProduct(product);
+            setProductForm({ ...product });
+        } else {
+            setEditingProduct(null);
+            setProductForm({
+                name: '',
+                productId: '',
+                price: 0,
+                quota: 0,
+                currency: 'USD',
+            });
+        }
+        setShowProductModal(true);
+    };
+
+    const closeProductModal = () => {
+        setShowProductModal(false);
+        setEditingProduct(null);
+        setProductForm({
+            name: '',
+            productId: '',
+            price: 0,
+            quota: 0,
+            currency: 'USD',
+        });
+    };
+
+    const saveProduct = () => {
+        if (!productForm.name || !productForm.productId || productForm.price <= 0 || productForm.quota <= 0 || !productForm.currency) {
+            showError(t('请填写完整的产品信息'));
+            return;
+        }
+
+        let newProducts = [...products];
+        if (editingProduct) {
+            // 编辑现有产品
+            const index = newProducts.findIndex(p => p.productId === editingProduct.productId);
+            if (index !== -1) {
+                newProducts[index] = { ...productForm };
+            }
+        } else {
+            // 添加新产品
+            if (newProducts.find(p => p.productId === productForm.productId)) {
+                showError(t('产品ID已存在'));
+                return;
+            }
+            newProducts.push({ ...productForm });
+        }
+
+        setProducts(newProducts);
+        closeProductModal();
+    };
+
+    const deleteProduct = (productId) => {
+        const newProducts = products.filter(p => p.productId !== productId);
+        setProducts(newProducts);
+    };
+
+    const columns = [
+        {
+            title: t('产品名称'),
+            dataIndex: 'name',
+            key: 'name',
+        },
+        {
+            title: t('产品ID'),
+            dataIndex: 'productId',
+            key: 'productId',
+        },
+        {
+            title: t('价格'),
+            dataIndex: 'price',
+            key: 'price',
+            render: (price, record) => `${record.currency === 'EUR' ? '€' : '$'}${price}`,
+        },
+        {
+            title: t('充值额度'),
+            dataIndex: 'quota',
+            key: 'quota',
+        },
+        {
+            title: t('操作'),
+            key: 'action',
+            render: (_, record) => (
+                <div className='flex gap-2'>
+                    <Button
+                        type='tertiary'
+                        size='small'
+                        onClick={() => openProductModal(record)}
+                    >
+                        {t('编辑')}
+                    </Button>
+                    <Button
+                        type='danger'
+                        theme='borderless'
+                        size='small'
+                        icon={<Trash2 size={14} />}
+                        onClick={() => deleteProduct(record.productId)}
+                    />
                 </div>
-              }
-            />
-          </div>
+            ),
+        },
+    ];
 
-          <Button onClick={submitCreemSetting} style={{ marginTop: 16 }}>
-            {t('更新 Creem 设置')}
-          </Button>
-        </Form.Section>
-      </Form>
-
-      {/* 产品配置模态框 */}
-      <Modal
-        title={editingProduct ? t('编辑产品') : t('添加产品')}
-        visible={showProductModal}
-        onOk={saveProduct}
-        onCancel={closeProductModal}
-        maskClosable={false}
-        size='small'
-        centered
-      >
-        <div className='space-y-4'>
-          <div>
-            <Text strong className='block mb-2'>
-              {t('产品名称')}
-            </Text>
-            <Input
-              value={productForm.name}
-              onChange={(value) => setProductForm({ ...productForm, name: value })}
-              placeholder={t('例如：基础套餐')}
-              size='large'
-            />
-          </div>
-          <div>
-            <Text strong className='block mb-2'>
-              {t('产品ID')}
-            </Text>
-            <Input
-              value={productForm.productId}
-              onChange={(value) => setProductForm({ ...productForm, productId: value })}
-              placeholder={t('例如：prod_6I8rBerHpPxyoiU9WK4kot')}
-              size='large'
-              disabled={!!editingProduct}
-            />
-          </div>
-          <div>
-            <Text strong className='block mb-2'>
-              {t('货币')}
-            </Text>
-            <Select
-              value={productForm.currency}
-              onChange={(value) => setProductForm({ ...productForm, currency: value })}
-              size='large'
-              className='w-full'
+    return (
+        <Spin spinning={loading}>
+            <Form
+                initValues={inputs}
+                onValueChange={handleFormChange}
+                getFormApi={(api) => (formApiRef.current = api)}
             >
-              <Select.Option value='USD'>USD (美元)</Select.Option>
-              <Select.Option value='EUR'>EUR (欧元)</Select.Option>
-            </Select>
-          </div>
-          <div>
-            <Text strong className='block mb-2'>
-              {t('价格')} ({productForm.currency === 'EUR' ? '欧元' : '美元'})
-            </Text>
-            <InputNumber
-              value={productForm.price}
-              onChange={(value) => setProductForm({ ...productForm, price: value })}
-              placeholder={t('例如：4.99')}
-              min={0.01}
-              precision={2}
-              size='large'
-              className='w-full'
-            />
-          </div>
-          <div>
-            <Text strong className='block mb-2'>
-              {t('充值额度')}
-            </Text>
-            <InputNumber
-              value={productForm.quota}
-              onChange={(value) => setProductForm({ ...productForm, quota: value })}
-              placeholder={t('例如：100000')}
-              min={1}
-              precision={0}
-              size='large'
-              className='w-full'
-            />
-          </div>
-        </div>
-      </Modal>
-    </Spin>
-  );
+                <Form.Section text={t('Creem 设置')}>
+                    <Text>
+                        Creem 是一个简单的支付处理平台，支持固定金额的产品销售。请在
+                        <a
+                            href='https://creem.io'
+                            target='_blank'
+                            rel='noreferrer'
+                        >
+                            Creem 官网
+                        </a>
+                        创建账户并获取 API 密钥。
+                        <br />
+                    </Text>
+                    <Banner
+                        type='info'
+                        description={t('Creem 只支持预设的固定金额产品，不支持自定义金额充值')}
+                    />
+
+                    <Row gutter={{ xs: 8, sm: 16, md: 24, lg: 24, xl: 24, xxl: 24 }}>
+                        <Col xs={24} sm={24} md={8} lg={8} xl={8}>
+                            <Form.Input
+                                field='CreemApiKey'
+                                label={t('API 密钥')}
+                                placeholder={t('creem_xxx 的 Creem API 密钥，敏感信息不显示')}
+                                type='password'
+                            />
+                        </Col>
+                        <Col xs={24} sm={24} md={8} lg={8} xl={8}>
+                            <Form.Input
+                                field='CreemWebhookSecret'
+                                label={t('Webhook 密钥')}
+                                placeholder={t('用于验证 Webhook 请求的密钥，敏感信息不显示')}
+                                type='password'
+                            />
+                        </Col>
+                        <Col xs={24} sm={24} md={8} lg={8} xl={8}>
+                            <Form.Switch
+                                field='CreemTestMode'
+                                label={t('测试模式')}
+                                extraText={t('启用后将使用 Creem Test Mode')}
+                            />
+                        </Col>
+                    </Row>
+
+                    <div style={{ marginTop: 24 }}>
+                        <div className='flex justify-between items-center mb-4'>
+                            <Text strong>{t('产品配置')}</Text>
+                            <Button
+                                type='primary'
+                                icon={<Plus size={16} />}
+                                onClick={() => openProductModal()}
+                            >
+                                {t('添加产品')}
+                            </Button>
+                        </div>
+
+                        <Table
+                            columns={columns}
+                            dataSource={products}
+                            pagination={false}
+                            empty={
+                                <div className='text-center py-8'>
+                                    <Text type='tertiary'>{t('暂无产品配置')}</Text>
+                                </div>
+                            }
+                        />
+                    </div>
+
+                    <Button onClick={submitCreemSetting} style={{ marginTop: 16 }}>
+                        {t('更新 Creem 设置')}
+                    </Button>
+                </Form.Section>
+            </Form>
+
+            {/* 产品配置模态框 */}
+            <Modal
+                title={editingProduct ? t('编辑产品') : t('添加产品')}
+                visible={showProductModal}
+                onOk={saveProduct}
+                onCancel={closeProductModal}
+                maskClosable={false}
+                size='small'
+                centered
+            >
+                <div className='space-y-4'>
+                    <div>
+                        <Text strong className='block mb-2'>
+                            {t('产品名称')}
+                        </Text>
+                        <Input
+                            value={productForm.name}
+                            onChange={(value) => setProductForm({ ...productForm, name: value })}
+                            placeholder={t('例如：基础套餐')}
+                            size='large'
+                        />
+                    </div>
+                    <div>
+                        <Text strong className='block mb-2'>
+                            {t('产品ID')}
+                        </Text>
+                        <Input
+                            value={productForm.productId}
+                            onChange={(value) => setProductForm({ ...productForm, productId: value })}
+                            placeholder={t('例如：prod_6I8rBerHpPxyoiU9WK4kot')}
+                            size='large'
+                            disabled={!!editingProduct}
+                        />
+                    </div>
+                    <div>
+                        <Text strong className='block mb-2'>
+                            {t('货币')}
+                        </Text>
+                        <Select
+                            value={productForm.currency}
+                            onChange={(value) => setProductForm({ ...productForm, currency: value })}
+                            size='large'
+                            className='w-full'
+                        >
+                            <Select.Option value='USD'>USD (美元)</Select.Option>
+                            <Select.Option value='EUR'>EUR (欧元)</Select.Option>
+                        </Select>
+                    </div>
+                    <div>
+                        <Text strong className='block mb-2'>
+                            {t('价格')} ({productForm.currency === 'EUR' ? '欧元' : '美元'})
+                        </Text>
+                        <InputNumber
+                            value={productForm.price}
+                            onChange={(value) => setProductForm({ ...productForm, price: value })}
+                            placeholder={t('例如：4.99')}
+                            min={0.01}
+                            precision={2}
+                            size='large'
+                            className='w-full'
+                        />
+                    </div>
+                    <div>
+                        <Text strong className='block mb-2'>
+                            {t('充值额度')}
+                        </Text>
+                        <InputNumber
+                            value={productForm.quota}
+                            onChange={(value) => setProductForm({ ...productForm, quota: value })}
+                            placeholder={t('例如：100000')}
+                            min={1}
+                            precision={0}
+                            size='large'
+                            className='w-full'
+                        />
+                    </div>
+                </div>
+            </Modal>
+        </Spin>
+    );
 }


### PR DESCRIPTION
通过creem的产品购买功能，实现充值功能。

在支付设置新增creem配置，支持： screet ， sign screet， test mode 选项，以及产品配置。

通过产品Id， 展示价格，amout 定义产品，并展示在 个人中心。

当用户点击 产品，会创建订单到 topup，通过在creem预定的product id，唤起creem 支付页面，

用户支付后，回调new-api 地址： https://my.new-api/api/creem/webhook 在回调中验证请求。

请求验证后，通过 callback中的 订单id 找到 topup 的未完成订单， 按照订单中设置 amout 值 加到 用户的 quote 上。