### PR TITLE
fix: 修复多行代码复制换行丢失问题 & 优化API参数处理#1828

### DIFF
--- a/web/src/components/common/markdown/MarkdownRenderer.jsx
+++ b/web/src/components/common/markdown/MarkdownRenderer.jsx
@@ -181,8 +181,8 @@ export function PreCode(props) {
                 e.preventDefault();
                 e.stopPropagation();
                 if (ref.current) {
-                  const code =
-                    ref.current.querySelector('code')?.innerText ?? '';
+                  const codeElement = ref.current.querySelector('code');
+                  const code = codeElement?.textContent ?? '';
                   copy(code).then((success) => {
                     if (success) {
                       Toast.success(t('代码已复制到剪贴板'));

--- a/web/src/helpers/api.js
+++ b/web/src/helpers/api.js
@@ -118,7 +118,6 @@ export const buildApiPayload = (
     model: inputs.model,
     group: inputs.group,
     messages: processedMessages,
-    group: inputs.group,
     stream: inputs.stream,
   };
 
@@ -132,13 +131,15 @@ export const buildApiPayload = (
     seed: 'seed',
   };
 
+
   Object.entries(parameterMappings).forEach(([key, param]) => {
-    if (
-      parameterEnabled[key] &&
-      inputs[param] !== undefined &&
-      inputs[param] !== null
-    ) {
-      payload[param] = inputs[param];
+    const enabled = parameterEnabled[key];
+    const value = inputs[param];
+    const hasValue = value !== undefined && value !== null;
+
+
+    if (enabled && hasValue) {
+      payload[param] = value;
     }
   });
 

--- a/web/src/helpers/utils.jsx
+++ b/web/src/helpers/utils.jsx
@@ -75,13 +75,17 @@ export async function copy(text) {
     await navigator.clipboard.writeText(text);
   } catch (e) {
     try {
-      // 构建input 执行 复制命令
-      var _input = window.document.createElement('input');
-      _input.value = text;
-      window.document.body.appendChild(_input);
-      _input.select();
-      window.document.execCommand('Copy');
-      window.document.body.removeChild(_input);
+      // 构建 textarea 执行复制命令，保留多行文本格式
+      const textarea = window.document.createElement('textarea');
+      textarea.value = text;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'fixed';
+      textarea.style.left = '-9999px';
+      textarea.style.top = '-9999px';
+      window.document.body.appendChild(textarea);
+      textarea.select();
+      window.document.execCommand('copy');
+      window.document.body.removeChild(textarea);
     } catch (e) {
       okay = false;
       console.error(e);


### PR DESCRIPTION
## 描述
本PR聚焦解决 #1828 反馈的核心问题——**多行代码复制后换行符丢失**，同时处理两处代码质量问题：一是API payload的重复属性，二是Markdown渲染中代码文本获取的逻辑冗余，最终保证复制功能格式准确性与API请求稳定性。

## 改动内容
| 文件路径 | 具体修改 | 目的 |
|----------|----------|------|
| `web/src/helpers/utils.jsx` | 1. 复制逻辑的表单控件从 `<input>` 替换为 `<textarea>`<br>2. 新增 `readonly` 属性防止手动编辑，叠加 `fixed` 定位（left/top: -9999px）隐藏元素 | 1. 核心修复：`<textarea>` 原生支持多行文本，解决换行符丢失问题（#1828）<br>2. 避免新增DOM元素影响页面布局流，同时防止用户误操作 |
| `web/src/helpers/api.js` | 1. 移除 `buildApiPayload` 中重复的 `group: inputs.group` 定义<br>2. 参数校验逻辑拆分为 `enabled`（是否启用）、`value`（入参值）、`hasValue`（非undefined/null校验）三个变量 | 1. 修复对象字面量重复键的语法错误，避免运行时潜在异常<br>2. 解耦复杂条件判断，提升逻辑可读性与后续可维护性 |
| `web/src/components/common/markdown/MarkdownRenderer.jsx` | 1. 拆分代码元素查询与文本获取：先存 `codeElement` 引用，再取文本<br>2. 文本获取从 `innerText` 切换为 `textContent` | 1. 避免链式调用的冗余，让代码执行链路更清晰<br>2. 精准获取原始代码文本（含空格、换行等格式），`innerText` 会受CSS样式影响，`textContent` 更贴合代码复制场景 |

## 测试步骤
1. 功能验证（#1828核心场景）：  
   - 进入 playground 或文档页，找到含多行代码的区块（如函数定义、代码示例）；  
   - 触发复制操作（如点击代码块右上角Copy按钮），粘贴到VS Code/记事本，检查换行符是否完整保留。  
2. API兼容性验证：  
   - 触发依赖 `buildApiPayload` 的接口请求（如提交prompt），打开浏览器DevTools的Network面板；  
   - 查看请求payload，确认 `group` 字段正常存在且无重复，Console面板无参数相关报错。  
3. 边界场景验证：  
   - 测试空代码块、超长高亮代码块的复制功能，确认无DOM异常或复制失败情况。

## 关联问题
- 修复 #1828