### PR TITLE
feat: `获取模型列表`按钮白名单

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -188,6 +188,8 @@ func FetchUpstreamModels(c *gin.Context) {
 		url = fmt.Sprintf("%s/v1beta/openai/models", baseURL) // Remove key in url since we need to use AuthHeader
 	case constant.ChannelTypeAli:
 		url = fmt.Sprintf("%s/compatible-mode/v1/models", baseURL)
+	case constant.ChannelTypeZhipu_v4:
+		url = fmt.Sprintf("%s/api/paas/v4/models", baseURL)
 	default:
 		url = fmt.Sprintf("%s/v1/models", baseURL)
 	}

--- a/web/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/src/components/table/channels/modals/EditChannelModal.jsx
@@ -85,6 +85,26 @@ const REGION_EXAMPLE = {
   'claude-3-5-sonnet-20240620': 'europe-west1',
 };
 
+// 支持并且已适配通过接口获取模型列表的渠道类型
+const MODEL_FETCHABLE_TYPES = new Set([
+  1,
+  4,
+  14,
+  34,
+  17,
+  26,
+  24,
+  47,
+  25,
+  20,
+  23,
+  31,
+  35,
+  40,
+  42,
+  48,
+]);
+
 function type2secretPrompt(type) {
   // inputs.type === 15 ? '按照如下格式输入：APIKey|SecretKey' : (inputs.type === 18 ? '按照如下格式输入：APPID|APISecret|APIKey' : '请输入渠道对应的鉴权密钥')
   switch (type) {
@@ -1872,13 +1892,15 @@ const EditChannelModal = (props) => {
                         >
                           {t('填入所有模型')}
                         </Button>
-                        <Button
-                          size='small'
-                          type='tertiary'
-                          onClick={() => fetchUpstreamModelList('models')}
-                        >
-                          {t('获取模型列表')}
-                        </Button>
+                        {MODEL_FETCHABLE_TYPES.has(inputs.type) && (
+                          <Button
+                            size='small'
+                            type='tertiary'
+                            onClick={() => fetchUpstreamModelList('models')}
+                          >
+                            {t('获取模型列表')}
+                          </Button>
+                        )}
                         <Button
                           size='small'
                           type='warning'


### PR DESCRIPTION
### PR 类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 文档更新
- [x] 其他

### PR 是否包含破坏性更新？

- [x] 是
- [ ] 否

仅为适当的渠道渲染`获取模型列表`按钮，新的渠道类型如果需要获取模型列表的功能，需要手动在`web/src/components/table/channels/modals/EditChannelModal.jsx`中加入白名单

### PR 描述

- 仅为白名单渠道渲染`获取模型列表`按钮
- 适配了智谱的模型列表获取

智谱
<img width="1202" height="654" alt="image" src="https://github.com/user-attachments/assets/734f5f34-c615-4b35-a32a-545111c744ee" />

火山
<img width="1182" height="872" alt="image" src="https://github.com/user-attachments/assets/b0eba8ab-33c8-42b5-9ea2-ad4b4756f5bb" />
