### PR TITLE
Refactor: Cache Proxy HTTP Clients with Reset on Channel Updates

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -8,6 +8,7 @@ import (
 	"one-api/constant"
 	"one-api/dto"
 	"one-api/model"
+	"one-api/service"
 	"strconv"
 	"strings"
 
@@ -633,6 +634,7 @@ func AddChannel(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	service.ResetProxyClientCache()
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",
@@ -894,6 +896,7 @@ func UpdateChannel(c *gin.Context) {
 		return
 	}
 	model.InitChannelCache()
+	service.ResetProxyClientCache()
 	channel.Key = ""
 	clearChannelInfo(&channel.Channel)
 	c.JSON(http.StatusOK, gin.H{

--- a/service/http_client.go
+++ b/service/http_client.go
@@ -7,12 +7,17 @@ import (
 	"net/http"
 	"net/url"
 	"one-api/common"
+	"sync"
 	"time"
 
 	"golang.org/x/net/proxy"
 )
 
-var httpClient *http.Client
+var (
+	httpClient      *http.Client
+	proxyClientLock sync.Mutex
+	proxyClients    = make(map[string]*http.Client)
+)
 
 func InitHttpClient() {
 	if common.RelayTimeout == 0 {
@@ -28,11 +33,30 @@ func GetHttpClient() *http.Client {
 	return httpClient
 }
 
+// ResetProxyClientCache 清空代理客户端缓存，确保下次使用时重新初始化
+func ResetProxyClientCache() {
+	proxyClientLock.Lock()
+	defer proxyClientLock.Unlock()
+	for _, client := range proxyClients {
+		if transport, ok := client.Transport.(*http.Transport); ok && transport != nil {
+			transport.CloseIdleConnections()
+		}
+	}
+	proxyClients = make(map[string]*http.Client)
+}
+
 // NewProxyHttpClient 创建支持代理的 HTTP 客户端
 func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
 	if proxyURL == "" {
 		return http.DefaultClient, nil
 	}
+
+	proxyClientLock.Lock()
+	if client, ok := proxyClients[proxyURL]; ok {
+		proxyClientLock.Unlock()
+		return client, nil
+	}
+	proxyClientLock.Unlock()
 
 	parsedURL, err := url.Parse(proxyURL)
 	if err != nil {
@@ -41,11 +65,15 @@ func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
 
 	switch parsedURL.Scheme {
 	case "http", "https":
-		return &http.Client{
+		client := &http.Client{
 			Transport: &http.Transport{
 				Proxy: http.ProxyURL(parsedURL),
 			},
-		}, nil
+		}
+		proxyClientLock.Lock()
+		proxyClients[proxyURL] = client
+		proxyClientLock.Unlock()
+		return client, nil
 
 	case "socks5", "socks5h":
 		// 获取认证信息
@@ -67,13 +95,17 @@ func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
 			return nil, err
 		}
 
-		return &http.Client{
+		client := &http.Client{
 			Transport: &http.Transport{
 				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 					return dialer.Dial(network, addr)
 				},
 			},
-		}, nil
+		}
+		proxyClientLock.Lock()
+		proxyClients[proxyURL] = client
+		proxyClientLock.Unlock()
+		return client, nil
 
 	default:
 		return nil, fmt.Errorf("unsupported proxy scheme: %s", parsedURL.Scheme)

--- a/service/http_client.go
+++ b/service/http_client.go
@@ -70,6 +70,7 @@ func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
 				Proxy: http.ProxyURL(parsedURL),
 			},
 		}
+		client.Timeout = time.Duration(common.RelayTimeout) * time.Second
 		proxyClientLock.Lock()
 		proxyClients[proxyURL] = client
 		proxyClientLock.Unlock()
@@ -102,6 +103,7 @@ func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
 				},
 			},
 		}
+		client.Timeout = time.Duration(common.RelayTimeout) * time.Second
 		proxyClientLock.Lock()
 		proxyClients[proxyURL] = client
 		proxyClientLock.Unlock()


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [x] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述
close https://github.com/QuantumNous/new-api/issues/1863
  - 引入 proxyClients 缓存，按代理 URL 存储已初始化的 *http.Client，避免重复创建客户端和连接池。
  - 命中缓存时直接复用客户端；添加 ResetProxyClientCache，在渠道增改后清空缓存并关闭空闲连接，确保配置更新即时生效。

  动机

  - 频繁为同一代理 URL 构造新的 http.Client 会重复握手、建立连接池，带来额外延迟与代理端负载。
  - 渠道配置变化后，立即刷新关联的代理客户端，防止继续使用过期的代理设置。

  涉及改动

  - service/http_client.go: 新增缓存 map 与互斥锁，支持缓存命中与主动刷新；在 HTTP/HTTPS 与 SOCKS5 初始化逻辑中写入缓存；提供
  ResetProxyClientCache 用于清理缓存和关闭空闲连接。
  - controller/channel.go: 在渠道新增、更新流程成功后调用 ResetProxyClientCache，触发代理客户端重建。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Proxy updates now take effect immediately after adding or updating channels, reducing stale connections.

- Refactor
  - Improved reuse of proxy clients to reduce overhead and speed repeated requests.

- Chores
  - Enhanced internal proxy cache management to improve stability and reduce unnecessary reconnections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->