### PR TITLE
解锁deepseek补全倍率；允许deepseek渠道获取模型

### DIFF
--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -501,7 +501,6 @@ func GetCompletionRatio(name string) float64 {
 }
 
 func getHardcodedCompletionModelRatio(name string) (float64, bool) {
-	lowercaseName := strings.ToLower(name)
 
 	isReservedModel := strings.HasSuffix(name, "-all") || strings.HasSuffix(name, "-gizmo-*")
 	if isReservedModel {
@@ -594,9 +593,6 @@ func getHardcodedCompletionModelRatio(name string) (float64, bool) {
 		}
 	}
 	// hint 只给官方上4倍率，由于开源模型供应商自行定价，不对其进行补全倍率进行强制对齐
-	if lowercaseName == "deepseek-chat" || lowercaseName == "deepseek-reasoner" {
-		return 4, true
-	}
 	if strings.HasPrefix(name, "ERNIE-Speed-") {
 		return 2, true
 	} else if strings.HasPrefix(name, "ERNIE-Lite-") {

--- a/web/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/src/components/table/channels/modals/EditChannelModal.jsx
@@ -103,6 +103,7 @@ const MODEL_FETCHABLE_TYPES = new Set([
   40,
   42,
   48,
+  43,
 ]);
 
 function type2secretPrompt(type) {


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [x] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

- 由于deepseek官方价格更新，现解除硬编码的补全倍率；
- 补充了[之前](https://github.com/QuantumNous/new-api/pull/1885)遗漏的deepseek渠道白名单 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled fetching upstream models for an additional channel type, expanding compatibility when editing channels.

* **Refactor**
  * Updated model ratio handling: specific models (e.g., deepseek-chat and deepseek-reasoner) no longer use a hardcoded ratio and now follow standard/default or configured ratios, aligning behavior with other models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->