### PR TITLE
fix: Redirect address after successful tg binding

### DIFF
--- a/controller/telegram.go
+++ b/controller/telegram.go
@@ -65,7 +65,7 @@ func TelegramBind(c *gin.Context) {
 		return
 	}
 
-	c.Redirect(302, "/setting")
+	c.Redirect(302, "/console/personal")
 }
 
 func TelegramLogin(c *gin.Context) {


### PR DESCRIPTION
tg绑定成功之后调整地址修改为现在的个人中心地址。
目前代码中还是老版本的/setting，已经不存在。