### PR TITLE
fix: Optimize sidebar refresh to avoid redundant loading states

### DIFF
--- a/web/src/components/layout/SiderBar.jsx
+++ b/web/src/components/layout/SiderBar.jsx
@@ -58,7 +58,7 @@ const SiderBar = ({ onNavigate = () => {} }) => {
     loading: sidebarLoading,
   } = useSidebar();
 
-  const showSkeleton = useMinimumLoadingTime(sidebarLoading);
+  const showSkeleton = useMinimumLoadingTime(sidebarLoading, 200);
 
   const [selectedKeys, setSelectedKeys] = useState(['home']);
   const [chatItems, setChatItems] = useState([]);

--- a/web/src/hooks/common/useHeaderBar.js
+++ b/web/src/hooks/common/useHeaderBar.js
@@ -40,7 +40,7 @@ export const useHeaderBar = ({ onMobileMenuToggle, drawerOpen }) => {
   const location = useLocation();
 
   const loading = statusState?.status === undefined;
-  const isLoading = useMinimumLoadingTime(loading);
+  const isLoading = useMinimumLoadingTime(loading, 200);
 
   const systemName = getSystemName();
   const logo = getLogo();


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

此次修改针对顶部栏和侧边栏刷新后渲染速度过慢的问题。通过在 `useSidebar` 中记录首次加载状态，仅在必要时展示加载动画，同时为刷新事件带上源标识和跳过骨架屏的标志，避免重复触发加载。另将顶部栏与侧边栏的最小骨架展示时间降至 200ms，提升首屏与刷新时的响应体验。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Header and sidebar loading indicators now display for at least 200 ms to reduce flicker.
  * Sidebar refreshes run quietly in the background without showing loaders unless necessary.

* **Bug Fixes**
  * More reliable sidebar setup when user settings are missing or invalid; sensible defaults are applied.
  * Prevents redundant/self-triggered refreshes, reducing interruptions during configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->