### PR TITLE
feat: Allow FIM chat requests without messages

### DIFF
--- a/relay/channel/siliconflow/adaptor.go
+++ b/relay/channel/siliconflow/adaptor.go
@@ -61,6 +61,16 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *rel
 }
 
 func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeneralOpenAIRequest) (any, error) {
+	// SiliconFlow requires messages array for FIM requests, even if client doesn't send it
+	if (request.Prefix != nil || request.Suffix != nil) && len(request.Messages) == 0 {
+		// Add an empty user message to satisfy SiliconFlow's requirement
+		request.Messages = []dto.Message{
+			{
+				Role:    "user",
+				Content: "",
+			},
+		}
+	}
 	return request, nil
 }
 

--- a/relay/helper/valid_request.go
+++ b/relay/helper/valid_request.go
@@ -275,7 +275,9 @@ func GetAndValidateTextRequest(c *gin.Context, relayMode int) (*dto.GeneralOpenA
 			return nil, errors.New("field prompt is required")
 		}
 	case relayconstant.RelayModeChatCompletions:
-		if len(textRequest.Messages) == 0 {
+		// For FIM (Fill-in-the-middle) requests with prefix/suffix, messages is optional
+		// It will be filled by provider-specific adaptors if needed (e.g., SiliconFlow)。Or it is allowed by model vendor(s) (e.g., DeepSeek)
+		if len(textRequest.Messages) == 0 && textRequest.Prefix == nil && textRequest.Suffix == nil {
 			return nil, errors.New("field messages is required")
 		}
 	case relayconstant.RelayModeEmbeddings:


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

close https://github.com/QuantumNous/new-api/issues/1649

为兼容prefix/subfix形式的 FIM 调用，当客户端未提供 messages 时，不再在入参校验阶段直接拒绝请求，同时在 SiliconFlow 适配器内补充一个空的 user 消息以满足上游服务的必填要求，从而避免这类请求被误判为无效。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for fill‑in‑the‑middle (FIM) prompts using Prefix/Suffix without requiring chat messages in chat completions.

* **Bug Fixes**
  * Reduced validation errors when submitting FIM requests without messages.
  * Improved compatibility with SiliconFlow by automatically adjusting requests to meet provider requirements, leading to fewer failed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->