### PR TITLE
fix: Gemini missing func name for multi-streaming tool calls (except the first)

### DIFF
--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -961,9 +961,15 @@ func GeminiChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *
 			// send first response
 			emptyResponse := helper.GenerateStartEmptyResponse(id, createAt, info.UpstreamModelName, nil)
 			if response.IsToolCall() {
-				emptyResponse.Choices[0].Delta.ToolCalls = make([]dto.ToolCallResponse, 1)
-				emptyResponse.Choices[0].Delta.ToolCalls[0] = *response.GetFirstToolCall()
-				emptyResponse.Choices[0].Delta.ToolCalls[0].Function.Arguments = ""
+				if len(emptyResponse.Choices) > 0 && len(response.Choices) > 0 {
+					toolCalls := response.Choices[0].Delta.ToolCalls
+					copiedToolCalls := make([]dto.ToolCallResponse, len(toolCalls))
+					for idx := range toolCalls {
+						copiedToolCalls[idx] = toolCalls[idx]
+						copiedToolCalls[idx].Function.Arguments = ""
+					}
+					emptyResponse.Choices[0].Delta.ToolCalls = copiedToolCalls
+				}
 				finishReason = constant.FinishReasonToolCalls
 				err = handleStream(c, info, emptyResponse)
 				if err != nil {


### PR DESCRIPTION
Before fix:
<img width="3177" height="1816" alt="image" src="https://github.com/user-attachments/assets/4abbb57b-37da-4946-9557-9eda4a38d520" />


After fix:
<img width="3056" height="2102" alt="image" src="https://github.com/user-attachments/assets/38b0c3a3-082c-404b-b43c-9683ce42b50a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevents tool-call arguments from appearing in the initial streamed response, improving privacy.
  - Adds safeguards when streaming responses with missing choices to reduce runtime errors.
  - Sanitizes tool-call data before it’s emitted during streaming, making streaming more robust and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->