### PR TITLE
fix: improve text visibility in warning box for dark mode in SettingsLog

### DIFF
--- a/web/src/pages/Setting/Operation/SettingsLog.jsx
+++ b/web/src/pages/Setting/Operation/SettingsLog.jsx
@@ -106,20 +106,21 @@ export default function SettingsLog(props) {
               <Text type="tertiary"> ({t('约')} {daysDiff} {t('天前')})</Text>
             )}
           </p>
-          <div style={{ 
-            background: '#fff7e6', 
-            border: '1px solid #ffd591', 
-            padding: '12px', 
+          <div style={{
+            background: '#fff7e6',
+            border: '1px solid #ffd591',
+            padding: '12px',
             borderRadius: '4px',
-            marginTop: '12px'
+            marginTop: '12px',
+            color: '#333'
           }}>
-            <Text type="warning" strong>⚠️ {t('注意')}：</Text>
-            <Text>{t('将删除')} </Text>
-            <Text strong type="danger">{targetTime}</Text>
+            <Text strong style={{ color: '#d46b08' }}>⚠️ {t('注意')}：</Text>
+            <Text style={{ color: '#333' }}>{t('将删除')} </Text>
+            <Text strong style={{ color: '#cf1322' }}>{targetTime}</Text>
             {daysDiff > 0 && (
-              <Text type="tertiary"> ({t('约')} {daysDiff} {t('天前')})</Text>
+              <Text style={{ color: '#8c8c8c' }}> ({t('约')} {daysDiff} {t('天前')})</Text>
             )}
-            <Text> {t('之前的所有日志')}</Text>
+            <Text style={{ color: '#333' }}> {t('之前的所有日志')}</Text>
           </div>
           <p style={{ marginTop: '12px' }}>
             <Text type="danger">{t('此操作不可恢复，请仔细确认时间后再操作！')}</Text>


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述
- Before
<img width="886" height="619" alt="image" src="https://github.com/user-attachments/assets/f9c95592-ca09-49ad-8590-bae81c1ae224" />

- After
<img width="881" height="624" alt="image" src="https://github.com/user-attachments/assets/6f872313-2d9d-4c6e-9ee3-2787dcb236d6" />

#### 问题
在日志设置页面的历史日志删除确认对话框中，警告提示框使用固定的浅黄色背景（`#fff7e6`），但文字颜色使用的是 Semi Design
的主题色（`type="warning"`, `type="danger"`,
`type="tertiary"`）。在暗色模式下，这些主题色会变成白色或浅色，导致在浅黄色背景上可见性很差，用户难以阅读警告信息。

#### 解决方案
将警告框内所有文本组件的颜色从主题相关的 `type` 属性改为显式的内联 `style` 颜色值：
- 容器添加默认文字颜色 `color: '#333'`
- "注意"文字使用橙色 `#d46b08`（警告色）
- 时间戳使用红色 `#cf1322`（危险色）
- "天前"提示使用灰色 `#8c8c8c`
- 其他文字使用深灰色 `#333`

这样无论在亮色还是暗色模式下，文字都能在浅黄色背景上保持良好的对比度和可读性。
