### PR TITLE
fix: enforce case-sensitive model name matching to support multiple channels with different case variants

### DIFF
--- a/model/main.go
+++ b/model/main.go
@@ -246,6 +246,45 @@ func InitLogDB() (err error) {
 	return err
 }
 
+// fixModelNameCollation updates the model_name column to use case-sensitive collation in MySQL
+func fixModelNameCollation() error {
+	if !common.UsingMySQL {
+		return nil // Only needed for MySQL
+	}
+
+	// Fix models.model_name column
+	var modelCollation string
+	err := DB.Raw("SELECT COLLATION_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'models' AND COLUMN_NAME = 'model_name'").Scan(&modelCollation).Error
+	if err != nil {
+		// Table might not exist yet, ignore error
+		common.SysLog(fmt.Sprintf("Could not check models.model_name collation: %v", err))
+	} else if !strings.HasSuffix(strings.ToLower(modelCollation), "_bin") {
+		common.SysLog("Updating models.model_name column to use case-sensitive collation (utf8mb4_bin)")
+		err = DB.Exec("ALTER TABLE models MODIFY COLUMN model_name VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL").Error
+		if err != nil {
+			return fmt.Errorf("failed to alter models.model_name column collation: %v", err)
+		}
+		common.SysLog("Successfully updated models.model_name column collation")
+	}
+
+	// Fix abilities.model column
+	var abilityCollation string
+	err = DB.Raw("SELECT COLLATION_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'abilities' AND COLUMN_NAME = 'model'").Scan(&abilityCollation).Error
+	if err != nil {
+		// Table might not exist yet, ignore error
+		common.SysLog(fmt.Sprintf("Could not check abilities.model collation: %v", err))
+	} else if !strings.HasSuffix(strings.ToLower(abilityCollation), "_bin") {
+		common.SysLog("Updating abilities.model column to use case-sensitive collation (utf8mb4_bin)")
+		err = DB.Exec("ALTER TABLE abilities MODIFY COLUMN model VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL").Error
+		if err != nil {
+			return fmt.Errorf("failed to alter abilities.model column collation: %v", err)
+		}
+		common.SysLog("Successfully updated abilities.model column collation")
+	}
+
+	return nil
+}
+
 func migrateDB() error {
 	err := DB.AutoMigrate(
 		&Channel{},
@@ -270,6 +309,13 @@ func migrateDB() error {
 	if err != nil {
 		return err
 	}
+
+	// Fix model_name column collation for case-sensitive comparison in MySQL
+	if err := fixModelNameCollation(); err != nil {
+		common.SysLog(fmt.Sprintf("Warning: failed to update model_name collation: %v", err))
+		// Don't return error, just log it as it's not critical for existing installations
+	}
+
 	return nil
 }
 

--- a/model/model_meta.go
+++ b/model/model_meta.go
@@ -54,7 +54,13 @@ func IsModelNameDuplicated(id int, name string) (bool, error) {
 		return false, nil
 	}
 	var cnt int64
-	err := DB.Model(&Model{}).Where("model_name = ? AND id <> ?", name, id).Count(&cnt).Error
+	var err error
+	// Use case-sensitive comparison for MySQL, PostgreSQL and SQLite are case-sensitive by default
+	if common.UsingMySQL {
+		err = DB.Model(&Model{}).Where("BINARY model_name = ? AND id <> ?", name, id).Count(&cnt).Error
+	} else {
+		err = DB.Model(&Model{}).Where("model_name = ? AND id <> ?", name, id).Count(&cnt).Error
+	}
 	return cnt > 0, err
 }
 


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

**修复目的**

修复 issue #1990 中报告的模型名称大小写敏感性问题。之前在MySQL 数据库中，`deepseek-ai/DeepSeek-V3.1-Terminus` 和`deepseek-ai/deepseek-v3.1-terminus`被视为相同的模型名称，导致无法为不同大小写的模型名称配置不同的渠道（例如硅基流动使用大写版本，英伟达使用小写版本）。

**实现细节**

1. **数据库模式更新**
   - 在 `Model` 结构体的 `ModelName` 字段添加`collation:utf8mb4_bin` 标签，使 MySQL使用区分大小写的排序规则
   - 在 `Ability` 结构体的 `Model` 字段添加相同的排序规则，确保能力表中的模型匹配也区分大小写

2. **查询逻辑优化**
   - 修改 `IsModelNameDuplicated()` 函数，对 MySQL 使用`BINARY` 关键字进行大小写敏感的比较
   - PostgreSQL 和 SQLite默认已经是大小写敏感的，无需特殊处理

3. **自动迁移支持**
   - 新增 `fixModelNameCollation()`迁移函数，在系统启动时自动检测并更新现有 MySQL数据库的字段排序规则
   - 迁移函数会检查当前排序规则，仅在必要时执行 ALTER TABLE 操作
   - 对不存在的表会优雅地忽略错误，不影响新安装

**影响范围**

- 新安装：数据库表将自动使用大小写敏感的排序规则
- 现有安装：首次启动时会自动执行迁移，将`models.model_name` 和 `abilities.model`字段更新为大小写敏感
- 用户现在可以创建和管理大小写不同但其他字符相同的模型，每个模型可以独立绑定渠道

**测试**
<img width="1823" height="367" alt="图片" src="https://github.com/user-attachments/assets/4bce29f5-f907-42bf-89f6-fec7dac84686" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Prevents duplicate model names that differ only by letter case by enforcing case-sensitive checks in MySQL environments.
  - Improves reliability of database migrations by automatically correcting column collations when needed.

- Chores
  - Adds migration step to align database collation with expected behavior, with non-blocking warnings if adjustments fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->