### PR TITLE
fix(auth): support x-api-key header for /v1/models endpoint

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -193,8 +193,8 @@ func TokenAuth() func(c *gin.Context) {
 			}
 			c.Request.Header.Set("Authorization", "Bearer "+key)
 		}
-		// 检查path包含/v1/messages
-		if strings.Contains(c.Request.URL.Path, "/v1/messages") {
+		// 检查path包含/v1/messages或/v1/models
+		if strings.Contains(c.Request.URL.Path, "/v1/messages") || strings.Contains(c.Request.URL.Path, "/v1/models") {
 			anthropicKey := c.Request.Header.Get("x-api-key")
 			if anthropicKey != "" {
 				c.Request.Header.Set("Authorization", "Bearer "+anthropicKey)


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

修复 #2422

**问题**: 当客户端仅使用 Anthropic 的 `x-api-key` 头部（不带 Bearer Token）请求 `/v1/models` 端点时，返回 401 未授权错误。

**原因**: `middleware/auth.go` 中的 `TokenAuth()` 中间件仅对 `/v1/messages` 路径提取 `x-api-key` 头部，未对 `/v1/models` 路径进行相同处理。

**解决方案**: 扩展 `TokenAuth()` 中间件的路径检查条件，使其同时支持 `/v1/messages` 和 `/v1/models` 路径的 `x-api-key` 头部认证。

这与 `router/relay-router.go` 中已有的 Anthropic 格式路由适配保持一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication validation to properly verify API credentials for additional endpoints, strengthening security coverage across supported operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->