### PR TITLE
feat: add OpenRouter pricing support to upstream ratio sync

### DIFF
--- a/dto/ratio_sync.go
+++ b/dto/ratio_sync.go
@@ -35,4 +35,5 @@ type SyncableChannel struct {
 	Name    string `json:"name"`
 	BaseURL string `json:"base_url"`
 	Status  int    `json:"status"`
+	Type    int    `json:"type"`
 }

--- a/web/src/components/settings/ChannelSelectorModal.jsx
+++ b/web/src/components/settings/ChannelSelectorModal.jsx
@@ -117,6 +117,7 @@ const ChannelSelectorModal = forwardRef(
       const getEndpointType = (ep) => {
         if (ep === '/api/ratio_config') return 'ratio_config';
         if (ep === '/api/pricing') return 'pricing';
+        if (ep === 'openrouter') return 'openrouter';
         return 'custom';
       };
 
@@ -127,6 +128,8 @@ const ChannelSelectorModal = forwardRef(
           updateEndpoint(channelId, '/api/ratio_config');
         } else if (val === 'pricing') {
           updateEndpoint(channelId, '/api/pricing');
+        } else if (val === 'openrouter') {
+          updateEndpoint(channelId, 'openrouter');
         } else {
           if (currentType !== 'custom') {
             updateEndpoint(channelId, '');
@@ -144,6 +147,7 @@ const ChannelSelectorModal = forwardRef(
             optionList={[
               { label: 'ratio_config', value: 'ratio_config' },
               { label: 'pricing', value: 'pricing' },
+              { label: 'OpenRouter', value: 'openrouter' },
               { label: 'custom', value: 'custom' },
             ]}
           />

--- a/web/src/pages/Setting/Ratio/UpstreamRatioSync.jsx
+++ b/web/src/pages/Setting/Ratio/UpstreamRatioSync.jsx
@@ -154,14 +154,20 @@ export default function UpstreamRatioSync(props) {
             const id = channel.key;
             const base = channel._originalData?.base_url || '';
             const name = channel.label || '';
+            const channelType = channel._originalData?.type;
             const isOfficial =
               id === -100 ||
               base === 'https://basellm.github.io' ||
               name === '官方倍率预设';
+            const isOpenRouter = channelType === 20;
             if (!merged[id]) {
-              merged[id] = isOfficial
-                ? '/llm-metadata/api/newapi/ratio_config-v1-base.json'
-                : DEFAULT_ENDPOINT;
+              if (isOfficial) {
+                merged[id] = '/llm-metadata/api/newapi/ratio_config-v1-base.json';
+              } else if (isOpenRouter) {
+                merged[id] = 'openrouter';
+              } else {
+                merged[id] = DEFAULT_ENDPOINT;
+              }
             }
           });
           return merged;
@@ -652,7 +658,7 @@ export default function UpstreamRatioSync(props) {
             color={text !== null && text !== undefined ? 'blue' : 'default'}
             shape='circle'
           >
-            {text !== null && text !== undefined ? text : t('未设置')}
+            {text !== null && text !== undefined ? String(text) : t('未设置')}
           </Tag>
         ),
       },
@@ -774,7 +780,7 @@ export default function UpstreamRatioSync(props) {
                     }
                   }}
                 >
-                  {upstreamVal}
+                  {String(upstreamVal)}
                 </Checkbox>
                 {!isConfident && (
                   <Tooltip


### PR DESCRIPTION
 ### PR 类型

  - [ ] Bug 修复
  - [x] 新功能
  - [ ] 文档更新
  - [ ] 其他

  ### PR 是否包含破坏性更新？

  - [ ] 是
  - [x] 否

  ### PR 描述

  为上游倍率同步功能新增 OpenRouter 数据源支持。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenRouter support as a new synchronization endpoint type for model pricing data

* **Improvements**
  * Enhanced channel configuration to include type information
  * Improved consistency in upstream value displays within the synchronization settings interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->