### PR TITLE
feat(ratio-sync): support models.dev ratio sync and fix Gemini cache ratios

### DIFF
--- a/setting/ratio_setting/cache_ratio.go
+++ b/setting/ratio_setting/cache_ratio.go
@@ -5,8 +5,9 @@ import (
 )
 
 var defaultCacheRatio = map[string]float64{
-	"gemini-3-flash-preview":              0.25,
-	"gemini-3-pro-preview":                0.25,
+	"gemini-3-flash-preview":              0.1,
+	"gemini-3-pro-preview":                0.1,
+	"gemini-3.1-pro-preview":              0.1,
 	"gpt-4":                               0.5,
 	"o1":                                  0.5,
 	"o1-2024-12-17":                       0.5,

--- a/web/src/components/settings/ChannelSelectorModal.jsx
+++ b/web/src/components/settings/ChannelSelectorModal.jsx
@@ -35,6 +35,13 @@ import {
 } from '@douyinfe/semi-ui';
 import { IconSearch } from '@douyinfe/semi-icons';
 
+const OFFICIAL_RATIO_PRESET_ID = -100;
+const MODELS_DEV_PRESET_ID = -101;
+const OFFICIAL_RATIO_PRESET_NAME = '官方倍率预设';
+const MODELS_DEV_PRESET_NAME = 'models.dev 价格预设';
+const OFFICIAL_RATIO_PRESET_BASE_URL = 'https://basellm.github.io';
+const MODELS_DEV_PRESET_BASE_URL = 'https://models.dev';
+
 const ChannelSelectorModal = forwardRef(
   (
     {
@@ -70,9 +77,12 @@ const ChannelSelectorModal = forwardRef(
       const base = record?._originalData?.base_url || '';
       const name = record?.label || '';
       return (
-        id === -100 ||
-        base === 'https://basellm.github.io' ||
-        name === '官方倍率预设'
+        id === OFFICIAL_RATIO_PRESET_ID ||
+        id === MODELS_DEV_PRESET_ID ||
+        base === OFFICIAL_RATIO_PRESET_BASE_URL ||
+        base === MODELS_DEV_PRESET_BASE_URL ||
+        name === OFFICIAL_RATIO_PRESET_NAME ||
+        name === MODELS_DEV_PRESET_NAME
       );
     };
 

--- a/web/src/pages/Setting/Ratio/UpstreamRatioSync.jsx
+++ b/web/src/pages/Setting/Ratio/UpstreamRatioSync.jsx
@@ -53,6 +53,16 @@ import {
 } from '@douyinfe/semi-illustrations';
 import ChannelSelectorModal from '../../../components/settings/ChannelSelectorModal';
 
+const OFFICIAL_RATIO_PRESET_ID = -100;
+const OFFICIAL_RATIO_PRESET_NAME = '官方倍率预设';
+const OFFICIAL_RATIO_PRESET_BASE_URL = 'https://basellm.github.io';
+const OFFICIAL_RATIO_PRESET_ENDPOINT =
+  '/llm-metadata/api/newapi/ratio_config-v1-base.json';
+const MODELS_DEV_PRESET_ID = -101;
+const MODELS_DEV_PRESET_NAME = 'models.dev 价格预设';
+const MODELS_DEV_PRESET_BASE_URL = 'https://models.dev';
+const MODELS_DEV_PRESET_ENDPOINT = 'https://models.dev/api.json';
+
 function ConflictConfirmModal({ t, visible, items, onOk, onCancel }) {
   const isMobile = useIsMobile();
   const columns = [
@@ -155,14 +165,20 @@ export default function UpstreamRatioSync(props) {
             const base = channel._originalData?.base_url || '';
             const name = channel.label || '';
             const channelType = channel._originalData?.type;
-            const isOfficial =
-              id === -100 ||
-              base === 'https://basellm.github.io' ||
-              name === '官方倍率预设';
+            const isOfficialRatioPreset =
+              id === OFFICIAL_RATIO_PRESET_ID ||
+              base === OFFICIAL_RATIO_PRESET_BASE_URL ||
+              name === OFFICIAL_RATIO_PRESET_NAME;
+            const isModelsDevPreset =
+              id === MODELS_DEV_PRESET_ID ||
+              base === MODELS_DEV_PRESET_BASE_URL ||
+              name === MODELS_DEV_PRESET_NAME;
             const isOpenRouter = channelType === 20;
             if (!merged[id]) {
-              if (isOfficial) {
-                merged[id] = '/llm-metadata/api/newapi/ratio_config-v1-base.json';
+              if (isModelsDevPreset) {
+                merged[id] = MODELS_DEV_PRESET_ENDPOINT;
+              } else if (isOfficialRatioPreset) {
+                merged[id] = OFFICIAL_RATIO_PRESET_ENDPOINT;
               } else if (isOpenRouter) {
                 merged[id] = 'openrouter';
               } else {


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [x] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述
close https://github.com/QuantumNous/new-api/issues/2827
支持从 models.dev 同步模型倍率，并修复 Gemini 缓存倍率默认值。

主要改动如下：

1. 新增 models.dev 价格预设（`ID = -101`），可在倍率同步时直接使用 `https://models.dev/api.json`。
2. 后端同步逻辑新增 models.dev 端点识别与解析流程，并转换为系统内部的 `model_ratio`、`completion_ratio`、`cache_ratio` 结构。
3. 对 models.dev 同名模型跨 provider 的冲突，采用“优先最便宜非零 input 成本；若仅有零成本则保留 0”策略。
4. 前端同步页面与渠道选择器支持识别和展示 models.dev 预设。
5. 修复 Gemini 默认缓存倍率：将 `gemini-3-flash-preview`、`gemini-3-pro-preview` 调整为 `0.1`，并新增 `gemini-3.1-pro-preview =
0.1`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added models.dev as a new upstream pricing data source for model cost synchronization
  * Introduced official and models.dev presets for streamlined channel configuration and data synchronization

* **Updates**
  * Updated default cache ratio values for Gemini model variants
  * Enhanced channel synchronization with improved preset detection and endpoint routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->