### PR TITLE
feat: add channel-level RPM limit

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -438,6 +438,9 @@ func validateChannel(channel *model.Channel, isAdd bool) error {
 	if err := channel.ValidateSettings(); err != nil {
 		return fmt.Errorf("渠道额外设置[channel setting] 格式错误：%s", err.Error())
 	}
+	if channel.GetSetting().ChannelRPMLimit < 0 {
+		return fmt.Errorf("渠道 RPM 限制不能小于 0")
+	}
 
 	// 如果是添加操作，检查 channel 和 key 是否为空
 	if isAdd {

--- a/dto/channel_settings.go
+++ b/dto/channel_settings.go
@@ -3,6 +3,7 @@ package dto
 type ChannelSettings struct {
 	ForceFormat            bool   `json:"force_format,omitempty"`
 	ThinkingToContent      bool   `json:"thinking_to_content,omitempty"`
+	ChannelRPMLimit        int    `json:"channel_rpm_limit,omitempty"`
 	Proxy                  string `json:"proxy"`
 	PassThroughBodyEnabled bool   `json:"pass_through_body_enabled,omitempty"`
 	SystemPrompt           string `json:"system_prompt,omitempty"`

--- a/middleware/channel-rate-limit.go
+++ b/middleware/channel-rate-limit.go
@@ -1,0 +1,85 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+
+	"github.com/gin-gonic/gin"
+)
+
+const channelRPMLimitMark = "CRPM"
+
+var channelRPMInMemoryLimiter common.InMemoryRateLimiter
+
+func ChannelRequestRateLimit() func(c *gin.Context) {
+	return func(c *gin.Context) {
+		channelID := common.GetContextKeyInt(c, constant.ContextKeyChannelId)
+		if channelID <= 0 {
+			c.Next()
+			return
+		}
+
+		setting, ok := common.GetContextKeyType[dto.ChannelSettings](c, constant.ContextKeyChannelSetting)
+		if !ok || setting.ChannelRPMLimit <= 0 {
+			c.Next()
+			return
+		}
+
+		allowed, err := checkChannelRPMLimit(channelID, setting.ChannelRPMLimit)
+		if err != nil {
+			abortWithOpenAiMessage(c, http.StatusInternalServerError, "channel_rate_limit_check_failed")
+			return
+		}
+		if !allowed {
+			abortWithOpenAiMessage(c, http.StatusTooManyRequests, fmt.Sprintf("channel rpm limit exceeded: %d/min", setting.ChannelRPMLimit))
+			return
+		}
+
+		c.Next()
+	}
+}
+
+func checkChannelRPMLimit(channelID int, rpmLimit int) (bool, error) {
+	if rpmLimit <= 0 {
+		return true, nil
+	}
+
+	if common.RedisEnabled && common.RDB != nil {
+		return checkChannelRPMLimitRedis(channelID, rpmLimit)
+	}
+	return checkChannelRPMLimitMemory(channelID, rpmLimit), nil
+}
+
+func getChannelRPMBucketKey(channelID int, now time.Time) string {
+	minuteBucket := now.Unix() / 60
+	return fmt.Sprintf("rateLimit:%s:channel:%d:%d", channelRPMLimitMark, channelID, minuteBucket)
+}
+
+func checkChannelRPMLimitRedis(channelID int, rpmLimit int) (bool, error) {
+	ctx := context.Background()
+	key := getChannelRPMBucketKey(channelID, time.Now())
+
+	count, err := common.RDB.Incr(ctx, key).Result()
+	if err != nil {
+		return false, err
+	}
+	if count == 1 {
+		if err := common.RDB.Expire(ctx, key, 70*time.Second).Err(); err != nil {
+			return false, err
+		}
+	}
+
+	return count <= int64(rpmLimit), nil
+}
+
+func checkChannelRPMLimitMemory(channelID int, rpmLimit int) bool {
+	channelRPMInMemoryLimiter.Init(70 * time.Second)
+	key := getChannelRPMBucketKey(channelID, time.Now())
+	return channelRPMInMemoryLimiter.Request(key, rpmLimit, 70)
+}

--- a/middleware/channel_rate_limit_test.go
+++ b/middleware/channel_rate_limit_test.go
@@ -1,0 +1,120 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+
+	"github.com/gin-gonic/gin"
+)
+
+func newChannelLimitRouter(channelLimit func(c *gin.Context) (int, int)) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		channelID, limit := channelLimit(c)
+		common.SetContextKey(c, constant.ContextKeyChannelId, channelID)
+		common.SetContextKey(c, constant.ContextKeyChannelSetting, dto.ChannelSettings{ChannelRPMLimit: limit})
+		c.Next()
+	})
+	r.Use(ChannelRequestRateLimit())
+	r.GET("/v1/chat/completions", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	return r
+}
+
+func TestChannelRequestRateLimitExceed(t *testing.T) {
+	prevRedisEnabled := common.RedisEnabled
+	common.RedisEnabled = false
+	t.Cleanup(func() {
+		common.RedisEnabled = prevRedisEnabled
+	})
+
+	channelID := int(time.Now().UnixNano()%1_000_000_000) + 1000
+	r := newChannelLimitRouter(func(c *gin.Context) (int, int) {
+		return channelID, 2
+	})
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d got status %d, want %d", i+1, w.Code, http.StatusOK)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("request 3 got status %d, want %d", w.Code, http.StatusTooManyRequests)
+	}
+}
+
+func TestChannelRequestRateLimitIsolatedByChannel(t *testing.T) {
+	prevRedisEnabled := common.RedisEnabled
+	common.RedisEnabled = false
+	t.Cleanup(func() {
+		common.RedisEnabled = prevRedisEnabled
+	})
+
+	baseID := int(time.Now().UnixNano()%1_000_000_000) + 2000
+	r := newChannelLimitRouter(func(c *gin.Context) (int, int) {
+		id, _ := strconv.Atoi(c.GetHeader("X-Channel-Id"))
+		return id, 1
+	})
+
+	reqA1 := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+	reqA1.Header.Set("X-Channel-Id", strconv.Itoa(baseID))
+	wA1 := httptest.NewRecorder()
+	r.ServeHTTP(wA1, reqA1)
+	if wA1.Code != http.StatusOK {
+		t.Fatalf("channel A first request got %d, want %d", wA1.Code, http.StatusOK)
+	}
+
+	reqA2 := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+	reqA2.Header.Set("X-Channel-Id", strconv.Itoa(baseID))
+	wA2 := httptest.NewRecorder()
+	r.ServeHTTP(wA2, reqA2)
+	if wA2.Code != http.StatusTooManyRequests {
+		t.Fatalf("channel A second request got %d, want %d", wA2.Code, http.StatusTooManyRequests)
+	}
+
+	reqB1 := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+	reqB1.Header.Set("X-Channel-Id", strconv.Itoa(baseID+1))
+	wB1 := httptest.NewRecorder()
+	r.ServeHTTP(wB1, reqB1)
+	if wB1.Code != http.StatusOK {
+		t.Fatalf("channel B first request got %d, want %d", wB1.Code, http.StatusOK)
+	}
+}
+
+func TestChannelRequestRateLimitDisabledWhenZero(t *testing.T) {
+	prevRedisEnabled := common.RedisEnabled
+	common.RedisEnabled = false
+	t.Cleanup(func() {
+		common.RedisEnabled = prevRedisEnabled
+	})
+
+	channelID := int(time.Now().UnixNano()%1_000_000_000) + 3000
+	r := newChannelLimitRouter(func(c *gin.Context) (int, int) {
+		return channelID, 0
+	})
+
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d got status %d, want %d", i+1, w.Code, http.StatusOK)
+		}
+	}
+}

--- a/router/relay-router.go
+++ b/router/relay-router.go
@@ -62,7 +62,7 @@ func SetRelayRouter(router *gin.Engine) {
 	playgroundRouter := router.Group("/pg")
 	playgroundRouter.Use(middleware.RouteTag("relay"))
 	playgroundRouter.Use(middleware.SystemPerformanceCheck())
-	playgroundRouter.Use(middleware.UserAuth(), middleware.Distribute())
+	playgroundRouter.Use(middleware.UserAuth(), middleware.Distribute(), middleware.ChannelRequestRateLimit())
 	{
 		playgroundRouter.POST("/chat/completions", controller.Playground)
 	}
@@ -74,7 +74,7 @@ func SetRelayRouter(router *gin.Engine) {
 	{
 		// WebSocket 路由（统一到 Relay）
 		wsRouter := relayV1Router.Group("")
-		wsRouter.Use(middleware.Distribute())
+		wsRouter.Use(middleware.Distribute(), middleware.ChannelRequestRateLimit())
 		wsRouter.GET("/realtime", func(c *gin.Context) {
 			controller.Relay(c, types.RelayFormatOpenAIRealtime)
 		})
@@ -82,7 +82,7 @@ func SetRelayRouter(router *gin.Engine) {
 	{
 		//http router
 		httpRouter := relayV1Router.Group("")
-		httpRouter.Use(middleware.Distribute())
+		httpRouter.Use(middleware.Distribute(), middleware.ChannelRequestRateLimit())
 
 		// claude related routes
 		httpRouter.POST("/messages", func(c *gin.Context) {
@@ -179,7 +179,7 @@ func SetRelayRouter(router *gin.Engine) {
 	relaySunoRouter := router.Group("/suno")
 	relaySunoRouter.Use(middleware.RouteTag("relay"))
 	relaySunoRouter.Use(middleware.SystemPerformanceCheck())
-	relaySunoRouter.Use(middleware.TokenAuth(), middleware.Distribute())
+	relaySunoRouter.Use(middleware.TokenAuth(), middleware.Distribute(), middleware.ChannelRequestRateLimit())
 	{
 		relaySunoRouter.POST("/submit/:action", controller.RelayTask)
 		relaySunoRouter.POST("/fetch", controller.RelayTaskFetch)
@@ -191,7 +191,7 @@ func SetRelayRouter(router *gin.Engine) {
 	relayGeminiRouter.Use(middleware.SystemPerformanceCheck())
 	relayGeminiRouter.Use(middleware.TokenAuth())
 	relayGeminiRouter.Use(middleware.ModelRequestRateLimit())
-	relayGeminiRouter.Use(middleware.Distribute())
+	relayGeminiRouter.Use(middleware.Distribute(), middleware.ChannelRequestRateLimit())
 	{
 		// Gemini API 路径格式: /v1beta/models/{model_name}:{action}
 		relayGeminiRouter.POST("/models/*path", func(c *gin.Context) {
@@ -202,7 +202,7 @@ func SetRelayRouter(router *gin.Engine) {
 
 func registerMjRouterGroup(relayMjRouter *gin.RouterGroup) {
 	relayMjRouter.GET("/image/:id", relay.RelayMidjourneyImage)
-	relayMjRouter.Use(middleware.TokenAuth(), middleware.Distribute())
+	relayMjRouter.Use(middleware.TokenAuth(), middleware.Distribute(), middleware.ChannelRequestRateLimit())
 	{
 		relayMjRouter.POST("/submit/action", controller.RelayMidjourney)
 		relayMjRouter.POST("/submit/shorten", controller.RelayMidjourney)

--- a/router/video-router.go
+++ b/router/video-router.go
@@ -18,7 +18,7 @@ func SetVideoRouter(router *gin.Engine) {
 
 	videoV1Router := router.Group("/v1")
 	videoV1Router.Use(middleware.RouteTag("relay"))
-	videoV1Router.Use(middleware.TokenAuth(), middleware.Distribute())
+	videoV1Router.Use(middleware.TokenAuth(), middleware.Distribute(), middleware.ChannelRequestRateLimit())
 	{
 		videoV1Router.POST("/video/generations", controller.RelayTask)
 		videoV1Router.GET("/video/generations/:task_id", controller.RelayTaskFetch)
@@ -33,7 +33,7 @@ func SetVideoRouter(router *gin.Engine) {
 
 	klingV1Router := router.Group("/kling/v1")
 	klingV1Router.Use(middleware.RouteTag("relay"))
-	klingV1Router.Use(middleware.KlingRequestConvert(), middleware.TokenAuth(), middleware.Distribute())
+	klingV1Router.Use(middleware.KlingRequestConvert(), middleware.TokenAuth(), middleware.Distribute(), middleware.ChannelRequestRateLimit())
 	{
 		klingV1Router.POST("/videos/text2video", controller.RelayTask)
 		klingV1Router.POST("/videos/image2video", controller.RelayTask)
@@ -44,7 +44,7 @@ func SetVideoRouter(router *gin.Engine) {
 	// Jimeng official API routes - direct mapping to official API format
 	jimengOfficialGroup := router.Group("jimeng")
 	jimengOfficialGroup.Use(middleware.RouteTag("relay"))
-	jimengOfficialGroup.Use(middleware.JimengRequestConvert(), middleware.TokenAuth(), middleware.Distribute())
+	jimengOfficialGroup.Use(middleware.JimengRequestConvert(), middleware.TokenAuth(), middleware.Distribute(), middleware.ChannelRequestRateLimit())
 	{
 		// Maps to: /?Action=CVSync2AsyncSubmitTask&Version=2022-08-31 and /?Action=CVSync2AsyncGetResult&Version=2022-08-31
 		jimengOfficialGroup.POST("/", controller.RelayTask)

--- a/web/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/src/components/table/channels/modals/EditChannelModal.jsx
@@ -186,6 +186,7 @@ const EditChannelModal = (props) => {
     // 渠道额外设置的默认值
     force_format: false,
     thinking_to_content: false,
+    channel_rpm_limit: 0,
     proxy: '',
     pass_through_body_enabled: false,
     system_prompt: '',
@@ -522,6 +523,7 @@ const EditChannelModal = (props) => {
   const [channelSettings, setChannelSettings] = useState({
     force_format: false,
     thinking_to_content: false,
+    channel_rpm_limit: 0,
     proxy: '',
     pass_through_body_enabled: false,
     system_prompt: '',
@@ -839,6 +841,10 @@ const EditChannelModal = (props) => {
           data.force_format = parsedSettings.force_format || false;
           data.thinking_to_content =
             parsedSettings.thinking_to_content || false;
+          data.channel_rpm_limit = Number(parsedSettings.channel_rpm_limit || 0);
+          if (Number.isNaN(data.channel_rpm_limit) || data.channel_rpm_limit < 0) {
+            data.channel_rpm_limit = 0;
+          }
           data.proxy = parsedSettings.proxy || '';
           data.pass_through_body_enabled =
             parsedSettings.pass_through_body_enabled || false;
@@ -849,6 +855,7 @@ const EditChannelModal = (props) => {
           console.error('解析渠道设置失败:', error);
           data.force_format = false;
           data.thinking_to_content = false;
+          data.channel_rpm_limit = 0;
           data.proxy = '';
           data.pass_through_body_enabled = false;
           data.system_prompt = '';
@@ -857,6 +864,7 @@ const EditChannelModal = (props) => {
       } else {
         data.force_format = false;
         data.thinking_to_content = false;
+        data.channel_rpm_limit = 0;
         data.proxy = '';
         data.pass_through_body_enabled = false;
         data.system_prompt = '';
@@ -962,6 +970,7 @@ const EditChannelModal = (props) => {
       setChannelSettings({
         force_format: data.force_format,
         thinking_to_content: data.thinking_to_content,
+        channel_rpm_limit: data.channel_rpm_limit || 0,
         proxy: data.proxy,
         pass_through_body_enabled: data.pass_through_body_enabled,
         system_prompt: data.system_prompt,
@@ -1320,6 +1329,7 @@ const EditChannelModal = (props) => {
     setChannelSettings({
       force_format: false,
       thinking_to_content: false,
+      channel_rpm_limit: 0,
       proxy: '',
       pass_through_body_enabled: false,
       system_prompt: '',
@@ -1686,6 +1696,7 @@ const EditChannelModal = (props) => {
     const channelExtraSettings = {
       force_format: localInputs.force_format || false,
       thinking_to_content: localInputs.thinking_to_content || false,
+      channel_rpm_limit: Number(localInputs.channel_rpm_limit || 0),
       proxy: localInputs.proxy || '',
       pass_through_body_enabled: localInputs.pass_through_body_enabled || false,
       system_prompt: localInputs.system_prompt || '',
@@ -1766,6 +1777,7 @@ const EditChannelModal = (props) => {
     // 清理不需要发送到后端的字段
     delete localInputs.force_format;
     delete localInputs.thinking_to_content;
+    delete localInputs.channel_rpm_limit;
     delete localInputs.proxy;
     delete localInputs.pass_through_body_enabled;
     delete localInputs.system_prompt;
@@ -3867,6 +3879,21 @@ const EditChannelModal = (props) => {
                       extraText={t(
                         '将 reasoning_content 转换为 <think> 标签拼接到内容中',
                       )}
+                    />
+
+                    <Form.InputNumber
+                      field='channel_rpm_limit'
+                      label={t('渠道 RPM 限制')}
+                      min={0}
+                      step={1}
+                      suffix={t('次/分钟')}
+                      onChange={(value) =>
+                        handleChannelSettingsChange(
+                          'channel_rpm_limit',
+                          Number(value || 0),
+                        )
+                      }
+                      extraText={t('每个渠道每分钟允许的最大请求数，0 表示不限制')}
                     />
 
                     <Form.Switch


### PR DESCRIPTION
## Summary
- add `channel_rpm_limit` to channel settings (`0` means unlimited)
- add channel-level request RPM middleware (Redis + in-memory fallback)
- apply middleware after channel distribution on relay/video routes
- add channel validation for negative RPM values
- add admin UI field in channel edit modal to configure channel RPM

## Behavior
- when a channel exceeds configured RPM, request returns HTTP 429
- rate limit is isolated by `channel_id`

## Tests
- `go test ./middleware -run TestChannelRequestRateLimit -count=1`
  - exceed path
  - per-channel isolation
  - disabled when set to `0`

## Notes
- no DB schema migration required; setting is stored in existing channel `setting` JSON field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-channel request rate limiting with configurable RPM (requests per minute) limits. Users can now set channel-specific rate limits in channel settings to control request throughput.

* **Tests**
  * Added comprehensive test coverage for channel-level rate limiting functionality, including limit enforcement, channel isolation, and disabled-limit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->