### PR TITLE
fix: Solve the problem that the url in Zipu encodes image content for base64

### DIFF
--- a/relay/channel/zhipu_4v/image.go
+++ b/relay/channel/zhipu_4v/image.go
@@ -91,6 +91,12 @@ func zhipu4vImageHandler(c *gin.Context, resp *http.Response, info *relaycommon.
 		}
 
 		var b64 string
+		// 解决智普中url为base64编码图片的内容
+		if data.Url != "" && !strings.HasPrefix(data.Url, "http") {
+			data.B64Image = data.Url
+			data.Url = ""
+		}
+
 		switch {
 		case data.B64Json != "":
 			b64 = data.B64Json


### PR DESCRIPTION
解决智普中url为base64编码图片的内容

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced image handling to support additional image data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->