### PR TITLE
fix #3327:  add support for new relay mode based on /v1/messages path

### DIFF
--- a/relay/channel/baidu_v2/adaptor.go
+++ b/relay/channel/baidu_v2/adaptor.go
@@ -56,6 +56,9 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	case constant.RelayModeRerank:
 		return fmt.Sprintf("%s/v2/rerank", info.ChannelBaseUrl), nil
 	default:
+		if strings.HasPrefix(info.RequestURLPath, "/v1/messages") {
+			return fmt.Sprintf("%s/v2/chat/completions", info.ChannelBaseUrl), nil
+		}
 	}
 	return "", fmt.Errorf("unsupported relay mode: %d", info.RelayMode)
 }

--- a/relay/channel/baidu_v2/adaptor.go
+++ b/relay/channel/baidu_v2/adaptor.go
@@ -56,7 +56,8 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	case constant.RelayModeRerank:
 		return fmt.Sprintf("%s/v2/rerank", info.ChannelBaseUrl), nil
 	default:
-		if strings.HasPrefix(info.RequestURLPath, "/v1/messages") {
+		requestPath, _, _ := strings.Cut(info.RequestURLPath, "?")
+		if requestPath == "/v1/messages" {
 			return fmt.Sprintf("%s/v2/chat/completions", info.ChannelBaseUrl), nil
 		}
 	}

--- a/relay/constant/relay_mode.go
+++ b/relay/constant/relay_mode.go
@@ -56,7 +56,7 @@ const (
 
 func Path2RelayMode(path string) int {
 	relayMode := RelayModeUnknown
-	if strings.HasPrefix(path, "/v1/chat/completions") || strings.HasPrefix(path, "/pg/chat/completions") {
+	if strings.HasPrefix(path, "/v1/chat/completions") || strings.HasPrefix(path, "/pg/chat/completions") || strings.HasPrefix(path, "/v1/messages") {
 		relayMode = RelayModeChatCompletions
 	} else if strings.HasPrefix(path, "/v1/completions") {
 		relayMode = RelayModeCompletions

--- a/relay/constant/relay_mode.go
+++ b/relay/constant/relay_mode.go
@@ -56,7 +56,7 @@ const (
 
 func Path2RelayMode(path string) int {
 	relayMode := RelayModeUnknown
-	if strings.HasPrefix(path, "/v1/chat/completions") || strings.HasPrefix(path, "/pg/chat/completions") || strings.HasPrefix(path, "/v1/messages") {
+	if strings.HasPrefix(path, "/v1/chat/completions") || strings.HasPrefix(path, "/pg/chat/completions") {
 		relayMode = RelayModeChatCompletions
 	} else if strings.HasPrefix(path, "/v1/completions") {
 		relayMode = RelayModeCompletions


### PR DESCRIPTION
修复claude 调用 千帆v2 的 kimi 报错:

```
500 {"error":{"type":"do_request_failed","message":"get request url failed: unsupported relay mode: 0 (request id: 
     ....)"},"type":"error"} 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request routing for Baidu v2 so unhandled/default relay requests for message operations are now routed to the correct chat completions endpoint, preventing unsupported-relay-mode failures for those requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->