### PR TITLE
fix: unify MAX_REQUEST_BODY_MB defaults and fallback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ docker run --name new-api -d --restart always \
 | `REDIS_CONN_STRING` | Redis connection string | - |
 | `STREAMING_TIMEOUT` | Streaming timeout (seconds) | `300` |
 | `STREAM_SCANNER_MAX_BUFFER_MB` | Max per-line buffer (MB) for the stream scanner; increase when upstream sends huge image/base64 payloads | `64` |
-| `MAX_REQUEST_BODY_MB` | Max request body size (MB, counted **after decompression**; prevents huge requests/zip bombs from exhausting memory). Exceeding it returns `413` | `32` |
+| `MAX_REQUEST_BODY_MB` | Max request body size (MB, counted **after decompression**; prevents huge requests/zip bombs from exhausting memory). Exceeding it returns `413` | `128` |
 | `AZURE_DEFAULT_API_VERSION` | Azure API version | `2025-04-01-preview` |
 | `ERROR_LOG_ENABLED` | Error log switch | `false` |
 | `PYROSCOPE_URL` | Pyroscope server address | - |

--- a/common/gin.go
+++ b/common/gin.go
@@ -57,10 +57,7 @@ func GetRequestBody(c *gin.Context) (io.Seeker, error) {
 		}
 	}
 
-	maxMB := constant.MaxRequestBodyMB
-	if maxMB <= 0 {
-		maxMB = 128 // 默认 128MB
-	}
+	maxMB := constant.EffectiveMaxRequestBodyMB()
 	maxBytes := int64(maxMB) << 20
 
 	contentLength := c.Request.ContentLength

--- a/common/init.go
+++ b/common/init.go
@@ -133,7 +133,7 @@ func initConstantEnv() {
 	constant.MaxFileDownloadMB = GetEnvOrDefault("MAX_FILE_DOWNLOAD_MB", 64)
 	constant.StreamScannerMaxBufferMB = GetEnvOrDefault("STREAM_SCANNER_MAX_BUFFER_MB", 64)
 	// MaxRequestBodyMB 请求体最大大小（解压后），用于防止超大请求/zip bomb导致内存暴涨
-	constant.MaxRequestBodyMB = GetEnvOrDefault("MAX_REQUEST_BODY_MB", 128)
+	constant.MaxRequestBodyMB = GetEnvOrDefault("MAX_REQUEST_BODY_MB", constant.DefaultMaxRequestBodyMB)
 	// ForceStreamOption 覆盖请求参数，强制返回usage信息
 	constant.ForceStreamOption = GetEnvOrDefaultBool("FORCE_STREAM_OPTION", true)
 	constant.CountToken = GetEnvOrDefaultBool("CountToken", true)

--- a/constant/env.go
+++ b/constant/env.go
@@ -1,5 +1,14 @@
 package constant
 
+const DefaultMaxRequestBodyMB = 128
+
+func EffectiveMaxRequestBodyMB() int {
+	if MaxRequestBodyMB <= 0 {
+		return DefaultMaxRequestBodyMB
+	}
+	return MaxRequestBodyMB
+}
+
 var StreamingTimeout int
 var DifyDebug bool
 var MaxFileDownloadMB int

--- a/constant/env_test.go
+++ b/constant/env_test.go
@@ -1,0 +1,29 @@
+package constant
+
+import "testing"
+
+func TestEffectiveMaxRequestBodyMB(t *testing.T) {
+	original := MaxRequestBodyMB
+	t.Cleanup(func() {
+		MaxRequestBodyMB = original
+	})
+
+	tests := []struct {
+		name  string
+		value int
+		want  int
+	}{
+		{name: "positive value", value: 64, want: 64},
+		{name: "zero falls back to default", value: 0, want: DefaultMaxRequestBodyMB},
+		{name: "negative falls back to default", value: -1, want: DefaultMaxRequestBodyMB},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			MaxRequestBodyMB = tt.value
+			if got := EffectiveMaxRequestBodyMB(); got != tt.want {
+				t.Fatalf("EffectiveMaxRequestBodyMB() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/middleware/gzip.go
+++ b/middleware/gzip.go
@@ -28,10 +28,7 @@ func DecompressRequestMiddleware() gin.HandlerFunc {
 			c.Next()
 			return
 		}
-		maxMB := constant.MaxRequestBodyMB
-		if maxMB <= 0 {
-			maxMB = 32
-		}
+		maxMB := constant.EffectiveMaxRequestBodyMB()
 		maxBytes := int64(maxMB) << 20
 
 		origBody := c.Request.Body


### PR DESCRIPTION
## Summary
  统一 `MAX_REQUEST_BODY_MB` 的默认值与兜底逻辑，修正文档和运行时行为不一致的问题

  当前项目中，`MAX_REQUEST_BODY_MB` 在文档、初始化代码以及请求体处理链路中的默认值和 `<= 0` 兜底行为并不一致。
  本 PR 将这些逻辑统一为 `128MB`，避免出现配置无效时不同链路执行结果不一致的问题。

 我在实际使用中128MB不够用，一直改到512MB才实现codex auto compact，但是考虑这个值能作为环境变量修改，就保持了128MB。

  ## Background
  项目中的请求体大小限制由环境变量 `MAX_REQUEST_BODY_MB` 控制，但此前存在两类不一致：

  1. 文档默认值与代码默认值不一致
     - README 中将 `MAX_REQUEST_BODY_MB` 默认值写为 `32`
     - 实际初始化代码中默认值为 `128`

  2. `MAX_REQUEST_BODY_MB <= 0` 时兜底行为不一致
     - 请求解压/入口限制中间件回退到 `32MB`
     - 请求体读取与缓存逻辑回退到 `128MB`

  由于解压中间件和请求体读取逻辑都在实际请求链路中生效，这种不一致会导致配置为 `0`、负数或依赖默认值时，系统表现不稳定，也容易让文档使用者产生误解。

  本 PR 统一了默认值来源和兜底逻辑，使其在所有相关代码路径中保持一致。

  ## Changes
  ### `constant/env.go`
  新增共享默认值常量与统一兜底函数：
  - 增加 `DefaultMaxRequestBodyMB = 128`
  - 增加 `EffectiveMaxRequestBodyMB()`，用于统一处理 `<= 0` 时回退到默认值的逻辑

  ### `common/init.go`
  统一初始化默认值来源：
  - 将 `MAX_REQUEST_BODY_MB` 的初始化默认值改为引用 `constant.DefaultMaxRequestBodyMB`
  - 避免默认值在不同文件中重复写死

  ### `middleware/gzip.go`
  统一请求解压/入口限制逻辑：
  - 改为通过 `constant.EffectiveMaxRequestBodyMB()` 获取有效限制值
  - 不再单独使用 `32MB` 作为 `<= 0` 的兜底值

  ### `common/gin.go`
  统一请求体读取与缓存限制逻辑：
  - 改为通过 `constant.EffectiveMaxRequestBodyMB()` 获取有效限制值
  - 与解压中间件保持一致，不再单独写死 `128MB` 回退逻辑

  ### `README.md`
  修正文档默认值：
  - 将 `MAX_REQUEST_BODY_MB` 的默认值从 `32` 更新为 `128`
  - 使 README 与实际代码行为保持一致

  ### `constant/env_test.go`
  新增测试覆盖：
  - 验证正整数配置时按实际值生效
  - 验证 `0` 时回退到默认值 `128`
  - 验证负数时回退到默认值 `128`

  ## Testing
  - 执行 `gofmt` 格式化相关 Go 文件
  - 本地执行：
    - `go test ./constant ./common ./middleware`
  - 验证结果：
    - `constant` 包测试通过
    - `common` 包测试通过
    - `middleware` 包当前无测试文件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the default maximum request body size limit from 32 MB to 128 MB, which is enforced after decompression and triggers HTTP 413 errors when exceeded.

* **Refactor**
  * Centralized request body size limit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->