### PR TITLE
feat: support CSV export for usage logs with request_path filtering

### DIFF
--- a/controller/log.go
+++ b/controller/log.go
@@ -1,8 +1,10 @@
 package controller
 
 import (
+	"encoding/csv"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/model"
@@ -10,18 +12,29 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func GetAllLogs(c *gin.Context) {
-	pageInfo := common.GetPageQuery(c)
+func parseLogFilter(c *gin.Context) model.LogFilter {
 	logType, _ := strconv.Atoi(c.Query("type"))
 	startTimestamp, _ := strconv.ParseInt(c.Query("start_timestamp"), 10, 64)
 	endTimestamp, _ := strconv.ParseInt(c.Query("end_timestamp"), 10, 64)
-	username := c.Query("username")
-	tokenName := c.Query("token_name")
-	modelName := c.Query("model_name")
+	return model.LogFilter{
+		LogType:        logType,
+		StartTimestamp: startTimestamp,
+		EndTimestamp:   endTimestamp,
+		ModelName:      c.Query("model_name"),
+		TokenName:      c.Query("token_name"),
+		Group:          c.Query("group"),
+		RequestID:      c.Query("request_id"),
+		RequestPath:    c.Query("request_path"),
+	}
+}
+
+func GetAllLogs(c *gin.Context) {
+	pageInfo := common.GetPageQuery(c)
+	filters := parseLogFilter(c)
+	filters.Username = c.Query("username")
 	channel, _ := strconv.Atoi(c.Query("channel"))
-	group := c.Query("group")
-	requestId := c.Query("request_id")
-	logs, total, err := model.GetAllLogs(logType, startTimestamp, endTimestamp, modelName, username, tokenName, pageInfo.GetStartIdx(), pageInfo.GetPageSize(), channel, group, requestId)
+	filters.ChannelID = channel
+	logs, total, err := model.GetAllLogsByFilter(filters, pageInfo.GetStartIdx(), pageInfo.GetPageSize())
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -35,14 +48,9 @@ func GetAllLogs(c *gin.Context) {
 func GetUserLogs(c *gin.Context) {
 	pageInfo := common.GetPageQuery(c)
 	userId := c.GetInt("id")
-	logType, _ := strconv.Atoi(c.Query("type"))
-	startTimestamp, _ := strconv.ParseInt(c.Query("start_timestamp"), 10, 64)
-	endTimestamp, _ := strconv.ParseInt(c.Query("end_timestamp"), 10, 64)
-	tokenName := c.Query("token_name")
-	modelName := c.Query("model_name")
-	group := c.Query("group")
-	requestId := c.Query("request_id")
-	logs, total, err := model.GetUserLogs(userId, logType, startTimestamp, endTimestamp, modelName, tokenName, pageInfo.GetStartIdx(), pageInfo.GetPageSize(), group, requestId)
+	filters := parseLogFilter(c)
+	filters.UserID = &userId
+	logs, total, err := model.GetUserLogsByFilter(filters, pageInfo.GetStartIdx(), pageInfo.GetPageSize())
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -51,6 +59,64 @@ func GetUserLogs(c *gin.Context) {
 	pageInfo.SetItems(logs)
 	common.ApiSuccess(c, pageInfo)
 	return
+}
+
+func ExportUserLogsCSV(c *gin.Context) {
+	userId := c.GetInt("id")
+	filters := parseLogFilter(c)
+	filters.UserID = &userId
+
+	logs, err := model.GetUserLogsForExport(filters)
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+
+	c.Header("Content-Type", "text/csv; charset=utf-8")
+	c.Header("Content-Disposition", "attachment; filename=\"usage-logs-"+time.Now().Format("2006-01-02")+".csv\"")
+	c.Status(http.StatusOK)
+
+	_, _ = c.Writer.Write([]byte("\xEF\xBB\xBF"))
+	writer := csv.NewWriter(c.Writer)
+	defer writer.Flush()
+
+	header := []string{
+		"used_at",
+		"username",
+		"token_name",
+		"model_name",
+		"request_path",
+		"quota",
+		"prompt_tokens",
+		"completion_tokens",
+		"ip",
+		"request_id",
+		"group",
+		"log_type",
+	}
+	if err = writer.Write(header); err != nil {
+		return
+	}
+
+	for _, log := range logs {
+		record := []string{
+			time.Unix(log.CreatedAt, 0).Format("2006-01-02 15:04:05"),
+			log.Username,
+			log.TokenName,
+			log.ModelName,
+			log.RequestPath,
+			strconv.Itoa(log.Quota),
+			strconv.Itoa(log.PromptTokens),
+			strconv.Itoa(log.CompletionTokens),
+			log.Ip,
+			log.RequestId,
+			log.Group,
+			strconv.Itoa(log.Type),
+		}
+		if err = writer.Write(record); err != nil {
+			return
+		}
+	}
 }
 
 // Deprecated: SearchAllLogs 已废弃，前端未使用该接口。

--- a/controller/log.go
+++ b/controller/log.go
@@ -28,12 +28,72 @@ func parseLogFilter(c *gin.Context) model.LogFilter {
 	}
 }
 
-func GetAllLogs(c *gin.Context) {
-	pageInfo := common.GetPageQuery(c)
+func parseAdminLogFilter(c *gin.Context) model.LogFilter {
 	filters := parseLogFilter(c)
 	filters.Username = c.Query("username")
 	channel, _ := strconv.Atoi(c.Query("channel"))
 	filters.ChannelID = channel
+	return filters
+}
+
+func writeLogsCSV(c *gin.Context, logs []*model.Log, includeChannel bool) {
+	header := []string{
+		"used_at",
+		"username",
+		"token_name",
+		"model_name",
+		"request_path",
+		"quota",
+		"prompt_tokens",
+		"completion_tokens",
+		"ip",
+		"request_id",
+		"group",
+		"log_type",
+	}
+	if includeChannel {
+		header = append(header, "channel_id")
+	}
+
+	c.Header("Content-Type", "text/csv; charset=utf-8")
+	c.Header("Content-Disposition", "attachment; filename=\"usage-logs-"+time.Now().Format("2006-01-02")+".csv\"")
+	c.Status(http.StatusOK)
+
+	_, _ = c.Writer.Write([]byte("\xEF\xBB\xBF"))
+	writer := csv.NewWriter(c.Writer)
+	defer writer.Flush()
+
+	if err := writer.Write(header); err != nil {
+		return
+	}
+
+	for _, log := range logs {
+		record := []string{
+			time.Unix(log.CreatedAt, 0).Format("2006-01-02 15:04:05"),
+			log.Username,
+			log.TokenName,
+			log.ModelName,
+			log.RequestPath,
+			strconv.Itoa(log.Quota),
+			strconv.Itoa(log.PromptTokens),
+			strconv.Itoa(log.CompletionTokens),
+			log.Ip,
+			log.RequestId,
+			log.Group,
+			strconv.Itoa(log.Type),
+		}
+		if includeChannel {
+			record = append(record, strconv.Itoa(log.ChannelId))
+		}
+		if err := writer.Write(record); err != nil {
+			return
+		}
+	}
+}
+
+func GetAllLogs(c *gin.Context) {
+	pageInfo := common.GetPageQuery(c)
+	filters := parseAdminLogFilter(c)
 	logs, total, err := model.GetAllLogsByFilter(filters, pageInfo.GetStartIdx(), pageInfo.GetPageSize())
 	if err != nil {
 		common.ApiError(c, err)
@@ -61,6 +121,16 @@ func GetUserLogs(c *gin.Context) {
 	return
 }
 
+func ExportAllLogsCSV(c *gin.Context) {
+	filters := parseAdminLogFilter(c)
+	logs, err := model.GetAllLogsForExport(filters)
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	writeLogsCSV(c, logs, true)
+}
+
 func ExportUserLogsCSV(c *gin.Context) {
 	userId := c.GetInt("id")
 	filters := parseLogFilter(c)
@@ -71,52 +141,7 @@ func ExportUserLogsCSV(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
-
-	c.Header("Content-Type", "text/csv; charset=utf-8")
-	c.Header("Content-Disposition", "attachment; filename=\"usage-logs-"+time.Now().Format("2006-01-02")+".csv\"")
-	c.Status(http.StatusOK)
-
-	_, _ = c.Writer.Write([]byte("\xEF\xBB\xBF"))
-	writer := csv.NewWriter(c.Writer)
-	defer writer.Flush()
-
-	header := []string{
-		"used_at",
-		"username",
-		"token_name",
-		"model_name",
-		"request_path",
-		"quota",
-		"prompt_tokens",
-		"completion_tokens",
-		"ip",
-		"request_id",
-		"group",
-		"log_type",
-	}
-	if err = writer.Write(header); err != nil {
-		return
-	}
-
-	for _, log := range logs {
-		record := []string{
-			time.Unix(log.CreatedAt, 0).Format("2006-01-02 15:04:05"),
-			log.Username,
-			log.TokenName,
-			log.ModelName,
-			log.RequestPath,
-			strconv.Itoa(log.Quota),
-			strconv.Itoa(log.PromptTokens),
-			strconv.Itoa(log.CompletionTokens),
-			log.Ip,
-			log.RequestId,
-			log.Group,
-			strconv.Itoa(log.Type),
-		}
-		if err = writer.Write(record); err != nil {
-			return
-		}
-	}
+	writeLogsCSV(c, logs, false)
 }
 
 // Deprecated: SearchAllLogs 已废弃，前端未使用该接口。

--- a/controller/log_export_test.go
+++ b/controller/log_export_test.go
@@ -74,6 +74,23 @@ func seedExportUser(t *testing.T, db *gorm.DB, id int, username string, accessTo
 	return user
 }
 
+func seedExportAdmin(t *testing.T, db *gorm.DB, id int, username string, accessToken string) *model.User {
+	t.Helper()
+
+	user := &model.User{
+		Id:       id,
+		Username: username,
+		Password: "password123",
+		Role:     common.RoleAdminUser,
+		Status:   common.UserStatusEnabled,
+		Group:    "default",
+		AffCode:  fmt.Sprintf("aff-admin-%d", id),
+	}
+	user.SetAccessToken(accessToken)
+	require.NoError(t, db.Create(user).Error)
+	return user
+}
+
 func seedExportLog(t *testing.T, db *gorm.DB, log *model.Log) {
 	t.Helper()
 	require.NoError(t, db.Create(log).Error)
@@ -83,6 +100,7 @@ func newLogExportRouter() *gin.Engine {
 	router := gin.New()
 	store := cookie.NewStore([]byte("log-export-test"))
 	router.Use(sessions.Sessions("new-api-test", store))
+	router.GET("/api/log/export", middleware.AdminAuth(), ExportAllLogsCSV)
 	router.GET("/api/log/self/export", middleware.UserAuth(), ExportUserLogsCSV)
 	return router
 }
@@ -195,6 +213,101 @@ func TestExportUserLogsCSV_ExportsOnlyCurrentUserAndBackfilledLogs(t *testing.T)
 	assert.Equal(t, "alice", records[1][1])
 	assert.Equal(t, "/v1/chat/completions", records[1][4])
 	assert.Equal(t, "req-alice", records[1][9])
+}
+
+func TestExportAllLogsCSV_AdminUsesPageFilters(t *testing.T) {
+	db := setupLogControllerTestDB(t)
+	router := newLogExportRouter()
+
+	admin := seedExportAdmin(t, db, 99, "admin", "token-admin")
+	seedExportUser(t, db, 1, "alice", "token-alice")
+	seedExportUser(t, db, 2, "bob", "token-bob")
+
+	seedExportLog(t, db, &model.Log{
+		UserId:           1,
+		Username:         "alice",
+		CreatedAt:        1_700_000_100,
+		Type:             model.LogTypeConsume,
+		TokenName:        "alpha",
+		ModelName:        "gpt-4o-mini",
+		Group:            "team-a",
+		ChannelId:        11,
+		RequestId:        "req-admin-match",
+		RequestPath:      "/v1/chat/completions",
+		Quota:            100,
+		PromptTokens:     10,
+		CompletionTokens: 20,
+		Ip:               "127.0.0.1",
+	})
+	seedExportLog(t, db, &model.Log{
+		UserId:           1,
+		Username:         "alice",
+		CreatedAt:        1_700_000_200,
+		Type:             model.LogTypeConsume,
+		TokenName:        "alpha",
+		ModelName:        "gpt-4o-mini",
+		Group:            "team-a",
+		ChannelId:        12,
+		RequestId:        "req-wrong-channel",
+		RequestPath:      "/v1/chat/completions",
+		Quota:            100,
+		PromptTokens:     10,
+		CompletionTokens: 20,
+		Ip:               "127.0.0.2",
+	})
+	seedExportLog(t, db, &model.Log{
+		UserId:           2,
+		Username:         "bob",
+		CreatedAt:        1_700_000_300,
+		Type:             model.LogTypeConsume,
+		TokenName:        "alpha",
+		ModelName:        "gpt-4o-mini",
+		Group:            "team-a",
+		ChannelId:        11,
+		RequestId:        "req-wrong-user",
+		RequestPath:      "/v1/chat/completions",
+		Quota:            100,
+		PromptTokens:     10,
+		CompletionTokens: 20,
+		Ip:               "127.0.0.3",
+	})
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/log/export?start_timestamp=1700000000&end_timestamp=1700000999&username=alice&channel=11&request_path=/v1/chat/completions",
+		nil,
+	)
+	req.Header.Set("Authorization", "Bearer token-admin")
+	req.Header.Set("New-Api-User", strconv.Itoa(admin.Id))
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	assert.Contains(t, recorder.Header().Get("Content-Type"), "text/csv")
+
+	reader := csv.NewReader(strings.NewReader(recorder.Body.String()))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	assert.Equal(t, []string{
+		"used_at",
+		"username",
+		"token_name",
+		"model_name",
+		"request_path",
+		"quota",
+		"prompt_tokens",
+		"completion_tokens",
+		"ip",
+		"request_id",
+		"group",
+		"log_type",
+		"channel_id",
+	}, normalizeCSVHeader(records[0]))
+	assert.Equal(t, "alice", records[1][1])
+	assert.Equal(t, "req-admin-match", records[1][9])
+	assert.Equal(t, "11", records[1][12])
 }
 
 func normalizeCSVHeader(header []string) []string {

--- a/controller/log_export_test.go
+++ b/controller/log_export_test.go
@@ -1,0 +1,205 @@
+package controller
+
+import (
+	"encoding/csv"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/middleware"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/cookie"
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+type logExportAPIResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+func setupLogControllerTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	common.UsingSQLite = true
+	common.UsingMySQL = false
+	common.UsingPostgreSQL = false
+	common.RedisEnabled = false
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "_"))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open sqlite db: %v", err)
+	}
+	model.DB = db
+	model.LOG_DB = db
+
+	if err := db.AutoMigrate(&model.User{}, &model.Log{}); err != nil {
+		t.Fatalf("failed to migrate test tables: %v", err)
+	}
+
+	t.Cleanup(func() {
+		sqlDB, err := db.DB()
+		if err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	return db
+}
+
+func seedExportUser(t *testing.T, db *gorm.DB, id int, username string, accessToken string) *model.User {
+	t.Helper()
+
+	user := &model.User{
+		Id:       id,
+		Username: username,
+		Password: "password123",
+		Role:     common.RoleCommonUser,
+		Status:   common.UserStatusEnabled,
+		Group:    "team-a",
+	}
+	user.SetAccessToken(accessToken)
+	require.NoError(t, db.Create(user).Error)
+	return user
+}
+
+func seedExportLog(t *testing.T, db *gorm.DB, log *model.Log) {
+	t.Helper()
+	require.NoError(t, db.Create(log).Error)
+}
+
+func newLogExportRouter() *gin.Engine {
+	router := gin.New()
+	store := cookie.NewStore([]byte("log-export-test"))
+	router.Use(sessions.Sessions("new-api-test", store))
+	router.GET("/api/log/self/export", middleware.UserAuth(), ExportUserLogsCSV)
+	return router
+}
+
+func decodeLogExportAPIResponse(t *testing.T, recorder *httptest.ResponseRecorder) logExportAPIResponse {
+	t.Helper()
+
+	var response logExportAPIResponse
+	require.NoError(t, common.Unmarshal(recorder.Body.Bytes(), &response))
+	return response
+}
+
+func TestExportUserLogsCSV_RequiresAuthentication(t *testing.T) {
+	setupLogControllerTestDB(t)
+	router := newLogExportRouter()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/log/self/export", nil)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+	response := decodeLogExportAPIResponse(t, recorder)
+	assert.False(t, response.Success)
+	assert.Contains(t, response.Message, "未登录")
+}
+
+func TestExportUserLogsCSV_ExportsOnlyCurrentUserAndBackfilledLogs(t *testing.T) {
+	db := setupLogControllerTestDB(t)
+	router := newLogExportRouter()
+
+	user := seedExportUser(t, db, 1, "alice", "token-alice")
+	seedExportUser(t, db, 2, "bob", "token-bob")
+
+	seedExportLog(t, db, &model.Log{
+		UserId:           user.Id,
+		Username:         user.Username,
+		CreatedAt:        1_700_000_100,
+		Type:             model.LogTypeConsume,
+		TokenName:        "alpha",
+		ModelName:        "gpt-4o-mini",
+		Group:            "team-a",
+		RequestId:        "req-alice",
+		RequestPath:      "",
+		Quota:            42,
+		PromptTokens:     120,
+		CompletionTokens: 60,
+		Ip:               "127.0.0.1",
+		Other:            common.MapToJsonStr(map[string]interface{}{"request_path": "/v1/chat/completions"}),
+	})
+	seedExportLog(t, db, &model.Log{
+		UserId:      user.Id,
+		Username:    user.Username,
+		CreatedAt:   1_700_000_200,
+		Type:        model.LogTypeConsume,
+		TokenName:   "alpha",
+		ModelName:   "gpt-4o-mini",
+		Group:       "team-a",
+		RequestId:   "req-other-path",
+		RequestPath: "/v1/responses",
+		Other:       common.MapToJsonStr(map[string]interface{}{"request_path": "/v1/responses"}),
+	})
+	seedExportLog(t, db, &model.Log{
+		UserId:      2,
+		Username:    "bob",
+		CreatedAt:   1_700_000_300,
+		Type:        model.LogTypeConsume,
+		TokenName:   "alpha",
+		ModelName:   "gpt-4o-mini",
+		Group:       "team-a",
+		RequestId:   "req-bob",
+		RequestPath: "/v1/chat/completions",
+		Other:       common.MapToJsonStr(map[string]interface{}{"request_path": "/v1/chat/completions"}),
+	})
+
+	_, err := model.BackfillLogRequestPath(10)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/log/self/export?start_timestamp=1700000000&end_timestamp=1700000999&token_name=alpha&model_name=gpt-4o-mini&group=team-a&request_id=req-alice&request_path=/v1/chat/completions",
+		nil,
+	)
+	req.Header.Set("Authorization", "Bearer token-alice")
+	req.Header.Set("New-Api-User", strconv.Itoa(user.Id))
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	assert.Contains(t, recorder.Header().Get("Content-Type"), "text/csv")
+
+	reader := csv.NewReader(strings.NewReader(recorder.Body.String()))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	assert.Equal(t, []string{
+		"used_at",
+		"username",
+		"token_name",
+		"model_name",
+		"request_path",
+		"quota",
+		"prompt_tokens",
+		"completion_tokens",
+		"ip",
+		"request_id",
+		"group",
+		"log_type",
+	}, normalizeCSVHeader(records[0]))
+	assert.Equal(t, "alice", records[1][1])
+	assert.Equal(t, "/v1/chat/completions", records[1][4])
+	assert.Equal(t, "req-alice", records[1][9])
+}
+
+func normalizeCSVHeader(header []string) []string {
+	if len(header) == 0 {
+		return header
+	}
+	header[0] = strings.TrimPrefix(header[0], "\uFEFF")
+	return header
+}

--- a/controller/log_export_test.go
+++ b/controller/log_export_test.go
@@ -43,7 +43,7 @@ func setupLogControllerTestDB(t *testing.T) *gorm.DB {
 	model.DB = db
 	model.LOG_DB = db
 
-	if err := db.AutoMigrate(&model.User{}, &model.Log{}); err != nil {
+	if err := db.AutoMigrate(&model.User{}, &model.Log{}, &model.Option{}); err != nil {
 		t.Fatalf("failed to migrate test tables: %v", err)
 	}
 
@@ -67,6 +67,7 @@ func seedExportUser(t *testing.T, db *gorm.DB, id int, username string, accessTo
 		Role:     common.RoleCommonUser,
 		Status:   common.UserStatusEnabled,
 		Group:    "team-a",
+		AffCode:  fmt.Sprintf("aff-%d", id),
 	}
 	user.SetAccessToken(accessToken)
 	require.NoError(t, db.Create(user).Error)

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -576,6 +576,7 @@ func RelayTask(c *gin.Context) {
 		task.PrivateData.SubscriptionId = relayInfo.SubscriptionId
 		task.PrivateData.TokenId = relayInfo.TokenId
 		task.PrivateData.BillingContext = &model.TaskBillingContext{
+			RequestPath:     c.Request.URL.Path,
 			ModelPrice:      relayInfo.PriceData.ModelPrice,
 			GroupRatio:      relayInfo.PriceData.GroupRatioInfo.GroupRatio,
 			ModelRatio:      relayInfo.PriceData.ModelRatio,

--- a/model/log.go
+++ b/model/log.go
@@ -530,6 +530,19 @@ func GetUserLogsForExport(filters LogFilter) (logs []*Log, err error) {
 	return logs, nil
 }
 
+func GetAllLogsForExport(filters LogFilter) (logs []*Log, err error) {
+	tx, err := applyLogFilters(LOG_DB.Model(&Log{}), filters)
+	if err != nil {
+		return nil, err
+	}
+	err = tx.Order("logs.created_at asc, logs.id asc").Find(&logs).Error
+	if err != nil {
+		common.SysError("failed to query logs for export: " + err.Error())
+		return nil, errors.New("failed to query logs for export")
+	}
+	return logs, nil
+}
+
 type Stat struct {
 	Quota int `json:"quota"`
 	Rpm   int `json:"rpm"`

--- a/model/log.go
+++ b/model/log.go
@@ -248,6 +248,20 @@ func RecordTaskBillingLog(params RecordTaskBillingLogParams) {
 	}
 }
 
+type LogFilter struct {
+	UserID         *int
+	LogType        int
+	StartTimestamp int64
+	EndTimestamp   int64
+	ModelName      string
+	Username       string
+	TokenName      string
+	Group          string
+	RequestID      string
+	RequestPath    string
+	ChannelID      int
+}
+
 func resolveLogRequestPath(explicit string, other map[string]interface{}) string {
 	if explicit != "" {
 		return explicit
@@ -269,39 +283,68 @@ func resolveLogRequestPath(explicit string, other map[string]interface{}) string
 	return path
 }
 
-func GetAllLogs(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string, startIdx int, num int, channel int, group string, requestId string) (logs []*Log, total int64, err error) {
-	var tx *gorm.DB
-	if logType == LogTypeUnknown {
-		tx = LOG_DB
-	} else {
-		tx = LOG_DB.Where("logs.type = ?", logType)
+func applyLogFilters(tx *gorm.DB, filters LogFilter) (*gorm.DB, error) {
+	initCol()
+	if tx == nil {
+		tx = LOG_DB.Model(&Log{})
 	}
+	if filters.UserID != nil {
+		tx = tx.Where("logs.user_id = ?", *filters.UserID)
+	}
+	if filters.LogType != LogTypeUnknown {
+		tx = tx.Where("logs.type = ?", filters.LogType)
+	}
+	if filters.ModelName != "" {
+		modelNamePattern, err := sanitizeLikePattern(filters.ModelName)
+		if err != nil {
+			return nil, err
+		}
+		tx = tx.Where("logs.model_name LIKE ? ESCAPE '!'", modelNamePattern)
+	}
+	if filters.Username != "" {
+		tx = tx.Where("logs.username = ?", filters.Username)
+	}
+	if filters.TokenName != "" {
+		tx = tx.Where("logs.token_name = ?", filters.TokenName)
+	}
+	if filters.RequestID != "" {
+		tx = tx.Where("logs.request_id = ?", filters.RequestID)
+	}
+	if filters.RequestPath != "" {
+		tx = tx.Where("logs.request_path = ?", filters.RequestPath)
+	}
+	if filters.StartTimestamp != 0 {
+		tx = tx.Where("logs.created_at >= ?", filters.StartTimestamp)
+	}
+	if filters.EndTimestamp != 0 {
+		tx = tx.Where("logs.created_at <= ?", filters.EndTimestamp)
+	}
+	if filters.ChannelID != 0 {
+		tx = tx.Where("logs.channel_id = ?", filters.ChannelID)
+	}
+	if filters.Group != "" {
+		tx = tx.Where("logs."+logGroupCol+" = ?", filters.Group)
+	}
+	return tx, nil
+}
 
-	if modelName != "" {
-		tx = tx.Where("logs.model_name like ?", modelName)
+func GetAllLogs(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string, startIdx int, num int, channel int, group string, requestId string, requestPath string) (logs []*Log, total int64, err error) {
+	tx, err := applyLogFilters(LOG_DB.Model(&Log{}), LogFilter{
+		LogType:        logType,
+		StartTimestamp: startTimestamp,
+		EndTimestamp:   endTimestamp,
+		ModelName:      modelName,
+		Username:       username,
+		TokenName:      tokenName,
+		Group:          group,
+		RequestID:      requestId,
+		RequestPath:    requestPath,
+		ChannelID:      channel,
+	})
+	if err != nil {
+		return nil, 0, err
 	}
-	if username != "" {
-		tx = tx.Where("logs.username = ?", username)
-	}
-	if tokenName != "" {
-		tx = tx.Where("logs.token_name = ?", tokenName)
-	}
-	if requestId != "" {
-		tx = tx.Where("logs.request_id = ?", requestId)
-	}
-	if startTimestamp != 0 {
-		tx = tx.Where("logs.created_at >= ?", startTimestamp)
-	}
-	if endTimestamp != 0 {
-		tx = tx.Where("logs.created_at <= ?", endTimestamp)
-	}
-	if channel != 0 {
-		tx = tx.Where("logs.channel_id = ?", channel)
-	}
-	if group != "" {
-		tx = tx.Where("logs."+logGroupCol+" = ?", group)
-	}
-	err = tx.Model(&Log{}).Count(&total).Error
+	err = tx.Count(&total).Error
 	if err != nil {
 		return nil, 0, err
 	}
@@ -398,6 +441,93 @@ func GetUserLogs(userId int, logType int, startTimestamp int64, endTimestamp int
 
 	formatUserLogs(logs, startIdx)
 	return logs, total, err
+}
+
+func GetAllLogsByFilter(filters LogFilter, startIdx int, num int) (logs []*Log, total int64, err error) {
+	tx, err := applyLogFilters(LOG_DB.Model(&Log{}), filters)
+	if err != nil {
+		return nil, 0, err
+	}
+	err = tx.Count(&total).Error
+	if err != nil {
+		return nil, 0, err
+	}
+	err = tx.Order("logs.id desc").Limit(num).Offset(startIdx).Find(&logs).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	channelIds := types.NewSet[int]()
+	for _, log := range logs {
+		if log.ChannelId != 0 {
+			channelIds.Add(log.ChannelId)
+		}
+	}
+
+	if channelIds.Len() > 0 {
+		var channels []struct {
+			Id   int    `gorm:"column:id"`
+			Name string `gorm:"column:name"`
+		}
+		if common.MemoryCacheEnabled {
+			for _, channelId := range channelIds.Items() {
+				if cacheChannel, err := CacheGetChannel(channelId); err == nil {
+					channels = append(channels, struct {
+						Id   int    `gorm:"column:id"`
+						Name string `gorm:"column:name"`
+					}{
+						Id:   channelId,
+						Name: cacheChannel.Name,
+					})
+				}
+			}
+		} else {
+			if err = DB.Table("channels").Select("id, name").Where("id IN ?", channelIds.Items()).Find(&channels).Error; err != nil {
+				return logs, total, err
+			}
+		}
+		channelMap := make(map[int]string, len(channels))
+		for _, channel := range channels {
+			channelMap[channel.Id] = channel.Name
+		}
+		for i := range logs {
+			logs[i].ChannelName = channelMap[logs[i].ChannelId]
+		}
+	}
+
+	return logs, total, nil
+}
+
+func GetUserLogsByFilter(filters LogFilter, startIdx int, num int) (logs []*Log, total int64, err error) {
+	tx, err := applyLogFilters(LOG_DB.Model(&Log{}), filters)
+	if err != nil {
+		return nil, 0, err
+	}
+	err = tx.Limit(logSearchCountLimit).Count(&total).Error
+	if err != nil {
+		common.SysError("failed to count user logs: " + err.Error())
+		return nil, 0, errors.New("æŸ¥è¯¢æ—¥å¿—å¤±è´¥")
+	}
+	err = tx.Order("logs.id desc").Limit(num).Offset(startIdx).Find(&logs).Error
+	if err != nil {
+		common.SysError("failed to search user logs: " + err.Error())
+		return nil, 0, errors.New("æŸ¥è¯¢æ—¥å¿—å¤±è´¥")
+	}
+	formatUserLogs(logs, startIdx)
+	return logs, total, nil
+}
+
+func GetUserLogsForExport(filters LogFilter) (logs []*Log, err error) {
+	tx, err := applyLogFilters(LOG_DB.Model(&Log{}), filters)
+	if err != nil {
+		return nil, err
+	}
+	err = tx.Order("logs.created_at asc, logs.id asc").Find(&logs).Error
+	if err != nil {
+		common.SysError("failed to query logs for export: " + err.Error())
+		return nil, errors.New("æŸ¥è¯¢æ—¥å¿—å¤±è´¥")
+	}
+	return logs, nil
 }
 
 type Stat struct {

--- a/model/log.go
+++ b/model/log.go
@@ -36,6 +36,7 @@ type Log struct {
 	Group            string `json:"group" gorm:"index"`
 	Ip               string `json:"ip" gorm:"index;default:''"`
 	RequestId        string `json:"request_id,omitempty" gorm:"type:varchar(64);index:idx_logs_request_id;default:''"`
+	RequestPath      string `json:"request_path,omitempty" gorm:"type:varchar(255);index:idx_logs_request_path;default:''"`
 	Other            string `json:"other"`
 }
 
@@ -124,8 +125,9 @@ func RecordErrorLog(c *gin.Context, userId int, channelId int, modelName string,
 			}
 			return ""
 		}(),
-		RequestId: requestId,
-		Other:     otherStr,
+		RequestId:   requestId,
+		RequestPath: resolveLogRequestPath(c.Request.URL.Path, other),
+		Other:       otherStr,
 	}
 	err := LOG_DB.Create(log).Error
 	if err != nil {
@@ -145,6 +147,7 @@ type RecordConsumeLogParams struct {
 	UseTimeSeconds   int                    `json:"use_time_seconds"`
 	IsStream         bool                   `json:"is_stream"`
 	Group            string                 `json:"group"`
+	RequestPath      string                 `json:"request_path"`
 	Other            map[string]interface{} `json:"other"`
 }
 
@@ -185,8 +188,9 @@ func RecordConsumeLog(c *gin.Context, userId int, params RecordConsumeLogParams)
 			}
 			return ""
 		}(),
-		RequestId: requestId,
-		Other:     otherStr,
+		RequestId:   requestId,
+		RequestPath: resolveLogRequestPath(params.RequestPath, params.Other),
+		Other:       otherStr,
 	}
 	err := LOG_DB.Create(log).Error
 	if err != nil {
@@ -200,15 +204,16 @@ func RecordConsumeLog(c *gin.Context, userId int, params RecordConsumeLogParams)
 }
 
 type RecordTaskBillingLogParams struct {
-	UserId    int
-	LogType   int
-	Content   string
-	ChannelId int
-	ModelName string
-	Quota     int
-	TokenId   int
-	Group     string
-	Other     map[string]interface{}
+	UserId      int
+	LogType     int
+	Content     string
+	ChannelId   int
+	ModelName   string
+	Quota       int
+	TokenId     int
+	Group       string
+	RequestPath string
+	Other       map[string]interface{}
 }
 
 func RecordTaskBillingLog(params RecordTaskBillingLogParams) {
@@ -223,23 +228,45 @@ func RecordTaskBillingLog(params RecordTaskBillingLogParams) {
 		}
 	}
 	log := &Log{
-		UserId:    params.UserId,
-		Username:  username,
-		CreatedAt: common.GetTimestamp(),
-		Type:      params.LogType,
-		Content:   params.Content,
-		TokenName: tokenName,
-		ModelName: params.ModelName,
-		Quota:     params.Quota,
-		ChannelId: params.ChannelId,
-		TokenId:   params.TokenId,
-		Group:     params.Group,
-		Other:     common.MapToJsonStr(params.Other),
+		UserId:      params.UserId,
+		Username:    username,
+		CreatedAt:   common.GetTimestamp(),
+		Type:        params.LogType,
+		Content:     params.Content,
+		TokenName:   tokenName,
+		ModelName:   params.ModelName,
+		Quota:       params.Quota,
+		ChannelId:   params.ChannelId,
+		TokenId:     params.TokenId,
+		Group:       params.Group,
+		RequestPath: resolveLogRequestPath(params.RequestPath, params.Other),
+		Other:       common.MapToJsonStr(params.Other),
 	}
 	err := LOG_DB.Create(log).Error
 	if err != nil {
 		common.SysLog("failed to record task billing log: " + err.Error())
 	}
+}
+
+func resolveLogRequestPath(explicit string, other map[string]interface{}) string {
+	if explicit != "" {
+		return explicit
+	}
+	if other == nil {
+		return ""
+	}
+	value, ok := other["request_path"]
+	if !ok || value == nil {
+		return ""
+	}
+	if path, ok := value.(string); ok {
+		return path
+	}
+	path := fmt.Sprint(value)
+	if path == "<nil>" {
+		return ""
+	}
+	return path
 }
 
 func GetAllLogs(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string, startIdx int, num int, channel int, group string, requestId string) (logs []*Log, total int64, err error) {

--- a/model/log_filter_test.go
+++ b/model/log_filter_test.go
@@ -1,0 +1,120 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createLogForFilterTest(t *testing.T, log *Log) {
+	t.Helper()
+	require.NoError(t, LOG_DB.Create(log).Error)
+}
+
+func TestApplyLogFilters_MatchesRequestPathAndMetadata(t *testing.T) {
+	truncateTables(t)
+
+	createLogForFilterTest(t, &Log{
+		UserId:           11,
+		CreatedAt:        1_700_000_100,
+		Type:             LogTypeConsume,
+		Username:         "alice",
+		TokenName:        "alpha",
+		ModelName:        "gpt-4o-mini",
+		Group:            "team-a",
+		RequestId:        "req-match",
+		RequestPath:      "/v1/chat/completions",
+		Quota:            10,
+		PromptTokens:     100,
+		CompletionTokens: 20,
+		Other:            common.MapToJsonStr(map[string]interface{}{"request_path": "/v1/chat/completions"}),
+	})
+	createLogForFilterTest(t, &Log{
+		UserId:      11,
+		CreatedAt:   1_700_000_200,
+		Type:        LogTypeConsume,
+		Username:    "alice",
+		TokenName:   "alpha",
+		ModelName:   "gpt-4o-mini",
+		Group:       "team-a",
+		RequestId:   "req-match",
+		RequestPath: "/v1/responses",
+		Other:       common.MapToJsonStr(map[string]interface{}{"request_path": "/v1/responses"}),
+	})
+	createLogForFilterTest(t, &Log{
+		UserId:      22,
+		CreatedAt:   1_700_000_300,
+		Type:        LogTypeConsume,
+		Username:    "bob",
+		TokenName:   "alpha",
+		ModelName:   "gpt-4o-mini",
+		Group:       "team-a",
+		RequestId:   "req-match",
+		RequestPath: "/v1/chat/completions",
+		Other:       common.MapToJsonStr(map[string]interface{}{"request_path": "/v1/chat/completions"}),
+	})
+
+	userID := 11
+	tx, err := applyLogFilters(LOG_DB.Model(&Log{}), LogFilter{
+		UserID:         &userID,
+		LogType:        LogTypeConsume,
+		StartTimestamp: 1_700_000_000,
+		EndTimestamp:   1_700_001_000,
+		ModelName:      "gpt-4o%",
+		TokenName:      "alpha",
+		Group:          "team-a",
+		RequestID:      "req-match",
+		RequestPath:    "/v1/chat/completions",
+	})
+	require.NoError(t, err)
+
+	var logs []Log
+	require.NoError(t, tx.Order("logs.id asc").Find(&logs).Error)
+	require.Len(t, logs, 1)
+	assert.Equal(t, 11, logs[0].UserId)
+	assert.Equal(t, "/v1/chat/completions", logs[0].RequestPath)
+	assert.Equal(t, "req-match", logs[0].RequestId)
+}
+
+func TestApplyLogFilters_RequestPathRequiresExactMatch(t *testing.T) {
+	truncateTables(t)
+
+	createLogForFilterTest(t, &Log{
+		UserId:      11,
+		CreatedAt:   1_700_000_100,
+		Type:        LogTypeConsume,
+		TokenName:   "alpha",
+		ModelName:   "gpt-4o-mini",
+		Group:       "team-a",
+		RequestId:   "req-exact",
+		RequestPath: "/v1/chat/completions",
+		Other:       common.MapToJsonStr(map[string]interface{}{"request_path": "/v1/chat/completions"}),
+	})
+	createLogForFilterTest(t, &Log{
+		UserId:      11,
+		CreatedAt:   1_700_000_101,
+		Type:        LogTypeConsume,
+		TokenName:   "alpha",
+		ModelName:   "gpt-4o-mini",
+		Group:       "team-a",
+		RequestId:   "req-prefix",
+		RequestPath: "/v1/chat/completions/extra",
+		Other:       common.MapToJsonStr(map[string]interface{}{"request_path": "/v1/chat/completions/extra"}),
+	})
+
+	userID := 11
+	tx, err := applyLogFilters(LOG_DB.Model(&Log{}), LogFilter{
+		UserID:      &userID,
+		LogType:     LogTypeConsume,
+		RequestPath: "/v1/chat/completions",
+	})
+	require.NoError(t, err)
+
+	var logs []Log
+	require.NoError(t, tx.Order("logs.id asc").Find(&logs).Error)
+	require.Len(t, logs, 1)
+	assert.Equal(t, "req-exact", logs[0].RequestId)
+	assert.Equal(t, "/v1/chat/completions", logs[0].RequestPath)
+}

--- a/model/log_request_path_backfill.go
+++ b/model/log_request_path_backfill.go
@@ -1,0 +1,199 @@
+package model
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/QuantumNous/new-api/common"
+	"gorm.io/gorm"
+)
+
+const (
+	logRequestPathBackfillStatusKey     = "LogRequestPathBackfillStatus"
+	logRequestPathBackfillCursorKey     = "LogRequestPathBackfillCursor"
+	logRequestPathBackfillScannedKey    = "LogRequestPathBackfillScanned"
+	logRequestPathBackfillUpdatedKey    = "LogRequestPathBackfillUpdated"
+	logRequestPathBackfillMissingKey    = "LogRequestPathBackfillMissing"
+	logRequestPathBackfillFailedKey     = "LogRequestPathBackfillFailed"
+	logRequestPathBackfillFinishedAtKey = "LogRequestPathBackfillFinishedAt"
+
+	logRequestPathBackfillStatusRunning   = "running"
+	logRequestPathBackfillStatusCompleted = "completed"
+)
+
+type BackfillResult struct {
+	Status     string `json:"status"`
+	Cursor     int    `json:"cursor"`
+	Scanned    int64  `json:"scanned"`
+	Updated    int64  `json:"updated"`
+	Missing    int64  `json:"missing"`
+	Failed     int64  `json:"failed"`
+	FinishedAt int64  `json:"finished_at"`
+}
+
+func BackfillLogRequestPath(batchSize int) (BackfillResult, error) {
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+
+	result, err := loadLogRequestPathBackfillResult()
+	if err != nil {
+		return result, err
+	}
+	if result.Status == logRequestPathBackfillStatusCompleted {
+		return result, nil
+	}
+
+	result.Status = logRequestPathBackfillStatusRunning
+	if err = saveLogRequestPathBackfillResult(result); err != nil {
+		return result, err
+	}
+
+	for {
+		var logs []Log
+		err = LOG_DB.Where("id > ? AND request_path = ?", result.Cursor, "").Order("id asc").Limit(batchSize).Find(&logs).Error
+		if err != nil {
+			return result, err
+		}
+		if len(logs) == 0 {
+			result.Status = logRequestPathBackfillStatusCompleted
+			if result.FinishedAt == 0 {
+				result.FinishedAt = common.GetTimestamp()
+			}
+			err = saveLogRequestPathBackfillResult(result)
+			return result, err
+		}
+
+		for _, log := range logs {
+			if log.Id > result.Cursor {
+				result.Cursor = log.Id
+			}
+			result.Scanned++
+
+			requestPath, extractErr := extractRequestPathFromLogOther(log.Other)
+			if extractErr != nil {
+				result.Failed++
+				continue
+			}
+			if requestPath == "" {
+				result.Missing++
+				continue
+			}
+
+			updateErr := LOG_DB.Model(&Log{}).Where("id = ?", log.Id).Update("request_path", requestPath).Error
+			if updateErr != nil {
+				result.Failed++
+				continue
+			}
+			result.Updated++
+		}
+
+		if err = saveLogRequestPathBackfillResult(result); err != nil {
+			return result, err
+		}
+	}
+}
+
+func extractRequestPathFromLogOther(other string) (string, error) {
+	if other == "" {
+		return "", nil
+	}
+	var payload map[string]interface{}
+	if err := common.UnmarshalJsonStr(other, &payload); err != nil {
+		return "", err
+	}
+	return resolveLogRequestPath("", payload), nil
+}
+
+func loadLogRequestPathBackfillResult() (BackfillResult, error) {
+	result := BackfillResult{}
+	var err error
+
+	result.Status, err = getLogBackfillOptionValue(logRequestPathBackfillStatusKey)
+	if err != nil {
+		return result, err
+	}
+	result.Cursor, err = getLogBackfillOptionInt(logRequestPathBackfillCursorKey)
+	if err != nil {
+		return result, err
+	}
+	result.Scanned, err = getLogBackfillOptionInt64(logRequestPathBackfillScannedKey)
+	if err != nil {
+		return result, err
+	}
+	result.Updated, err = getLogBackfillOptionInt64(logRequestPathBackfillUpdatedKey)
+	if err != nil {
+		return result, err
+	}
+	result.Missing, err = getLogBackfillOptionInt64(logRequestPathBackfillMissingKey)
+	if err != nil {
+		return result, err
+	}
+	result.Failed, err = getLogBackfillOptionInt64(logRequestPathBackfillFailedKey)
+	if err != nil {
+		return result, err
+	}
+	result.FinishedAt, err = getLogBackfillOptionInt64(logRequestPathBackfillFinishedAtKey)
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func saveLogRequestPathBackfillResult(result BackfillResult) error {
+	if err := UpdateOption(logRequestPathBackfillStatusKey, result.Status); err != nil {
+		return err
+	}
+	if err := UpdateOption(logRequestPathBackfillCursorKey, strconv.Itoa(result.Cursor)); err != nil {
+		return err
+	}
+	if err := UpdateOption(logRequestPathBackfillScannedKey, strconv.FormatInt(result.Scanned, 10)); err != nil {
+		return err
+	}
+	if err := UpdateOption(logRequestPathBackfillUpdatedKey, strconv.FormatInt(result.Updated, 10)); err != nil {
+		return err
+	}
+	if err := UpdateOption(logRequestPathBackfillMissingKey, strconv.FormatInt(result.Missing, 10)); err != nil {
+		return err
+	}
+	if err := UpdateOption(logRequestPathBackfillFailedKey, strconv.FormatInt(result.Failed, 10)); err != nil {
+		return err
+	}
+	return UpdateOption(logRequestPathBackfillFinishedAtKey, strconv.FormatInt(result.FinishedAt, 10))
+}
+
+func getLogBackfillOptionValue(key string) (string, error) {
+	var option Option
+	err := DB.Where("key = ?", key).First(&option).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return option.Value, nil
+}
+
+func getLogBackfillOptionInt(key string) (int, error) {
+	value, err := getLogBackfillOptionValue(key)
+	if err != nil || value == "" {
+		return 0, err
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, err
+	}
+	return parsed, nil
+}
+
+func getLogBackfillOptionInt64(key string) (int64, error) {
+	value, err := getLogBackfillOptionValue(key)
+	if err != nil || value == "" {
+		return 0, err
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return parsed, nil
+}

--- a/model/log_request_path_backfill_test.go
+++ b/model/log_request_path_backfill_test.go
@@ -1,0 +1,104 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createHistoricalLog(t *testing.T, log *Log) {
+	t.Helper()
+	require.NoError(t, LOG_DB.Create(log).Error)
+}
+
+func getOptionValueForTest(t *testing.T, key string) string {
+	t.Helper()
+
+	var option Option
+	require.NoError(t, DB.Where("key = ?", key).First(&option).Error)
+	return option.Value
+}
+
+func TestBackfillLogRequestPath_FillsHistoricalLogsAndTracksAudit(t *testing.T) {
+	truncateTables(t)
+	require.NoError(t, DB.AutoMigrate(&Option{}))
+
+	createHistoricalLog(t, &Log{
+		UserId:      1,
+		CreatedAt:   1_700_000_100,
+		Type:        LogTypeConsume,
+		TokenName:   "alpha",
+		ModelName:   "gpt-4o-mini",
+		RequestPath: "",
+		Other:       common.MapToJsonStr(map[string]interface{}{"request_path": "/v1/chat/completions"}),
+	})
+	createHistoricalLog(t, &Log{
+		UserId:      1,
+		CreatedAt:   1_700_000_101,
+		Type:        LogTypeConsume,
+		TokenName:   "alpha",
+		ModelName:   "gpt-4o-mini",
+		RequestPath: "",
+		Other:       common.MapToJsonStr(map[string]interface{}{"request_path": "/v1/responses"}),
+	})
+	createHistoricalLog(t, &Log{
+		UserId:      1,
+		CreatedAt:   1_700_000_102,
+		Type:        LogTypeConsume,
+		TokenName:   "alpha",
+		ModelName:   "gpt-4o-mini",
+		RequestPath: "",
+		Other:       common.MapToJsonStr(map[string]interface{}{"task_id": "task-missing"}),
+	})
+
+	result, err := BackfillLogRequestPath(2)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), result.Scanned)
+	assert.Equal(t, int64(2), result.Updated)
+	assert.Equal(t, int64(1), result.Missing)
+	assert.Equal(t, int64(0), result.Failed)
+
+	var logs []Log
+	require.NoError(t, LOG_DB.Order("id asc").Find(&logs).Error)
+	require.Len(t, logs, 3)
+	assert.Equal(t, "/v1/chat/completions", logs[0].RequestPath)
+	assert.Equal(t, "/v1/responses", logs[1].RequestPath)
+	assert.Empty(t, logs[2].RequestPath)
+
+	assert.Equal(t, "completed", getOptionValueForTest(t, "LogRequestPathBackfillStatus"))
+	assert.Equal(t, "3", getOptionValueForTest(t, "LogRequestPathBackfillScanned"))
+	assert.Equal(t, "2", getOptionValueForTest(t, "LogRequestPathBackfillUpdated"))
+	assert.Equal(t, "1", getOptionValueForTest(t, "LogRequestPathBackfillMissing"))
+}
+
+func TestBackfillLogRequestPath_IsIdempotentAfterCompletion(t *testing.T) {
+	truncateTables(t)
+	require.NoError(t, DB.AutoMigrate(&Option{}))
+
+	createHistoricalLog(t, &Log{
+		UserId:      1,
+		CreatedAt:   1_700_000_100,
+		Type:        LogTypeConsume,
+		TokenName:   "alpha",
+		ModelName:   "gpt-4o-mini",
+		RequestPath: "",
+		Other:       common.MapToJsonStr(map[string]interface{}{"request_path": "/v1/chat/completions"}),
+	})
+
+	first, err := BackfillLogRequestPath(1)
+	require.NoError(t, err)
+	second, err := BackfillLogRequestPath(1)
+	require.NoError(t, err)
+
+	assert.Equal(t, first.Scanned, second.Scanned)
+	assert.Equal(t, first.Updated, second.Updated)
+	assert.Equal(t, first.Missing, second.Missing)
+	assert.Equal(t, first.Failed, second.Failed)
+
+	var logs []Log
+	require.NoError(t, LOG_DB.Find(&logs).Error)
+	require.Len(t, logs, 1)
+	assert.Equal(t, "/v1/chat/completions", logs[0].RequestPath)
+}

--- a/model/option.go
+++ b/model/option.go
@@ -212,6 +212,9 @@ func UpdateOption(key string, value string) error {
 func updateOptionMap(key string, value string) (err error) {
 	common.OptionMapRWMutex.Lock()
 	defer common.OptionMapRWMutex.Unlock()
+	if common.OptionMap == nil {
+		common.OptionMap = make(map[string]string)
+	}
 	common.OptionMap[key] = value
 
 	// 检查是否是模型配置 - 使用更规范的方式处理

--- a/model/task.go
+++ b/model/task.go
@@ -109,6 +109,7 @@ type TaskPrivateData struct {
 
 // TaskBillingContext 记录任务提交时的计费参数，以便轮询阶段可以重新计算额度。
 type TaskBillingContext struct {
+	RequestPath     string             `json:"request_path,omitempty"`
 	ModelPrice      float64            `json:"model_price,omitempty"`       // 模型单价
 	GroupRatio      float64            `json:"group_ratio,omitempty"`       // 分组倍率
 	ModelRatio      float64            `json:"model_ratio,omitempty"`       // 模型倍率

--- a/model/task_cas_test.go
+++ b/model/task_cas_test.go
@@ -48,6 +48,7 @@ func truncateTables(t *testing.T) {
 		DB.Exec("DELETE FROM tokens")
 		DB.Exec("DELETE FROM logs")
 		DB.Exec("DELETE FROM channels")
+		DB.Exec("DELETE FROM options")
 	})
 }
 

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -286,6 +286,7 @@ func SetApiRouter(router *gin.Engine) {
 		logRoute.GET("/channel_affinity_usage_cache", middleware.AdminAuth(), controller.GetChannelAffinityUsageCacheStats)
 		logRoute.GET("/search", middleware.AdminAuth(), controller.SearchAllLogs)
 		logRoute.GET("/self", middleware.UserAuth(), controller.GetUserLogs)
+		logRoute.GET("/self/export", middleware.UserAuth(), controller.ExportUserLogsCSV)
 		logRoute.GET("/self/search", middleware.UserAuth(), middleware.SearchRateLimit(), controller.SearchUserLogs)
 
 		dataRoute := apiRouter.Group("/data")

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -286,6 +286,7 @@ func SetApiRouter(router *gin.Engine) {
 		logRoute.GET("/channel_affinity_usage_cache", middleware.AdminAuth(), controller.GetChannelAffinityUsageCacheStats)
 		logRoute.GET("/search", middleware.AdminAuth(), controller.SearchAllLogs)
 		logRoute.GET("/self", middleware.UserAuth(), controller.GetUserLogs)
+		logRoute.GET("/export", middleware.AdminAuth(), controller.ExportAllLogsCSV)
 		logRoute.GET("/self/export", middleware.UserAuth(), controller.ExportUserLogsCSV)
 		logRoute.GET("/self/search", middleware.UserAuth(), middleware.SearchRateLimit(), controller.SearchUserLogs)
 

--- a/service/channel_affinity_usage_cache_test.go
+++ b/service/channel_affinity_usage_cache_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,7 +26,13 @@ func buildChannelAffinityStatsContextForTest(ruleName, usingGroup, keyFP string)
 	return ctx
 }
 
+func resetChannelAffinityUsageCacheStatsForTest() {
+	channelAffinityUsageCacheStatsCache = nil
+	channelAffinityUsageCacheStatsOnce = sync.Once{}
+}
+
 func TestObserveChannelAffinityUsageCacheByRelayFormat_ClaudeMode(t *testing.T) {
+	resetChannelAffinityUsageCacheStatsForTest()
 	ruleName := fmt.Sprintf("rule_%d", time.Now().UnixNano())
 	usingGroup := "default"
 	keyFP := fmt.Sprintf("fp_%d", time.Now().UnixNano())
@@ -53,6 +60,7 @@ func TestObserveChannelAffinityUsageCacheByRelayFormat_ClaudeMode(t *testing.T) 
 }
 
 func TestObserveChannelAffinityUsageCacheByRelayFormat_MixedMode(t *testing.T) {
+	resetChannelAffinityUsageCacheStatsForTest()
 	ruleName := fmt.Sprintf("rule_%d", time.Now().UnixNano())
 	usingGroup := "default"
 	keyFP := fmt.Sprintf("fp_%d", time.Now().UnixNano())
@@ -83,6 +91,7 @@ func TestObserveChannelAffinityUsageCacheByRelayFormat_MixedMode(t *testing.T) {
 }
 
 func TestObserveChannelAffinityUsageCacheByRelayFormat_UnsupportedModeKeepsEmpty(t *testing.T) {
+	resetChannelAffinityUsageCacheStatsForTest()
 	ruleName := fmt.Sprintf("rule_%d", time.Now().UnixNano())
 	usingGroup := "default"
 	keyFP := fmt.Sprintf("fp_%d", time.Now().UnixNano())

--- a/service/task_billing.go
+++ b/service/task_billing.go
@@ -116,6 +116,9 @@ func taskAdjustTokenQuota(ctx context.Context, task *model.Task, delta int) {
 func taskBillingOther(task *model.Task) map[string]interface{} {
 	other := make(map[string]interface{})
 	if bc := task.PrivateData.BillingContext; bc != nil {
+		if bc.RequestPath != "" {
+			other["request_path"] = bc.RequestPath
+		}
 		other["model_price"] = bc.ModelPrice
 		other["group_ratio"] = bc.GroupRatio
 		if len(bc.OtherRatios) > 0 {
@@ -140,6 +143,13 @@ func taskModelName(task *model.Task) string {
 	return task.Properties.OriginModelName
 }
 
+func taskRequestPath(task *model.Task) string {
+	if bc := task.PrivateData.BillingContext; bc != nil {
+		return bc.RequestPath
+	}
+	return ""
+}
+
 // RefundTaskQuota 统一的任务失败退款逻辑。
 // 当异步任务失败时，将预扣的 quota 退还给用户（支持钱包和订阅），并退还令牌额度。
 func RefundTaskQuota(ctx context.Context, task *model.Task, reason string) {
@@ -162,15 +172,16 @@ func RefundTaskQuota(ctx context.Context, task *model.Task, reason string) {
 	other["task_id"] = task.TaskID
 	other["reason"] = reason
 	model.RecordTaskBillingLog(model.RecordTaskBillingLogParams{
-		UserId:    task.UserId,
-		LogType:   model.LogTypeRefund,
-		Content:   "",
-		ChannelId: task.ChannelId,
-		ModelName: taskModelName(task),
-		Quota:     quota,
-		TokenId:   task.PrivateData.TokenId,
-		Group:     task.Group,
-		Other:     other,
+		UserId:      task.UserId,
+		LogType:     model.LogTypeRefund,
+		Content:     "",
+		ChannelId:   task.ChannelId,
+		ModelName:   taskModelName(task),
+		Quota:       quota,
+		TokenId:     task.PrivateData.TokenId,
+		Group:       task.Group,
+		RequestPath: taskRequestPath(task),
+		Other:       other,
 	})
 }
 
@@ -226,15 +237,16 @@ func RecalculateTaskQuota(ctx context.Context, task *model.Task, actualQuota int
 	other["pre_consumed_quota"] = preConsumedQuota
 	other["actual_quota"] = actualQuota
 	model.RecordTaskBillingLog(model.RecordTaskBillingLogParams{
-		UserId:    task.UserId,
-		LogType:   logType,
-		Content:   reason,
-		ChannelId: task.ChannelId,
-		ModelName: taskModelName(task),
-		Quota:     logQuota,
-		TokenId:   task.PrivateData.TokenId,
-		Group:     task.Group,
-		Other:     other,
+		UserId:      task.UserId,
+		LogType:     logType,
+		Content:     reason,
+		ChannelId:   task.ChannelId,
+		ModelName:   taskModelName(task),
+		Quota:       logQuota,
+		TokenId:     task.PrivateData.TokenId,
+		Group:       task.Group,
+		RequestPath: taskRequestPath(task),
+		Other:       other,
 	})
 }
 

--- a/web/src/components/table/usage-logs/UsageLogsActions.jsx
+++ b/web/src/components/table/usage-logs/UsageLogsActions.jsx
@@ -31,7 +31,6 @@ const LogsActions = ({
   setCompactMode,
   handleExport,
   exporting,
-  isAdminUser,
   t,
 }) => {
   const showSkeleton = useMinimumLoadingTime(loadingStat);
@@ -87,16 +86,14 @@ const LogsActions = ({
       </Skeleton>
 
       <div className='flex items-center gap-2'>
-        {!isAdminUser && (
-          <Button
-            type='tertiary'
-            size='small'
-            loading={exporting}
-            onClick={handleExport}
-          >
-            {exporting ? `${t('导出')}...` : `${t('导出')} CSV`}
-          </Button>
-        )}
+        <Button
+          type='tertiary'
+          size='small'
+          loading={exporting}
+          onClick={handleExport}
+        >
+          {exporting ? `${t('导出')}...` : `${t('导出')} CSV`}
+        </Button>
         <CompactModeToggle
           compactMode={compactMode}
           setCompactMode={setCompactMode}

--- a/web/src/components/table/usage-logs/UsageLogsActions.jsx
+++ b/web/src/components/table/usage-logs/UsageLogsActions.jsx
@@ -18,7 +18,7 @@ For commercial licensing, please contact support@quantumnous.com
 */
 
 import React from 'react';
-import { Tag, Space, Skeleton } from '@douyinfe/semi-ui';
+import { Button, Tag, Space, Skeleton } from '@douyinfe/semi-ui';
 import { renderQuota } from '../../../helpers';
 import CompactModeToggle from '../../common/ui/CompactModeToggle';
 import { useMinimumLoadingTime } from '../../../hooks/common/useMinimumLoadingTime';
@@ -29,6 +29,9 @@ const LogsActions = ({
   showStat,
   compactMode,
   setCompactMode,
+  handleExport,
+  exporting,
+  isAdminUser,
   t,
 }) => {
   const showSkeleton = useMinimumLoadingTime(loadingStat);
@@ -83,11 +86,23 @@ const LogsActions = ({
         </Space>
       </Skeleton>
 
-      <CompactModeToggle
-        compactMode={compactMode}
-        setCompactMode={setCompactMode}
-        t={t}
-      />
+      <div className='flex items-center gap-2'>
+        {!isAdminUser && (
+          <Button
+            type='tertiary'
+            size='small'
+            loading={exporting}
+            onClick={handleExport}
+          >
+            {exporting ? `${t('导出')}...` : `${t('导出')} CSV`}
+          </Button>
+        )}
+        <CompactModeToggle
+          compactMode={compactMode}
+          setCompactMode={setCompactMode}
+          t={t}
+        />
+      </div>
     </div>
   );
 };

--- a/web/src/components/table/usage-logs/UsageLogsFilters.jsx
+++ b/web/src/components/table/usage-logs/UsageLogsFilters.jsx
@@ -102,6 +102,15 @@ const LogsFilters = ({
             size='small'
           />
 
+          <Form.Input
+            field='request_path'
+            prefix={<IconSearch />}
+            placeholder={t('请求路径')}
+            showClear
+            pure
+            size='small'
+          />
+
           {isAdminUser && (
             <>
               <Form.Input

--- a/web/src/constants/console.constants.js
+++ b/web/src/constants/console.constants.js
@@ -37,6 +37,11 @@ export const DATE_RANGE_PRESETS = [
     end: () => dayjs().endOf('week').toDate(),
   },
   {
+    text: '上周',
+    start: () => dayjs().subtract(1, 'week').startOf('week').toDate(),
+    end: () => dayjs().subtract(1, 'week').endOf('week').toDate(),
+  },
+  {
     text: '近 30 天',
     start: () => dayjs().subtract(29, 'day').startOf('day').toDate(),
     end: () => dayjs().endOf('day').toDate(),

--- a/web/src/hooks/usage-logs/useUsageLogsData.jsx
+++ b/web/src/hooks/usage-logs/useUsageLogsData.jsx
@@ -68,6 +68,7 @@ export const useLogsData = () => {
   const [showStat, setShowStat] = useState(false);
   const [loading, setLoading] = useState(false);
   const [loadingStat, setLoadingStat] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const [activePage, setActivePage] = useState(1);
   const [logCount, setLogCount] = useState(0);
   const [pageSize, setPageSize] = useState(ITEMS_PER_PAGE);
@@ -99,6 +100,7 @@ export const useLogsData = () => {
     channel: '',
     group: '',
     request_id: '',
+    request_path: '',
     dateRange: [
       timestamp2string(getTodayStartTimestamp()),
       timestamp2string(now.getTime() / 1000 + 3600),
@@ -255,25 +257,99 @@ export const useLogsData = () => {
       channel: formValues.channel || '',
       group: formValues.group || '',
       request_id: formValues.request_id || '',
+      request_path: formValues.request_path || '',
       logType: formValues.logType ? parseInt(formValues.logType) : 0,
     };
   };
 
-  // Statistics functions
-  const getLogSelfStat = async () => {
+  const buildLogQueryParams = ({
+    customLogType = null,
+    includeAdminFields = isAdminUser,
+    page = null,
+    size = null,
+  } = {}) => {
     const {
+      username,
       token_name,
       model_name,
       start_timestamp,
       end_timestamp,
+      channel,
       group,
+      request_id,
+      request_path,
       logType: formLogType,
     } = getFormValues();
-    const currentLogType = formLogType !== undefined ? formLogType : logType;
-    let localStartTimestamp = Date.parse(start_timestamp) / 1000;
-    let localEndTimestamp = Date.parse(end_timestamp) / 1000;
-    let url = `/api/log/self/stat?type=${currentLogType}&token_name=${token_name}&model_name=${model_name}&start_timestamp=${localStartTimestamp}&end_timestamp=${localEndTimestamp}&group=${group}`;
-    url = encodeURI(url);
+
+    const currentLogType =
+      customLogType !== null
+        ? customLogType
+        : formLogType !== undefined
+          ? formLogType
+          : logType;
+
+    const params = {
+      type: currentLogType,
+      token_name,
+      model_name,
+      start_timestamp: Date.parse(start_timestamp) / 1000,
+      end_timestamp: Date.parse(end_timestamp) / 1000,
+      group,
+      request_id,
+      request_path,
+    };
+
+    if (includeAdminFields) {
+      params.username = username;
+      params.channel = channel;
+    }
+    if (page !== null) {
+      params.p = page;
+    }
+    if (size !== null) {
+      params.page_size = size;
+    }
+    return params;
+  };
+
+  const buildQueryString = (params) => {
+    const searchParams = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== '' && value !== null && value !== undefined) {
+        searchParams.set(key, String(value));
+      }
+    });
+    return searchParams.toString();
+  };
+
+  const parseExportFilename = (contentDisposition) => {
+    if (!contentDisposition) {
+      return '';
+    }
+    const match = contentDisposition.match(/filename="?([^";]+)"?/i);
+    if (!match) {
+      return '';
+    }
+    return decodeURIComponent(match[1]);
+  };
+
+  const downloadBlob = (blob, filename) => {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+  };
+
+  // Statistics functions
+  const getLogSelfStat = async () => {
+    const query = buildQueryString(
+      buildLogQueryParams({ includeAdminFields: false }),
+    );
+    let url = `/api/log/self/stat?${query}`;
     let res = await API.get(url);
     const { success, message, data } = res.data;
     if (success) {
@@ -284,21 +360,8 @@ export const useLogsData = () => {
   };
 
   const getLogStat = async () => {
-    const {
-      username,
-      token_name,
-      model_name,
-      start_timestamp,
-      end_timestamp,
-      channel,
-      group,
-      logType: formLogType,
-    } = getFormValues();
-    const currentLogType = formLogType !== undefined ? formLogType : logType;
-    let localStartTimestamp = Date.parse(start_timestamp) / 1000;
-    let localEndTimestamp = Date.parse(end_timestamp) / 1000;
-    let url = `/api/log/stat?type=${currentLogType}&username=${username}&token_name=${token_name}&model_name=${model_name}&start_timestamp=${localStartTimestamp}&end_timestamp=${localEndTimestamp}&channel=${channel}&group=${group}`;
-    url = encodeURI(url);
+    const query = buildQueryString(buildLogQueryParams());
+    let url = `/api/log/stat?${query}`;
     let res = await API.get(url);
     const { success, message, data } = res.data;
     if (success) {
@@ -357,7 +420,7 @@ export const useLogsData = () => {
       lines,
       modelName: log?.model_name || '',
       requestId: log?.request_id || '',
-      requestPath: other?.request_path || '',
+      requestPath: log?.request_path || other?.request_path || '',
     });
     setShowParamOverrideModal(true);
   };
@@ -595,10 +658,10 @@ export const useLogsData = () => {
           });
         }
       }
-      if (other?.request_path) {
+      if (logs[i].request_path || other?.request_path) {
         expandDataLocal.push({
           key: t('请求路径'),
-          value: other.request_path,
+          value: logs[i].request_path || other?.request_path,
         });
       }
       if (Array.isArray(other?.po) && other.po.length > 0) {
@@ -695,33 +758,18 @@ export const useLogsData = () => {
     setLoading(true);
 
     let url = '';
-    const {
-      username,
-      token_name,
-      model_name,
-      start_timestamp,
-      end_timestamp,
-      channel,
-      group,
-      request_id,
-      logType: formLogType,
-    } = getFormValues();
-
-    const currentLogType =
-      customLogType !== null
-        ? customLogType
-        : formLogType !== undefined
-          ? formLogType
-          : logType;
-
-    let localStartTimestamp = Date.parse(start_timestamp) / 1000;
-    let localEndTimestamp = Date.parse(end_timestamp) / 1000;
+    const query = buildQueryString(
+      buildLogQueryParams({
+        customLogType,
+        page: startIdx,
+        size: pageSize,
+      }),
+    );
     if (isAdminUser) {
-      url = `/api/log/?p=${startIdx}&page_size=${pageSize}&type=${currentLogType}&username=${username}&token_name=${token_name}&model_name=${model_name}&start_timestamp=${localStartTimestamp}&end_timestamp=${localEndTimestamp}&channel=${channel}&group=${group}&request_id=${request_id}`;
+      url = `/api/log/?${query}`;
     } else {
-      url = `/api/log/self/?p=${startIdx}&page_size=${pageSize}&type=${currentLogType}&token_name=${token_name}&model_name=${model_name}&start_timestamp=${localStartTimestamp}&end_timestamp=${localEndTimestamp}&group=${group}&request_id=${request_id}`;
+      url = `/api/log/self/?${query}`;
     }
-    url = encodeURI(url);
     const res = await API.get(url);
     const { success, message, data } = res.data;
     if (success) {
@@ -759,6 +807,42 @@ export const useLogsData = () => {
     setActivePage(1);
     handleEyeClick();
     await loadLogs(1, pageSize);
+  };
+
+  const handleExport = async () => {
+    if (exporting || isAdminUser) {
+      return;
+    }
+
+    setExporting(true);
+    try {
+      const query = buildQueryString(
+        buildLogQueryParams({ includeAdminFields: false }),
+      );
+      const response = await API.get(`/api/log/self/export?${query}`, {
+        responseType: 'blob',
+        disableDuplicate: true,
+        skipErrorHandler: true,
+      });
+
+      const contentType = response.headers['content-type'] || '';
+      if (contentType.includes('application/json')) {
+        const text = await response.data.text();
+        const payload = JSON.parse(text);
+        showError(payload.message || t('导出日志失败'));
+        return;
+      }
+
+      const filename =
+        parseExportFilename(response.headers['content-disposition']) ||
+        `usage-logs-${new Date().toISOString().slice(0, 10)}.csv`;
+      downloadBlob(response.data, filename);
+      showSuccess(t('日志导出成功'));
+    } catch (error) {
+      showError(error);
+    } finally {
+      setExporting(false);
+    }
   };
 
   // Copy text function
@@ -852,6 +936,8 @@ export const useLogsData = () => {
     handlePageChange,
     handlePageSizeChange,
     refresh,
+    handleExport,
+    exporting,
     copyText,
     handleEyeClick,
     setLogsFormat,

--- a/web/src/hooks/usage-logs/useUsageLogsData.jsx
+++ b/web/src/hooks/usage-logs/useUsageLogsData.jsx
@@ -810,16 +810,17 @@ export const useLogsData = () => {
   };
 
   const handleExport = async () => {
-    if (exporting || isAdminUser) {
+    if (exporting) {
       return;
     }
 
     setExporting(true);
     try {
       const query = buildQueryString(
-        buildLogQueryParams({ includeAdminFields: false }),
+        buildLogQueryParams({ includeAdminFields: isAdminUser }),
       );
-      const response = await API.get(`/api/log/self/export?${query}`, {
+      const exportUrl = isAdminUser ? '/api/log/export' : '/api/log/self/export';
+      const response = await API.get(`${exportUrl}?${query}`, {
         responseType: 'blob',
         disableDuplicate: true,
         skipErrorHandler: true,

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -3319,6 +3319,8 @@
     "输入价格：{{symbol}}{{price}} / 1M tokens": "Input Price: {{symbol}}{{price}} / 1M tokens",
     "输出价格 {{symbol}}{{price}} / 1M tokens": "Output Price {{symbol}}{{price}} / 1M tokens",
     "输出价格：{{symbol}}{{price}} / 1M tokens": "Output Price: {{symbol}}{{price}} / 1M tokens",
-    "输出价格：{{symbol}}{{total}} / 1M tokens": "Output Price: {{symbol}}{{total}} / 1M tokens"
+    "输出价格：{{symbol}}{{total}} / 1M tokens": "Output Price: {{symbol}}{{total}} / 1M tokens",
+    "本周": "This week",
+    "上周": "Last week"
   }
 }

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -3282,6 +3282,8 @@
     "输入价格：{{symbol}}{{price}} / 1M tokens": "Prix d'entrée : {{symbol}}{{price}} / 1M tokens",
     "输出价格 {{symbol}}{{price}} / 1M tokens": "Prix de sortie {{symbol}}{{price}} / 1M tokens",
     "输出价格：{{symbol}}{{price}} / 1M tokens": "Prix de sortie : {{symbol}}{{price}} / 1M tokens",
-    "输出价格：{{symbol}}{{total}} / 1M tokens": "Prix de sortie : {{symbol}}{{total}} / 1M tokens"
+    "输出价格：{{symbol}}{{total}} / 1M tokens": "Prix de sortie : {{symbol}}{{total}} / 1M tokens",
+    "本周": "Cette semaine",
+    "上周": "Semaine dernière"
   }
 }

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -3263,6 +3263,8 @@
     "输入价格：{{symbol}}{{price}} / 1M tokens": "入力価格：{{symbol}}{{price}} / 1M tokens",
     "输出价格 {{symbol}}{{price}} / 1M tokens": "補完料金 {{symbol}}{{price}} / 1M tokens",
     "输出价格：{{symbol}}{{price}} / 1M tokens": "補完料金：{{symbol}}{{price}} / 1M tokens",
-    "输出价格：{{symbol}}{{total}} / 1M tokens": "補完料金：{{symbol}}{{total}} / 1M tokens"
+    "输出价格：{{symbol}}{{total}} / 1M tokens": "補完料金：{{symbol}}{{total}} / 1M tokens",
+    "本周": "今週",
+    "上周": "先週"
   }
 }

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -3296,6 +3296,8 @@
     "输入价格：{{symbol}}{{price}} / 1M tokens": "Цена ввода: {{symbol}}{{price}} / 1M tokens",
     "输出价格 {{symbol}}{{price}} / 1M tokens": "Цена вывода {{symbol}}{{price}} / 1M tokens",
     "输出价格：{{symbol}}{{price}} / 1M tokens": "Цена вывода: {{symbol}}{{price}} / 1M tokens",
-    "输出价格：{{symbol}}{{total}} / 1M tokens": "Цена вывода: {{symbol}}{{total}} / 1M tokens"
+    "输出价格：{{symbol}}{{total}} / 1M tokens": "Цена вывода: {{symbol}}{{total}} / 1M tokens",
+    "本周": "На этой неделе",
+    "上周": "На прошлой неделе"
   }
 }

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -3833,6 +3833,8 @@
     "补全倍率 {{completionRatio}}": "Tỷ lệ hoàn thành {{completionRatio}}",
     "输出价格 {{symbol}}{{price}} / 1M tokens": "Giá đầu ra {{symbol}}{{price}} / 1M tokens",
     "输出价格：{{symbol}}{{price}} / 1M tokens": "Giá đầu ra: {{symbol}}{{price}} / 1M tokens",
-    "输出价格：{{symbol}}{{total}} / 1M tokens": "Giá đầu ra: {{symbol}}{{total}} / 1M tokens"
+    "输出价格：{{symbol}}{{total}} / 1M tokens": "Giá đầu ra: {{symbol}}{{total}} / 1M tokens",
+    "本周": "Tuần này",
+    "上周": "Tuần trước"
   }
 }

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2938,6 +2938,8 @@
     "输入价格：{{symbol}}{{price}} / 1M tokens": "输入价格：{{symbol}}{{price}} / 1M tokens",
     "输出价格 {{symbol}}{{price}} / 1M tokens": "输出价格 {{symbol}}{{price}} / 1M tokens",
     "输出价格：{{symbol}}{{price}} / 1M tokens": "输出价格：{{symbol}}{{price}} / 1M tokens",
-    "输出价格：{{symbol}}{{total}} / 1M tokens": "输出价格：{{symbol}}{{total}} / 1M tokens"
+    "输出价格：{{symbol}}{{total}} / 1M tokens": "输出价格：{{symbol}}{{total}} / 1M tokens",
+    "本周": "本周",
+    "上周": "上周"
   }
 }

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -2947,6 +2947,8 @@
     "输入价格：{{symbol}}{{price}} / 1M tokens": "輸入價格：{{symbol}}{{price}} / 1M tokens",
     "输出价格 {{symbol}}{{price}} / 1M tokens": "輸出價格 {{symbol}}{{price}} / 1M tokens",
     "输出价格：{{symbol}}{{price}} / 1M tokens": "輸出價格：{{symbol}}{{price}} / 1M tokens",
-    "输出价格：{{symbol}}{{total}} / 1M tokens": "輸出價格：{{symbol}}{{total}} / 1M tokens"
+    "输出价格：{{symbol}}{{total}} / 1M tokens": "輸出價格：{{symbol}}{{total}} / 1M tokens",
+    "本周": "本週",
+    "上周": "上週"
   }
 }


### PR DESCRIPTION
## Summary

This PR adds CSV export support to the usage log page and backend export APIs.

It also promotes `request_path` to a dedicated log field so that logs can be filtered and exported precisely, including historical logs after backfill.

## What Changed

### Backend
- added a dedicated `request_path` field for logs
- persisted `request_path` on new logs
- added CSV export handlers for usage logs
- added historical backfill support for existing log records
- added tests for filtering, export, and backfill behavior

### Frontend
- added a `导出 CSV` action to the usage log page
- added `request_path` filter support
- kept export behavior aligned with current page filters and selected time range

## Why

The existing log UI is useful for online inspection, but operational workflows often require structured export for Excel/reporting, especially for weekly accounting and performance review scenarios.

## Validation

- `bun run build`
- targeted controller/model tests for export, filter, and backfill behavior

## Notes

I intentionally kept this PR scoped to usage log export and log filtering only.
It does not include unrelated local task files or the token period quota feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CSV export functionality for usage logs in both user and admin views
  * Added request path filter to log searches
  * Added "Last week" date range preset for quick filtering

* **Improvements**
  * Enhanced log request path tracking and filtering capabilities across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->