### PR TITLE
fix(vertex): convert Claude format request for Gemini models in Verte…

### DIFF
--- a/relay/channel/vertex/adaptor.go
+++ b/relay/channel/vertex/adaptor.go
@@ -92,6 +92,10 @@ func removeFunctionResponseID(request *dto.GeminiChatRequest) {
 }
 
 func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.ClaudeRequest) (any, error) {
+	if a.RequestMode == RequestModeGemini {
+		geminiAdaptor := gemini.Adaptor{}
+		return geminiAdaptor.ConvertClaudeRequest(c, info, request)
+	}
 	if v, ok := claudeModelMap[info.UpstreamModelName]; ok {
 		c.Set("request_model", v)
 	} else {


### PR DESCRIPTION
## Problem

When routing a Claude-format request (`/v1/messages`) through a Vertex channel with a Gemini model, the request was sent to the Gemini endpoint still in Anthropic format, causing an error.

## Root Cause

`ConvertClaudeRequest` in the Vertex adaptor always returned the request as Anthropic format (via `copyRequest`), regardless of `RequestMode`. It lacked the `RequestModeGemini` branch that `ConvertOpenAIRequest` already handles correctly.

## Fix

Add a `RequestModeGemini` branch in `ConvertClaudeRequest` that delegates to `gemini.Adaptor.ConvertClaudeRequest`, which performs the correct Claude → (OpenAI →) Gemini conversion.

```go
if a.RequestMode == RequestModeGemini {
    geminiAdaptor := gemini.Adaptor{}
    return geminiAdaptor.ConvertClaudeRequest(c, info, request)
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced request processing with intelligent adaptive routing capabilities. The adapter now intelligently routes requests to the appropriate handler based on the active model mode configuration. This improvement enhances flexibility and support for multiple model types while preserving backward compatibility with existing request handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->