### PR TITLE
feat: compatible gpt thinking to nil

### DIFF
--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -333,6 +333,7 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 		if strings.HasPrefix(info.UpstreamModelName, "gpt-5") {
 			request.Temperature = nil
 			request.TopP = nil
+			request.THINKING = nil
 			request.LogProbs = nil
 		}
 


### PR DESCRIPTION
gpt5不再支持thinking, 兼容一下客户端误传报错的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer GPT model versions by ensuring unsupported parameters are properly disabled during request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->