### PR TITLE
feat: add per-token and per-channel usage statistics charts on dashboard

### DIFF
--- a/controller/usedata.go
+++ b/controller/usedata.go
@@ -27,6 +27,45 @@ func GetAllQuotaDates(c *gin.Context) {
 	return
 }
 
+func GetChannelQuotaStats(c *gin.Context) {
+	startTimestamp, _ := strconv.ParseInt(c.Query("start_timestamp"), 10, 64)
+	endTimestamp, _ := strconv.ParseInt(c.Query("end_timestamp"), 10, 64)
+
+	stats, err := model.GetChannelQuotaStats(startTimestamp, endTimestamp)
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "",
+		"data":    stats,
+	})
+}
+
+func GetTokenQuotaStats(c *gin.Context) {
+	userId := c.GetInt("id")
+	startTimestamp, _ := strconv.ParseInt(c.Query("start_timestamp"), 10, 64)
+	endTimestamp, _ := strconv.ParseInt(c.Query("end_timestamp"), 10, 64)
+
+	// 管理员可通过 all=true 查看全局令牌统计
+	allUsers := false
+	if c.GetInt("role") >= common.RoleAdminUser {
+		allUsers = c.Query("all") == "true"
+	}
+
+	stats, err := model.GetTokenQuotaStats(userId, startTimestamp, endTimestamp, allUsers)
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "",
+		"data":    stats,
+	})
+}
+
 func GetUserQuotaDates(c *gin.Context) {
 	userId := c.GetInt("id")
 	startTimestamp, _ := strconv.ParseInt(c.Query("start_timestamp"), 10, 64)

--- a/model/log.go
+++ b/model/log.go
@@ -478,3 +478,103 @@ func DeleteOldLog(ctx context.Context, targetTimestamp int64, limit int) (int64,
 
 	return total, nil
 }
+
+// TokenQuotaStat 令牌维度的用量聚合数据（按小时分桶）
+type TokenQuotaStat struct {
+	TokenId   int    `json:"token_id"`
+	TokenName string `json:"token_name"`
+	Quota     int    `json:"quota"`
+	Count     int    `json:"count"`
+	CreatedAt int64  `json:"created_at"`
+}
+
+// GetTokenQuotaStats 查询按 token_id + 小时分桶的用量统计
+// allUsers=true 时不过滤 user_id（管理员查看全局）
+func GetTokenQuotaStats(userId int, startTimestamp int64, endTimestamp int64, allUsers bool) ([]*TokenQuotaStat, error) {
+	var stats []*TokenQuotaStat
+	tx := LOG_DB.Table("logs").
+		Select("token_id, token_name, SUM(quota) as quota, COUNT(*) as count, (created_at - created_at % 3600) as created_at").
+		Where("type = ?", LogTypeConsume)
+
+	if !allUsers {
+		tx = tx.Where("user_id = ?", userId)
+	}
+	if startTimestamp != 0 {
+		tx = tx.Where("created_at >= ?", startTimestamp)
+	}
+	if endTimestamp != 0 {
+		tx = tx.Where("created_at <= ?", endTimestamp)
+	}
+
+	tx = tx.Group("token_id, token_name, (created_at - created_at % 3600)").
+		Order("created_at ASC")
+
+	err := tx.Find(&stats).Error
+	return stats, err
+}
+
+// ChannelQuotaStat 渠道维度的用量聚合数据（按小时分桶）
+type ChannelQuotaStat struct {
+	ChannelId   int    `json:"channel_id"`
+	ChannelName string `json:"channel_name"`
+	Quota       int    `json:"quota"`
+	Count       int    `json:"count"`
+	CreatedAt   int64  `json:"created_at"`
+}
+
+// GetChannelQuotaStats 查询按 channel_id + 小时分桶的用量统计（管理员用）
+// LOG_DB 和 DB 可能是不同数据库，故分两步查询再合并 channel name
+func GetChannelQuotaStats(startTimestamp int64, endTimestamp int64) ([]*ChannelQuotaStat, error) {
+	var stats []*ChannelQuotaStat
+	tx := LOG_DB.Table("logs").
+		Select("channel_id, SUM(quota) as quota, COUNT(*) as count, (created_at - created_at % 3600) as created_at").
+		Where("type = ?", LogTypeConsume)
+
+	if startTimestamp != 0 {
+		tx = tx.Where("created_at >= ?", startTimestamp)
+	}
+	if endTimestamp != 0 {
+		tx = tx.Where("created_at <= ?", endTimestamp)
+	}
+
+	tx = tx.Group("channel_id, (created_at - created_at % 3600)").
+		Order("created_at ASC")
+
+	if err := tx.Find(&stats).Error; err != nil {
+		return nil, err
+	}
+
+	// 收集去重的 channel_id
+	seen := make(map[int]bool)
+	channelIds := make([]int, 0)
+	for _, s := range stats {
+		if !seen[s.ChannelId] {
+			channelIds = append(channelIds, s.ChannelId)
+			seen[s.ChannelId] = true
+		}
+	}
+
+	// 从 DB 批量查询渠道名称
+	channelNameMap := make(map[int]string)
+	if len(channelIds) > 0 {
+		type chInfo struct {
+			Id   int
+			Name string
+		}
+		var channels []chInfo
+		DB.Table("channels").Select("id, name").Where("id IN ?", channelIds).Find(&channels)
+		for _, ch := range channels {
+			channelNameMap[ch.Id] = ch.Name
+		}
+	}
+
+	for _, s := range stats {
+		if name, ok := channelNameMap[s.ChannelId]; ok {
+			s.ChannelName = name
+		} else {
+			s.ChannelName = fmt.Sprintf("#%d", s.ChannelId)
+		}
+	}
+
+	return stats, nil
+}

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -293,6 +293,8 @@ func SetApiRouter(router *gin.Engine) {
 		dataRoute := apiRouter.Group("/data")
 		dataRoute.GET("/", middleware.AdminAuth(), controller.GetAllQuotaDates)
 		dataRoute.GET("/self", middleware.UserAuth(), controller.GetUserQuotaDates)
+		dataRoute.GET("/self/token_stats", middleware.UserAuth(), controller.GetTokenQuotaStats)
+		dataRoute.GET("/channel_stats", middleware.AdminAuth(), controller.GetChannelQuotaStats)
 
 		logRoute.Use(middleware.CORS(), middleware.CriticalRateLimit())
 		{

--- a/web/src/components/dashboard/ChartsPanel.jsx
+++ b/web/src/components/dashboard/ChartsPanel.jsx
@@ -18,7 +18,7 @@ For commercial licensing, please contact support@quantumnous.com
 */
 
 import React from 'react';
-import { Card, Tabs, TabPane } from '@douyinfe/semi-ui';
+import { Card, Tabs, TabPane, Switch, Typography } from '@douyinfe/semi-ui';
 import { PieChart } from 'lucide-react';
 import { VChart } from '@visactor/react-vchart';
 
@@ -29,10 +29,17 @@ const ChartsPanel = ({
   spec_model_line,
   spec_pie,
   spec_rank_bar,
+  spec_token_bar,
+  spec_token_pie,
+  spec_channel_bar,
+  spec_channel_pie,
   CARD_PROPS,
   CHART_CONFIG,
   FLEX_CENTER_GAP2,
   hasApiInfoPanel,
+  isAdminUser,
+  showAllTokens,
+  onToggleAllTokens,
   t,
 }) => {
   return (
@@ -44,6 +51,18 @@ const ChartsPanel = ({
           <div className={FLEX_CENTER_GAP2}>
             <PieChart size={16} />
             {t('模型数据分析')}
+            {isAdminUser && (
+              <div className='ml-4 flex items-center gap-2'>
+                <Switch
+                  checked={showAllTokens}
+                  onChange={onToggleAllTokens}
+                  size='small'
+                />
+                <Typography.Text size='small' type='tertiary'>
+                  {showAllTokens ? t('所有令牌') : t('仅我的令牌')}
+                </Typography.Text>
+              </div>
+            )}
           </div>
           <Tabs
             type='slash'
@@ -54,6 +73,14 @@ const ChartsPanel = ({
             <TabPane tab={<span>{t('消耗趋势')}</span>} itemKey='2' />
             <TabPane tab={<span>{t('调用次数分布')}</span>} itemKey='3' />
             <TabPane tab={<span>{t('调用次数排行')}</span>} itemKey='4' />
+            <TabPane tab={<span>{t('令牌消耗分布')}</span>} itemKey='5' />
+            <TabPane tab={<span>{t('令牌消耗占比')}</span>} itemKey='6' />
+            {isAdminUser && (
+              <TabPane tab={<span>{t('渠道消耗分布')}</span>} itemKey='7' />
+            )}
+            {isAdminUser && (
+              <TabPane tab={<span>{t('渠道消耗占比')}</span>} itemKey='8' />
+            )}
           </Tabs>
         </div>
       }
@@ -71,6 +98,18 @@ const ChartsPanel = ({
         )}
         {activeChartTab === '4' && (
           <VChart spec={spec_rank_bar} option={CHART_CONFIG} />
+        )}
+        {activeChartTab === '5' && (
+          <VChart spec={spec_token_bar} option={CHART_CONFIG} />
+        )}
+        {activeChartTab === '6' && (
+          <VChart spec={spec_token_pie} option={CHART_CONFIG} />
+        )}
+        {activeChartTab === '7' && (
+          <VChart spec={spec_channel_bar} option={CHART_CONFIG} />
+        )}
+        {activeChartTab === '8' && (
+          <VChart spec={spec_channel_pie} option={CHART_CONFIG} />
         )}
       </div>
     </Card>

--- a/web/src/components/dashboard/index.jsx
+++ b/web/src/components/dashboard/index.jsx
@@ -17,7 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { getRelativeTime } from '../../helpers';
 import { UserContext } from '../../context/User';
 import { StatusContext } from '../../context/Status';
@@ -87,6 +87,8 @@ const Dashboard = () => {
 
   // ========== 数据处理 ==========
   const initChart = async () => {
+    dashboardData.loadTokenStats();
+    dashboardData.loadChannelStats();
     await dashboardData.loadQuotaData().then((data) => {
       if (data && data.length > 0) {
         dashboardCharts.updateChartData(data);
@@ -125,6 +127,7 @@ const Dashboard = () => {
   );
   const faqData = statusState?.status?.faq || [];
 
+  // ========== Uptime 数据 ==========
   const uptimeLegendData = Object.entries(UPTIME_STATUS_MAP).map(
     ([status, info]) => ({
       status: Number(status),
@@ -134,6 +137,28 @@ const Dashboard = () => {
   );
 
   // ========== Effects ==========
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    dashboardData.loadTokenStats();
+  }, [dashboardData.showAllTokens]);
+
+  useEffect(() => {
+    if (dashboardData.tokenStatsData && dashboardData.tokenStatsData.length > 0) {
+      dashboardCharts.updateTokenChartData(dashboardData.tokenStatsData);
+    }
+  }, [dashboardData.tokenStatsData]);
+
+  useEffect(() => {
+    if (dashboardData.channelStatsData && dashboardData.channelStatsData.length > 0) {
+      dashboardCharts.updateChannelChartData(dashboardData.channelStatsData);
+    }
+  }, [dashboardData.channelStatsData]);
+
   useEffect(() => {
     initChart();
   }, []);
@@ -182,10 +207,17 @@ const Dashboard = () => {
             spec_model_line={dashboardCharts.spec_model_line}
             spec_pie={dashboardCharts.spec_pie}
             spec_rank_bar={dashboardCharts.spec_rank_bar}
+            spec_token_bar={dashboardCharts.spec_token_bar}
+            spec_token_pie={dashboardCharts.spec_token_pie}
+            spec_channel_bar={dashboardCharts.spec_channel_bar}
+            spec_channel_pie={dashboardCharts.spec_channel_pie}
             CARD_PROPS={CARD_PROPS}
             CHART_CONFIG={CHART_CONFIG}
             FLEX_CENTER_GAP2={FLEX_CENTER_GAP2}
             hasApiInfoPanel={dashboardData.hasApiInfoPanel}
+            isAdminUser={dashboardData.isAdminUser}
+            showAllTokens={dashboardData.showAllTokens}
+            onToggleAllTokens={(value) => dashboardData.setShowAllTokens(value)}
             t={dashboardData.t}
           />
 

--- a/web/src/hooks/dashboard/useDashboardCharts.jsx
+++ b/web/src/hooks/dashboard/useDashboardCharts.jsx
@@ -27,6 +27,10 @@ import {
   getQuotaWithUnit,
 } from '../../helpers';
 import {
+  timestamp2string1,
+  isDataCrossYear,
+} from '../../helpers/utils';
+import {
   processRawData,
   calculateTrendData,
   aggregateDataByTimeAndModel,
@@ -176,6 +180,268 @@ export const useDashboardCharts = (
     },
     color: {
       specified: modelColorMap,
+    },
+  });
+
+  const [spec_token_pie, setSpecTokenPie] = useState({
+    type: 'pie',
+    data: [
+      {
+        id: 'tokenPieData',
+        values: [{ type: 'null', value: '0' }],
+      },
+    ],
+    outerRadius: 0.8,
+    innerRadius: 0.5,
+    padAngle: 0.6,
+    valueField: 'value',
+    categoryField: 'type',
+    pie: {
+      style: {
+        cornerRadius: 10,
+      },
+      state: {
+        hover: {
+          outerRadius: 0.85,
+          stroke: '#000',
+          lineWidth: 1,
+        },
+        selected: {
+          outerRadius: 0.85,
+          stroke: '#000',
+          lineWidth: 1,
+        },
+      },
+    },
+    title: {
+      visible: true,
+      text: t('令牌消耗占比'),
+      subtext: `${t('总计')}：${renderQuota(0, 2)}`,
+    },
+    legends: {
+      visible: true,
+      orient: 'left',
+    },
+    label: {
+      visible: true,
+    },
+    tooltip: {
+      mark: {
+        content: [
+          {
+            key: (datum) => datum['type'],
+            value: (datum) => renderQuota(datum['value'] || 0, 2),
+          },
+        ],
+      },
+    },
+    color: {
+      specified: {},
+    },
+  });
+
+  const [spec_token_bar, setSpecTokenBar] = useState({
+    type: 'bar',
+    data: [
+      {
+        id: 'tokenBarData',
+        values: [],
+      },
+    ],
+    xField: 'Time',
+    yField: 'Usage',
+    seriesField: 'Token',
+    stack: true,
+    legends: {
+      visible: true,
+      selectMode: 'single',
+    },
+    title: {
+      visible: true,
+      text: t('令牌消耗分布'),
+      subtext: `${t('总计')}：${renderQuota(0, 2)}`,
+    },
+    bar: {
+      state: {
+        hover: {
+          stroke: '#000',
+          lineWidth: 1,
+        },
+      },
+    },
+    tooltip: {
+      mark: {
+        content: [
+          {
+            key: (datum) => datum['Token'],
+            value: (datum) => renderQuota(datum['rawQuota'] || 0, 4),
+          },
+        ],
+      },
+      dimension: {
+        content: [
+          {
+            key: (datum) => datum['Token'],
+            value: (datum) => datum['rawQuota'] || 0,
+          },
+        ],
+        updateContent: (array) => {
+          array.sort((a, b) => b.value - a.value);
+          let sum = 0;
+          for (let i = 0; i < array.length; i++) {
+            if (array[i].key == '其他') {
+              continue;
+            }
+            let value = parseFloat(array[i].value);
+            if (isNaN(value)) {
+              value = 0;
+            }
+            if (array[i].datum && array[i].datum.TimeSum) {
+              sum = array[i].datum.TimeSum;
+            }
+            array[i].value = renderQuota(value, 4);
+          }
+          array.unshift({
+            key: t('总计'),
+            value: renderQuota(sum, 4),
+          });
+          return array;
+        },
+      },
+    },
+    color: {
+      specified: {},
+    },
+  });
+
+  const [spec_channel_pie, setSpecChannelPie] = useState({
+    type: 'pie',
+    data: [
+      {
+        id: 'channelPieData',
+        values: [{ type: 'null', value: '0' }],
+      },
+    ],
+    outerRadius: 0.8,
+    innerRadius: 0.5,
+    padAngle: 0.6,
+    valueField: 'value',
+    categoryField: 'type',
+    pie: {
+      style: {
+        cornerRadius: 10,
+      },
+      state: {
+        hover: {
+          outerRadius: 0.85,
+          stroke: '#000',
+          lineWidth: 1,
+        },
+        selected: {
+          outerRadius: 0.85,
+          stroke: '#000',
+          lineWidth: 1,
+        },
+      },
+    },
+    title: {
+      visible: true,
+      text: t('渠道消耗占比'),
+      subtext: `${t('总计')}：${renderQuota(0, 2)}`,
+    },
+    legends: {
+      visible: true,
+      orient: 'left',
+    },
+    label: {
+      visible: true,
+    },
+    tooltip: {
+      mark: {
+        content: [
+          {
+            key: (datum) => datum['type'],
+            value: (datum) => renderQuota(datum['value'] || 0, 2),
+          },
+        ],
+      },
+    },
+    color: {
+      specified: {},
+    },
+  });
+
+  const [spec_channel_bar, setSpecChannelBar] = useState({
+    type: 'bar',
+    data: [
+      {
+        id: 'channelBarData',
+        values: [],
+      },
+    ],
+    xField: 'Time',
+    yField: 'Usage',
+    seriesField: 'Channel',
+    stack: true,
+    legends: {
+      visible: true,
+      selectMode: 'single',
+    },
+    title: {
+      visible: true,
+      text: t('渠道消耗分布'),
+      subtext: `${t('总计')}：${renderQuota(0, 2)}`,
+    },
+    bar: {
+      state: {
+        hover: {
+          stroke: '#000',
+          lineWidth: 1,
+        },
+      },
+    },
+    tooltip: {
+      mark: {
+        content: [
+          {
+            key: (datum) => datum['Channel'],
+            value: (datum) => renderQuota(datum['rawQuota'] || 0, 4),
+          },
+        ],
+      },
+      dimension: {
+        content: [
+          {
+            key: (datum) => datum['Channel'],
+            value: (datum) => datum['rawQuota'] || 0,
+          },
+        ],
+        updateContent: (array) => {
+          array.sort((a, b) => b.value - a.value);
+          let sum = 0;
+          for (let i = 0; i < array.length; i++) {
+            if (array[i].key == '其他') {
+              continue;
+            }
+            let value = parseFloat(array[i].value);
+            if (isNaN(value)) {
+              value = 0;
+            }
+            if (array[i].datum && array[i].datum.TimeSum) {
+              sum = array[i].datum.TimeSum;
+            }
+            array[i].value = renderQuota(value, 4);
+          }
+          array.unshift({
+            key: t('总计'),
+            value: renderQuota(sum, 4),
+          });
+          return array;
+        },
+      },
+    },
+    color: {
+      specified: {},
     },
   });
 
@@ -426,6 +692,208 @@ export const useDashboardCharts = (
     ],
   );
 
+  const updateTokenChartData = useCallback(
+    (data) => {
+      const uniqueTokens = new Set();
+      let totalQuota = 0;
+      let totalTimes = 0;
+
+      const showYear = isDataCrossYear(data.map((item) => item.created_at));
+
+      const aggregatedData = new Map();
+      const tokenTotals = new Map(); 
+
+      data.forEach((item) => {
+        const tokenKey = item.token_name || t('未知');
+        uniqueTokens.add(tokenKey);
+        totalQuota += item.quota;
+        totalTimes += item.count;
+
+        const timeKey = timestamp2string1(
+          item.created_at,
+          dataExportDefaultTime,
+          showYear,
+        );
+        const key = `${timeKey}-${tokenKey}`;
+
+        if (!aggregatedData.has(key)) {
+          aggregatedData.set(key, {
+            time: timeKey,
+            token: tokenKey,
+            quota: 0,
+            count: 0,
+          });
+        }
+
+        const existing = aggregatedData.get(key);
+        existing.quota += item.quota;
+        existing.count += item.count;
+
+        updateMapValue(tokenTotals, tokenKey, item.quota);
+      });
+
+      const newTokenColors = generateModelColors(uniqueTokens, {});
+      
+      const newPieData = Array.from(tokenTotals)
+        .map(([token, quota]) => ({
+          type: token,
+          value: quota,
+        }))
+        .sort((a, b) => b.value - a.value);
+
+      const chartTimePoints = generateChartTimePoints(
+        aggregatedData,
+        data,
+        dataExportDefaultTime,
+      );
+
+      let newLineData = [];
+
+      chartTimePoints.forEach((time) => {
+        let timeData = Array.from(uniqueTokens).map((token) => {
+          const key = `${time}-${token}`;
+          const aggregated = aggregatedData.get(key);
+          return {
+            Time: time,
+            Token: token,
+            rawQuota: aggregated?.quota || 0,
+            Usage: aggregated?.quota
+              ? getQuotaWithUnit(aggregated.quota, 4)
+              : 0,
+          };
+        });
+
+        const timeSum = timeData.reduce((sum, item) => sum + item.rawQuota, 0);
+        timeData.sort((a, b) => b.rawQuota - a.rawQuota);
+        timeData = timeData.map((item) => ({ ...item, TimeSum: timeSum }));
+        newLineData.push(...timeData);
+      });
+
+      newLineData.sort((a, b) => a.Time.localeCompare(b.Time));
+
+      updateChartSpec(
+        setSpecTokenPie,
+        newPieData,
+        `${t('总计')}：${renderQuota(totalQuota, 2)}`,
+        newTokenColors,
+        'tokenPieData',
+      );
+
+      updateChartSpec(
+        setSpecTokenBar,
+        newLineData,
+        `${t('总计')}：${renderQuota(totalQuota, 2)}`,
+        newTokenColors,
+        'tokenBarData',
+      );
+    },
+    [
+      dataExportDefaultTime,
+      generateModelColors,
+      t,
+    ],
+  );
+
+  const updateChannelChartData = useCallback(
+    (data) => {
+      const uniqueChannels = new Set();
+      let totalQuota = 0;
+
+      const showYear = isDataCrossYear(data.map((item) => item.created_at));
+
+      const aggregatedData = new Map();
+      const channelTotals = new Map();
+
+      data.forEach((item) => {
+        const channelKey = item.channel_name || `#${item.channel_id}`;
+        uniqueChannels.add(channelKey);
+        totalQuota += item.quota;
+
+        const timeKey = timestamp2string1(
+          item.created_at,
+          dataExportDefaultTime,
+          showYear,
+        );
+        const key = `${timeKey}-${channelKey}`;
+
+        if (!aggregatedData.has(key)) {
+          aggregatedData.set(key, {
+            time: timeKey,
+            token: channelKey,
+            quota: 0,
+            count: 0,
+          });
+        }
+
+        const existing = aggregatedData.get(key);
+        existing.quota += item.quota;
+        existing.count += item.count;
+
+        updateMapValue(channelTotals, channelKey, item.quota);
+      });
+
+      const newChannelColors = generateModelColors(uniqueChannels, {});
+
+      const newPieData = Array.from(channelTotals)
+        .map(([channel, quota]) => ({
+          type: channel,
+          value: quota,
+        }))
+        .sort((a, b) => b.value - a.value);
+
+      const chartTimePoints = generateChartTimePoints(
+        aggregatedData,
+        data,
+        dataExportDefaultTime,
+      );
+
+      let newBarData = [];
+
+      chartTimePoints.forEach((time) => {
+        let timeData = Array.from(uniqueChannels).map((channel) => {
+          const key = `${time}-${channel}`;
+          const aggregated = aggregatedData.get(key);
+          return {
+            Time: time,
+            Channel: channel,
+            rawQuota: aggregated?.quota || 0,
+            Usage: aggregated?.quota
+              ? getQuotaWithUnit(aggregated.quota, 4)
+              : 0,
+          };
+        });
+
+        const timeSum = timeData.reduce((sum, item) => sum + item.rawQuota, 0);
+        timeData.sort((a, b) => b.rawQuota - a.rawQuota);
+        timeData = timeData.map((item) => ({ ...item, TimeSum: timeSum }));
+        newBarData.push(...timeData);
+      });
+
+      newBarData.sort((a, b) => a.Time.localeCompare(b.Time));
+
+      updateChartSpec(
+        setSpecChannelPie,
+        newPieData,
+        `${t('总计')}：${renderQuota(totalQuota, 2)}`,
+        newChannelColors,
+        'channelPieData',
+      );
+
+      updateChartSpec(
+        setSpecChannelBar,
+        newBarData,
+        `${t('总计')}：${renderQuota(totalQuota, 2)}`,
+        newChannelColors,
+        'channelBarData',
+      );
+    },
+    [
+      dataExportDefaultTime,
+      generateModelColors,
+      t,
+    ],
+  );
+
   // ========== 初始化图表主题 ==========
   useEffect(() => {
     initVChartSemiTheme({
@@ -439,9 +907,15 @@ export const useDashboardCharts = (
     spec_line,
     spec_model_line,
     spec_rank_bar,
+    spec_token_bar,
+    spec_token_pie,
+    spec_channel_bar,
+    spec_channel_pie,
 
     // 函数
     updateChartData,
+    updateTokenChartData,
+    updateChannelChartData,
     generateModelColors,
   };
 };

--- a/web/src/hooks/dashboard/useDashboardData.js
+++ b/web/src/hooks/dashboard/useDashboardData.js
@@ -61,6 +61,13 @@ export const useDashboardData = (userState, userDispatch, statusState) => {
   const [lineData, setLineData] = useState([]);
   const [modelColors, setModelColors] = useState({});
 
+  // ========== 令牌数据状态 ==========
+  const [tokenStatsData, setTokenStatsData] = useState([]);
+  const [showAllTokens, setShowAllTokens] = useState(false);
+
+  // ========== 渠道数据状态 ==========
+  const [channelStatsData, setChannelStatsData] = useState([]);
+
   // ========== 图表状态 ==========
   const [activeChartTab, setActiveChartTab] = useState('1');
 
@@ -144,6 +151,10 @@ export const useDashboardData = (userState, userDispatch, statusState) => {
       localStorage.setItem('data_export_default_time', value);
       return;
     }
+    if (name === 'show_all_tokens') {
+      setShowAllTokens(value);
+      return;
+    }
     setInputs((inputs) => ({ ...inputs, [name]: value }));
   }, []);
 
@@ -223,11 +234,56 @@ export const useDashboardData = (userState, userDispatch, statusState) => {
     }
   }, [userDispatch]);
 
+  const loadTokenStats = useCallback(async () => {
+    try {
+      const { start_timestamp, end_timestamp } = inputs;
+      let localStartTimestamp = Date.parse(start_timestamp) / 1000;
+      let localEndTimestamp = Date.parse(end_timestamp) / 1000;
+
+      const url = `/api/data/self/token_stats?start_timestamp=${localStartTimestamp}&end_timestamp=${localEndTimestamp}&all=${showAllTokens}`;
+      const res = await API.get(url);
+      const { success, message, data } = res.data;
+      if (success) {
+        setTokenStatsData(data);
+        return data;
+      } else {
+        showError(message);
+        return [];
+      }
+    } catch (err) {
+      return [];
+    }
+  }, [inputs, showAllTokens]);
+
+  const loadChannelStats = useCallback(async () => {
+    if (!isAdminUser) return [];
+    try {
+      const { start_timestamp, end_timestamp } = inputs;
+      let localStartTimestamp = Date.parse(start_timestamp) / 1000;
+      let localEndTimestamp = Date.parse(end_timestamp) / 1000;
+
+      const url = `/api/data/channel_stats?start_timestamp=${localStartTimestamp}&end_timestamp=${localEndTimestamp}`;
+      const res = await API.get(url);
+      const { success, message, data } = res.data;
+      if (success) {
+        setChannelStatsData(data);
+        return data;
+      } else {
+        showError(message);
+        return [];
+      }
+    } catch (err) {
+      return [];
+    }
+  }, [inputs, isAdminUser]);
+
   const refresh = useCallback(async () => {
+    loadTokenStats();
+    loadChannelStats();
     const data = await loadQuotaData();
     await loadUptimeData();
     return data;
-  }, [loadQuotaData, loadUptimeData]);
+  }, [loadQuotaData, loadTokenStats, loadChannelStats, loadUptimeData]);
 
   const handleSearchConfirm = useCallback(
     async (updateChartDataCallback) => {
@@ -279,6 +335,10 @@ export const useDashboardData = (userState, userDispatch, statusState) => {
     setLineData,
     modelColors,
     setModelColors,
+    tokenStatsData,
+    showAllTokens,
+    setShowAllTokens,
+    channelStatsData,
 
     // 图表状态
     activeChartTab,
@@ -312,6 +372,8 @@ export const useDashboardData = (userState, userDispatch, statusState) => {
     handleCloseModal,
     loadQuotaData,
     loadUptimeData,
+    loadTokenStats,
+    loadChannelStats,
     getUserData,
     refresh,
     handleSearchConfirm,


### PR DESCRIPTION
### PR 类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

**在仪表盘的「模型数据分析」面板中新增令牌维度和渠道维度的用量统计图表。**

#### 后端
- 新增 `GET /api/data/self/token_stats` 接口（UserAuth），从 `logs` 表按 `token_id` + 小时分桶做 `GROUP BY` 聚合，返回每个令牌的分时用量
  - 管理员可通过 `?all=true` 查看系统内所有令牌的统计
- 新增 `GET /api/data/channel_stats` 接口（AdminAuth），按 `channel_id` + 小时分桶聚合
  - 因 `LOG_DB` 和 `DB` 可能是不同数据库，采用两步查询：先从 `LOG_DB` 聚合日志，再从 `DB` 批量查询渠道名称后合并

#### 前端
- 新增 4 个图表 Tab：
  - **Tab 5 — 令牌消耗分布**：堆叠柱状图，X 轴为时间，按令牌分色堆叠（所有用户可见）
  - **Tab 6 — 令牌消耗占比**：饼图，展示各令牌消耗占比（所有用户可见）
  - **Tab 7 — 渠道消耗分布**：堆叠柱状图，按渠道分色堆叠（仅管理员）
  - **Tab 8 — 渠道消耗占比**：饼图，展示各渠道消耗占比（仅管理员）
- 管理员可通过 Switch 开关切换「仅我的令牌」/「所有令牌」

#### 技术细节
- 直接查询 `logs` 表，利用已有索引（`token_id`、`channel_id`、`created_at`），无数据库迁移
- 兼容 SQLite / MySQL / PostgreSQL 三种数据库
- 前端图表复用 VChart 现有 spec 模式，与原有 4 个模型图表风格完全一致

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added token consumption statistics with hourly breakdown and optional admin toggle to view all tokens or personal usage only.
  * Added channel consumption statistics (administrators only) with hourly aggregation.
  * All statistics support custom time-range filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->