### PR TITLE
fix: propagate client request context to upstream HTTP requests

### DIFF
--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -295,7 +295,7 @@ func DoApiRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody
 	if common2.DebugEnabled {
 		println("fullRequestURL:", fullRequestURL)
 	}
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
@@ -326,7 +326,7 @@ func DoFormRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBod
 	if common2.DebugEnabled {
 		println("fullRequestURL:", fullRequestURL)
 	}
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
@@ -382,7 +382,7 @@ func DoWssRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody
 }
 
 func startPingKeepAlive(c *gin.Context, pingInterval time.Duration) context.CancelFunc {
-	pingerCtx, stopPinger := context.WithCancel(context.Background())
+	pingerCtx, stopPinger := context.WithCancel(c.Request.Context())
 
 	gopool.Go(func() {
 		defer func() {
@@ -432,9 +432,6 @@ func startPingKeepAlive(c *gin.Context, pingInterval time.Duration) context.Canc
 				}
 			// 收到退出信号
 			case <-pingerCtx.Done():
-				return
-			// request 结束
-			case <-c.Request.Context().Done():
 				return
 			// 超时保护，防止goroutine无限运行
 			case <-pingTimeout.C:
@@ -517,6 +514,14 @@ func doRequest(c *gin.Context, req *http.Request, info *common.RelayInfo) (*http
 
 	resp, err := client.Do(req)
 	if err != nil {
+		// 区分客户端主动断开和真正的上游错误
+		// 客户端断开时不记录错误日志、不重试、不影响渠道状态
+		if c.Request.Context().Err() != nil {
+			logger.LogInfo(c, "request cancelled by client: "+err.Error())
+			return nil, types.NewError(err, types.ErrorCodeDoRequestFailed,
+				types.ErrOptionWithSkipRetry(),
+				types.ErrOptionWithHideErrMsg("client disconnected"))
+		}
 		logger.LogError(c, "do request failed: "+err.Error())
 		return nil, types.NewError(err, types.ErrorCodeDoRequestFailed, types.ErrOptionWithHideErrMsg("upstream error: do request failed"))
 	}
@@ -534,7 +539,7 @@ func DoTaskApiRequest(a TaskAdaptor, c *gin.Context, info *common.RelayInfo, req
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}

--- a/relay/channel/coze/relay-coze.go
+++ b/relay/channel/coze/relay-coze.go
@@ -218,7 +218,7 @@ func checkIfChatComplete(a *Adaptor, c *gin.Context, info *relaycommon.RelayInfo
 
 	requestURL = requestURL + "?conversation_id=" + c.GetString("coze_conversation_id") + "&chat_id=" + c.GetString("coze_chat_id")
 	// 将 conversationId和chatId作为参数发送get请求
-	req, err := http.NewRequest("GET", requestURL, nil)
+	req, err := http.NewRequestWithContext(c.Request.Context(), "GET", requestURL, nil)
 	if err != nil {
 		return err, false
 	}
@@ -263,7 +263,7 @@ func getChatDetail(a *Adaptor, c *gin.Context, info *relaycommon.RelayInfo) (*ht
 	requestURL := fmt.Sprintf("%s/v3/chat/message/list", info.ChannelBaseUrl)
 
 	requestURL = requestURL + "?conversation_id=" + c.GetString("coze_conversation_id") + "&chat_id=" + c.GetString("coze_chat_id")
-	req, err := http.NewRequest("GET", requestURL, nil)
+	req, err := http.NewRequestWithContext(c.Request.Context(), "GET", requestURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}

--- a/relay/channel/dify/relay-dify.go
+++ b/relay/channel/dify/relay-dify.go
@@ -88,7 +88,7 @@ func uploadDifyFile(c *gin.Context, info *relaycommon.RelayInfo, user string, me
 		writer.Close()
 
 		// Create HTTP request
-		req, err := http.NewRequest("POST", uploadUrl, body)
+		req, err := http.NewRequestWithContext(c.Request.Context(), "POST", uploadUrl, body)
 		if err != nil {
 			common.SysLog("failed to create request: " + err.Error())
 			return nil

--- a/relay/channel/jimeng/adaptor.go
+++ b/relay/channel/jimeng/adaptor.go
@@ -108,7 +108,7 @@ func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, request
 	if err != nil {
 		return nil, fmt.Errorf("get request url failed: %w", err)
 	}
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}

--- a/relay/channel/replicate/adaptor.go
+++ b/relay/channel/replicate/adaptor.go
@@ -471,7 +471,7 @@ func uploadFileFromForm(c *gin.Context, info *relaycommon.RelayInfo, fieldCandid
 	}
 	uploadURL := relaycommon.GetFullRequestURL(baseURL, "/v1/files", info.ChannelType)
 
-	req, err := http.NewRequest(http.MethodPost, uploadURL, &body)
+	req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodPost, uploadURL, &body)
 	if err != nil {
 		return "", fmt.Errorf("replicate adaptor: create upload request failed: %w", err)
 	}

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -108,7 +108,7 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	scanner.Split(bufio.ScanLines)
 	SetEventStreamHeaders(c)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(c.Request.Context())
 	defer cancel()
 
 	ctx = context.WithValue(ctx, "stop_chan", stopChan)
@@ -165,9 +165,6 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 					return
 				case <-stopChan:
 					return
-				case <-c.Request.Context().Done():
-					// 监听客户端断开连接
-					return
 				case <-pingTimeout.C:
 					logger.LogError(c, "ping goroutine max duration reached")
 					return
@@ -218,8 +215,6 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 			case <-stopChan:
 				return
 			case <-ctx.Done():
-				return
-			case <-c.Request.Context().Done():
 				return
 			default:
 			}
@@ -276,8 +271,8 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	case <-stopChan:
 		// 正常结束
 		logger.LogInfo(c, "streaming finished")
-	case <-c.Request.Context().Done():
-		// 客户端断开连接
+	case <-ctx.Done():
+		// 客户端断开连接或 context 被取消
 		logger.LogInfo(c, "client disconnected")
 	}
 }


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

**问题：** 当客户端在请求过程中断开连接时，上游 HTTP 请求不会被自动取消，继续消耗资源直到请求完成或超时。

**根本原因：** relay 层所有上游请求使用 `http.NewRequest()` 创建，未传播客户端的 request context。同时 `StreamScannerHandler` 和 `startPingKeepAlive` 使用 `context.Background()` 作为父 context，与客户端 context 完全断开。

**修复内容：**

1. **核心 relay 函数**（`DoApiRequest`、`DoFormRequest`、`DoTaskApiRequest`）：`http.NewRequest()` → `http.NewRequestWithContext(c.Request.Context(), ...)`，客户端断开时上游请求自动取消。

2. **Channel 适配器**（jimeng、coze、dify、replicate）：同样改为 `NewRequestWithContext`。

3. **StreamScannerHandler**：内部 context 从 `context.WithCancel(context.Background())` 改为 `context.WithCancel(c.Request.Context())`，移除了多处冗余的 `c.Request.Context().Done()` 监听（因为父 context 取消时子 context 自动取消）。

4. **startPingKeepAlive**：同样将 context 父级从 `context.Background()` 改为 `c.Request.Context()`。

**效果：** 客户端断开后，上游 TCP 连接会被立即取消，不再等待上游响应完成，显著减少资源浪费。

**不在本次修改范围：** 异步任务轮询函数（如 suno/vidu/kling 等的 FetchTask）和管理操作（如 ollama 模型管理、百度 token 获取）不在客户端请求链路中，不需要传播客户端 context。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent propagation of request cancellation and timeouts to outbound API calls, uploads, and streaming operations.
  * Improved handling when a client disconnects: operations stop promptly and return controlled, non-retriable errors to avoid unnecessary work and noisy upstream failures.
  * Removed redundant cancellation checks for cleaner, more predictable shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->