### PR TITLE
feat(ratio-setting): add compatibility for gemma-4 model suffix handling

### DIFF
--- a/model/channel_cache.go
+++ b/model/channel_cache.go
@@ -96,7 +96,15 @@ func SyncChannelCache(frequency int) {
 func GetRandomSatisfiedChannel(group string, model string, retry int) (*Channel, error) {
 	// if memory cache is disabled, get channel directly from database
 	if !common.MemoryCacheEnabled {
-		return GetChannel(group, model, retry)
+		channel, err := GetChannel(group, model, retry)
+		if err != nil || channel != nil {
+			return channel, err
+		}
+		normalizedModel := ratio_setting.FormatMatchingModelName(model)
+		if normalizedModel != "" && normalizedModel != model {
+			return GetChannel(group, normalizedModel, retry)
+		}
+		return nil, nil
 	}
 
 	channelSyncLock.RLock()

--- a/model/channel_cache.go
+++ b/model/channel_cache.go
@@ -96,15 +96,7 @@ func SyncChannelCache(frequency int) {
 func GetRandomSatisfiedChannel(group string, model string, retry int) (*Channel, error) {
 	// if memory cache is disabled, get channel directly from database
 	if !common.MemoryCacheEnabled {
-		channel, err := GetChannel(group, model, retry)
-		if err != nil || channel != nil {
-			return channel, err
-		}
-		normalizedModel := ratio_setting.FormatMatchingModelName(model)
-		if normalizedModel != "" && normalizedModel != model {
-			return GetChannel(group, normalizedModel, retry)
-		}
-		return nil, nil
+		return GetChannel(group, model, retry)
 	}
 
 	channelSyncLock.RLock()

--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/setting/model_setting"
 	"github.com/QuantumNous/new-api/setting/operation_setting"
 	"github.com/QuantumNous/new-api/setting/reasoning"
 	"github.com/QuantumNous/new-api/types"
@@ -722,6 +723,21 @@ func GetAudioCompletionRatioCopy() map[string]float64 {
 	return audioCompletionRatioMap.ReadAll()
 }
 
+// NormalizeGemma4EffortModelName 在开启 Gemini thinking adapter 时，
+// 将 gemma-4* 的 effort 后缀（如 -minimal/-high）归一化为基础模型名。
+func NormalizeGemma4EffortModelName(name string) string {
+	if !model_setting.GetGeminiSettings().ThinkingAdapterEnabled {
+		return name
+	}
+	if !strings.HasPrefix(name, "gemma-4") {
+		return name
+	}
+	if baseModel, level, ok := reasoning.TrimEffortSuffix(name); ok && level != "" {
+		return baseModel
+	}
+	return name
+}
+
 // 转换模型名，减少渠道必须配置各种带参数模型
 func FormatMatchingModelName(name string) string {
 
@@ -731,12 +747,9 @@ func FormatMatchingModelName(name string) string {
 		name = handleThinkingBudgetModel(name, "gemini-2.5-flash", "gemini-2.5-flash-thinking-*")
 	} else if strings.HasPrefix(name, "gemini-2.5-pro") {
 		name = handleThinkingBudgetModel(name, "gemini-2.5-pro", "gemini-2.5-pro-thinking-*")
-	} else if strings.HasPrefix(name, "gemma-4") {
-		// 兼容 gemma-4* 思考后缀（如 -minimal/-high）
-		if baseModel, level, ok := reasoning.TrimEffortSuffix(name); ok && level != "" {
-			name = baseModel
-		}
 	}
+
+	name = NormalizeGemma4EffortModelName(name)
 
 	if strings.HasPrefix(name, "gpt-4-gizmo") {
 		name = "gpt-4-gizmo-*"

--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/setting/operation_setting"
+	"github.com/QuantumNous/new-api/setting/reasoning"
 	"github.com/QuantumNous/new-api/types"
 )
 
@@ -730,6 +731,11 @@ func FormatMatchingModelName(name string) string {
 		name = handleThinkingBudgetModel(name, "gemini-2.5-flash", "gemini-2.5-flash-thinking-*")
 	} else if strings.HasPrefix(name, "gemini-2.5-pro") {
 		name = handleThinkingBudgetModel(name, "gemini-2.5-pro", "gemini-2.5-pro-thinking-*")
+	} else if strings.HasPrefix(name, "gemma-4") {
+		// 兼容 gemma-4* 思考后缀（如 -minimal/-high）
+		if baseModel, level, ok := reasoning.TrimEffortSuffix(name); ok && level != "" {
+			name = baseModel
+		}
 	}
 
 	if strings.HasPrefix(name, "gpt-4-gizmo") {


### PR DESCRIPTION
根据 AIS 和相关文档，Gemma 4 已支持通过 `thinkingLevel` 控制思考开关。

即使 newapi 支持 `gemma-4-26b-a4b-it-minimal` 。

<img width="513" height="1040" alt="image" src="https://github.com/user-attachments/assets/f443e523-b27a-4edd-ac53-da4c240cdcbc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of gemma-4 model names to ensure consistent formatting across different model variants and configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->