### PR TITLE
feat: add model alias and deprecated model forwarding

### DIFF
--- a/controller/model_config.go
+++ b/controller/model_config.go
@@ -1,0 +1,98 @@
+// Package controller provides HTTP handlers
+// model_config.go - Admin APIs for model alias and deprecated model configuration
+package controller
+
+import (
+	"net/http"
+
+	"github.com/QuantumNous/new-api/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ModelAliasRequest represents a request to add/update a model alias
+type ModelAliasRequest struct {
+	Alias  string `json:"alias" binding:"required"`
+	Target string `json:"target" binding:"required"`
+}
+
+// DeprecatedModelRequest represents a request to add/update a deprecated model
+type DeprecatedModelRequest struct {
+	Deprecated  string `json:"deprecated" binding:"required"`
+	Replacement string `json:"replacement" binding:"required"`
+	Reason      string `json:"reason"`
+}
+
+// ListModelAliasesAPI returns all model aliases
+func ListModelAliasesAPI(c *gin.Context) {
+	aliases := middleware.ListModelAliases()
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    aliases,
+	})
+}
+
+// AddModelAliasAPI adds or updates a model alias
+func AddModelAliasAPI(c *gin.Context) {
+	var req ModelAliasRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"message": "Invalid request: " + err.Error(),
+		})
+		return
+	}
+
+	middleware.AddModelAlias(req.Alias, req.Target)
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "Model alias added successfully",
+	})
+}
+
+// RemoveModelAliasAPI removes a model alias
+func RemoveModelAliasAPI(c *gin.Context) {
+	alias := c.Param("alias")
+	middleware.RemoveModelAlias(alias)
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "Model alias removed successfully",
+	})
+}
+
+// ListDeprecatedModelsAPI returns all deprecated models
+func ListDeprecatedModelsAPI(c *gin.Context) {
+	models := middleware.ListDeprecatedModels()
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    models,
+	})
+}
+
+// AddDeprecatedModelAPI adds or updates a deprecated model
+func AddDeprecatedModelAPI(c *gin.Context) {
+	var req DeprecatedModelRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"message": "Invalid request: " + err.Error(),
+		})
+		return
+	}
+
+	middleware.AddDeprecatedModel(req.Deprecated, req.Replacement, req.Reason)
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "Deprecated model added successfully",
+	})
+}
+
+// RemoveDeprecatedModelAPI removes a deprecated model
+func RemoveDeprecatedModelAPI(c *gin.Context) {
+	model := c.Param("model")
+	middleware.RemoveDeprecatedModel(model)
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "Deprecated model removed successfully",
+	})
+}

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -116,6 +116,9 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 		return
 	}
 
+	// Apply model name corrections (alias resolution and deprecated model forwarding)
+	helper.CorrectModelName(c, request)
+
 	relayInfo, err := relaycommon.GenRelayInfo(c, relayFormat, request, ws)
 	if err != nil {
 		newAPIError = types.NewError(err, types.ErrorCodeGenRelayInfoFailed)

--- a/middleware/deprecated_model.go
+++ b/middleware/deprecated_model.go
@@ -1,0 +1,127 @@
+// Package middleware provides HTTP middleware for the gateway
+// deprecated_model.go - Deprecated model forwarding for smooth migration
+package middleware
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/QuantumNous/new-api/logger"
+
+	"github.com/gin-gonic/gin"
+)
+
+// DeprecatedModelConfig represents a deprecated model and its replacement
+type DeprecatedModelConfig struct {
+	// Deprecated is the old model name that will be forwarded
+	Deprecated string `json:"deprecated"`
+	// Replacement is the new model to use instead
+	Replacement string `json:"replacement"`
+	// Reason explains why the model was deprecated (optional)
+	Reason string `json:"reason,omitempty"`
+	// CutoffDate is when requests for this model will be rejected (optional)
+	CutoffDate string `json:"cutoff_date,omitempty"`
+}
+
+// DeprecatedModelMapping holds all deprecated model configurations
+type DeprecatedModelMapping struct {
+	mu     sync.RWMutex
+	config map[string]DeprecatedModelConfig // deprecated -> config
+}
+
+// globalDeprecatedMapping is the global deprecated model mapping instance
+var globalDeprecatedMapping = &DeprecatedModelMapping{
+	config: make(map[string]DeprecatedModelConfig),
+}
+
+// DefaultDeprecatedModels provides the default list of deprecated models
+// These are models that have been discontinued by their providers
+var DefaultDeprecatedModels = []DeprecatedModelConfig{
+	// Claude v2 series (discontinued)
+	{Deprecated: "claude-2", Replacement: "claude-sonnet-4-6", Reason: "Claude 2 series discontinued by Anthropic"},
+	{Deprecated: "claude-2.0", Replacement: "claude-sonnet-4-6", Reason: "Claude 2 series discontinued by Anthropic"},
+	{Deprecated: "claude-2.1", Replacement: "claude-sonnet-4-6", Reason: "Claude 2 series discontinued by Anthropic"},
+	{Deprecated: "claude-instant-1", Replacement: "claude-haiku-3-5", Reason: "Claude Instant discontinued by Anthropic"},
+	// OpenAI legacy models
+	{Deprecated: "gpt-4-0314", Replacement: "gpt-4-turbo", Reason: "Legacy GPT-4 snapshot"},
+	{Deprecated: "gpt-4-0613", Replacement: "gpt-4-turbo", Reason: "Legacy GPT-4 snapshot"},
+	{Deprecated: "gpt-3.5-turbo-0301", Replacement: "gpt-3.5-turbo", Reason: "Legacy GPT-3.5 snapshot"},
+	{Deprecated: "gpt-3.5-turbo-0613", Replacement: "gpt-3.5-turbo", Reason: "Legacy GPT-3.5 snapshot"},
+	{Deprecated: "gpt-3.5-turbo-instruct", Replacement: "gpt-3.5-turbo", Reason: "Instruct variant discontinued"},
+	// Gemini legacy
+	{Deprecated: "gemini-1.0-pro", Replacement: "gemini-2.5-flash", Reason: "Legacy Gemini Pro"},
+}
+
+// InitDeprecatedModels initializes the deprecated model mapping with defaults and custom config
+func InitDeprecatedModels(customModels []DeprecatedModelConfig) {
+	globalDeprecatedMapping.mu.Lock()
+	defer globalDeprecatedMapping.mu.Unlock()
+
+	// Clear existing config
+	globalDeprecatedMapping.config = make(map[string]DeprecatedModelConfig)
+
+	// Load defaults
+	for _, dm := range DefaultDeprecatedModels {
+		globalDeprecatedMapping.config[strings.ToLower(dm.Deprecated)] = dm
+	}
+
+	// Override/add custom deprecated models
+	for _, dm := range customModels {
+		globalDeprecatedMapping.config[strings.ToLower(dm.Deprecated)] = dm
+	}
+}
+
+// GetReplacementForDeprecated checks if a model is deprecated and returns its replacement
+// Returns: replacement model, whether it was deprecated, and the reason
+func GetReplacementForDeprecated(c *gin.Context, modelName string) (string, bool, string) {
+	if modelName == "" {
+		return modelName, false, ""
+	}
+
+	globalDeprecatedMapping.mu.RLock()
+	defer globalDeprecatedMapping.mu.RUnlock()
+
+	lowerModel := strings.ToLower(modelName)
+	if config, ok := globalDeprecatedMapping.config[lowerModel]; ok {
+		logger.LogInfo(c, "[DeprecatedModel] Forwarding deprecated model: %s -> %s (%s)",
+			modelName, config.Replacement, config.Reason)
+		return config.Replacement, true, config.Reason
+	}
+
+	return modelName, false, ""
+}
+
+// AddDeprecatedModel adds or updates a deprecated model mapping at runtime
+func AddDeprecatedModel(deprecated, replacement, reason string) {
+	globalDeprecatedMapping.mu.Lock()
+	defer globalDeprecatedMapping.mu.Unlock()
+	globalDeprecatedMapping.config[strings.ToLower(deprecated)] = DeprecatedModelConfig{
+		Deprecated:  deprecated,
+		Replacement: replacement,
+		Reason:      reason,
+	}
+}
+
+// RemoveDeprecatedModel removes a deprecated model mapping
+func RemoveDeprecatedModel(deprecated string) {
+	globalDeprecatedMapping.mu.Lock()
+	defer globalDeprecatedMapping.mu.Unlock()
+	delete(globalDeprecatedMapping.config, strings.ToLower(deprecated))
+}
+
+// ListDeprecatedModels returns all current deprecated model mappings
+func ListDeprecatedModels() map[string]DeprecatedModelConfig {
+	globalDeprecatedMapping.mu.RLock()
+	defer globalDeprecatedMapping.mu.RUnlock()
+
+	result := make(map[string]DeprecatedModelConfig)
+	for k, v := range globalDeprecatedMapping.config {
+		result[k] = v
+	}
+	return result
+}
+
+// init initializes default deprecated models on package load
+func init() {
+	InitDeprecatedModels(nil)
+}

--- a/middleware/model_alias.go
+++ b/middleware/model_alias.go
@@ -1,0 +1,146 @@
+// Package middleware provides HTTP middleware for the gateway
+// model_alias.go - Configurable model alias mapping for user convenience
+package middleware
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/logger"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ModelAliasConfig represents a single model alias configuration
+type ModelAliasConfig struct {
+	// Alias is the user-facing model name
+	Alias string `json:"alias"`
+	// Target is the actual model name to use
+	Target string `json:"target"`
+	// Pattern is an optional regex pattern for flexible matching
+	Pattern string `json:"pattern,omitempty"`
+}
+
+// ModelAliasMapping holds all alias configurations
+type ModelAliasMapping struct {
+	mu     sync.RWMutex
+	config map[string]string // alias -> target
+	regex  []*regexp.Regexp  // compiled patterns
+}
+
+// globalAliasMapping is the global alias mapping instance
+var globalAliasMapping = &ModelAliasMapping{
+	config: make(map[string]string),
+}
+
+// DefaultModelAliases provides sensible defaults for common naming variations
+// These are loaded on startup and can be overridden via configuration
+var DefaultModelAliases = []ModelAliasConfig{
+	// OpenAI aliases
+	{Alias: "gpt4", Target: "gpt-4"},
+	{Alias: "gpt4o", Target: "gpt-4o"},
+	{Alias: "gpt35", Target: "gpt-3.5-turbo"},
+	{Alias: "gpt-3.5", Target: "gpt-3.5-turbo"},
+	// Claude aliases
+	{Alias: "claude-opus", Target: "claude-opus-4-6"},
+	{Alias: "claude-sonnet", Target: "claude-sonnet-4-6"},
+	{Alias: "claude-haiku", Target: "claude-haiku-3-5"},
+	{Alias: "claude-3.5-sonnet", Target: "claude-sonnet-4-6"},
+	{Alias: "claude-3-5-sonnet", Target: "claude-sonnet-4-6"},
+	{Alias: "claude-3.5-haiku", Target: "claude-haiku-3-5"},
+	{Alias: "claude-3-opus", Target: "claude-opus-4-6"},
+	{Alias: "claude-3-sonnet", Target: "claude-sonnet-4-6"},
+	// Gemini aliases
+	{Alias: "gemini-pro", Target: "gemini-2.5-flash"},
+	{Alias: "gemini-flash", Target: "gemini-2.5-flash"},
+	// DeepSeek aliases
+	{Alias: "deepseek", Target: "deepseek-chat"},
+	{Alias: "deepseek-v3", Target: "deepseek-chat"},
+}
+
+// InitModelAliases initializes the model alias mapping with defaults and custom config
+func InitModelAliases(customAliases []ModelAliasConfig) {
+	globalAliasMapping.mu.Lock()
+	defer globalAliasMapping.mu.Unlock()
+
+	// Clear existing config
+	globalAliasMapping.config = make(map[string]string)
+	globalAliasMapping.regex = nil
+
+	// Load defaults
+	for _, alias := range DefaultModelAliases {
+		globalAliasMapping.config[strings.ToLower(alias.Alias)] = alias.Target
+	}
+
+	// Override/add custom aliases
+	for _, alias := range customAliases {
+		if alias.Pattern != "" {
+			if re, err := regexp.Compile(alias.Pattern); err == nil {
+				globalAliasMapping.regex = append(globalAliasMapping.regex, re)
+			}
+		}
+		globalAliasMapping.config[strings.ToLower(alias.Alias)] = alias.Target
+	}
+}
+
+// ResolveModelAlias resolves a model name through alias mapping
+// Returns the resolved model name and whether an alias was applied
+func ResolveModelAlias(c *gin.Context, modelName string) (string, bool) {
+	if modelName == "" {
+		return modelName, false
+	}
+
+	globalAliasMapping.mu.RLock()
+	defer globalAliasMapping.mu.RUnlock()
+
+	// Try exact match (case-insensitive)
+	lowerModel := strings.ToLower(modelName)
+	if target, ok := globalAliasMapping.config[lowerModel]; ok {
+		logger.LogInfo(c, "[ModelAlias] Resolved: %s -> %s", modelName, target)
+		return target, true
+	}
+
+	// Try pattern matching
+	for _, re := range globalAliasMapping.regex {
+		if re.MatchString(modelName) {
+			// Pattern match would require more complex mapping
+			// For now, just log the match
+			logger.LogDebug(c, "[ModelAlias] Pattern matched: %s", modelName)
+		}
+	}
+
+	return modelName, false
+}
+
+// AddModelAlias adds or updates a model alias at runtime
+func AddModelAlias(alias, target string) {
+	globalAliasMapping.mu.Lock()
+	defer globalAliasMapping.mu.Unlock()
+	globalAliasMapping.config[strings.ToLower(alias)] = target
+}
+
+// RemoveModelAlias removes a model alias
+func RemoveModelAlias(alias string) {
+	globalAliasMapping.mu.Lock()
+	defer globalAliasMapping.mu.Unlock()
+	delete(globalAliasMapping.config, strings.ToLower(alias))
+}
+
+// ListModelAliases returns all current alias mappings
+func ListModelAliases() map[string]string {
+	globalAliasMapping.mu.RLock()
+	defer globalAliasMapping.mu.RUnlock()
+
+	result := make(map[string]string)
+	for k, v := range globalAliasMapping.config {
+		result[k] = v
+	}
+	return result
+}
+
+// init initializes default aliases on package load
+func init() {
+	InitModelAliases(nil)
+}

--- a/relay/helper/model_correction.go
+++ b/relay/helper/model_correction.go
@@ -1,0 +1,69 @@
+// Package helper provides utility functions for relay operations
+// model_correction.go - Model name correction for user convenience
+package helper
+
+import (
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/logger"
+	"github.com/QuantumNous/new-api/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CorrectModelName applies model alias and deprecated model forwarding
+// This function should be called after GetAndValidateRequest
+// Returns: corrected model name, whether any correction was applied
+func CorrectModelName(c *gin.Context, request dto.Request) string {
+	originalModel := getModelName(request)
+	if originalModel == "" {
+		return originalModel
+	}
+
+	// Apply corrections in order: deprecated first, then alias
+	currentModel := originalModel
+	wasCorrected := false
+
+	// 1. Check for deprecated models
+	if replacement, deprecated, reason := middleware.GetReplacementForDeprecated(c, currentModel); deprecated {
+		currentModel = replacement
+		wasCorrected = true
+		logger.LogInfo(c, "[ModelCorrection] Deprecated model forwarded: %s -> %s (%s)",
+			originalModel, replacement, reason)
+	}
+
+	// 2. Check for model aliases
+	if resolved, aliased := middleware.ResolveModelAlias(c, currentModel); aliased {
+		currentModel = resolved
+		wasCorrected = true
+	}
+
+	// Update the request if correction was applied
+	if wasCorrected && currentModel != originalModel {
+		request.SetModelName(currentModel)
+		logger.LogInfo(c, "[ModelCorrection] Model corrected: %s -> %s", originalModel, currentModel)
+	}
+
+	return currentModel
+}
+
+// getModelName extracts model name from different request types
+func getModelName(request dto.Request) string {
+	switch r := request.(type) {
+	case *dto.GeneralOpenAIRequest:
+		return r.Model
+	case *dto.ClaudeRequest:
+		return r.Model
+	case *dto.ImageRequest:
+		return r.Model
+	case *dto.AudioRequest:
+		return r.Model
+	case *dto.EmbeddingRequest:
+		return r.Model
+	case *dto.RerankRequest:
+		return r.Model
+	case *dto.GeminiChatRequest:
+		return r.Model
+	default:
+		return ""
+	}
+}

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -203,6 +203,18 @@ func SetApiRouter(router *gin.Engine) {
 			ratioSyncRoute.GET("/channels", controller.GetSyncableChannels)
 			ratioSyncRoute.POST("/fetch", controller.FetchUpstreamRatios)
 		}
+		// Model configuration (alias and deprecated models)
+		modelConfigRoute := apiRouter.Group("/model-config")
+		modelConfigRoute.Use(middleware.AdminAuth())
+		{
+			modelConfigRoute.GET("/aliases", controller.ListModelAliasesAPI)
+			modelConfigRoute.POST("/aliases", controller.AddModelAliasAPI)
+			modelConfigRoute.DELETE("/aliases/:alias", controller.RemoveModelAliasAPI)
+			modelConfigRoute.GET("/deprecated", controller.ListDeprecatedModelsAPI)
+			modelConfigRoute.POST("/deprecated", controller.AddDeprecatedModelAPI)
+			modelConfigRoute.DELETE("/deprecated/:model", controller.RemoveDeprecatedModelAPI)
+		}
+
 		channelRoute := apiRouter.Group("/channel")
 		channelRoute.Use(middleware.AdminAuth())
 		{


### PR DESCRIPTION
Add configurable model alias resolution and deprecated model forwarding for better user experience:

- Model aliases: Users can use common short names (e.g., "gpt4" -> "gpt-4")
- Deprecated models: Automatically forward discontinued models to replacements
- Admin APIs: Configure aliases and deprecated models at runtime

This helps users avoid 404 errors from typos and provides smooth migration when providers discontinue models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin API endpoints to manage model name aliases (list, add, remove operations).
  * Added admin API endpoints to manage deprecated models with replacement configurations.
  * Implemented automatic model name correction that applies aliases and deprecation mappings to incoming requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->