### PR TITLE
feat(token): add batch API for fetching token keys

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -334,3 +334,26 @@ func DeleteTokenBatch(c *gin.Context) {
 		"data":    count,
 	})
 }
+
+func GetTokenKeysBatch(c *gin.Context) {
+	tokenBatch := TokenBatch{}
+	if err := c.ShouldBindJSON(&tokenBatch); err != nil || len(tokenBatch.Ids) == 0 {
+		common.ApiErrorI18n(c, i18n.MsgInvalidParams)
+		return
+	}
+	if len(tokenBatch.Ids) > 100 {
+		common.ApiErrorI18n(c, i18n.MsgBatchTooMany, map[string]any{"Max": 100})
+		return
+	}
+	userId := c.GetInt("id")
+	tokens, err := model.GetTokenKeysByIds(tokenBatch.Ids, userId)
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	keysMap := make(map[int]string)
+	for _, t := range tokens {
+		keysMap[t.Id] = t.GetFullKey()
+	}
+	common.ApiSuccess(c, gin.H{"keys": keysMap})
+}

--- a/i18n/keys.go
+++ b/i18n/keys.go
@@ -25,6 +25,7 @@ const (
 	MsgDeleteFailed      = "common.delete_failed"
 	MsgAlreadyExists     = "common.already_exists"
 	MsgNameCannotBeEmpty = "common.name_cannot_be_empty"
+	MsgBatchTooMany      = "common.batch_too_many"
 )
 
 // Token related messages

--- a/i18n/locales/en.yaml
+++ b/i18n/locales/en.yaml
@@ -21,6 +21,7 @@ common.delete_success: "Deletion successful"
 common.delete_failed: "Deletion failed"
 common.already_exists: "Already exists"
 common.name_cannot_be_empty: "Name cannot be empty"
+common.batch_too_many: "Too many items in batch request, maximum is {{.Max}}"
 
 # Token messages
 token.name_too_long: "Token name is too long"

--- a/i18n/locales/zh-CN.yaml
+++ b/i18n/locales/zh-CN.yaml
@@ -22,6 +22,7 @@ common.delete_success: "删除成功"
 common.delete_failed: "删除失败"
 common.already_exists: "已存在"
 common.name_cannot_be_empty: "名称不能为空"
+common.batch_too_many: "批量请求数量过多，最多 {{.Max}} 条"
 
 # Token messages
 token.name_too_long: "令牌名称过长"

--- a/i18n/locales/zh-TW.yaml
+++ b/i18n/locales/zh-TW.yaml
@@ -22,6 +22,7 @@ common.delete_success: "刪除成功"
 common.delete_failed: "刪除失敗"
 common.already_exists: "已存在"
 common.name_cannot_be_empty: "名稱不能為空"
+common.batch_too_many: "批次請求數量過多，最多 {{.Max}} 條"
 
 # Token messages
 token.name_too_long: "令牌名稱過長"

--- a/model/token.go
+++ b/model/token.go
@@ -481,3 +481,11 @@ func BatchDeleteTokens(ids []int, userId int) (int, error) {
 
 	return len(tokens), nil
 }
+
+func GetTokenKeysByIds(ids []int, userId int) ([]Token, error) {
+	var tokens []Token
+	err := DB.Select("id", commonKeyCol).
+		Where("user_id = ? AND id IN (?)", userId, ids).
+		Find(&tokens).Error
+	return tokens, err
+}

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -257,6 +257,7 @@ func SetApiRouter(router *gin.Engine) {
 			tokenRoute.PUT("/", controller.UpdateToken)
 			tokenRoute.DELETE("/:id", controller.DeleteToken)
 			tokenRoute.POST("/batch", controller.DeleteTokenBatch)
+			tokenRoute.POST("/batch/keys", middleware.CriticalRateLimit(), middleware.DisableCache(), controller.GetTokenKeysBatch)
 		}
 
 		usageRoute := apiRouter.Group("/usage")

--- a/web/src/helpers/token.js
+++ b/web/src/helpers/token.js
@@ -34,6 +34,20 @@ export async function fetchTokenKey(tokenId) {
 }
 
 /**
+ * 批量获取多个令牌的真实 key
+ * @param {number[]} tokenIds
+ * @returns {Promise<Record<number, string>>} 返回 {id: key} map，key 不带 sk- 前缀
+ */
+export async function fetchTokenKeysBatch(tokenIds) {
+  const response = await API.post('/api/token/batch/keys', { ids: tokenIds });
+  const { success, data, message } = response.data || {};
+  if (!success || !data?.keys) {
+    throw new Error(message || 'Failed to fetch token keys');
+  }
+  return data.keys;
+}
+
+/**
  * 获取可用的 token keys
  * @returns {Promise<string[]>} 返回 active 状态的不带 sk- 前缀的真实 token key 数组
  */

--- a/web/src/hooks/tokens/useTokensData.jsx
+++ b/web/src/hooks/tokens/useTokensData.jsx
@@ -31,6 +31,7 @@ import { ITEMS_PER_PAGE } from '../../constants';
 import { useTableCompactMode } from '../common/useTableCompactMode';
 import {
   fetchTokenKey as fetchTokenKeyById,
+  fetchTokenKeysBatch,
   getServerAddress,
   encodeChannelConnectionString,
 } from '../../helpers/token';
@@ -408,14 +409,17 @@ export const useTokensData = (openFluentNotification, openCCSwitchModal) => {
       return;
     }
     try {
-      const keys = await Promise.all(
-        selectedKeys.map((token) => fetchTokenKey(token, { suppressError: true })),
-      );
+      const ids = selectedKeys.map((token) => token.id);
+      const keysMap = await fetchTokenKeysBatch(ids);
+
+      setResolvedTokenKeys((prev) => ({ ...prev, ...keysMap }));
+
       let content = '';
-      for (let i = 0; i < selectedKeys.length; i++) {
-        const fullKey = keys[i];
+      for (const token of selectedKeys) {
+        const fullKey = keysMap[token.id];
+        if (!fullKey) continue;
         if (copyType === 'name+key') {
-          content += `${selectedKeys[i].name}    sk-${fullKey}\n`;
+          content += `${token.name}    sk-${fullKey}\n`;
         } else {
           content += `sk-${fullKey}\n`;
         }


### PR DESCRIPTION
## 📝 变更描述 / Description

前端批量复制 token key 时，原实现对每个 token 逐一请求 `GET /api/token/:id` 获取真实 key，选中数量较多时会密集触发默认限流（globalApiRateLimit），导致部分请求被拒绝、复制内容不完整。

本 PR 新增批量获取接口 `POST /api/token/batch/keys`，一次请求返回所有选中 token 的 key，前端改为调用该批量接口，避免并发请求打到限流。

**后端：**
- `model/token.go`：新增 `GetTokenKeysByIds`，单次查询批量获取 token key
- `controller/token.go`：新增 `GetTokenKeysBatch`，校验参数并限制单批最多 100 条
- `router/api-router.go`：注册 `POST /batch/keys` 路由，使用 `CriticalRateLimit` + `DisableCache` 中间件
- `i18n`：新增 `common.batch_too_many` 错误消息（en/zh-CN/zh-TW）

**前端：**
- `helpers/token.js`：新增 `fetchTokenKeysBatch` 批量获取函数
- `useTokensData.jsx`：批量复制逻辑从 `Promise.all` 逐一请求改为调用批量接口

## 🚀 变更类型 / Type of change
- [x] ⚡ 性能优化 / 重构 (Refactor)

## 🔗 关联任务 / Related Issue
- Closes #4110

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自撰写此描述，去除了 AI 原始输出的冗余。
- [x] **深度理解:** 我已**完全理解**这些更改的工作原理及潜在影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过了测试或手动验证。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
<img width="2712" height="770" alt="image" src="https://github.com/user-attachments/assets/f2eb52c3-2f70-4158-934e-e8d8c2320873" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk token key retrieval endpoint (POST) with a maximum of 100 IDs per request
  * Frontend support for fetching token keys in bulk and improved batch-copy behavior using the bulk results

* **Localization**
  * Added localized error message for exceeding batch size (EN, zh-CN, zh-TW)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->