### PR TITLE
fix(email): 修复 SMTP 25 端口无认证配置下邮件发送失败问题

### DIFF
--- a/common/email.go
+++ b/common/email.go
@@ -26,7 +26,17 @@ func shouldUseSMTPLoginAuth() bool {
 	return isOutlookServer(SMTPAccount) || slices.Contains(EmailLoginAuthServerList, SMTPServer)
 }
 
+func shouldUseSMTPAuth() bool {
+	if SMTPForceAuthLogin {
+		return true
+	}
+	return SMTPPort != 25
+}
+
 func getSMTPAuth() smtp.Auth {
+	if !shouldUseSMTPAuth() {
+		return nil
+	}
 	if shouldUseSMTPLoginAuth() {
 		return LoginAuth(SMTPAccount, SMTPToken)
 	}
@@ -70,8 +80,10 @@ func SendEmail(subject string, receiver string, content string) error {
 			return err
 		}
 		defer client.Close()
-		if err = client.Auth(auth); err != nil {
-			return err
+		if auth != nil {
+			if err = client.Auth(auth); err != nil {
+				return err
+			}
 		}
 		if err = client.Mail(SMTPFrom); err != nil {
 			return err

--- a/common/email.go
+++ b/common/email.go
@@ -107,7 +107,50 @@ func SendEmail(subject string, receiver string, content string) error {
 			return err
 		}
 	} else {
-		err = smtp.SendMail(addr, auth, SMTPFrom, to, mail)
+		client, dialErr := smtp.Dial(addr)
+		if dialErr != nil {
+			return dialErr
+		}
+		defer client.Close()
+
+		if ok, _ := client.Extension("STARTTLS"); ok {
+			tlsConfig := &tls.Config{
+				InsecureSkipVerify: true,
+				ServerName:         SMTPServer,
+			}
+			if err = client.StartTLS(tlsConfig); err != nil {
+				return err
+			}
+		}
+
+		if auth != nil {
+			if err = client.Auth(auth); err != nil {
+				return err
+			}
+		}
+		if err = client.Mail(SMTPFrom); err != nil {
+			return err
+		}
+		for _, receiver := range to {
+			receiver = strings.TrimSpace(receiver)
+			if receiver == "" {
+				continue
+			}
+			if err = client.Rcpt(receiver); err != nil {
+				return err
+			}
+		}
+		w, dataErr := client.Data()
+		if dataErr != nil {
+			return dataErr
+		}
+		if _, err = w.Write(mail); err != nil {
+			return err
+		}
+		if err = w.Close(); err != nil {
+			return err
+		}
+		err = client.Quit()
 	}
 	if err != nil {
 		SysError(fmt.Sprintf("failed to send email to %s: %v", receiver, err))


### PR DESCRIPTION
本次合并主要修复 SMTP 配置为 25 端口且无需认证时邮件发送失败的问题：通过增加认证条件判断，仅在需要且存在认证信息时才执行 Auth，避免无认证场景下错误认证导致发送失败；同时优化发送流程并兼容 STARTTLS。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved SMTP email sending reliability with more flexible authentication handling based on server configuration.
  * Added automatic STARTTLS support when available for enhanced security on standard SMTP connections.
  * Enhanced email delivery stability through better handling of authentication and connection scenarios across different server types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->