### PR TITLE
perf: optimize memory alloc

### DIFF
--- a/common/gin.go
+++ b/common/gin.go
@@ -110,16 +110,23 @@ func UnmarshalBodyReusable(c *gin.Context, v any) error {
 	if err != nil {
 		return err
 	}
-	requestBody, err := storage.Bytes()
-	if err != nil {
-		return err
-	}
 	contentType := c.Request.Header.Get("Content-Type")
 	if strings.HasPrefix(contentType, "application/json") {
-		err = Unmarshal(requestBody, v)
+		if _, err = storage.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+		err = DecodeJson(storage, v)
 	} else if strings.Contains(contentType, gin.MIMEPOSTForm) {
+		requestBody, err := storage.Bytes()
+		if err != nil {
+			return err
+		}
 		err = parseFormData(requestBody, v)
 	} else if strings.Contains(contentType, gin.MIMEMultipartPOSTForm) {
+		requestBody, err := storage.Bytes()
+		if err != nil {
+			return err
+		}
 		err = parseMultipartFormData(c, requestBody, v)
 	} else {
 		// skip for now

--- a/dto/claude.go
+++ b/dto/claude.go
@@ -3,7 +3,6 @@ package dto
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/types"
@@ -247,22 +246,22 @@ func (c *ClaudeRequest) GetTokenCountMeta() *types.TokenCountMeta {
 		MaxTokens: maxTokens,
 	}
 
-	var texts = make([]string, 0)
 	var fileMeta = make([]*types.FileMeta, 0)
+	var textBuilder tokenTextBuilder
 
 	// system
 	if c.System != nil {
 		if c.IsStringSystem() {
 			sys := c.GetStringSystem()
 			if sys != "" {
-				texts = append(texts, sys)
+				textBuilder.Add(sys)
 			}
 		} else {
 			systemMedia := c.ParseSystem()
 			for _, media := range systemMedia {
 				switch media.Type {
 				case "text":
-					texts = append(texts, media.GetText())
+					textBuilder.Add(media.GetText())
 				case "image":
 					if source := media.ToFileSource(); source != nil {
 						fileMeta = append(fileMeta, &types.FileMeta{
@@ -278,11 +277,11 @@ func (c *ClaudeRequest) GetTokenCountMeta() *types.TokenCountMeta {
 	// messages
 	for _, message := range c.Messages {
 		tokenCountMeta.MessagesCount++
-		texts = append(texts, message.Role)
+		textBuilder.Add(message.Role)
 		if message.IsStringContent() {
 			content := message.GetStringContent()
 			if content != "" {
-				texts = append(texts, content)
+				textBuilder.Add(content)
 			}
 			continue
 		}
@@ -291,7 +290,7 @@ func (c *ClaudeRequest) GetTokenCountMeta() *types.TokenCountMeta {
 		for _, media := range content {
 			switch media.Type {
 			case "text":
-				texts = append(texts, media.GetText())
+				textBuilder.Add(media.GetText())
 			case "image":
 				if source := media.ToFileSource(); source != nil {
 					fileMeta = append(fileMeta, &types.FileMeta{
@@ -301,16 +300,16 @@ func (c *ClaudeRequest) GetTokenCountMeta() *types.TokenCountMeta {
 				}
 			case "tool_use":
 				if media.Name != "" {
-					texts = append(texts, media.Name)
+					textBuilder.Add(media.Name)
 				}
 				if media.Input != nil {
 					b, _ := common.Marshal(media.Input)
-					texts = append(texts, string(b))
+					textBuilder.Add(string(b))
 				}
 			case "tool_result":
 				if media.Content != nil {
 					b, _ := common.Marshal(media.Content)
-					texts = append(texts, string(b))
+					textBuilder.Add(string(b))
 				}
 			}
 		}
@@ -324,14 +323,14 @@ func (c *ClaudeRequest) GetTokenCountMeta() *types.TokenCountMeta {
 			for _, t := range normalTools {
 				tokenCountMeta.ToolsCount++
 				if t.Name != "" {
-					texts = append(texts, t.Name)
+					textBuilder.Add(t.Name)
 				}
 				if t.Description != "" {
-					texts = append(texts, t.Description)
+					textBuilder.Add(t.Description)
 				}
 				if t.InputSchema != nil {
 					b, _ := common.Marshal(t.InputSchema)
-					texts = append(texts, string(b))
+					textBuilder.Add(string(b))
 				}
 			}
 		}
@@ -339,17 +338,17 @@ func (c *ClaudeRequest) GetTokenCountMeta() *types.TokenCountMeta {
 			for _, t := range webSearchTools {
 				tokenCountMeta.ToolsCount++
 				if t.Name != "" {
-					texts = append(texts, t.Name)
+					textBuilder.Add(t.Name)
 				}
 				if t.UserLocation != nil {
 					b, _ := common.Marshal(t.UserLocation)
-					texts = append(texts, string(b))
+					textBuilder.Add(string(b))
 				}
 			}
 		}
 	}
 
-	tokenCountMeta.CombineText = strings.Join(texts, "\n")
+	tokenCountMeta.CombineText = textBuilder.String()
 	tokenCountMeta.Files = fileMeta
 	return &tokenCountMeta
 }

--- a/dto/embedding.go
+++ b/dto/embedding.go
@@ -1,8 +1,6 @@
 package dto
 
 import (
-	"strings"
-
 	"github.com/QuantumNous/new-api/types"
 
 	"github.com/gin-gonic/gin"
@@ -33,15 +31,15 @@ type EmbeddingRequest struct {
 }
 
 func (r *EmbeddingRequest) GetTokenCountMeta() *types.TokenCountMeta {
-	var texts = make([]string, 0)
+	var textBuilder tokenTextBuilder
 
 	inputs := r.ParseInput()
 	for _, input := range inputs {
-		texts = append(texts, input)
+		textBuilder.Add(input)
 	}
 
 	return &types.TokenCountMeta{
-		CombineText: strings.Join(texts, "\n"),
+		CombineText: textBuilder.String(),
 	}
 }
 

--- a/dto/gemini.go
+++ b/dto/gemini.go
@@ -73,11 +73,11 @@ func (r *GeminiChatRequest) GetTokenCountMeta() *types.TokenCountMeta {
 		maxTokens = int(*r.GenerationConfig.MaxOutputTokens)
 	}
 
-	var inputTexts []string
+	var textBuilder tokenTextBuilder
 	for _, content := range r.Contents {
 		for _, part := range content.Parts {
 			if part.Text != "" {
-				inputTexts = append(inputTexts, part.Text)
+				textBuilder.Add(part.Text)
 			}
 			if source := part.InlineData.ToFileSource(); source != nil {
 				mimeType := part.InlineData.MimeType
@@ -99,9 +99,8 @@ func (r *GeminiChatRequest) GetTokenCountMeta() *types.TokenCountMeta {
 		}
 	}
 
-	inputText := strings.Join(inputTexts, "\n")
 	return &types.TokenCountMeta{
-		CombineText: inputText,
+		CombineText: textBuilder.String(),
 		Files:       files,
 		MaxTokens:   maxTokens,
 	}

--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -110,27 +110,29 @@ type GeneralOpenAIRequest struct {
 
 func (r *GeneralOpenAIRequest) GetTokenCountMeta() *types.TokenCountMeta {
 	var tokenCountMeta types.TokenCountMeta
-	var texts = make([]string, 0)
 	var fileMeta = make([]*types.FileMeta, 0)
+	var textBuilder tokenTextBuilder
 
 	if r.Prompt != nil {
 		switch v := r.Prompt.(type) {
 		case string:
-			texts = append(texts, v)
+			textBuilder.Add(v)
 		case []any:
 			for _, item := range v {
 				if str, ok := item.(string); ok {
-					texts = append(texts, str)
+					textBuilder.Add(str)
 				}
 			}
 		default:
-			texts = append(texts, fmt.Sprintf("%v", r.Prompt))
+			textBuilder.Add(fmt.Sprintf("%v", r.Prompt))
 		}
 	}
 
 	if r.Input != nil {
 		inputs := r.ParseInput()
-		texts = append(texts, inputs...)
+		for _, input := range inputs {
+			textBuilder.Add(input)
+		}
 	}
 
 	maxTokens := lo.FromPtrOr(r.MaxTokens, uint(0))
@@ -143,11 +145,11 @@ func (r *GeneralOpenAIRequest) GetTokenCountMeta() *types.TokenCountMeta {
 
 	for _, message := range r.Messages {
 		tokenCountMeta.MessagesCount++
-		texts = append(texts, message.Role)
+		textBuilder.Add(message.Role)
 		if message.Content != nil {
 			if message.Name != nil {
 				tokenCountMeta.NameCount++
-				texts = append(texts, *message.Name)
+				textBuilder.Add(*message.Name)
 			}
 			arrayContent := message.ParseContent()
 			for _, m := range arrayContent {
@@ -169,7 +171,7 @@ func (r *GeneralOpenAIRequest) GetTokenCountMeta() *types.TokenCountMeta {
 					}
 					fileMeta = append(fileMeta, meta)
 				} else if m.Type == ContentTypeText {
-					texts = append(texts, m.Text)
+					textBuilder.Add(m.Text)
 				}
 			}
 		}
@@ -179,19 +181,19 @@ func (r *GeneralOpenAIRequest) GetTokenCountMeta() *types.TokenCountMeta {
 		openaiTools := r.Tools
 		for _, tool := range openaiTools {
 			tokenCountMeta.ToolsCount++
-			texts = append(texts, tool.Function.Name)
+			textBuilder.Add(tool.Function.Name)
 			if tool.Function.Description != "" {
-				texts = append(texts, tool.Function.Description)
+				textBuilder.Add(tool.Function.Description)
 			}
 			if tool.Function.Parameters != nil {
-				texts = append(texts, fmt.Sprintf("%v", tool.Function.Parameters))
+				textBuilder.Add(fmt.Sprintf("%v", tool.Function.Parameters))
 			}
 		}
 		//toolTokens := CountTokenInput(countStr, request.Model)
 		//tkm += 8
 		//tkm += toolTokens
 	}
-	tokenCountMeta.CombineText = strings.Join(texts, "\n")
+	tokenCountMeta.CombineText = textBuilder.String()
 	tokenCountMeta.Files = fileMeta
 	return &tokenCountMeta
 }
@@ -862,7 +864,7 @@ type OpenAIResponsesRequest struct {
 
 func (r *OpenAIResponsesRequest) GetTokenCountMeta() *types.TokenCountMeta {
 	var fileMeta = make([]*types.FileMeta, 0)
-	var texts = make([]string, 0)
+	var textBuilder tokenTextBuilder
 
 	if r.Input != nil {
 		inputs := r.ParseInput()
@@ -883,37 +885,37 @@ func (r *OpenAIResponsesRequest) GetTokenCountMeta() *types.TokenCountMeta {
 					})
 				}
 			} else {
-				texts = append(texts, input.Text)
+				textBuilder.Add(input.Text)
 			}
 		}
 	}
 
 	if len(r.Instructions) > 0 {
-		texts = append(texts, string(r.Instructions))
+		textBuilder.Add(string(r.Instructions))
 	}
 
 	if len(r.Metadata) > 0 {
-		texts = append(texts, string(r.Metadata))
+		textBuilder.Add(string(r.Metadata))
 	}
 
 	if len(r.Text) > 0 {
-		texts = append(texts, string(r.Text))
+		textBuilder.Add(string(r.Text))
 	}
 
 	if len(r.ToolChoice) > 0 {
-		texts = append(texts, string(r.ToolChoice))
+		textBuilder.Add(string(r.ToolChoice))
 	}
 
 	if len(r.Prompt) > 0 {
-		texts = append(texts, string(r.Prompt))
+		textBuilder.Add(string(r.Prompt))
 	}
 
 	if len(r.Tools) > 0 {
-		texts = append(texts, string(r.Tools))
+		textBuilder.Add(string(r.Tools))
 	}
 
 	return &types.TokenCountMeta{
-		CombineText: strings.Join(texts, "\n"),
+		CombineText: textBuilder.String(),
 		Files:       fileMeta,
 		MaxTokens:   int(lo.FromPtrOr(r.MaxOutputTokens, uint(0))),
 	}

--- a/dto/rerank.go
+++ b/dto/rerank.go
@@ -2,7 +2,6 @@ package dto
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/QuantumNous/new-api/types"
 	"github.com/gin-gonic/gin"
@@ -23,18 +22,18 @@ func (r *RerankRequest) IsStream(c *gin.Context) bool {
 }
 
 func (r *RerankRequest) GetTokenCountMeta() *types.TokenCountMeta {
-	var texts = make([]string, 0)
+	var textBuilder tokenTextBuilder
 
 	for _, document := range r.Documents {
-		texts = append(texts, fmt.Sprintf("%v", document))
+		textBuilder.Add(fmt.Sprintf("%v", document))
 	}
 
 	if r.Query != "" {
-		texts = append(texts, r.Query)
+		textBuilder.Add(r.Query)
 	}
 
 	return &types.TokenCountMeta{
-		CombineText: strings.Join(texts, "\n"),
+		CombineText: textBuilder.String(),
 	}
 }
 

--- a/dto/token_text_builder.go
+++ b/dto/token_text_builder.go
@@ -1,0 +1,20 @@
+package dto
+
+import "strings"
+
+type tokenTextBuilder struct {
+	builder   strings.Builder
+	partCount int
+}
+
+func (b *tokenTextBuilder) Add(text string) {
+	if b.partCount > 0 {
+		b.builder.WriteByte('\n')
+	}
+	b.builder.WriteString(text)
+	b.partCount++
+}
+
+func (b *tokenTextBuilder) String() string {
+	return b.builder.String()
+}

--- a/dto/token_text_builder_test.go
+++ b/dto/token_text_builder_test.go
@@ -1,0 +1,67 @@
+package dto
+
+import "testing"
+
+func TestTokenTextBuilderMatchesJoinSemantics(t *testing.T) {
+	parts := []string{"alpha", "", "beta", "gamma"}
+
+	var builder tokenTextBuilder
+	for _, part := range parts {
+		builder.Add(part)
+	}
+
+	got := builder.String()
+	want := "alpha\n\nbeta\ngamma"
+	if got != want {
+		t.Fatalf("unexpected builder result, got %q want %q", got, want)
+	}
+}
+
+func TestGeneralOpenAIRequestGetTokenCountMetaPreservesSemantics(t *testing.T) {
+	name := "tool-name"
+	req := &GeneralOpenAIRequest{
+		Prompt: []any{"prompt-a", "", "prompt-b"},
+		Input:  []any{"input-a", "input-b"},
+		Messages: []Message{
+			{
+				Role: "user",
+				Name: &name,
+				Content: []MediaContent{
+					{Type: ContentTypeText, Text: "hello"},
+					{Type: ContentTypeImageURL, ImageUrl: &MessageImageUrl{Url: "https://example.com/a.png", Detail: "high"}},
+				},
+			},
+		},
+		Tools: []ToolCallRequest{
+			{
+				Type: "function",
+				Function: FunctionRequest{
+					Name:        "lookup",
+					Description: "tool desc",
+					Parameters: map[string]any{
+						"type": "object",
+					},
+				},
+			},
+		},
+	}
+
+	meta := req.GetTokenCountMeta()
+	if meta == nil {
+		t.Fatalf("expected meta")
+	}
+
+	wantText := "prompt-a\n\nprompt-b\ninput-a\ninput-b\nuser\ntool-name\nlookup\ntool desc\nmap[type:object]"
+	if meta.CombineText != wantText {
+		t.Fatalf("unexpected CombineText, got %q want %q", meta.CombineText, wantText)
+	}
+	if meta.MessagesCount != 1 {
+		t.Fatalf("unexpected MessagesCount: %d", meta.MessagesCount)
+	}
+	if meta.NameCount != 1 {
+		t.Fatalf("unexpected NameCount: %d", meta.NameCount)
+	}
+	if meta.ToolsCount != 1 {
+		t.Fatalf("unexpected ToolsCount: %d", meta.ToolsCount)
+	}
+}

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/QuantumNous/new-api/types"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
 )
 
 type ModelRequest struct {
@@ -170,12 +171,61 @@ func Distribute() func(c *gin.Context) {
 // - application/x-www-form-urlencoded
 // - multipart/form-data
 func getModelFromRequest(c *gin.Context) (*ModelRequest, error) {
+	if modelRequest, ok, err := extractModelRequestFromJSONBody(c); ok || err != nil {
+		if err != nil {
+			return nil, errors.New(i18n.T(c, i18n.MsgDistributorInvalidRequest, map[string]any{"Error": err.Error()}))
+		}
+		return modelRequest, nil
+	}
+
 	var modelRequest ModelRequest
 	err := common.UnmarshalBodyReusable(c, &modelRequest)
 	if err != nil {
 		return nil, errors.New(i18n.T(c, i18n.MsgDistributorInvalidRequest, map[string]any{"Error": err.Error()}))
 	}
 	return &modelRequest, nil
+}
+
+func extractModelRequestFromJSONBody(c *gin.Context) (*ModelRequest, bool, error) {
+	if c == nil || c.Request == nil {
+		return nil, false, nil
+	}
+	if !strings.HasPrefix(c.ContentType(), gin.MIMEJSON) {
+		return nil, false, nil
+	}
+
+	storage, err := common.GetBodyStorage(c)
+	if err != nil {
+		return nil, false, err
+	}
+
+	bodyBytes, err := storage.Bytes()
+	if err != nil {
+		return nil, false, err
+	}
+	if !gjson.ValidBytes(bodyBytes) {
+		return nil, false, nil
+	}
+
+	root := gjson.ParseBytes(bodyBytes)
+	if !root.IsObject() {
+		return nil, false, nil
+	}
+
+	modelResult := root.Get("model")
+	groupResult := root.Get("group")
+	if !isStringOrMissingJSONField(modelResult) || !isStringOrMissingJSONField(groupResult) {
+		return nil, false, nil
+	}
+
+	return &ModelRequest{
+		Model: modelResult.String(),
+		Group: groupResult.String(),
+	}, true, nil
+}
+
+func isStringOrMissingJSONField(result gjson.Result) bool {
+	return !result.Exists() || result.Type == gjson.String
 }
 
 func getModelRequest(c *gin.Context) (*ModelRequest, bool, error) {

--- a/middleware/distributor_test.go
+++ b/middleware/distributor_test.go
@@ -1,0 +1,65 @@
+package middleware
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	_ = i18n.Init()
+}
+
+func TestExtractModelRequestFromJSONBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := `{"model":"gpt-4.1","group":"vip","messages":[{"role":"user","content":"hello"}]}`
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(body))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	modelRequest, ok, err := extractModelRequestFromJSONBody(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, &ModelRequest{
+		Model: "gpt-4.1",
+		Group: "vip",
+	}, modelRequest)
+
+	var decoded map[string]any
+	require.NoError(t, common.UnmarshalBodyReusable(ctx, &decoded))
+	require.Equal(t, "gpt-4.1", decoded["model"])
+	require.Equal(t, "vip", decoded["group"])
+}
+
+func TestGetModelFromRequestFallsBackForTypeMismatch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := `{"model":123,"group":"vip"}`
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(body))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	modelRequest, err := getModelFromRequest(ctx)
+	require.Nil(t, modelRequest)
+	require.Error(t, err)
+}
+
+func TestExtractModelRequestFromJSONBodySkipsNonJSONObject(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(`[]`))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	modelRequest, ok, err := extractModelRequestFromJSONBody(ctx)
+	require.NoError(t, err)
+	require.Nil(t, modelRequest)
+	require.False(t, ok)
+}

--- a/relay/common/override.go
+++ b/relay/common/override.go
@@ -17,6 +17,7 @@ import (
 )
 
 var negativeIndexRegexp = regexp.MustCompile(`\.(-\d+)`)
+var simpleLegacyOverrideKeyRegexp = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
 const (
 	paramOverrideContextRequestHeaders = "request_headers"
@@ -656,6 +657,19 @@ func compareNumeric(jsonValue, targetValue gjson.Result, operator string) (bool,
 
 // applyOperationsLegacy 原参数覆盖方法
 func applyOperationsLegacy(jsonData []byte, paramOverride map[string]interface{}, auditRecorder *paramOverrideAuditRecorder) ([]byte, error) {
+	if canApplyLegacyOverridesDirectly(paramOverride) {
+		workingJSON := jsonData
+		for key, value := range paramOverride {
+			var err error
+			workingJSON, err = sjson.SetBytes(workingJSON, key, value)
+			if err != nil {
+				return nil, err
+			}
+			auditRecorder.recordOperation("set", key, "", "", value)
+		}
+		return workingJSON, nil
+	}
+
 	reqMap := make(map[string]interface{})
 	err := common.Unmarshal(jsonData, &reqMap)
 	if err != nil {
@@ -668,6 +682,18 @@ func applyOperationsLegacy(jsonData []byte, paramOverride map[string]interface{}
 	}
 
 	return common.Marshal(reqMap)
+}
+
+func canApplyLegacyOverridesDirectly(paramOverride map[string]interface{}) bool {
+	if len(paramOverride) == 0 {
+		return false
+	}
+	for key := range paramOverride {
+		if !simpleLegacyOverrideKeyRegexp.MatchString(strings.TrimSpace(key)) {
+			return false
+		}
+	}
+	return true
 }
 
 func applyOperations(jsonStr string, operations []ParamOperation, conditionContext map[string]interface{}) (string, error) {

--- a/relay/common/override_test.go
+++ b/relay/common/override_test.go
@@ -518,6 +518,33 @@ func TestApplyParamOverrideSetWithDescriptionKeepsCompatibility(t *testing.T) {
 	assertJSONEqual(t, `{"model":"gpt-4","temperature":0.1}`, string(outWithDesc))
 }
 
+func TestCanApplyLegacyOverridesDirectly(t *testing.T) {
+	override := map[string]interface{}{
+		"model":        "gpt-4.1",
+		"service_tier": "flex",
+		"top-p":        0.9,
+	}
+
+	if !canApplyLegacyOverridesDirectly(override) {
+		t.Fatalf("expected simple top-level overrides to use direct path")
+	}
+}
+
+func TestCanApplyLegacyOverridesDirectlyRejectsPathLikeKeys(t *testing.T) {
+	testCases := []map[string]interface{}{
+		{"metadata.trace": "x"},
+		{"tools[0]": true},
+		{"tools.*.enabled": true},
+		{"x y": true},
+	}
+
+	for _, override := range testCases {
+		if canApplyLegacyOverridesDirectly(override) {
+			t.Fatalf("expected override %#v to fall back to legacy map path", override)
+		}
+	}
+}
+
 func TestApplyParamOverrideSetKeepOrigin(t *testing.T) {
 	input := []byte(`{"model":"gpt-4","temperature":0.7}`)
 	override := map[string]interface{}{


### PR DESCRIPTION
AI Generated:
- 分发前读取 model/group 的逻辑做了轻量化处理。原来仅为了拿顶层字段也会完整反序列化请求体，现在优先直接从 JSON body 提取顶层字段，只有不满足条件时才回退原逻辑，减少一次整包 JSON 解码。
- legacy param override 的常见场景改成直接在原 JSON 上做顶层字段替换。对于 model、service_tier 这类简单 key，不再走整包 Unmarshal -> map -> Marshal，只在复杂 path 规则下保留旧逻辑，降低 override 的额外内存开销。
- UnmarshalBodyReusable 在处理 JSON 时不再先把 body 复制成一份新的 []byte，而是直接从 BodyStorage 解码，再复位请求体，减少一次不必要的 body 拷贝。
- CombineText 的构造方式从 []string + strings.Join 改成 builder 逐段拼接，在保持结果一致的前提下，去掉中间切片分配，降低 token 统计和敏感词检查前的瞬时内存占用。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved request parsing efficiency for JSON payloads.
  * Streamlined token counting mechanism across multiple request types.
  * Optimized legacy override application with fast path support for simple configuration keys.

* **Tests**
  * Added comprehensive test coverage for request parsing, token counting validation, and override handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->