### PR TITLE
bug-fix: default token group to auto when DefaultUseAutoGroup is enabled

### DIFF
--- a/web/src/components/table/tokens/modals/EditTokenModal.jsx
+++ b/web/src/components/table/tokens/modals/EditTokenModal.jsx
@@ -72,7 +72,7 @@ const EditTokenModal = (props) => {
     model_limits_enabled: false,
     model_limits: [],
     allow_ips: '',
-    group: '',
+    group: statusState?.status?.default_use_auto_group ? 'auto' : '',
     cross_group_retry: false,
     tokenCount: 1,
   });


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 修复设置了"创建令牌默认选择auto分组"无效, 依旧是默认用户分组的bug

## 📝 变更描述 / Description
在初始化值的时候,就判断是否设置了默认"auto",并赋值默认值

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #3189 

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
关闭"默认使用auto分组"
<img width="887" height="791" alt="image" src="https://github.com/user-attachments/assets/49b1f166-223d-48dd-ad4a-5683aeff5b60" />
开启"默认使用auto分组"
<img width="897" height="711" alt="image" src="https://github.com/user-attachments/assets/f531c00c-8702-4c19-8976-279f3b4d9e4b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token editing form group field now defaults to 'auto' when auto-grouping is configured, instead of always defaulting to empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->