### PR TITLE
修复当没有首字响应时间前端显示为NaN的问题

### DIFF
--- a/web/src/components/table/usage-logs/UsageLogsColumnDefs.jsx
+++ b/web/src/components/table/usage-logs/UsageLogsColumnDefs.jsx
@@ -230,6 +230,7 @@ function renderUseTime(type, t) {
 }
 
 function renderFirstUseTime(type, t) {
+  if (type == null) return null;
   let time = parseFloat(type) / 1000.0;
   time = time.toFixed(1);
   if (time < 3) {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
当没有首字响应时间的时候,比如错误日志, 流式首字响应时间前端会显示为NaN
增加当没有首字响应时间时, 前端改为不显示
## 📸 运行证明 / Proof of Work
* 修改前:
<img width="2430" height="300" alt="image" src="https://github.com/user-attachments/assets/4f290c10-731a-4ed4-915d-54346066ad61" />
* 修改后
<img width="2066" height="258" alt="image" src="https://github.com/user-attachments/assets/b4479543-e032-47b9-968f-dd7d2701b02c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where usage logs could fail to display properly when certain data was unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->