### PR TITLE
fix: do not charge prompt tokens when stream aborts with no output

### DIFF
--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -102,7 +102,7 @@ func calculateTextQuotaSummary(ctx *gin.Context, relayInfo *relaycommon.RelayInf
 		// incorrect. The zero-TotalTokens guard below will set Quota=0.
 		// For non-stream requests (or normally-ended streams) with missing usage,
 		// fall back to estimated prompt tokens as before.
-		if relayInfo.IsStream && !relayInfo.StreamStatus.IsNormalEnd() {
+		if relayInfo.IsStream && !relayInfo.StreamStatus.IsNormalEnd() && relayInfo.SendResponseCount == 0 {
 			usage = &dto.Usage{}
 		} else {
 			usage = &dto.Usage{

--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -96,10 +96,20 @@ func calculateTextQuotaSummary(ctx *gin.Context, relayInfo *relaycommon.RelayInf
 	summary.IsClaudeUsageSemantic = summary.UsageSemantic == "anthropic"
 
 	if usage == nil {
-		usage = &dto.Usage{
-			PromptTokens:     relayInfo.GetEstimatePromptTokens(),
-			CompletionTokens: 0,
-			TotalTokens:      relayInfo.GetEstimatePromptTokens(),
+		// When a stream ends abnormally (client disconnect, upstream timeout, etc.)
+		// before any completion tokens are produced, do not charge prompt tokens.
+		// The user received no output; billing with estimated prompt tokens is
+		// incorrect. The zero-TotalTokens guard below will set Quota=0.
+		// For non-stream requests (or normally-ended streams) with missing usage,
+		// fall back to estimated prompt tokens as before.
+		if relayInfo.IsStream && !relayInfo.StreamStatus.IsNormalEnd() {
+			usage = &dto.Usage{}
+		} else {
+			usage = &dto.Usage{
+				PromptTokens:     relayInfo.GetEstimatePromptTokens(),
+				CompletionTokens: 0,
+				TotalTokens:      relayInfo.GetEstimatePromptTokens(),
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem

Fixes #4168.

When a streaming request fails before producing any completion tokens (e.g. the client disconnects or the upstream times out), `calculateTextQuotaSummary` in `service/text_quota.go` was synthesizing a usage struct:

```go
// before this fix
if usage == nil {
    usage = &dto.Usage{
        PromptTokens:     relayInfo.GetEstimatePromptTokens(),
        CompletionTokens: 0,
        TotalTokens:      relayInfo.GetEstimatePromptTokens(),
    }
}
```

Because `TotalTokens` ended up non-zero, the zero-charge guard at the bottom of the function was bypassed:

```go
if summary.TotalTokens == 0 {
    summary.Quota = 0   // never reached for failed streams
}
```

Result: users were billed for the estimated prompt tokens on requests where they received **zero output**. Issue #4168 reports ~95.7M quota (~$191 USD) incorrectly charged to 99 users in a single production day.

## Root cause

The synthetic usage fallback was introduced in PR #3400 to handle upstreams that return HTTP 200 but omit usage data. It was applied unconditionally, even to streams that aborted abnormally.

## Fix

When `usage == nil` **and** the stream ended abnormally (`relayInfo.IsStream && !relayInfo.StreamStatus.IsNormalEnd()`), substitute an all-zero `dto.Usage{}` instead of the estimated-prompt-token one. This lets `TotalTokens = 0` flow through to the existing zero-charge guard, setting `Quota = 0`.

Non-streaming requests and normally-completed streams retain the previous estimated-prompt-token fallback behavior unchanged.

```go
if usage == nil {
    if relayInfo.IsStream && !relayInfo.StreamStatus.IsNormalEnd() {
        usage = &dto.Usage{}   // no output → no charge
    } else {
        usage = &dto.Usage{
            PromptTokens:     relayInfo.GetEstimatePromptTokens(),
            ...
        }
    }
}
```

## Testing

- `go build ./service/...` passes
- `go test ./service/...` passes (all existing tests green)
- Manually traced the code path: for `StreamEndReasonClientGone` and `StreamEndReasonTimeout` with `usage == nil`, `summary.TotalTokens` is now 0, `summary.Quota` is 0, and `SettleBilling` is called with 0 (refunding any pre-deducted quota).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed billing calculation for abnormally terminated streaming requests. Estimated prompt-token charges are no longer applied when a stream fails to complete normally and no responses were sent.
  * Ensures more accurate token reporting and prevents inadvertent billing for failed or incomplete processing, improving billing reliability and user trust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->