### PR TITLE
Improve channel affinity reliability and Claude cache recovery

### DIFF
--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/i18n"
+	"github.com/QuantumNous/new-api/logger"
 	"github.com/QuantumNous/new-api/model"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/service"
@@ -48,6 +49,16 @@ func Distribute() func(c *gin.Context) {
 				return
 			}
 			if channel.Status != common.ChannelStatusEnabled {
+				logDistributorChannelDecision(
+					c,
+					channel,
+					modelRequest.Model,
+					"request_failed",
+					"specific_channel_disabled",
+					i18n.T(c, i18n.MsgDistributorChannelDisabled),
+					http.StatusForbidden,
+					true,
+				)
 				abortWithOpenAiMessage(c, http.StatusForbidden, i18n.T(c, i18n.MsgDistributorChannelDisabled))
 				return
 			}
@@ -101,29 +112,28 @@ func Distribute() func(c *gin.Context) {
 
 				if preferredChannelID, found := service.GetPreferredChannelByAffinity(c, modelRequest.Model, usingGroup); found {
 					preferred, err := model.CacheGetChannel(preferredChannelID)
-					if err == nil && preferred != nil {
-						if preferred.Status != common.ChannelStatusEnabled {
-							if service.ShouldSkipRetryAfterChannelAffinityFailure(c) {
-								abortWithOpenAiMessage(c, http.StatusForbidden, i18n.T(c, i18n.MsgDistributorChannelDisabled))
-								return
+					if err != nil || preferred == nil {
+						cleared := service.ClearCurrentChannelAffinity(c)
+						logDistributorAffinityFallback(c, preferredChannelID, nil, modelRequest.Model, "preferred_channel_missing", cleared)
+					} else if preferred.Status != common.ChannelStatusEnabled {
+						cleared := service.ClearCurrentChannelAffinity(c)
+						logDistributorAffinityFallback(c, preferredChannelID, preferred, modelRequest.Model, "preferred_channel_disabled", cleared)
+					} else if usingGroup == "auto" {
+						userGroup := common.GetContextKeyString(c, constant.ContextKeyUserGroup)
+						autoGroups := service.GetUserAutoGroup(userGroup)
+						for _, g := range autoGroups {
+							if model.IsChannelEnabledForGroupModel(g, modelRequest.Model, preferred.Id) {
+								selectGroup = g
+								common.SetContextKey(c, constant.ContextKeyAutoGroup, g)
+								channel = preferred
+								service.MarkChannelAffinityUsed(c, g, preferred.Id)
+								break
 							}
-						} else if usingGroup == "auto" {
-							userGroup := common.GetContextKeyString(c, constant.ContextKeyUserGroup)
-							autoGroups := service.GetUserAutoGroup(userGroup)
-							for _, g := range autoGroups {
-								if model.IsChannelEnabledForGroupModel(g, modelRequest.Model, preferred.Id) {
-									selectGroup = g
-									common.SetContextKey(c, constant.ContextKeyAutoGroup, g)
-									channel = preferred
-									service.MarkChannelAffinityUsed(c, g, preferred.Id)
-									break
-								}
-							}
-						} else if model.IsChannelEnabledForGroupModel(usingGroup, modelRequest.Model, preferred.Id) {
-							channel = preferred
-							selectGroup = usingGroup
-							service.MarkChannelAffinityUsed(c, usingGroup, preferred.Id)
 						}
+					} else if model.IsChannelEnabledForGroupModel(usingGroup, modelRequest.Model, preferred.Id) {
+						channel = preferred
+						selectGroup = usingGroup
+						service.MarkChannelAffinityUsed(c, usingGroup, preferred.Id)
 					}
 				}
 
@@ -432,4 +442,105 @@ func extractModelNameFromGeminiPath(path string) string {
 
 	// 返回模型名部分
 	return path[startIndex : startIndex+colonIndex]
+}
+
+func logDistributorAffinityFallback(c *gin.Context, channelID int, channel *model.Channel, modelName string, decisionReason string, cacheCleared bool) {
+	usingGroup := common.GetContextKeyString(c, constant.ContextKeyUsingGroup)
+	channelName := ""
+	channelStatus := -1
+	if channel != nil {
+		channelName = channel.Name
+		channelStatus = channel.Status
+	}
+
+	adminInfo := map[string]interface{}{
+		"cache_cleared": cacheCleared,
+	}
+	service.AppendChannelAffinityAdminInfo(c, adminInfo)
+
+	logger.LogWarn(
+		c.Request.Context(),
+		fmt.Sprintf(
+			"event=fallback_triggered status=affinity_channel_unavailable decision_reason=%s model=%s channel_id=%d channel_name=%q channel_status=%d using_group=%s request_path=%s cache_cleared=%t",
+			decisionReason,
+			modelName,
+			channelID,
+			channelName,
+			channelStatus,
+			usingGroup,
+			c.Request.URL.Path,
+			cacheCleared,
+		),
+	)
+}
+
+func logDistributorChannelDecision(
+	c *gin.Context,
+	channel *model.Channel,
+	modelName string,
+	event string,
+	decisionReason string,
+	message string,
+	statusCode int,
+	recordErrorLog bool,
+) {
+	usingGroup := common.GetContextKeyString(c, constant.ContextKeyUsingGroup)
+	channelID := 0
+	channelName := ""
+	channelStatus := -1
+	if channel != nil {
+		channelID = channel.Id
+		channelName = channel.Name
+		channelStatus = channel.Status
+	}
+
+	adminInfo := map[string]interface{}{
+		"channel_id":     channelID,
+		"channel_name":   channelName,
+		"channel_status": channelStatus,
+	}
+	service.AppendChannelAffinityAdminInfo(c, adminInfo)
+
+	other := map[string]interface{}{
+		"event":           event,
+		"decision_reason": decisionReason,
+		"status_code":     statusCode,
+		"request_path":    c.Request.URL.Path,
+		"using_group":     usingGroup,
+		"channel_id":      channelID,
+		"channel_name":    channelName,
+		"channel_status":  channelStatus,
+		"admin_info":      adminInfo,
+	}
+
+	if recordErrorLog && constant.ErrorLogEnabled {
+		model.RecordErrorLog(
+			c,
+			c.GetInt("id"),
+			channelID,
+			modelName,
+			c.GetString("token_name"),
+			message,
+			c.GetInt("token_id"),
+			0,
+			false,
+			usingGroup,
+			other,
+		)
+	}
+
+	logger.LogError(
+		c.Request.Context(),
+		fmt.Sprintf(
+			"event=%s status=channel_disabled decision_reason=%s model=%s channel_id=%d channel_name=%q channel_status=%d using_group=%s request_path=%s",
+			event,
+			decisionReason,
+			modelName,
+			channelID,
+			channelName,
+			channelStatus,
+			usingGroup,
+			c.Request.URL.Path,
+		),
+	)
 }

--- a/service/channel_affinity.go
+++ b/service/channel_affinity.go
@@ -235,6 +235,25 @@ func ClearChannelAffinityCacheByRuleName(ruleName string) (int, error) {
 	return deleted, nil
 }
 
+func ClearCurrentChannelAffinity(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	cacheKey, _, ok := getChannelAffinityContext(c)
+	if !ok || strings.TrimSpace(cacheKey) == "" {
+		return false
+	}
+
+	cache := getChannelAffinityCache()
+	if _, err := cache.DeleteMany([]string{cacheKey}); err != nil {
+		common.SysError(fmt.Sprintf("channel affinity cache delete failed: key=%s, err=%v", cacheKey, err))
+		return false
+	}
+
+	c.Set(ginKeyChannelAffinitySkipRetry, false)
+	return true
+}
+
 func matchAnyRegexCached(patterns []string, s string) bool {
 	if len(patterns) == 0 || s == "" {
 		return false

--- a/service/channel_affinity_template_test.go
+++ b/service/channel_affinity_template_test.go
@@ -176,6 +176,35 @@ func TestShouldSkipRetryAfterChannelAffinityFailure(t *testing.T) {
 	}
 }
 
+func TestClearCurrentChannelAffinity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cache := getChannelAffinityCache()
+	cacheKeySuffix := fmt.Sprintf("test-clear:%d", time.Now().UnixNano())
+	require.NoError(t, cache.SetWithTTL(cacheKeySuffix, 9527, time.Minute))
+
+	ctx := buildChannelAffinityTemplateContextForTest(channelAffinityMeta{
+		CacheKey:   cache.FullKey(cacheKeySuffix),
+		RuleName:   "rule-clear-cache",
+		SkipRetry:  true,
+		UsingGroup: "default",
+		ModelName:  "claude-sonnet-4-6",
+	})
+	ctx.Set(ginKeyChannelAffinitySkipRetry, true)
+
+	foundBefore := ShouldSkipRetryAfterChannelAffinityFailure(ctx)
+	require.True(t, foundBefore)
+
+	cleared := ClearCurrentChannelAffinity(ctx)
+	require.True(t, cleared)
+
+	_, found, err := cache.Get(cacheKeySuffix)
+	require.NoError(t, err)
+	require.False(t, found)
+
+	require.False(t, ShouldSkipRetryAfterChannelAffinityFailure(ctx))
+}
+
 func TestChannelAffinityHitCodexTemplatePassHeadersEffective(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/setting/operation_setting/channel_affinity_setting.go
+++ b/setting/operation_setting/channel_affinity_setting.go
@@ -103,7 +103,7 @@ var channelAffinitySetting = ChannelAffinitySetting{
 			ValueRegex:            "",
 			TTLSeconds:            0,
 			ParamOverrideTemplate: buildPassHeaderTemplate(claudeCliPassThroughHeaders),
-			SkipRetryOnFailure:    true,
+			SkipRetryOnFailure:    false,
 			IncludeUsingGroup:     true,
 			IncludeRuleName:       true,
 			UserAgentInclude:      nil,

--- a/setting/operation_setting/channel_affinity_setting_test.go
+++ b/setting/operation_setting/channel_affinity_setting_test.go
@@ -1,0 +1,22 @@
+package operation_setting
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaudeCliTraceDoesNotSkipRetryOnFailure(t *testing.T) {
+	setting := GetChannelAffinitySetting()
+	require.NotNil(t, setting)
+
+	for _, rule := range setting.Rules {
+		if strings.EqualFold(strings.TrimSpace(rule.Name), "claude cli trace") {
+			require.False(t, rule.SkipRetryOnFailure)
+			return
+		}
+	}
+
+	t.Fatalf("claude cli trace rule not found")
+}

--- a/web/src/pages/Setting/Operation/SettingsChannelAffinity.jsx
+++ b/web/src/pages/Setting/Operation/SettingsChannelAffinity.jsx
@@ -284,6 +284,20 @@ export default function SettingsChannelAffinity(props) {
     }
   }, [paramTemplateDraft, t]);
 
+  const claudeCliRule = useMemo(
+    () =>
+      (rules || []).find(
+        (rule) => (rule?.name || '').trim().toLowerCase() === 'claude cli trace',
+      ) || null,
+    [rules],
+  );
+
+  const claudeCliCacheCount = useMemo(() => {
+    const name = (claudeCliRule?.name || '').trim();
+    if (!name) return 0;
+    return Number(cacheStats?.by_rule_name?.[name] || 0);
+  }, [cacheStats, claudeCliRule]);
+
   const updateParamTemplateDraft = (value) => {
     const next = typeof value === 'string' ? value : '';
     setParamTemplateDraft(next);
@@ -408,6 +422,14 @@ export default function SettingsChannelAffinity(props) {
         await refreshCacheStats();
       },
     });
+  };
+
+  const confirmClearClaudeCliCache = () => {
+    if (!claudeCliRule) {
+      showWarning(t('当前未找到 Claude CLI 亲和规则'));
+      return;
+    }
+    confirmClearRuleCache(claudeCliRule);
   };
 
   const setRulesJsonToForm = (jsonString) => {
@@ -978,6 +1000,40 @@ export default function SettingsChannelAffinity(props) {
             </Row>
 
             <Divider style={{ marginTop: 12, marginBottom: 12 }} />
+
+            <div
+              style={{
+                marginBottom: 12,
+                padding: 12,
+                borderRadius: 10,
+                border: '1px solid var(--semi-color-warning-light-default)',
+                background: 'var(--semi-color-warning-light-default)',
+              }}
+            >
+              <Space wrap align='center'>
+                <Tag color='orange' size='large'>
+                  {t('Claude Code 快捷运维')}
+                </Tag>
+                <Text>
+                  {t('当前 Claude CLI 亲和缓存条目')}：{claudeCliCacheCount}
+                </Text>
+                <Button
+                  type='warning'
+                  theme='solid'
+                  disabled={!claudeCliRule}
+                  onClick={confirmClearClaudeCliCache}
+                >
+                  {t('清空 Claude Code 缓存')}
+                </Button>
+              </Space>
+              <div style={{ marginTop: 6 }}>
+                <Text type='tertiary' size='small'>
+                  {t(
+                    '当 Claude Code 命中历史渠道后出现异常或切换不上新渠道时，可优先使用这里的一键清理。',
+                  )}
+                </Text>
+              </div>
+            </div>
 
             <Space style={{ marginBottom: 10 }}>
               <Button


### PR DESCRIPTION
## Summary
- auto-clear stale affinity bindings when the preferred channel is disabled or missing
- log distributor-stage channel disable decisions with channel context for faster debugging
- let Claude CLI affinity flows retry instead of hard-failing on affinity errors
- add a dedicated Claude Code cache-clear shortcut in channel affinity settings

## Why
This fixes a high-impact connectivity issue where Claude Code and other affinity-bound traffic could get pinned to disabled historical channels and return opaque 403 errors. The new behavior degrades gracefully, preserves routing continuity, and adds enough observability to identify the bad channel quickly when something does go wrong.

## Testing
- go test ./setting/operation_setting ./service ./middleware
- bun run build

## Notes
- excluded unrelated local workspace changes from this PR on purpose


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UI option to clear Claude Code cache in channel affinity settings.
  * Enhanced channel affinity management with ability to clear cache entries.

* **Improvements**
  * Improved channel handling for disabled channels with better logging and error tracking.
  * Claude CLI trace rule now retries on failure by default.

* **Tests**
  * Added test coverage for cache clearing functionality.
  * Added verification for Claude CLI trace retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->