### PR TITLE
fix: auto 分组跨分组重试用优先级数量替代 RetryTimes 判断跳组

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -188,6 +189,7 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 
 	for ; retryParam.GetRetry() <= common.RetryTimes; retryParam.IncreaseRetry() {
 		relayInfo.RetryIndex = retryParam.GetRetry()
+		retryParam.ExcludeChannelIDs = getUsedChannelIDs(c)
 		channel, channelErr := getChannel(c, relayInfo, retryParam)
 		if channelErr != nil {
 			logger.LogError(c, channelErr.Error())
@@ -221,6 +223,10 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 
 		if newAPIError == nil {
 			relayInfo.LastError = nil
+			useChannel := c.GetStringSlice("use_channel")
+			if len(useChannel) > 1 {
+				service.ForceUpdateChannelAffinity(c, channel.Id)
+			}
 			return
 		}
 
@@ -252,6 +258,20 @@ func addUsedChannel(c *gin.Context, channelId int) {
 	useChannel := c.GetStringSlice("use_channel")
 	useChannel = append(useChannel, fmt.Sprintf("%d", channelId))
 	c.Set("use_channel", useChannel)
+}
+
+func getUsedChannelIDs(c *gin.Context) []int {
+	useChannel := c.GetStringSlice("use_channel")
+	if len(useChannel) == 0 {
+		return nil
+	}
+	ids := make([]int, 0, len(useChannel))
+	for _, s := range useChannel {
+		if id, err := strconv.Atoi(s); err == nil {
+			ids = append(ids, id)
+		}
+	}
+	return ids
 }
 
 func fastTokenCountMetaForPricing(request dto.Request) *types.TokenCountMeta {

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -159,7 +159,11 @@ func Distribute() func(c *gin.Context) {
 		SetupContextForSelectedChannel(c, channel, modelRequest.Model)
 		c.Next()
 		if channel != nil && c.Writer != nil && c.Writer.Status() < http.StatusBadRequest {
-			service.RecordChannelAffinity(c, channel.Id)
+			finalChannelID := common.GetContextKeyInt(c, constant.ContextKeyChannelId)
+			if finalChannelID <= 0 {
+				finalChannelID = channel.Id
+			}
+			service.RecordChannelAffinity(c, finalChannelID)
 		}
 	}
 }

--- a/model/channel_cache.go
+++ b/model/channel_cache.go
@@ -190,6 +190,31 @@ func GetRandomSatisfiedChannel(group string, model string, retry int) (*Channel,
 	return nil, errors.New("channel not found")
 }
 
+// GetGroupModelPriorityCount 返回指定分组和模型的不同优先级数量（用于跨分组重试判断）
+func GetGroupModelPriorityCount(group string, modelName string) int {
+	if !common.MemoryCacheEnabled {
+		return 0
+	}
+	channelSyncLock.RLock()
+	defer channelSyncLock.RUnlock()
+
+	channels := group2model2channels[group][modelName]
+	if len(channels) == 0 {
+		normalizedModel := ratio_setting.FormatMatchingModelName(modelName)
+		channels = group2model2channels[group][normalizedModel]
+	}
+	if len(channels) <= 1 {
+		return len(channels)
+	}
+	uniquePriorities := make(map[int]bool)
+	for _, channelId := range channels {
+		if channel, ok := channelsIDM[channelId]; ok {
+			uniquePriorities[int(channel.GetPriority())] = true
+		}
+	}
+	return len(uniquePriorities)
+}
+
 func CacheGetChannel(id int) (*Channel, error) {
 	if !common.MemoryCacheEnabled {
 		return GetChannelById(id, true)

--- a/model/channel_cache.go
+++ b/model/channel_cache.go
@@ -93,7 +93,7 @@ func SyncChannelCache(frequency int) {
 	}
 }
 
-func GetRandomSatisfiedChannel(group string, model string, retry int) (*Channel, error) {
+func GetRandomSatisfiedChannel(group string, model string, retry int, excludeIDs ...int) (*Channel, error) {
 	// if memory cache is disabled, get channel directly from database
 	if !common.MemoryCacheEnabled {
 		return GetChannel(group, model, retry)
@@ -115,7 +115,15 @@ func GetRandomSatisfiedChannel(group string, model string, retry int) (*Channel,
 		return nil, nil
 	}
 
+	excludeSet := make(map[int]bool, len(excludeIDs))
+	for _, id := range excludeIDs {
+		excludeSet[id] = true
+	}
+
 	if len(channels) == 1 {
+		if excludeSet[channels[0]] {
+			return nil, nil
+		}
 		if channel, ok := channelsIDM[channels[0]]; ok {
 			return channel, nil
 		}
@@ -124,11 +132,17 @@ func GetRandomSatisfiedChannel(group string, model string, retry int) (*Channel,
 
 	uniquePriorities := make(map[int]bool)
 	for _, channelId := range channels {
+		if excludeSet[channelId] {
+			continue
+		}
 		if channel, ok := channelsIDM[channelId]; ok {
 			uniquePriorities[int(channel.GetPriority())] = true
 		} else {
 			return nil, fmt.Errorf("数据库一致性错误，渠道# %d 不存在，请联系管理员修复", channelId)
 		}
+	}
+	if len(uniquePriorities) == 0 {
+		return nil, nil
 	}
 	var sortedUniquePriorities []int
 	for priority := range uniquePriorities {
@@ -145,6 +159,9 @@ func GetRandomSatisfiedChannel(group string, model string, retry int) (*Channel,
 	var sumWeight = 0
 	var targetChannels []*Channel
 	for _, channelId := range channels {
+		if excludeSet[channelId] {
+			continue
+		}
 		if channel, ok := channelsIDM[channelId]; ok {
 			if channel.GetPriority() == targetPriority {
 				sumWeight += channel.GetWeight()

--- a/service/channel_affinity.go
+++ b/service/channel_affinity.go
@@ -702,6 +702,30 @@ func RecordChannelAffinity(c *gin.Context, channelID int) {
 	}
 }
 
+func ForceUpdateChannelAffinity(c *gin.Context, successChannelID int) {
+	if successChannelID <= 0 {
+		return
+	}
+	setting := operation_setting.GetChannelAffinitySetting()
+	if setting == nil || !setting.Enabled {
+		return
+	}
+	cacheKey, ttlSeconds, ok := getChannelAffinityContext(c)
+	if !ok {
+		return
+	}
+	if ttlSeconds <= 0 {
+		ttlSeconds = setting.DefaultTTLSeconds
+	}
+	if ttlSeconds <= 0 {
+		ttlSeconds = 3600
+	}
+	cache := getChannelAffinityCache()
+	if err := cache.SetWithTTL(cacheKey, successChannelID, time.Duration(ttlSeconds)*time.Second); err != nil {
+		common.SysError(fmt.Sprintf("force update channel affinity failed: key=%s, channel=%d, err=%v", cacheKey, successChannelID, err))
+	}
+}
+
 type ChannelAffinityUsageCacheStats struct {
 	RuleName            string `json:"rule_name"`
 	UsingGroup          string `json:"using_group"`

--- a/service/channel_select.go
+++ b/service/channel_select.go
@@ -66,20 +66,16 @@ func (p *RetryParam) ResetRetryNextTry() {
 //   - When GetRandomSatisfiedChannel returns nil (priorities exhausted), moves to next group.
 //     当 GetRandomSatisfiedChannel 返回 nil（优先级用完）时，切换到下一个分组。
 //
-// Example flow (2 groups, each with 2 priorities, RetryTimes=3):
-// 示例流程（2个分组，每个有2个优先级，RetryTimes=3）：
+// Example flow (2 groups: GroupA has 2 priorities, GroupB has 2 priorities, RetryTimes=5):
+// 示例流程（2个分组：GroupA 有2个优先级，GroupB 有2个优先级，RetryTimes=5）：
 //
 //	Retry=0: GroupA, priority0 (startRetryIndex=0, priorityRetry=0)
-//	         分组A, 优先级0
-//
 //	Retry=1: GroupA, priority1 (startRetryIndex=0, priorityRetry=1)
-//	         分组A, 优先级1
-//
 //	Retry=2: GroupA exhausted → GroupB, priority0 (startRetryIndex=2, priorityRetry=0)
-//	         分组A用完 → 分组B, 优先级0
-//
 //	Retry=3: GroupB, priority1 (startRetryIndex=2, priorityRetry=1)
-//	         分组B, 优先级1
+//	Retry=4: GroupB exhausted → no more groups, outer loop ends
+//
+// 全局 Retry 始终递增，不会被重置，确保不超过 RetryTimes 预算。
 func CacheGetRandomSatisfiedChannel(param *RetryParam) (*model.Channel, string, error) {
 	var channel *model.Channel
 	var err error
@@ -103,15 +99,23 @@ func CacheGetRandomSatisfiedChannel(param *RetryParam) (*model.Channel, string, 
 			}
 		}
 
+		// startRetryIndex: 当前分组开始时的全局 Retry 值
+		// 不重置全局 Retry，通过差值计算组内优先级，确保不超过 RetryTimes 预算
+		startRetryIndex := 0
+		if v, exists := common.GetContextKey(param.Ctx, constant.ContextKeyAutoGroupRetryIndex); exists {
+			if idx, ok := v.(int); ok {
+				startRetryIndex = idx
+			}
+		}
+
 		for i := startGroupIndex; i < len(autoGroups); i++ {
 			autoGroup := autoGroups[i]
-			// Calculate priorityRetry for current group
-			// 计算当前分组的 priorityRetry
-			priorityRetry := param.GetRetry()
-			// If moved to a new group, reset priorityRetry and update startRetryIndex
-			// 如果切换到新分组，重置 priorityRetry 并更新 startRetryIndex
+			// priorityRetry = 全局 Retry - 当前分组起始 Retry，表示组内已用的优先级数
+			priorityRetry := param.GetRetry() - startRetryIndex
+			// 如果在本次调用中切换到新分组，priorityRetry 从 0 开始
 			if i > startGroupIndex {
 				priorityRetry = 0
+				startRetryIndex = param.GetRetry()
 			}
 
 			// 跨分组重试时，检查当前分组的优先级是否已耗尽
@@ -121,8 +125,7 @@ func CacheGetRandomSatisfiedChannel(param *RetryParam) (*model.Channel, string, 
 				if priorityCount > 0 && priorityRetry >= priorityCount {
 					logger.LogDebug(param.Ctx, "Group %s priorities exhausted (priorityRetry=%d >= priorityCount=%d), switching to next group", autoGroup, priorityRetry, priorityCount)
 					common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupIndex, i+1)
-					common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupRetryIndex, 0)
-					param.SetRetry(0)
+					common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupRetryIndex, param.GetRetry())
 					continue
 				}
 			}
@@ -131,22 +134,16 @@ func CacheGetRandomSatisfiedChannel(param *RetryParam) (*model.Channel, string, 
 
 			channel, _ = model.GetRandomSatisfiedChannel(autoGroup, param.ModelName, priorityRetry)
 			if channel == nil {
-				// Current group has no available channel for this model, try next group
 				// 当前分组没有该模型的可用渠道，尝试下一个分组
 				logger.LogDebug(param.Ctx, "No available channel in group %s for model %s at priorityRetry %d, trying next group", autoGroup, param.ModelName, priorityRetry)
-				// 重置状态以尝试下一个分组
 				common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupIndex, i+1)
-				common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupRetryIndex, 0)
-				// Reset retry counter so outer loop can continue for next group
-				// 重置重试计数器，以便外层循环可以为下一个分组继续
-				param.SetRetry(0)
+				common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupRetryIndex, param.GetRetry())
 				continue
 			}
 			common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroup, autoGroup)
 			selectGroup = autoGroup
 			logger.LogDebug(param.Ctx, "Auto selected group: %s", autoGroup)
 
-			// Prepare state for next retry
 			// 为下一次重试准备状态
 			if crossGroupRetry {
 				priorityCount := model.GetGroupModelPriorityCount(autoGroup, param.ModelName)
@@ -154,11 +151,8 @@ func CacheGetRandomSatisfiedChannel(param *RetryParam) (*model.Channel, string, 
 					// 当前分组的优先级已全部使用，下次重试切换到下一个分组
 					logger.LogDebug(param.Ctx, "Current group %s priorities will be exhausted after this retry (priorityRetry=%d, priorityCount=%d), preparing switch to next group", autoGroup, priorityRetry, priorityCount)
 					common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupIndex, i+1)
-					param.SetRetry(0)
-					param.ResetRetryNextTry()
+					common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupRetryIndex, param.GetRetry()+1)
 				} else {
-					// Stay in current group, save current state
-					// 保持在当前分组，保存当前状态
 					common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupIndex, i)
 				}
 			} else {

--- a/service/channel_select.go
+++ b/service/channel_select.go
@@ -113,6 +113,20 @@ func CacheGetRandomSatisfiedChannel(param *RetryParam) (*model.Channel, string, 
 			if i > startGroupIndex {
 				priorityRetry = 0
 			}
+
+			// 跨分组重试时，检查当前分组的优先级是否已耗尽
+			// 如果 priorityRetry >= 该分组的优先级数量，说明已经没有新的优先级可用，应跳到下一个分组
+			if crossGroupRetry && priorityRetry > 0 {
+				priorityCount := model.GetGroupModelPriorityCount(autoGroup, param.ModelName)
+				if priorityCount > 0 && priorityRetry >= priorityCount {
+					logger.LogDebug(param.Ctx, "Group %s priorities exhausted (priorityRetry=%d >= priorityCount=%d), switching to next group", autoGroup, priorityRetry, priorityCount)
+					common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupIndex, i+1)
+					common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupRetryIndex, 0)
+					param.SetRetry(0)
+					continue
+				}
+			}
+
 			logger.LogDebug(param.Ctx, "Auto selecting group: %s, priorityRetry: %d", autoGroup, priorityRetry)
 
 			channel, _ = model.GetRandomSatisfiedChannel(autoGroup, param.ModelName, priorityRetry)
@@ -134,20 +148,20 @@ func CacheGetRandomSatisfiedChannel(param *RetryParam) (*model.Channel, string, 
 
 			// Prepare state for next retry
 			// 为下一次重试准备状态
-			if crossGroupRetry && priorityRetry >= common.RetryTimes {
-				// Current group has exhausted all retries, prepare to switch to next group
-				// This request still uses current group, but next retry will use next group
-				// 当前分组已用完所有重试次数，准备切换到下一个分组
-				// 本次请求仍使用当前分组，但下次重试将使用下一个分组
-				logger.LogDebug(param.Ctx, "Current group %s retries exhausted (priorityRetry=%d >= RetryTimes=%d), preparing switch to next group for next retry", autoGroup, priorityRetry, common.RetryTimes)
-				common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupIndex, i+1)
-				// Reset retry counter so outer loop can continue for next group
-				// 重置重试计数器，以便外层循环可以为下一个分组继续
-				param.SetRetry(0)
-				param.ResetRetryNextTry()
+			if crossGroupRetry {
+				priorityCount := model.GetGroupModelPriorityCount(autoGroup, param.ModelName)
+				if priorityCount > 0 && priorityRetry >= priorityCount-1 {
+					// 当前分组的优先级已全部使用，下次重试切换到下一个分组
+					logger.LogDebug(param.Ctx, "Current group %s priorities will be exhausted after this retry (priorityRetry=%d, priorityCount=%d), preparing switch to next group", autoGroup, priorityRetry, priorityCount)
+					common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupIndex, i+1)
+					param.SetRetry(0)
+					param.ResetRetryNextTry()
+				} else {
+					// Stay in current group, save current state
+					// 保持在当前分组，保存当前状态
+					common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupIndex, i)
+				}
 			} else {
-				// Stay in current group, save current state
-				// 保持在当前分组，保存当前状态
 				common.SetContextKey(param.Ctx, constant.ContextKeyAutoGroupIndex, i)
 			}
 			break

--- a/service/channel_select.go
+++ b/service/channel_select.go
@@ -12,11 +12,12 @@ import (
 )
 
 type RetryParam struct {
-	Ctx          *gin.Context
-	TokenGroup   string
-	ModelName    string
-	Retry        *int
-	resetNextTry bool
+	Ctx               *gin.Context
+	TokenGroup        string
+	ModelName         string
+	Retry             *int
+	ExcludeChannelIDs []int
+	resetNextTry      bool
 }
 
 func (p *RetryParam) GetRetry() int {
@@ -132,7 +133,7 @@ func CacheGetRandomSatisfiedChannel(param *RetryParam) (*model.Channel, string, 
 
 			logger.LogDebug(param.Ctx, "Auto selecting group: %s, priorityRetry: %d", autoGroup, priorityRetry)
 
-			channel, _ = model.GetRandomSatisfiedChannel(autoGroup, param.ModelName, priorityRetry)
+			channel, _ = model.GetRandomSatisfiedChannel(autoGroup, param.ModelName, priorityRetry, param.ExcludeChannelIDs...)
 			if channel == nil {
 				// 当前分组没有该模型的可用渠道，尝试下一个分组
 				logger.LogDebug(param.Ctx, "No available channel in group %s for model %s at priorityRetry %d, trying next group", autoGroup, param.ModelName, priorityRetry)
@@ -161,7 +162,7 @@ func CacheGetRandomSatisfiedChannel(param *RetryParam) (*model.Channel, string, 
 			break
 		}
 	} else {
-		channel, err = model.GetRandomSatisfiedChannel(param.TokenGroup, param.ModelName, param.GetRetry())
+		channel, err = model.GetRandomSatisfiedChannel(param.TokenGroup, param.ModelName, param.GetRetry(), param.ExcludeChannelIDs...)
 		if err != nil {
 			return nil, param.TokenGroup, err
 		}


### PR DESCRIPTION
## 📝 变更描述 / Description

修复 auto 分组「跨分组重试」不生效的问题。

原逻辑用全局 `RetryTimes` 判断是否该跳组：
```go
if crossGroupRetry && priorityRetry >= common.RetryTimes {
```

但 `GetRandomSatisfiedChannel` 在 `retry >= len(uniquePriorities)` 时会 clamp 到最后一个优先级，仍然返回 channel。当分组内该模型的优先级数量远小于 `RetryTimes` 时，所有重试都耗在同一个分组反复选同一个渠道，永远不会触发跳组。

修复方案：
1. `model/channel_cache.go` — 新增 `GetGroupModelPriorityCount` 函数，查询分组内某模型的实际优先级数量
2. `service/channel_select.go` — 用实际优先级数量替代 `RetryTimes` 判断跳组时机：每个优先级用完后立刻跳到下一个分组

修复后行为：如果分组内只有 1 个优先级（如只有 1 个渠道有该模型），失败 1 次就跳到下一个分组；如果有 3 个优先级，用完 3 个优先级后跳组。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- Closes #4225

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 Bug fix，我已提交或关联对应 Issue。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

场景验证（分组内只有 1 个渠道有该模型，priorityCount=1）：

修复前：`3->3->3->3->3->3->3->3`（7 次重试全打在同一个渠道）
修复后：`3->下一分组渠道->...`（失败 1 次即跳组）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retries now can exclude previously used channels so subsequent attempts avoid the same channels.
  * Added a way to force-update channel affinity after a successful relay to improve future routing.

* **Refactor**
  * Improved cross-group retry behavior: group switching uses per-group priority availability rather than a fixed retry limit.
  * Pre-checks skip groups whose priorities are exhausted, preserving global retry state.

* **Bug Fixes**
  * Affinity recording now respects a final channel selection when present, reducing incorrect affinity assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->