### PR TITLE
feat: 支持豆包多模态向量化模型,支持文本图像视频向量化

### DIFF
--- a/relay/channel/volcengine/adaptor.go
+++ b/relay/channel/volcengine/adaptor.go
@@ -263,6 +263,9 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 			}
 			return fmt.Sprintf("%s/api/v3/chat/completions", baseUrl), nil
 		case constant.RelayModeEmbeddings:
+			if IsMultimodalEmbeddingModel(info.UpstreamModelName) {
+				return fmt.Sprintf("%s/api/v3/embeddings/multimodal", baseUrl), nil
+			}
 			return fmt.Sprintf("%s/api/v3/embeddings", baseUrl), nil
 		//豆包的图生图也走generations接口: https://www.volcengine.com/docs/82379/1824121
 		case constant.RelayModeImagesGenerations, constant.RelayModeImagesEdits:
@@ -322,6 +325,9 @@ func (a *Adaptor) ConvertRerankRequest(c *gin.Context, relayMode int, request dt
 }
 
 func (a *Adaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.EmbeddingRequest) (any, error) {
+	if IsMultimodalEmbeddingModel(info.UpstreamModelName) {
+		return convertToMultimodalEmbeddingRequest(request)
+	}
 	return request, nil
 }
 

--- a/relay/channel/volcengine/embedding_multimodal.go
+++ b/relay/channel/volcengine/embedding_multimodal.go
@@ -1,0 +1,130 @@
+package volcengine
+
+import (
+	"fmt"
+
+	"github.com/QuantumNous/new-api/dto"
+)
+
+var MultimodalEmbeddingModels = map[string]bool{
+	"doubao-embedding-vision-251215": true,
+}
+
+func IsMultimodalEmbeddingModel(model string) bool {
+	return MultimodalEmbeddingModels[model]
+}
+
+type MultimodalEmbeddingInput struct {
+	Type     string                  `json:"type"`
+	Text     string                  `json:"text,omitempty"`
+	ImageURL *MultimodalImageURLItem `json:"image_url,omitempty"`
+	VideoURL *MultimodalVideoURLItem `json:"video_url,omitempty"`
+}
+
+type MultimodalImageURLItem struct {
+	URL string `json:"url"`
+}
+
+type MultimodalVideoURLItem struct {
+	URL string `json:"url"`
+}
+
+type MultimodalEmbeddingRequest struct {
+	Model          string                     `json:"model"`
+	Input          []MultimodalEmbeddingInput `json:"input"`
+	EncodingFormat string                     `json:"encoding_format,omitempty"`
+	Dimensions     *int                       `json:"dimensions,omitempty"`
+	User           string                     `json:"user,omitempty"`
+}
+
+func convertToMultimodalEmbeddingRequest(request dto.EmbeddingRequest) (*MultimodalEmbeddingRequest, error) {
+	inputs, err := convertInputToMultimodal(request.Input)
+	if err != nil {
+		return nil, err
+	}
+	return &MultimodalEmbeddingRequest{
+		Model:          request.Model,
+		Input:          inputs,
+		EncodingFormat: request.EncodingFormat,
+		Dimensions:     request.Dimensions,
+		User:           request.User,
+	}, nil
+}
+
+func convertInputToMultimodal(input any) ([]MultimodalEmbeddingInput, error) {
+	if input == nil {
+		return nil, fmt.Errorf("embedding input is empty")
+	}
+
+	switch v := input.(type) {
+	case string:
+		return []MultimodalEmbeddingInput{{Type: "text", Text: v}}, nil
+	case []any:
+		return convertSliceToMultimodal(v)
+	default:
+		return nil, fmt.Errorf("unsupported embedding input type: %T", input)
+	}
+}
+
+func convertSliceToMultimodal(items []any) ([]MultimodalEmbeddingInput, error) {
+	if len(items) == 0 {
+		return nil, fmt.Errorf("embedding input is empty")
+	}
+
+	result := make([]MultimodalEmbeddingInput, 0, len(items))
+	for _, item := range items {
+		switch v := item.(type) {
+		case string:
+			result = append(result, MultimodalEmbeddingInput{Type: "text", Text: v})
+		case map[string]any:
+			entry, err := parseMultimodalInputItem(v)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, entry)
+		default:
+			return nil, fmt.Errorf("unsupported embedding input item type: %T", item)
+		}
+	}
+	return result, nil
+}
+
+func parseMultimodalInputItem(m map[string]any) (MultimodalEmbeddingInput, error) {
+	typeStr, ok := m["type"].(string)
+	if !ok || typeStr == "" {
+		return MultimodalEmbeddingInput{}, fmt.Errorf("multimodal input item missing required 'type' field")
+	}
+	switch typeStr {
+	case "text":
+		text, _ := m["text"].(string)
+		return MultimodalEmbeddingInput{Type: "text", Text: text}, nil
+	case "image_url":
+		urlObj, ok := m["image_url"].(map[string]any)
+		if !ok {
+			return MultimodalEmbeddingInput{}, fmt.Errorf("invalid image_url format")
+		}
+		url, _ := urlObj["url"].(string)
+		if url == "" {
+			return MultimodalEmbeddingInput{}, fmt.Errorf("image_url.url is required")
+		}
+		return MultimodalEmbeddingInput{
+			Type:     "image_url",
+			ImageURL: &MultimodalImageURLItem{URL: url},
+		}, nil
+	case "video_url":
+		urlObj, ok := m["video_url"].(map[string]any)
+		if !ok {
+			return MultimodalEmbeddingInput{}, fmt.Errorf("invalid video_url format")
+		}
+		url, _ := urlObj["url"].(string)
+		if url == "" {
+			return MultimodalEmbeddingInput{}, fmt.Errorf("video_url.url is required")
+		}
+		return MultimodalEmbeddingInput{
+			Type:     "video_url",
+			VideoURL: &MultimodalVideoURLItem{URL: url},
+		}, nil
+	default:
+		return MultimodalEmbeddingInput{}, fmt.Errorf("unsupported multimodal input type: %s", typeStr)
+	}
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
增加豆包多模态向量化支持, 模型id: doubao-embedding-vision-251215
官方文档: https://www.volcengine.com/docs/82379/1523520

## 📝 变更描述 / Description
豆包多模态向量增加了图像和视频的支持, 这在标准的openai格式中不支持, 需要转换
1. 当只有文本的时候, 按openai的兼容格式实现
2. 当请求体有图像和视频时, 按豆包官方格式请求, 透传到官方模型

## 📸 运行证明 / Proof of Work
* 文本向量化请求:
```
curl http://localhost:30001/v1/embeddings \
  --request POST \
  --header 'Content-Type: application/json' \
  --data '{
  "model": "doubao-embedding-vision-251215",
  "input": [
    "hello"
  ],
  "encoding_format": "float"
}'
```
<img width="1222" height="763" alt="image" src="https://github.com/user-attachments/assets/595c619c-9be0-4aa6-a24e-0bb8ed23a7f2" />

* 图像向量化请求:
```
curl http://localhost:30001/v1/embeddings \
  --request POST \
  --header 'Content-Type: application/json' \
  --data '{
  "model": "doubao-embedding-vision-251215",
  "input": [
    {
      "type": "text",
      "text": "hello"
    },
    {
      "type": "image_url",
      "image_url": {
        "url": "https://ark-project.tos-cn-beijing.volces.com/doc_image/tower.png"
      }
    }
  ],
  "encoding_format": "float"
}'
```
<img width="1331" height="910" alt="image" src="https://github.com/user-attachments/assets/d42d7c45-6946-424f-ab85-104fd66203cd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multimodal embeddings, enabling generation of embeddings from text, images, and videos
  * Compatible models now automatically route to multimodal embedding endpoints
  * Enhanced request conversion to properly handle multimodal input formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->