### PR TITLE
支持服务优雅关闭,避免重启回复中断和面板缓存数据丢失

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
@@ -192,10 +196,30 @@ func main() {
 	// Log startup success message
 	common.LogStartupSuccess(startTime, port)
 
-	err = server.Run(":" + port)
-	if err != nil {
-		common.FatalLog("failed to start HTTP server: " + err.Error())
+	srv := &http.Server{
+		Addr:    ":" + port,
+		Handler: server,
 	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			common.FatalLog("failed to start HTTP server: " + err.Error())
+		}
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-quit
+	common.SysLog(fmt.Sprintf("received signal: %v, shutting down...", sig))
+
+	// SSE streams may run for minutes; give them time to finish before forced exit
+	shutdownTimeout := time.Duration(common.GetEnvOrDefault("SHUTDOWN_TIMEOUT_SECONDS", 120)) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		common.SysError(fmt.Sprintf("server forced to shutdown: %v", err))
+	}
+	common.SysLog("server exited")
 }
 
 func InjectUmamiAnalytics() {

--- a/main.go
+++ b/main.go
@@ -219,6 +219,10 @@ func main() {
 	if err := srv.Shutdown(ctx); err != nil {
 		common.SysError(fmt.Sprintf("server forced to shutdown: %v", err))
 	}
+	// 内存中的看板数据保存入库，避免重启丢失未落库数据 (issue #5679)
+	if common.DataExportEnabled {
+		model.SaveQuotaDataCache()
+	}
 	common.SysLog("server exited")
 }
 


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
    支持服务优雅关闭,避免重启时流式回复被打断；并在关闭时落库数据看板缓存,避免重启丢失未导出的看板数据。

## 🔗 关联 Issue / Related Issue
Fixes #5679

## 📝 变更描述 / Description
  将 main.go 中原来的 server.Run() 阻塞启动方式改为 http.Server + goroutine 启动，监听 SIGINT/SIGTERM 信号后调用 srv.Shutdown() 实现优雅关闭。
   这样在部署重启或容器停止时，已有的请求（特别是 SSE 长连接）能在超时时间内正常完成，而不是被直接杀掉。超时时间通过环境变量 `SHUTDOWN_TIMEOUT_SECONDS` 控制，默认 120 秒。

  在此基础上，关闭流程末尾(`srv.Shutdown()` 之后、进程退出前)新增对数据看板缓存的强制落库：当 `DataExportEnabled` 开启时调用 `model.SaveQuotaDataCache()`，把内存中尚未到达 `DataExportInterval` 导出周期的聚合数据写入 `quota_data` 表。解决 #5679 —— 此前每次重启最多会丢失一个导出周期(默认 5 分钟)的看板数据。该 flush 依赖优雅关闭提供的退出时机，故与本 PR 一并提交。

## 📸 运行证明 / Proof of Work
1. docker compose启动
2. 执行一个较长的流式回复
3. docker compose up -d
4. 系统会等待流式回复结束再重启, 最长等待120s(可配置)
<img width="1504" height="78" alt="image" src="https://github.com/user-attachments/assets/e491f032-f6bf-4b70-bf5d-0b3c09eb43c7" />
<img width="1510" height="406" alt="image" src="https://github.com/user-attachments/assets/5ec3412f-3602-4b36-9381-b125902c5a23" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced HTTP server startup to run non-blocking and handle startup errors more safely.
  * Added graceful shutdown on termination signals (SIGINT/SIGTERM), using a configurable default 120-second timeout.
  * Ensures shutdown is followed by optional persistence of in-memory quota/board data when data export is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
