### PR TITLE
feat(ali): add DashScope multimodal embedding support (qwen3-vl-embedding)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,12 @@
 .github
 .git
 *.md
+*.exe
+*.db
+*.db-journal
+*.lock
+*.out
+*.err
 .vscode
 .gitignore
 Makefile
@@ -8,3 +14,8 @@ docs
 .eslintcache
 .gocache
 /web/node_modules
+logs
+data
+upload
+electron/node_modules
+electron/dist

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ upload
 *.db
 build
 *.db-journal
+*.lock
+*.out
+*.err
 logs
 web/dist
 .env

--- a/docs/deployment/free-koyeb-neon.md
+++ b/docs/deployment/free-koyeb-neon.md
@@ -1,0 +1,80 @@
+# Free deployment: Koyeb + Neon
+
+This guide is for running the full application for personal use without installing Docker locally.
+
+Koyeb builds the existing `Dockerfile` in the cloud. Neon provides a free PostgreSQL database. Do not use SQLite on free cloud instances, because local files are not a reliable long-term database there.
+
+## 1. Push the project to GitHub
+
+Commit and push this repository to a GitHub repository. You do not need to upload local runtime files such as:
+
+- `new-api.exe`
+- `one-api.db`
+- `logs/`
+- `one-api*.out`
+- `one-api*.err`
+- `one-api.lock`
+
+## 2. Create a Neon PostgreSQL database
+
+Create a free Neon project and copy the PostgreSQL connection string.
+
+Use the pooled or direct connection string, but keep `sslmode=require`.
+
+Example format:
+
+```text
+postgresql://user:password@host/dbname?sslmode=require
+```
+
+## 3. Create the Koyeb service
+
+Create a Koyeb Web Service from the GitHub repository.
+
+Recommended settings:
+
+- Builder: `Dockerfile`
+- Dockerfile path: `Dockerfile`
+- Port: `3000`
+- Instance: free instance
+
+## 4. Set environment variables
+
+Required:
+
+```text
+SQL_DSN=postgresql://user:password@host/dbname?sslmode=require
+SESSION_SECRET=replace-with-a-long-random-string
+PORT=3000
+```
+
+Optional for personal use:
+
+```text
+MEMORY_CACHE_ENABLED=true
+SYNC_FREQUENCY=60
+CHANNEL_UPDATE_FREQUENCY=30
+BATCH_UPDATE_ENABLED=true
+BATCH_UPDATE_INTERVAL=5
+```
+
+Leave `REDIS_CONN_STRING` empty unless you also have a Redis service. The application will disable Redis automatically when it is not set.
+
+## 5. Open the deployed URL
+
+After the deployment succeeds, open the HTTPS URL provided by Koyeb on your phone.
+
+On first startup, the application creates the root user automatically when no user exists:
+
+```text
+username: root
+password: 123456
+```
+
+Change the password immediately after logging in.
+
+## Free tier limitations
+
+Free instances can sleep after inactivity, so the first request from your phone may take extra time while the service wakes up.
+
+For stable long-running use, move to a paid instance or a VPS later. The same PostgreSQL database can usually be reused.

--- a/relay/channel/ali/adaptor.go
+++ b/relay/channel/ali/adaptor.go
@@ -81,7 +81,11 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	default:
 		switch info.RelayMode {
 		case constant.RelayModeEmbeddings:
-			fullRequestURL = fmt.Sprintf("%s/compatible-mode/v1/embeddings", info.ChannelBaseUrl)
+			if isMultimodalEmbeddingModel(info.UpstreamModelName) {
+				fullRequestURL = fmt.Sprintf("%s/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding", info.ChannelBaseUrl)
+			} else {
+				fullRequestURL = fmt.Sprintf("%s/compatible-mode/v1/embeddings", info.ChannelBaseUrl)
+			}
 		case constant.RelayModeRerank:
 			fullRequestURL = fmt.Sprintf("%s/api/v1/services/rerank/text-rerank/text-rerank", info.ChannelBaseUrl)
 		case constant.RelayModeResponses:
@@ -203,6 +207,9 @@ func (a *Adaptor) ConvertRerankRequest(c *gin.Context, relayMode int, request dt
 }
 
 func (a *Adaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.EmbeddingRequest) (any, error) {
+	if isMultimodalEmbeddingModel(info.UpstreamModelName) {
+		return convertToMultimodalEmbeddingRequest(request)
+	}
 	return request, nil
 }
 
@@ -237,6 +244,13 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycom
 			err, usage = aliImageHandler(a, c, resp, info)
 		case constant.RelayModeRerank:
 			err, usage = RerankHandler(c, resp, info)
+		case constant.RelayModeEmbeddings:
+			if isMultimodalEmbeddingModel(info.UpstreamModelName) {
+				err, usage = MultimodalEmbeddingHandler(c, resp, info)
+			} else {
+				adaptor := openai.Adaptor{}
+				usage, err = adaptor.DoResponse(c, resp, info)
+			}
 		default:
 			adaptor := openai.Adaptor{}
 			usage, err = adaptor.DoResponse(c, resp, info)

--- a/relay/channel/ali/dto.go
+++ b/relay/channel/ali/dto.go
@@ -234,3 +234,41 @@ type AliRerankResponse struct {
 	RequestId string   `json:"request_id"`
 	AliError
 }
+// ==================== Multimodal Embedding ====================
+
+type AliMultimodalContent struct {
+	Text  string `json:"text,omitempty"`
+	Image string `json:"image,omitempty"`
+	Video string `json:"video,omitempty"`
+}
+
+type AliMultimodalEmbeddingInput struct {
+	Contents []AliMultimodalContent `json:"contents"`
+}
+
+type AliMultimodalEmbeddingParameters struct {
+	EnableFusion bool `json:"enable_fusion"`
+}
+
+type AliMultimodalEmbeddingRequest struct {
+	Model      string                           `json:"model"`
+	Input      AliMultimodalEmbeddingInput      `json:"input"`
+	Parameters AliMultimodalEmbeddingParameters `json:"parameters"`
+}
+
+type AliMultimodalEmbeddingItem struct {
+	Embedding []float64 `json:"embedding"`
+	Index     int       `json:"index"`
+}
+
+type AliMultimodalEmbeddingOutput struct {
+	Embeddings []AliMultimodalEmbeddingItem `json:"embeddings"`
+}
+
+type AliMultimodalEmbeddingResponse struct {
+	Output    AliMultimodalEmbeddingOutput `json:"output"`
+	Usage     AliUsage                     `json:"usage"`
+	RequestId string                       `json:"request_id"`
+	Code      string                       `json:"code,omitempty"`
+	Message   string                       `json:"message,omitempty"`
+}

--- a/relay/channel/ali/embedding.go
+++ b/relay/channel/ali/embedding.go
@@ -1,0 +1,182 @@
+package ali
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/types"
+
+	"github.com/gin-gonic/gin"
+)
+
+// isMultimodalEmbeddingModel checks if the model name indicates a multimodal embedding model.
+func isMultimodalEmbeddingModel(modelName string) bool {
+	lower := strings.ToLower(modelName)
+	return strings.Contains(lower, "vl-embedding")
+}
+
+// convertToMultimodalEmbeddingRequest converts an OpenAI-format EmbeddingRequest
+// to a DashScope multimodal embedding request.
+func convertToMultimodalEmbeddingRequest(request dto.EmbeddingRequest) (*AliMultimodalEmbeddingRequest, error) {
+	contents, err := parseInputToContents(request.Input)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AliMultimodalEmbeddingRequest{
+		Model: request.Model,
+		Input: AliMultimodalEmbeddingInput{
+			Contents: contents,
+		},
+		Parameters: AliMultimodalEmbeddingParameters{
+			EnableFusion: true,
+		},
+	}, nil
+}
+
+// parseInputToContents converts the OpenAI embedding input (any type) into
+// DashScope multimodal content entries.
+// Supported input formats:
+//   - string: treated as text
+//   - []string: each element treated as text
+//   - []any: each element can be a string (text) or a map with type/image_url/video_url keys
+func parseInputToContents(input any) ([]AliMultimodalContent, error) {
+	if input == nil {
+		return nil, fmt.Errorf("input is nil")
+	}
+
+	var contents []AliMultimodalContent
+
+	switch v := input.(type) {
+	case string:
+		contents = append(contents, AliMultimodalContent{Text: v})
+	case []any:
+		for _, item := range v {
+			switch elem := item.(type) {
+			case string:
+				contents = append(contents, AliMultimodalContent{Text: elem})
+			case map[string]any:
+				content, err := parseMapToContent(elem)
+				if err != nil {
+					return nil, err
+				}
+				contents = append(contents, content)
+			default:
+				return nil, fmt.Errorf("unsupported input element type: %T", elem)
+			}
+		}
+	default:
+		return nil, fmt.Errorf("unsupported input type: %T", v)
+	}
+
+	if len(contents) == 0 {
+		return nil, fmt.Errorf("no valid content found in input")
+	}
+
+	return contents, nil
+}
+
+// parseMapToContent converts a map input element to an AliMultimodalContent.
+// Supports two formats:
+//   - OpenAI vision style: {"type": "image_url", "image_url": {"url": "..."}}
+//   - DashScope native style: {"image": "..."} or {"video": "..."} or {"text": "..."}
+func parseMapToContent(m map[string]any) (AliMultimodalContent, error) {
+	// DashScope native shorthand: {"text": "..."}, {"image": "..."}, {"video": "..."}
+	if text, ok := m["text"].(string); ok {
+		return AliMultimodalContent{Text: text}, nil
+	}
+	if image, ok := m["image"].(string); ok {
+		return AliMultimodalContent{Image: image}, nil
+	}
+	if video, ok := m["video"].(string); ok {
+		return AliMultimodalContent{Video: video}, nil
+	}
+
+	// OpenAI vision-compatible format: {"type": "image_url", "image_url": {"url": "..."}}
+	if typeName, ok := m["type"].(string); ok {
+		switch typeName {
+		case "text":
+			if textObj, ok := m["text"].(string); ok {
+				return AliMultimodalContent{Text: textObj}, nil
+			}
+		case "image_url":
+			if imgObj, ok := m["image_url"].(map[string]any); ok {
+				if url, ok := imgObj["url"].(string); ok {
+					return AliMultimodalContent{Image: url}, nil
+				}
+			}
+		case "video_url":
+			if vidObj, ok := m["video_url"].(map[string]any); ok {
+				if url, ok := vidObj["url"].(string); ok {
+					return AliMultimodalContent{Video: url}, nil
+				}
+			}
+		}
+	}
+
+	return AliMultimodalContent{}, fmt.Errorf("cannot parse content map: %v", m)
+}
+
+// MultimodalEmbeddingHandler processes the DashScope multimodal embedding response
+// and converts it to OpenAI-compatible format.
+func MultimodalEmbeddingHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (*types.NewAPIError, *dto.Usage) {
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return types.NewOpenAIError(err, types.ErrorCodeReadResponseBodyFailed, http.StatusInternalServerError), nil
+	}
+	service.CloseResponseBodyGracefully(resp)
+
+	var aliResponse AliMultimodalEmbeddingResponse
+	err = json.Unmarshal(responseBody, &aliResponse)
+	if err != nil {
+		return types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError), nil
+	}
+
+	// Check for DashScope error response
+	if aliResponse.Code != "" {
+		return types.WithOpenAIError(types.OpenAIError{
+			Message: aliResponse.Message,
+			Type:    aliResponse.Code,
+			Param:   aliResponse.RequestId,
+			Code:    aliResponse.Code,
+		}, resp.StatusCode), nil
+	}
+
+	// Convert to OpenAI embedding response format
+	var embeddingItems []dto.EmbeddingResponseItem
+	for i, item := range aliResponse.Output.Embeddings {
+		embeddingItems = append(embeddingItems, dto.EmbeddingResponseItem{
+			Object:    "embedding",
+			Index:     i,
+			Embedding: item.Embedding,
+		})
+	}
+
+	usage := dto.Usage{
+		PromptTokens:     aliResponse.Usage.TotalTokens,
+		CompletionTokens: 0,
+		TotalTokens:      aliResponse.Usage.TotalTokens,
+	}
+
+	embeddingResponse := dto.EmbeddingResponse{
+		Object: "list",
+		Data:   embeddingItems,
+		Model:  info.UpstreamModelName,
+		Usage:  usage,
+	}
+
+	jsonResponse, err := json.Marshal(embeddingResponse)
+	if err != nil {
+		return types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError), nil
+	}
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(resp.StatusCode)
+	c.Writer.Write(jsonResponse)
+	return nil, &usage
+}


### PR DESCRIPTION
## Summary

Add native DashScope multimodal embedding API support for models like `qwen3-vl-embedding`.

Currently, the Ali channel routes all embedding requests through the OpenAI-compatible endpoint (`/compatible-mode/v1/embeddings`), which only supports text input. Multimodal embedding models (e.g. `qwen3-vl-embedding`) require the DashScope native multimodal endpoint with a different request/response structure.

## Changes

### New file: `relay/channel/ali/embedding.go`
- `isMultimodalEmbeddingModel()` - detects multimodal embedding models by checking if the model name contains `vl-embedding`
- `convertToMultimodalEmbeddingRequest()` - converts OpenAI-style EmbeddingRequest to DashScope multimodal style (input.contents array with text/image/video entries)
- `MultimodalEmbeddingHandler()` - parses DashScope multimodal embedding response and converts it to OpenAI-compatible EmbeddingResponse
- Supports multiple input styles: plain string, string array, and mixed content array (DashScope native + OpenAI vision style)

### Modified: `relay/channel/ali/dto.go`
- Added 6 DTO structs for multimodal embedding request/response serialization

### Modified: `relay/channel/ali/adaptor.go`
- `GetRequestURL`: routes multimodal models to `/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding`
- `ConvertEmbeddingRequest`: delegates to multimodal converter when applicable
- `DoResponse`: delegates to `MultimodalEmbeddingHandler` for multimodal models, falls back to `openai.Adaptor` for standard text embeddings

## Design
Follows the same pattern as the existing `rerank.go` handler - model detection, request conversion, custom response handler. Non-multimodal embedding models are completely unaffected (original code paths preserved).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multimodal embedding models on the Ali/DashScope channel, accepting text, image, and video inputs and returning compatible embedding responses.
  * Automatic routing and request/response transformation for multimodal embeddings to preserve compatibility with existing clients.
* **Documentation**
  * Added a new free deployment guide for Koyeb + Neon.
* **Chores**
  * Expanded ignore rules to exclude additional build/runtime artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->