### PR TITLE
feat: always check stripe api for webhook event

### DIFF
--- a/controller/topup_stripe.go
+++ b/controller/topup_stripe.go
@@ -280,12 +280,12 @@ func sessionAsyncPaymentFailed(ctx context.Context, event stripe.Event) error {
 	}
 
 	referenceId := sess.ClientReferenceID
-	log.Printf("Stripe 异步支付失败(API验证): %s", referenceId)
-
 	if len(referenceId) == 0 {
 		log.Println("异步支付失败事件未提供支付单号")
 		return nil
 	}
+
+	log.Printf("Stripe 异步支付失败(API验证): %s", referenceId)
 
 	if sess.PaymentStatus == stripe.CheckoutSessionPaymentStatusPaid {
 		log.Printf("Stripe API显示支付已成功，拒绝标记订单为失败: %s", referenceId)

--- a/controller/topup_stripe.go
+++ b/controller/topup_stripe.go
@@ -186,42 +186,95 @@ func StripeWebhook(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
+// retrieveAndVerifyCheckoutSession calls the Stripe API to retrieve the authoritative
+// checkout session state, rather than trusting the webhook event payload alone.
+func retrieveAndVerifyCheckoutSession(sessionId string) (*stripe.CheckoutSession, error) {
+	if sessionId == "" {
+		return nil, fmt.Errorf("empty checkout session ID")
+	}
+	if !strings.HasPrefix(setting.StripeApiSecret, "sk_") && !strings.HasPrefix(setting.StripeApiSecret, "rk_") {
+		return nil, fmt.Errorf("invalid Stripe API key configured")
+	}
+	stripe.Key = setting.StripeApiSecret
+	sess, err := session.Get(sessionId, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve checkout session %s from Stripe API: %w", sessionId, err)
+	}
+	return sess, nil
+}
+
 func sessionCompleted(event stripe.Event) {
-	customerId := event.GetObjectValue("customer")
-	referenceId := event.GetObjectValue("client_reference_id")
-	status := event.GetObjectValue("status")
-	if "complete" != status {
-		log.Println("错误的Stripe Checkout完成状态:", status, ",", referenceId)
+	sessionId := event.GetObjectValue("id")
+	sess, err := retrieveAndVerifyCheckoutSession(sessionId)
+	if err != nil {
+		log.Printf("Stripe Checkout Session API验证失败: %v", err)
 		return
 	}
 
-	paymentStatus := event.GetObjectValue("payment_status")
-	if paymentStatus != "paid" {
-		log.Printf("Stripe Checkout 支付尚未完成，payment_status: %s, ref: %s（等待异步支付结果）", paymentStatus, referenceId)
+	if sess.Status != stripe.CheckoutSessionStatusComplete {
+		log.Printf("Stripe API返回非完成状态: %s, session: %s", sess.Status, sessionId)
 		return
 	}
 
-	fulfillOrder(event, referenceId, customerId)
+	if sess.PaymentStatus != stripe.CheckoutSessionPaymentStatusPaid {
+		log.Printf("Stripe Checkout 支付尚未完成，payment_status: %s, session: %s（等待异步支付结果）", sess.PaymentStatus, sessionId)
+		return
+	}
+
+	referenceId := sess.ClientReferenceID
+	customerId := ""
+	if sess.Customer != nil {
+		customerId = sess.Customer.ID
+	}
+
+	fulfillOrder(sess, event.Type, referenceId, customerId)
 }
 
 // sessionAsyncPaymentSucceeded handles delayed payment methods (bank transfer, SEPA, etc.)
 // that confirm payment after the checkout session completes.
 func sessionAsyncPaymentSucceeded(event stripe.Event) {
-	customerId := event.GetObjectValue("customer")
-	referenceId := event.GetObjectValue("client_reference_id")
-	log.Printf("Stripe 异步支付成功: %s", referenceId)
+	sessionId := event.GetObjectValue("id")
+	sess, err := retrieveAndVerifyCheckoutSession(sessionId)
+	if err != nil {
+		log.Printf("Stripe 异步支付成功事件API验证失败: %v", err)
+		return
+	}
 
-	fulfillOrder(event, referenceId, customerId)
+	if sess.PaymentStatus != stripe.CheckoutSessionPaymentStatusPaid {
+		log.Printf("Stripe API返回异步支付未完成，payment_status: %s, session: %s", sess.PaymentStatus, sessionId)
+		return
+	}
+
+	referenceId := sess.ClientReferenceID
+	customerId := ""
+	if sess.Customer != nil {
+		customerId = sess.Customer.ID
+	}
+	log.Printf("Stripe 异步支付成功(API验证): %s", referenceId)
+
+	fulfillOrder(sess, event.Type, referenceId, customerId)
 }
 
 // sessionAsyncPaymentFailed marks orders as failed when delayed payment methods
 // ultimately fail (e.g. bank transfer not received, SEPA rejected).
 func sessionAsyncPaymentFailed(event stripe.Event) {
-	referenceId := event.GetObjectValue("client_reference_id")
-	log.Printf("Stripe 异步支付失败: %s", referenceId)
+	sessionId := event.GetObjectValue("id")
+	sess, err := retrieveAndVerifyCheckoutSession(sessionId)
+	if err != nil {
+		log.Printf("Stripe 异步支付失败事件API验证失败: %v", err)
+		return
+	}
+
+	referenceId := sess.ClientReferenceID
+	log.Printf("Stripe 异步支付失败(API验证): %s", referenceId)
 
 	if len(referenceId) == 0 {
 		log.Println("异步支付失败事件未提供支付单号")
+		return
+	}
+
+	if sess.PaymentStatus == stripe.CheckoutSessionPaymentStatusPaid {
+		log.Printf("Stripe API显示支付已成功，拒绝标记订单为失败: %s", referenceId)
 		return
 	}
 
@@ -252,10 +305,15 @@ func sessionAsyncPaymentFailed(event stripe.Event) {
 	log.Printf("充值订单已标记为失败: %s", referenceId)
 }
 
-// fulfillOrder is the shared logic for crediting quota after payment is confirmed.
-func fulfillOrder(event stripe.Event, referenceId string, customerId string) {
+// fulfillOrder is the shared logic for crediting quota after payment is confirmed via Stripe API.
+func fulfillOrder(sess *stripe.CheckoutSession, eventType stripe.EventType, referenceId string, customerId string) {
 	if len(referenceId) == 0 {
 		log.Println("未提供支付单号")
+		return
+	}
+
+	if sess.AmountTotal <= 0 {
+		log.Printf("Stripe API返回无效支付金额: %d, ref: %s", sess.AmountTotal, referenceId)
 		return
 	}
 
@@ -263,9 +321,9 @@ func fulfillOrder(event stripe.Event, referenceId string, customerId string) {
 	defer UnlockOrder(referenceId)
 	payload := map[string]any{
 		"customer":     customerId,
-		"amount_total": event.GetObjectValue("amount_total"),
-		"currency":     strings.ToUpper(event.GetObjectValue("currency")),
-		"event_type":   string(event.Type),
+		"amount_total": sess.AmountTotal,
+		"currency":     strings.ToUpper(string(sess.Currency)),
+		"event_type":   string(eventType),
 	}
 	if err := model.CompleteSubscriptionOrder(referenceId, common.GetJsonString(payload)); err == nil {
 		return
@@ -280,19 +338,24 @@ func fulfillOrder(event stripe.Event, referenceId string, customerId string) {
 		return
 	}
 
-	total, _ := strconv.ParseFloat(event.GetObjectValue("amount_total"), 64)
-	currency := strings.ToUpper(event.GetObjectValue("currency"))
-	log.Printf("收到款项：%s, %.2f(%s)", referenceId, total/100, currency)
+	currency := strings.ToUpper(string(sess.Currency))
+	log.Printf("收到款项(API验证)：%s, %.2f(%s)", referenceId, float64(sess.AmountTotal)/100, currency)
 }
 
 func sessionExpired(event stripe.Event) {
-	referenceId := event.GetObjectValue("client_reference_id")
-	status := event.GetObjectValue("status")
-	if "expired" != status {
-		log.Println("错误的Stripe Checkout过期状态:", status, ",", referenceId)
+	sessionId := event.GetObjectValue("id")
+	sess, err := retrieveAndVerifyCheckoutSession(sessionId)
+	if err != nil {
+		log.Printf("Stripe Checkout过期事件API验证失败: %v", err)
 		return
 	}
 
+	if sess.Status != stripe.CheckoutSessionStatusExpired {
+		log.Printf("Stripe API返回非过期状态: %s, session: %s", sess.Status, sessionId)
+		return
+	}
+
+	referenceId := sess.ClientReferenceID
 	if len(referenceId) == 0 {
 		log.Println("未提供支付单号")
 		return
@@ -319,7 +382,7 @@ func sessionExpired(event stripe.Event) {
 	}
 
 	topUp.Status = common.TopUpStatusExpired
-	err := topUp.Update()
+	err = topUp.Update()
 	if err != nil {
 		log.Println("过期充值订单失败", referenceId, ", err:", err.Error())
 		return

--- a/controller/topup_stripe.go
+++ b/controller/topup_stripe.go
@@ -173,19 +173,25 @@ func StripeWebhook(c *gin.Context) {
 
 	ctx := c.Request.Context()
 
+	var handlerErr error
 	switch event.Type {
 	case stripe.EventTypeCheckoutSessionCompleted:
-		sessionCompleted(ctx, event)
+		handlerErr = sessionCompleted(ctx, event)
 	case stripe.EventTypeCheckoutSessionExpired:
-		sessionExpired(ctx, event)
+		handlerErr = sessionExpired(ctx, event)
 	case stripe.EventTypeCheckoutSessionAsyncPaymentSucceeded:
-		sessionAsyncPaymentSucceeded(ctx, event)
+		handlerErr = sessionAsyncPaymentSucceeded(ctx, event)
 	case stripe.EventTypeCheckoutSessionAsyncPaymentFailed:
-		sessionAsyncPaymentFailed(ctx, event)
+		handlerErr = sessionAsyncPaymentFailed(ctx, event)
 	default:
 		log.Printf("不支持的Stripe Webhook事件类型: %s\n", event.Type)
 	}
 
+	if handlerErr != nil {
+		log.Printf("Stripe Webhook处理失败，将返回5xx以触发重试: %v", handlerErr)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
 	c.Status(http.StatusOK)
 }
 
@@ -212,22 +218,21 @@ func retrieveAndVerifyCheckoutSession(ctx context.Context, sessionId string) (*s
 	return sess, nil
 }
 
-func sessionCompleted(ctx context.Context, event stripe.Event) {
+func sessionCompleted(ctx context.Context, event stripe.Event) error {
 	sessionId := event.GetObjectValue("id")
 	sess, err := retrieveAndVerifyCheckoutSession(ctx, sessionId)
 	if err != nil {
-		log.Printf("Stripe Checkout Session API验证失败: %v", err)
-		return
+		return fmt.Errorf("Stripe Checkout Session API验证失败: %w", err)
 	}
 
 	if sess.Status != stripe.CheckoutSessionStatusComplete {
 		log.Printf("Stripe API返回非完成状态: %s, session: %s", sess.Status, sessionId)
-		return
+		return nil
 	}
 
 	if sess.PaymentStatus != stripe.CheckoutSessionPaymentStatusPaid {
 		log.Printf("Stripe Checkout 支付尚未完成，payment_status: %s, session: %s（等待异步支付结果）", sess.PaymentStatus, sessionId)
-		return
+		return nil
 	}
 
 	referenceId := sess.ClientReferenceID
@@ -237,21 +242,21 @@ func sessionCompleted(ctx context.Context, event stripe.Event) {
 	}
 
 	fulfillOrder(sess, event.Type, referenceId, customerId)
+	return nil
 }
 
 // sessionAsyncPaymentSucceeded handles delayed payment methods (bank transfer, SEPA, etc.)
 // that confirm payment after the checkout session completes.
-func sessionAsyncPaymentSucceeded(ctx context.Context, event stripe.Event) {
+func sessionAsyncPaymentSucceeded(ctx context.Context, event stripe.Event) error {
 	sessionId := event.GetObjectValue("id")
 	sess, err := retrieveAndVerifyCheckoutSession(ctx, sessionId)
 	if err != nil {
-		log.Printf("Stripe 异步支付成功事件API验证失败: %v", err)
-		return
+		return fmt.Errorf("Stripe 异步支付成功事件API验证失败: %w", err)
 	}
 
 	if sess.PaymentStatus != stripe.CheckoutSessionPaymentStatusPaid {
 		log.Printf("Stripe API返回异步支付未完成，payment_status: %s, session: %s", sess.PaymentStatus, sessionId)
-		return
+		return nil
 	}
 
 	referenceId := sess.ClientReferenceID
@@ -262,16 +267,16 @@ func sessionAsyncPaymentSucceeded(ctx context.Context, event stripe.Event) {
 	log.Printf("Stripe 异步支付成功(API验证): %s", referenceId)
 
 	fulfillOrder(sess, event.Type, referenceId, customerId)
+	return nil
 }
 
 // sessionAsyncPaymentFailed marks orders as failed when delayed payment methods
 // ultimately fail (e.g. bank transfer not received, SEPA rejected).
-func sessionAsyncPaymentFailed(ctx context.Context, event stripe.Event) {
+func sessionAsyncPaymentFailed(ctx context.Context, event stripe.Event) error {
 	sessionId := event.GetObjectValue("id")
 	sess, err := retrieveAndVerifyCheckoutSession(ctx, sessionId)
 	if err != nil {
-		log.Printf("Stripe 异步支付失败事件API验证失败: %v", err)
-		return
+		return fmt.Errorf("Stripe 异步支付失败事件API验证失败: %w", err)
 	}
 
 	referenceId := sess.ClientReferenceID
@@ -279,12 +284,12 @@ func sessionAsyncPaymentFailed(ctx context.Context, event stripe.Event) {
 
 	if len(referenceId) == 0 {
 		log.Println("异步支付失败事件未提供支付单号")
-		return
+		return nil
 	}
 
 	if sess.PaymentStatus == stripe.CheckoutSessionPaymentStatusPaid {
 		log.Printf("Stripe API显示支付已成功，拒绝标记订单为失败: %s", referenceId)
-		return
+		return nil
 	}
 
 	LockOrder(referenceId)
@@ -293,25 +298,26 @@ func sessionAsyncPaymentFailed(ctx context.Context, event stripe.Event) {
 	topUp := model.GetTopUpByTradeNo(referenceId)
 	if topUp == nil {
 		log.Println("异步支付失败，充值订单不存在:", referenceId)
-		return
+		return nil
 	}
 
 	if topUp.PaymentMethod != PaymentMethodStripe {
 		log.Printf("异步支付失败，订单支付方式不匹配: %s, ref: %s", topUp.PaymentMethod, referenceId)
-		return
+		return nil
 	}
 
 	if topUp.Status != common.TopUpStatusPending {
 		log.Printf("异步支付失败，订单状态非pending: %s, ref: %s", topUp.Status, referenceId)
-		return
+		return nil
 	}
 
 	topUp.Status = common.TopUpStatusFailed
 	if err := topUp.Update(); err != nil {
 		log.Printf("标记充值订单失败出错: %v, ref: %s", err, referenceId)
-		return
+		return nil
 	}
 	log.Printf("充值订单已标记为失败: %s", referenceId)
+	return nil
 }
 
 // fulfillOrder is the shared logic for crediting quota after payment is confirmed via Stripe API.
@@ -351,39 +357,38 @@ func fulfillOrder(sess *stripe.CheckoutSession, eventType stripe.EventType, refe
 	log.Printf("收到款项(API验证)：%s, %.2f(%s)", referenceId, float64(sess.AmountTotal)/100, currency)
 }
 
-func sessionExpired(ctx context.Context, event stripe.Event) {
+func sessionExpired(ctx context.Context, event stripe.Event) error {
 	sessionId := event.GetObjectValue("id")
 	sess, err := retrieveAndVerifyCheckoutSession(ctx, sessionId)
 	if err != nil {
-		log.Printf("Stripe Checkout过期事件API验证失败: %v", err)
-		return
+		return fmt.Errorf("Stripe Checkout过期事件API验证失败: %w", err)
 	}
 
 	if sess.Status != stripe.CheckoutSessionStatusExpired {
 		log.Printf("Stripe API返回非过期状态: %s, session: %s", sess.Status, sessionId)
-		return
+		return nil
 	}
 
 	referenceId := sess.ClientReferenceID
 	if len(referenceId) == 0 {
 		log.Println("未提供支付单号")
-		return
+		return nil
 	}
 
 	// Subscription order expiration
 	LockOrder(referenceId)
 	defer UnlockOrder(referenceId)
 	if err := model.ExpireSubscriptionOrder(referenceId); err == nil {
-		return
+		return nil
 	} else if err != nil && !errors.Is(err, model.ErrSubscriptionOrderNotFound) {
 		log.Println("过期订阅订单失败", referenceId, ", err:", err.Error())
-		return
+		return nil
 	}
 
 	topUp := model.GetTopUpByTradeNo(referenceId)
 	if topUp == nil {
 		log.Println("充值订单不存在", referenceId)
-		return
+		return nil
 	}
 
 	if topUp.Status != common.TopUpStatusPending {
@@ -394,10 +399,11 @@ func sessionExpired(ctx context.Context, event stripe.Event) {
 	err = topUp.Update()
 	if err != nil {
 		log.Println("过期充值订单失败", referenceId, ", err:", err.Error())
-		return
+		return nil
 	}
 
 	log.Println("充值订单已过期", referenceId)
+	return nil
 }
 
 // genStripeLink generates a Stripe Checkout session URL for payment.

--- a/controller/topup_stripe.go
+++ b/controller/topup_stripe.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -170,15 +171,17 @@ func StripeWebhook(c *gin.Context) {
 		return
 	}
 
+	ctx := c.Request.Context()
+
 	switch event.Type {
 	case stripe.EventTypeCheckoutSessionCompleted:
-		sessionCompleted(event)
+		sessionCompleted(ctx, event)
 	case stripe.EventTypeCheckoutSessionExpired:
-		sessionExpired(event)
+		sessionExpired(ctx, event)
 	case stripe.EventTypeCheckoutSessionAsyncPaymentSucceeded:
-		sessionAsyncPaymentSucceeded(event)
+		sessionAsyncPaymentSucceeded(ctx, event)
 	case stripe.EventTypeCheckoutSessionAsyncPaymentFailed:
-		sessionAsyncPaymentFailed(event)
+		sessionAsyncPaymentFailed(ctx, event)
 	default:
 		log.Printf("不支持的Stripe Webhook事件类型: %s\n", event.Type)
 	}
@@ -188,7 +191,7 @@ func StripeWebhook(c *gin.Context) {
 
 // retrieveAndVerifyCheckoutSession calls the Stripe API to retrieve the authoritative
 // checkout session state, rather than trusting the webhook event payload alone.
-func retrieveAndVerifyCheckoutSession(sessionId string) (*stripe.CheckoutSession, error) {
+func retrieveAndVerifyCheckoutSession(ctx context.Context, sessionId string) (*stripe.CheckoutSession, error) {
 	if sessionId == "" {
 		return nil, fmt.Errorf("empty checkout session ID")
 	}
@@ -196,16 +199,22 @@ func retrieveAndVerifyCheckoutSession(sessionId string) (*stripe.CheckoutSession
 		return nil, fmt.Errorf("invalid Stripe API key configured")
 	}
 	stripe.Key = setting.StripeApiSecret
-	sess, err := session.Get(sessionId, nil)
+
+	apiCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	sess, err := session.Get(sessionId, &stripe.CheckoutSessionParams{
+		Params: stripe.Params{Context: apiCtx},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve checkout session %s from Stripe API: %w", sessionId, err)
 	}
 	return sess, nil
 }
 
-func sessionCompleted(event stripe.Event) {
+func sessionCompleted(ctx context.Context, event stripe.Event) {
 	sessionId := event.GetObjectValue("id")
-	sess, err := retrieveAndVerifyCheckoutSession(sessionId)
+	sess, err := retrieveAndVerifyCheckoutSession(ctx, sessionId)
 	if err != nil {
 		log.Printf("Stripe Checkout Session API验证失败: %v", err)
 		return
@@ -232,9 +241,9 @@ func sessionCompleted(event stripe.Event) {
 
 // sessionAsyncPaymentSucceeded handles delayed payment methods (bank transfer, SEPA, etc.)
 // that confirm payment after the checkout session completes.
-func sessionAsyncPaymentSucceeded(event stripe.Event) {
+func sessionAsyncPaymentSucceeded(ctx context.Context, event stripe.Event) {
 	sessionId := event.GetObjectValue("id")
-	sess, err := retrieveAndVerifyCheckoutSession(sessionId)
+	sess, err := retrieveAndVerifyCheckoutSession(ctx, sessionId)
 	if err != nil {
 		log.Printf("Stripe 异步支付成功事件API验证失败: %v", err)
 		return
@@ -257,9 +266,9 @@ func sessionAsyncPaymentSucceeded(event stripe.Event) {
 
 // sessionAsyncPaymentFailed marks orders as failed when delayed payment methods
 // ultimately fail (e.g. bank transfer not received, SEPA rejected).
-func sessionAsyncPaymentFailed(event stripe.Event) {
+func sessionAsyncPaymentFailed(ctx context.Context, event stripe.Event) {
 	sessionId := event.GetObjectValue("id")
-	sess, err := retrieveAndVerifyCheckoutSession(sessionId)
+	sess, err := retrieveAndVerifyCheckoutSession(ctx, sessionId)
 	if err != nil {
 		log.Printf("Stripe 异步支付失败事件API验证失败: %v", err)
 		return
@@ -342,9 +351,9 @@ func fulfillOrder(sess *stripe.CheckoutSession, eventType stripe.EventType, refe
 	log.Printf("收到款项(API验证)：%s, %.2f(%s)", referenceId, float64(sess.AmountTotal)/100, currency)
 }
 
-func sessionExpired(event stripe.Event) {
+func sessionExpired(ctx context.Context, event stripe.Event) {
 	sessionId := event.GetObjectValue("id")
-	sess, err := retrieveAndVerifyCheckoutSession(sessionId)
+	sess, err := retrieveAndVerifyCheckoutSession(ctx, sessionId)
 	if err != nil {
 		log.Printf("Stripe Checkout过期事件API验证失败: %v", err)
 		return

--- a/controller/topup_stripe.go
+++ b/controller/topup_stripe.go
@@ -313,8 +313,7 @@ func sessionAsyncPaymentFailed(ctx context.Context, event stripe.Event) error {
 
 	topUp.Status = common.TopUpStatusFailed
 	if err := topUp.Update(); err != nil {
-		log.Printf("标记充值订单失败出错: %v, ref: %s", err, referenceId)
-		return nil
+		return fmt.Errorf("标记充值订单失败出错, ref: %s: %w", referenceId, err)
 	}
 	log.Printf("充值订单已标记为失败: %s", referenceId)
 	return nil
@@ -342,7 +341,7 @@ func fulfillOrder(sess *stripe.CheckoutSession, eventType stripe.EventType, refe
 	}
 	if err := model.CompleteSubscriptionOrder(referenceId, common.GetJsonString(payload)); err == nil {
 		return
-	} else if err != nil && !errors.Is(err, model.ErrSubscriptionOrderNotFound) {
+	} else if !errors.Is(err, model.ErrSubscriptionOrderNotFound) {
 		log.Println("complete subscription order failed:", err.Error(), referenceId)
 		return
 	}
@@ -380,7 +379,7 @@ func sessionExpired(ctx context.Context, event stripe.Event) error {
 	defer UnlockOrder(referenceId)
 	if err := model.ExpireSubscriptionOrder(referenceId); err == nil {
 		return nil
-	} else if err != nil && !errors.Is(err, model.ErrSubscriptionOrderNotFound) {
+	} else if !errors.Is(err, model.ErrSubscriptionOrderNotFound) {
 		log.Println("过期订阅订单失败", referenceId, ", err:", err.Error())
 		return nil
 	}
@@ -398,8 +397,7 @@ func sessionExpired(ctx context.Context, event stripe.Event) error {
 	topUp.Status = common.TopUpStatusExpired
 	err = topUp.Update()
 	if err != nil {
-		log.Println("过期充值订单失败", referenceId, ", err:", err.Error())
-		return nil
+		return fmt.Errorf("过期充值订单失败, ref: %s: %w", referenceId, err)
 	}
 
 	log.Println("充值订单已过期", referenceId)


### PR DESCRIPTION
## 📝 变更描述 / Description
修改 Stripe 回调的处理逻辑，收到回调后，请求 Stripe API 验证回调内容，再执行后续逻辑。
通过向 Stripe API 请求真实状态，避免出现伪造回调、重放攻击、Secret 泄漏等风险。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)


## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
已通过 Stripe 正式环境手工测试。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment processing reliability by validating events against authoritative payment service records before fulfillment.
  * Strengthened validation to require confirmed payment status and a positive payment amount before completing orders.
  * Enhanced handling of failed and expired payment sessions to prevent erroneous order processing.
  * Webhook handlers now trigger automatic retries on transient errors and use time-bounded verification to avoid hangs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->