### PR TITLE
  Fix redemption code double-claim race

### DIFF
--- a/model/redemption.go
+++ b/model/redemption.go
@@ -127,7 +127,7 @@ func Redeem(key string, userId int) (quota int, err error) {
 	}
 	common.RandomSleep()
 	err = DB.Transaction(func(tx *gorm.DB) error {
-		err := tx.Set("gorm:query_option", "FOR UPDATE").Where(keyCol+" = ?", key).First(redemption).Error
+		err := tx.Where(keyCol+" = ?", key).First(redemption).Error
 		if err != nil {
 			return errors.New("无效的兑换码")
 		}
@@ -137,15 +137,30 @@ func Redeem(key string, userId int) (quota int, err error) {
 		if redemption.ExpiredTime != 0 && redemption.ExpiredTime < common.GetTimestamp() {
 			return errors.New("该兑换码已过期")
 		}
+		now := common.GetTimestamp()
+		claim := tx.Model(&Redemption{}).
+			Where("id = ? AND status = ?", redemption.Id, common.RedemptionCodeStatusEnabled).
+			Where("expired_time = 0 OR expired_time >= ?", now).
+			Updates(map[string]interface{}{
+				"redeemed_time": now,
+				"status":        common.RedemptionCodeStatusUsed,
+				"used_user_id":  userId,
+			})
+		if claim.Error != nil {
+			return claim.Error
+		}
+		if claim.RowsAffected != 1 {
+			return errors.New("redemption code already claimed")
+		}
+
 		err = tx.Model(&User{}).Where("id = ?", userId).Update("quota", gorm.Expr("quota + ?", redemption.Quota)).Error
 		if err != nil {
 			return err
 		}
-		redemption.RedeemedTime = common.GetTimestamp()
+		redemption.RedeemedTime = now
 		redemption.Status = common.RedemptionCodeStatusUsed
 		redemption.UsedUserId = userId
-		err = tx.Save(redemption).Error
-		return err
+		return nil
 	})
 	if err != nil {
 		common.SysError("redemption failed: " + err.Error())


### PR DESCRIPTION
修复兑换码并发兑换时可能重复增加余额的问题。

  原兑换流程先查询兑换码状态，再更新用户余额和兑换码状态。虽然代码尝试通过 `FOR UPDATE` 加锁，但当前 GORM 写法不能可靠生
  成行级锁；同时接口只按用户维度加锁，不同用户并发提交同一个兑换码时，仍可能同时通过状态检查。

  本次改动将兑换码使用过程改为条件更新认领：只有当兑换码仍处于可用状态且未过期时，才能先把它标记为已使用。只有认领成功的
  请求才会继续增加用户余额，从而避免同一个兑换码被并发重复使用。
## 🚀 变更类型 / Type of change

  - [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
  - [ ]  新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
  - [ ]  性能优化 / 重构 (Refactor)
  - [ ] 📝 文档更新 (Documentation)
  ##  提交前检查项 / Checklist

  - [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
  - [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://
  github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
  - [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接
  归类为 bug。
  - [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
  - [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
  - [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
  - [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of redemption code claiming process with enhanced state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->