### PR TITLE
feat(home): sync language and theme to custom homepage iframe on change

### DIFF
--- a/web/src/pages/Home/index.jsx
+++ b/web/src/pages/Home/index.jsx
@@ -142,6 +142,14 @@ const Home = () => {
   }, []);
 
   useEffect(() => {
+    if (!homePageContent || !homePageContent.startsWith('https://')) return;
+    const iframe = document.querySelector('iframe');
+    if (!iframe || !iframe.contentWindow) return;
+    iframe.contentWindow.postMessage({ lang: i18n.language }, '*');
+    iframe.contentWindow.postMessage({ themeMode: actualTheme }, '*');
+  }, [i18n.language, actualTheme, homePageContent]);
+
+  useEffect(() => {
     const timer = setInterval(() => {
       setEndpointIndex((prev) => (prev + 1) % endpointItems.length);
     }, 3000);


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

## 📝 变更描述 / Description

**问题**：当 `首页内容` 配置为 `https://...` URL（iframe 渲染分支）时，`Home/index.jsx` 仅在 `displayHomePageContent()` 拉取数据后通过 `iframe.onload` postMessage 一次 `{ lang, themeMode }`。后续用户切换语言/主题时没有任何 useEffect 监听 `i18n.language` / `actualTheme` 的变化重发，因此 iframe 内嵌页面在初始加载后**永远卡在初始的语言和主题上**，直到用户刷新整个页面。

**修复**：新增一个 useEffect，依赖 `[i18n.language, actualTheme, homePageContent]`，当 `homePageContent` 是 `https://` 开头时（仅 iframe 渲染分支），向 iframe 重新 postMessage 当前的 `lang` 和 `themeMode`。

**Why this works**：
- 复用现有的 `iframe.onload` 那次 postMessage 所约定的字段（`{ lang }`、`{ themeMode }`），未引入新协议
- 仅在 URL 分支触发；markdown/HTML 注入分支（`dangerouslySetInnerHTML`）走 early return，行为完全不变
- 8 行 useEffect，纯前端、无后端改动、无新依赖

---

**Problem**: When `home_page_content` is a `https://...` URL (iframe branch), the parent only posts `{ lang, themeMode }` to the iframe once, inside the `iframe.onload` callback fired on first load. Subsequent language or theme switches are silently dropped, so the embedded page is forever stuck on whatever was active at load time — until the user reloads the whole page.

**Fix**: Add a small useEffect that re-posts the current `lang` and `themeMode` to the iframe whenever `[i18n.language, actualTheme, homePageContent]` changes, gated on the URL branch.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
None — straightforward functional gap, not tracked in an issue.

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述。
- [x] **非重复提交:** 已搜索 Issues 与 PRs，未发现重复。
- [x] **Bug fix 说明:** 这是明确的功能缺陷（通信协议设计上发了首次但未发后续），非设计取舍。
- [x] **变更理解:** 改动仅 8 行，仅影响 iframe 渲染分支，markdown/HTML 注入分支不受影响。
- [x] **范围聚焦:** 仅修改 `web/src/pages/Home/index.jsx`，无其他文件改动。
- [x] **本地验证:** 已在生产环境（本人 fork 镜像）部署验证：切换右上角语言/主题，iframe 内自定义首页同步切换文案与主题。
- [x] **安全合规:** 无敏感凭据，无新依赖。

## 📸 运行证明 / Proof of Work

### 验证步骤
1. 后台 `首页内容` 字段填一个返回 HTML 的 https URL，且该 HTML 内监听 `window.addEventListener('message', e => { if (e.data.lang) ...; if (e.data.themeMode) ...; })`
2. 主站打开首页 → 右上角切换语言（中/英/日/...）
3. 切换主题（黑/白）

### 验证结果（本 fork 已上线）
- 修复前：iframe 内文案永远停在首次加载语言，需 F5 才能切换
- 修复后：切换语言 → iframe postMessage 收到 `{ lang: 'en' }` → iframe 内通过监听 message 同步切换文案；主题同理

### 改动 diff（8 行）
```jsx
useEffect(() => {
  if (!homePageContent || !homePageContent.startsWith('https://')) return;
  const iframe = document.querySelector('iframe');
  if (!iframe || !iframe.contentWindow) return;
  iframe.contentWindow.postMessage({ lang: i18n.language }, '*');
  iframe.contentWindow.postMessage({ themeMode: actualTheme }, '*');
}, [i18n.language, actualTheme, homePageContent]);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced synchronization of language and theme settings with embedded web content, ensuring embedded interfaces automatically update when these settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->