### PR TITLE
fix(claude): preserve `output_config` on OpenAI-compat path

### DIFF
--- a/dto/claude.go
+++ b/dto/claude.go
@@ -424,7 +424,9 @@ func (c *ClaudeRequest) GetEfforts() string {
 func MergeEffortIntoOutputConfig(existing json.RawMessage, effort string) json.RawMessage {
 	oc := map[string]any{}
 	if len(existing) > 0 {
-		_ = common.Unmarshal(existing, &oc)
+		if err := common.Unmarshal(existing, &oc); err != nil {
+			common.SysLog("MergeEffortIntoOutputConfig: existing output_config is not a JSON object, ignoring: " + err.Error())
+		}
 	}
 	oc["effort"] = effort
 	b, _ := common.Marshal(oc)

--- a/dto/claude.go
+++ b/dto/claude.go
@@ -421,6 +421,16 @@ func (c *ClaudeRequest) GetEfforts() string {
 	return ""
 }
 
+func MergeEffortIntoOutputConfig(existing json.RawMessage, effort string) json.RawMessage {
+	oc := map[string]any{}
+	if len(existing) > 0 {
+		_ = common.Unmarshal(existing, &oc)
+	}
+	oc["effort"] = effort
+	b, _ := common.Marshal(oc)
+	return b
+}
+
 // ProcessTools 处理工具列表，支持类型断言
 func ProcessTools(tools []any) ([]*Tool, []*ClaudeWebSearchTool) {
 	var normalTools []*Tool

--- a/dto/claude_output_config_test.go
+++ b/dto/claude_output_config_test.go
@@ -1,0 +1,47 @@
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeEffortIntoOutputConfig_NilExisting(t *testing.T) {
+	result := MergeEffortIntoOutputConfig(nil, "xhigh")
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(result, &m))
+	require.Equal(t, "xhigh", m["effort"])
+	require.Len(t, m, 1)
+}
+
+func TestMergeEffortIntoOutputConfig_PreservesTaskBudget(t *testing.T) {
+	existing := json.RawMessage(`{"task_budget":{"type":"tokens","total":50000}}`)
+	result := MergeEffortIntoOutputConfig(existing, "high")
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(result, &m))
+	require.Equal(t, "high", m["effort"])
+	tb, ok := m["task_budget"].(map[string]any)
+	require.True(t, ok, "task_budget should be preserved")
+	require.Equal(t, "tokens", tb["type"])
+	require.Equal(t, float64(50000), tb["total"])
+}
+
+func TestMergeEffortIntoOutputConfig_OverridesExistingEffort(t *testing.T) {
+	existing := json.RawMessage(`{"effort":"low","task_budget":{"type":"tokens","total":20000}}`)
+	result := MergeEffortIntoOutputConfig(existing, "xhigh")
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(result, &m))
+	require.Equal(t, "xhigh", m["effort"])
+	_, ok := m["task_budget"]
+	require.True(t, ok, "task_budget should be preserved after effort override")
+}
+
+func TestMergeEffortIntoOutputConfig_EmptyJSON(t *testing.T) {
+	existing := json.RawMessage(`{}`)
+	result := MergeEffortIntoOutputConfig(existing, "medium")
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(result, &m))
+	require.Equal(t, "medium", m["effort"])
+	require.Len(t, m, 1)
+}

--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -83,6 +83,7 @@ type GeneralOpenAIRequest struct {
 	//xai
 	SearchParameters json.RawMessage `json:"search_parameters,omitempty"`
 	// claude
+	OutputConfig     json.RawMessage   `json:"output_config,omitempty"`
 	WebSearchOptions *WebSearchOptions `json:"web_search_options,omitempty"`
 	// OpenRouter Params
 	Usage     json.RawMessage `json:"usage,omitempty"`

--- a/relay/channel/claude/adaptor.go
+++ b/relay/channel/claude/adaptor.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/relay/channel"
@@ -77,6 +78,21 @@ func CommonClaudeHeadersOperation(c *gin.Context, req *http.Header, info *relayc
 		req.Set("anthropic-beta", anthropicBeta)
 	}
 	model_setting.GetClaudeSettings().WriteHeaders(info.OriginModelName, req)
+}
+
+func EnsureBetaHeader(c *gin.Context, beta string) {
+	if c == nil {
+		return
+	}
+	existing := c.Request.Header.Get("anthropic-beta")
+	if strings.Contains(existing, beta) {
+		return
+	}
+	if existing != "" {
+		c.Request.Header.Set("anthropic-beta", existing+","+beta)
+	} else {
+		c.Request.Header.Set("anthropic-beta", beta)
+	}
 }
 
 func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *relaycommon.RelayInfo) error {

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -1,6 +1,7 @@
 package claude
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -435,6 +436,11 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 
 	claudeRequest.Prompt = ""
 	claudeRequest.Messages = claudeMessages
+
+	if bytes.Contains(claudeRequest.OutputConfig, []byte(`"task_budget"`)) {
+		EnsureBetaHeader(c, "task-budgets-2026-03-13")
+	}
+
 	return &claudeRequest, nil
 }
 

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -153,13 +153,17 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 		claudeRequest.MaxTokens = &defaultMaxTokens
 	}
 
+	if len(textRequest.OutputConfig) > 0 {
+		claudeRequest.OutputConfig = textRequest.OutputConfig
+	}
+
 	if baseModel, effortLevel, ok := reasoning.TrimEffortSuffix(textRequest.Model); ok && effortLevel != "" &&
 		(strings.HasPrefix(textRequest.Model, "claude-opus-4-6") || strings.HasPrefix(textRequest.Model, "claude-opus-4-7")) {
 		claudeRequest.Model = baseModel
 		claudeRequest.Thinking = &dto.Thinking{
 			Type: "adaptive",
 		}
-		claudeRequest.OutputConfig = json.RawMessage(fmt.Sprintf(`{"effort":"%s"}`, effortLevel))
+		claudeRequest.OutputConfig = dto.MergeEffortIntoOutputConfig(claudeRequest.OutputConfig, effortLevel)
 		if strings.HasPrefix(baseModel, "claude-opus-4-7") {
 			// Opus 4.7 rejects non-default temperature/top_p/top_k with 400
 			// and defaults display to "omitted"; restore the 4.6 visible summary.
@@ -178,7 +182,7 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 		if strings.HasPrefix(trimmedModel, "claude-opus-4-7") {
 			// Opus 4.7 rejects thinking.type="enabled"; use adaptive at high effort.
 			claudeRequest.Thinking = &dto.Thinking{Type: "adaptive", Display: "summarized"}
-			claudeRequest.OutputConfig = json.RawMessage(`{"effort":"high"}`)
+			claudeRequest.OutputConfig = dto.MergeEffortIntoOutputConfig(claudeRequest.OutputConfig, "high")
 			claudeRequest.Temperature = nil
 			claudeRequest.TopP = nil
 			claudeRequest.TopK = nil

--- a/relay/channel/claude/relay_claude_output_config_test.go
+++ b/relay/channel/claude/relay_claude_output_config_test.go
@@ -2,9 +2,12 @@ package claude
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/QuantumNous/new-api/dto"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,4 +70,52 @@ func TestOutputConfig_ThinkingSuffix47Merge(t *testing.T) {
 	require.Equal(t, "high", m["effort"], "thinking suffix should set effort=high for 4.7")
 	_, ok := m["task_budget"]
 	require.True(t, ok, "task_budget should survive thinking merge")
+}
+
+func TestEnsureBetaHeader_InjectsWhenTaskBudgetPresent(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = &http.Request{Header: http.Header{}}
+
+	req := dto.GeneralOpenAIRequest{
+		Model:        "claude-opus-4-7",
+		Messages:     []dto.Message{{Role: "user", Content: "hi"}},
+		OutputConfig: json.RawMessage(`{"task_budget":{"type":"tokens","total":50000}}`),
+	}
+	_, err := RequestOpenAI2ClaudeMessage(c, req)
+	require.NoError(t, err)
+	require.Contains(t, c.Request.Header.Get("anthropic-beta"), "task-budgets-2026-03-13")
+}
+
+func TestEnsureBetaHeader_NoInjectWithoutTaskBudget(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = &http.Request{Header: http.Header{}}
+
+	req := dto.GeneralOpenAIRequest{
+		Model:        "claude-opus-4-7",
+		Messages:     []dto.Message{{Role: "user", Content: "hi"}},
+		OutputConfig: json.RawMessage(`{"effort":"high"}`),
+	}
+	_, err := RequestOpenAI2ClaudeMessage(c, req)
+	require.NoError(t, err)
+	require.Empty(t, c.Request.Header.Get("anthropic-beta"))
+}
+
+func TestEnsureBetaHeader_AppendsToExisting(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = &http.Request{Header: http.Header{}}
+	c.Request.Header.Set("anthropic-beta", "some-other-beta-2025-01-01")
+
+	req := dto.GeneralOpenAIRequest{
+		Model:        "claude-opus-4-7",
+		Messages:     []dto.Message{{Role: "user", Content: "hi"}},
+		OutputConfig: json.RawMessage(`{"task_budget":{"type":"tokens","total":50000}}`),
+	}
+	_, err := RequestOpenAI2ClaudeMessage(c, req)
+	require.NoError(t, err)
+	beta := c.Request.Header.Get("anthropic-beta")
+	require.Contains(t, beta, "some-other-beta-2025-01-01")
+	require.Contains(t, beta, "task-budgets-2026-03-13")
 }

--- a/relay/channel/claude/relay_claude_output_config_test.go
+++ b/relay/channel/claude/relay_claude_output_config_test.go
@@ -1,0 +1,70 @@
+package claude
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutputConfig_BareModelPassthrough(t *testing.T) {
+	req := dto.GeneralOpenAIRequest{
+		Model:        "claude-opus-4-7",
+		Messages:     []dto.Message{{Role: "user", Content: "hi"}},
+		OutputConfig: json.RawMessage(`{"task_budget":{"type":"tokens","total":50000}}`),
+	}
+	cr, err := RequestOpenAI2ClaudeMessage(nil, req)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(cr.OutputConfig, &m))
+	tb, ok := m["task_budget"].(map[string]any)
+	require.True(t, ok, "task_budget should pass through on bare model")
+	require.Equal(t, "tokens", tb["type"])
+	require.Equal(t, float64(50000), tb["total"])
+}
+
+func TestOutputConfig_SuffixMergesEffort(t *testing.T) {
+	req := dto.GeneralOpenAIRequest{
+		Model:        "claude-opus-4-7-xhigh",
+		Messages:     []dto.Message{{Role: "user", Content: "hi"}},
+		OutputConfig: json.RawMessage(`{"task_budget":{"type":"tokens","total":50000}}`),
+	}
+	cr, err := RequestOpenAI2ClaudeMessage(nil, req)
+	require.NoError(t, err)
+	require.Equal(t, "claude-opus-4-7", cr.Model, "suffix should be stripped")
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(cr.OutputConfig, &m))
+	require.Equal(t, "xhigh", m["effort"], "effort should be set from suffix")
+	tb, ok := m["task_budget"].(map[string]any)
+	require.True(t, ok, "task_budget should survive suffix merge")
+	require.Equal(t, float64(50000), tb["total"])
+}
+
+func TestOutputConfig_SuffixNoOutputConfig(t *testing.T) {
+	req := dto.GeneralOpenAIRequest{
+		Model:    "claude-opus-4-6-high",
+		Messages: []dto.Message{{Role: "user", Content: "hi"}},
+	}
+	cr, err := RequestOpenAI2ClaudeMessage(nil, req)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(cr.OutputConfig, &m))
+	require.Equal(t, "high", m["effort"])
+	require.Len(t, m, 1, "only effort should be present when no user output_config")
+}
+
+func TestOutputConfig_ThinkingSuffix47Merge(t *testing.T) {
+	req := dto.GeneralOpenAIRequest{
+		Model:        "claude-opus-4-7-thinking",
+		Messages:     []dto.Message{{Role: "user", Content: "hi"}},
+		OutputConfig: json.RawMessage(`{"task_budget":{"type":"tokens","total":30000}}`),
+	}
+	cr, err := RequestOpenAI2ClaudeMessage(nil, req)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(cr.OutputConfig, &m))
+	require.Equal(t, "high", m["effort"], "thinking suffix should set effort=high for 4.7")
+	_, ok := m["task_budget"]
+	require.True(t, ok, "task_budget should survive thinking merge")
+}

--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
-	"github.com/QuantumNous/new-api/relay/channel/claude"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/service"
@@ -101,10 +100,6 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 			request.Model = strings.TrimSuffix(request.Model, "-thinking")
 		}
 		info.UpstreamModelName = request.Model
-	}
-
-	if bytes.Contains(request.OutputConfig, []byte(`"task_budget"`)) {
-		claude.EnsureBetaHeader(c, "task-budgets-2026-03-13")
 	}
 
 	if info.ChannelSetting.SystemPrompt != "" {

--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -2,7 +2,6 @@ package relay
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -58,7 +57,7 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 		request.Thinking = &dto.Thinking{
 			Type: "adaptive",
 		}
-		request.OutputConfig = json.RawMessage(fmt.Sprintf(`{"effort":"%s"}`, effortLevel))
+		request.OutputConfig = dto.MergeEffortIntoOutputConfig(request.OutputConfig, effortLevel)
 		if strings.HasPrefix(request.Model, "claude-opus-4-7") {
 			// Opus 4.7 rejects non-default temperature/top_p/top_k with 400
 			// and defaults display to "omitted"; restore the 4.6 visible summary.
@@ -77,7 +76,7 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 			if strings.HasPrefix(baseModel, "claude-opus-4-7") {
 				// Opus 4.7 rejects thinking.type="enabled"; use adaptive at high effort.
 				request.Thinking = &dto.Thinking{Type: "adaptive", Display: "summarized"}
-				request.OutputConfig = json.RawMessage(`{"effort":"high"}`)
+				request.OutputConfig = dto.MergeEffortIntoOutputConfig(request.OutputConfig, "high")
 				request.Temperature = nil
 				request.TopP = nil
 				request.TopK = nil

--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/relay/channel/claude"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/service"
@@ -100,6 +101,10 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 			request.Model = strings.TrimSuffix(request.Model, "-thinking")
 		}
 		info.UpstreamModelName = request.Model
+	}
+
+	if bytes.Contains(request.OutputConfig, []byte(`"task_budget"`)) {
+		claude.EnsureBetaHeader(c, "task-budgets-2026-03-13")
 	}
 
 	if info.ChannelSetting.SystemPrompt != "" {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

修复 OpenAI 兼容端点 `/v1/chat/completions` 调用 Claude 模型时，`output_config` 字段（`task_budget`）被静默丢弃的问题。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #4317
- 
## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

  ```bash
  curl -X POST http://localhost:13001/v1/chat/completions \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer sk-****" \
    -H "anthropic-beta: task-budgets-2026-03-13" \
    -d '{"model":"claude-opus-4-7","max_tokens":128,"messages":[{"role":"user","content":"reply with single letter
  A"}],"output_config":{"effort":"high","task_budget":{"type":"tokens","total":20000}}}'
  ```

  ```json
  {"id":"msg_01PhJUfX283EfZMik1Ei4GFb","model":"claude-opus-4-7","object":"chat.completion","created":1776451877,"choices":[{"index":0,"message":{"role":"assistant","content":"A
  "},"finish_reason":"stop"}],"usage":{"prompt_tokens":54,"completion_tokens":5,"total_tokens":59}}
  HTTP_STATUS: 200
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude requests accept an output configuration that preserves user task-budget settings while allowing effort levels to be applied across model variants and suffixes.
  * HTTP request handling will append the appropriate beta flag when task-budget settings are present.

* **Bug Fixes**
  * Preserve existing output configuration when applying effort instead of overwriting it.

* **Tests**
  * Added tests covering output-config merging, effort handling for model suffixes, and header behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->