### PR TITLE
fix: default Anthropic channel test to /v1/messages endpoint

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -53,6 +53,9 @@ func normalizeChannelTestEndpoint(channel *model.Channel, modelName, endpointTyp
 	if channel != nil && channel.Type == constant.ChannelTypeCodex {
 		return string(constant.EndpointTypeOpenAIResponse)
 	}
+	if channel != nil && channel.Type == constant.ChannelTypeAnthropic {
+		return string(constant.EndpointTypeAnthropic)
+	}
 	return normalized
 }
 


### PR DESCRIPTION
Fixes #4281

## Problem

When testing an Anthropic channel without specifying an `endpointType`, the channel test logic defaults to `/v1/chat/completions` instead of the correct Anthropic native path `/v1/messages`. This causes test requests to fail or behave incorrectly for Anthropic channels.

The root cause is in `normalizeChannelTestEndpoint` in `controller/channel-test.go`: it handles special cases for Compact models and Codex channels, but has no fallback for Anthropic-type channels.

## Solution

Add a check in `normalizeChannelTestEndpoint` so that when the channel type is `ChannelTypeAnthropic` and no `endpointType` is explicitly given, the function returns `EndpointTypeAnthropic` which maps to `/v1/messages`.

```go
if channel != nil && channel.Type == constant.ChannelTypeAnthropic {
    return string(constant.EndpointTypeAnthropic)
}
```

This follows the same pattern already used for `ChannelTypeCodex` → `EndpointTypeOpenAIResponse`.

## Testing

- Create or edit a channel with type set to Anthropic Claude, leave `endpointType` unset.
- Run the channel test — the request now correctly goes to `/v1/messages` instead of `/v1/chat/completions`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed endpoint type detection for Anthropic channels during testing to ensure proper request routing and relay format configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->