### PR TITLE
fix: decrement used_quota when refunding async task quota

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -960,6 +960,16 @@ func UpdateUserUsedQuotaAndRequestCount(id int, quota int) {
 	updateUserUsedQuotaAndRequestCount(id, quota, 1)
 }
 
+// UpdateUserUsedQuota adjusts a user's used_quota without touching request_count.
+// Pass a negative quota to reduce used_quota on refunds.
+func UpdateUserUsedQuota(id int, quota int) {
+	if common.BatchUpdateEnabled {
+		addNewRecord(BatchUpdateTypeUsedQuota, id, quota)
+		return
+	}
+	updateUserUsedQuota(id, quota)
+}
+
 func updateUserUsedQuotaAndRequestCount(id int, quota int, count int) {
 	err := DB.Model(&User{}).Where("id = ?", id).Updates(
 		map[string]interface{}{

--- a/service/task_billing.go
+++ b/service/task_billing.go
@@ -164,7 +164,11 @@ func RefundTaskQuota(ctx context.Context, task *model.Task, reason string) {
 	// 2. 退还令牌额度
 	taskAdjustTokenQuota(ctx, task, -quota)
 
-	// 3. 记录日志
+	// 3. 减少已用额度统计
+	model.UpdateUserUsedQuota(task.UserId, -quota)
+	model.UpdateChannelUsedQuota(task.ChannelId, -quota)
+
+	// 4. 记录日志
 	other := taskBillingOther(task)
 	other["task_id"] = task.TaskID
 	other["reason"] = reason
@@ -226,6 +230,8 @@ func RecalculateTaskQuota(ctx context.Context, task *model.Task, actualQuota int
 	} else {
 		logType = model.LogTypeRefund
 		logQuota = -quotaDelta
+		model.UpdateUserUsedQuota(task.UserId, quotaDelta)
+		model.UpdateChannelUsedQuota(task.ChannelId, quotaDelta)
 	}
 	other := taskBillingOther(task)
 	other["task_id"] = task.TaskID


### PR DESCRIPTION
Fixes #4211

## Problem

When an async task fails (triggering `RefundTaskQuota`) or is over-charged (triggering `RecalculateTaskQuota` with a negative delta), the system correctly restores the user's remaining quota (wallet balance) but **does not decrement `used_quota`**. Since the frontend displays total quota as `remaining + used`, every refund inflates the total by the refunded amount.

Example from the issue:
- Start: remaining ¥10, used ¥0, total ¥10
- After pre-charge: remaining ¥7.74, used ¥2.26, total ¥10 ✅
- After task failure refund: remaining ¥10, used **¥2.26** (unchanged), total **¥12.26** ❌

Root causes in `service/task_billing.go`:
1. `RefundTaskQuota`: calls `taskAdjustFunding(-quota)` but never calls `UpdateUserUsedQuota` or `UpdateChannelUsedQuota`.
2. `RecalculateTaskQuota`: in the `quotaDelta > 0` (extra charge) branch it correctly calls `UpdateUserUsedQuotaAndRequestCount` + `UpdateChannelUsedQuota`, but the `quotaDelta < 0` (refund) branch had no such calls.

## Solution

- Add `model.UpdateUserUsedQuota(id, quota int)` — like `UpdateUserUsedQuotaAndRequestCount` but without incrementing `request_count`, suitable for refund adjustments.
- `RefundTaskQuota`: after restoring the wallet, call `model.UpdateUserUsedQuota(task.UserId, -quota)` and `model.UpdateChannelUsedQuota(task.ChannelId, -quota)`.
- `RecalculateTaskQuota` refund branch: call the same two functions with `quotaDelta` (which is negative).

## Testing

1. Set up a user with an initial balance (e.g., ¥10).
2. Trigger an async task that pre-charges (e.g., ¥2.26).
3. Let the task fail so `RefundTaskQuota` is called.
4. Verify: remaining = ¥10, used = ¥0, total = ¥10 (no inflation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced quota refund operations to properly track used quota at both user and channel levels.
  * Improved quota recalculation accuracy during refund scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->