### PR TITLE
fix(relay): sanitize Opus 4.7 params for bare model and reasoning_effort paths

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -203,6 +203,13 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 		}
 	}
 
+	// Opus 4.7 (bare, no effort/thinking suffix) rejects non-default temperature/top_p/top_k
+	if strings.HasPrefix(claudeRequest.Model, "claude-opus-4-7") {
+		claudeRequest.Temperature = nil
+		claudeRequest.TopP = nil
+		claudeRequest.TopK = nil
+	}
+
 	if textRequest.ReasoningEffort != "" {
 		switch textRequest.ReasoningEffort {
 		case "low":
@@ -236,6 +243,15 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 				Type:         "enabled",
 				BudgetTokens: &budgetTokens,
 			}
+		}
+	}
+
+	// Opus 4.7 rejects thinking.type="enabled"; convert to adaptive
+	if strings.HasPrefix(claudeRequest.Model, "claude-opus-4-7") && claudeRequest.Thinking != nil && claudeRequest.Thinking.Type == "enabled" {
+		claudeRequest.Thinking.Type = "adaptive"
+		claudeRequest.Thinking.BudgetTokens = nil
+		if claudeRequest.Thinking.Display == "" {
+			claudeRequest.Thinking.Display = "summarized"
 		}
 	}
 

--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -103,19 +103,17 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 		info.UpstreamModelName = request.Model
 	}
 
-	// Opus 4.7 (bare, no effort/thinking suffix) rejects non-default temperature/top_p/top_k
+	// Opus 4.7 rejects non-default temperature/top_p/top_k and thinking.type="enabled"
 	if strings.HasPrefix(request.Model, "claude-opus-4-7") {
 		request.Temperature = nil
 		request.TopP = nil
 		request.TopK = nil
-	}
-
-	// Opus 4.7 rejects thinking.type="enabled"; convert to adaptive
-	if strings.HasPrefix(request.Model, "claude-opus-4-7") && request.Thinking != nil && request.Thinking.Type == "enabled" {
-		request.Thinking.Type = "adaptive"
-		request.Thinking.BudgetTokens = nil
-		if request.Thinking.Display == "" {
-			request.Thinking.Display = "summarized"
+		if request.Thinking != nil && request.Thinking.Type == "enabled" {
+			request.Thinking.Type = "adaptive"
+			request.Thinking.BudgetTokens = nil
+			if request.Thinking.Display == "" {
+				request.Thinking.Display = "summarized"
+			}
 		}
 	}
 

--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -110,6 +110,15 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 		request.TopK = nil
 	}
 
+	// Opus 4.7 rejects thinking.type="enabled"; convert to adaptive
+	if strings.HasPrefix(request.Model, "claude-opus-4-7") && request.Thinking != nil && request.Thinking.Type == "enabled" {
+		request.Thinking.Type = "adaptive"
+		request.Thinking.BudgetTokens = nil
+		if request.Thinking.Display == "" {
+			request.Thinking.Display = "summarized"
+		}
+	}
+
 	if info.ChannelSetting.SystemPrompt != "" {
 		if request.System == nil {
 			request.SetStringSystem(info.ChannelSetting.SystemPrompt)

--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -103,6 +103,13 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 		info.UpstreamModelName = request.Model
 	}
 
+	// Opus 4.7 (bare, no effort/thinking suffix) rejects non-default temperature/top_p/top_k
+	if strings.HasPrefix(request.Model, "claude-opus-4-7") {
+		request.Temperature = nil
+		request.TopP = nil
+		request.TopK = nil
+	}
+
 	if info.ChannelSetting.SystemPrompt != "" {
 		if request.System == nil {
 			request.SetStringSystem(info.ChannelSetting.SystemPrompt)


### PR DESCRIPTION
## Summary

Follow-up to 47d7bca — two code paths were missed for Claude Opus 4.7 compatibility:

1. **Bare `claude-opus-4-7` (no effort/thinking suffix)**: client-supplied `temperature`/`top_p`/`top_k` are forwarded as-is to the Anthropic API, causing HTTP 400 "Improperly formed request". The existing effort-suffix and `-thinking` branches handle this correctly, but the bare model name falls through without sanitization.

2. **`reasoning_effort` / `reasoning` parameters**: these set `thinking.type="enabled"` which Opus 4.7 also rejects (only `"adaptive"` is accepted). This affects the OpenAI-compat relay path.

## Changes

- `relay/channel/claude/relay-claude.go`:
  - After effort/thinking branches, unconditionally clear `temperature`/`top_p`/`top_k` for any `claude-opus-4-7` prefix model
  - After `ReasoningEffort`/`Reasoning` branches, convert `thinking.type="enabled"` → `"adaptive"` (with `display="summarized"`) for Opus 4.7

- `relay/claude_handler.go`:
  - After effort/thinking branches, unconditionally clear `temperature`/`top_p`/`top_k` for any `claude-opus-4-7` prefix model

## Test plan
- [ ] Send request to bare `claude-opus-4-7` with `temperature: 0.7` — should succeed (param stripped)
- [ ] Send request to `claude-opus-4-7` with `reasoning_effort: "high"` — thinking type should be `adaptive`, not `enabled`
- [ ] Send request to `claude-opus-4-7-high` — should still work as before (no regression)
- [ ] Send request to `claude-opus-4-6` — should still work as before (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured requests for the claude-opus-4-7 model are accepted by upstream by removing unsupported numeric tuning parameters.
  * Standardized advanced "thinking"/effort settings for that model by converting incompatible modes and applying sensible defaults to ensure consistent, non-rejected responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->