### PR TITLE
fix(minimax): use usage_characters as PromptTokens for TTS billing

### DIFF
--- a/relay/channel/minimax/tts.go
+++ b/relay/channel/minimax/tts.go
@@ -163,7 +163,7 @@ func handleTTSResponse(c *gin.Context, resp *http.Response, info *relaycommon.Re
 	}
 
 	usage = &dto.Usage{
-		PromptTokens:     info.GetEstimatePromptTokens(),
+		PromptTokens:     int(minimaxResp.ExtraInfo.UsageCharacters),
 		CompletionTokens: 0,
 		TotalTokens:      int(minimaxResp.ExtraInfo.UsageCharacters),
 	}


### PR DESCRIPTION
Bug 修复 (Bug fix)：
  描述：
  - MiniMax TTS 通过 `extra_info.usage_characters` 返回官方计费字符数（汉字算 2，其它算 1）
  - 原代码将该值放入 `TotalTokens`，但 `calculateTextQuotaSummary()` 会用 `PromptTokens + CompletionTokens` 覆盖
  `TotalTokens`，导致字符数被静默丢弃
  实际扣费基于：
  `GetEstimatePromptTokens()`（客户端文本估算），与官方字符计费存在显著偏差，中文场景尤为明显（每个汉字官方计 2 字符）
  - 此 fix 将 `UsageCharacters` 移入 `PromptTokens`，使其真正参与扣费计算
 
  影响范围：
  仅 `relay/channel/minimax/tts.go` 的 `handleTTSResponse`，仅在 `RelayMode == RelayModeAudioSpeech` 时调用。MiniMax
  对话、图像等其它模式不受影响。
  
  官方响应体示例：
    {
    "data": {
      "audio": "<hex编码的audio>",
      "status": 2
    },
    "extra_info": {
      "audio_length": 9900,
      "audio_sample_rate": 32000,
      "audio_size": 160323,
      "bitrate": 128000,
      "word_count": 52,
      "invisible_character_ratio": 0,
      "usage_characters": 26,
      "audio_format": "mp3",
      "audio_channel": 1
    },
    "trace_id": "01b8bf9bb7433cc75c18eee6cfa8fe21",
    "base_resp": {
      "status_code": 0,
      "status_msg": "success"
    }
  }

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of token usage reporting for text-to-speech requests by calculating prompt tokens from actual response data instead of precomputed estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->