### PR TITLE
fix(user): block registration when inviter is banned

### DIFF
--- a/controller/oauth.go
+++ b/controller/oauth.go
@@ -266,7 +266,11 @@ func findOrCreateOAuthUser(c *gin.Context, provider oauth.Provider, oauthUser *o
 	affCode := session.Get("aff")
 	inviterId := 0
 	if affCode != nil {
-		inviterId, _ = model.GetUserIdByAffCode(affCode.(string))
+		var affErr error
+		inviterId, affErr = model.GetUserIdByAffCode(affCode.(string))
+		if affErr != nil {
+			return nil, affErr
+		}
 	}
 
 	// Use transaction to ensure user creation and OAuth binding are atomic

--- a/controller/user.go
+++ b/controller/user.go
@@ -173,7 +173,11 @@ func Register(c *gin.Context) {
 		return
 	}
 	affCode := user.AffCode // this code is the inviter's code, not the user's own code
-	inviterId, _ := model.GetUserIdByAffCode(affCode)
+	inviterId, err := model.GetUserIdByAffCode(affCode)
+	if affCode != "" && err != nil {
+		common.ApiError(c, err)
+		return
+	}
 	cleanUser := model.User{
 		Username:    user.Username,
 		Password:    user.Password,

--- a/model/user.go
+++ b/model/user.go
@@ -308,8 +308,14 @@ func GetUserIdByAffCode(affCode string) (int, error) {
 		return 0, errors.New("affCode 为空！")
 	}
 	var user User
-	err := DB.Select("id").First(&user, "aff_code = ?", affCode).Error
-	return user.Id, err
+	err := DB.Select("id, status").First(&user, "aff_code = ?", affCode).Error
+	if err != nil {
+		return 0, err
+	}
+	if user.Status != common.UserStatusEnabled {
+		return 0, errors.New("邀请码无效")
+	}
+	return user.Id, nil
 }
 
 func DeleteUserById(id int) (err error) {


### PR DESCRIPTION
Validate inviter status in GetUserIdByAffCode — if the inviter's account is disabled, return an error instead of silently ignoring the invite code. Both password and OAuth registration paths now reject the request with an error when a banned user's invite code is used.

## 📝 Description

A banned user's invite code should no longer be accepted during registration.
Previously, `GetUserIdByAffCode` only matched by `aff_code` without checking
the inviter's account status, allowing banned accounts to keep accumulating
invite bonuses through bulk-registered users.

The fix adds a status check in `GetUserIdByAffCode`: if the matched user is
not `UserStatusEnabled`, an error is returned. Both the password registration
path (`controller/user.go`) and the OAuth registration path
(`controller/oauth.go`) now propagate this error and reject the request
outright, rather than silently falling back to "no inviter".

The check is placed at the model layer so both registration paths are covered
without duplicating logic.

## 🚀 Type of change
- [x] ✨ New feature

## ✅ Checklist
- [x] I have personally written and reviewed this description.
- [x] Searched existing Issues and PRs — no duplicates found.
- [x] I understand how these changes work and their potential impact.
- [x] No unrelated changes included.
- [x] Built locally and manually verified that registration with a banned user's invite code returns an error.
- [x] No credentials exposed; follows project coding conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved affiliate code validation and error handling during user registration and OAuth authentication. The system now properly validates referral codes and reports invalid or unusable codes instead of proceeding silently with default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->