### PR TITLE
feat(ratio-sync): add create_cache_ratio support for upstream sync

### DIFF
--- a/controller/ratio_sync.go
+++ b/controller/ratio_sync.go
@@ -821,11 +821,12 @@ func cacheFieldCount(c modelsDevCandidate) int {
 
 // convertModelsDevToRatioData parses models.dev /api.json and converts
 // provider pricing metadata into local ratio format.
-// models.dev costs are USD per 1M tokens:
+// models.dev costs are USD per 1M tokens. Four ratios may be emitted:
 //
-//	model_ratio = input_cost_per_1M / 2
-//	completion_ratio = output_cost / input_cost
-//	cache_ratio = cache_read_cost / input_cost
+//	model_ratio        = input_cost_per_1M / 2
+//	completion_ratio   = output_cost / input_cost
+//	cache_ratio        = cache_read_cost / input_cost
+//	create_cache_ratio = cache_write_cost / input_cost
 //
 // Duplicate model keys across providers are resolved by selecting the
 // cheapest non-zero input cost. If only zero-priced candidates exist,

--- a/controller/ratio_sync.go
+++ b/controller/ratio_sync.go
@@ -59,7 +59,7 @@ func valuesEqual(a, b interface{}) bool {
 	return a == b
 }
 
-var ratioTypes = []string{"model_ratio", "completion_ratio", "cache_ratio", "model_price"}
+var ratioTypes = []string{"model_ratio", "completion_ratio", "cache_ratio", "create_cache_ratio", "model_price"}
 
 type upstreamResult struct {
 	Name string         `json:"name"`
@@ -611,9 +611,10 @@ func convertOpenRouterToRatioData(reader io.Reader) (map[string]any, error) {
 		Data []struct {
 			ID      string `json:"id"`
 			Pricing struct {
-				Prompt         string `json:"prompt"`
-				Completion     string `json:"completion"`
-				InputCacheRead string `json:"input_cache_read"`
+				Prompt          string `json:"prompt"`
+				Completion      string `json:"completion"`
+				InputCacheRead  string `json:"input_cache_read"`
+				InputCacheWrite string `json:"input_cache_write"`
 			} `json:"pricing"`
 		} `json:"data"`
 	}
@@ -625,6 +626,7 @@ func convertOpenRouterToRatioData(reader io.Reader) (map[string]any, error) {
 	modelRatioMap := make(map[string]any)
 	completionRatioMap := make(map[string]any)
 	cacheRatioMap := make(map[string]any)
+	createCacheRatioMap := make(map[string]any)
 
 	for _, m := range orResp.Data {
 		promptPrice, promptErr := strconv.ParseFloat(m.Pricing.Prompt, 64)
@@ -675,6 +677,15 @@ func convertOpenRouterToRatioData(reader io.Reader) (map[string]any, error) {
 				cacheRatioMap[m.ID] = cacheRatio
 			}
 		}
+
+		// Convert input_cache_write to create_cache_ratio (= cache_write_price / prompt_price)
+		if m.Pricing.InputCacheWrite != "" {
+			if cacheWritePrice, err := strconv.ParseFloat(m.Pricing.InputCacheWrite, 64); err == nil && cacheWritePrice >= 0 {
+				createCacheRatio := cacheWritePrice / promptPrice
+				createCacheRatio = roundRatioValue(createCacheRatio)
+				createCacheRatioMap[m.ID] = createCacheRatio
+			}
+		}
 	}
 
 	converted := make(map[string]any)
@@ -686,6 +697,9 @@ func convertOpenRouterToRatioData(reader io.Reader) (map[string]any, error) {
 	}
 	if len(cacheRatioMap) > 0 {
 		converted["cache_ratio"] = cacheRatioMap
+	}
+	if len(createCacheRatioMap) > 0 {
+		converted["create_cache_ratio"] = createCacheRatioMap
 	}
 
 	return converted, nil
@@ -700,16 +714,18 @@ type modelsDevModel struct {
 }
 
 type modelsDevCost struct {
-	Input     *float64 `json:"input"`
-	Output    *float64 `json:"output"`
-	CacheRead *float64 `json:"cache_read"`
+	Input      *float64 `json:"input"`
+	Output     *float64 `json:"output"`
+	CacheRead  *float64 `json:"cache_read"`
+	CacheWrite *float64 `json:"cache_write"`
 }
 
 type modelsDevCandidate struct {
-	Provider  string
-	Input     float64
-	Output    *float64
-	CacheRead *float64
+	Provider   string
+	Input      float64
+	Output     *float64
+	CacheRead  *float64
+	CacheWrite *float64
 }
 
 func cloneFloatPtr(v *float64) *float64 {
@@ -755,11 +771,17 @@ func buildModelsDevCandidate(provider string, cost modelsDevCost) (modelsDevCand
 		cacheRead = cloneFloatPtr(cost.CacheRead)
 	}
 
+	var cacheWrite *float64
+	if cost.CacheWrite != nil && isValidNonNegativeCost(*cost.CacheWrite) {
+		cacheWrite = cloneFloatPtr(cost.CacheWrite)
+	}
+
 	return modelsDevCandidate{
-		Provider:  provider,
-		Input:     input,
-		Output:    output,
-		CacheRead: cacheRead,
+		Provider:   provider,
+		Input:      input,
+		Output:     output,
+		CacheRead:  cacheRead,
+		CacheWrite: cacheWrite,
 	}, true
 }
 
@@ -773,8 +795,28 @@ func shouldReplaceModelsDevCandidate(current, next modelsDevCandidate) bool {
 	if nextNonZero && !nearlyEqual(next.Input, current.Input) {
 		return next.Input < current.Input
 	}
+	// At equal input price, prefer richer cache metadata. Resellers that
+	// mirror list prices (e.g. 302ai for Claude) often sort lexicographically
+	// first but omit cache_read/cache_write; preferring candidates with more
+	// cache fields keeps authoritative values like Anthropic's cache_write.
+	currentCacheFields := cacheFieldCount(current)
+	nextCacheFields := cacheFieldCount(next)
+	if nextCacheFields != currentCacheFields {
+		return nextCacheFields > currentCacheFields
+	}
 	// Stable tie-breaker for deterministic result.
 	return next.Provider < current.Provider
+}
+
+func cacheFieldCount(c modelsDevCandidate) int {
+	count := 0
+	if c.CacheRead != nil {
+		count++
+	}
+	if c.CacheWrite != nil {
+		count++
+	}
+	return count
 }
 
 // convertModelsDevToRatioData parses models.dev /api.json and converts
@@ -835,6 +877,7 @@ func convertModelsDevToRatioData(reader io.Reader) (map[string]any, error) {
 	modelRatioMap := make(map[string]any)
 	completionRatioMap := make(map[string]any)
 	cacheRatioMap := make(map[string]any)
+	createCacheRatioMap := make(map[string]any)
 
 	for modelName, candidate := range selectedCandidates {
 		if candidate.Input == 0 {
@@ -854,6 +897,11 @@ func convertModelsDevToRatioData(reader io.Reader) (map[string]any, error) {
 			cacheRatio := *candidate.CacheRead / candidate.Input
 			cacheRatioMap[modelName] = roundRatioValue(cacheRatio)
 		}
+
+		if candidate.CacheWrite != nil {
+			createCacheRatio := *candidate.CacheWrite / candidate.Input
+			createCacheRatioMap[modelName] = roundRatioValue(createCacheRatio)
+		}
 	}
 
 	converted := make(map[string]any)
@@ -865,6 +913,9 @@ func convertModelsDevToRatioData(reader io.Reader) (map[string]any, error) {
 	}
 	if len(cacheRatioMap) > 0 {
 		converted["cache_ratio"] = cacheRatioMap
+	}
+	if len(createCacheRatioMap) > 0 {
+		converted["create_cache_ratio"] = createCacheRatioMap
 	}
 	return converted, nil
 }

--- a/web/src/pages/Setting/Ratio/UpstreamRatioSync.jsx
+++ b/web/src/pages/Setting/Ratio/UpstreamRatioSync.jsx
@@ -293,6 +293,7 @@ export default function UpstreamRatioSync(props) {
       ModelRatio: JSON.parse(props.options.ModelRatio || '{}'),
       CompletionRatio: JSON.parse(props.options.CompletionRatio || '{}'),
       CacheRatio: JSON.parse(props.options.CacheRatio || '{}'),
+      CreateCacheRatio: JSON.parse(props.options.CreateCacheRatio || '{}'),
       ModelPrice: JSON.parse(props.options.ModelPrice || '{}'),
     };
 
@@ -303,7 +304,8 @@ export default function UpstreamRatioSync(props) {
       if (
         currentRatios.ModelRatio[model] !== undefined ||
         currentRatios.CompletionRatio[model] !== undefined ||
-        currentRatios.CacheRatio[model] !== undefined
+        currentRatios.CacheRatio[model] !== undefined ||
+        currentRatios.CreateCacheRatio[model] !== undefined
       )
         return 'ratio';
       return null;
@@ -366,6 +368,7 @@ export default function UpstreamRatioSync(props) {
         ModelRatio: { ...currentRatios.ModelRatio },
         CompletionRatio: { ...currentRatios.CompletionRatio },
         CacheRatio: { ...currentRatios.CacheRatio },
+        CreateCacheRatio: { ...currentRatios.CreateCacheRatio },
         ModelPrice: { ...currentRatios.ModelPrice },
       };
 
@@ -378,6 +381,7 @@ export default function UpstreamRatioSync(props) {
           delete finalRatios.ModelRatio[model];
           delete finalRatios.CompletionRatio[model];
           delete finalRatios.CacheRatio[model];
+          delete finalRatios.CreateCacheRatio[model];
         }
         if (hasRatio) {
           delete finalRatios.ModelPrice[model];
@@ -500,6 +504,9 @@ export default function UpstreamRatioSync(props) {
                 {t('补全倍率')}
               </Select.Option>
               <Select.Option value='cache_ratio'>{t('缓存倍率')}</Select.Option>
+              <Select.Option value='create_cache_ratio'>
+                {t('缓存创建倍率')}
+              </Select.Option>
               <Select.Option value='model_price'>{t('固定价格')}</Select.Option>
             </Select>
           </div>
@@ -518,6 +525,7 @@ export default function UpstreamRatioSync(props) {
           'model_ratio',
           'completion_ratio',
           'cache_ratio',
+          'create_cache_ratio',
         ].some((rt) => rt in ratioTypes);
         const billingConflict = hasPrice && hasOtherRatio;
 
@@ -597,6 +605,7 @@ export default function UpstreamRatioSync(props) {
             model_ratio: t('模型倍率'),
             completion_ratio: t('补全倍率'),
             cache_ratio: t('缓存倍率'),
+            create_cache_ratio: t('缓存创建倍率'),
             model_price: t('固定价格'),
           };
           const baseTag = (
@@ -880,6 +889,9 @@ export default function UpstreamRatioSync(props) {
             ModelRatio: JSON.parse(props.options.ModelRatio || '{}'),
             CompletionRatio: JSON.parse(props.options.CompletionRatio || '{}'),
             CacheRatio: JSON.parse(props.options.CacheRatio || '{}'),
+            CreateCacheRatio: JSON.parse(
+              props.options.CreateCacheRatio || '{}',
+            ),
             ModelPrice: JSON.parse(props.options.ModelPrice || '{}'),
           };
           await performSync(curRatios);


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
本次 PR 为上游倍率同步功能增加了对 **create_cache_ratio（缓存创建倍率）** 的支持。

**变更内容：**
1. **后端 (controller/ratio_sync.go)**：
   - 将 `create_cache_ratio` 添加到支持的 ratioTypes 列表中
   - 针对 OpenRouter 数据源：解析 `InputCacheWrite` 定价字段，转换为 create_cache_ratio
   - 针对 models.dev 数据源：新增 `CacheWrite` 字段到 cost/candidate 结构体，在价格候选者选择时优先选择包含更完整缓存元数据的候选者
   - 为两个上游数据源添加 createCacheRatioMap 转换逻辑

2. **前端 (web/src/pages/Setting/Ratio/UpstreamRatioSync.jsx)**：
   - 在同步逻辑中处理 CreateCacheRatio 字段
   - 在 UI 选择器中新增 "缓存创建倍率" 选项
   - 在模型冲突检测和清理逻辑中包含 CreateCacheRatio

**技术实现说明：**
- 缓存创建倍率的计算逻辑与其他倍率一致：`cache_write_price / prompt_price`
- models.dev 候选者选择算法现在会优先考虑包含 cache_read 和 cache_write 元数据的候选者（优先于仅包含基础价格的候选者），以确保获取权威的缓存定价数据

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes https://github.com/QuantumNous/new-api/issues/2679

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)

- new-api
<img width="1835" height="447" alt="c1ed49bf-024b-4e34-941a-be47893c198d" src="https://github.com/user-attachments/assets/31838efa-5f59-4077-930e-356e9d262b2f" />
- models.dev
<img width="1780" height="774" alt="dda01a1d-4995-4c11-b58c-2625a417c174" src="https://github.com/user-attachments/assets/5ed7253e-04d7-4fc6-a6ed-86dd9c1090f8" />
- OpenRouter
<img width="1875" height="754" alt="fcb4a82d9bb77206777d454775fad61e" src="https://github.com/user-attachments/assets/b3704585-255f-4622-b2f8-e26b82b3cc23" />

#### 备注：新版前端合并后需要移植


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cache creation ratio configuration in upstream ratio sync settings
  * Enhanced upstream provider integration to process cache write pricing information
  * Improved model candidate selection logic with better tie-breaking based on cache metadata availability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->