### PR TITLE
refactor: UpdateOption to validate in-memory before persisting to the…

### DIFF
--- a/model/option.go
+++ b/model/option.go
@@ -207,7 +207,12 @@ func SyncOptions(frequency int) {
 }
 
 func UpdateOption(key string, value string) error {
-	// Save to database first
+	// Validate in-memory first so we never persist an invalid value to the DB.
+	if err := updateOptionMap(key, value); err != nil {
+		return err
+	}
+
+	// Save to database only after successful in-memory update.
 	option := Option{
 		Key: key,
 	}
@@ -218,14 +223,18 @@ func UpdateOption(key string, value string) error {
 	// If save value does not contain primary key, it will execute Create,
 	// otherwise it will execute Update (with all fields).
 	DB.Save(&option)
-	// Update OptionMap
-	return updateOptionMap(key, value)
+
+	return nil
 }
 
 func updateOptionMap(key string, value string) (err error) {
 	common.OptionMapRWMutex.Lock()
-	defer common.OptionMapRWMutex.Unlock()
-	common.OptionMap[key] = value
+	defer func() {
+		if err == nil {
+			common.OptionMap[key] = value
+		}
+		common.OptionMapRWMutex.Unlock()
+	}()
 
 	// 检查是否是模型配置 - 使用更规范的方式处理
 	if handleConfigUpdate(key, value) {


### PR DESCRIPTION
## 📝 变更描述 / Description
UpdateOption 原本先将值写入数据库，再调用 updateOptionMap 做内存校验。若校验失败，数据库中已落地了无效值，导致内存与数据库状态不一致。

本次调整将顺序反转：先执行 updateOptionMap 做校验，通过后才持久化到数据库。同时，内存中 OptionMap 的赋值也改为仅在校验无误（err == nil）时才执行，避免中间状态污染。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [x] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of option updates by validating settings before persisting to the database, ensuring errors are caught and handled before any changes are committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->