### PR TITLE
feat(playground): 增加图片预览并支持按分组过滤模型

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -525,11 +525,21 @@ func GetUserModels(c *gin.Context) {
 		return
 	}
 	groups := service.GetUserUsableGroups(user.Group)
+	requestedGroup := strings.TrimSpace(c.Query("group"))
 	var models []string
-	for group := range groups {
-		for _, g := range model.GetGroupEnabledModels(group) {
-			if !common.StringsContains(models, g) {
-				models = append(models, g)
+
+	if requestedGroup != "" {
+		if _, ok := groups[requestedGroup]; ok {
+			models = model.GetGroupEnabledModels(requestedGroup)
+		}
+	}
+
+	if len(models) == 0 {
+		for group := range groups {
+			for _, g := range model.GetGroupEnabledModels(group) {
+				if !common.StringsContains(models, g) {
+					models = append(models, g)
+				}
 			}
 		}
 	}

--- a/web/src/components/playground/MessageContent.jsx
+++ b/web/src/components/playground/MessageContent.jsx
@@ -17,11 +17,22 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 
-import React, { useRef, useEffect } from 'react';
-import { Typography, TextArea, Button } from '@douyinfe/semi-ui';
+import React, { useRef, useEffect, useState } from 'react';
+import { Typography, TextArea, Button, Modal } from '@douyinfe/semi-ui';
 import MarkdownRenderer from '../common/markdown/MarkdownRenderer';
 import ThinkingContent from './ThinkingContent';
-import { Loader2, Check, X, Settings, AlertTriangle } from 'lucide-react';
+import {
+  Loader2,
+  Check,
+  X,
+  Settings,
+  AlertTriangle,
+  ZoomIn,
+  Download,
+  Plus,
+  Minus,
+  RotateCcw,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { isAdmin } from '../../helpers/utils';
 
@@ -39,9 +50,23 @@ const MessageContent = ({
   const { t } = useTranslation();
   const previousContentLengthRef = useRef(0);
   const lastContentRef = useRef('');
+  const previewContainerRef = useRef(null);
+  const previewPanStateRef = useRef({
+    pointerId: null,
+    startX: 0,
+    startY: 0,
+    scrollLeft: 0,
+    scrollTop: 0,
+  });
+  const [previewImageUrl, setPreviewImageUrl] = useState('');
+  const [previewScale, setPreviewScale] = useState(1);
+  const [isPreviewPanning, setIsPreviewPanning] = useState(false);
 
   const isThinkingStatus =
     message.status === 'loading' || message.status === 'incomplete';
+  const hasImageContent =
+    Array.isArray(message.content) &&
+    message.content.some((item) => item.type === 'image_url');
 
   useEffect(() => {
     if (!isThinkingStatus) {
@@ -49,6 +74,85 @@ const MessageContent = ({
       lastContentRef.current = '';
     }
   }, [isThinkingStatus]);
+
+  useEffect(() => {
+    if (previewImageUrl) {
+      setPreviewScale(1);
+      setIsPreviewPanning(false);
+      if (previewContainerRef.current) {
+        previewContainerRef.current.scrollTo({ left: 0, top: 0 });
+      }
+    }
+  }, [previewImageUrl]);
+
+  const clampScale = (scale) => Math.min(6, Math.max(0.5, scale));
+
+  const handlePreviewZoom = (delta) => {
+    setPreviewScale((prev) => clampScale(Number((prev + delta).toFixed(2))));
+  };
+
+  const handlePreviewWheel = (event) => {
+    event.preventDefault();
+    const delta = event.deltaY < 0 ? 0.2 : -0.2;
+    setPreviewScale((prev) => clampScale(Number((prev + delta).toFixed(2))));
+  };
+
+  const handlePreviewDownload = () => {
+    if (!previewImageUrl) return;
+
+    const link = document.createElement('a');
+    link.href = previewImageUrl;
+    link.download = `playground-image-${Date.now()}.png`;
+    link.rel = 'noopener';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  const stopPreviewPanning = () => {
+    setIsPreviewPanning(false);
+    previewPanStateRef.current.pointerId = null;
+  };
+
+  const handlePreviewPointerDown = (event) => {
+    if (previewScale <= 1 || !previewContainerRef.current) return;
+
+    previewPanStateRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      scrollLeft: previewContainerRef.current.scrollLeft,
+      scrollTop: previewContainerRef.current.scrollTop,
+    };
+    setIsPreviewPanning(true);
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    event.preventDefault();
+  };
+
+  const handlePreviewPointerMove = (event) => {
+    if (
+      !isPreviewPanning ||
+      previewPanStateRef.current.pointerId !== event.pointerId ||
+      !previewContainerRef.current
+    ) {
+      return;
+    }
+
+    const deltaX = event.clientX - previewPanStateRef.current.startX;
+    const deltaY = event.clientY - previewPanStateRef.current.startY;
+
+    previewContainerRef.current.scrollLeft =
+      previewPanStateRef.current.scrollLeft - deltaX;
+    previewContainerRef.current.scrollTop =
+      previewPanStateRef.current.scrollTop - deltaY;
+  };
+
+  const handlePreviewPointerUp = (event) => {
+    if (previewPanStateRef.current.pointerId !== event.pointerId) return;
+
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+    stopPreviewPanning();
+  };
 
   if (message.status === 'error') {
     let errorText;
@@ -207,6 +311,7 @@ const MessageContent = ({
   if (
     message.role === 'assistant' &&
     isThinkingStatus &&
+    !hasImageContent &&
     !finalExtractedThinkingContent &&
     (!finalDisplayableFinalContent ||
       finalDisplayableFinalContent.trim() === '')
@@ -306,25 +411,49 @@ const MessageContent = ({
             return (
               <div>
                 {imageContents.length > 0 && (
-                  <div className='mb-3 space-y-2'>
+                  <div className='mb-3 flex flex-wrap gap-3'>
                     {imageContents.map((imgItem, index) => (
-                      <div key={index} className='max-w-sm'>
-                        <img
-                          src={imgItem.image_url.url}
-                          alt={`用户上传的图片 ${index + 1}`}
-                          className='rounded-lg max-w-full h-auto shadow-sm border'
-                          style={{ maxHeight: '300px' }}
-                          onError={(e) => {
-                            e.target.style.display = 'none';
-                            e.target.nextSibling.style.display = 'block';
-                          }}
-                        />
-                        <div
-                          className='text-red-500 text-sm p-2 bg-red-50 rounded-lg border border-red-200'
-                          style={{ display: 'none' }}
+                      <div
+                        key={index}
+                        className='group'
+                        style={{
+                          width: styleState.isMobile ? '132px' : '168px',
+                        }}
+                      >
+                        <button
+                          type='button'
+                          className='relative block w-full overflow-hidden rounded-xl border border-[var(--semi-color-border)] bg-[var(--semi-color-fill-0)] shadow-sm transition-all duration-200 hover:shadow-md hover:-translate-y-0.5'
+                          onClick={() => setPreviewImageUrl(imgItem.image_url.url)}
                         >
-                          图片加载失败: {imgItem.image_url.url}
-                        </div>
+                          <img
+                            src={imgItem.image_url.url}
+                            alt={`${t('图片预览')} ${index + 1}`}
+                            className='block w-full object-cover'
+                            style={{
+                              height: styleState.isMobile ? '132px' : '168px',
+                            }}
+                            onError={(e) => {
+                              e.target.style.display = 'none';
+                              e.target.nextSibling.style.display = 'flex';
+                            }}
+                          />
+                          <div
+                            className='hidden items-center justify-center text-red-500 text-xs p-3 bg-red-50'
+                            style={{
+                              height: styleState.isMobile ? '132px' : '168px',
+                            }}
+                          >
+                            {t('图片加载失败')}
+                          </div>
+                          <div className='pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-between bg-gradient-to-t from-black/70 via-black/20 to-transparent px-3 py-2 text-white opacity-100 sm:opacity-0 sm:transition-opacity sm:duration-200 sm:group-hover:opacity-100'>
+                            <Typography.Text
+                              className='!text-white !text-xs'
+                            >
+                              {t('点击查看大图')}
+                            </Typography.Text>
+                            <ZoomIn size={14} />
+                          </div>
+                        </button>
                       </div>
                     ))}
                   </div>
@@ -405,6 +534,121 @@ const MessageContent = ({
           return null;
         })()
       )}
+
+      <Modal
+        title={t('图片预览')}
+        visible={!!previewImageUrl}
+        footer={null}
+        onCancel={() => {
+          setPreviewImageUrl('');
+          setPreviewScale(1);
+          stopPreviewPanning();
+        }}
+        width={styleState.isMobile ? '94vw' : 960}
+        centered
+        bodyStyle={{
+          padding: styleState.isMobile ? 12 : 20,
+        }}
+      >
+        <div className='mb-3 flex flex-wrap items-center justify-between gap-2'>
+          <div className='flex items-center gap-2'>
+            <Button
+              icon={<Minus size={14} />}
+              theme='light'
+              type='tertiary'
+              size='small'
+              onClick={() => handlePreviewZoom(-0.2)}
+              disabled={previewScale <= 0.5}
+            >
+              {t('缩小')}
+            </Button>
+            <Button
+              icon={<Plus size={14} />}
+              theme='light'
+              type='tertiary'
+              size='small'
+              onClick={() => handlePreviewZoom(0.2)}
+              disabled={previewScale >= 6}
+            >
+              {t('放大')}
+            </Button>
+            <Button
+              icon={<RotateCcw size={14} />}
+              theme='light'
+              type='tertiary'
+              size='small'
+              onClick={() => setPreviewScale(1)}
+            >
+              {t('重置')}
+            </Button>
+            <Typography.Text className='text-xs sm:text-sm text-[var(--semi-color-text-1)]'>
+              {t('缩放')}: {Math.round(previewScale * 100)}%
+            </Typography.Text>
+          </div>
+          <Button
+            icon={<Download size={14} />}
+            theme='solid'
+            type='primary'
+            size='small'
+            onClick={handlePreviewDownload}
+          >
+            {t('下载图片')}
+          </Button>
+        </div>
+
+        <div
+          ref={previewContainerRef}
+          className='overflow-auto rounded-xl'
+          style={{
+            background: 'var(--semi-color-fill-0)',
+            minHeight: styleState.isMobile ? '240px' : '320px',
+            maxHeight: styleState.isMobile ? '72vh' : '80vh',
+            cursor:
+              previewScale > 1 ? (isPreviewPanning ? 'grabbing' : 'grab') : 'default',
+            userSelect: isPreviewPanning ? 'none' : 'auto',
+            touchAction: previewScale > 1 ? 'none' : 'auto',
+          }}
+          onWheel={handlePreviewWheel}
+          onPointerDown={handlePreviewPointerDown}
+          onPointerMove={handlePreviewPointerMove}
+          onPointerUp={handlePreviewPointerUp}
+          onPointerCancel={stopPreviewPanning}
+          onPointerLeave={handlePreviewPointerUp}
+        >
+          {previewImageUrl && (
+            <div
+              className='flex min-h-full min-w-full items-center justify-center p-3'
+              style={{
+                minWidth: previewScale > 1 ? `${previewScale * 100}%` : '100%',
+              }}
+            >
+              <img
+                src={previewImageUrl}
+                alt={t('图片预览')}
+                className='block rounded-lg shadow-sm'
+                draggable={false}
+                style={{
+                  width: previewScale <= 1 ? '100%' : `${previewScale * 100}%`,
+                  maxWidth: 'none',
+                  maxHeight:
+                    previewScale <= 1
+                      ? styleState.isMobile
+                        ? '70vh'
+                        : '78vh'
+                      : 'none',
+                  objectFit: 'contain',
+                  transition: 'width 0.12s ease-out',
+                }}
+              />
+            </div>
+          )}
+        </div>
+        <Typography.Text className='mt-3 block text-xs text-[var(--semi-color-text-2)]'>
+          {previewScale > 1
+            ? t('可使用滚轮继续缩放，并按住拖拽平移查看细节')
+            : t('可使用滚轮继续缩放查看细节')}
+        </Typography.Text>
+      </Modal>
     </div>
   );
 };

--- a/web/src/helpers/api.js
+++ b/web/src/helpers/api.js
@@ -212,11 +212,10 @@ export const processModelsData = (data, currentModel) => {
 // 处理分组数据
 export const processGroupsData = (data, userGroup) => {
   let groupOptions = Object.entries(data).map(([group, info]) => ({
-    label:
-      info.desc.length > 20 ? info.desc.substring(0, 20) + '...' : info.desc,
+    label: group,
     value: group,
+    desc: info.desc,
     ratio: info.ratio,
-    fullLabel: info.desc,
   }));
 
   if (groupOptions.length === 0) {

--- a/web/src/helpers/render.jsx
+++ b/web/src/helpers/render.jsx
@@ -919,17 +919,13 @@ export const renderGroupOption = (item) => {
   const {
     disabled,
     selected,
-    label,
     value,
     focused,
-    className,
-    style,
     onMouseEnter,
     onClick,
-    empty,
-    emptyContent,
     ...rest
   } = item;
+  const desc = rest.desc;
 
   const baseStyle = {
     display: 'flex',
@@ -969,9 +965,11 @@ export const renderGroupOption = (item) => {
         <Typography.Text strong type={disabled ? 'tertiary' : undefined}>
           {value}
         </Typography.Text>
-        <Typography.Text type='secondary' size='small'>
-          {label}
-        </Typography.Text>
+        {desc && desc !== value && (
+          <Typography.Text type='secondary' size='small'>
+            {desc}
+          </Typography.Text>
+        )}
       </div>
       {item.ratio && renderRatio(item.ratio)}
     </div>

--- a/web/src/helpers/utils.jsx
+++ b/web/src/helpers/utils.jsx
@@ -347,6 +347,69 @@ export const getTextContent = (message) => {
   return typeof message.content === 'string' ? message.content : '';
 };
 
+export const extractImageUrlsFromContent = (content) => {
+  if (!Array.isArray(content)) return [];
+
+  return content
+    .filter((item) => item?.type === 'image_url' && item?.image_url?.url)
+    .map((item) => item.image_url.url)
+    .filter((url) => typeof url === 'string' && url.trim() !== '');
+};
+
+export const extractImageUrls = (items = []) => {
+  if (!Array.isArray(items)) return [];
+
+  return items
+    .map((item) => {
+      if (!item) return '';
+      if (typeof item === 'string') return item;
+      if (typeof item.image_url?.url === 'string') return item.image_url.url;
+      if (typeof item.url === 'string') return item.url;
+      return '';
+    })
+    .filter((url) => url.trim() !== '');
+};
+
+export const buildMixedMessageContent = (textContent = '', imageUrls = []) => {
+  const validImageUrls = imageUrls.filter((url) => url && url.trim() !== '');
+
+  if (validImageUrls.length === 0) {
+    return textContent || '';
+  }
+
+  const parts = validImageUrls.map((url) => ({
+    type: 'image_url',
+    image_url: { url: url.trim() },
+  }));
+
+  if (textContent) {
+    return [{ type: 'text', text: textContent }, ...parts];
+  }
+
+  return parts;
+};
+
+export const mergeMessageContent = (
+  currentContent,
+  { text = '', textMode = 'append', imageUrls = [] } = {},
+) => {
+  const currentText = getTextContent({ content: currentContent });
+  const currentImageUrls = extractImageUrlsFromContent(currentContent);
+  const normalizedNewImages = extractImageUrls(imageUrls);
+
+  const nextText =
+    textMode === 'replace' ? text || '' : `${currentText}${text || ''}`;
+  const nextImageUrls = [...currentImageUrls];
+
+  normalizedNewImages.forEach((url) => {
+    if (!nextImageUrls.includes(url)) {
+      nextImageUrls.push(url);
+    }
+  });
+
+  return buildMixedMessageContent(nextText, nextImageUrls);
+};
+
 // 处理 think 标签
 export const processThinkTags = (content, reasoningContent = '') => {
   if (!content || !content.includes('<think>')) {
@@ -419,16 +482,8 @@ export const buildMessageContent = (
     return '';
   }
 
-  const validImageUrls = imageUrls.filter((url) => url && url.trim() !== '');
-
-  if (imageEnabled && validImageUrls.length > 0) {
-    return [
-      { type: 'text', text: textContent || '' },
-      ...validImageUrls.map((url) => ({
-        type: 'image_url',
-        image_url: { url: url.trim() },
-      })),
-    ];
+  if (imageEnabled && imageUrls.length > 0) {
+    return buildMixedMessageContent(textContent || '', imageUrls);
   }
 
   return textContent || '';

--- a/web/src/hooks/playground/useApiRequest.jsx
+++ b/web/src/hooks/playground/useApiRequest.jsx
@@ -30,6 +30,11 @@ import {
   handleApiError,
   processThinkTags,
   processIncompleteThinkTags,
+  getTextContent,
+  extractImageUrlsFromContent,
+  extractImageUrls,
+  buildMixedMessageContent,
+  mergeMessageContent,
 } from '../../helpers';
 
 export const useApiRequest = (
@@ -57,9 +62,25 @@ export const useApiRequest = (
     [],
   );
 
+  const getResponseTextContent = useCallback((content) => {
+    if (Array.isArray(content)) {
+      return content
+        .filter(
+          (item) =>
+            item?.type === 'text' &&
+            typeof item?.text === 'string' &&
+            item.text.trim() !== '',
+        )
+        .map((item) => item.text)
+        .join('');
+    }
+
+    return typeof content === 'string' ? content : '';
+  }, []);
+
   // 流式消息更新
   const streamMessageUpdate = useCallback(
-    (textChunk, type) => {
+    (payload, type) => {
       setMessage((prevMessage) => {
         const lastMessage = prevMessage[prevMessage.length - 1];
         if (!lastMessage) return prevMessage;
@@ -78,24 +99,26 @@ export const useApiRequest = (
             newMessage = {
               ...newMessage,
               reasoningContent:
-                (lastMessage.reasoningContent || '') + textChunk,
+                (lastMessage.reasoningContent || '') + (payload || ''),
               status: MESSAGE_STATUS.INCOMPLETE,
               isThinkingComplete: false,
             };
           } else if (type === 'content') {
-            const shouldCollapseReasoning =
-              !lastMessage.content && lastMessage.reasoningContent;
-            const newContent = (lastMessage.content || '') + textChunk;
+            const newContent = mergeMessageContent(lastMessage.content, {
+              text: payload || '',
+              textMode: 'append',
+            });
+            const newTextContent = getTextContent({ content: newContent });
 
             let shouldCollapseFromThinkTag = false;
             let thinkingCompleteFromTags = lastMessage.isThinkingComplete;
 
             if (
               lastMessage.isReasoningExpanded &&
-              newContent.includes('</think>')
+              newTextContent.includes('</think>')
             ) {
-              const thinkMatches = newContent.match(/<think>/g);
-              const thinkCloseMatches = newContent.match(/<\/think>/g);
+              const thinkMatches = newTextContent.match(/<think>/g);
+              const thinkCloseMatches = newTextContent.match(/<\/think>/g);
               if (
                 thinkMatches &&
                 thinkCloseMatches &&
@@ -123,6 +146,15 @@ export const useApiRequest = (
               status: MESSAGE_STATUS.INCOMPLETE,
               ...autoCollapseState,
             };
+          } else if (type === 'image') {
+            newMessage = {
+              ...newMessage,
+              content: mergeMessageContent(lastMessage.content, {
+                imageUrls: payload,
+                textMode: 'append',
+              }),
+              status: MESSAGE_STATUS.INCOMPLETE,
+            };
           }
 
           return [...prevMessage.slice(0, -1), newMessage];
@@ -131,7 +163,7 @@ export const useApiRequest = (
         return prevMessage;
       });
     },
-    [setMessage, applyAutoCollapseLogic],
+    [setMessage, applyAutoCollapseLogic, mergeMessageContent, getTextContent],
   );
 
   // 完成消息
@@ -241,13 +273,22 @@ export const useApiRequest = (
 
         if (data.choices?.[0]) {
           const choice = data.choices[0];
-          let content = choice.message?.content || '';
+          const rawContent = choice.message?.content;
+          const responseImageUrls = [
+            ...extractImageUrlsFromContent(rawContent),
+            ...extractImageUrls(choice.message?.images),
+          ];
+          let content = getResponseTextContent(rawContent);
           let reasoningContent =
             choice.message?.reasoning_content ||
             choice.message?.reasoning ||
             '';
 
           const processed = processThinkTags(content, reasoningContent);
+          const finalContent = buildMixedMessageContent(
+            processed.content,
+            responseImageUrls,
+          );
 
           setMessage((prevMessage) => {
             const newMessages = [...prevMessage];
@@ -260,7 +301,7 @@ export const useApiRequest = (
 
               newMessages[newMessages.length - 1] = {
                 ...lastMessage,
-                content: processed.content,
+                content: finalContent,
                 reasoningContent: processed.reasoningContent,
                 status: MESSAGE_STATUS.COMPLETE,
                 ...autoCollapseState,
@@ -297,7 +338,17 @@ export const useApiRequest = (
         });
       }
     },
-    [setDebugData, setActiveDebugTab, setMessage, t, applyAutoCollapseLogic],
+    [
+      setDebugData,
+      setActiveDebugTab,
+      setMessage,
+      t,
+      applyAutoCollapseLogic,
+      buildMixedMessageContent,
+      extractImageUrls,
+      extractImageUrlsFromContent,
+      getResponseTextContent,
+    ],
   );
 
   // SSE请求
@@ -369,6 +420,12 @@ export const useApiRequest = (
             if (delta.content) {
               streamMessageUpdate(delta.content, 'content');
             }
+            if (delta.images) {
+              const imageUrls = extractImageUrls(delta.images);
+              if (imageUrls.length > 0) {
+                streamMessageUpdate(imageUrls, 'image');
+              }
+            }
           }
         } catch (error) {
           console.error('Failed to parse SSE message:', error);
@@ -424,7 +481,10 @@ export const useApiRequest = (
             if (lastMessage && lastMessage.status !== MESSAGE_STATUS.COMPLETE && lastMessage.status !== MESSAGE_STATUS.ERROR) {
               newMessages[newMessages.length - 1] = {
                 ...lastMessage,
-                content: (lastMessage.content || '') + errorMessage,
+                content: mergeMessageContent(lastMessage.content, {
+                  text: errorMessage,
+                  textMode: 'append',
+                }),
                 errorCode: errorCode,
                 status: MESSAGE_STATUS.ERROR,
               };
@@ -486,7 +546,6 @@ export const useApiRequest = (
       streamMessageUpdate,
       completeMessage,
       t,
-      applyAutoCollapseLogic,
     ],
   );
 
@@ -507,8 +566,12 @@ export const useApiRequest = (
         lastMessage.status === MESSAGE_STATUS.LOADING ||
         lastMessage.status === MESSAGE_STATUS.INCOMPLETE
       ) {
+        const currentTextContent = getTextContent({
+          content: lastMessage.content,
+        });
+        const currentImageUrls = extractImageUrlsFromContent(lastMessage.content);
         const processed = processIncompleteThinkTags(
-          lastMessage.content || '',
+          currentTextContent,
           lastMessage.reasoningContent || '',
         );
 
@@ -520,7 +583,10 @@ export const useApiRequest = (
             ...lastMessage,
             status: MESSAGE_STATUS.COMPLETE,
             reasoningContent: processed.reasoningContent || null,
-            content: processed.content,
+            content: buildMixedMessageContent(
+              processed.content,
+              currentImageUrls,
+            ),
             ...autoCollapseState,
           },
         ];
@@ -532,7 +598,14 @@ export const useApiRequest = (
       }
       return prevMessage;
     });
-  }, [setMessage, applyAutoCollapseLogic, saveMessages]);
+  }, [
+    setMessage,
+    applyAutoCollapseLogic,
+    saveMessages,
+    getTextContent,
+    extractImageUrlsFromContent,
+    buildMixedMessageContent,
+  ]);
 
   // 发送请求
   const sendRequest = useCallback(

--- a/web/src/hooks/playground/useDataLoader.js
+++ b/web/src/hooks/playground/useDataLoader.js
@@ -33,7 +33,9 @@ export const useDataLoader = (
 
   const loadModels = useCallback(async () => {
     try {
-      const res = await API.get(API_ENDPOINTS.USER_MODELS);
+      const res = await API.get(API_ENDPOINTS.USER_MODELS, {
+        params: inputs.group ? { group: inputs.group } : undefined,
+      });
       const { success, message, data } = res.data;
 
       if (success) {
@@ -52,7 +54,7 @@ export const useDataLoader = (
     } catch (error) {
       showError(t('加载模型失败'));
     }
-  }, [inputs.model, handleInputChange, setModels, t]);
+  }, [inputs.group, inputs.model, handleInputChange, setModels, t]);
 
   const loadGroups = useCallback(async () => {
     try {
@@ -87,6 +89,12 @@ export const useDataLoader = (
       loadGroups();
     }
   }, [userState?.user, loadModels, loadGroups]);
+
+  useEffect(() => {
+    if (userState?.user && inputs.group) {
+      loadModels();
+    }
+  }, [userState?.user, inputs.group, loadModels]);
 
   return {
     loadModels,

--- a/web/src/hooks/playground/usePlaygroundState.js
+++ b/web/src/hooks/playground/usePlaygroundState.js
@@ -20,7 +20,6 @@ For commercial licensing, please contact support@quantumnous.com
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  DEFAULT_MESSAGES,
   getDefaultMessages,
   DEFAULT_CONFIG,
   DEBUG_TABS,
@@ -32,7 +31,12 @@ import {
   loadMessages,
   saveMessages,
 } from '../../components/playground/configStorage';
-import { processIncompleteThinkTags } from '../../helpers';
+import {
+  processIncompleteThinkTags,
+  getTextContent,
+  extractImageUrlsFromContent,
+  buildMixedMessageContent,
+} from '../../helpers';
 
 export const usePlaygroundState = () => {
   const { t } = useTranslation();
@@ -117,7 +121,6 @@ export const usePlaygroundState = () => {
   const sseSourceRef = useRef(null);
   const chatRef = useRef(null);
   const saveConfigTimeoutRef = useRef(null);
-  const saveMessagesTimeoutRef = useRef(null);
 
   // 配置更新函数
   const handleInputChange = useCallback((name, value) => {
@@ -233,15 +236,17 @@ export const usePlaygroundState = () => {
       lastMsg.status === MESSAGE_STATUS.LOADING ||
       lastMsg.status === MESSAGE_STATUS.INCOMPLETE
     ) {
+      const currentTextContent = getTextContent({ content: lastMsg.content });
+      const currentImageUrls = extractImageUrlsFromContent(lastMsg.content);
       const processed = processIncompleteThinkTags(
-        lastMsg.content || '',
+        currentTextContent,
         lastMsg.reasoningContent || '',
       );
 
       const fixedLastMsg = {
         ...lastMsg,
         status: MESSAGE_STATUS.COMPLETE,
-        content: processed.content,
+        content: buildMixedMessageContent(processed.content, currentImageUrls),
         reasoningContent: processed.reasoningContent || null,
         isThinkingComplete: true,
       };


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
1、操练场中补充图片消息展示能力
2、操练场中让模型列表跟随所选分组刷新，并优化分组显示

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [√] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [√] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [√] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [√] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [√] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [√] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
<img width="1912" height="914" alt="image" src="https://github.com/user-attachments/assets/55189b09-0b11-4e83-b9b4-9057e4bd024f" />
<img width="1912" height="914" alt="image" src="https://github.com/user-attachments/assets/fa82ffc3-a7e0-430f-bb26-c44ebaa45c0c" />
<img width="377" height="403" alt="image" src="https://github.com/user-attachments/assets/a9229105-e6b1-4f32-9363-ce075cdd0254" />
<img width="362" height="493" alt="image" src="https://github.com/user-attachments/assets/be34d9c7-cb60-47e2-a6b3-056cfb415ccc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filter available models by group/collection for more efficient model selection and organization
  * Interactive image preview modal with zoom, pan, and download controls for viewing images in messages

* **Improvements**
  * Enhanced support for displaying messages with both text and image content together
  * Refined group option labeling and description formatting in the interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->