### PR TITLE
fix: correct gpt-5.5 completion ratio

### DIFF
--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -515,6 +515,9 @@ func getHardcodedCompletionModelRatio(name string) (float64, bool) {
 		}
 		// gpt-5 匹配
 		if strings.HasPrefix(name, "gpt-5") {
+			if strings.HasPrefix(name, "gpt-5.5") {
+				return 6, true
+			}
 			if strings.HasPrefix(name, "gpt-5.4") {
 				if strings.HasPrefix(name, "gpt-5.4-nano") {
 					return 6.25, true

--- a/setting/ratio_setting/model_ratio_test.go
+++ b/setting/ratio_setting/model_ratio_test.go
@@ -1,0 +1,22 @@
+package ratio_setting
+
+import "testing"
+
+func TestGetCompletionRatioInfoGPT55UsesOfficialOutputMultiplier(t *testing.T) {
+	info := GetCompletionRatioInfo("gpt-5.5")
+
+	if info.Ratio != 6 {
+		t.Fatalf("gpt-5.5 completion ratio = %v, want 6", info.Ratio)
+	}
+	if !info.Locked {
+		t.Fatal("gpt-5.5 completion ratio should be locked to the official multiplier")
+	}
+}
+
+func TestGetCompletionRatioGPT55DatedVariant(t *testing.T) {
+	got := GetCompletionRatio("gpt-5.5-2026-04-24")
+
+	if got != 6 {
+		t.Fatalf("gpt-5.5 dated variant completion ratio = %v, want 6", got)
+	}
+}


### PR DESCRIPTION
## Summary\n- Add a gpt-5.5-specific completion ratio rule so it uses the official 6x output/input multiplier instead of falling through to the gpt-5 default 8x rule.\n- Add regression coverage for gpt-5.5 and dated gpt-5.5 variants.\n\n## Test\n- go test ./setting/ratio_setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed completion ratio calculation for `gpt-5.5` model variants to use the correct official multiplier value, ensuring accurate resource allocation and billing.

* **Tests**
  * Added test coverage for `gpt-5.5` model completion ratio handling, including support for dated variant formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->