### PR TITLE
fix: resolve model owned_by from active channels

### DIFF
--- a/controller/model.go
+++ b/controller/model.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
@@ -109,9 +110,66 @@ func init() {
 	})
 }
 
-func ListModels(c *gin.Context, modelType int) {
-	userOpenAiModels := make([]dto.OpenAIModels, 0)
+func channelOwnerName(channelType int) string {
+	apiType, success := common.ChannelType2APIType(channelType)
+	if !success {
+		return strings.ToLower(constant.GetChannelTypeName(channelType))
+	}
+	adaptor := relay.GetAdaptor(apiType)
+	if adaptor == nil {
+		return strings.ToLower(constant.GetChannelTypeName(channelType))
+	}
+	adaptor.Init(&relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{
+		ChannelType: channelType,
+	}})
+	if name := strings.TrimSpace(adaptor.GetChannelName()); name != "" {
+		return name
+	}
+	return strings.ToLower(constant.GetChannelTypeName(channelType))
+}
 
+func getPreferredModelOwners(modelNames []string, groups []string) map[string]string {
+	channelTypes, err := model.GetPreferredModelOwnerChannelTypes(modelNames, groups)
+	if err != nil {
+		common.SysLog(fmt.Sprintf("GetPreferredModelOwnerChannelTypes error: %v", err))
+		return map[string]string{}
+	}
+
+	ownerByChannelType := make(map[int]string)
+	owners := make(map[string]string, len(channelTypes))
+	for modelName, channelType := range channelTypes {
+		owner, ok := ownerByChannelType[channelType]
+		if !ok {
+			owner = channelOwnerName(channelType)
+			ownerByChannelType[channelType] = owner
+		}
+		if owner != "" {
+			owners[modelName] = owner
+		}
+	}
+	return owners
+}
+
+func buildOpenAIModel(modelName string, ownerByModel map[string]string) dto.OpenAIModels {
+	var oaiModel dto.OpenAIModels
+	if staticModel, ok := openAIModelsMap[modelName]; ok {
+		oaiModel = staticModel
+	} else {
+		oaiModel = dto.OpenAIModels{
+			Id:      modelName,
+			Object:  "model",
+			Created: 1626777600,
+			OwnedBy: "custom",
+		}
+	}
+	if owner, ok := ownerByModel[modelName]; ok && owner != "" {
+		oaiModel.OwnedBy = owner
+	}
+	oaiModel.SupportedEndpointTypes = model.GetModelSupportEndpointTypes(modelName)
+	return oaiModel
+}
+
+func ListModels(c *gin.Context, modelType int) {
 	acceptUnsetRatioModel := operation_setting.SelfUseModeEnabled
 	if !acceptUnsetRatioModel {
 		userId := c.GetInt("id")
@@ -123,6 +181,8 @@ func ListModels(c *gin.Context, modelType int) {
 		}
 	}
 
+	userModelNames := make([]string, 0)
+	ownerGroups := make([]string, 0)
 	modelLimitEnable := common.GetContextKeyBool(c, constant.ContextKeyTokenModelLimitEnabled)
 	if modelLimitEnable {
 		s, ok := common.GetContextKey(c, constant.ContextKeyTokenModelLimit)
@@ -139,18 +199,7 @@ func ListModels(c *gin.Context, modelType int) {
 					continue
 				}
 			}
-			if oaiModel, ok := openAIModelsMap[allowModel]; ok {
-				oaiModel.SupportedEndpointTypes = model.GetModelSupportEndpointTypes(allowModel)
-				userOpenAiModels = append(userOpenAiModels, oaiModel)
-			} else {
-				userOpenAiModels = append(userOpenAiModels, dto.OpenAIModels{
-					Id:                     allowModel,
-					Object:                 "model",
-					Created:                1626777600,
-					OwnedBy:                "custom",
-					SupportedEndpointTypes: model.GetModelSupportEndpointTypes(allowModel),
-				})
-			}
+			userModelNames = append(userModelNames, allowModel)
 		}
 	} else {
 		userId := c.GetInt("id")
@@ -169,7 +218,8 @@ func ListModels(c *gin.Context, modelType int) {
 		}
 		var models []string
 		if tokenGroup == "auto" {
-			for _, autoGroup := range service.GetUserAutoGroup(userGroup) {
+			ownerGroups = service.GetUserAutoGroup(userGroup)
+			for _, autoGroup := range ownerGroups {
 				groupModels := model.GetGroupEnabledModels(autoGroup)
 				for _, g := range groupModels {
 					if !common.StringsContains(models, g) {
@@ -178,6 +228,7 @@ func ListModels(c *gin.Context, modelType int) {
 				}
 			}
 		} else {
+			ownerGroups = []string{group}
 			models = model.GetGroupEnabledModels(group)
 		}
 		for _, modelName := range models {
@@ -187,19 +238,14 @@ func ListModels(c *gin.Context, modelType int) {
 					continue
 				}
 			}
-			if oaiModel, ok := openAIModelsMap[modelName]; ok {
-				oaiModel.SupportedEndpointTypes = model.GetModelSupportEndpointTypes(modelName)
-				userOpenAiModels = append(userOpenAiModels, oaiModel)
-			} else {
-				userOpenAiModels = append(userOpenAiModels, dto.OpenAIModels{
-					Id:                     modelName,
-					Object:                 "model",
-					Created:                1626777600,
-					OwnedBy:                "custom",
-					SupportedEndpointTypes: model.GetModelSupportEndpointTypes(modelName),
-				})
-			}
+			userModelNames = append(userModelNames, modelName)
 		}
+	}
+
+	ownerByModel := getPreferredModelOwners(userModelNames, ownerGroups)
+	userOpenAiModels := make([]dto.OpenAIModels, 0, len(userModelNames))
+	for _, modelName := range userModelNames {
+		userOpenAiModels = append(userOpenAiModels, buildOpenAIModel(modelName, ownerByModel))
 	}
 
 	switch modelType {

--- a/controller/model.go
+++ b/controller/model.go
@@ -169,6 +169,42 @@ func buildOpenAIModel(modelName string, ownerByModel map[string]string) dto.Open
 	return oaiModel
 }
 
+type modelListGroups struct {
+	userGroup   string
+	tokenGroup  string
+	ownerGroups []string
+}
+
+func getModelListGroups(c *gin.Context) (modelListGroups, error) {
+	tokenGroup := common.GetContextKeyString(c, constant.ContextKeyTokenGroup)
+	userGroup := common.GetContextKeyString(c, constant.ContextKeyUserGroup)
+	if userGroup == "" && (tokenGroup == "" || tokenGroup == "auto") {
+		var err error
+		userGroup, err = model.GetUserGroup(c.GetInt("id"), false)
+		if err != nil {
+			return modelListGroups{}, err
+		}
+	}
+
+	if tokenGroup == "auto" {
+		return modelListGroups{
+			userGroup:   userGroup,
+			tokenGroup:  tokenGroup,
+			ownerGroups: service.GetUserAutoGroup(userGroup),
+		}, nil
+	}
+
+	group := userGroup
+	if tokenGroup != "" {
+		group = tokenGroup
+	}
+	return modelListGroups{
+		userGroup:   userGroup,
+		tokenGroup:  tokenGroup,
+		ownerGroups: []string{group},
+	}, nil
+}
+
 func ListModels(c *gin.Context, modelType int) {
 	acceptUnsetRatioModel := operation_setting.SelfUseModeEnabled
 	if !acceptUnsetRatioModel {
@@ -182,7 +218,15 @@ func ListModels(c *gin.Context, modelType int) {
 	}
 
 	userModelNames := make([]string, 0)
-	ownerGroups := make([]string, 0)
+	groups, err := getModelListGroups(c)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": "get user group failed",
+		})
+		return
+	}
+	ownerGroups := groups.ownerGroups
 	modelLimitEnable := common.GetContextKeyBool(c, constant.ContextKeyTokenModelLimitEnabled)
 	if modelLimitEnable {
 		s, ok := common.GetContextKey(c, constant.ContextKeyTokenModelLimit)
@@ -202,23 +246,8 @@ func ListModels(c *gin.Context, modelType int) {
 			userModelNames = append(userModelNames, allowModel)
 		}
 	} else {
-		userId := c.GetInt("id")
-		userGroup, err := model.GetUserGroup(userId, false)
-		if err != nil {
-			c.JSON(http.StatusOK, gin.H{
-				"success": false,
-				"message": "get user group failed",
-			})
-			return
-		}
-		group := userGroup
-		tokenGroup := common.GetContextKeyString(c, constant.ContextKeyTokenGroup)
-		if tokenGroup != "" {
-			group = tokenGroup
-		}
 		var models []string
-		if tokenGroup == "auto" {
-			ownerGroups = service.GetUserAutoGroup(userGroup)
+		if groups.tokenGroup == "auto" {
 			for _, autoGroup := range ownerGroups {
 				groupModels := model.GetGroupEnabledModels(autoGroup)
 				for _, g := range groupModels {
@@ -228,8 +257,7 @@ func ListModels(c *gin.Context, modelType int) {
 				}
 			}
 		} else {
-			ownerGroups = []string{group}
-			models = model.GetGroupEnabledModels(group)
+			models = model.GetGroupEnabledModels(ownerGroups[0])
 		}
 		for _, modelName := range models {
 			if !acceptUnsetRatioModel {
@@ -242,7 +270,10 @@ func ListModels(c *gin.Context, modelType int) {
 		}
 	}
 
-	ownerByModel := getPreferredModelOwners(userModelNames, ownerGroups)
+	ownerByModel := map[string]string{}
+	if len(ownerGroups) > 0 {
+		ownerByModel = getPreferredModelOwners(userModelNames, ownerGroups)
+	}
 	userOpenAiModels := make([]dto.OpenAIModels, 0, len(userModelNames))
 	for _, modelName := range userModelNames {
 		userOpenAiModels = append(userOpenAiModels, buildOpenAIModel(modelName, ownerByModel))

--- a/controller/model_owned_by_test.go
+++ b/controller/model_owned_by_test.go
@@ -1,0 +1,55 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelOwnerNameUsesAdaptorChannelName(t *testing.T) {
+	tests := []struct {
+		name        string
+		channelType int
+		expected    string
+	}{
+		{
+			name:        "openai",
+			channelType: constant.ChannelTypeOpenAI,
+			expected:    "openai",
+		},
+		{
+			name:        "codex",
+			channelType: constant.ChannelTypeCodex,
+			expected:    "codex",
+		},
+		{
+			name:        "openrouter",
+			channelType: constant.ChannelTypeOpenRouter,
+			expected:    "openrouter",
+		},
+		{
+			name:        "azure fallback",
+			channelType: constant.ChannelTypeAzure,
+			expected:    "azure",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, channelOwnerName(tt.channelType))
+		})
+	}
+}
+
+func TestBuildOpenAIModelOverridesOwnedBy(t *testing.T) {
+	modelItem := buildOpenAIModel("gpt-5.4", map[string]string{"gpt-5.4": "openai"})
+	require.Equal(t, "gpt-5.4", modelItem.Id)
+	require.Equal(t, "openai", modelItem.OwnedBy)
+}
+
+func TestBuildOpenAIModelFallsBackToCustomForUnknownModels(t *testing.T) {
+	modelItem := buildOpenAIModel("custom-test-model", nil)
+	require.Equal(t, "custom-test-model", modelItem.Id)
+	require.Equal(t, "custom", modelItem.OwnedBy)
+}

--- a/controller/model_owned_by_test.go
+++ b/controller/model_owned_by_test.go
@@ -1,9 +1,12 @@
 package controller
 
 import (
+	"net/http/httptest"
 	"testing"
 
+	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,4 +55,31 @@ func TestBuildOpenAIModelFallsBackToCustomForUnknownModels(t *testing.T) {
 	modelItem := buildOpenAIModel("custom-test-model", nil)
 	require.Equal(t, "custom-test-model", modelItem.Id)
 	require.Equal(t, "custom", modelItem.OwnedBy)
+}
+
+func TestGetModelListGroupsUsesUserGroupWhenTokenGroupIsEmpty(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	common.SetContextKey(ctx, constant.ContextKeyUserGroup, "default")
+
+	groups, err := getModelListGroups(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, "default", groups.userGroup)
+	require.Empty(t, groups.tokenGroup)
+	require.Equal(t, []string{"default"}, groups.ownerGroups)
+}
+
+func TestGetModelListGroupsUsesExplicitTokenGroup(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	common.SetContextKey(ctx, constant.ContextKeyUserGroup, "default")
+	common.SetContextKey(ctx, constant.ContextKeyTokenGroup, "vip")
+
+	groups, err := getModelListGroups(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, "default", groups.userGroup)
+	require.Equal(t, "vip", groups.tokenGroup)
+	require.Equal(t, []string{"vip"}, groups.ownerGroups)
 }

--- a/model/model_meta.go
+++ b/model/model_meta.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/QuantumNous/new-api/common"
 
@@ -131,6 +132,62 @@ func GetBoundChannelsByModelsMap(modelNames []string) (map[string][]BoundChannel
 	}
 	for _, r := range rows {
 		result[r.Model] = append(result[r.Model], BoundChannel{Name: r.Name, Type: r.Type})
+	}
+	return result, nil
+}
+
+func normalizeLookupValues(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	return normalized
+}
+
+func GetPreferredModelOwnerChannelTypes(modelNames []string, groups []string) (map[string]int, error) {
+	result := make(map[string]int)
+	modelNames = normalizeLookupValues(modelNames)
+	if len(modelNames) == 0 {
+		return result, nil
+	}
+
+	type row struct {
+		Model       string
+		ChannelType int
+	}
+	var rows []row
+
+	query := DB.Table("abilities").
+		Select("abilities.model as model, channels.type as channel_type").
+		Joins("JOIN channels ON abilities.channel_id = channels.id").
+		Where("abilities.model IN ? AND abilities.enabled = ? AND channels.status = ?", modelNames, true, common.ChannelStatusEnabled).
+		Order("COALESCE(abilities.priority, 0) DESC").
+		Order("abilities.weight DESC").
+		Order("abilities.channel_id ASC")
+
+	groups = normalizeLookupValues(groups)
+	if len(groups) > 0 {
+		query = query.Where("abilities."+commonGroupCol+" IN ?", groups)
+	}
+
+	if err := query.Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	for _, r := range rows {
+		if _, ok := result[r.Model]; ok {
+			continue
+		}
+		result[r.Model] = r.ChannelType
 	}
 	return result, nil
 }

--- a/model/model_owner_test.go
+++ b/model/model_owner_test.go
@@ -1,0 +1,141 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/stretchr/testify/require"
+)
+
+func clearPreferredOwnerTables(t *testing.T) {
+	t.Helper()
+	require.NoError(t, DB.Exec("DELETE FROM abilities").Error)
+	require.NoError(t, DB.Exec("DELETE FROM channels").Error)
+}
+
+func insertPreferredOwnerCandidate(
+	t *testing.T,
+	channelID int,
+	modelName string,
+	group string,
+	channelType int,
+	priority int64,
+	weight uint,
+	channelStatus int,
+	abilityEnabled bool,
+) {
+	t.Helper()
+	require.NoError(t, DB.Create(&Channel{
+		Id:     channelID,
+		Type:   channelType,
+		Key:    fmt.Sprintf("key-%d", channelID),
+		Status: channelStatus,
+		Name:   fmt.Sprintf("channel-%d", channelID),
+	}).Error)
+	require.NoError(t, DB.Create(&Ability{
+		Group:     group,
+		Model:     modelName,
+		ChannelId: channelID,
+		Enabled:   abilityEnabled,
+		Priority:  &priority,
+		Weight:    weight,
+	}).Error)
+}
+
+func TestGetPreferredModelOwnerChannelTypes(t *testing.T) {
+	const modelName = "gpt-5.4"
+
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T)
+		groups   []string
+		expected int
+		found    bool
+	}{
+		{
+			name: "openai only",
+			setup: func(t *testing.T) {
+				insertPreferredOwnerCandidate(t, 1, modelName, "default", constant.ChannelTypeOpenAI, 0, 0, common.ChannelStatusEnabled, true)
+			},
+			groups:   []string{"default"},
+			expected: constant.ChannelTypeOpenAI,
+			found:    true,
+		},
+		{
+			name: "codex only",
+			setup: func(t *testing.T) {
+				insertPreferredOwnerCandidate(t, 1, modelName, "default", constant.ChannelTypeCodex, 0, 0, common.ChannelStatusEnabled, true)
+			},
+			groups:   []string{"default"},
+			expected: constant.ChannelTypeCodex,
+			found:    true,
+		},
+		{
+			name: "priority wins",
+			setup: func(t *testing.T) {
+				insertPreferredOwnerCandidate(t, 1, modelName, "default", constant.ChannelTypeOpenAI, 1, 100, common.ChannelStatusEnabled, true)
+				insertPreferredOwnerCandidate(t, 2, modelName, "default", constant.ChannelTypeCodex, 2, 0, common.ChannelStatusEnabled, true)
+			},
+			groups:   []string{"default"},
+			expected: constant.ChannelTypeCodex,
+			found:    true,
+		},
+		{
+			name: "weight wins when priority is equal",
+			setup: func(t *testing.T) {
+				insertPreferredOwnerCandidate(t, 1, modelName, "default", constant.ChannelTypeOpenAI, 1, 10, common.ChannelStatusEnabled, true)
+				insertPreferredOwnerCandidate(t, 2, modelName, "default", constant.ChannelTypeCodex, 1, 20, common.ChannelStatusEnabled, true)
+			},
+			groups:   []string{"default"},
+			expected: constant.ChannelTypeCodex,
+			found:    true,
+		},
+		{
+			name: "channel id stabilizes exact ties",
+			setup: func(t *testing.T) {
+				insertPreferredOwnerCandidate(t, 2, modelName, "default", constant.ChannelTypeCodex, 1, 10, common.ChannelStatusEnabled, true)
+				insertPreferredOwnerCandidate(t, 1, modelName, "default", constant.ChannelTypeOpenAI, 1, 10, common.ChannelStatusEnabled, true)
+			},
+			groups:   []string{"default"},
+			expected: constant.ChannelTypeOpenAI,
+			found:    true,
+		},
+		{
+			name: "group filter excludes other groups",
+			setup: func(t *testing.T) {
+				insertPreferredOwnerCandidate(t, 1, modelName, "vip", constant.ChannelTypeCodex, 10, 100, common.ChannelStatusEnabled, true)
+				insertPreferredOwnerCandidate(t, 2, modelName, "default", constant.ChannelTypeOpenAI, 1, 0, common.ChannelStatusEnabled, true)
+			},
+			groups:   []string{"default"},
+			expected: constant.ChannelTypeOpenAI,
+			found:    true,
+		},
+		{
+			name: "disabled candidates are ignored",
+			setup: func(t *testing.T) {
+				insertPreferredOwnerCandidate(t, 1, modelName, "default", constant.ChannelTypeCodex, 10, 100, common.ChannelStatusEnabled, false)
+				insertPreferredOwnerCandidate(t, 2, modelName, "default", constant.ChannelTypeOpenAI, 1, 0, common.ChannelStatusManuallyDisabled, true)
+			},
+			groups: []string{"default"},
+			found:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearPreferredOwnerTables(t)
+			tt.setup(t)
+
+			owners, err := GetPreferredModelOwnerChannelTypes([]string{modelName}, tt.groups)
+			require.NoError(t, err)
+
+			got, ok := owners[modelName]
+			require.Equal(t, tt.found, ok)
+			if tt.found {
+				require.Equal(t, tt.expected, got)
+			}
+		})
+	}
+}

--- a/model/task_cas_test.go
+++ b/model/task_cas_test.go
@@ -26,6 +26,7 @@ func TestMain(m *testing.M) {
 	common.RedisEnabled = false
 	common.BatchUpdateEnabled = false
 	common.LogConsumeEnabled = true
+	initCol()
 
 	sqlDB, err := db.DB()
 	if err != nil {
@@ -39,6 +40,7 @@ func TestMain(m *testing.M) {
 		&Token{},
 		&Log{},
 		&Channel{},
+		&Ability{},
 		&TopUp{},
 		&SubscriptionPlan{},
 		&SubscriptionOrder{},
@@ -58,6 +60,7 @@ func truncateTables(t *testing.T) {
 		DB.Exec("DELETE FROM tokens")
 		DB.Exec("DELETE FROM logs")
 		DB.Exec("DELETE FROM channels")
+		DB.Exec("DELETE FROM abilities")
 		DB.Exec("DELETE FROM top_ups")
 		DB.Exec("DELETE FROM subscription_orders")
 		DB.Exec("DELETE FROM subscription_plans")


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)
修复 `/v1/models` 返回的 `owned_by` 可能不准确的问题。
之前 `owned_by` 来自全局静态模型表，同名模型会被后写入的 provider 覆盖，导致返回值不一定符合当前用户实际可用渠道。现在改为基于当前请求可见模型对应的 enabled abilities 和 channels 计算 owner，并按 `priority -> weight -> channel_id` 选择主渠道；静态模型表仅作为兜底。
这样 `/v1/models` 返回的 `owned_by` 会更贴近当前 token / 用户实际可路由的渠道配置，同时不改变响应结构。


## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Close #4398

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
```
curl -X GET 'http://localhost:3000/v1/models' -H 'Authorization: sk-xxx'
```

未修改前：
<img width="384" height="202" alt="image" src="https://github.com/user-attachments/assets/5ce1c737-c1be-4588-9df4-9167db7fbca4" />
修改后：
<img width="387" height="204" alt="image" src="https://github.com/user-attachments/assets/e7b0cd2b-096b-4564-8726-70ccb155d652" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved model listing: ownership and supported endpoints are now resolved centrally and displayed more accurately, honoring preferred sources and group context.
  * Better handling of model/group inputs to deduplicate and normalize lookup behavior.

* **Tests**
  * Added extensive tests for ownership resolution, preferred-source selection, grouping behavior, and related DB-backed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->