### PR TITLE
feat: 支持通过 APP_BASE_PATH 配置子路径部署

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ docker run --name new-api -d --restart always \
 
 🎉 After deployment is complete, visit `http://localhost:3000` to start using!
 
+If you want to serve the app behind a sub-path such as `http://localhost:3000/new-api`, set `APP_BASE_PATH=/new-api` before starting the service. When you also configure `ServerAddress` for OAuth or payment callbacks, include the same sub-path in that value. If `FRONTEND_BASE_URL` is used to redirect web traffic to a separate frontend host, the backend appends the original request URI to it; with `APP_BASE_PATH=/new-api`, set `FRONTEND_BASE_URL=https://cdn.example.com` so `/new-api/console` redirects to `https://cdn.example.com/new-api/console`, and do not include `/new-api` in both variables.
+
 📖 For more deployment methods, please refer to [Deployment Guide](https://docs.newapi.pro/en/docs/installation)
 
 ---

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -151,6 +151,8 @@ docker run --name new-api -d --restart always \
 
 🎉 部署完成后，访问 `http://localhost:3000` 即可使用！
 
+如果你希望通过 `http://localhost:3000/new-api` 这样的子路径访问服务，请在启动前设置 `APP_BASE_PATH=/new-api`。若你还配置了用于 OAuth 或支付回调的 `ServerAddress`，请确保它也包含相同的子路径。若使用 `FRONTEND_BASE_URL` 将网页流量重定向到独立前端域名，后端会把原始请求 URI 追加到该地址后面；当 `APP_BASE_PATH=/new-api` 时，通常设置 `FRONTEND_BASE_URL=https://cdn.example.com`，这样 `/new-api/console` 会重定向到 `https://cdn.example.com/new-api/console`，不要在两个变量里重复配置同一个 `/new-api`。
+
 📖 更多部署方式请参考 [部署指南](https://docs.newapi.pro/zh/docs/installation)
 
 ---

--- a/common/base_path.go
+++ b/common/base_path.go
@@ -1,0 +1,82 @@
+package common
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+var AppBasePath = ""
+
+func NormalizeBasePath(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" || trimmed == "/" {
+		return "", nil
+	}
+	if !strings.HasPrefix(trimmed, "/") {
+		return "", fmt.Errorf("APP_BASE_PATH must start with '/'")
+	}
+	if strings.ContainsAny(trimmed, "?#") {
+		return "", fmt.Errorf("APP_BASE_PATH must not contain query or fragment")
+	}
+
+	normalized := strings.TrimRight(trimmed, "/")
+	if normalized == "" {
+		return "", nil
+	}
+	cleaned := path.Clean(normalized)
+	if cleaned != normalized {
+		return "", fmt.Errorf("APP_BASE_PATH contains invalid path segments")
+	}
+	return normalized, nil
+}
+
+func SessionCookiePath() string {
+	if AppBasePath == "" {
+		return "/"
+	}
+	return AppBasePath
+}
+
+func WithAppBasePath(routePath string) string {
+	if AppBasePath == "" {
+		if routePath == "" {
+			return "/"
+		}
+		return routePath
+	}
+
+	if routePath == "" || routePath == "/" {
+		return AppBasePath
+	}
+
+	normalized := routePath
+	if !strings.HasPrefix(normalized, "/") {
+		normalized = "/" + normalized
+	}
+	if normalized == AppBasePath || strings.HasPrefix(normalized, AppBasePath+"/") {
+		return normalized
+	}
+	return AppBasePath + normalized
+}
+
+func StripAppBasePath(requestPath string) (string, bool) {
+	if AppBasePath == "" {
+		if requestPath == "" {
+			return "/", true
+		}
+		return requestPath, true
+	}
+
+	if requestPath == AppBasePath {
+		return "/", true
+	}
+	if strings.HasPrefix(requestPath, AppBasePath+"/") {
+		stripped := strings.TrimPrefix(requestPath, AppBasePath)
+		if stripped == "" {
+			return "/", true
+		}
+		return stripped, true
+	}
+	return "", false
+}

--- a/common/base_path_test.go
+++ b/common/base_path_test.go
@@ -1,0 +1,69 @@
+package common
+
+import "testing"
+
+func TestNormalizeBasePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "root", input: "/", want: ""},
+		{name: "single segment", input: "/new-api", want: "/new-api"},
+		{name: "strip trailing slash", input: "/new-api/", want: "/new-api"},
+		{name: "nested path", input: "/foo/bar", want: "/foo/bar"},
+		{name: "missing leading slash", input: "new-api", wantErr: true},
+		{name: "double slash", input: "/foo//bar", wantErr: true},
+		{name: "dot segment", input: "/foo/./bar", wantErr: true},
+		{name: "dot dot segment", input: "/foo/../bar", wantErr: true},
+		{name: "query fragment", input: "/foo?bar", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeBasePath(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil and %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeBasePath() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizeBasePath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWithAppBasePath(t *testing.T) {
+	original := AppBasePath
+	t.Cleanup(func() {
+		AppBasePath = original
+	})
+
+	AppBasePath = "/new-api"
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "root", path: "/", want: "/new-api"},
+		{name: "console", path: "/console", want: "/new-api/console"},
+		{name: "already prefixed", path: "/new-api/console", want: "/new-api/console"},
+		{name: "empty", path: "", want: "/new-api"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := WithAppBasePath(tt.path); got != tt.want {
+				t.Fatalf("WithAppBasePath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/common/embed-file-system.go
+++ b/common/embed-file-system.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"embed"
 	"io/fs"
 	"net/http"
 	"os"
@@ -32,7 +31,7 @@ func (e *embedFileSystem) Open(name string) (http.File, error) {
 	return e.FileSystem.Open(name)
 }
 
-func EmbedFolder(fsEmbed embed.FS, targetPath string) static.ServeFileSystem {
+func EmbedFolder(fsEmbed fs.FS, targetPath string) static.ServeFileSystem {
 	efs, err := fs.Sub(fsEmbed, targetPath)
 	if err != nil {
 		panic(err)

--- a/common/init.go
+++ b/common/init.go
@@ -64,6 +64,11 @@ func InitEnv() {
 	if os.Getenv("SQLITE_PATH") != "" {
 		SQLitePath = os.Getenv("SQLITE_PATH")
 	}
+	appBasePath, err := NormalizeBasePath(os.Getenv("APP_BASE_PATH"))
+	if err != nil {
+		log.Fatalf("invalid APP_BASE_PATH: %v", err)
+	}
+	AppBasePath = appBasePath
 	if *LogDir != "" {
 		var err error
 		*LogDir, err = filepath.Abs(*LogDir)

--- a/common/sys_log.go
+++ b/common/sys_log.go
@@ -51,12 +51,20 @@ func LogStartupSuccess(startTime time.Time, port string) {
 	fmt.Fprintf(gin.DefaultWriter, "\n")
 
 	if !IsRunningInContainer() {
-		fmt.Fprintf(gin.DefaultWriter, "  ➜  \033[1mLocal:\033[0m   http://localhost:%s/\n", port)
+		fmt.Fprintf(gin.DefaultWriter, "  ->  \033[1mLocal:\033[0m   %s\n", startupURL("localhost", port))
 	}
 
 	for _, ip := range networkIps {
-		fmt.Fprintf(gin.DefaultWriter, "  ➜  \033[1mNetwork:\033[0m http://%s:%s/\n", ip, port)
+		fmt.Fprintf(gin.DefaultWriter, "  ->  \033[1mNetwork:\033[0m %s\n", startupURL(ip, port))
 	}
 
 	fmt.Fprintf(gin.DefaultWriter, "\n")
+}
+
+func startupURL(host string, port string) string {
+	rootPath := "/"
+	if AppBasePath != "" {
+		rootPath = AppBasePath + "/"
+	}
+	return fmt.Sprintf("http://%s:%s%s", host, port, rootPath)
 }

--- a/common/sys_log_test.go
+++ b/common/sys_log_test.go
@@ -1,0 +1,37 @@
+package common
+
+import "testing"
+
+func TestStartupURL(t *testing.T) {
+	original := AppBasePath
+	t.Cleanup(func() {
+		AppBasePath = original
+	})
+
+	tests := []struct {
+		name     string
+		basePath string
+		want     string
+	}{
+		{
+			name:     "without base path",
+			basePath: "",
+			want:     "http://localhost:3000/",
+		},
+		{
+			name:     "with base path",
+			basePath: "/app",
+			want:     "http://localhost:3000/app/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			AppBasePath = tt.basePath
+
+			if got := startupURL("localhost", "3000"); got != tt.want {
+				t.Fatalf("startupURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/controller/telegram.go
+++ b/controller/telegram.go
@@ -66,7 +66,7 @@ func TelegramBind(c *gin.Context) {
 		return
 	}
 
-	c.Redirect(302, "/console/personal")
+	c.Redirect(302, common.WithAppBasePath("/console/personal"))
 }
 
 func TelegramLogin(c *gin.Context) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@
 # Quick Start:
 #   1. docker-compose up -d
 #   2. Access at http://localhost:3000
+#   3. Optional: set APP_BASE_PATH=/new-api to serve the UI and API under /new-api
 #
 # Using MySQL instead of PostgreSQL:
 #   1. Comment out the postgres service and SQL_DSN line 15
@@ -33,6 +34,8 @@ services:
       - ERROR_LOG_ENABLED=true # 是否启用错误日志记录 (Whether to enable error log recording)
       - BATCH_UPDATE_ENABLED=true  # 是否启用批量更新 (Whether to enable batch update)
       - NODE_NAME=new-api-node-1  # 节点名称，用于审计日志中标识节点身份；多节点/容器部署时建议设置 (Node name used in audit logs; recommended when running multiple instances or in containers)
+#      - APP_BASE_PATH=/new-api  # 可选：将前端和 API 都挂载到子路径，例如 /new-api (Optional: serve the UI and API under a sub-path such as /new-api)
+#      - SERVER_ADDRESS=http://localhost:3000/new-api  # 若使用 OAuth/支付回调，建议包含同样的子路径 (Include the same sub-path when configuring OAuth/payment callback URLs)
 #      - STREAMING_TIMEOUT=300  # 流模式无响应超时时间，单位秒，默认120秒，如果出现空补全可以尝试改为更大值 （Streaming timeout in seconds, default is 120s. Increase if experiencing empty completions）
 #      - SESSION_SECRET=random_string  # 多机部署时设置，必须修改这个随机字符串！！ （multi-node deployment, set this to a random string!!!!!!!）
 #      - SYNC_FREQUENCY=60  # Uncomment if regular database syncing is needed
@@ -47,7 +50,7 @@ services:
     networks:
       - new-api-network
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O - http://localhost:3000/api/status | grep -o '\"success\":\\s*true' || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O - \"http://localhost:3000$${APP_BASE_PATH}/api/status\" | grep -o '\"success\":\\s*true' || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
+	"html"
 	"log"
 	"net/http"
 	"os"
@@ -171,7 +172,7 @@ func main() {
 	// Initialize session store
 	store := cookie.NewStore([]byte(common.SessionSecret))
 	store.Options(sessions.Options{
-		Path:     "/",
+		Path:     common.SessionCookiePath(),
 		MaxAge:   2592000, // 30 days
 		HttpOnly: true,
 		Secure:   false,
@@ -179,6 +180,7 @@ func main() {
 	})
 	server.Use(sessions.Sessions("session", store))
 
+	InjectAppBasePath()
 	InjectUmamiAnalytics()
 	InjectGoogleAnalytics()
 
@@ -196,6 +198,41 @@ func main() {
 	if err != nil {
 		common.FatalLog("failed to start HTTP server: " + err.Error())
 	}
+}
+
+func InjectAppBasePath() {
+	indexPage = injectAppBasePath(indexPage, common.AppBasePath)
+}
+
+func injectAppBasePath(page []byte, appBasePath string) []byte {
+	page = bytes.ReplaceAll(
+		page,
+		[]byte(`"__APP_BASE_PATH_PLACEHOLDER__"`),
+		[]byte(strconv.Quote(appBasePath)),
+	)
+	return injectAppBaseHref(page, appBaseHref(appBasePath))
+}
+
+func injectAppBaseHref(page []byte, href string) []byte {
+	baseTag := []byte(`<base href="` + html.EscapeString(href) + `" />`)
+	for _, candidate := range []string{
+		`<base href="./" />`,
+		`<base href="/" />`,
+		`<base href="%BASE_URL%" />`,
+		`<base href="__APP_BASE_PATH_HREF_PLACEHOLDER__" />`,
+	} {
+		if bytes.Contains(page, []byte(candidate)) {
+			return bytes.Replace(page, []byte(candidate), baseTag, 1)
+		}
+	}
+	return bytes.Replace(page, []byte(`<head>`), []byte("<head>\n    "+string(baseTag)), 1)
+}
+
+func appBaseHref(appBasePath string) string {
+	if appBasePath == "" {
+		return "/"
+	}
+	return strings.TrimRight(appBasePath, "/") + "/"
 }
 
 func InjectUmamiAnalytics() {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInjectAppBasePath(t *testing.T) {
+	index := []byte(`<!doctype html>
+<html>
+  <head>
+    <base href="./" />
+  </head>
+  <body>
+    <script>
+      window.__NEW_API_RUNTIME__ = { appBasePath: "__APP_BASE_PATH_PLACEHOLDER__" };
+    </script>
+  </body>
+</html>`)
+
+	got := injectAppBasePath(index, "/new-api")
+
+	if strings.Contains(string(got), "__APP_BASE_PATH_PLACEHOLDER__") {
+		t.Fatalf("injectAppBasePath() left placeholder in HTML: %s", got)
+	}
+
+	if !strings.Contains(string(got), `window.__NEW_API_RUNTIME__ = { appBasePath: "/new-api" };`) {
+		t.Fatalf("injectAppBasePath() did not inject the expected base path: %s", got)
+	}
+
+	if !strings.Contains(string(got), `<base href="/new-api/" />`) {
+		t.Fatalf("injectAppBasePath() did not inject the expected base href: %s", got)
+	}
+}
+
+func TestInjectAppBasePathUsesRootBaseHrefWhenEmpty(t *testing.T) {
+	index := []byte(`<base href="./" />`)
+
+	got := injectAppBasePath(index, "")
+
+	if !strings.Contains(string(got), `<base href="/" />`) {
+		t.Fatalf("injectAppBasePath() did not inject root base href: %s", got)
+	}
+}
+
+func TestInjectAppBasePathEscapesQuotes(t *testing.T) {
+	index := []byte(`window.__NEW_API_RUNTIME__ = { appBasePath: "__APP_BASE_PATH_PLACEHOLDER__" };`)
+
+	got := injectAppBasePath(index, `/new-api/"quoted"`)
+
+	if !strings.Contains(string(got), `"/new-api/\"quoted\""`) {
+		t.Fatalf("injectAppBasePath() did not JSON-escape the base path: %s", got)
+	}
+}

--- a/middleware/base_path.go
+++ b/middleware/base_path.go
@@ -1,0 +1,63 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	OriginalRequestPathKey = "original_request_path"
+	OriginalRequestURIKey  = "original_request_uri"
+)
+
+func StripAppBasePath() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if common.AppBasePath == "" || c.Request == nil || c.Request.URL == nil {
+			c.Next()
+			return
+		}
+
+		originalPath := c.Request.URL.Path
+		strippedPath, ok := common.StripAppBasePath(originalPath)
+		if !ok {
+			c.Next()
+			return
+		}
+
+		c.Set(OriginalRequestPathKey, originalPath)
+		c.Set(OriginalRequestURIKey, c.Request.RequestURI)
+
+		c.Request.URL.Path = strippedPath
+		if c.Request.URL.RawPath != "" {
+			if strippedRawPath, ok := common.StripAppBasePath(c.Request.URL.RawPath); ok {
+				c.Request.URL.RawPath = strippedRawPath
+			} else {
+				c.Request.URL.RawPath = ""
+			}
+		}
+		c.Request.RequestURI = stripRequestURIBasePath(c.Request.RequestURI)
+
+		c.Next()
+	}
+}
+
+func stripRequestURIBasePath(requestURI string) string {
+	if requestURI == "" || common.AppBasePath == "" {
+		return requestURI
+	}
+
+	pathPart := requestURI
+	queryPart := ""
+	if idx := strings.IndexByte(requestURI, '?'); idx >= 0 {
+		pathPart = requestURI[:idx]
+		queryPart = requestURI[idx:]
+	}
+
+	strippedPath, ok := common.StripAppBasePath(pathPart)
+	if !ok {
+		return requestURI
+	}
+	return strippedPath + queryPart
+}

--- a/middleware/base_path_test.go
+++ b/middleware/base_path_test.go
@@ -1,0 +1,66 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/gin-gonic/gin"
+)
+
+func TestStripAppBasePathForRelayStylePaths(t *testing.T) {
+	original := common.AppBasePath
+	common.AppBasePath = "/app"
+	t.Cleanup(func() {
+		common.AppBasePath = original
+	})
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	group := engine.Group(common.AppBasePath)
+	group.Use(StripAppBasePath())
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "openai relay", path: "/app/v1/chat/completions?stream=true", want: "/v1/chat/completions"},
+		{name: "playground relay", path: "/app/pg/chat/completions", want: "/pg/chat/completions"},
+		{name: "gemini relay", path: "/app/v1beta/models/gemini-pro:generateContent", want: "/v1beta/models/gemini-pro:generateContent"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			group.Any(tt.want, func(c *gin.Context) {
+				if got := c.Request.URL.Path; got != tt.want {
+					t.Fatalf("URL.Path = %q, want %q", got, tt.want)
+				}
+				if got := c.GetString(OriginalRequestPathKey); got != requestPathOnly(tt.path) {
+					t.Fatalf("original path = %q, want %q", got, requestPathOnly(tt.path))
+				}
+				if tt.name == "openai relay" && c.Request.RequestURI != "/v1/chat/completions?stream=true" {
+					t.Fatalf("RequestURI = %q, want stripped URI with query", c.Request.RequestURI)
+				}
+				c.Status(http.StatusNoContent)
+			})
+
+			req := httptest.NewRequest(http.MethodPost, tt.path, nil)
+			recorder := httptest.NewRecorder()
+			engine.ServeHTTP(recorder, req)
+			if recorder.Code != http.StatusNoContent {
+				t.Fatalf("%s status = %d, want %d", tt.path, recorder.Code, http.StatusNoContent)
+			}
+		})
+	}
+}
+
+func requestPathOnly(target string) string {
+	for i, ch := range target {
+		if ch == '?' {
+			return target[:i]
+		}
+	}
+	return target
+}

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetApiRouter(router *gin.Engine) {
+func SetApiRouter(router gin.IRouter) {
 	apiRouter := router.Group("/api")
 	apiRouter.Use(middleware.RouteTag("api"))
 	apiRouter.Use(gzip.Gzip(gzip.DefaultCompression))

--- a/router/dashboard.go
+++ b/router/dashboard.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetDashboardRouter(router *gin.Engine) {
+func SetDashboardRouter(router gin.IRouter) {
 	apiRouter := router.Group("/")
 	apiRouter.Use(middleware.RouteTag("old_api"))
 	apiRouter.Use(gzip.Gzip(gzip.DefaultCompression))

--- a/router/main.go
+++ b/router/main.go
@@ -1,8 +1,8 @@
 package router
 
 import (
-	"embed"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"strings"
@@ -13,21 +13,33 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetRouter(router *gin.Engine, buildFS embed.FS, indexPage []byte) {
-	SetApiRouter(router)
-	SetDashboardRouter(router)
-	SetRelayRouter(router)
-	SetVideoRouter(router)
+func SetRouter(router *gin.Engine, buildFS fs.FS, indexPage []byte) {
+	var routeRoot gin.IRouter = router
+	if common.AppBasePath != "" {
+		baseGroup := router.Group(common.AppBasePath)
+		baseGroup.Use(middleware.StripAppBasePath())
+		routeRoot = baseGroup
+	}
+
+	SetApiRouter(routeRoot)
+	SetDashboardRouter(routeRoot)
+	SetRelayRouter(routeRoot)
+	SetVideoRouter(routeRoot)
 	frontendBaseUrl := os.Getenv("FRONTEND_BASE_URL")
 	if common.IsMasterNode && frontendBaseUrl != "" {
 		frontendBaseUrl = ""
 		common.SysLog("FRONTEND_BASE_URL is ignored on master node")
 	}
 	if frontendBaseUrl == "" {
-		SetWebRouter(router, buildFS, indexPage)
+		SetWebRouter(routeRoot, buildFS)
+		SetWebNoRouteHandler(router, indexPage)
 	} else {
 		frontendBaseUrl = strings.TrimSuffix(frontendBaseUrl, "/")
 		router.NoRoute(func(c *gin.Context) {
+			if _, ok := common.StripAppBasePath(c.Request.URL.Path); !ok {
+				c.Status(http.StatusNotFound)
+				return
+			}
 			c.Set(middleware.RouteTagKey, "web")
 			c.Redirect(http.StatusMovedPermanently, fmt.Sprintf("%s%s", frontendBaseUrl, c.Request.RequestURI))
 		})

--- a/router/main_test.go
+++ b/router/main_test.go
@@ -1,0 +1,135 @@
+package router
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/gin-gonic/gin"
+)
+
+func TestSetRouterWithoutBasePath(t *testing.T) {
+	engine := newTestEngine(t, "")
+
+	resp := performRequest(engine, http.MethodGet, "/api/status")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("GET /api/status status = %d, want %d", resp.Code, http.StatusOK)
+	}
+
+	spaResp := performRequest(engine, http.MethodGet, "/console")
+	if spaResp.Code != http.StatusOK {
+		t.Fatalf("GET /console status = %d, want %d", spaResp.Code, http.StatusOK)
+	}
+	if !strings.Contains(spaResp.Body.String(), "test index") {
+		t.Fatalf("GET /console body = %q, want SPA index", spaResp.Body.String())
+	}
+}
+
+func TestSetRouterWithBasePath(t *testing.T) {
+	engine := newTestEngine(t, "/new-api")
+
+	indexResp := performRequest(engine, http.MethodGet, "/new-api")
+	if indexResp.Code != http.StatusMovedPermanently {
+		t.Fatalf("GET /new-api status = %d, want %d", indexResp.Code, http.StatusMovedPermanently)
+	}
+	if location := indexResp.Header().Get("Location"); location != "/new-api/" {
+		t.Fatalf("GET /new-api redirect location = %q, want %q", location, "/new-api/")
+	}
+
+	slashResp := performRequest(engine, http.MethodGet, "/new-api/")
+	if slashResp.Code != http.StatusOK {
+		t.Fatalf("GET /new-api/ status = %d, want %d", slashResp.Code, http.StatusOK)
+	}
+	if !strings.Contains(slashResp.Body.String(), "test index") {
+		t.Fatalf("GET /new-api/ body = %q, want SPA index", slashResp.Body.String())
+	}
+
+	consoleResp := performRequest(engine, http.MethodGet, "/new-api/console/channel")
+	if consoleResp.Code != http.StatusOK {
+		t.Fatalf("GET /new-api/console/channel status = %d, want %d", consoleResp.Code, http.StatusOK)
+	}
+	if !strings.Contains(consoleResp.Body.String(), "test index") {
+		t.Fatalf("GET /new-api/console/channel body = %q, want SPA index", consoleResp.Body.String())
+	}
+
+	assetResp := performRequest(engine, http.MethodGet, "/new-api/assets/app.js")
+	if assetResp.Code != http.StatusOK {
+		t.Fatalf("GET /new-api/assets/app.js status = %d, want %d", assetResp.Code, http.StatusOK)
+	}
+	if !strings.Contains(assetResp.Body.String(), "asset-ok") {
+		t.Fatalf("GET /new-api/assets/app.js body = %q, want asset contents", assetResp.Body.String())
+	}
+
+	apiNotFound := performRequest(engine, http.MethodGet, "/new-api/api/unknown")
+	if apiNotFound.Code != http.StatusNotFound {
+		t.Fatalf("GET /new-api/api/unknown status = %d, want %d", apiNotFound.Code, http.StatusNotFound)
+	}
+	if !strings.Contains(apiNotFound.Body.String(), "\"error\"") {
+		t.Fatalf("GET /new-api/api/unknown body = %q, want API not-found payload", apiNotFound.Body.String())
+	}
+
+	rootResp := performRequest(engine, http.MethodGet, "/")
+	if rootResp.Code != http.StatusNotFound {
+		t.Fatalf("GET / status = %d, want %d", rootResp.Code, http.StatusNotFound)
+	}
+
+	rootAPIResp := performRequest(engine, http.MethodGet, "/api/status")
+	if rootAPIResp.Code != http.StatusNotFound {
+		t.Fatalf("GET /api/status status = %d, want %d", rootAPIResp.Code, http.StatusNotFound)
+	}
+}
+
+func TestSetRouterWithFrontendBaseURLAndBasePath(t *testing.T) {
+	engine := newTestEngineWithFrontendBaseURL(t, "/new-api", "https://cdn.example.com")
+
+	consoleResp := performRequest(engine, http.MethodGet, "/new-api/console?x=1")
+	if consoleResp.Code != http.StatusMovedPermanently {
+		t.Fatalf("GET /new-api/console status = %d, want %d", consoleResp.Code, http.StatusMovedPermanently)
+	}
+	if location := consoleResp.Header().Get("Location"); location != "https://cdn.example.com/new-api/console?x=1" {
+		t.Fatalf("GET /new-api/console redirect location = %q, want %q", location, "https://cdn.example.com/new-api/console?x=1")
+	}
+
+	rootResp := performRequest(engine, http.MethodGet, "/console")
+	if rootResp.Code != http.StatusNotFound {
+		t.Fatalf("GET /console status = %d, want %d", rootResp.Code, http.StatusNotFound)
+	}
+}
+
+func newTestEngine(t *testing.T, basePath string) *gin.Engine {
+	return newTestEngineWithFrontendBaseURL(t, basePath, "")
+}
+
+func newTestEngineWithFrontendBaseURL(t *testing.T, basePath string, frontendBaseURL string) *gin.Engine {
+	t.Helper()
+
+	original := common.AppBasePath
+	common.AppBasePath = basePath
+	t.Cleanup(func() {
+		common.AppBasePath = original
+	})
+	t.Setenv("FRONTEND_BASE_URL", frontendBaseURL)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	SetRouter(engine, newTestBuildFS(), []byte("<!doctype html><html><body>test index</body></html>"))
+	return engine
+}
+
+func newTestBuildFS() fs.FS {
+	return fstest.MapFS{
+		"web/dist/index.html":    &fstest.MapFile{Data: []byte("<!doctype html><html><body>test index</body></html>")},
+		"web/dist/assets/app.js": &fstest.MapFile{Data: []byte("console.log('asset-ok');")},
+	}
+}
+
+func performRequest(engine *gin.Engine, method string, target string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, target, nil)
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, req)
+	return recorder
+}

--- a/router/relay-router.go
+++ b/router/relay-router.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetRelayRouter(router *gin.Engine) {
+func SetRelayRouter(router gin.IRouter) {
 	router.Use(middleware.CORS())
 	router.Use(middleware.DecompressRequestMiddleware())
 	router.Use(middleware.BodyStorageCleanup()) // 清理请求体存储

--- a/router/video-router.go
+++ b/router/video-router.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetVideoRouter(router *gin.Engine) {
+func SetVideoRouter(router gin.IRouter) {
 	// Video proxy: accepts either session auth (dashboard) or token auth (API clients)
 	videoProxyRouter := router.Group("/v1")
 	videoProxyRouter.Use(middleware.RouteTag("relay"))

--- a/router/web-router.go
+++ b/router/web-router.go
@@ -1,7 +1,7 @@
 package router
 
 import (
-	"embed"
+	"io/fs"
 	"net/http"
 	"strings"
 
@@ -9,22 +9,98 @@ import (
 	"github.com/QuantumNous/new-api/controller"
 	"github.com/QuantumNous/new-api/middleware"
 	"github.com/gin-contrib/gzip"
-	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
 )
 
-func SetWebRouter(router *gin.Engine, buildFS embed.FS, indexPage []byte) {
+func SetWebRouter(router gin.IRouter, buildFS fs.FS) {
+	webFS, err := fs.Sub(buildFS, "web/dist")
+	if err != nil {
+		panic(err)
+	}
+
 	router.Use(gzip.Gzip(gzip.DefaultCompression))
 	router.Use(middleware.GlobalWebRateLimit())
 	router.Use(middleware.Cache())
-	router.Use(static.Serve("/", common.EmbedFolder(buildFS, "web/dist")))
+
+	router.GET("/assets/*filepath", func(c *gin.Context) {
+		filePath := "assets/" + strings.TrimPrefix(c.Param("filepath"), "/")
+		serveEmbeddedStaticFile(c, webFS, filePath)
+	})
+
+	entries, err := fs.ReadDir(webFS, ".")
+	if err != nil {
+		panic(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		filePath := entry.Name()
+		router.GET("/"+filePath, func(c *gin.Context) {
+			serveEmbeddedStaticFile(c, webFS, filePath)
+		})
+	}
+}
+
+func SetWebNoRouteHandler(router *gin.Engine, indexPage []byte) {
 	router.NoRoute(func(c *gin.Context) {
+		requestPath := c.Request.URL.Path
+		if common.AppBasePath != "" && requestPath == common.AppBasePath {
+			target := common.AppBasePath + "/"
+			if rawQuery := c.Request.URL.RawQuery; rawQuery != "" {
+				target += "?" + rawQuery
+			}
+			c.Redirect(http.StatusMovedPermanently, target)
+			return
+		}
+
+		strippedPath, ok := common.StripAppBasePath(requestPath)
+		if !ok {
+			c.Status(http.StatusNotFound)
+			return
+		}
+
 		c.Set(middleware.RouteTagKey, "web")
-		if strings.HasPrefix(c.Request.RequestURI, "/v1") || strings.HasPrefix(c.Request.RequestURI, "/api") || strings.HasPrefix(c.Request.RequestURI, "/assets") {
+		if isAPINotFoundPath(strippedPath) {
 			controller.RelayNotFound(c)
 			return
 		}
 		c.Header("Cache-Control", "no-cache")
 		c.Data(http.StatusOK, "text/html; charset=utf-8", indexPage)
 	})
+}
+
+func isAPINotFoundPath(requestPath string) bool {
+	apiPrefixes := []string{
+		"/api",
+		"/assets",
+		"/dashboard",
+		"/jimeng",
+		"/kling",
+		"/mj",
+		"/pg",
+		"/suno",
+		"/v1",
+		"/v1beta",
+	}
+	for _, prefix := range apiPrefixes {
+		if requestPath == prefix || strings.HasPrefix(requestPath, prefix+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func serveEmbeddedStaticFile(c *gin.Context, webFS fs.FS, filePath string) {
+	info, err := fs.Stat(webFS, filePath)
+	if err != nil {
+		c.Status(http.StatusNotFound)
+		return
+	}
+	if info.IsDir() {
+		c.Status(http.StatusNotFound)
+		return
+	}
+
+	c.FileFromFS(filePath, http.FS(webFS))
 }

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,8 @@
 <html lang="zh">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="/logo.png" />
+    <base href="%BASE_URL%" />
+    <link rel="icon" href="%BASE_URL%logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#ffffff" />
     <meta
@@ -17,6 +18,11 @@
     />
     <meta name="generator" content="new-api" />
     <title>New API</title>
+    <script>
+      window.__NEW_API_RUNTIME__ = {
+        appBasePath: "__APP_BASE_PATH_PLACEHOLDER__",
+      };
+    </script>
     <!--umami-->
     <!--Google Analytics-->
   </head>
@@ -24,6 +30,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script type="module" src="/src/index.jsx"></script>
+    <script type="module" src="./src/index.jsx"></script>
   </body>
 </html>

--- a/web/package.json
+++ b/web/package.json
@@ -44,6 +44,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "bun test",
     "lint": "prettier . --check",
     "lint:fix": "prettier . --write",
     "eslint": "bunx eslint \"**/*.{js,jsx}\" --cache",

--- a/web/src/components/auth/LoginForm.jsx
+++ b/web/src/components/auth/LoginForm.jsx
@@ -39,6 +39,7 @@ import {
   prepareCredentialRequestOptions,
   buildAssertionResult,
   isPasskeySupported,
+  withBasePath,
 } from '../../helpers';
 import Turnstile from 'react-turnstile';
 import {
@@ -135,12 +136,12 @@ const LoginForm = () => {
     (status.custom_oauth_providers || []).length > 0;
   const hasOAuthLoginOptions = Boolean(
     status.github_oauth ||
-      status.discord_oauth ||
-      status.oidc_enabled ||
-      status.wechat_login ||
-      status.linuxdo_oauth ||
-      status.telegram_oauth ||
-      hasCustomOAuthProviders,
+    status.discord_oauth ||
+    status.oidc_enabled ||
+    status.wechat_login ||
+    status.linuxdo_oauth ||
+    status.telegram_oauth ||
+    hasCustomOAuthProviders,
   );
 
   useEffect(() => {
@@ -669,7 +670,7 @@ const LoginForm = () => {
                       {hasUserAgreement && (
                         <>
                           <a
-                            href='/user-agreement'
+                            href={withBasePath('/user-agreement')}
                             target='_blank'
                             rel='noopener noreferrer'
                             className='text-blue-600 hover:text-blue-800 mx-1'
@@ -682,7 +683,7 @@ const LoginForm = () => {
                       {hasPrivacyPolicy && (
                         <>
                           <a
-                            href='/privacy-policy'
+                            href={withBasePath('/privacy-policy')}
                             target='_blank'
                             rel='noopener noreferrer'
                             className='text-blue-600 hover:text-blue-800 mx-1'
@@ -775,7 +776,7 @@ const LoginForm = () => {
                         {hasUserAgreement && (
                           <>
                             <a
-                              href='/user-agreement'
+                              href={withBasePath('/user-agreement')}
                               target='_blank'
                               rel='noopener noreferrer'
                               className='text-blue-600 hover:text-blue-800 mx-1'
@@ -788,7 +789,7 @@ const LoginForm = () => {
                         {hasPrivacyPolicy && (
                           <>
                             <a
-                              href='/privacy-policy'
+                              href={withBasePath('/privacy-policy')}
                               target='_blank'
                               rel='noopener noreferrer'
                               className='text-blue-600 hover:text-blue-800 mx-1'
@@ -958,8 +959,7 @@ const LoginForm = () => {
         style={{ top: '50%', left: '-120px' }}
       />
       <div className='w-full max-w-sm mt-[60px]'>
-        {showEmailLogin ||
-        !hasOAuthLoginOptions
+        {showEmailLogin || !hasOAuthLoginOptions
           ? renderEmailLoginForm()
           : renderOAuthOptions()}
         {renderWeChatLoginModal()}

--- a/web/src/components/auth/RegisterForm.jsx
+++ b/web/src/components/auth/RegisterForm.jsx
@@ -31,6 +31,7 @@ import {
   setUserData,
   onDiscordOAuthClicked,
   onCustomOAuthClicked,
+  withBasePath,
 } from '../../helpers';
 import Turnstile from 'react-turnstile';
 import {
@@ -133,12 +134,12 @@ const RegisterForm = () => {
     (status.custom_oauth_providers || []).length > 0;
   const hasOAuthRegisterOptions = Boolean(
     status.github_oauth ||
-      status.discord_oauth ||
-      status.oidc_enabled ||
-      status.wechat_login ||
-      status.linuxdo_oauth ||
-      status.telegram_oauth ||
-      hasCustomOAuthProviders,
+    status.discord_oauth ||
+    status.oidc_enabled ||
+    status.wechat_login ||
+    status.linuxdo_oauth ||
+    status.telegram_oauth ||
+    hasCustomOAuthProviders,
   );
 
   const [showEmailVerification, setShowEmailVerification] = useState(false);
@@ -648,7 +649,7 @@ const RegisterForm = () => {
                         {hasUserAgreement && (
                           <>
                             <a
-                              href='/user-agreement'
+                              href={withBasePath('/user-agreement')}
                               target='_blank'
                               rel='noopener noreferrer'
                               className='text-blue-600 hover:text-blue-800 mx-1'
@@ -661,7 +662,7 @@ const RegisterForm = () => {
                         {hasPrivacyPolicy && (
                           <>
                             <a
-                              href='/privacy-policy'
+                              href={withBasePath('/privacy-policy')}
                               target='_blank'
                               rel='noopener noreferrer'
                               className='text-blue-600 hover:text-blue-800 mx-1'
@@ -781,8 +782,7 @@ const RegisterForm = () => {
         style={{ top: '50%', left: '-120px' }}
       />
       <div className='w-full max-w-sm mt-[60px]'>
-        {showEmailRegister ||
-        !hasOAuthRegisterOptions
+        {showEmailRegister || !hasOAuthRegisterOptions
           ? renderEmailRegisterForm()
           : renderOAuthOptions()}
         {renderWeChatLoginModal()}

--- a/web/src/components/playground/MessageContent.jsx
+++ b/web/src/components/playground/MessageContent.jsx
@@ -23,7 +23,7 @@ import MarkdownRenderer from '../common/markdown/MarkdownRenderer';
 import ThinkingContent from './ThinkingContent';
 import { Loader2, Check, X, Settings, AlertTriangle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { isAdmin } from '../../helpers/utils';
+import { isAdmin, openWithBasePath } from '../../helpers';
 
 const MessageContent = ({
   message,
@@ -77,7 +77,10 @@ const MessageContent = ({
           >
             <div className='flex items-center gap-2'>
               <AlertTriangle size={16} className='text-orange-500 shrink-0' />
-              <Typography.Text strong className='!text-[var(--semi-color-text-0)]'>
+              <Typography.Text
+                strong
+                className='!text-[var(--semi-color-text-0)]'
+              >
                 {t('模型价格未配置')}
               </Typography.Text>
             </div>
@@ -93,7 +96,9 @@ const MessageContent = ({
                 theme='light'
                 type='warning'
                 icon={<Settings size={14} />}
-                onClick={() => window.open('/console/setting?tab=ratio', '_blank')}
+                onClick={() =>
+                  openWithBasePath('/console/setting?tab=ratio', '_blank')
+                }
               >
                 {t('前往设置')}
               </Button>

--- a/web/src/components/settings/personal/cards/AccountManagement.jsx
+++ b/web/src/components/settings/personal/cards/AccountManagement.jsx
@@ -51,6 +51,7 @@ import {
   onDiscordOAuthClicked,
   onCustomOAuthClicked,
   getOAuthProviderIcon,
+  withBasePath,
 } from '../../../../helpers';
 import TwoFASetting from '../components/TwoFASetting';
 
@@ -469,7 +470,7 @@ const AccountManagement = ({
                 <div className='flex justify-center'>
                   <div className='scale-90'>
                     <TelegramLoginButton
-                      dataAuthUrl='/api/oauth/telegram/bind'
+                      dataAuthUrl={withBasePath('/api/oauth/telegram/bind')}
                       botName={status.telegram_bot_name}
                     />
                   </div>

--- a/web/src/components/setup/SetupWizard.jsx
+++ b/web/src/components/setup/SetupWizard.jsx
@@ -19,7 +19,7 @@ For commercial licensing, please contact support@quantumnous.com
 
 import React, { useEffect, useState, useRef } from 'react';
 import { Card, Divider, Steps, Form } from '@douyinfe/semi-ui';
-import { API, showError, showNotice } from '../../helpers';
+import { API, redirectToApp, showError, showNotice } from '../../helpers';
 import { useTranslation } from 'react-i18next';
 
 import StepNavigation from './components/StepNavigation';
@@ -86,7 +86,7 @@ const SetupWizard = () => {
 
         // If setup is already completed, redirect to home
         if (data.status) {
-          window.location.href = '/';
+          redirectToApp('/');
           return;
         }
 

--- a/web/src/components/table/channels/modals/ModelTestModal.jsx
+++ b/web/src/components/table/channels/modals/ModelTestModal.jsx
@@ -31,7 +31,13 @@ import {
 } from '@douyinfe/semi-ui';
 import { IconSearch, IconInfoCircle } from '@douyinfe/semi-icons';
 import { Settings } from 'lucide-react';
-import { copy, showError, showInfo, showSuccess } from '../../../../helpers';
+import {
+  copy,
+  openWithBasePath,
+  showError,
+  showInfo,
+  showSuccess,
+} from '../../../../helpers';
 import { MODEL_TABLE_PAGE_SIZE } from '../../../../constants';
 
 const ModelTestModal = ({
@@ -199,7 +205,9 @@ const ModelTestModal = ({
                     theme='light'
                     type='warning'
                     icon={<Settings size={12} />}
-                    onClick={() => window.open('/console/setting?tab=ratio', '_blank')}
+                    onClick={() =>
+                      openWithBasePath('/console/setting?tab=ratio', '_blank')
+                    }
                     style={{ width: 'fit-content' }}
                   >
                     {t('前往设置')}

--- a/web/src/components/table/channels/modals/OllamaModelModal.jsx
+++ b/web/src/components/table/channels/modals/OllamaModelModal.jsx
@@ -49,6 +49,7 @@ import {
   getUserIdFromLocalStorage,
   showError,
   showSuccess,
+  withBasePath,
 } from '../../../../helpers';
 
 const { Text, Title } = Typography;
@@ -339,15 +340,18 @@ const OllamaModelModal = ({
         ...authHeaders,
       };
 
-      const response = await fetch('/api/channel/ollama/pull/stream', {
-        method: 'POST',
-        headers: fetchHeaders,
-        body: JSON.stringify({
-          channel_id: channelId,
-          model_name: pullModelName.trim(),
-        }),
-        signal: controller.signal,
-      });
+      const response = await fetch(
+        withBasePath('/api/channel/ollama/pull/stream'),
+        {
+          method: 'POST',
+          headers: fetchHeaders,
+          body: JSON.stringify({
+            channel_id: channelId,
+            model_name: pullModelName.trim(),
+          }),
+          signal: controller.signal,
+        },
+      );
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/web/src/components/table/tokens/index.jsx
+++ b/web/src/components/table/tokens/index.jsx
@@ -28,6 +28,7 @@ import {
 } from '@douyinfe/semi-ui';
 import {
   API,
+  getAppOrigin,
   showError,
   getModelCategories,
   selectFilter,
@@ -229,7 +230,7 @@ function TokensPage() {
         serverAddress = status.server_address || '';
       } catch (_) {}
     }
-    if (!serverAddress) serverAddress = window.location.origin;
+    if (!serverAddress) serverAddress = getAppOrigin();
 
     let apiKeyToUse = '';
     if (overrideKey) {

--- a/web/src/components/table/tokens/modals/CCSwitchModal.jsx
+++ b/web/src/components/table/tokens/modals/CCSwitchModal.jsx
@@ -27,7 +27,7 @@ import {
   Typography,
 } from '@douyinfe/semi-ui';
 import { useTranslation } from 'react-i18next';
-import { selectFilter } from '../../../../helpers';
+import { getAppOrigin, selectFilter } from '../../../../helpers';
 
 const APP_CONFIGS = {
   claude: {
@@ -60,7 +60,7 @@ function getServerAddress() {
       if (status.server_address) return status.server_address;
     }
   } catch (_) {}
-  return window.location.origin;
+  return getAppOrigin();
 }
 
 function buildCCSwitchURL(app, name, models, apiKey) {

--- a/web/src/components/topup/index.jsx
+++ b/web/src/components/topup/index.jsx
@@ -27,6 +27,7 @@ import {
   renderQuota,
   renderQuotaWithAmount,
   copy,
+  getAppOrigin,
   getQuotaPerUnit,
 } from '../../helpers';
 import { Modal, Toast } from '@douyinfe/semi-ui';
@@ -647,7 +648,7 @@ const TopUp = () => {
                 ? data.waffo_min_topup
                 : enableWaffoPancakeTopUp
                   ? data.waffo_pancake_min_topup
-                : 1;
+                  : 1;
           setEnableOnlineTopUp(enableOnlineTopUp);
           setEnableStripeTopUp(enableStripeTopUp);
           setEnableCreemTopUp(enableCreemTopUp);
@@ -699,7 +700,7 @@ const TopUp = () => {
     const res = await API.get('/api/user/aff');
     const { success, message, data } = res.data;
     if (success) {
-      let link = `${window.location.origin}/register?aff=${data}`;
+      let link = `${getAppOrigin()}/register?aff=${data}`;
       setAffLink(link);
     } else {
       showError(message);

--- a/web/src/helpers/api.js
+++ b/web/src/helpers/api.js
@@ -25,30 +25,31 @@ import {
 } from './utils';
 import axios from 'axios';
 import { MESSAGE_ROLES } from '../constants/playground.constants';
+import {
+  getAbsoluteAppUrl,
+  getApiBaseUrl,
+  openWithBasePath,
+} from './base-path';
 
 export let API = axios.create({
-  baseURL: import.meta.env.VITE_REACT_APP_SERVER_URL
-    ? import.meta.env.VITE_REACT_APP_SERVER_URL
-    : '',
+  baseURL: getApiBaseUrl(),
   headers: {
     'New-API-User': getUserIdFromLocalStorage(),
     'Cache-Control': 'no-store',
   },
 });
 
-
 function redirectToOAuthUrl(url, options = {}) {
   const { openInNewTab = false } = options;
   const targetUrl = typeof url === 'string' ? url : url.toString();
 
   if (openInNewTab) {
-    window.open(targetUrl, '_blank');
+    openWithBasePath(targetUrl, '_blank');
     return;
   }
 
   window.location.assign(targetUrl);
 }
-
 
 function patchAPIInstance(instance) {
   const originalGet = instance.get.bind(instance);
@@ -82,9 +83,7 @@ patchAPIInstance(API);
 
 export function updateAPI() {
   API = axios.create({
-    baseURL: import.meta.env.VITE_REACT_APP_SERVER_URL
-      ? import.meta.env.VITE_REACT_APP_SERVER_URL
-      : '',
+    baseURL: getApiBaseUrl(),
     headers: {
       'New-API-User': getUserIdFromLocalStorage(),
       'Cache-Control': 'no-store',
@@ -271,7 +270,7 @@ async function prepareOAuthState(options = {}) {
 export async function onDiscordOAuthClicked(client_id, options = {}) {
   const state = await prepareOAuthState(options);
   if (!state) return;
-  const redirect_uri = `${window.location.origin}/oauth/discord`;
+  const redirect_uri = getAbsoluteAppUrl('/oauth/discord');
   const response_type = 'code';
   const scope = 'identify+openid';
   redirectToOAuthUrl(
@@ -289,7 +288,7 @@ export async function onOIDCClicked(
   if (!state) return;
   const url = new URL(auth_url);
   url.searchParams.set('client_id', client_id);
-  url.searchParams.set('redirect_uri', `${window.location.origin}/oauth/oidc`);
+  url.searchParams.set('redirect_uri', getAbsoluteAppUrl('/oauth/oidc'));
   url.searchParams.set('response_type', 'code');
   url.searchParams.set('scope', 'openid profile email');
   url.searchParams.set('state', state);
@@ -330,7 +329,7 @@ export async function onCustomOAuthClicked(provider, options = {}) {
   if (!state) return;
 
   try {
-    const redirect_uri = `${window.location.origin}/oauth/${provider.slug}`;
+    const redirect_uri = getAbsoluteAppUrl(`/oauth/${provider.slug}`);
 
     // Check if authorization_endpoint is a full URL or relative path
     let authUrl;

--- a/web/src/helpers/auth.jsx
+++ b/web/src/helpers/auth.jsx
@@ -18,8 +18,7 @@ For commercial licensing, please contact support@quantumnous.com
 */
 
 import React from 'react';
-import { Navigate } from 'react-router-dom';
-import { history } from './history';
+import { Navigate, useLocation } from 'react-router-dom';
 
 export function authHeader() {
   // return authorization header with jwt token
@@ -43,16 +42,18 @@ export const AuthRedirect = ({ children }) => {
 };
 
 function PrivateRoute({ children }) {
+  const location = useLocation();
   if (!localStorage.getItem('user')) {
-    return <Navigate to='/login' state={{ from: history.location }} />;
+    return <Navigate to='/login' state={{ from: location }} />;
   }
   return children;
 }
 
 export function AdminRoute({ children }) {
+  const location = useLocation();
   const raw = localStorage.getItem('user');
   if (!raw) {
-    return <Navigate to='/login' state={{ from: history.location }} />;
+    return <Navigate to='/login' state={{ from: location }} />;
   }
   try {
     const user = JSON.parse(raw);

--- a/web/src/helpers/base-path.js
+++ b/web/src/helpers/base-path.js
@@ -44,6 +44,25 @@ export function normalizeBasePath(basePath) {
   return normalized;
 }
 
+const APP_BASE_PATH_PLACEHOLDER = '__APP_BASE_PATH_PLACEHOLDER__';
+
+export function normalizeRuntimeBasePath(basePath) {
+  if (basePath === APP_BASE_PATH_PLACEHOLDER) {
+    return '';
+  }
+
+  try {
+    return normalizeBasePath(basePath);
+  } catch (error) {
+    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      console.warn(
+        `Ignoring invalid runtime appBasePath: ${error.message || error}`,
+      );
+    }
+    return '';
+  }
+}
+
 const runtimeBasePath =
   typeof window !== 'undefined' &&
   window.__NEW_API_RUNTIME__ &&
@@ -52,7 +71,7 @@ const runtimeBasePath =
     : '';
 
 export const APP_BASE_PATH =
-  normalizeBasePath(runtimeBasePath) ||
+  normalizeRuntimeBasePath(runtimeBasePath) ||
   normalizeBasePath(import.meta.env?.BASE_URL || '/');
 
 function isAbsoluteUrl(url) {

--- a/web/src/helpers/base-path.js
+++ b/web/src/helpers/base-path.js
@@ -1,0 +1,107 @@
+/*
+Copyright (C) 2025 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+
+export function normalizeBasePath(basePath) {
+  const raw = typeof basePath === 'string' ? basePath.trim() : '';
+  if (!raw || raw === '/' || raw === '.' || raw === './') {
+    return '';
+  }
+
+  if (!raw.startsWith('/')) {
+    throw new Error('APP_BASE_PATH must start with "/"');
+  }
+  if (/[?#]/.test(raw)) {
+    throw new Error('APP_BASE_PATH must not contain query or fragment');
+  }
+
+  const normalized = raw.replace(/\/+$/, '');
+  if (!normalized) {
+    return '';
+  }
+  const hasInvalidSegment = normalized
+    .split('/')
+    .slice(1)
+    .some((segment) => segment === '' || segment === '.' || segment === '..');
+  if (hasInvalidSegment) {
+    throw new Error('APP_BASE_PATH contains invalid path segments');
+  }
+  return normalized;
+}
+
+const runtimeBasePath =
+  typeof window !== 'undefined' &&
+  window.__NEW_API_RUNTIME__ &&
+  typeof window.__NEW_API_RUNTIME__.appBasePath === 'string'
+    ? window.__NEW_API_RUNTIME__.appBasePath
+    : '';
+
+export const APP_BASE_PATH =
+  normalizeBasePath(runtimeBasePath) ||
+  normalizeBasePath(import.meta.env?.BASE_URL || '/');
+
+function isAbsoluteUrl(url) {
+  return /^(?:[a-z][a-z\d+\-.]*:)?\/\//i.test(url);
+}
+
+export function withBasePath(url = '/') {
+  if (!url) {
+    return APP_BASE_PATH || '/';
+  }
+  if (
+    isAbsoluteUrl(url) ||
+    url.startsWith('mailto:') ||
+    url.startsWith('tel:') ||
+    url.startsWith('ccswitch:')
+  ) {
+    return url;
+  }
+  if (url.startsWith('#')) {
+    return `${APP_BASE_PATH}${url}`;
+  }
+
+  const normalizedUrl = url.startsWith('/') ? url : `/${url}`;
+  if (
+    !APP_BASE_PATH ||
+    normalizedUrl === APP_BASE_PATH ||
+    normalizedUrl.startsWith(`${APP_BASE_PATH}/`)
+  ) {
+    return normalizedUrl;
+  }
+  return `${APP_BASE_PATH}${normalizedUrl}`;
+}
+
+export function getAppOrigin() {
+  return `${window.location.origin}${APP_BASE_PATH}`;
+}
+
+export function getAbsoluteAppUrl(url = '/') {
+  return new URL(withBasePath(url), window.location.origin).toString();
+}
+
+export function getApiBaseUrl() {
+  return import.meta.env?.VITE_REACT_APP_SERVER_URL || APP_BASE_PATH || '';
+}
+
+export function redirectToApp(url) {
+  window.location.assign(withBasePath(url));
+}
+
+export function openWithBasePath(url, target = '_blank', features) {
+  return window.open(withBasePath(url), target, features);
+}

--- a/web/src/helpers/base-path.test.js
+++ b/web/src/helpers/base-path.test.js
@@ -19,7 +19,30 @@ For commercial licensing, please contact support@quantumnous.com
 
 import { describe, expect, test } from 'bun:test';
 
-import { normalizeBasePath } from './base-path';
+import { normalizeBasePath, normalizeRuntimeBasePath } from './base-path';
+
+let runtimeImportId = 0;
+
+async function importBasePathWithRuntime(appBasePath) {
+  const hadWindow = Object.prototype.hasOwnProperty.call(globalThis, 'window');
+  const previousWindow = globalThis.window;
+  globalThis.window = {
+    __NEW_API_RUNTIME__: {
+      appBasePath,
+    },
+  };
+
+  try {
+    runtimeImportId += 1;
+    return await import(`./base-path.js?runtime-test=${runtimeImportId}`);
+  } finally {
+    if (hadWindow) {
+      globalThis.window = previousWindow;
+    } else {
+      delete globalThis.window;
+    }
+  }
+}
 
 describe('normalizeBasePath', () => {
   test.each([
@@ -39,4 +62,35 @@ describe('normalizeBasePath', () => {
       expect(() => normalizeBasePath(input)).toThrow();
     },
   );
+});
+
+describe('runtime base path', () => {
+  test('ignores the unresolved HTML placeholder', async () => {
+    const mod = await importBasePathWithRuntime('__APP_BASE_PATH_PLACEHOLDER__');
+
+    expect(normalizeRuntimeBasePath('__APP_BASE_PATH_PLACEHOLDER__')).toBe('');
+    expect(mod.APP_BASE_PATH).toBe('');
+  });
+
+  test('warns and falls back when runtime base path is invalid', async () => {
+    const originalWarn = console.warn;
+    const warnings = [];
+    console.warn = (...args) => warnings.push(args);
+
+    try {
+      const mod = await importBasePathWithRuntime('app');
+
+      expect(mod.APP_BASE_PATH).toBe('');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0][0]).toContain('Ignoring invalid runtime appBasePath');
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test('uses valid runtime base path before fallback', async () => {
+    const mod = await importBasePathWithRuntime('/new-api/');
+
+    expect(mod.APP_BASE_PATH).toBe('/new-api');
+  });
 });

--- a/web/src/helpers/base-path.test.js
+++ b/web/src/helpers/base-path.test.js
@@ -17,25 +17,26 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 
-import React, { useContext, useEffect } from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
-import { StatusContext } from '../../context/Status';
-import { redirectToApp } from '../../helpers';
+import { describe, expect, test } from 'bun:test';
 
-const SetupCheck = ({ children }) => {
-  const [statusState] = useContext(StatusContext);
-  const location = useLocation();
+import { normalizeBasePath } from './base-path';
 
-  useEffect(() => {
-    if (
-      statusState?.status?.setup === false &&
-      location.pathname !== '/setup'
-    ) {
-      redirectToApp('/setup');
-    }
-  }, [statusState?.status?.setup, location.pathname]);
+describe('normalizeBasePath', () => {
+  test.each([
+    ['', ''],
+    ['/', ''],
+    ['.', ''],
+    ['./', ''],
+    ['/new-api', '/new-api'],
+    ['/new-api/', '/new-api'],
+  ])('normalizes %p to %p', (input, expected) => {
+    expect(normalizeBasePath(input)).toBe(expected);
+  });
 
-  return children;
-};
-
-export default SetupCheck;
+  test.each(['app', '/a//b', '/a/./b', '/a/../b', '/app?x=1'])(
+    'rejects invalid base path %p',
+    (input) => {
+      expect(() => normalizeBasePath(input)).toThrow();
+    },
+  );
+});

--- a/web/src/helpers/index.js
+++ b/web/src/helpers/index.js
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 
+export * from './base-path';
 export * from './history';
 export * from './auth';
 export * from './utils';

--- a/web/src/helpers/token.js
+++ b/web/src/helpers/token.js
@@ -18,6 +18,7 @@ For commercial licensing, please contact support@quantumnous.com
 */
 
 import { API } from './api';
+import { getAppOrigin } from './base-path';
 
 /**
  * 按需获取单个令牌的真实 key
@@ -89,7 +90,7 @@ export function getServerAddress() {
   }
 
   if (!serverAddress) {
-    serverAddress = window.location.origin;
+    serverAddress = getAppOrigin();
   }
 
   return serverAddress;

--- a/web/src/helpers/utils.jsx
+++ b/web/src/helpers/utils.jsx
@@ -27,6 +27,7 @@ import {
 } from '../constants/playground.constants';
 import { TABLE_COMPACT_MODES_KEY } from '../constants';
 import { MOBILE_BREAKPOINT } from '../hooks/common/useIsMobile';
+import { openWithBasePath, redirectToApp, withBasePath } from './base-path';
 
 const HTMLToastContent = ({ htmlContent }) => {
   return <div dangerouslySetInnerHTML={{ __html: htmlContent }} />;
@@ -54,7 +55,7 @@ export function getSystemName() {
 
 export function getLogo() {
   let logo = localStorage.getItem('logo');
-  if (!logo) return '/logo.png';
+  if (!logo) return withBasePath('/logo.png');
   return logo;
 }
 
@@ -128,7 +129,7 @@ export function showError(error) {
           // 清除用户状态
           localStorage.removeItem('user');
           // toast.error('错误：未登录或登录已过期，请重新登录！', showErrorOptions);
-          window.location.href = '/login?expired=true';
+          redirectToApp('/login?expired=true');
           break;
         case 429:
           Toast.error('错误：请求次数过多，请稍后再试！');
@@ -171,7 +172,7 @@ export function showNotice(message, isHTML = false) {
 }
 
 export function openPage(url) {
-  window.open(url);
+  openWithBasePath(url);
 }
 
 export function removeTrailingSlash(url) {

--- a/web/src/hooks/chat/useTokenKeys.js
+++ b/web/src/hooks/chat/useTokenKeys.js
@@ -19,7 +19,7 @@ For commercial licensing, please contact support@quantumnous.com
 
 import { useEffect, useState } from 'react';
 import { fetchTokenKeys, getServerAddress } from '../../helpers/token';
-import { showError } from '../../helpers';
+import { redirectToApp, showError } from '../../helpers';
 
 export function useTokenKeys(id) {
   const [keys, setKeys] = useState([]);
@@ -32,7 +32,7 @@ export function useTokenKeys(id) {
       if (fetchedKeys.length === 0) {
         showError('当前没有可用的启用令牌，请确认是否有令牌处于启用状态！');
         setTimeout(() => {
-          window.location.href = '/console/token';
+          redirectToApp('/console/token');
         }, 1500); // 延迟 1.5 秒后跳转
       }
       setKeys(fetchedKeys);

--- a/web/src/hooks/playground/useApiRequest.jsx
+++ b/web/src/hooks/playground/useApiRequest.jsx
@@ -30,6 +30,7 @@ import {
   handleApiError,
   processThinkTags,
   processIncompleteThinkTags,
+  withBasePath,
 } from '../../helpers';
 
 export const useApiRequest = (
@@ -185,14 +186,17 @@ export const useApiRequest = (
       setActiveDebugTab(DEBUG_TABS.REQUEST);
 
       try {
-        const response = await fetch(API_ENDPOINTS.CHAT_COMPLETIONS, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'New-Api-User': getUserIdFromLocalStorage(),
+        const response = await fetch(
+          withBasePath(API_ENDPOINTS.CHAT_COMPLETIONS),
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'New-Api-User': getUserIdFromLocalStorage(),
+            },
+            body: JSON.stringify(payload),
           },
-          body: JSON.stringify(payload),
-        });
+        );
 
         if (!response.ok) {
           let errorBody = '';
@@ -313,7 +317,7 @@ export const useApiRequest = (
       }));
       setActiveDebugTab(DEBUG_TABS.REQUEST);
 
-      const source = new SSE(API_ENDPOINTS.CHAT_COMPLETIONS, {
+      const source = new SSE(withBasePath(API_ENDPOINTS.CHAT_COMPLETIONS), {
         headers: {
           'Content-Type': 'application/json',
           'New-Api-User': getUserIdFromLocalStorage(),

--- a/web/src/hooks/tokens/useTokensData.jsx
+++ b/web/src/hooks/tokens/useTokensData.jsx
@@ -23,6 +23,7 @@ import { Modal } from '@douyinfe/semi-ui';
 import {
   API,
   copy,
+  getAppOrigin,
   showError,
   showSuccess,
   encodeToBase64,
@@ -229,7 +230,7 @@ export const useTokensData = (openFluentNotification, openCCSwitchModal) => {
       serverAddress = status.server_address;
     }
     if (serverAddress === '') {
-      serverAddress = window.location.origin;
+      serverAddress = getAppOrigin();
     }
     if (url.includes('{cherryConfig}') === true) {
       let cherryConfig = {
@@ -296,8 +297,7 @@ export const useTokensData = (openFluentNotification, openCCSwitchModal) => {
   // Search tokens function
   const searchTokens = async (page = 1, size = pageSize) => {
     const normalizedPage = Number.isInteger(page) && page > 0 ? page : 1;
-    const normalizedSize =
-      Number.isInteger(size) && size > 0 ? size : pageSize;
+    const normalizedSize = Number.isInteger(size) && size > 0 ? size : pageSize;
 
     const { searchKeyword, searchToken } = getFormValues();
     if (searchKeyword === '' && searchToken === '') {

--- a/web/src/index.jsx
+++ b/web/src/index.jsx
@@ -32,6 +32,7 @@ import { LocaleProvider } from '@douyinfe/semi-ui';
 import { useTranslation } from 'react-i18next';
 import zh_CN from '@douyinfe/semi-ui/lib/es/locale/source/zh_CN';
 import en_GB from '@douyinfe/semi-ui/lib/es/locale/source/en_GB';
+import { APP_BASE_PATH } from './helpers/base-path';
 
 // 欢迎信息（二次开发者未经允许不准将此移除）
 // Welcome message (Do not remove this without permission from the original developer)
@@ -60,6 +61,7 @@ root.render(
     <StatusProvider>
       <UserProvider>
         <BrowserRouter
+          basename={APP_BASE_PATH || '/'}
           future={{
             v7_startTransition: true,
             v7_relativeSplatPath: true,

--- a/web/src/pages/Home/index.jsx
+++ b/web/src/pages/Home/index.jsx
@@ -25,7 +25,7 @@ import {
   ScrollList,
   ScrollItem,
 } from '@douyinfe/semi-ui';
-import { API, showError, copy, showSuccess } from '../../helpers';
+import { API, copy, getAppOrigin, showError, showSuccess } from '../../helpers';
 import { useIsMobile } from '../../hooks/common/useIsMobile';
 import { API_ENDPOINTS } from '../../constants/common.constant';
 import { StatusContext } from '../../context/Status';
@@ -75,8 +75,7 @@ const Home = () => {
   const isMobile = useIsMobile();
   const isDemoSiteMode = statusState?.status?.demo_site_enabled || false;
   const docsLink = statusState?.status?.docs_link || '';
-  const serverAddress =
-    statusState?.status?.server_address || `${window.location.origin}`;
+  const serverAddress = statusState?.status?.server_address || getAppOrigin();
   const endpointItems = API_ENDPOINTS.map((e) => ({ value: e }));
   const [endpointIndex, setEndpointIndex] = useState(0);
   const isChinese = i18n.language.startsWith('zh');

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -24,84 +24,121 @@ import path from 'path';
 import { codeInspectorPlugin } from 'code-inspector-plugin';
 const { vitePluginSemi } = pkg;
 
-// https://vitejs.dev/config/
-export default defineConfig({
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
-  plugins: [
-    codeInspectorPlugin({
-      bundler: 'vite',
-    }),
-    {
-      name: 'treat-js-files-as-jsx',
-      async transform(code, id) {
-        if (!/src\/.*\.js$/.test(id)) {
-          return null;
-        }
+function normalizeBasePath(basePath) {
+  const raw = typeof basePath === 'string' ? basePath.trim() : '';
+  if (!raw || raw === '/' || raw === '.' || raw === './') {
+    return '';
+  }
+  if (!raw.startsWith('/')) {
+    throw new Error('APP_BASE_PATH must start with "/"');
+  }
+  if (/[?#]/.test(raw)) {
+    throw new Error('APP_BASE_PATH must not contain query or fragment');
+  }
 
-        // Use the exposed transform from vite, instead of directly
-        // transforming with esbuild
-        return transformWithEsbuild(code, id, {
-          loader: 'jsx',
-          jsx: 'automatic',
-        });
+  const normalized = raw.replace(/\/+$/, '');
+  if (!normalized) {
+    return '';
+  }
+  const hasInvalidSegment = normalized
+    .split('/')
+    .slice(1)
+    .some((segment) => segment === '' || segment === '.' || segment === '..');
+  if (hasInvalidSegment) {
+    throw new Error('APP_BASE_PATH contains invalid path segments');
+  }
+  return normalized;
+}
+
+const appBasePath = normalizeBasePath(process.env.APP_BASE_PATH);
+
+function createProxyEntries(prefixes) {
+  return prefixes.reduce((acc, prefix) => {
+    acc[prefix] = {
+      target: 'http://localhost:3000',
+      changeOrigin: true,
+    };
+    if (appBasePath) {
+      acc[`${appBasePath}${prefix}`] = {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      };
+    }
+    return acc;
+  }, {});
+}
+
+// https://vitejs.dev/config/
+export default defineConfig(({ command }) => {
+  const viteBase =
+    command === 'build' ? './' : appBasePath ? `${appBasePath}/` : '/';
+
+  return {
+    base: viteBase,
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
       },
     },
-    react(),
-    vitePluginSemi({
-      cssLayer: true,
-    }),
-  ],
-  optimizeDeps: {
-    force: true,
-    esbuildOptions: {
-      loader: {
-        '.js': 'jsx',
-        '.json': 'json',
+    plugins: [
+      codeInspectorPlugin({
+        bundler: 'vite',
+      }),
+      {
+        name: 'treat-js-files-as-jsx',
+        async transform(code, id) {
+          if (!/src\/.*\.js$/.test(id)) {
+            return null;
+          }
+
+          // Use the exposed transform from vite, instead of directly
+          // transforming with esbuild
+          return transformWithEsbuild(code, id, {
+            loader: 'jsx',
+            jsx: 'automatic',
+          });
+        },
       },
-    },
-  },
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          'react-core': ['react', 'react-dom', 'react-router-dom'],
-          'semi-ui': ['@douyinfe/semi-icons', '@douyinfe/semi-ui'],
-          tools: ['axios', 'history', 'marked'],
-          'react-components': [
-            'react-dropzone',
-            'react-fireworks',
-            'react-telegram-login',
-            'react-toastify',
-            'react-turnstile',
-          ],
-          i18n: [
-            'i18next',
-            'react-i18next',
-            'i18next-browser-languagedetector',
-          ],
+      react(),
+      vitePluginSemi({
+        cssLayer: true,
+      }),
+    ],
+    optimizeDeps: {
+      force: true,
+      esbuildOptions: {
+        loader: {
+          '.js': 'jsx',
+          '.json': 'json',
         },
       },
     },
-  },
-  server: {
-    host: '0.0.0.0',
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
-      },
-      '/mj': {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
-      },
-      '/pg': {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            'react-core': ['react', 'react-dom', 'react-router-dom'],
+            'semi-ui': ['@douyinfe/semi-icons', '@douyinfe/semi-ui'],
+            tools: ['axios', 'history', 'marked'],
+            'react-components': [
+              'react-dropzone',
+              'react-fireworks',
+              'react-telegram-login',
+              'react-toastify',
+              'react-turnstile',
+            ],
+            i18n: [
+              'i18next',
+              'react-i18next',
+              'i18next-browser-languagedetector',
+            ],
+          },
+        },
       },
     },
-  },
+    server: {
+      host: '0.0.0.0',
+      proxy: createProxyEntries(['/api', '/mj', '/pg', '/v1', '/v1beta']),
+    },
+  };
 });


### PR DESCRIPTION
refactor(router): 重构路由设置以支持子路径
feat(web): 添加 base-path 工具函数处理子路径逻辑
feat(common): 实现基础路径相关工具函数
test: 添加基础路径相关测试用例
docs: 更新文档说明子路径配置方法

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

增加子路径访问，在环境变量中配置`APP_BASE_PATH=/new-api`
首页访问路径就变成`http://127.0.0.1/new-api`

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [x] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #4411


## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)

### 本地运行测试
构建前端
```
cd web
bun run build
```
构建后端
```
PS D:\project\new-api\feat-sub-path> $env:APP_BASE_PATH="/new-api"
PS D:\project\new-api\feat-sub-path> go run .
[SYS] 2026/04/24 - 16:36:45 | initializing token encoders
[SYS] 2026/04/24 - 16:36:45 | token encoders initialized
[SYS] 2026/04/24 - 16:36:45 | SQL_DSN not set, using SQLite as database
[SYS] 2026/04/24 - 16:36:45 | database migration started
[SYS] 2026/04/24 - 16:36:49 | system is already initialized at: 2026-03-31 18:32:30 +0800 CST 
[SYS] 2026/04/24 - 16:36:49 | REDIS_CONN_STRING not set, Redis is not enabled 
[SYS] 2026/04/24 - 16:36:49 | i18n initialized with languages: zh-CN, zh-TW, en 
[SYS] 2026/04/24 - 16:36:49 | Loaded 0 custom OAuth providers 
[SYS] 2026/04/24 - 16:36:49 | New API v0.0.0 started 
[SYS] 2026/04/24 - 16:36:49 | 正在更新数据看板数据... 
[INFO] 2026/04/24 - 16:36:49 | SYSTEM | codex credential auto-refresh task started: tick=10m0s threshold=24h0m0s 
[SYS] 2026/04/24 - 16:36:49 | upstream model update task started: interval=30m0s 
[INFO] 2026/04/24 - 16:36:49 | SYSTEM | subscription quota reset task started: tick=1m0s
[SYS] 2026/04/24 - 16:36:49 | 保存数据看板数据成功，共保存0条数据

  LLMGateway v0.0.0  ready in 4000 ms

  ->  Local:   http://localhost:3000/new-api/
  ->  Network: http://172.31.48.1:3000/new-api/
  ->  Network: http://172.25.160.1:3000/new-api/

```

### docker-compose运行测试
构建docker镜像
```bash
docker  build -t new-api:local .
```

修改`docker-compose.yml`
- 修改镜像为本地镜像 `new-api:local`
- 添加一行`APP_BASE_PATH=/new-api `

示例：
```yml
services:
  new-api:
    image: new-api:local
    container_name: new-api
    restart: always
    command: --log-dir /app/logs
    ports:
      - "3000:3000"
    volumes:
      - ./data:/data
      - ./logs:/app/logs
    environment:
      - APP_BASE_PATH=/new-api 
```
启动docker compose
```
docker compose up -d
```

查看日志
```
docker compose logs -f
...
new-api   | [SYS] 2026/04/24 - 16:40:42 | batch update enabled with interval 5s
new-api   | [SYS] 2026/04/24 - 16:40:42 | 正在更新数据看板数据...
new-api   | [SYS] 2026/04/24 - 16:40:42 | upstream model update task started: interval=30m0s
new-api   | [INFO] 2026/04/24 - 16:40:42 | SYSTEM | subscription quota reset task started: tick=1m0s
new-api   | [INFO] 2026/04/24 - 16:40:42 | SYSTEM | codex credential auto-refresh task started: tick=10m0s threshold=24h0m0s
new-api   | [SYS] 2026/04/24 - 16:40:42 | 保存数据看板数据成功，共保存0条数据
new-api   |
new-api   |   New API   ready in 308 ms
new-api   |
new-api   |   ->  Network: http://172.18.0.4:3000/new-api/
new-api   |
postgres  | Data page checksums are disabled.
```



### 运行截图测试

<img width="962" height="393" alt="Snipaste_2026-04-24_15-51-31" src="https://github.com/user-attachments/assets/9728d608-8d9c-4744-a7fc-7b60d6d78d4f" />


<img width="748" height="352" alt="Snipaste_2026-04-24_15-55-43" src="https://github.com/user-attachments/assets/2deb5c5d-fcca-4b2b-a981-73fa0c9992c8" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support running the app under a configurable URL sub-path (APP_BASE_PATH), with routing, asset loading, redirects, cookies, and OAuth/callback URLs honoring the base path.
  * Frontend routing and helpers updated so links, redirects, and API calls work correctly when mounted under a prefix.

* **Documentation**
  * README (and Chinese translation) updated with step-by-step sub-path configuration, callback URL guidance, and an example redirect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->