### PR TITLE
feat(claude): support /v1/messages/count_tokens with local estimation

### DIFF
--- a/controller/claude_count_tokens.go
+++ b/controller/claude_count_tokens.go
@@ -1,0 +1,35 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/types"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ClaudeCountTokens implements POST /v1/messages/count_tokens.
+//
+// The estimate is computed locally — no upstream channel is selected
+// and no quota is consumed. This is what makes the endpoint suitable
+// for the SDK / CLI to poll before every chat.
+func ClaudeCountTokens(c *gin.Context) {
+	var req dto.ClaudeRequest
+	if err := common.UnmarshalBodyReusable(c, &req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"type": "error",
+			"error": types.ClaudeError{
+				Type:    "invalid_request_error",
+				Message: "invalid JSON body: " + err.Error(),
+			},
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"input_tokens": service.EstimateClaudeInputTokens(&req),
+	})
+}

--- a/router/relay-router.go
+++ b/router/relay-router.go
@@ -71,6 +71,16 @@ func SetRelayRouter(router *gin.Engine) {
 	relayV1Router.Use(middleware.SystemPerformanceCheck())
 	relayV1Router.Use(middleware.TokenAuth())
 	relayV1Router.Use(middleware.ModelRequestRateLimit())
+
+	// Anthropic's /v1/messages/count_tokens — local estimate only. Mounted
+	// directly on relayV1Router so it inherits TokenAuth + RouteTag +
+	// SystemPerformanceCheck + ModelRequestRateLimit, but NOT
+	// middleware.Distribute(). No channel is selected, no quota is consumed.
+	// Anthropic's spec defines this endpoint as token-counting only; the
+	// project's Distribute pipeline would otherwise pick a channel + run
+	// PreConsume on a request that never reaches an upstream.
+	relayV1Router.POST("/messages/count_tokens", controller.ClaudeCountTokens)
+
 	{
 		// WebSocket 路由（统一到 Relay）
 		wsRouter := relayV1Router.Group("")

--- a/service/claude_token_estimator.go
+++ b/service/claude_token_estimator.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"encoding/json"
+
+	"github.com/QuantumNous/new-api/dto"
+)
+
+// EstimateClaudeInputTokens returns a free, fast local estimate of
+// input_tokens for an Anthropic /v1/messages/count_tokens request.
+//
+// Reuses ClaudeRequest.GetTokenCountMeta to do the canonical flattening
+// of system / messages (text, tool_use, tool_result) / tools, and then
+// the project's existing Claude-tuned tokenizer EstimateTokenByModel to
+// turn that into a token count. This means the value matches whatever
+// /v1/messages itself would report on the same body, so callers can
+// reason about the two numbers consistently.
+//
+// Image tokens are intentionally NOT added: getImageToken requires a
+// RelayInfo + http.Request context, which this route deliberately
+// avoids by bypassing the channel pipeline. The Claude CLI context-bar
+// probe (the failure mode this endpoint exists to mitigate) never
+// carries images, so the gap doesn't matter for that case. Requests
+// that do contain images will under-estimate, which is documented and
+// acceptable for an estimate endpoint.
+func EstimateClaudeInputTokens(req *dto.ClaudeRequest) int {
+	if req == nil {
+		return 0
+	}
+	normalizeRequestTools(req)
+	meta := req.GetTokenCountMeta()
+	if meta == nil {
+		return 0
+	}
+	return EstimateTokenByModel(req.Model, meta.CombineText)
+}
+
+// normalizeRequestTools converts raw map[string]any entries (which is what
+// json.Unmarshal of `tools` produces when the field is declared as `any`)
+// into the typed *dto.Tool / *dto.ClaudeWebSearchTool values that
+// dto.ProcessTools (called from GetTokenCountMeta) accepts. Without this,
+// every tool entry on a count_tokens request is silently dropped on the
+// `default: continue` arm of ProcessTools — see dto/claude.go:439-442.
+//
+// Mutates req.Tools in place. Safe because the request is parsed in this
+// handler and not shared with anything else (count_tokens does not enter
+// the channel pipeline).
+//
+// Web-search tools are distinguished from normal tools by the presence of
+// a top-level "type" field, matching how the Anthropic SDK serializes them.
+func normalizeRequestTools(req *dto.ClaudeRequest) {
+	if req == nil || req.Tools == nil {
+		return
+	}
+	rawTools, ok := req.Tools.([]any)
+	if !ok {
+		return
+	}
+	normalized := make([]any, 0, len(rawTools))
+	for _, t := range rawTools {
+		switch t.(type) {
+		case *dto.Tool, dto.Tool, *dto.ClaudeWebSearchTool, dto.ClaudeWebSearchTool:
+			normalized = append(normalized, t)
+			continue
+		}
+		m, ok := t.(map[string]any)
+		if !ok {
+			continue
+		}
+		b, err := json.Marshal(m)
+		if err != nil {
+			continue
+		}
+		if _, isWebSearch := m["type"]; isWebSearch {
+			var ws dto.ClaudeWebSearchTool
+			if err := json.Unmarshal(b, &ws); err == nil && ws.Type != "" {
+				normalized = append(normalized, &ws)
+			}
+			continue
+		}
+		var tool dto.Tool
+		if err := json.Unmarshal(b, &tool); err == nil && tool.Name != "" {
+			normalized = append(normalized, &tool)
+		}
+	}
+	req.Tools = normalized
+}

--- a/service/claude_token_estimator.go
+++ b/service/claude_token_estimator.go
@@ -1,8 +1,7 @@
 package service
 
 import (
-	"encoding/json"
-
+	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
 )
 
@@ -67,19 +66,19 @@ func normalizeRequestTools(req *dto.ClaudeRequest) {
 		if !ok {
 			continue
 		}
-		b, err := json.Marshal(m)
+		b, err := common.Marshal(m)
 		if err != nil {
 			continue
 		}
 		if _, isWebSearch := m["type"]; isWebSearch {
 			var ws dto.ClaudeWebSearchTool
-			if err := json.Unmarshal(b, &ws); err == nil && ws.Type != "" {
+			if err := common.Unmarshal(b, &ws); err == nil && ws.Type != "" {
 				normalized = append(normalized, &ws)
 			}
 			continue
 		}
 		var tool dto.Tool
-		if err := json.Unmarshal(b, &tool); err == nil && tool.Name != "" {
+		if err := common.Unmarshal(b, &tool); err == nil && tool.Name != "" {
 			normalized = append(normalized, &tool)
 		}
 	}

--- a/service/claude_token_estimator.go
+++ b/service/claude_token_estimator.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
 )
@@ -45,8 +47,20 @@ func EstimateClaudeInputTokens(req *dto.ClaudeRequest) int {
 // handler and not shared with anything else (count_tokens does not enter
 // the channel pipeline).
 //
-// Web-search tools are distinguished from normal tools by the presence of
-// a top-level "type" field, matching how the Anthropic SDK serializes them.
+// Web-search tools are distinguished from regular user-defined tools by a
+// top-level "type" field whose value begins with "web_search" (e.g.
+// "web_search_20250305", "web_search_20250604"). Other Anthropic server tools
+// — computer_*, bash_*, text_editor_*, code_execution_*, mcp_* — also carry
+// a top-level "type" but have a completely different shape from
+// ClaudeWebSearchTool; if we unmarshalled them into that struct we would lose
+// the rest of their schema from the estimate (ProcessTools would then only
+// see Name + UserLocation). Prefix-matching the web-search family is a
+// deliberate narrow allowlist: unknown "type" values fall through to the
+// dto.Tool path so ProcessTools still sees Name / Description / InputSchema.
+// (dto.Tool doesn't model every server-tool field, so undercount can still
+// happen for exotic server tools — that's an upstream schema gap outside
+// this PR's scope; the fallthrough at least stops the regression from
+// misrouting.)
 func normalizeRequestTools(req *dto.ClaudeRequest) {
 	if req == nil || req.Tools == nil {
 		return
@@ -70,12 +84,18 @@ func normalizeRequestTools(req *dto.ClaudeRequest) {
 		if err != nil {
 			continue
 		}
-		if _, isWebSearch := m["type"]; isWebSearch {
-			var ws dto.ClaudeWebSearchTool
-			if err := common.Unmarshal(b, &ws); err == nil && ws.Type != "" {
-				normalized = append(normalized, &ws)
+		if typeVal, hasType := m["type"]; hasType {
+			if typeStr, ok := typeVal.(string); ok && strings.HasPrefix(typeStr, "web_search") {
+				var ws dto.ClaudeWebSearchTool
+				if err := common.Unmarshal(b, &ws); err == nil && ws.Type != "" {
+					normalized = append(normalized, &ws)
+				}
+				continue
 			}
-			continue
+			// Non-web-search server tools (computer_*, bash_*, ...): fall
+			// through to the dto.Tool path below so ProcessTools still sees
+			// Name / Description / InputSchema instead of truncating the
+			// tool to just Name + UserLocation.
 		}
 		var tool dto.Tool
 		if err := common.Unmarshal(b, &tool); err == nil && tool.Name != "" {

--- a/service/claude_token_estimator_test.go
+++ b/service/claude_token_estimator_test.go
@@ -1,9 +1,9 @@
 package service
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
 )
 
@@ -70,7 +70,7 @@ func TestEstimateClaudeInputTokens(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var req dto.ClaudeRequest
 			if tc.body != "" {
-				if err := json.Unmarshal([]byte(tc.body), &req); err != nil {
+				if err := common.Unmarshal([]byte(tc.body), &req); err != nil {
 					t.Fatalf("unmarshal: %v", err)
 				}
 			} else {

--- a/service/claude_token_estimator_test.go
+++ b/service/claude_token_estimator_test.go
@@ -141,4 +141,50 @@ func TestNormalizeRequestTools(t *testing.T) {
 			t.Errorf("expected 1 surviving tool, got %d (%v)", len(got), got)
 		}
 	})
+
+	t.Run("non-web-search server tool routes to dto.Tool, not ClaudeWebSearchTool", func(t *testing.T) {
+		// Anthropic's built-in server tools (computer_*, bash_*, text_editor_*,
+		// code_execution_*, mcp_*) also carry a top-level "type" field, but
+		// their shape is different from ClaudeWebSearchTool. Previously they
+		// were routed into ClaudeWebSearchTool and ProcessTools then only saw
+		// Name + UserLocation, dropping the rest of the tool schema from the
+		// estimate. The fix narrows web-search routing to a "web_search"
+		// prefix allowlist; unknown types must fall through to dto.Tool.
+		req := &dto.ClaudeRequest{Tools: []any{
+			map[string]any{
+				"type":         "computer_20250124",
+				"name":         "computer",
+				"description":  "Operate a virtual desktop",
+				"input_schema": map[string]any{"type": "object"},
+			},
+		}}
+		normalizeRequestTools(req)
+		got, ok := req.Tools.([]any)
+		if !ok || len(got) != 1 {
+			t.Fatalf("expected 1 tool, got %v (%T)", req.Tools, req.Tools)
+		}
+		if _, isWS := got[0].(*dto.ClaudeWebSearchTool); isWS {
+			t.Errorf("computer_20250124 must NOT be routed to *ClaudeWebSearchTool")
+		}
+		if _, isTool := got[0].(*dto.Tool); !isTool {
+			t.Errorf("expected *dto.Tool, got %T", got[0])
+		}
+	})
+
+	t.Run("web_search variant (future version suffix) still routes to ClaudeWebSearchTool via prefix rule", func(t *testing.T) {
+		req := &dto.ClaudeRequest{Tools: []any{
+			map[string]any{
+				"type": "web_search_20250604",
+				"name": "web_search",
+			},
+		}}
+		normalizeRequestTools(req)
+		got, ok := req.Tools.([]any)
+		if !ok || len(got) != 1 {
+			t.Fatalf("expected 1 tool, got %v (%T)", req.Tools, req.Tools)
+		}
+		if _, isWS := got[0].(*dto.ClaudeWebSearchTool); !isWS {
+			t.Errorf("web_search_20250604 should route to *ClaudeWebSearchTool, got %T", got[0])
+		}
+	})
 }

--- a/service/claude_token_estimator_test.go
+++ b/service/claude_token_estimator_test.go
@@ -1,0 +1,144 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/QuantumNous/new-api/dto"
+)
+
+func TestEstimateClaudeInputTokens(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{
+			name: "empty messages",
+			body: `{"model":"claude-haiku-4-5","max_tokens":1024,"messages":[]}`,
+			want: 0,
+		},
+		{
+			name: "single short user message",
+			body: `{"model":"claude-haiku-4-5","max_tokens":1024,"messages":[{"role":"user","content":"count"}]}`,
+			want: 4,
+		},
+		{
+			name: "string system + user",
+			body: `{"model":"claude-haiku-4-5","max_tokens":1024,"system":"You are helpful.","messages":[{"role":"user","content":"hello"}]}`,
+			want: 9,
+		},
+		{
+			name: "CLI-probe shape: trivial message + bash tool schema",
+			body: `{"model":"claude-haiku-4-5","max_tokens":1,"messages":[{"role":"user","content":"count"}],"tools":[{"name":"Bash","description":"Execute a shell command on the host","input_schema":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}]}`,
+			want: 43,
+		},
+		{
+			name: "system as array of text blocks",
+			body: `{"model":"claude-haiku-4-5","max_tokens":1024,"system":[{"type":"text","text":"You are a helpful assistant."}],"messages":[{"role":"user","content":"hi"}]}`,
+			want: 12,
+		},
+		{
+			name: "CJK content",
+			body: `{"model":"claude-haiku-4-5","max_tokens":1024,"messages":[{"role":"user","content":"你好世界，请用中文回答我的问题"}]}`,
+			want: 20,
+		},
+		{
+			name: "tool_use block on assistant turn",
+			body: `{"model":"claude-haiku-4-5","max_tokens":1024,"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls"}}]}]}`,
+			want: 10,
+		},
+		{
+			name: "tool_result block on user turn",
+			body: `{"model":"claude-haiku-4-5","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"file1\nfile2"}]}]}`,
+			want: 9,
+		},
+		{
+			name: "web-search tool (different schema, distinguished by type field)",
+			body: `{"model":"claude-haiku-4-5","max_tokens":1024,"messages":[{"role":"user","content":"news"}],"tools":[{"type":"web_search_20250305","name":"web_search","max_uses":3}]}`,
+			want: 7,
+		},
+		{
+			name: "tools array with already-typed entries (defensive: caller pre-normalized)",
+			// Synthesised in-test below via direct ClaudeRequest construction.
+			body: "",
+			want: 18,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var req dto.ClaudeRequest
+			if tc.body != "" {
+				if err := json.Unmarshal([]byte(tc.body), &req); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+			} else {
+				// pre-typed tool entry — exercises the early-return arm of
+				// normalizeRequestTools.
+				req = dto.ClaudeRequest{
+					Model: "claude-haiku-4-5",
+					Messages: []dto.ClaudeMessage{
+						{Role: "user", Content: "list"},
+					},
+					Tools: []any{
+						&dto.Tool{
+							Name:        "ListFiles",
+							Description: "List directory contents",
+							InputSchema: map[string]any{"type": "object"},
+						},
+					},
+				}
+			}
+			got := EstimateClaudeInputTokens(&req)
+			if got != tc.want {
+				t.Errorf("EstimateClaudeInputTokens() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEstimateClaudeInputTokens_NilSafety(t *testing.T) {
+	if got := EstimateClaudeInputTokens(nil); got != 0 {
+		t.Errorf("nil request should return 0, got %d", got)
+	}
+
+	// Empty model string + no content — should not panic.
+	if got := EstimateClaudeInputTokens(&dto.ClaudeRequest{}); got != 0 {
+		t.Errorf("zero-value request should return 0, got %d", got)
+	}
+}
+
+func TestNormalizeRequestTools(t *testing.T) {
+	t.Run("nil tools", func(t *testing.T) {
+		req := &dto.ClaudeRequest{}
+		normalizeRequestTools(req)
+		if req.Tools != nil {
+			t.Errorf("expected Tools to remain nil, got %v", req.Tools)
+		}
+	})
+
+	t.Run("non-array tools field is left alone", func(t *testing.T) {
+		req := &dto.ClaudeRequest{Tools: "not-an-array"}
+		normalizeRequestTools(req)
+		if got, ok := req.Tools.(string); !ok || got != "not-an-array" {
+			t.Errorf("expected non-array Tools to be preserved, got %v", req.Tools)
+		}
+	})
+
+	t.Run("malformed tool entry is dropped, others survive", func(t *testing.T) {
+		req := &dto.ClaudeRequest{Tools: []any{
+			map[string]any{"name": "Good", "description": "ok"},
+			map[string]any{"description": "missing name"}, // no Name → dropped
+			"a string entry",                              // wrong shape → dropped
+		}}
+		normalizeRequestTools(req)
+		got, ok := req.Tools.([]any)
+		if !ok {
+			t.Fatalf("expected []any after normalize, got %T", req.Tools)
+		}
+		if len(got) != 1 {
+			t.Errorf("expected 1 surviving tool, got %d (%v)", len(got), got)
+		}
+	})
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

## 📝 变更描述 / Description

实现 Anthropic `/v1/messages/count_tokens` 端点的本地估算，避免 Claude SDK / CLI 在该端点 404 时退化为发送 `max_tokens=1` 的伪请求。

**真实事故场景**：单个 Claude Code Desktop session 在一分钟内对同一上游 channel 发出 250 个伪 probe 请求（每个请求体 ~53KB，全是 tool schema 但 `max_tokens=1`），打爆上游 RPM 配额，导致同 channel 上其他用户在 ~2 分钟内收到 429。本地估算端点解决根因：SDK 拿到 200 + 一个合理的 `input_tokens` 数字就不会 fallback。

实现要点：
- 路由直接挂在 `relayV1Router` 上而**不是** `httpRouter`，跳过 `middleware.Distribute()`——这与 Anthropic 规范一致（count_tokens 不路由到上游、不消费配额）
- 估算复用项目已有的 `ClaudeRequest.GetTokenCountMeta()` + `EstimateTokenByModel()`，与 `/v1/messages` 实际计费的 tokenizer 一致
- 一个小 helper `normalizeRequestTools()` 修了 `dto.ProcessTools` 在收到 raw `map[string]any` tool 时静默丢弃的 latent bug——CLI probe 体里 80%+ 的字节都是 tool schema，不修这个 estimate 会严重偏低
- 图片 token 暂不计入（需要 RelayInfo + http.Request context，本路由刻意没有）；CLI probe 不带图片，不影响本 PR 解决的失败场景

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #1694
- Closes #2847
- Closes #1979

参考 #2384（已 close 未 merge）。本 PR 与之相比：不引入新 RelayFormat enum、不改 adaptor、不改 distributor、不引入 autoban 旁路。改动面只有一条新路由 + 一个 controller + 一个 estimator，对所有未触达 `/v1/messages/count_tokens` 的代码路径零影响。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已搜索现有 Issues / PRs，#1694 / #2847 / #1979 / #2384 全部确认未解决。
- [ ] **Bug fix 说明:** 此 PR 不是 bug fix。
- [x] **变更理解:** 已理解 `httpRouter` 中间件链含 `Distribute()`，刻意挂到 `relayV1Router` 上避开。
- [x] **范围聚焦:** 仅 4 个文件 +276 行；diff 中无 fork CI / 个人配置等无关改动。
- [x] **本地验证:** `go test ./service/ -run 'TestEstimateClaude|TestNormalizeRequestTools' -v` 全部通过；`go build ./...` 通过；本地 curl 实测端点返回正确 shape。
- [x] **安全合规:** 无凭据；遵循项目的 typed error helper（`types.ClaudeError`）+ body parser（`common.UnmarshalBodyReusable`）。

## 📸 运行证明 / Proof of Work

**1. 单元测试 (12 cases passed)**

```
$ go test ./service/ -run 'TestEstimateClaude|TestNormalizeRequestTools' -v
=== RUN   TestEstimateClaudeInputTokens
    --- PASS: empty messages (0.00s)                                  → 0
    --- PASS: single short user message (0.00s)                       → 4
    --- PASS: string system + user (0.00s)                            → 9
    --- PASS: CLI-probe shape: trivial message + bash tool schema     → 43
    --- PASS: system as array of text blocks (0.00s)                  → 12
    --- PASS: CJK content (0.00s)                                     → 20
    --- PASS: tool_use block on assistant turn (0.00s)                → 10
    --- PASS: tool_result block on user turn (0.00s)                  → 9
    --- PASS: web-search tool (distinguished by type field)           → 7
    --- PASS: tools array with already-typed entries                  → 18
=== RUN   TestEstimateClaudeInputTokens_NilSafety       — PASS (2 cases)
=== RUN   TestNormalizeRequestTools                     — PASS (3 cases)
PASS    ok  github.com/QuantumNous/new-api/service  0.6s
```

**2. 端到端: 不带 PR 时 SDK 行为 (实测自我们生产环境的事故)**

CLI 检测到 `/v1/messages/count_tokens` 返 404，退化为发送伪请求到 `/v1/messages`。截取一个真实的 53KB 伪请求体（已脱敏，源自我们的 OSS 归档）：

```json
{
  "model": "claude-haiku-4-5-20251001",
  "max_tokens": 1,
  "messages": [{"role": "user", "content": "count"}],
  "tools": [
    /* 18 个完整 tool schema，~52KB，含 Bash / AskUserQuestion / ... */
  ]
}
```

请求头 `user-agent: claude-cli/2.1.111 (external, claude-desktop-3p, agent-sdk/0.2.111)`。同一 device_id + session_id 在 60 秒内连发 250 个，149 个被上游返 `429 rate limit reached for RPM`。

**3. 带 PR 时端点行为 (实测自本地 build)**

```
$ curl -sX POST http://127.0.0.1:3000/v1/messages/count_tokens \
    -H "Authorization: Bearer sk-..." \
    -H "anthropic-version: 2023-06-01" \
    -H "content-type: application/json" \
    -d @cli-probe-body.json
{"input_tokens":43}

$ # SDK 接受 200，停止发送伪请求
```

错误路径 (malformed body):

```
$ curl -sX POST http://127.0.0.1:3000/v1/messages/count_tokens \
    -H "Authorization: Bearer sk-..." \
    -H "content-type: application/json" \
    -d 'not json'
{"type":"error","error":{"type":"invalid_request_error","message":"invalid JSON body: ..."}}
```

## 维护者可能的问题 / Anticipated reviewer questions

**Q: 为什么不直接转发到上游？**
A: 大部分 Claude 兼容上游（Qiniu QNAIGC / OpenRouter / 等）自己也没实现这个端点 (实测 Qiniu 返 404)。即使是 Anthropic 官方端点，虽免费但仍占 RPM 配额，pass-through 不解决我们这个 PR 要解的问题。

**Q: 为什么不用真 tokenizer (tiktoken / anthropic-tokenizer)?**
A: 项目已有 `EstimateTokenByModel(model, text)` 带 Claude-tuned multipliers (`Word 1.13, CJK 1.21, MathSymbol 4.52, ...`)，用在 `service/token_counter.go` 等多处。本 PR 不引入新依赖，复用已有实现，估算与 `/v1/messages` 自身计费一致。

**Q: `normalizeRequestTools` 是否应该改 `dto.ProcessTools` 而不是在 estimator 自己 normalize？**
A: 改 `ProcessTools` 是更彻底的 fix，但会影响所有 caller（distributor / handler / 其他 future code paths）的行为，scope 太大、回归风险也大。本 PR 只改自己 reach 到的代码，把 latent bug 在 estimator 边界处兜住。如果维护者倾向把 normalize 提到 `ProcessTools`，欢迎反馈，我可以再开一个 PR 单独处理。

**Q: 图片 token 不算合理吗？**
A: Anthropic 规范说 count_tokens 应当包含图片。我们权衡的是：(1) `getImageToken` 需要 `RelayInfo + http.Request`，本路由刻意不走 channel pipeline；(2) 触发本 PR 的 CLI probe 失败模式不带图片；(3) 真要加图片可后续 PR，需要把 image-token 计算从 `service/token_counter.go` 中抽成 standalone helper。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POST /v1/messages/count_tokens to return an estimated input-token count for Claude-style messages.
  * Added a local token estimator that normalizes diverse message shapes and tool representations (including web-search variants) before estimating.
* **Tests**
  * Added comprehensive tests for estimator accuracy, tool normalization, routing of web-search vs non-web-search tools, and nil-safety.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4441)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->