### PR TITLE
feat: 增强使用日志统计功能，新增输入、输出及缓存读指标

### DIFF
--- a/controller/log.go
+++ b/controller/log.go
@@ -112,9 +112,12 @@ func GetLogsStat(c *gin.Context) {
 		"success": true,
 		"message": "",
 		"data": gin.H{
-			"quota": stat.Quota,
-			"rpm":   stat.Rpm,
-			"tpm":   stat.Tpm,
+			"quota":           stat.Quota,
+			"rpm":             stat.Rpm,
+			"tpm":             stat.Tpm,
+			"prompt_tokens":   stat.PromptTokens,
+			"completion_tokens": stat.CompletionTokens,
+			"cache_tokens":    stat.CacheTokens,
 		},
 	})
 	return
@@ -139,9 +142,12 @@ func GetLogsSelfStat(c *gin.Context) {
 		"success": true,
 		"message": "",
 		"data": gin.H{
-			"quota": quotaNum.Quota,
-			"rpm":   quotaNum.Rpm,
-			"tpm":   quotaNum.Tpm,
+			"quota":           quotaNum.Quota,
+			"rpm":             quotaNum.Rpm,
+			"tpm":             quotaNum.Tpm,
+			"prompt_tokens":   quotaNum.PromptTokens,
+			"completion_tokens": quotaNum.CompletionTokens,
+			"cache_tokens":    quotaNum.CacheTokens,
 			//"token": tokenNum,
 		},
 	})

--- a/model/log.go
+++ b/model/log.go
@@ -427,9 +427,12 @@ func GetUserLogs(userId int, logType int, startTimestamp int64, endTimestamp int
 }
 
 type Stat struct {
-	Quota int `json:"quota"`
-	Rpm   int `json:"rpm"`
-	Tpm   int `json:"tpm"`
+	Quota           int `json:"quota"`
+	Rpm             int `json:"rpm"`
+	Tpm             int `json:"tpm"`
+	PromptTokens    int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	CacheTokens     int `json:"cache_tokens"`
 }
 
 func SumUsedQuota(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string, channel int, group string) (stat Stat, err error) {
@@ -438,19 +441,47 @@ func SumUsedQuota(logType int, startTimestamp int64, endTimestamp int64, modelNa
 	// 为rpm和tpm创建单独的查询
 	rpmTpmQuery := LOG_DB.Table("logs").Select("count(*) rpm, sum(prompt_tokens) + sum(completion_tokens) tpm")
 
+	// 为prompt_tokens创建单独的查询（统计筛选范围内的总和）
+	promptTokensQuery := LOG_DB.Table("logs").Select("sum(prompt_tokens) prompt_tokens")
+
+	// 为completion_tokens创建单独的查询（统计筛选范围内的总和）
+	completionTokensQuery := LOG_DB.Table("logs").Select("sum(completion_tokens) completion_tokens")
+
+	// 为cache_tokens创建单独的查询（统计筛选范围内的总和，从JSON字段中提取）
+	var cacheTokensQuery *gorm.DB
+	if common.UsingPostgreSQL {
+		cacheTokensQuery = LOG_DB.Table("logs").Select("COALESCE(SUM((other::jsonb->>'cache_tokens')::int), 0) cache_tokens")
+	} else if common.UsingSQLite {
+		cacheTokensQuery = LOG_DB.Table("logs").Select("COALESCE(SUM(json_extract(other, '$.cache_tokens')), 0) cache_tokens")
+	} else { // MySQL
+		cacheTokensQuery = LOG_DB.Table("logs").Select("COALESCE(SUM(CAST(JSON_EXTRACT(other, '$.cache_tokens') AS SIGNED)), 0) cache_tokens")
+	}
+
 	if username != "" {
 		tx = tx.Where("username = ?", username)
 		rpmTpmQuery = rpmTpmQuery.Where("username = ?", username)
+		promptTokensQuery = promptTokensQuery.Where("username = ?", username)
+		completionTokensQuery = completionTokensQuery.Where("username = ?", username)
+		cacheTokensQuery = cacheTokensQuery.Where("username = ?", username)
 	}
 	if tokenName != "" {
 		tx = tx.Where("token_name = ?", tokenName)
 		rpmTpmQuery = rpmTpmQuery.Where("token_name = ?", tokenName)
+		promptTokensQuery = promptTokensQuery.Where("token_name = ?", tokenName)
+		completionTokensQuery = completionTokensQuery.Where("token_name = ?", tokenName)
+		cacheTokensQuery = cacheTokensQuery.Where("token_name = ?", tokenName)
 	}
 	if startTimestamp != 0 {
 		tx = tx.Where("created_at >= ?", startTimestamp)
+		promptTokensQuery = promptTokensQuery.Where("created_at >= ?", startTimestamp)
+		completionTokensQuery = completionTokensQuery.Where("created_at >= ?", startTimestamp)
+		cacheTokensQuery = cacheTokensQuery.Where("created_at >= ?", startTimestamp)
 	}
 	if endTimestamp != 0 {
 		tx = tx.Where("created_at <= ?", endTimestamp)
+		promptTokensQuery = promptTokensQuery.Where("created_at <= ?", endTimestamp)
+		completionTokensQuery = completionTokensQuery.Where("created_at <= ?", endTimestamp)
+		cacheTokensQuery = cacheTokensQuery.Where("created_at <= ?", endTimestamp)
 	}
 	if modelName != "" {
 		modelNamePattern, err := sanitizeLikePattern(modelName)
@@ -459,18 +490,30 @@ func SumUsedQuota(logType int, startTimestamp int64, endTimestamp int64, modelNa
 		}
 		tx = tx.Where("model_name LIKE ? ESCAPE '!'", modelNamePattern)
 		rpmTpmQuery = rpmTpmQuery.Where("model_name LIKE ? ESCAPE '!'", modelNamePattern)
+		promptTokensQuery = promptTokensQuery.Where("model_name LIKE ? ESCAPE '!'", modelNamePattern)
+		completionTokensQuery = completionTokensQuery.Where("model_name LIKE ? ESCAPE '!'", modelNamePattern)
+		cacheTokensQuery = cacheTokensQuery.Where("model_name LIKE ? ESCAPE '!'", modelNamePattern)
 	}
 	if channel != 0 {
 		tx = tx.Where("channel_id = ?", channel)
 		rpmTpmQuery = rpmTpmQuery.Where("channel_id = ?", channel)
+		promptTokensQuery = promptTokensQuery.Where("channel_id = ?", channel)
+		completionTokensQuery = completionTokensQuery.Where("channel_id = ?", channel)
+		cacheTokensQuery = cacheTokensQuery.Where("channel_id = ?", channel)
 	}
 	if group != "" {
 		tx = tx.Where(logGroupCol+" = ?", group)
 		rpmTpmQuery = rpmTpmQuery.Where(logGroupCol+" = ?", group)
+		promptTokensQuery = promptTokensQuery.Where(logGroupCol+" = ?", group)
+		completionTokensQuery = completionTokensQuery.Where(logGroupCol+" = ?", group)
+		cacheTokensQuery = cacheTokensQuery.Where(logGroupCol+" = ?", group)
 	}
 
 	tx = tx.Where("type = ?", LogTypeConsume)
 	rpmTpmQuery = rpmTpmQuery.Where("type = ?", LogTypeConsume)
+	promptTokensQuery = promptTokensQuery.Where("type = ?", LogTypeConsume)
+	completionTokensQuery = completionTokensQuery.Where("type = ?", LogTypeConsume)
+	cacheTokensQuery = cacheTokensQuery.Where("type = ?", LogTypeConsume)
 
 	// 只统计最近60秒的rpm和tpm
 	rpmTpmQuery = rpmTpmQuery.Where("created_at >= ?", time.Now().Add(-60*time.Second).Unix())
@@ -482,6 +525,18 @@ func SumUsedQuota(logType int, startTimestamp int64, endTimestamp int64, modelNa
 	}
 	if err := rpmTpmQuery.Scan(&stat).Error; err != nil {
 		common.SysError("failed to query rpm/tpm stat: " + err.Error())
+		return stat, errors.New("查询统计数据失败")
+	}
+	if err := promptTokensQuery.Scan(&stat).Error; err != nil {
+		common.SysError("failed to query prompt tokens stat: " + err.Error())
+		return stat, errors.New("查询统计数据失败")
+	}
+	if err := completionTokensQuery.Scan(&stat).Error; err != nil {
+		common.SysError("failed to query completion tokens stat: " + err.Error())
+		return stat, errors.New("查询统计数据失败")
+	}
+	if err := cacheTokensQuery.Scan(&stat).Error; err != nil {
+		common.SysError("failed to query cache tokens stat: " + err.Error())
 		return stat, errors.New("查询统计数据失败")
 	}
 

--- a/web/src/components/table/usage-logs/UsageLogsActions.jsx
+++ b/web/src/components/table/usage-logs/UsageLogsActions.jsx
@@ -37,6 +37,9 @@ const LogsActions = ({
   const placeholder = (
     <Space>
       <Skeleton.Title style={{ width: 108, height: 21, borderRadius: 6 }} />
+      <Skeleton.Title style={{ width: 120, height: 21, borderRadius: 6 }} />
+      <Skeleton.Title style={{ width: 120, height: 21, borderRadius: 6 }} />
+      <Skeleton.Title style={{ width: 145, height: 21, borderRadius: 6 }} />
       <Skeleton.Title style={{ width: 65, height: 21, borderRadius: 6 }} />
       <Skeleton.Title style={{ width: 64, height: 21, borderRadius: 6 }} />
     </Space>
@@ -56,6 +59,39 @@ const LogsActions = ({
             className='!rounded-lg'
           >
             {t('消耗额度')}: {renderQuota(stat.quota)}
+          </Tag>
+          <Tag
+            color='green'
+            style={{
+              fontWeight: 500,
+              boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
+              padding: 13,
+            }}
+            className='!rounded-lg'
+          >
+            {t('输入')}: {stat.prompt_tokens?.toLocaleString() || 0}
+          </Tag>
+          <Tag
+            color='purple'
+            style={{
+              fontWeight: 500,
+              boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
+              padding: 13,
+            }}
+            className='!rounded-lg'
+          >
+            {t('缓存读')}: {stat.cache_tokens?.toLocaleString() || 0}
+          </Tag>
+          <Tag
+            color='orange'
+            style={{
+              fontWeight: 500,
+              boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
+              padding: 13,
+            }}
+            className='!rounded-lg'
+          >
+            {t('输出')}: {stat.completion_tokens?.toLocaleString() || 0}
           </Tag>
           <Tag
             color='pink'

--- a/web/src/hooks/usage-logs/useUsageLogsData.jsx
+++ b/web/src/hooks/usage-logs/useUsageLogsData.jsx
@@ -89,6 +89,9 @@ export const useLogsData = () => {
   const [stat, setStat] = useState({
     quota: 0,
     token: 0,
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    cache_tokens: 0,
   });
 
   // Form state


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
在原“使用日志”界面中，仅统计“额度消耗”、“RPM”、“TPM”三项指标。为了方便用户更精细地分析 token 使用情况，增加了对 Prompt Tokens（输入）、Completion Tokens（输出） 以及 缓存命中 Token（缓存读） 的筛选范围统计。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ x ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [ x ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ x ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ x ] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [ x ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [ x ] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
<img width="565" height="83" alt="PixPin_2026-04-24_20-41-01" src="https://github.com/user-attachments/assets/cdb4a606-06a1-41c4-9149-3ee732f9c12e" />
<img width="1280" height="704" alt="PixPin_2026-04-24_20-34-29" src="https://github.com/user-attachments/assets/ac7de6e9-fde1-448a-b938-ea165473210a" />
<img width="1280" height="704" alt="PixPin_2026-04-24_20-36-43" src="https://github.com/user-attachments/assets/6e165723-5e72-4813-b930-f72955f90ce5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Usage statistics now display detailed token breakdown, including separate metrics for prompt tokens (input), completion tokens (output), and cache tokens (cache read) across all usage logs and statistics views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->