### PR TITLE
fix(openai): tolerate object response arguments

### DIFF
--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -134,8 +134,37 @@ type FunctionResponse struct {
 	Description string `json:"description,omitempty"`
 	Name        string `json:"name,omitempty"`
 	// call function with arguments in JSON format
-	Parameters any    `json:"parameters,omitempty"` // request
-	Arguments  string `json:"arguments"`            // response
+	Parameters any               `json:"parameters,omitempty"` // request
+	Arguments  ResponseArguments `json:"arguments"`            // response
+}
+
+// ResponseArguments accepts both the canonical JSON string form and the object
+// form occasionally emitted by Responses streaming events.
+type ResponseArguments string
+
+func (a *ResponseArguments) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		*a = ""
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*a = ResponseArguments(s)
+		return nil
+	}
+	if !json.Valid(data) {
+		return fmt.Errorf("invalid response arguments JSON")
+	}
+	*a = ResponseArguments(string(data))
+	return nil
+}
+
+func (a ResponseArguments) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(a))
+}
+
+func (a ResponseArguments) String() string {
+	return string(a)
 }
 
 type ChatCompletionsStreamResponse struct {
@@ -346,7 +375,7 @@ type ResponsesOutput struct {
 	Size      string                   `json:"size"`
 	CallId    string                   `json:"call_id,omitempty"`
 	Name      string                   `json:"name,omitempty"`
-	Arguments string                   `json:"arguments,omitempty"`
+	Arguments ResponseArguments        `json:"arguments,omitempty"`
 }
 
 type ResponsesOutputContent struct {

--- a/dto/openai_response_test.go
+++ b/dto/openai_response_test.go
@@ -1,0 +1,50 @@
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestResponsesOutputArgumentsAcceptsObject(t *testing.T) {
+	var output ResponsesOutput
+	err := json.Unmarshal([]byte(`{"type":"function_call","arguments":{"query":"hello","limit":3}}`), &output)
+	if err != nil {
+		t.Fatalf("Unmarshal ResponsesOutput failed: %v", err)
+	}
+	if got := output.Arguments.String(); got != `{"query":"hello","limit":3}` {
+		t.Fatalf("unexpected arguments: %s", got)
+	}
+}
+
+func TestResponsesOutputArgumentsAcceptsNull(t *testing.T) {
+	var output ResponsesOutput
+	err := json.Unmarshal([]byte(`{"type":"function_call","arguments":null}`), &output)
+	if err != nil {
+		t.Fatalf("Unmarshal ResponsesOutput failed: %v", err)
+	}
+	if got := output.Arguments.String(); got != "" {
+		t.Fatalf("unexpected arguments: %s", got)
+	}
+}
+
+func TestResponsesOutputArgumentsAcceptsArray(t *testing.T) {
+	var output ResponsesOutput
+	err := json.Unmarshal([]byte(`{"type":"function_call","arguments":["hello",3]}`), &output)
+	if err != nil {
+		t.Fatalf("Unmarshal ResponsesOutput failed: %v", err)
+	}
+	if got := output.Arguments.String(); got != `["hello",3]` {
+		t.Fatalf("unexpected arguments: %s", got)
+	}
+}
+
+func TestFunctionResponseArgumentsAcceptsString(t *testing.T) {
+	var fn FunctionResponse
+	err := json.Unmarshal([]byte(`{"name":"x","arguments":"{\"query\":\"hello\"}"}`), &fn)
+	if err != nil {
+		t.Fatalf("Unmarshal FunctionResponse failed: %v", err)
+	}
+	if got := fn.Arguments.String(); got != `{"query":"hello"}` {
+		t.Fatalf("unexpected arguments: %s", got)
+	}
+}

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -485,7 +485,7 @@ func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.ChatCo
 					Type:  "function",
 					Index: common.GetPointer(fcIdx),
 					Function: dto.FunctionResponse{
-						Arguments: *claudeResponse.Delta.PartialJson,
+						Arguments: dto.ResponseArguments(*claudeResponse.Delta.PartialJson),
 					},
 				})
 			case "signature_delta":
@@ -546,7 +546,7 @@ func ResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.OpenAITextRe
 				Type: "function", // compatible with other OpenAI derivative applications
 				Function: dto.FunctionResponse{
 					Name:      message.Name,
-					Arguments: string(args),
+					Arguments: dto.ResponseArguments(string(args)),
 				},
 			})
 		case "thinking":

--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -1005,7 +1005,7 @@ func getResponseToolCall(item *dto.GeminiPart) *dto.ToolCallResponse {
 		ID:   fmt.Sprintf("call_%s", common.GetUUID()),
 		Type: "function",
 		Function: dto.FunctionResponse{
-			Arguments: string(argsBytes),
+			Arguments: dto.ResponseArguments(string(argsBytes)),
 			Name:      item.FunctionCall.FunctionName,
 		},
 	}

--- a/relay/channel/ollama/stream.go
+++ b/relay/channel/ollama/stream.go
@@ -138,7 +138,7 @@ func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 					// arguments -> string
 					argBytes, _ := json.Marshal(tc.Function.Arguments)
 					toolId := fmt.Sprintf("call_%d", toolCallIndex)
-					tr := dto.ToolCallResponse{ID: toolId, Type: "function", Function: dto.FunctionResponse{Name: tc.Function.Name, Arguments: string(argBytes)}}
+					tr := dto.ToolCallResponse{ID: toolId, Type: "function", Function: dto.FunctionResponse{Name: tc.Function.Name, Arguments: dto.ResponseArguments(string(argBytes))}}
 					tr.SetIndex(toolCallIndex)
 					toolCallIndex++
 					delta.Choices[0].Delta.ToolCalls = append(delta.Choices[0].Delta.ToolCalls, tr)

--- a/relay/channel/openai/chat_via_responses.go
+++ b/relay/channel/openai/chat_via_responses.go
@@ -258,7 +258,7 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 			ID:   callID,
 			Type: "function",
 			Function: dto.FunctionResponse{
-				Arguments: argsDelta,
+				Arguments: dto.ResponseArguments(argsDelta),
 			},
 		}
 		tool.SetIndex(idx)
@@ -408,7 +408,7 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 				toolCallNameByID[callID] = name
 			}
 
-			newArgs := streamResp.Item.Arguments
+			newArgs := streamResp.Item.Arguments.String()
 			prevArgs := toolCallArgsByID[callID]
 			argsDelta := ""
 			if newArgs != "" {

--- a/relay/channel/openai/helper.go
+++ b/relay/channel/openai/helper.go
@@ -85,7 +85,7 @@ func ProcessStreamResponse(streamResponse dto.ChatCompletionsStreamResponse, res
 			}
 			for _, tool := range choice.Delta.ToolCalls {
 				responseTextBuilder.WriteString(tool.Function.Name)
-				responseTextBuilder.WriteString(tool.Function.Arguments)
+				responseTextBuilder.WriteString(tool.Function.Arguments.String())
 			}
 		}
 	}
@@ -132,7 +132,7 @@ func processChatCompletions(streamResp string, streamItems []string, responseTex
 				}
 				for _, tool := range choice.Delta.ToolCalls {
 					responseTextBuilder.WriteString(tool.Function.Name)
-					responseTextBuilder.WriteString(tool.Function.Arguments)
+					responseTextBuilder.WriteString(tool.Function.Arguments.String())
 				}
 			}
 		}

--- a/service/convert.go
+++ b/service/convert.go
@@ -343,13 +343,14 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 			claudeResponses = append(claudeResponses, resp)
 			// 首块包含工具 delta，则追加 input_json_delta
 			if toolCall.Function.Arguments != "" {
+				partialJSON := toolCall.Function.Arguments.String()
 				idx := 0
 				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
 					Index: &idx,
 					Type:  "content_block_delta",
 					Delta: &dto.ClaudeMediaMessage{
 						Type:        "input_json_delta",
-						PartialJson: &toolCall.Function.Arguments,
+						PartialJson: &partialJSON,
 					},
 				})
 			}
@@ -515,12 +516,13 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 				}
 
 				if len(toolCall.Function.Arguments) > 0 {
+					partialJSON := toolCall.Function.Arguments.String()
 					claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
 						Index: &idx,
 						Type:  "content_block_delta",
 						Delta: &dto.ClaudeMediaMessage{
 							Type:        "input_json_delta",
-							PartialJson: &toolCall.Function.Arguments,
+							PartialJson: &partialJSON,
 						},
 					})
 				}


### PR DESCRIPTION
## 变更描述 / Description

本 PR 修复 OpenAI Responses 流式/转换链路中 `arguments` 字段只能按字符串解析的问题。

目前代码里 `FunctionResponse.Arguments` 和 `ResponsesOutput.Arguments` 都按 `string` 建模。但在 Responses API 的部分工具调用事件里，上游可能返回对象格式的 `arguments`，例如：

```json
{
  "type": "function_call",
  "arguments": {
    "query": "hello",
    "limit": 3
  }
}
```

这种 payload 在 Go 里反序列化到 `string` 会失败，进而导致响应转换中断。实际表现可能是流式响应提前断开、上游响应无法正常转换，或者下游客户端看到解码/连接中断类错误。

本 PR 新增 `dto.ResponseArguments` 类型，使 `arguments` 同时兼容两种输入：

- 标准字符串格式：`"{\"query\":\"hello\"}"`
- 对象格式：`{"query":"hello","limit":3}`

内部仍统一保存为 JSON 字符串，并且 `MarshalJSON` 继续输出字符串，避免影响现有 OpenAI Chat Completions / Claude / Gemini / Ollama 转换链路对工具参数字符串的预期。

同时，本 PR 把相关转换代码改为显式使用 `ResponseArguments(...)` 或 `.String()`，避免类型变化后在 Claude、Gemini、Ollama、OpenAI Responses 转换路径中出现不一致。

## 为什么之前一直没发现？

这个问题比较隐蔽，主要原因是历史测试和常见请求都覆盖在 `arguments` 为字符串的路径上：

- Chat Completions 传统工具调用里，`tool_calls[].function.arguments` 通常就是字符串。
- 大多数已有 provider 转换逻辑也会主动把工具参数 marshal 成字符串后再传递。
- 只有 Responses API 的部分事件或中间转换场景可能直接给出对象格式 `arguments`。
- 原有测试没有覆盖 `ResponsesOutput.arguments` 为 JSON object 的反序列化场景。

因此正常聊天、普通工具调用、以及大部分 provider 转换都不会触发该错误。只有当 Responses 流式事件中出现对象型 `arguments` 时，才会暴露出结构体字段类型过窄的问题，需要足够多的请求来发现此问题。

本 PR 增加了对象型 `arguments` 的回归测试，避免之后再把该字段收窄回纯 `string`。

## 变更类型 / Type of change

- [x] Bug 修复 (Bug fix)
- [ ] 新功能 (New feature)
- [ ] 性能优化 / 重构 (Refactor)
- [ ] 文档更新 (Documentation)

## 关联任务 / Related Issue

- Closes # （无）

## 提交前检查项 / Checklist

- [x] 人工确认：我已整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] 非重复提交：已检查当前分支只包含本修复，不包含自定义邀请注册等无关改动。
- [x] Bug fix 说明：该问题是实际 payload 形态与 DTO 类型定义不兼容导致的解析失败。
- [x] 变更理解：本 PR 只放宽 `arguments` 入站解析，出站仍保持字符串格式，降低兼容风险。
- [x] 范围聚焦：本 PR 未包含与当前任务无关的代码改动。
- [x] 本地验证：已运行相关测试。
- [x] 安全合规：代码中无敏感凭据。

## 运行证明 / Proof of Work

本地验证命令：

```bash
go test ./dto ./relay/channel/openai ./service
```

结果：

```text
ok   github.com/QuantumNous/new-api/dto
?    github.com/QuantumNous/new-api/relay/channel/openai [no test files]
ok   github.com/QuantumNous/new-api/service
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Unified and improved handling of tool-call/function arguments across integrations (OpenAI, Claude, Gemini, Ollama) to ensure consistent behavior for streaming and non‑streaming responses.

* **Tests**
  * Added tests validating robust JSON parsing/serialization of response arguments (objects, arrays, null, and escaped JSON strings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->