### PR TITLE
fix: 流式请求客户端断连后继续读取上游响应，避免 usage 丢失

### DIFF
--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -224,13 +224,13 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 
 		for scanner.Scan() {
 			// 检查是否需要停止
+			// 不监听 c.Request.Context().Done()：客户端断连不应中断上游读取，
+			// 否则拿不到最后的 usage 事件（如 message_delta），导致计费缺失。
+			// 上游响应流会自然结束（EOF/[DONE]），streaming timeout 兜底防止无限阻塞。
 			select {
 			case <-stopChan:
 				return
 			case <-ctx.Done():
-				return
-			case <-c.Request.Context().Done():
-				info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, c.Request.Context().Err())
 				return
 			default:
 			}
@@ -282,13 +282,13 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	})
 
 	// 主循环等待完成或超时
+	// 不监听 c.Request.Context().Done()：客户端断连不应终止流程，
+	// scanner 会继续读完上游流拿到 usage，然后通过 stopChan 通知主循环退出。
 	select {
 	case <-ticker.C:
 		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonTimeout, nil)
 	case <-stopChan:
 		// EndReason already set by the goroutine that triggered stopChan
-	case <-c.Request.Context().Done():
-		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, c.Request.Context().Err())
 	}
 
 	if info.StreamStatus.IsNormalEnd() && !info.StreamStatus.HasErrors() {


### PR DESCRIPTION
## 问题

`StreamScannerHandler`（`relay/helper/stream_scanner.go`）中，scanner goroutine 和主循环都监听了 `c.Request.Context().Done()`。客户端断连时 scanner 立即停止读取上游响应流，导致最后的 `message_delta` 事件（含 `output_tokens` 等 usage 信息）丢失，计费记录不完整，造成上下游账单差异。

## 根因

- scanner goroutine（第 232 行）：`case <-c.Request.Context().Done()` → 客户端断连立即 return
- 主循环（第 290 行）：`case <-c.Request.Context().Done()` → 客户端断连结束整个流程

## 修复

去掉 scanner goroutine 和主循环中的 `c.Request.Context().Done()` 监听。客户端断连后 scanner 继续读完上游流拿到完整 usage 数据再退出。

**不影响资源回收**：
- 上游响应流会自然结束（EOF 或 `[DONE]`）
- streaming timeout（`ticker`）兜底防止无限阻塞
- `stopChan` 机制确保所有 goroutine 正确退出
- ping goroutine 保留 `c.Request.Context().Done()` 检查（客户端断连后无需继续 ping，且 ping goroutine 正常退出不会触发 `stopChan`）

## 实际案例

通过对比上下游账单发现：上游 100 条记录中有 2 条在 new-api 侧缺失计费记录（`quota=0`），均为客户端断连导致 scanner 提前停止、未读到 usage 事件。

Fixes #4463

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream handling to ensure final usage-related events are properly captured during stream completion, rather than being lost during termination. Stream timeout and shutdown coordination now work more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->