### PR TITLE
fix(verification): use Redis as authoritative code store if enabled

### DIFF
--- a/common/verification.go
+++ b/common/verification.go
@@ -1,10 +1,14 @@
 package common
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
 )
 
@@ -23,6 +27,19 @@ var verificationMap map[string]verificationValue
 var verificationMapMaxSize = 10
 var VerificationValidMinutes = 10
 
+func verificationKey(key string, purpose string) string {
+	return purpose + key
+}
+
+func verificationRedisEnabled() bool {
+	return RedisEnabled && RDB != nil
+}
+
+func verificationRedisKey(key string, purpose string) string {
+	sum := sha256.Sum256([]byte(purpose + ":" + key))
+	return "verification:" + purpose + ":" + hex.EncodeToString(sum[:])
+}
+
 func GenerateVerificationCode(length int) string {
 	code := uuid.New().String()
 	code = strings.Replace(code, "-", "", -1)
@@ -32,10 +49,25 @@ func GenerateVerificationCode(length int) string {
 	return code[:length]
 }
 
-func RegisterVerificationCodeWithKey(key string, code string, purpose string) {
+func RegisterVerificationCodeWithKey(key string, code string, purpose string) error {
+	if verificationRedisEnabled() {
+		err := RedisSet(verificationRedisKey(key, purpose), code, time.Duration(VerificationValidMinutes)*time.Minute)
+		if err != nil {
+			SysLog("failed to save verification code to Redis: " + err.Error())
+			deleteVerificationCodeInMemory(key, purpose)
+			return err
+		}
+		deleteVerificationCodeInMemory(key, purpose)
+		return nil
+	}
+	registerVerificationCodeInMemory(key, code, purpose)
+	return nil
+}
+
+func registerVerificationCodeInMemory(key string, code string, purpose string) {
 	verificationMutex.Lock()
 	defer verificationMutex.Unlock()
-	verificationMap[purpose+key] = verificationValue{
+	verificationMap[verificationKey(key, purpose)] = verificationValue{
 		code: code,
 		time: time.Now(),
 	}
@@ -45,9 +77,23 @@ func RegisterVerificationCodeWithKey(key string, code string, purpose string) {
 }
 
 func VerifyCodeWithKey(key string, code string, purpose string) bool {
+	if verificationRedisEnabled() {
+		value, err := RedisGet(verificationRedisKey(key, purpose))
+		if err == nil {
+			return code == value
+		}
+		if !errors.Is(err, redis.Nil) {
+			SysLog("failed to get verification code from Redis: " + err.Error())
+		}
+		return false
+	}
+	return verifyCodeWithKeyInMemory(key, code, purpose)
+}
+
+func verifyCodeWithKeyInMemory(key string, code string, purpose string) bool {
 	verificationMutex.Lock()
 	defer verificationMutex.Unlock()
-	value, okay := verificationMap[purpose+key]
+	value, okay := verificationMap[verificationKey(key, purpose)]
 	now := time.Now()
 	if !okay || int(now.Sub(value.time).Seconds()) >= VerificationValidMinutes*60 {
 		return false
@@ -56,9 +102,19 @@ func VerifyCodeWithKey(key string, code string, purpose string) bool {
 }
 
 func DeleteKey(key string, purpose string) {
+	if verificationRedisEnabled() {
+		err := RedisDelKey(verificationRedisKey(key, purpose))
+		if err != nil {
+			SysLog("failed to delete verification code from Redis: " + err.Error())
+		}
+	}
+	deleteVerificationCodeInMemory(key, purpose)
+}
+
+func deleteVerificationCodeInMemory(key string, purpose string) {
 	verificationMutex.Lock()
 	defer verificationMutex.Unlock()
-	delete(verificationMap, purpose+key)
+	delete(verificationMap, verificationKey(key, purpose))
 }
 
 // no lock inside, so the caller must lock the verificationMap before calling!

--- a/common/verification_test.go
+++ b/common/verification_test.go
@@ -1,0 +1,94 @@
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+func resetVerificationTestState(t *testing.T) {
+	t.Helper()
+
+	oldRedisEnabled := RedisEnabled
+	oldRDB := RDB
+	oldMap := verificationMap
+	oldValidMinutes := VerificationValidMinutes
+
+	RedisEnabled = false
+	RDB = nil
+	verificationMap = make(map[string]verificationValue)
+	VerificationValidMinutes = 10
+
+	t.Cleanup(func() {
+		RedisEnabled = oldRedisEnabled
+		RDB = oldRDB
+		verificationMap = oldMap
+		VerificationValidMinutes = oldValidMinutes
+	})
+}
+
+func TestVerificationCodeMemoryFallback(t *testing.T) {
+	resetVerificationTestState(t)
+
+	if err := RegisterVerificationCodeWithKey("user@example.com", "123456", EmailVerificationPurpose); err != nil {
+		t.Fatalf("expected verification code registration to succeed: %v", err)
+	}
+
+	if !VerifyCodeWithKey("user@example.com", "123456", EmailVerificationPurpose) {
+		t.Fatal("expected verification code to match")
+	}
+	if VerifyCodeWithKey("user@example.com", "000000", EmailVerificationPurpose) {
+		t.Fatal("expected wrong verification code to fail")
+	}
+
+	DeleteKey("user@example.com", EmailVerificationPurpose)
+	if VerifyCodeWithKey("user@example.com", "123456", EmailVerificationPurpose) {
+		t.Fatal("expected deleted verification code to fail")
+	}
+}
+
+func TestVerificationCodeMemoryExpiration(t *testing.T) {
+	resetVerificationTestState(t)
+
+	verificationMap[verificationKey("user@example.com", EmailVerificationPurpose)] = verificationValue{
+		code: "123456",
+		time: time.Now().Add(-time.Duration(VerificationValidMinutes)*time.Minute - time.Second),
+	}
+
+	if VerifyCodeWithKey("user@example.com", "123456", EmailVerificationPurpose) {
+		t.Fatal("expected expired verification code to fail")
+	}
+}
+
+func TestVerificationCodeRedisFailureDoesNotFallbackToMemory(t *testing.T) {
+	resetVerificationTestState(t)
+
+	client := redis.NewClient(&redis.Options{
+		Addr:         "127.0.0.1:0",
+		DialTimeout:  time.Millisecond,
+		ReadTimeout:  time.Millisecond,
+		WriteTimeout: time.Millisecond,
+	})
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	RedisEnabled = true
+	RDB = client
+	verificationMap[verificationKey("user@example.com", EmailVerificationPurpose)] = verificationValue{
+		code: "stale",
+		time: time.Now(),
+	}
+
+	if VerifyCodeWithKey("user@example.com", "stale", EmailVerificationPurpose) {
+		t.Fatal("expected Redis-enabled verification not to fallback to memory")
+	}
+
+	if err := RegisterVerificationCodeWithKey("user@example.com", "123456", EmailVerificationPurpose); err == nil {
+		t.Fatal("expected Redis write failure")
+	}
+	if _, ok := verificationMap[verificationKey("user@example.com", EmailVerificationPurpose)]; ok {
+		t.Fatal("expected Redis write failure to clear stale in-memory code")
+	}
+}

--- a/controller/misc.go
+++ b/controller/misc.go
@@ -282,7 +282,14 @@ func SendEmailVerification(c *gin.Context) {
 		return
 	}
 	code := common.GenerateVerificationCode(6)
-	common.RegisterVerificationCodeWithKey(email, code, common.EmailVerificationPurpose)
+	if err := common.RegisterVerificationCodeWithKey(email, code, common.EmailVerificationPurpose); err != nil {
+		logger.LogError(c.Request.Context(), fmt.Sprintf("failed to save email verification code for %s: %s", email, err.Error()))
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": "验证码发送失败，请稍后重试",
+		})
+		return
+	}
 	subject := fmt.Sprintf("%s邮箱验证邮件", common.SystemName)
 	content := fmt.Sprintf("<p>您好，你正在进行%s邮箱验证。</p>"+
 		"<p>您的验证码为: <strong>%s</strong></p>"+
@@ -310,7 +317,14 @@ func SendPasswordResetEmail(c *gin.Context) {
 	}
 	if model.IsEmailAlreadyTaken(email) {
 		code := common.GenerateVerificationCode(0)
-		common.RegisterVerificationCodeWithKey(email, code, common.PasswordResetPurpose)
+		if err := common.RegisterVerificationCodeWithKey(email, code, common.PasswordResetPurpose); err != nil {
+			logger.LogError(c.Request.Context(), fmt.Sprintf("failed to save password reset token for %s: %s", email, err.Error()))
+			c.JSON(http.StatusOK, gin.H{
+				"success": true,
+				"message": "",
+			})
+			return
+		}
 		link := fmt.Sprintf("%s/user/reset?email=%s&token=%s", system_setting.ServerAddress, email, code)
 		subject := fmt.Sprintf("%s密码重置", common.SystemName)
 		content := fmt.Sprintf("<p>您好，你正在进行%s密码重置。</p>"+

--- a/controller/user.go
+++ b/controller/user.go
@@ -223,6 +223,9 @@ func Register(c *gin.Context) {
 			return
 		}
 	}
+	if common.EmailVerificationEnabled {
+		common.DeleteKey(user.Email, common.EmailVerificationPurpose)
+	}
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
@@ -1027,6 +1030,7 @@ func EmailBind(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	common.DeleteKey(email, common.EmailVerificationPurpose)
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

new-api 在多实例部署时，发送邮箱验证码和校验验证码的请求可能落到不同实例。当前验证码虽然会优先写入 Redis，但校验时在 Redis 读取失败或 key 不存在时仍会回退到本机内存 map，导致各实例之间验证码状态不一致，可能出现验证码已发送但无法正常校验的情况。

本次调整后，Redis 可用时验证码只以 Redis 为准：
- Redis 写入失败会返回错误，避免继续发送不可用的验证码邮件；
- Redis 读取失败或 key 不存在时直接校验失败，不再回退到内存；
- Redis 模式下会清理同 key 的旧内存验证码，避免旧状态残留；
- 非 Redis 模式仍保持原有内存验证码逻辑。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (暂无关联 Issue)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

本地验证通过：

```bash
go test -count=1 ./common ./controller


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Verification codes now support Redis-backed storage for improved reliability and scalability when enabled, with automatic fallback to in-memory storage.

* **Bug Fixes**
  * Verification codes are now properly removed after successful use, preventing unauthorized reuse.
  * Enhanced error handling and logging for verification code operations with improved failure responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->