### PR TITLE
fix: use configured currency symbol in top-up history payment amount column

### DIFF
--- a/web/src/components/topup/modals/TopupHistoryModal.jsx
+++ b/web/src/components/topup/modals/TopupHistoryModal.jsx
@@ -34,7 +34,7 @@ import {
 } from '@douyinfe/semi-illustrations';
 import { Coins } from 'lucide-react';
 import { IconSearch } from '@douyinfe/semi-icons';
-import { API, timestamp2string } from '../../../helpers';
+import { API, timestamp2string, convertUSDToCurrency, convertCNYToCurrency } from '../../../helpers';
 import { isAdmin } from '../../../helpers/utils';
 import { useIsMobile } from '../../../hooks/common/useIsMobile';
 const { Text } = Typography;
@@ -55,6 +55,25 @@ const PAYMENT_METHOD_MAP = {
   alipay: '支付宝',
   wxpay: '微信',
 };
+
+// Providers that store Money in CNY; all others store Money in USD.
+const CNY_PROVIDERS = new Set(['epay']);
+const CNY_METHODS = new Set(['alipay', 'wxpay']);
+
+function renderPaymentAmount(money, record) {
+  if (money == null || isNaN(money)) {
+    return <Text type='danger'>-</Text>;
+  }
+  const provider = record?.payment_provider || '';
+  const method = record?.payment_method || '';
+  const isCNY =
+    CNY_PROVIDERS.has(provider) ||
+    (provider === '' && CNY_METHODS.has(method));
+  const display = isCNY
+    ? convertCNYToCurrency(money)
+    : convertUSDToCurrency(money);
+  return <Text type='danger'>{display}</Text>;
+}
 
 const TopupHistoryModal = ({ visible, onCancel, t }) => {
   const [loading, setLoading] = useState(false);
@@ -207,7 +226,7 @@ const TopupHistoryModal = ({ visible, onCancel, t }) => {
         title: t('支付金额'),
         dataIndex: 'money',
         key: 'money',
-        render: (money) => <Text type='danger'>¥{money.toFixed(2)}</Text>,
+        render: (money, record) => renderPaymentAmount(money, record),
       },
       {
         title: t('状态'),

--- a/web/src/helpers/render.jsx
+++ b/web/src/helpers/render.jsx
@@ -1139,6 +1139,26 @@ export function convertUSDToCurrency(usdAmount, digits = 2) {
   return symbol + convertedAmount.toFixed(digits);
 }
 
+/**
+ * 将人民币金额转换为当前选择的货币
+ * @param {number} cnyAmount - 人民币金额
+ * @param {number} digits - 小数位数
+ * @returns {string} - 格式化后的货币字符串
+ */
+export function convertCNYToCurrency(cnyAmount, digits = 2) {
+  const { symbol, type } = getCurrencyConfig();
+  if (type === 'CNY') {
+    return symbol + Number(cnyAmount).toFixed(digits);
+  }
+  // Convert CNY → USD using usd_exchange_rate, then to display currency
+  let usdExchangeRate = 7;
+  try {
+    const s = JSON.parse(localStorage.getItem('status') || '{}');
+    usdExchangeRate = s?.usd_exchange_rate || 7;
+  } catch (e) {}
+  return convertUSDToCurrency(cnyAmount / usdExchangeRate, digits);
+}
+
 export function renderQuota(quota, digits = 2) {
   let quotaPerUnit = localStorage.getItem('quota_per_unit');
   const quotaDisplayType = localStorage.getItem('quota_display_type') || 'USD';


### PR DESCRIPTION
## 问题描述 / Problem

充值账单历史弹窗（`TopupHistoryModal`）的「支付金额」列对所有记录硬编码了 `¥`，与运营商在「系统设置」中配置的 `QuotaDisplayType` 完全无关。使用 Stripe、Creem 或 Waffo（美元计价网关）且将 `QuotaDisplayType` 设为 `USD` 或 `CUSTOM` 的运营商，看到的是错误的货币符号和未换算的金额。

The "支付金额" column in the top-up history modal hardcodes `¥` for every record, ignoring the operator's configured `QuotaDisplayType`. Operators using Stripe, Creem, or Waffo with `QuotaDisplayType=USD` or `CUSTOM` see the wrong currency symbol and unconverted amounts.

## 原因 / Root Cause

`TopupHistoryModal.jsx` 原代码：
```jsx
render: (money) => <Text type='danger'>¥{money.toFixed(2)}</Text>
```

## 修复方案 / Fix

`TopUp.Money` 的货币语义因支付网关而异：

| 网关 | Money 货币 |
|---|---|
| stripe / creem / waffo | USD |
| epay / alipay / wxpay | CNY |

**修改内容（仅前端，2 个文件）：**

1. `web/src/helpers/render.jsx` — 新增 `convertCNYToCurrency()` 工具函数：CNY 金额 → 当前显示货币（复用已有的 `getCurrencyConfig()` 和 `convertUSDToCurrency()`）
2. `web/src/components/topup/modals/TopupHistoryModal.jsx` — 以 provider-aware 的 `renderPaymentAmount()` 替换硬编码的 `¥`：USD 网关调用 `convertUSDToCurrency()`；CNY 网关调用 `convertCNYToCurrency()`

**Note**: `WeChatPaymentModal.jsx` 中也有 `¥` 字面量，但那里显示的是用户需要用微信钱包扫码支付的实际人民币金额（结构上只能是 CNY），有意不在本 PR 修改。

## 修复后效果 / After Fix

| 场景 | 修复前 | 修复后 |
|---|---|---|
| Stripe + USD 显示 | `¥10.00` ❌ | `$10.00` ✓ |
| Stripe + CNY 显示 | `¥10.00` ❌ | `¥73.00` ✓ |
| Epay + CNY 显示 | `¥73.00` ✓ | `¥73.00` ✓ |
| Epay + USD 显示 | `¥73.00` ❌ | `$10.00` ✓ |
| Creem + CUSTOM 显示 | `¥5.00` ❌ | `€5.00` ✓ |

无后端改动；对现有 CNY 部署无回归。

## ✅ 提交前检查项 / Checklist

- [x] 代码已在本地构建验证（`bun run build` 零错误）
- [x] 仅修改 bug 相关文件，无无关改动
- [x] 复用了项目现有的 `getCurrencyConfig()` / `convertUSDToCurrency()` helpers
- [x] 对所有支付网关（stripe/creem/waffo/epay/alipay/wxpay）均已考虑
- [x] 无破坏性变更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transaction history now displays the correct currency (CNY or USD) based on the payment method used.
  * Added dynamic currency conversion with automatic USD exchange rate retrieval from system configuration.

* **Bug Fixes**
  * Invalid or null transaction amounts now display as "-" placeholder for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->