### PR TITLE
fix(user): return access token in login response

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -103,10 +103,29 @@ func setupLogin(user *model.User, c *gin.Context) {
 		common.ApiErrorI18n(c, i18n.MsgUserSessionSaveFailed)
 		return
 	}
+
+	// Ensure user has an access token for API authentication
+	token := user.GetAccessToken()
+	if token == "" {
+		randI := common.GetRandomInt(4)
+		key, err := common.GenerateRandomKey(29 + randI)
+		if err != nil {
+			common.ApiErrorI18n(c, i18n.MsgGenerateFailed)
+			return
+		}
+		token = key
+		user.SetAccessToken(token)
+		if err := user.Update(false); err != nil {
+			common.ApiError(c, err)
+			return
+		}
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"message": "",
 		"success": true,
 		"data": map[string]any{
+			"token":        token,
 			"id":           user.Id,
 			"username":     user.Username,
 			"display_name": user.DisplayName,


### PR DESCRIPTION
## Summary

Login endpoint `/api/user/login` was missing the `token` field in its response despite the API documentation specifying `data.token`.

**Root cause**: `setupLogin()` created a session/cookie for browser-based auth but did not return or generate an access token for API authentication. This left API clients unable to authenticate after login.

**Fix**: `setupLogin()` now ensures the user has an `access_token` in the DB (generating one if missing) and returns it as `data.token`.

## Changes

- `controller/user.go`: `setupLogin()` now returns `data.token`

## Test Plan

- [ ] Verify login response now includes `data.token` field
- [ ] Verify token is a valid 29-32 char string
- [ ] Verify subsequent API calls work with the returned token
- [ ] Verify existing users without tokens get one auto-generated on login
- [ ] Verify new users get a token on first login

## Notes

- Visual verify: stub — requires running backend to test login flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API authentication tokens are now included in login responses. Users will automatically receive an access token upon login if one isn't already present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->