### PR TITLE
fix: preserve Claude reasoning content in message conversions

### DIFF
--- a/dto/claude.go
+++ b/dto/claude.go
@@ -120,8 +120,9 @@ type ClaudeMessageSource struct {
 }
 
 type ClaudeMessage struct {
-	Role    string `json:"role"`
-	Content any    `json:"content"`
+	Role             string          `json:"role"`
+	Content          any             `json:"content"`
+	ReasoningContent json.RawMessage `json:"reasoning_content,omitempty"`
 }
 
 func (c *ClaudeMessage) IsStringContent() bool {

--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -279,12 +279,21 @@ type Message struct {
 	Content          any             `json:"content"`
 	Name             *string         `json:"name,omitempty"`
 	Prefix           *bool           `json:"prefix,omitempty"`
-	ReasoningContent string          `json:"reasoning_content,omitempty"`
+	ReasoningContent json.RawMessage `json:"reasoning_content,omitempty"`
 	Reasoning        string          `json:"reasoning,omitempty"`
 	ToolCalls        json.RawMessage `json:"tool_calls,omitempty"`
 	ToolCallId       string          `json:"tool_call_id,omitempty"`
 	parsedContent    []MediaContent
 	//parsedStringContent *string
+}
+
+func (m *Message) SetReasoningContent(content string) {
+	encoded, _ := common.Marshal(content)
+	m.ReasoningContent = encoded
+}
+
+func (m *Message) GetReasoningContent() string {
+	return common.JsonRawMessageToString(m.ReasoningContent)
 }
 
 type MediaContent struct {

--- a/dto/openai_request_zero_value_test.go
+++ b/dto/openai_request_zero_value_test.go
@@ -71,3 +71,17 @@ func TestOpenAIResponsesRequestPreserveExplicitZeroValues(t *testing.T) {
 	require.True(t, gjson.GetBytes(encoded, "stream").Exists())
 	require.True(t, gjson.GetBytes(encoded, "top_p").Exists())
 }
+
+func TestOpenAIMessagePreserveReasoningContentRaw(t *testing.T) {
+	raw := []byte(`{"role":"assistant","content":"","reasoning_content":" "}`)
+
+	var message Message
+	err := common.Unmarshal(raw, &message)
+	require.NoError(t, err)
+	require.Equal(t, " ", message.GetReasoningContent())
+	require.JSONEq(t, `" "`, string(message.ReasoningContent))
+
+	encoded, err := common.Marshal(message)
+	require.NoError(t, err)
+	require.Equal(t, " ", gjson.GetBytes(encoded, "reasoning_content").String())
+}

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -264,7 +264,7 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 			Role:    message.Role,
 			Content: message.Content,
 		}
-		if message.ReasoningContent != "" {
+		if len(message.ReasoningContent) > 0 {
 			fmtMessage.ReasoningContent = message.ReasoningContent
 		}
 		if message.Role == "tool" {
@@ -334,12 +334,8 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 			claudeMessage := dto.ClaudeMessage{
 				Role: message.Role,
 			}
-			if message.ReasoningContent != "" {
-				reasoningContent, err := common.Marshal(message.ReasoningContent)
-				if err != nil {
-					return nil, err
-				}
-				claudeMessage.ReasoningContent = reasoningContent
+			if len(message.ReasoningContent) > 0 {
+				claudeMessage.ReasoningContent = message.ReasoningContent
 			}
 			if message.Role == "tool" {
 				if len(claudeMessages) > 0 && claudeMessages[len(claudeMessages)-1].Role == "user" {
@@ -577,12 +573,14 @@ func ResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.OpenAITextRe
 	}
 	choice.SetStringContent(responseText)
 	if len(responseThinking) > 0 {
-		choice.ReasoningContent = responseThinking
+		choice.Message.SetReasoningContent(responseThinking)
 	}
 	if len(tools) > 0 {
 		choice.Message.SetToolCalls(tools)
 	}
-	choice.Message.ReasoningContent = thinkingContent
+	if len(thinkingContent) > 0 {
+		choice.Message.SetReasoningContent(thinkingContent)
+	}
 	fullTextResponse.Model = claudeResponse.Model
 	choices = append(choices, choice)
 	fullTextResponse.Choices = choices

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -264,6 +264,9 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 			Role:    message.Role,
 			Content: message.Content,
 		}
+		if message.ReasoningContent != "" {
+			fmtMessage.ReasoningContent = message.ReasoningContent
+		}
 		if message.Role == "tool" {
 			fmtMessage.ToolCallId = message.ToolCallId
 		}
@@ -330,6 +333,13 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 			}
 			claudeMessage := dto.ClaudeMessage{
 				Role: message.Role,
+			}
+			if message.ReasoningContent != "" {
+				reasoningContent, err := common.Marshal(message.ReasoningContent)
+				if err != nil {
+					return nil, err
+				}
+				claudeMessage.ReasoningContent = reasoningContent
 			}
 			if message.Role == "tool" {
 				if len(claudeMessages) > 0 && claudeMessages[len(claudeMessages)-1].Role == "user" {

--- a/relay/channel/claude/relay_claude_test.go
+++ b/relay/channel/claude/relay_claude_test.go
@@ -380,3 +380,35 @@ func TestRequestOpenAI2ClaudeMessage_ConvertsTextFileContentToText(t *testing.T)
 	require.NotNil(t, content[0].Text)
 	require.Equal(t, "alpha\nbeta", *content[0].Text)
 }
+
+func TestRequestOpenAI2ClaudeMessagePreservesReasoningContent(t *testing.T) {
+	message := dto.Message{
+		Role:             "assistant",
+		Content:          "",
+		ReasoningContent: " ",
+	}
+	message.SetToolCalls([]dto.ToolCallRequest{
+		{
+			ID:   "call_123",
+			Type: "function",
+			Function: dto.FunctionRequest{
+				Name:      "lookup",
+				Arguments: `{"query":"moonshot"}`,
+			},
+		},
+	})
+	request := dto.GeneralOpenAIRequest{
+		Model:    "kimi-k2-thinking",
+		Messages: []dto.Message{message},
+	}
+
+	claudeRequest, err := RequestOpenAI2ClaudeMessage(nil, request)
+	require.NoError(t, err)
+	require.Len(t, claudeRequest.Messages, 2)
+	require.JSONEq(t, `" "`, string(claudeRequest.Messages[1].ReasoningContent))
+
+	content, ok := claudeRequest.Messages[1].Content.([]dto.ClaudeMediaMessage)
+	require.True(t, ok)
+	require.NotEmpty(t, content)
+	require.Equal(t, "tool_use", content[len(content)-1].Type)
+}

--- a/relay/channel/claude/relay_claude_test.go
+++ b/relay/channel/claude/relay_claude_test.go
@@ -383,10 +383,10 @@ func TestRequestOpenAI2ClaudeMessage_ConvertsTextFileContentToText(t *testing.T)
 
 func TestRequestOpenAI2ClaudeMessagePreservesReasoningContent(t *testing.T) {
 	message := dto.Message{
-		Role:             "assistant",
-		Content:          "",
-		ReasoningContent: " ",
+		Role:    "assistant",
+		Content: "",
 	}
+	message.SetReasoningContent(" ")
 	message.SetToolCalls([]dto.ToolCallRequest{
 		{
 			ID:   "call_123",

--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -1097,7 +1097,7 @@ func responseGeminiChat2OpenAI(c *gin.Context, response *dto.GeminiChatResponse)
 						toolCalls = append(toolCalls, *call)
 					}
 				} else if part.Thought {
-					choice.Message.ReasoningContent = part.Text
+					choice.Message.SetReasoningContent(part.Text)
 				} else {
 					if part.ExecutableCode != nil {
 						texts = append(texts, "```"+part.ExecutableCode.Language+"\n"+part.ExecutableCode.Code+"\n```")

--- a/relay/channel/ollama/stream.go
+++ b/relay/channel/ollama/stream.go
@@ -273,7 +273,7 @@ func ollamaChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.R
 
 	msg := dto.Message{Role: "assistant", Content: contentPtr(content)}
 	if rc := reasoningBuilder.String(); rc != "" {
-		msg.ReasoningContent = rc
+		msg.SetReasoningContent(rc)
 	}
 	full := dto.OpenAITextResponse{
 		Id:      common.GetUUID(),

--- a/relay/channel/openai/relay-openai.go
+++ b/relay/channel/openai/relay-openai.go
@@ -245,7 +245,7 @@ func OpenaiHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respo
 		completionTokens := simpleResponse.Usage.CompletionTokens
 		if completionTokens == 0 {
 			for _, choice := range simpleResponse.Choices {
-				ctkm := service.CountTextToken(choice.Message.StringContent()+choice.Message.ReasoningContent+choice.Message.Reasoning, info.UpstreamModelName)
+				ctkm := service.CountTextToken(choice.Message.StringContent()+choice.Message.GetReasoningContent()+choice.Message.Reasoning, info.UpstreamModelName)
 				completionTokens += ctkm
 			}
 		}

--- a/service/convert.go
+++ b/service/convert.go
@@ -135,7 +135,7 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 			Role: claudeMessage.Role,
 		}
 		if len(claudeMessage.ReasoningContent) > 0 {
-			openAIMessage.ReasoningContent = common.JsonRawMessageToString(claudeMessage.ReasoningContent)
+			openAIMessage.ReasoningContent = claudeMessage.ReasoningContent
 		}
 
 		//log.Printf("claudeMessage.Content: %v", claudeMessage.Content)

--- a/service/convert.go
+++ b/service/convert.go
@@ -134,6 +134,9 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 		openAIMessage := dto.Message{
 			Role: claudeMessage.Role,
 		}
+		if len(claudeMessage.ReasoningContent) > 0 {
+			openAIMessage.ReasoningContent = common.JsonRawMessageToString(claudeMessage.ReasoningContent)
+		}
 
 		//log.Printf("claudeMessage.Content: %v", claudeMessage.Content)
 		if claudeMessage.IsStringContent() {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

deepseek/kimi 的交错思考在message上新增了reasoning_content，和原生Anthropic端点不一致，需要补充字段进行兼容。
该PR处理
- 原生Anthropic端点透传reasoning_content
- OpenAI和Anthropic端点互相转换，处理特定厂商（deepseek/kimi）的特殊字段

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #4408

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserves assistant "reasoning" content when converting messages between different AI model formats, both directions.
* **Bug Fixes**
  * Ensures reasoning content is forwarded only when present, avoiding accidental overwrites.
* **Tests**
  * Added unit tests validating reasoning-content preservation, including edge-case raw values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->