### PR TITLE
fix: 客户端断连时取消上游请求并停止重试

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -319,6 +319,9 @@ func shouldRetry(c *gin.Context, openaiErr *types.NewAPIError, retryTimes int) b
 	if openaiErr == nil {
 		return false
 	}
+	if clientRequestDone(c) {
+		return false
+	}
 	if service.ShouldSkipRetryAfterChannelAffinityFailure(c) {
 		return false
 	}
@@ -345,6 +348,10 @@ func shouldRetry(c *gin.Context, openaiErr *types.NewAPIError, retryTimes int) b
 		return false
 	}
 	return operation_setting.ShouldRetryByStatusCode(code)
+}
+
+func clientRequestDone(c *gin.Context) bool {
+	return c != nil && c.Request != nil && c.Request.Context().Err() != nil
 }
 
 func processChannelError(c *gin.Context, channelError types.ChannelError, err *types.NewAPIError) {
@@ -606,6 +613,9 @@ func respondTaskError(c *gin.Context, taskErr *dto.TaskError) {
 
 func shouldRetryTaskRelay(c *gin.Context, channelId int, taskErr *dto.TaskError, retryTimes int) bool {
 	if taskErr == nil {
+		return false
+	}
+	if clientRequestDone(c) {
 		return false
 	}
 	if service.ShouldSkipRetryAfterChannelAffinityFailure(c) {

--- a/controller/relay_retry_test.go
+++ b/controller/relay_retry_test.go
@@ -1,0 +1,54 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldRetryReturnsFalseWhenClientRequestDone(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	reqCtx, cancel := context.WithCancel(req.Context())
+	cancel()
+	ctx.Request = req.WithContext(reqCtx)
+
+	err := types.NewErrorWithStatusCode(
+		fmt.Errorf("upstream error"),
+		types.ErrorCodeBadResponse,
+		http.StatusInternalServerError,
+	)
+
+	require.False(t, shouldRetry(ctx, err, 1))
+}
+
+func TestShouldRetryTaskRelayReturnsFalseWhenClientRequestDone(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+	reqCtx, cancel := context.WithCancel(req.Context())
+	cancel()
+	ctx.Request = req.WithContext(reqCtx)
+
+	taskErr := &dto.TaskError{
+		Code:       "upstream_error",
+		Message:    "upstream error",
+		StatusCode: http.StatusInternalServerError,
+	}
+
+	require.False(t, shouldRetryTaskRelay(ctx, 1, taskErr, 1))
+}

--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -295,7 +295,7 @@ func DoApiRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody
 	if common2.DebugEnabled {
 		println("fullRequestURL:", fullRequestURL)
 	}
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
@@ -326,7 +326,7 @@ func DoFormRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBod
 	if common2.DebugEnabled {
 		println("fullRequestURL:", fullRequestURL)
 	}
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
@@ -534,7 +534,7 @@ func DoTaskApiRequest(a TaskAdaptor, c *gin.Context, info *common.RelayInfo, req
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}

--- a/relay/channel/api_request_test.go
+++ b/relay/channel/api_request_test.go
@@ -1,14 +1,83 @@
 package channel
 
 import (
+	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/QuantumNous/new-api/dto"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/types"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
+
+type contextTestAdaptor struct {
+	url string
+}
+
+func (a *contextTestAdaptor) Init(info *relaycommon.RelayInfo) {}
+
+func (a *contextTestAdaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
+	return a.url, nil
+}
+
+func (a *contextTestAdaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *relaycommon.RelayInfo) error {
+	return nil
+}
+
+func (a *contextTestAdaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeneralOpenAIRequest) (any, error) {
+	return nil, nil
+}
+
+func (a *contextTestAdaptor) ConvertRerankRequest(c *gin.Context, relayMode int, request dto.RerankRequest) (any, error) {
+	return nil, nil
+}
+
+func (a *contextTestAdaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.EmbeddingRequest) (any, error) {
+	return nil, nil
+}
+
+func (a *contextTestAdaptor) ConvertAudioRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.AudioRequest) (io.Reader, error) {
+	return nil, nil
+}
+
+func (a *contextTestAdaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.ImageRequest) (any, error) {
+	return nil, nil
+}
+
+func (a *contextTestAdaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {
+	return nil, nil
+}
+
+func (a *contextTestAdaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBody io.Reader) (any, error) {
+	return nil, nil
+}
+
+func (a *contextTestAdaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
+	return nil, nil
+}
+
+func (a *contextTestAdaptor) GetModelList() []string {
+	return nil
+}
+
+func (a *contextTestAdaptor) GetChannelName() string {
+	return "context-test"
+}
+
+func (a *contextTestAdaptor) ConvertClaudeRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.ClaudeRequest) (any, error) {
+	return nil, nil
+}
+
+func (a *contextTestAdaptor) ConvertGeminiRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeminiChatRequest) (any, error) {
+	return nil, nil
+}
 
 func TestProcessHeaderOverride_ChannelTestSkipsPassthroughRules(t *testing.T) {
 	t.Parallel()
@@ -31,6 +100,36 @@ func TestProcessHeaderOverride_ChannelTestSkipsPassthroughRules(t *testing.T) {
 	headers, err := processHeaderOverride(info, ctx)
 	require.NoError(t, err)
 	require.Empty(t, headers)
+}
+
+func TestDoApiRequestUsesClientRequestContext(t *testing.T) {
+	service.InitHttpClient()
+
+	var called atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	reqCtx, cancel := context.WithCancel(req.Context())
+	cancel()
+	ctx.Request = req.WithContext(reqCtx)
+
+	resp, err := DoApiRequest(
+		&contextTestAdaptor{url: upstream.URL},
+		ctx,
+		&relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{}},
+		strings.NewReader(`{}`),
+	)
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.False(t, called.Load(), "upstream must not be called after downstream request context is cancelled")
 }
 
 func TestProcessHeaderOverride_ChannelTestSkipsClientHeaderPlaceholder(t *testing.T) {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 这是人工整理后的简洁 PR 描述，避免公开完整可复现利用脚本；完整 PoC 如需提供，建议走 Security Advisory 私下沟通。

## 📝 变更描述 / Description

本 PR 将客户端请求的 `Context` 传递给上游 HTTP 请求，并在客户端请求已经取消时停止 relay retry。

具体改动：

- `DoApiRequest` / `DoFormRequest` / `DoTaskApiRequest` 使用 `http.NewRequestWithContext(c.Request.Context(), ...)` 创建上游请求；
- 当下游客户端断开或取消请求时，上游 HTTP 请求会随客户端 context 一起取消；
- `shouldRetry` / `shouldRetryTaskRelay` 在客户端请求已取消时直接返回 `false`，避免对已断开的下游继续切换渠道重试；
- 补充单元测试，覆盖已取消客户端 context 下不应继续请求上游、不应 retry。

为什么这样能生效：

当前流式处理在客户端断开时会停止向下游读取/写入，但上游 HTTP 请求未继承客户端 context，导致某些情况下上游仍继续生成和计费。将客户端 context 绑定到上游请求后，客户端主动关闭连接、SDK `stream.close()` / `client.close()`、网络断开或超时取消都会传递给上游连接，从而避免上游继续生成对下游不可见的尾部内容，也避免断连后继续重试浪费上游额度。

## 风险/滥用场景说明

该问题可能被恶意客户端或中间代理利用：攻击者可以构造流式 Responses / function-call / structured-output 请求，让模型先输出用户可见答案或可用的工具参数，再输出较长的隐藏尾部字段、padding、reason 或其他不会展示给最终用户的内容。攻击者在拿到前半部分有效结果后主动关闭下游流。

在未传播客户端 context 的情况下，new-api 会认为下游已经断开并停止处理当前流，但真实上游请求可能继续生成隐藏尾部内容并产生费用；由于 new-api 没有继续读取完整上游流，也可能拿不到最终 `usage` 事件，造成上下游计费差异。

本 PR 不公开完整利用脚本，仅说明触发模式；如维护者需要完整 PoC，建议通过 Security Advisory 私下共享。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - 客户端断连时上游请求未取消，可能造成上游继续计费和无意义重试
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Refs #4184
- Refs #4463
- Refs #4168

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有 Issues 与 PRs，确认相关问题存在但当前修复路径不同于 #4464。
- [x] **Bug fix 说明:** 本 PR 关联客户端断连导致上游继续处理/计费的问题，并采用取消上游请求而非忽略客户端断连的策略。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据；完整 PoC 不在公开 PR 描述中披露。

## 📸 运行证明 / Proof of Work

本地已运行：

```bash
go test ./relay/channel ./controller
# ok  github.com/QuantumNous/new-api/relay/channel
# ok  github.com/QuantumNous/new-api/controller
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved request cancellation handling: the system now correctly stops processing, prevents unnecessary retries, and cancels upstream requests when a client request is cancelled or times out, improving resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->