### PR TITLE
fix: merge text-only content blocks to string in Claude-to-OpenAI conversion

### DIFF
--- a/service/convert.go
+++ b/service/convert.go
@@ -203,7 +203,31 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 			}
 
 			if len(mediaMessages) > 0 && len(toolCalls) == 0 {
-				openAIMessage.SetMediaContent(mediaMessages)
+				// If all content blocks are text-only (no images), merge into a single string.
+				// Some upstream providers (e.g., NVIDIA) don't support array content in user messages.
+				allText := true
+				for _, mm := range mediaMessages {
+					if mm.Type != "text" && mm.Type != "input_text" {
+						allText = false
+						break
+					}
+				}
+				if allText {
+					var textParts []string
+					for _, mm := range mediaMessages {
+						if mm.Text != "" {
+							textParts = append(textParts, mm.Text)
+						}
+					}
+					if len(textParts) > 0 {
+						openAIMessage.SetStringContent(strings.Join(textParts, "\n"))
+					} else {
+						// All text blocks are empty; set empty string as fallback to ensure message has content.
+						openAIMessage.SetStringContent("")
+					}
+				} else {
+					openAIMessage.SetMediaContent(mediaMessages)
+				}
 			}
 		}
 		if len(openAIMessage.ParseContent()) > 0 || len(openAIMessage.ToolCalls) > 0 {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

Claude Code 通过 `/v1/messages` 端点发送请求时，user message 的 content 为多个 text block 组成的 array（如 `[{"type":"text","text":"..."},{"type":"text","text":"..."}]`）。经过 `ClaudeToOpenAIRequest` 转换后，content 仍保持 array 格式。

部分上游 provider（如 NVIDIA）的后端使用 `"".join(content)` 处理 user message content，不接受 list 格式，导致 500 错误：`sequence item 0: expected str instance, list found`。

修复方案：在 `ClaudeToOpenAIRequest` 中，当 `mediaMessages` 全部为 text-only block（无 image）时，使用 `strings.Join` 合并为单一 string content。包含 image 的混合 content 继续使用 array 格式，不受影响。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

**修复前（500 错误）：**
```
curl -X POST localhost:3000/v1/messages -d '{"model":"deepseek-ai/deepseek-v4-pro","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}'
→ Internal server error: sequence item 0: expected str instance, list found
```

**修复后（200 成功）：**
```
curl -X POST localhost:3000/v1/messages -d '{"model":"deepseek-ai/deepseek-v4-pro","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}'
→ 200 OK, content blocks 正确合并为 string
```
