### PR TITLE
feat(ali): add Happy Horse 1.0 video model support

### DIFF
--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -387,8 +387,8 @@ func (a *TaskAdaptor) convertToHappyHorseRequest(info *relaycommon.RelayInfo, up
 			aliReq.Input.Media = append(aliReq.Input.Media, AliMediaItem{Type: "reference_image", URL: url})
 		}
 	} else if isEdit {
-		if len(req.Videos) < 1 {
-			return nil, fmt.Errorf("happyhorse video-edit requires exactly 1 video")
+		if len(req.Videos) != 1 {
+			return nil, fmt.Errorf("happyhorse video-edit requires exactly 1 video, got %d", len(req.Videos))
 		}
 		if len(req.Images) > 5 {
 			return nil, fmt.Errorf("happyhorse video-edit supports at most 5 reference images, got %d", len(req.Images))

--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -56,8 +56,8 @@ type AliVideoParameters struct {
 	Resolution   string `json:"resolution,omitempty"`      // 分辨率: 480P/720P/1080P（图生视频、首尾帧生视频）
 	Size         string `json:"size,omitempty"`            // 尺寸: 如 "832*480"（文生视频）
 	Duration     int    `json:"duration,omitempty"`        // 时长: 3-10秒
-	Ratio        string `json:"ratio,omitempty"`           // 宽高比: Happy Horse t2v/r2v
-	AudioSetting string `json:"audio_setting,omitempty"`   // 声音控制: Happy Horse video-edit (auto/origin)
+	Ratio        *string `json:"ratio,omitempty"`           // 宽高比: Happy Horse t2v/r2v
+	AudioSetting *string `json:"audio_setting,omitempty"`  // 声音控制: Happy Horse video-edit (auto/origin)
 	PromptExtend bool   `json:"prompt_extend,omitempty"`   // 是否开启prompt智能改写
 	Watermark    *bool  `json:"watermark,omitempty"`       // 是否添加水印
 	Audio        *bool  `json:"audio,omitempty"`           // 是否添加音频（wan2.5）
@@ -268,7 +268,7 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 	}
 
 	// Happy Horse 模型使用不同的请求格式（media 数组）
-	if strings.HasPrefix(req.Model, "happyhorse-1.0") {
+	if strings.HasPrefix(upstreamModel, "happyhorse-1.0") {
 		return a.convertToHappyHorseRequest(info, upstreamModel, req)
 	}
 
@@ -369,21 +369,31 @@ func (a *TaskAdaptor) convertToHappyHorseRequest(info *relaycommon.RelayInfo, up
 		},
 	}
 
-	isT2V := strings.Contains(req.Model, "-t2v")
-	isI2V := strings.Contains(req.Model, "-i2v")
-	isR2V := strings.Contains(req.Model, "-r2v")
-	isEdit := strings.Contains(req.Model, "-video-edit")
+	isT2V := strings.Contains(upstreamModel, "-t2v")
+	isI2V := strings.Contains(upstreamModel, "-i2v")
+	isR2V := strings.Contains(upstreamModel, "-r2v")
+	isEdit := strings.Contains(upstreamModel, "-video-edit")
 
-	if isI2V && len(req.Images) > 0 {
+	if isI2V {
+		if len(req.Images) != 1 {
+			return nil, fmt.Errorf("happyhorse i2v requires exactly 1 first-frame image, got %d", len(req.Images))
+		}
 		aliReq.Input.Media = []AliMediaItem{{Type: "first_frame", URL: req.Images[0]}}
-	} else if isR2V && len(req.Images) > 0 {
+	} else if isR2V {
+		if len(req.Images) < 1 || len(req.Images) > 9 {
+			return nil, fmt.Errorf("happyhorse r2v requires 1-9 reference images, got %d", len(req.Images))
+		}
 		for _, url := range req.Images {
 			aliReq.Input.Media = append(aliReq.Input.Media, AliMediaItem{Type: "reference_image", URL: url})
 		}
 	} else if isEdit {
-		if len(req.Videos) > 0 {
-			aliReq.Input.Media = append(aliReq.Input.Media, AliMediaItem{Type: "video", URL: req.Videos[0]})
+		if len(req.Videos) < 1 {
+			return nil, fmt.Errorf("happyhorse video-edit requires exactly 1 video")
 		}
+		if len(req.Images) > 5 {
+			return nil, fmt.Errorf("happyhorse video-edit supports at most 5 reference images, got %d", len(req.Images))
+		}
+		aliReq.Input.Media = append(aliReq.Input.Media, AliMediaItem{Type: "video", URL: req.Videos[0]})
 		for _, url := range req.Images {
 			aliReq.Input.Media = append(aliReq.Input.Media, AliMediaItem{Type: "reference_image", URL: url})
 		}
@@ -401,6 +411,12 @@ func (a *TaskAdaptor) convertToHappyHorseRequest(info *relaycommon.RelayInfo, up
 	if !isEdit {
 		if req.Duration > 0 {
 			aliReq.Parameters.Duration = req.Duration
+		} else if req.Seconds != "" {
+			seconds, err := strconv.Atoi(req.Seconds)
+			if err != nil {
+				return nil, errors.Wrap(err, "convert seconds to int failed")
+			}
+			aliReq.Parameters.Duration = seconds
 		} else {
 			aliReq.Parameters.Duration = 5
 		}
@@ -408,10 +424,10 @@ func (a *TaskAdaptor) convertToHappyHorseRequest(info *relaycommon.RelayInfo, up
 
 	if req.Metadata != nil {
 		if ratio, ok := req.Metadata["ratio"].(string); ok && (isT2V || isR2V) {
-			aliReq.Parameters.Ratio = ratio
+			aliReq.Parameters.Ratio = lo.ToPtr(ratio)
 		}
 		if audioSetting, ok := req.Metadata["audio_setting"].(string); ok && isEdit {
-			aliReq.Parameters.AudioSetting = audioSetting
+			aliReq.Parameters.AudioSetting = lo.ToPtr(audioSetting)
 		}
 		if watermark, ok := req.Metadata["watermark"].(bool); ok {
 			aliReq.Parameters.Watermark = lo.ToPtr(watermark)

--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -26,6 +26,12 @@ import (
 // Request / Response structures
 // ============================
 
+// AliMediaItem Happy Horse media 数组元素
+type AliMediaItem struct {
+	Type string `json:"type"` // first_frame, reference_image, video
+	URL  string `json:"url"`
+}
+
 // AliVideoRequest 阿里通义万相视频生成请求
 type AliVideoRequest struct {
 	Model      string              `json:"model"`
@@ -35,24 +41,27 @@ type AliVideoRequest struct {
 
 // AliVideoInput 视频输入参数
 type AliVideoInput struct {
-	Prompt         string `json:"prompt,omitempty"`          // 文本提示词
-	ImgURL         string `json:"img_url,omitempty"`         // 首帧图像URL或Base64（图生视频）
-	FirstFrameURL  string `json:"first_frame_url,omitempty"` // 首帧图片URL（首尾帧生视频）
-	LastFrameURL   string `json:"last_frame_url,omitempty"`  // 尾帧图片URL（首尾帧生视频）
-	AudioURL       string `json:"audio_url,omitempty"`       // 音频URL（wan2.5支持）
-	NegativePrompt string `json:"negative_prompt,omitempty"` // 反向提示词
-	Template       string `json:"template,omitempty"`        // 视频特效模板
+	Prompt         string         `json:"prompt,omitempty"`          // 文本提示词
+	ImgURL         string         `json:"img_url,omitempty"`         // 首帧图像URL或Base64（图生视频）
+	FirstFrameURL  string         `json:"first_frame_url,omitempty"` // 首帧图片URL（首尾帧生视频）
+	LastFrameURL   string         `json:"last_frame_url,omitempty"`  // 尾帧图片URL（首尾帧生视频）
+	AudioURL       string         `json:"audio_url,omitempty"`       // 音频URL（wan2.5支持）
+	NegativePrompt string         `json:"negative_prompt,omitempty"` // 反向提示词
+	Template       string         `json:"template,omitempty"`        // 视频特效模板
+	Media          []AliMediaItem `json:"media,omitempty"`           // Happy Horse media 数组
 }
 
 // AliVideoParameters 视频参数
 type AliVideoParameters struct {
-	Resolution   string `json:"resolution,omitempty"`    // 分辨率: 480P/720P/1080P（图生视频、首尾帧生视频）
-	Size         string `json:"size,omitempty"`          // 尺寸: 如 "832*480"（文生视频）
-	Duration     int    `json:"duration,omitempty"`      // 时长: 3-10秒
-	PromptExtend bool   `json:"prompt_extend,omitempty"` // 是否开启prompt智能改写
-	Watermark    bool   `json:"watermark,omitempty"`     // 是否添加水印
-	Audio        *bool  `json:"audio,omitempty"`         // 是否添加音频（wan2.5）
-	Seed         int    `json:"seed,omitempty"`          // 随机数种子
+	Resolution   string `json:"resolution,omitempty"`      // 分辨率: 480P/720P/1080P（图生视频、首尾帧生视频）
+	Size         string `json:"size,omitempty"`            // 尺寸: 如 "832*480"（文生视频）
+	Duration     int    `json:"duration,omitempty"`        // 时长: 3-10秒
+	Ratio        string `json:"ratio,omitempty"`           // 宽高比: Happy Horse t2v/r2v
+	AudioSetting string `json:"audio_setting,omitempty"`   // 声音控制: Happy Horse video-edit (auto/origin)
+	PromptExtend bool   `json:"prompt_extend,omitempty"`   // 是否开启prompt智能改写
+	Watermark    *bool  `json:"watermark,omitempty"`       // 是否添加水印
+	Audio        *bool  `json:"audio,omitempty"`           // 是否添加音频（wan2.5）
+	Seed         int    `json:"seed,omitempty"`            // 随机数种子
 }
 
 // AliVideoResponse 阿里通义万相响应
@@ -257,6 +266,12 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 	if info.IsModelMapped {
 		upstreamModel = info.UpstreamModelName
 	}
+
+	// Happy Horse 模型使用不同的请求格式（media 数组）
+	if strings.HasPrefix(req.Model, "happyhorse-1.0") {
+		return a.convertToHappyHorseRequest(info, upstreamModel, req)
+	}
+
 	aliReq := &AliVideoRequest{
 		Model: upstreamModel,
 		Input: AliVideoInput{
@@ -265,7 +280,7 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 		},
 		Parameters: &AliVideoParameters{
 			PromptExtend: true, // 默认开启智能改写
-			Watermark:    false,
+			Watermark:    lo.ToPtr(false),
 		},
 	}
 
@@ -338,6 +353,69 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 
 	if aliReq.Model != upstreamModel {
 		return nil, errors.New("can't change model with metadata")
+	}
+
+	return aliReq, nil
+}
+
+func (a *TaskAdaptor) convertToHappyHorseRequest(info *relaycommon.RelayInfo, upstreamModel string, req relaycommon.TaskSubmitReq) (*AliVideoRequest, error) {
+	aliReq := &AliVideoRequest{
+		Model: upstreamModel,
+		Input: AliVideoInput{
+			Prompt: req.Prompt,
+		},
+		Parameters: &AliVideoParameters{
+			Watermark: lo.ToPtr(false),
+		},
+	}
+
+	isT2V := strings.Contains(req.Model, "-t2v")
+	isI2V := strings.Contains(req.Model, "-i2v")
+	isR2V := strings.Contains(req.Model, "-r2v")
+	isEdit := strings.Contains(req.Model, "-video-edit")
+
+	if isI2V && len(req.Images) > 0 {
+		aliReq.Input.Media = []AliMediaItem{{Type: "first_frame", URL: req.Images[0]}}
+	} else if isR2V && len(req.Images) > 0 {
+		for _, url := range req.Images {
+			aliReq.Input.Media = append(aliReq.Input.Media, AliMediaItem{Type: "reference_image", URL: url})
+		}
+	} else if isEdit {
+		if len(req.Videos) > 0 {
+			aliReq.Input.Media = append(aliReq.Input.Media, AliMediaItem{Type: "video", URL: req.Videos[0]})
+		}
+		for _, url := range req.Images {
+			aliReq.Input.Media = append(aliReq.Input.Media, AliMediaItem{Type: "reference_image", URL: url})
+		}
+	}
+
+	resolution := "1080P"
+	if req.Size != "" {
+		resolution = strings.ToUpper(req.Size)
+		if !strings.HasSuffix(resolution, "P") {
+			resolution += "P"
+		}
+	}
+	aliReq.Parameters.Resolution = resolution
+
+	if !isEdit {
+		if req.Duration > 0 {
+			aliReq.Parameters.Duration = req.Duration
+		} else {
+			aliReq.Parameters.Duration = 5
+		}
+	}
+
+	if req.Metadata != nil {
+		if ratio, ok := req.Metadata["ratio"].(string); ok && (isT2V || isR2V) {
+			aliReq.Parameters.Ratio = ratio
+		}
+		if audioSetting, ok := req.Metadata["audio_setting"].(string); ok && isEdit {
+			aliReq.Parameters.AudioSetting = audioSetting
+		}
+		if watermark, ok := req.Metadata["watermark"].(bool); ok {
+			aliReq.Parameters.Watermark = lo.ToPtr(watermark)
+		}
 	}
 
 	return aliReq, nil

--- a/relay/channel/task/ali/constants.go
+++ b/relay/channel/task/ali/constants.go
@@ -6,6 +6,10 @@ var ModelList = []string{
 	"wan2.2-i2v-plus",    // 万相2.2专业版（无声视频）
 	"wanx2.1-i2v-plus",   // 万相2.1专业版（无声视频）
 	"wanx2.1-i2v-turbo",  // 万相2.1极速版（无声视频）
+	"happyhorse-1.0-t2v",        // Happy Horse 文生视频
+	"happyhorse-1.0-i2v",        // Happy Horse 首帧图生视频
+	"happyhorse-1.0-r2v",        // Happy Horse 参考图生视频
+	"happyhorse-1.0-video-edit", // Happy Horse 视频编辑
 }
 
 var ChannelName = "ali"

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -673,6 +673,7 @@ type TaskSubmitReq struct {
 	Mode           string                 `json:"mode,omitempty"`
 	Image          string                 `json:"image,omitempty"`
 	Images         []string               `json:"images,omitempty"`
+	Videos         []string               `json:"videos,omitempty"`
 	Size           string                 `json:"size,omitempty"`
 	Duration       int                    `json:"duration,omitempty"`
 	Seconds        string                 `json:"seconds,omitempty"`


### PR DESCRIPTION
## Summary

Add support for [Alibaba Cloud Bailian Happy Horse 1.0](https://help.aliyun.com/zh/model-studio/developer-reference/happy-horse-api) video generation models in the `ali` channel adaptor.

Happy Horse 1.0 is a video generation model on Alibaba Cloud Bailian (DashScope API) that shares the same DashScope endpoint as Wanxiang models (`/api/v1/services/aigc/video-generation/video-synthesis`), but uses a different request format — a `media` array instead of flat fields (`img_url`, `first_frame_url`, etc.).

### Changes

- **Model registration**: Add 4 Happy Horse model IDs to `ModelList`:
  - `happyhorse-1.0-t2v` — text-to-video
  - `happyhorse-1.0-i2v` — first frame image-to-video
  - `happyhorse-1.0-r2v` — reference images-to-video (1-9 images, use `character1`/`character2` in prompt)
  - `happyhorse-1.0-video-edit` — video editing (1 video + 0-5 reference images)

- **Request format**: Add `AliMediaItem` struct and `Media` field for the `media` array format:
  ```json
  {"input": {"media": [{"type": "first_frame", "url": "..."}, {"type": "reference_image", "url": "..."}]}}
  ```

- **New parameters**: Add `Ratio` (aspect ratio for t2v/r2v) and `AudioSetting` (audio control for video-edit: `auto`/`origin`) to `AliVideoParameters`

- **Watermark fix**: Change `Watermark` from `bool` to `*bool` pointer type. Happy Horse API defaults watermark to `true`, but Go's `omitempty` tag silently drops `false` values, causing watermarks to always appear. Using `*bool` ensures `false` is serialized. This also fixes a latent bug for Wanxiang models.

- **Auto-detection**: `convertToAliRequest` detects Happy Horse models by `"happyhorse-1.0"` prefix and routes to `convertToHappyHorseRequest`

### Files changed

| File | Change |
|------|--------|
| `relay/channel/task/ali/constants.go` | Add 4 Happy Horse models to `ModelList` |
| `relay/channel/task/ali/adaptor.go` | Add `AliMediaItem`, `Media` field, `Ratio`/`AudioSetting` params, `*bool` Watermark, `convertToHappyHorseRequest` method |

### Happy Horse parameter differences vs Wanxiang

| Parameter | t2v | i2v | r2v | video-edit |
|-----------|-----|-----|-----|------------|
| ratio | 16:9/9:16/1:1/4:3/3:4 | N/A (follows input) | 16:9/9:16/1:1/4:3/3:4 | N/A |
| duration | 3-15s | 3-15s | 3-15s | N/A (follows input) |
| resolution | 720P/1080P | 720P/1080P | 720P/1080P | 720P/1080P |
| watermark | ✅ (**default: true**) | ✅ (**default: true**) | ✅ (**default: true**) | ✅ (**default: true**) |
| audio_setting | N/A | N/A | N/A | auto/origin |

### References

- [Happy Horse API Documentation](https://help.aliyun.com/zh/model-studio/developer-reference/happy-horse-api)
- [DashScope Video Generation API](https://help.aliyun.com/zh/model-studio/developer-reference/video-generation-api)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Happy Horse video models (t2v, i2v, r2v, video-edit).
  * Accept ordered media inputs (first_frame/reference_image/video) and a new videos array.
  * New parameters: aspect ratio, audio setting, and nullable watermark.
  * Enforced model-specific media rules and defaults for resolution, duration, and watermark.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->