### PR TITLE
feat: support web search for zhipu via web_search_options

### DIFF
--- a/relay/channel/zhipu_4v/adaptor.go
+++ b/relay/channel/zhipu_4v/adaptor.go
@@ -90,7 +90,7 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 	if lo.FromPtrOr(request.TopP, 0) >= 1 {
 		request.TopP = lo.ToPtr(0.99)
 	}
-	return requestOpenAI2Zhipu(*request), nil
+	return injectZhipuWebSearch(requestOpenAI2Zhipu(*request), request.WebSearchOptions), nil
 }
 
 func (a *Adaptor) ConvertRerankRequest(c *gin.Context, relayMode int, request dto.RerankRequest) (any, error) {

--- a/relay/channel/zhipu_4v/relay-zhipu_v4.go
+++ b/relay/channel/zhipu_4v/relay-zhipu_v4.go
@@ -58,3 +58,25 @@ func requestOpenAI2Zhipu(request dto.GeneralOpenAIRequest) *dto.GeneralOpenAIReq
 	}
 	return out
 }
+
+func injectZhipuWebSearch(req *dto.GeneralOpenAIRequest, opts *dto.WebSearchOptions) any {
+	if opts == nil {
+		return req
+	}
+	ws := map[string]any{
+		"enable":        true,
+		"search_engine": "search_pro_jina",
+	}
+	// medium 不显式设值，使用智谱上游默认。
+	switch opts.SearchContextSize {
+	case "low":
+		ws["count"] = 5
+	case "high":
+		ws["count"] = 15
+		ws["content_size"] = "high"
+	}
+	m := req.ToMap()
+	tools, _ := m["tools"].([]any)
+	m["tools"] = append(tools, map[string]any{"type": "web_search", "web_search": ws})
+	return m
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
增加智谱官方支持的web search功能

## 📝 变更描述 / Description
智谱的web search 与 OpenAI的格式不兼容
`https://docs.z.ai/api-reference/llm/chat-completion`
因此要进行转换

## 🚀 变更类型 / Type of change
将OpenAI标准的web search格式
转换为智谱的格式

## 📸 运行证明 / Proof of Work
请求:
```
curl http://localhost:3000/v1/chat/completions \
  --request POST \
  --header 'Authorization: ' \
  --header 'Content-Type: application/json' \
  --data '{
  "model": "glm-5.1",
  "messages": [
    {
      "role": "user",
      "content": "今天福州天气?"
    }
  ],
  "web_search_options": {
    "search_context_size": "low"
  }
}'
```
返回:
<img width="2760" height="1806" alt="image" src="https://github.com/user-attachments/assets/965fee81-3cb7-48fb-9200-67a0f4bb5cc7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated web search functionality into the Zhipu channel. Users can now enable web search with configurable parameters including search type selection, result count, and optional content size settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->