### PR TITLE
feat(verification): back email/reset codes with Redis when available

### DIFF
--- a/common/verification.go
+++ b/common/verification.go
@@ -1,10 +1,12 @@
 package common
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
 )
 
@@ -17,6 +19,8 @@ const (
 	EmailVerificationPurpose = "v"
 	PasswordResetPurpose     = "r"
 )
+
+const verificationRedisPrefix = "verify_code:"
 
 var verificationMutex sync.Mutex
 var verificationMap map[string]verificationValue
@@ -32,7 +36,18 @@ func GenerateVerificationCode(length int) string {
 	return code[:length]
 }
 
+func verificationRedisKey(key, purpose string) string {
+	return verificationRedisPrefix + purpose + ":" + key
+}
+
 func RegisterVerificationCodeWithKey(key string, code string, purpose string) {
+	if RedisEnabled {
+		ttl := time.Duration(VerificationValidMinutes) * time.Minute
+		if err := RedisSet(verificationRedisKey(key, purpose), code, ttl); err != nil {
+			SysError("RegisterVerificationCodeWithKey: redis set failed: " + err.Error())
+		}
+		return
+	}
 	verificationMutex.Lock()
 	defer verificationMutex.Unlock()
 	verificationMap[purpose+key] = verificationValue{
@@ -45,6 +60,16 @@ func RegisterVerificationCodeWithKey(key string, code string, purpose string) {
 }
 
 func VerifyCodeWithKey(key string, code string, purpose string) bool {
+	if RedisEnabled {
+		stored, err := RedisGet(verificationRedisKey(key, purpose))
+		if err != nil {
+			if err != redis.Nil {
+				SysError("VerifyCodeWithKey: redis get failed: " + err.Error())
+			}
+			return false
+		}
+		return stored == code
+	}
 	verificationMutex.Lock()
 	defer verificationMutex.Unlock()
 	value, okay := verificationMap[purpose+key]
@@ -56,6 +81,12 @@ func VerifyCodeWithKey(key string, code string, purpose string) bool {
 }
 
 func DeleteKey(key string, purpose string) {
+	if RedisEnabled {
+		if err := RDB.Del(context.Background(), verificationRedisKey(key, purpose)).Err(); err != nil {
+			SysError("DeleteKey: redis del failed: " + err.Error())
+		}
+		return
+	}
 	verificationMutex.Lock()
 	defer verificationMutex.Unlock()
 	delete(verificationMap, purpose+key)

--- a/common/verification.go
+++ b/common/verification.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	"context"
+	"crypto/subtle"
 	"strings"
 	"sync"
 	"time"
@@ -68,7 +68,7 @@ func VerifyCodeWithKey(key string, code string, purpose string) bool {
 			}
 			return false
 		}
-		return stored == code
+		return subtle.ConstantTimeCompare([]byte(stored), []byte(code)) == 1
 	}
 	verificationMutex.Lock()
 	defer verificationMutex.Unlock()
@@ -82,7 +82,7 @@ func VerifyCodeWithKey(key string, code string, purpose string) bool {
 
 func DeleteKey(key string, purpose string) {
 	if RedisEnabled {
-		if err := RDB.Del(context.Background(), verificationRedisKey(key, purpose)).Err(); err != nil {
+		if err := RedisDelKey(verificationRedisKey(key, purpose)); err != nil {
 			SysError("DeleteKey: redis del failed: " + err.Error())
 		}
 		return

--- a/common/verification_test.go
+++ b/common/verification_test.go
@@ -1,0 +1,38 @@
+package common
+
+import "testing"
+
+// Exercise the in-process map fallback path that's used when Redis is
+// disabled. The Redis path is covered by live testing.
+func TestVerifyCodeWithKey_MemoryFallback(t *testing.T) {
+	prevRedis := RedisEnabled
+	RedisEnabled = false
+	t.Cleanup(func() { RedisEnabled = prevRedis })
+
+	const key = "user@example.com"
+	const code = "abc123"
+
+	if VerifyCodeWithKey(key, code, EmailVerificationPurpose) {
+		t.Fatalf("expected false before code is registered")
+	}
+
+	RegisterVerificationCodeWithKey(key, code, EmailVerificationPurpose)
+
+	if !VerifyCodeWithKey(key, code, EmailVerificationPurpose) {
+		t.Fatalf("expected true after registration")
+	}
+
+	if VerifyCodeWithKey(key, "wrong", EmailVerificationPurpose) {
+		t.Fatalf("expected false for wrong code")
+	}
+
+	// Different purpose namespace must not collide.
+	if VerifyCodeWithKey(key, code, PasswordResetPurpose) {
+		t.Fatalf("purposes must be isolated")
+	}
+
+	DeleteKey(key, EmailVerificationPurpose)
+	if VerifyCodeWithKey(key, code, EmailVerificationPurpose) {
+		t.Fatalf("expected false after DeleteKey")
+	}
+}


### PR DESCRIPTION
## Summary
\`common/verification.go\` stores email-verification and password-reset codes in an in-process \`map\` (\`verificationMap\`) protected by a \`sync.Mutex\`, with no Redis branch. This breaks horizontal scaling: when new-api runs with >1 replica behind a load balancer, the first request (e.g. \`POST /api/email_verification\`) registers the code in pod A's memory, the next request (\`POST /api/user/register\`) is routed to pod B and finds nothing — registration always fails.

Since \`common/redis.go\` is already integrated and most other in-memory fallbacks (caches, rate limiters, notify limit) already check \`RedisEnabled\`, it was natural to extend the same pattern here.

## Changes
- \`RegisterVerificationCodeWithKey\` uses \`RedisSet\` with \`VerificationValidMinutes\` TTL when \`RedisEnabled\`.
- \`VerifyCodeWithKey\` uses \`RedisGet\` + equality compare; on Redis error it fails closed (returns false).
- \`DeleteKey\` uses \`RDB.Del\`.
- The in-memory path is preserved unchanged for single-pod deployments.
- Redis key shape: \`verify_code:<purpose>:<key>\`.
- Adds a small unit test covering the in-memory contract (registration, wrong code, purpose isolation, deletion).

## Test plan
- [x] \`go test ./common/ -run TestVerifyCodeWithKey_MemoryFallback\` passes
- [x] Live verification in a multi-pod deployment (Redis-on path) — codes registered on pod A successfully verified on pod B.

## Backwards compatibility
- No API surface changes: \`RegisterVerificationCodeWithKey\`, \`VerifyCodeWithKey\`, \`DeleteKey\` keep their signatures.
- No new env vars, no migration, no schema changes.
- Single-pod / Redis-off deployments behave identically (the in-memory \`map\` path is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Redis-backed verification code storage with TTL-based expiry for more reliable, scalable, and secure verification handling (includes protections against timing attacks).

* **Tests**
  * Added unit tests covering verification lifecycle: registration, validation, cross-purpose isolation, incorrect-code handling, and deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->