### PR TITLE
fix: aggregate SSE upstream into chat.completion JSON for non-stream clients

### DIFF
--- a/relay/channel/openai/chat_via_responses.go
+++ b/relay/channel/openai/chat_via_responses.go
@@ -548,3 +548,234 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 	}
 	return usage, nil
 }
+
+// OaiResponsesSSEToChatJSON handles the case where the client requested a
+// non-streaming chat completion but the upstream /v1/responses endpoint
+// returned an SSE stream (common for reasoning models). It parses the SSE
+// events, accumulates output text / tool calls / usage, builds a single
+// dto.OpenAITextResponse, and writes it to the client as one JSON body.
+//
+// This avoids the bug where, in the original code path, when upstream returns
+// SSE for a non-stream client request, raw SSE chunks (with empty choices) get
+// forwarded directly to the client.
+func OaiResponsesSSEToChatJSON(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
+	if resp == nil || resp.Body == nil {
+		return nil, types.NewOpenAIError(fmt.Errorf("invalid response"), types.ErrorCodeBadResponse, http.StatusInternalServerError)
+	}
+	defer service.CloseResponseBodyGracefully(resp)
+
+	responseId := helper.GetResponseID(c)
+	createAt := time.Now().Unix()
+	model := info.UpstreamModelName
+
+	var (
+		usage      = &dto.Usage{}
+		outputText strings.Builder
+		usageText  strings.Builder
+		streamErr  *types.NewAPIError
+	)
+
+	toolCallIndexByID := make(map[string]int)
+	toolCallNameByID := make(map[string]string)
+	toolCallArgsByID := make(map[string]string)
+	toolCallOrder := make([]string, 0)
+	toolCallCanonicalIDByItemID := make(map[string]string)
+
+	registerToolCall := func(callID string) {
+		if _, ok := toolCallIndexByID[callID]; ok {
+			return
+		}
+		toolCallIndexByID[callID] = len(toolCallOrder)
+		toolCallOrder = append(toolCallOrder, callID)
+	}
+
+	helper.StreamScannerHandler(c, resp, info, func(data string, sr *helper.StreamResult) {
+		if streamErr != nil {
+			sr.Stop(streamErr)
+			return
+		}
+
+		var streamResp dto.ResponsesStreamResponse
+		if err := common.UnmarshalJsonStr(data, &streamResp); err != nil {
+			logger.LogError(c, "failed to unmarshal responses stream event: "+err.Error())
+			return
+		}
+
+		switch streamResp.Type {
+		case "response.created":
+			if streamResp.Response != nil {
+				if streamResp.Response.Model != "" {
+					model = streamResp.Response.Model
+				}
+				if streamResp.Response.CreatedAt != 0 {
+					createAt = int64(streamResp.Response.CreatedAt)
+				}
+			}
+
+		case "response.output_text.delta":
+			if streamResp.Delta != "" {
+				outputText.WriteString(streamResp.Delta)
+				usageText.WriteString(streamResp.Delta)
+			}
+
+		case "response.output_item.added", "response.output_item.done":
+			if streamResp.Item == nil || streamResp.Item.Type != "function_call" {
+				break
+			}
+			itemID := strings.TrimSpace(streamResp.Item.ID)
+			callID := strings.TrimSpace(streamResp.Item.CallId)
+			if callID == "" {
+				callID = itemID
+			}
+			if itemID != "" && callID != "" {
+				toolCallCanonicalIDByItemID[itemID] = callID
+			}
+			if callID == "" {
+				break
+			}
+			registerToolCall(callID)
+			if name := strings.TrimSpace(streamResp.Item.Name); name != "" {
+				toolCallNameByID[callID] = name
+				usageText.WriteString(name)
+			}
+			if args := streamResp.Item.ArgumentsString(); args != "" {
+				toolCallArgsByID[callID] = args
+			}
+
+		case "response.function_call_arguments.delta":
+			itemID := strings.TrimSpace(streamResp.ItemID)
+			callID := toolCallCanonicalIDByItemID[itemID]
+			if callID == "" {
+				callID = itemID
+			}
+			if callID == "" {
+				break
+			}
+			registerToolCall(callID)
+			toolCallArgsByID[callID] += streamResp.Delta
+			usageText.WriteString(streamResp.Delta)
+
+		case "response.completed":
+			if streamResp.Response != nil {
+				if streamResp.Response.Model != "" {
+					model = streamResp.Response.Model
+				}
+				if streamResp.Response.CreatedAt != 0 {
+					createAt = int64(streamResp.Response.CreatedAt)
+				}
+				if streamResp.Response.Usage != nil {
+					if streamResp.Response.Usage.InputTokens != 0 {
+						usage.PromptTokens = streamResp.Response.Usage.InputTokens
+						usage.InputTokens = streamResp.Response.Usage.InputTokens
+					}
+					if streamResp.Response.Usage.OutputTokens != 0 {
+						usage.CompletionTokens = streamResp.Response.Usage.OutputTokens
+						usage.OutputTokens = streamResp.Response.Usage.OutputTokens
+					}
+					if streamResp.Response.Usage.TotalTokens != 0 {
+						usage.TotalTokens = streamResp.Response.Usage.TotalTokens
+					} else {
+						usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+					}
+					if streamResp.Response.Usage.InputTokensDetails != nil {
+						usage.PromptTokensDetails.CachedTokens = streamResp.Response.Usage.InputTokensDetails.CachedTokens
+						usage.PromptTokensDetails.ImageTokens = streamResp.Response.Usage.InputTokensDetails.ImageTokens
+						usage.PromptTokensDetails.AudioTokens = streamResp.Response.Usage.InputTokensDetails.AudioTokens
+					}
+					if streamResp.Response.Usage.CompletionTokenDetails.ReasoningTokens != 0 {
+						usage.CompletionTokenDetails.ReasoningTokens = streamResp.Response.Usage.CompletionTokenDetails.ReasoningTokens
+					}
+				}
+			}
+
+		case "response.error", "response.failed":
+			if streamResp.Response != nil {
+				if oaiErr := streamResp.Response.GetOpenAIError(); oaiErr != nil && oaiErr.Type != "" {
+					streamErr = types.WithOpenAIError(*oaiErr, http.StatusInternalServerError)
+					sr.Stop(streamErr)
+					return
+				}
+			}
+			streamErr = types.NewOpenAIError(fmt.Errorf("responses stream error: %s", streamResp.Type), types.ErrorCodeBadResponse, http.StatusInternalServerError)
+			sr.Stop(streamErr)
+			return
+
+		default:
+		}
+	})
+
+	if streamErr != nil {
+		return nil, streamErr
+	}
+
+	if usage.TotalTokens == 0 {
+		usage = service.ResponseText2Usage(c, usageText.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
+	}
+
+	sawToolCall := len(toolCallOrder) > 0
+	finishReason := "stop"
+	if sawToolCall && outputText.Len() == 0 {
+		finishReason = "tool_calls"
+	}
+
+	msg := dto.Message{
+		Role:    "assistant",
+		Content: outputText.String(),
+	}
+
+	if sawToolCall {
+		toolCalls := make([]dto.ToolCallResponse, 0, len(toolCallOrder))
+		for _, callID := range toolCallOrder {
+			tc := dto.ToolCallResponse{
+				ID:   callID,
+				Type: "function",
+				Function: dto.FunctionResponse{
+					Name:      toolCallNameByID[callID],
+					Arguments: toolCallArgsByID[callID],
+				},
+			}
+			toolCalls = append(toolCalls, tc)
+		}
+		toolCallsBytes, err := common.Marshal(toolCalls)
+		if err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeJsonMarshalFailed, http.StatusInternalServerError)
+		}
+		msg.ToolCalls = toolCallsBytes
+	}
+
+	chatResp := &dto.OpenAITextResponse{
+		Id:      responseId,
+		Model:   model,
+		Object:  "chat.completion",
+		Created: createAt,
+		Choices: []dto.OpenAITextResponseChoice{
+			{
+				Index:        0,
+				Message:      msg,
+				FinishReason: finishReason,
+			},
+		},
+		Usage: *usage,
+	}
+
+	var (
+		responseBody []byte
+		err          error
+	)
+	switch info.RelayFormat {
+	case types.RelayFormatClaude:
+		claudeResp := service.ResponseOpenAI2Claude(chatResp, info)
+		responseBody, err = common.Marshal(claudeResp)
+	case types.RelayFormatGemini:
+		geminiResp := service.ResponseOpenAI2Gemini(chatResp, info)
+		responseBody, err = common.Marshal(geminiResp)
+	default:
+		responseBody, err = common.Marshal(chatResp)
+	}
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeJsonMarshalFailed, http.StatusInternalServerError)
+	}
+
+	service.IOCopyBytesGracefully(c, resp, responseBody)
+	return usage, nil
+}

--- a/relay/chat_completions_via_responses.go
+++ b/relay/chat_completions_via_responses.go
@@ -139,15 +139,31 @@ func chatCompletionsViaResponses(c *gin.Context, info *relaycommon.RelayInfo, ad
 	statusCodeMappingStr := c.GetString("status_code_mapping")
 
 	httpResp = resp.(*http.Response)
-	info.IsStream = info.IsStream || strings.HasPrefix(httpResp.Header.Get("Content-Type"), "text/event-stream")
+	clientWantsStream := info.IsStream
+	upstreamIsSSE := strings.HasPrefix(httpResp.Header.Get("Content-Type"), "text/event-stream")
+	info.IsStream = clientWantsStream || upstreamIsSSE
 	if httpResp.StatusCode != http.StatusOK {
 		newApiErr := service.RelayErrorHandler(c.Request.Context(), httpResp, false)
 		service.ResetStatusCode(newApiErr, statusCodeMappingStr)
 		return nil, newApiErr
 	}
 
-	if info.IsStream {
+	if clientWantsStream {
+		// Client requested stream — forward as SSE regardless of upstream format.
 		usage, newApiErr := openaichannel.OaiResponsesToChatStreamHandler(c, info, httpResp)
+		if newApiErr != nil {
+			service.ResetStatusCode(newApiErr, statusCodeMappingStr)
+			return nil, newApiErr
+		}
+		return usage, nil
+	}
+
+	if upstreamIsSSE {
+		// Client wants non-stream JSON, but upstream returned SSE (common for
+		// reasoning models). Buffer and aggregate the SSE stream into a full
+		// chat.completion JSON before writing to the client.
+		info.IsStream = false
+		usage, newApiErr := openaichannel.OaiResponsesSSEToChatJSON(c, info, httpResp)
 		if newApiErr != nil {
 			service.ResetStatusCode(newApiErr, statusCodeMappingStr)
 			return nil, newApiErr


### PR DESCRIPTION
## Problem

When a client requests a non-streaming `/v1/chat/completions` for a reasoning model (gpt-5.x, o1, etc.), `relay/chat_completions_via_responses.go` forwards the request to upstream `/v1/responses`. If upstream returns an SSE stream (which is the common case for these models), the existing dispatch logic at line 142 conflates *upstream's* SSE format with the *client's* stream preference:

```go
info.IsStream = info.IsStream || strings.HasPrefix(httpResp.Header.Get("Content-Type"), "text/event-stream")
```

The result: `IsStream` becomes `true`, the request goes to `OaiResponsesToChatStreamHandler`, and raw SSE chunks are forwarded to the client even though the client wanted a single JSON response. The client ends up with a malformed payload like:

```
data: {"choices":[],"usage":{"prompt_tokens":12,"completion_tokens":0,...}}
data: [DONE]
```

`choices: []` is empty — the actual content never reaches the client.

## Reproduction

1. Configure a channel that proxies `/v1/responses`-style upstream (e.g. xixiapi.cc, longxiadev, luciferai) for a reasoning model like `gpt-5.5`.
2. Call new-api with `stream: false`:

```bash
curl https://your-newapi/v1/chat/completions \
  -H "Authorization: Bearer <token>" \
  -d '{"model":"gpt-5.5","messages":[{"role":"user","content":"reply OK"}],"max_tokens":20}'
```

3. Direct curl to the same upstream returns proper JSON; via new-api you get the SSE stub above.

## Fix

Preserve the client's original `IsStream` and route the new "client-JSON + upstream-SSE" case through a dedicated aggregator:

- `relay/chat_completions_via_responses.go`: split dispatch into three cases — client wants stream, client wants JSON but upstream is SSE, both non-stream.
- `relay/channel/openai/chat_via_responses.go`: new `OaiResponsesSSEToChatJSON` reads the upstream SSE via `helper.StreamScannerHandler`, accumulates `output_text.delta`, function-call args, and the final `response.completed.usage`, then emits a single `dto.OpenAITextResponse` to the client. Claude / Gemini relay format passthrough is preserved.

The two existing handlers (`OaiResponsesToChatHandler`, `OaiResponsesToChatStreamHandler`) are unchanged.

## Verification

- `go build ./relay/...` and `go vet ./relay/...` pass.
- Direct upstream call still returns the same JSON (no upstream change).
- After the fix, non-stream `gpt-5.5` returns `{"choices":[{"message":{"content":"OK"}}], "usage":{...}}` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of chat completion requests when upstream responses arrive in different formats than expected, ensuring proper conversion and delivery to clients.
  * Enhanced error handling for invalid upstream responses with appropriate API error responses instead of raw data passthrough.

* **Improvements**
  * Refined response stream decision logic to better match client expectations with upstream capabilities.
  * Enhanced token usage tracking, including support for reasoning tokens when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->