### PR TITLE
Enhance Redis client to support Sentinel high availability

### DIFF
--- a/common/redis.go
+++ b/common/redis.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -22,22 +23,64 @@ func RedisKeyCacheSeconds() int {
 
 // InitRedisClient This function is called after init()
 func InitRedisClient() (err error) {
-	if os.Getenv("REDIS_CONN_STRING") == "" {
+	if os.Getenv("REDIS_CONN_STRING") == "" && os.Getenv("REDIS_SENTINEL_ADDRS") == "" {
 		RedisEnabled = false
-		SysLog("REDIS_CONN_STRING not set, Redis is not enabled")
+		SysLog("REDIS_CONN_STRING and REDIS_SENTINEL_ADDRS not set, Redis is not enabled")
 		return nil
 	}
 	if os.Getenv("SYNC_FREQUENCY") == "" {
 		SysLog("SYNC_FREQUENCY not set, use default value 60")
 		SyncFrequency = 60
 	}
-	SysLog("Redis is enabled")
-	opt, err := redis.ParseURL(os.Getenv("REDIS_CONN_STRING"))
-	if err != nil {
-		FatalLog("failed to parse Redis connection string: " + err.Error())
+
+	poolSize := GetEnvOrDefault("REDIS_POOL_SIZE", 10)
+	sentinelAddrs := os.Getenv("REDIS_SENTINEL_ADDRS")
+	connString := os.Getenv("REDIS_CONN_STRING")
+
+	if sentinelAddrs != "" {
+		// 1. Sentinel mode enabled, parse sentinel addresses and master name
+
+		// export REDIS_SENTINEL_ADDRS="192.168.1.10:26379,192.168.1.20:26379,192.168.1.30:26379"
+		// export REDIS_MASTER_NAME="mymaster"
+		// export REDIS_PASSWORD="MyStrongPassword123"
+		// export REDIS_SENTINEL_USERNAME="sentinel_user" (optional)
+		// export REDIS_SENTINEL_PASSWORD="sentinel_pass" (optional)
+		parts := strings.Split(sentinelAddrs, ",")
+		addrs := make([]string, 0, len(parts))
+		for _, part := range parts {
+			addr := strings.TrimSpace(part)
+			if addr != "" {
+				addrs = append(addrs, addr)
+			}
+		}
+		if len(addrs) == 0 {
+			FatalLog("REDIS_SENTINEL_ADDRS is set but no valid sentinel addresses were found")
+		}
+		masterName := GetEnvOrDefaultString("REDIS_MASTER_NAME", "mymaster")
+		password := os.Getenv("REDIS_PASSWORD")
+		sentinelUsername := GetEnvOrDefaultString("REDIS_SENTINEL_USERNAME", "")
+		sentinelPassword := GetEnvOrDefaultString("REDIS_SENTINEL_PASSWORD", "")
+
+		SysLog("Redis is enabled [Sentinel Mode], SentinelAddrs: " + sentinelAddrs + ", MasterName: " + masterName)
+
+		RDB = redis.NewFailoverClient(&redis.FailoverOptions{
+			MasterName:       masterName,
+			SentinelAddrs:    addrs,
+			SentinelUsername: sentinelUsername,
+			SentinelPassword: sentinelPassword,
+			Password:         password,
+			PoolSize:         poolSize,
+		})
+	} else {
+		// 2. Fallback to standalone mode, parse connection string
+		SysLog("Redis is enabled [Standalone/Proxy Mode]")
+		opt, err := redis.ParseURL(connString)
+		if err != nil {
+			FatalLog("failed to parse Redis connection string: " + err.Error())
+		}
+		opt.PoolSize = poolSize
+		RDB = redis.NewClient(opt)
 	}
-	opt.PoolSize = GetEnvOrDefault("REDIS_POOL_SIZE", 10)
-	RDB = redis.NewClient(opt)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -46,10 +89,8 @@ func InitRedisClient() (err error) {
 	if err != nil {
 		FatalLog("Redis ping test failed: " + err.Error())
 	}
-	if DebugEnabled {
-		SysLog(fmt.Sprintf("Redis connected to %s", opt.Addr))
-		SysLog(fmt.Sprintf("Redis database: %d", opt.DB))
-	}
+
+	SysLog("Redis connection test passed")
 	return err
 }
 

--- a/common/redis.go
+++ b/common/redis.go
@@ -63,12 +63,14 @@ func InitRedisClient() (err error) {
 
 		SysLog("Redis is enabled [Sentinel Mode], SentinelAddrs: " + sentinelAddrs + ", MasterName: " + masterName)
 
+		db := GetEnvOrDefault("REDIS_DB", 0)
 		RDB = redis.NewFailoverClient(&redis.FailoverOptions{
 			MasterName:       masterName,
 			SentinelAddrs:    addrs,
 			SentinelUsername: sentinelUsername,
 			SentinelPassword: sentinelPassword,
 			Password:         password,
+			DB:               db,
 			PoolSize:         poolSize,
 		})
 	} else {


### PR DESCRIPTION
Previously, `InitRedisClient` lacked support for Redis Sentinel. This update allows the application to connect to a Sentinel cluster for automatic failover.

Configuration is driven by the following new environment variables:
* REDIS_SENTINEL_ADDRS (e.g., "192.168.1.10:26379,192.168.1.20:26379...")
* REDIS_MASTER_NAME (e.g., "mymaster")
* REDIS_PASSWORD
* REDIS_SENTINEL_USERNAME (Optional)
* REDIS_SENTINEL_PASSWORD (Optional)

# ⚠️ 提交说明 / PR Notice

## 📝 变更描述 / Description
[官方文档](https://docs.newapi.pro/zh/docs/installation/deployment-methods/cluster-deployment#redis-%E9%AB%98%E5%8F%AF%E7%94%A8%E9%85%8D%E7%BD%AE) 中描述了支持Redis的哨兵模式，但经过检查后，实际代码中并没支持。本次修改了common/redis.go 文件中 InitRedisClient 函数，目的就是为了支持该项功能。改动由copilot辅助完成，且由人工进行了review，并进行了集群测试。以下为该功能的新增的环境变量配置说明，后续会更新进入文档。

```shell
# 哨兵的地址，这里假设有3个哨兵
export REDIS_SENTINEL_ADDRS="192.168.1.10:26379,192.168.1.20:26379,192.168.1.30:26379"
# 哨兵模式下的主节点名称
export REDIS_MASTER_NAME="mymaster"
# Redis 数据库的密码
export REDIS_PASSWORD="MyStrongPassword123"
# 可选，哨兵认证时的用户名（如果设置免认证，则不用设置）
export REDIS_SENTINEL_USERNAME="sentinel_user" (optional)
# 可选，哨兵认证时的密码（如果设置免认证，则不用设置）
export REDIS_SENTINEL_PASSWORD="sentinel_pass" (optional)
```


## 🚀 变更类型 / Type of change
- [x] ✨ 新功能 (New feature) - 改动较小，仅限于common/redis.go 文件中 InitRedisClient 函数。#2258


## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- 实际运行的测试日志，**结果表明redis集群连接测试通过**： 
<img width="1918" height="410" alt="image" src="https://github.com/user-attachments/assets/798f2c3c-df46-43b6-b03d-c56650042528" />

<br>

- copliot自动化测试的日志，**所有测试用例均通过**： 
- <img width="304"  alt="image" src="https://github.com/user-attachments/assets/aeadda43-a70f-4126-aaae-9df594cee76e" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Redis Sentinel (high-availability) support and failover-capable client initialization
  * Client now initializes conditionally based on environment configuration

* **Improvements**
  * Improved connection initialization and configuration handling
  * Reduced verbose debug output, replaced with a concise successful-connection message
<!-- end of auto-generated comment: release notes by coderabbit.ai -->