### PR TITLE
fix: Anthropic 与 Chat Completions 转换的思考块问题

### DIFF
--- a/dto/claude.go
+++ b/dto/claude.go
@@ -25,7 +25,7 @@ type ClaudeMediaMessage struct {
 	PartialJson  *string              `json:"partial_json,omitempty"`
 	Role         string               `json:"role,omitempty"`
 	Thinking     *string              `json:"thinking,omitempty"`
-	Signature    string               `json:"signature,omitempty"`
+	Signature    *string              `json:"signature,omitempty"`
 	Delta        string               `json:"delta,omitempty"`
 	CacheControl json.RawMessage      `json:"cache_control,omitempty"`
 	// tool_calls

--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -281,6 +281,7 @@ type Message struct {
 	Prefix           *bool           `json:"prefix,omitempty"`
 	ReasoningContent *string         `json:"reasoning_content,omitempty"`
 	Reasoning        *string         `json:"reasoning,omitempty"`
+	ReasoningOpaque  *string         `json:"reasoning_opaque,omitempty"`
 	ToolCalls        json.RawMessage `json:"tool_calls,omitempty"`
 	ToolCallId       string          `json:"tool_call_id,omitempty"`
 	parsedContent    []MediaContent
@@ -439,6 +440,13 @@ func (m *Message) GetReasoningContent() string {
 		return *m.ReasoningContent
 	}
 	return *m.Reasoning
+}
+
+func (m *Message) GetReasoningOpaque() string {
+	if m.ReasoningOpaque == nil {
+		return ""
+	}
+	return *m.ReasoningOpaque
 }
 
 func (m *Message) GetPrefix() bool {

--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -89,6 +89,7 @@ type ChatCompletionsStreamResponseChoiceDelta struct {
 	Content          *string            `json:"content,omitempty"`
 	ReasoningContent *string            `json:"reasoning_content,omitempty"`
 	Reasoning        *string            `json:"reasoning,omitempty"`
+	ReasoningOpaque  *string            `json:"reasoning_opaque,omitempty"`
 	Role             string             `json:"role,omitempty"`
 	ToolCalls        []ToolCallResponse `json:"tool_calls,omitempty"`
 }
@@ -117,6 +118,13 @@ func (c *ChatCompletionsStreamResponseChoiceDelta) GetReasoningContent() string 
 func (c *ChatCompletionsStreamResponseChoiceDelta) SetReasoningContent(s string) {
 	c.ReasoningContent = &s
 	//c.Reasoning = &s
+}
+
+func (c *ChatCompletionsStreamResponseChoiceDelta) GetReasoningOpaque() string {
+	if c.ReasoningOpaque == nil {
+		return ""
+	}
+	return *c.ReasoningOpaque
 }
 
 type ToolCallResponse struct {

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -39,6 +39,10 @@ type ClaudeConvertInfo struct {
 	Usage            *dto.Usage
 	FinishReason     string
 	Done             bool
+	ReasoningContent string
+	ReasoningOpaque  string
+	SentThinking     bool
+	SentSignature    bool
 
 	ToolCallBaseIndex      int
 	ToolCallMaxIndexOffset int

--- a/service/convert.go
+++ b/service/convert.go
@@ -32,7 +32,15 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 		openAIRequest.Stream = lo.ToPtr(lo.FromPtr(claudeRequest.Stream))
 	}
 
-	isOpenRouter := info.ChannelType == constant.ChannelTypeOpenRouter
+	channelType := 0
+	originModelName := ""
+	if info != nil && info.ChannelMeta != nil {
+		channelType = info.ChannelType
+	}
+	if info != nil {
+		originModelName = info.OriginModelName
+	}
+	isOpenRouter := channelType == constant.ChannelTypeOpenRouter
 
 	if isOpenRouter {
 		if effort := claudeRequest.GetEfforts(); effort != "" {
@@ -59,7 +67,7 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 		}
 	} else {
 		thinkingSuffix := "-thinking"
-		if strings.HasSuffix(info.OriginModelName, thinkingSuffix) &&
+		if strings.HasSuffix(originModelName, thinkingSuffix) &&
 			!strings.HasSuffix(openAIRequest.Model, thinkingSuffix) {
 			openAIRequest.Model = openAIRequest.Model + thinkingSuffix
 		}
@@ -149,6 +157,13 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 
 			for _, mediaMsg := range contents {
 				switch mediaMsg.Type {
+				case "thinking":
+					if mediaMsg.Thinking != nil {
+						openAIMessage.ReasoningContent = mediaMsg.Thinking
+					}
+					if mediaMsg.Signature != "" {
+						openAIMessage.ReasoningOpaque = common.GetPointer[string](mediaMsg.Signature)
+					}
 				case "text", "input_text":
 					message := dto.MediaContent{
 						Type:         "text",
@@ -615,6 +630,16 @@ func ResponseOpenAI2Claude(openAIResponse *dto.OpenAITextResponse, info *relayco
 	}
 	for _, choice := range openAIResponse.Choices {
 		stopReason = stopReasonOpenAI2Claude(choice.FinishReason)
+		if reasoning := choice.Message.GetReasoningContent(); reasoning != "" {
+			thinkingBlock := dto.ClaudeMediaMessage{
+				Type:     "thinking",
+				Thinking: common.GetPointer[string](reasoning),
+			}
+			if signature := choice.Message.GetReasoningOpaque(); signature != "" {
+				thinkingBlock.Signature = signature
+			}
+			contents = append(contents, thinkingBlock)
+		}
 		if choice.FinishReason == "tool_calls" {
 			for _, toolUse := range choice.Message.ParseToolCalls() {
 				claudeContent := dto.ClaudeMediaMessage{}

--- a/service/convert.go
+++ b/service/convert.go
@@ -161,8 +161,8 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 					if mediaMsg.Thinking != nil {
 						openAIMessage.ReasoningContent = mediaMsg.Thinking
 					}
-					if mediaMsg.Signature != "" {
-						openAIMessage.ReasoningOpaque = common.GetPointer[string](mediaMsg.Signature)
+					if mediaMsg.Signature != nil {
+						openAIMessage.ReasoningOpaque = mediaMsg.Signature
 					}
 				case "text", "input_text":
 					message := dto.MediaContent{
@@ -282,7 +282,21 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 	// so we may have multiple open blocks and must stop each one explicitly.
 	stopOpenBlocks := func() {
 		switch info.ClaudeConvertInfo.LastMessagesType {
-		case relaycommon.LastMessageTypeText, relaycommon.LastMessageTypeThinking:
+		case relaycommon.LastMessageTypeThinking:
+			if !info.ClaudeConvertInfo.SentSignature {
+				idx := info.ClaudeConvertInfo.Index
+				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
+					Index: &idx,
+					Type:  "content_block_delta",
+					Delta: &dto.ClaudeMediaMessage{
+						Type:      "signature_delta",
+						Signature: common.GetPointer[string](info.ClaudeConvertInfo.ReasoningOpaque),
+					},
+				})
+				info.ClaudeConvertInfo.SentSignature = true
+			}
+			claudeResponses = append(claudeResponses, generateStopBlock(info.ClaudeConvertInfo.Index))
+		case relaycommon.LastMessageTypeText:
 			claudeResponses = append(claudeResponses, generateStopBlock(info.ClaudeConvertInfo.Index))
 		case relaycommon.LastMessageTypeTools:
 			base := info.ClaudeConvertInfo.ToolCallBaseIndex
@@ -374,6 +388,12 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 		// 判断首个响应是否存在内容（非标准的 OpenAI 响应）
 		if len(openAIResponse.Choices) > 0 {
 			reasoning := openAIResponse.Choices[0].Delta.GetReasoningContent()
+			if reasoning != "" {
+				info.ClaudeConvertInfo.ReasoningContent += reasoning
+			}
+			if opaque := openAIResponse.Choices[0].Delta.GetReasoningOpaque(); opaque != "" {
+				info.ClaudeConvertInfo.ReasoningOpaque += opaque
+			}
 			content := openAIResponse.Choices[0].Delta.GetContentString()
 
 			if reasoning != "" {
@@ -389,6 +409,8 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 						Thinking: common.GetPointer[string](""),
 					},
 				})
+				info.ClaudeConvertInfo.SentThinking = true
+				info.ClaudeConvertInfo.SentSignature = false
 				idx2 := idx
 				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
 					Index: &idx2,
@@ -477,6 +499,12 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 		return claudeResponses
 	} else {
 		chosenChoice := openAIResponse.Choices[0]
+		if reasoning := chosenChoice.Delta.GetReasoningContent(); reasoning != "" {
+			info.ClaudeConvertInfo.ReasoningContent += reasoning
+		}
+		if opaque := chosenChoice.Delta.GetReasoningOpaque(); opaque != "" {
+			info.ClaudeConvertInfo.ReasoningOpaque += opaque
+		}
 		doneChunk := chosenChoice.FinishReason != nil && *chosenChoice.FinishReason != ""
 		if doneChunk {
 			info.FinishReason = *chosenChoice.FinishReason
@@ -558,6 +586,8 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 								Thinking: common.GetPointer[string](""),
 							},
 						})
+						info.ClaudeConvertInfo.SentThinking = true
+						info.ClaudeConvertInfo.SentSignature = false
 					}
 					info.ClaudeConvertInfo.LastMessagesType = relaycommon.LastMessageTypeThinking
 					claudeResponse.Delta = &dto.ClaudeMediaMessage{
@@ -636,7 +666,7 @@ func ResponseOpenAI2Claude(openAIResponse *dto.OpenAITextResponse, info *relayco
 				Thinking: common.GetPointer[string](reasoning),
 			}
 			if signature := choice.Message.GetReasoningOpaque(); signature != "" {
-				thinkingBlock.Signature = signature
+				thinkingBlock.Signature = common.GetPointer[string](signature)
 			}
 			contents = append(contents, thinkingBlock)
 		}

--- a/service/convert_test.go
+++ b/service/convert_test.go
@@ -1,0 +1,176 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/require"
+)
+
+func testRelayInfo() *relaycommon.RelayInfo {
+	return &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{},
+	}
+}
+
+func TestClaudeToOpenAIRequestPreservesThinkingForToolUse(t *testing.T) {
+	thinking := "I need to inspect the file before answering."
+	signature := "EqQBCgIYAhIM1xYvopaqueSignature"
+	claudeRequest := dto.ClaudeRequest{
+		Model: "deepseek-v4-pro",
+		Messages: []dto.ClaudeMessage{
+			{
+				Role: "assistant",
+				Content: []dto.ClaudeMediaMessage{
+					{
+						Type:      "thinking",
+						Thinking:  &thinking,
+						Signature: signature,
+					},
+					{
+						Type:  "tool_use",
+						Id:    "call_123",
+						Name:  "read",
+						Input: map[string]any{"filePath": "/tmp/1.txt"},
+					},
+				},
+			},
+		},
+	}
+
+	openAIRequest, err := ClaudeToOpenAIRequest(claudeRequest, testRelayInfo())
+	require.NoError(t, err)
+	require.Len(t, openAIRequest.Messages, 1)
+
+	message := openAIRequest.Messages[0]
+	require.Equal(t, "assistant", message.Role)
+	require.Equal(t, thinking, message.GetReasoningContent())
+	require.Equal(t, signature, message.GetReasoningOpaque())
+	require.Len(t, message.ParseToolCalls(), 1)
+	require.JSONEq(t, `{"filePath":"/tmp/1.txt"}`, message.ParseToolCalls()[0].Function.Arguments)
+}
+
+func TestClaudeToOpenAIRequestPreservesSignedThinkingContent(t *testing.T) {
+	thinking := "Visible reasoning that DeepSeek needs for tool replay."
+	signature := "EqQBCgIYAhIMsignedOpaqueBlob"
+	claudeRequest := dto.ClaudeRequest{
+		Model: "deepseek-v4-pro",
+		Messages: []dto.ClaudeMessage{
+			{
+				Role: "assistant",
+				Content: []dto.ClaudeMediaMessage{
+					{
+						Type:      "thinking",
+						Thinking:  &thinking,
+						Signature: signature,
+					},
+					{
+						Type:  "tool_use",
+						Id:    "call_456",
+						Name:  "lookup",
+						Input: map[string]any{"query": "reasoning"},
+					},
+				},
+			},
+		},
+	}
+
+	openAIRequest, err := ClaudeToOpenAIRequest(claudeRequest, testRelayInfo())
+	require.NoError(t, err)
+	require.Len(t, openAIRequest.Messages, 1)
+	require.Equal(t, thinking, openAIRequest.Messages[0].GetReasoningContent())
+	require.Equal(t, signature, openAIRequest.Messages[0].GetReasoningOpaque())
+	require.Len(t, openAIRequest.Messages[0].ParseToolCalls(), 1)
+}
+
+func TestClaudeToOpenAIRequestSkipsEmptyThinkingOnlyMessage(t *testing.T) {
+	claudeRequest := dto.ClaudeRequest{
+		Model: "deepseek-v4-pro",
+		Messages: []dto.ClaudeMessage{
+			{
+				Role: "assistant",
+				Content: []dto.ClaudeMediaMessage{
+					{Type: "thinking"},
+				},
+			},
+		},
+	}
+
+	openAIRequest, err := ClaudeToOpenAIRequest(claudeRequest, testRelayInfo())
+	require.NoError(t, err)
+	require.Empty(t, openAIRequest.Messages)
+}
+
+func TestClaudeToOpenAIRequestHandlesNilRelayInfo(t *testing.T) {
+	claudeRequest := dto.ClaudeRequest{Model: "deepseek-v4-pro"}
+
+	openAIRequest, err := ClaudeToOpenAIRequest(claudeRequest, nil)
+	require.NoError(t, err)
+	require.Equal(t, "deepseek-v4-pro", openAIRequest.Model)
+}
+
+func TestClaudeToOpenAIRequestPreservesThinkingWithNilChannelMeta(t *testing.T) {
+	thinking := "Need to call a tool."
+	claudeRequest := dto.ClaudeRequest{
+		Model: "deepseek-v4-pro",
+		Messages: []dto.ClaudeMessage{
+			{
+				Role: "assistant",
+				Content: []dto.ClaudeMediaMessage{
+					{Type: "thinking", Thinking: &thinking},
+					{Type: "tool_use", Id: "call_123", Name: "read"},
+				},
+			},
+		},
+	}
+
+	openAIRequest, err := ClaudeToOpenAIRequest(claudeRequest, &relaycommon.RelayInfo{})
+	require.NoError(t, err)
+	require.Len(t, openAIRequest.Messages, 1)
+	require.Equal(t, thinking, openAIRequest.Messages[0].GetReasoningContent())
+}
+
+func TestResponseOpenAI2ClaudePreservesReasoningBeforeToolUse(t *testing.T) {
+	reasoning := "Need the file content first."
+	opaque := "EqQBCgIYAhIMsignedOpaqueBlob"
+	toolCalls := []dto.ToolCallRequest{
+		{
+			ID:   "call_123",
+			Type: "function",
+			Function: dto.FunctionRequest{
+				Name:      "read",
+				Arguments: `{"filePath":"/tmp/1.txt"}`,
+			},
+		},
+	}
+	toolCallsJSON, err := common.Marshal(toolCalls)
+	require.NoError(t, err)
+
+	openAIResponse := &dto.OpenAITextResponse{
+		Id:    "chatcmpl_123",
+		Model: "deepseek-v4-pro",
+		Choices: []dto.OpenAITextResponseChoice{
+			{
+				Message: dto.Message{
+					Role:             "assistant",
+					ReasoningContent: &reasoning,
+					ReasoningOpaque:  &opaque,
+					ToolCalls:        toolCallsJSON,
+				},
+				FinishReason: "tool_calls",
+			},
+		},
+	}
+
+	claudeResponse := ResponseOpenAI2Claude(openAIResponse, &relaycommon.RelayInfo{})
+	require.Len(t, claudeResponse.Content, 2)
+	require.Equal(t, "thinking", claudeResponse.Content[0].Type)
+	require.NotNil(t, claudeResponse.Content[0].Thinking)
+	require.Equal(t, reasoning, *claudeResponse.Content[0].Thinking)
+	require.Equal(t, opaque, claudeResponse.Content[0].Signature)
+	require.Equal(t, "tool_use", claudeResponse.Content[1].Type)
+	require.Equal(t, "call_123", claudeResponse.Content[1].Id)
+	require.Equal(t, "read", claudeResponse.Content[1].Name)
+}

--- a/service/convert_test.go
+++ b/service/convert_test.go
@@ -6,13 +6,153 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/types"
 	"github.com/stretchr/testify/require"
 )
 
 func testRelayInfo() *relaycommon.RelayInfo {
 	return &relaycommon.RelayInfo{
-		ChannelMeta: &relaycommon.ChannelMeta{},
+		ChannelMeta:       &relaycommon.ChannelMeta{},
+		ClaudeConvertInfo: &relaycommon.ClaudeConvertInfo{},
 	}
+}
+
+func TestStreamResponseOpenAI2ClaudeEmitsSignatureBeforeToolUse(t *testing.T) {
+	info := testRelayInfo()
+	info.RelayFormat = types.RelayFormatClaude
+	info.SendResponseCount = 1
+	reasoning := "Need to inspect the file."
+	opaque := "EqQBCgIYAhIMsignedOpaqueBlob"
+
+	start := &dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_123",
+		Model: "deepseek-v4-pro",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{
+				Index: 0,
+				Delta: dto.ChatCompletionsStreamResponseChoiceDelta{
+					Role:             "assistant",
+					ReasoningContent: &reasoning,
+				},
+			},
+		},
+	}
+	responses := StreamResponseOpenAI2Claude(start, info)
+	require.Len(t, responses, 3)
+	require.Equal(t, "content_block_start", responses[1].Type)
+	require.Equal(t, "thinking", responses[1].ContentBlock.Type)
+	require.NotNil(t, responses[1].ContentBlock.Thinking)
+	require.Equal(t, "", *responses[1].ContentBlock.Thinking)
+	require.Equal(t, "thinking_delta", responses[2].Delta.Type)
+	require.Equal(t, reasoning, *responses[2].Delta.Thinking)
+
+	info.SendResponseCount++
+	signature := &dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_123",
+		Model: "deepseek-v4-pro",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{
+				Index: 0,
+				Delta: dto.ChatCompletionsStreamResponseChoiceDelta{
+					ReasoningOpaque: &opaque,
+				},
+			},
+		},
+	}
+	responses = StreamResponseOpenAI2Claude(signature, info)
+	require.Empty(t, responses)
+
+	info.SendResponseCount++
+	args := `{"filePath":"/tmp/1.txt"}`
+	tool := &dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_123",
+		Model: "deepseek-v4-pro",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{
+				Index: 0,
+				Delta: dto.ChatCompletionsStreamResponseChoiceDelta{
+					ToolCalls: []dto.ToolCallResponse{
+						{
+							Index: common.GetPointer[int](0),
+							ID:    "call_123",
+							Type:  "function",
+							Function: dto.FunctionResponse{
+								Name:      "read",
+								Arguments: args,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	responses = StreamResponseOpenAI2Claude(tool, info)
+	require.GreaterOrEqual(t, len(responses), 4)
+	require.Equal(t, "content_block_delta", responses[0].Type)
+	require.Equal(t, "signature_delta", responses[0].Delta.Type)
+	require.NotNil(t, responses[0].Delta.Signature)
+	require.Equal(t, opaque, *responses[0].Delta.Signature)
+	require.Equal(t, "content_block_stop", responses[1].Type)
+	require.Equal(t, "content_block_start", responses[2].Type)
+	require.Equal(t, "tool_use", responses[2].ContentBlock.Type)
+}
+
+func TestStreamResponseOpenAI2ClaudeEmitsBlankSignatureBeforeToolUse(t *testing.T) {
+	info := testRelayInfo()
+	info.RelayFormat = types.RelayFormatClaude
+	info.SendResponseCount = 1
+	reasoning := "Need to inspect the file."
+
+	start := &dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_123",
+		Model: "deepseek-v4-pro",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{
+				Index: 0,
+				Delta: dto.ChatCompletionsStreamResponseChoiceDelta{
+					Role:             "assistant",
+					ReasoningContent: &reasoning,
+				},
+			},
+		},
+	}
+	responses := StreamResponseOpenAI2Claude(start, info)
+	require.Len(t, responses, 3)
+	require.Equal(t, "thinking_delta", responses[2].Delta.Type)
+
+	info.SendResponseCount++
+	args := `{"filePath":"/tmp/1.txt"}`
+	tool := &dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_123",
+		Model: "deepseek-v4-pro",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{
+				Index: 0,
+				Delta: dto.ChatCompletionsStreamResponseChoiceDelta{
+					ToolCalls: []dto.ToolCallResponse{
+						{
+							Index: common.GetPointer[int](0),
+							ID:    "call_123",
+							Type:  "function",
+							Function: dto.FunctionResponse{
+								Name:      "read",
+								Arguments: args,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	responses = StreamResponseOpenAI2Claude(tool, info)
+	require.GreaterOrEqual(t, len(responses), 4)
+	require.Equal(t, "content_block_delta", responses[0].Type)
+	require.Equal(t, "signature_delta", responses[0].Delta.Type)
+	require.NotNil(t, responses[0].Delta.Signature)
+	require.Equal(t, "", *responses[0].Delta.Signature)
+	require.Equal(t, "content_block_stop", responses[1].Type)
+	require.Equal(t, "content_block_start", responses[2].Type)
+	require.Equal(t, "tool_use", responses[2].ContentBlock.Type)
 }
 
 func TestClaudeToOpenAIRequestPreservesThinkingForToolUse(t *testing.T) {
@@ -27,7 +167,7 @@ func TestClaudeToOpenAIRequestPreservesThinkingForToolUse(t *testing.T) {
 					{
 						Type:      "thinking",
 						Thinking:  &thinking,
-						Signature: signature,
+						Signature: &signature,
 					},
 					{
 						Type:  "tool_use",
@@ -64,7 +204,7 @@ func TestClaudeToOpenAIRequestPreservesSignedThinkingContent(t *testing.T) {
 					{
 						Type:      "thinking",
 						Thinking:  &thinking,
-						Signature: signature,
+						Signature: &signature,
 					},
 					{
 						Type:  "tool_use",
@@ -169,7 +309,8 @@ func TestResponseOpenAI2ClaudePreservesReasoningBeforeToolUse(t *testing.T) {
 	require.Equal(t, "thinking", claudeResponse.Content[0].Type)
 	require.NotNil(t, claudeResponse.Content[0].Thinking)
 	require.Equal(t, reasoning, *claudeResponse.Content[0].Thinking)
-	require.Equal(t, opaque, claudeResponse.Content[0].Signature)
+	require.NotNil(t, claudeResponse.Content[0].Signature)
+	require.Equal(t, opaque, *claudeResponse.Content[0].Signature)
 	require.Equal(t, "tool_use", claudeResponse.Content[1].Type)
 	require.Equal(t, "call_123", claudeResponse.Content[1].Id)
 	require.Equal(t, "read", claudeResponse.Content[1].Name)


### PR DESCRIPTION
对于入口是 Anthropic，出口是 OpenAI Chat Completions 兼容 API 的情况，使用 OpenCode 调用 deepseek v4 pro 或者 kimi k2.6 之类的模型，会出现在第一个工具调用之后提示

```
The `reasoning_content` in the thinking mode must be passed back to the API.
```

的情况，有以下两个原因：

1. new-api 在从 Anthropic 转换到 Chat Completions 的路径上，并没有对传入的思考块进行转换，而是直接丢弃了
2. OpenCode 在接收到来自 Anthropic 接口的，带有文本内容但是不带签名的思考块的时候，能在界面上显示出来，但是并不会发回给 API

对于第一个问题，我已经实现了思考块的转换。对于第二个问题，我认为签名字段和思考文本内容字段一样，就算是空字符串也不能是 null 值

有关思考块转换，我现在的实现是，在 Chat Completions 接口上，使用 `reasoning_opaque` 字段存储签名值。Chat Responses 并没有一个标准的思考签名存储字段，但是据我的观察，其他的应用程序[有在使用](https://github.com/badlogic/pi-mono/discussions/1501) `reasoning_opaque` 传输签名。但是对于来回都是同一渠道并且国产模型的场合，似乎也不会设计到思考签名。所以这大概算是一个保守设计





## Summary
- Add `reasoning_opaque` as an OpenAI-compatible extension field for opaque reasoning metadata.
- Preserve Anthropic thinking blocks across OpenAI-compatible conversion by mapping `thinking` to `reasoning_content` and `signature` to `reasoning_opaque`.
- Restore `reasoning_content`/`reasoning_opaque` back to Anthropic `thinking` blocks before tool-use replay.

## Why
DeepSeek thinking mode requires assistant reasoning content to be replayed when a tool call occurs. Without preserving this metadata through Anthropic/OpenAI-compatible conversion, follow-up tool-result requests can fail with a missing reasoning-content error. Anthropic also carries signed thinking via `signature`, so this keeps the opaque signature separate from visible reasoning text.

## Tests
- `go test ./service`
- `go test ./relay/channel/deepseek`

## Notes
- `reasoning_opaque` is treated as a compatibility extension for new-api/OpenAI-compatible traffic, not as visible reasoning text.
- Existing `go test ./relay/channel/claude` currently has unrelated file-content conversion test failures on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional opaque reasoning field and nullable signature support in messages and stream responses.
  * Converters now preserve and emit "thinking" reasoning content and opaque signatures across formats, and prepend thinking blocks where applicable.

* **Bug Fixes**
  * Ensure safe handling of missing relay/channel info and skip empty-only thinking messages.
  * Emit signature-related deltas before tool-use outputs.

* **Tests**
  * Added tests covering reasoning preservation, signature ordering, nil relay handling, and empty-thinking cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->