### PR TITLE
fix: 修复claudecode使用deepseek-v4系列, 上游响应tool_use前没有thinking内容,导致后续对话报错

### DIFF
--- a/relay/channel/ali/adaptor.go
+++ b/relay/channel/ali/adaptor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/relay/channel"
 	"github.com/QuantumNous/new-api/relay/channel/claude"
+	"github.com/QuantumNous/new-api/relay/channel/deepseek"
 	"github.com/QuantumNous/new-api/relay/channel/openai"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/constant"
@@ -72,6 +73,7 @@ func (a *Adaptor) ConvertGeminiRequest(*gin.Context, *relaycommon.RelayInfo, *dt
 
 func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, info *relaycommon.RelayInfo, req *dto.ClaudeRequest) (any, error) {
 	if supportsAliAnthropicMessages(info.UpstreamModelName) {
+		deepseek.EnsureThinkingBeforeToolUse(req)
 		return req, nil
 	}
 

--- a/relay/channel/deepseek/adaptor.go
+++ b/relay/channel/deepseek/adaptor.go
@@ -40,6 +40,8 @@ func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, info *relaycommon.RelayIn
 	if err := applyDeepSeekV4ClaudeThinkingSuffix(info, claudeRequest); err != nil {
 		return nil, err
 	}
+	// DeepSeek V4 requires thinking blocks before tool_use when thinking is enabled
+	EnsureThinkingBeforeToolUse(claudeRequest)
 	return claudeRequest, nil
 }
 

--- a/relay/channel/deepseek/thinking.go
+++ b/relay/channel/deepseek/thinking.go
@@ -1,0 +1,77 @@
+package deepseek
+
+import (
+	"strings"
+
+	"github.com/QuantumNous/new-api/dto"
+)
+
+// EnsureThinkingBeforeToolUse ensures that when thinking mode is enabled,
+// every tool_use block in assistant messages has a preceding thinking block.
+// DeepSeek V4 requires thinking blocks before tool_use when thinking is enabled.
+func EnsureThinkingBeforeToolUse(req *dto.ClaudeRequest) {
+	if req == nil || len(req.Messages) == 0 {
+		return
+	}
+	// Only process deepseek-v4-* models
+	if !isDeepSeekV4(req.Model) {
+		return
+	}
+	// Thinking disabled? skip
+	if req.Thinking != nil && req.Thinking.Type == "disabled" {
+		return
+	}
+	for i := range req.Messages {
+		msg := &req.Messages[i]
+		if msg.Role != "assistant" {
+			continue
+		}
+		contentList, ok := msg.Content.([]any)
+		if !ok || len(contentList) == 0 {
+			continue
+		}
+		contentList, fixed := ensureThinkingInContentArray(contentList)
+		if fixed {
+			msg.Content = contentList
+		}
+	}
+}
+
+// isDeepSeekV4 checks if the model name belongs to DeepSeek V4 series.
+func isDeepSeekV4(modelName string) bool {
+	return strings.HasPrefix(modelName, "deepseek-v4-")
+}
+
+// ensureThinkingInContentArray inserts an empty thinking block at position 0
+// if the content array contains any tool_use without a thinking block as the first element.
+// Returns the modified slice and whether modifications were made.
+func ensureThinkingInContentArray(contentList []any) ([]any, bool) {
+	if len(contentList) == 0 {
+		return contentList, false
+	}
+	// Check if the first element is already a thinking block
+	if first, ok := contentList[0].(map[string]any); ok && first["type"] == "thinking" {
+		return contentList, false
+	}
+	// Check if there are any tool_use blocks
+	hasToolUse := false
+	for _, item := range contentList {
+		if m, ok := item.(map[string]any); ok && m["type"] == "tool_use" {
+			hasToolUse = true
+			break
+		}
+	}
+	if !hasToolUse {
+		return contentList, false
+	}
+	// Insert empty thinking block at the beginning
+	emptyStr := ""
+	thinkingBlock := map[string]any{
+		"type":     "thinking",
+		"thinking": emptyStr,
+	}
+	contentList = append(contentList, nil)
+	copy(contentList[1:], contentList[0:])
+	contentList[0] = thinkingBlock
+	return contentList, true
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

修复claudecode使用接口deepseek-v4系列([api.deepseek.com/anthropic](https://api.deepseek.com/anthropic/v1/messages)容易复现), 上游响应tool_use前没有thinking内容,导致后续对话报错(The `content[].thinking` in the thinking mode must be passed back to the API.), 
1. 目前已知deepseek-v4系列默认开启thinking模式[quick_start](https://api-docs.deepseek.com/zh-cn/quick_start/pricing), 
2. 又已知在两个 user 消息之间，如果模型未进行工具调用，则中间 assistant 的 reasoning_content 无需参与上下文拼接，在后续轮次中将其传入 API 会被忽略。在两个 user 消息之间，如果模型进行了工具调用，则中间 assistant 的 reasoning_content 需参与上下文拼接，在后续所有 user 交互轮次中必须回传给 API。 [thinking_mode](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode)
3. 
## 📝 变更描述 / Description

修复为检测到开启deepseek-v4系列时,如果未禁用thinking时,如果assistant消息前没有thiking内容则自动补充空thiking内容。

错误消息体

```json
[
   // {"memo": "更多历史消息"},
    {
      "content": [
        {
          "content": "warning: LF will be replaced by CRLF in docs/superpowers/specs/2026-05-01-client-naming-design.md.\nThe file will have its original line endings in your working directory\n[master 95ccf8a9] docs(spec): add client naming \u0026 address tracking design\n 1 file changed, 49 insertions(+)\n create mode 100644 docs/superpowers/specs/2026-05-01-client-naming-design.md",
          "is_error": false,
          "tool_use_id": "toolu_5862fee7544643348ce991ec",
          "type": "tool_result"
        }
      ],
      "role": "user"
    },
    {
      "content": [
        {
          "id": "toolu_9c16f9c821ff435eac6d59b7",
          "input": {
            "status": "completed",
            "taskId": "3"
          },
          "name": "TaskUpdate",
          "type": "tool_use"
        }
      ],
      "role": "assistant"
    },
    {
      "content": [
        {
          "content": "Updated task #3 status",
          "tool_use_id": "toolu_9c16f9c821ff435eac6d59b7",
          "type": "tool_result"
        }
      ],
      "role": "user"
    }
  ],
```

```bash
./test\ copy.sh 
{"error":{"type":"invalid_request_error","message":"The `content[].thinking` in the thinking mode must be passed back to the API. (request id: 202605021803088601583108268d9d6ZUp0IBtu)"},"type":"error"}
```

修复消息体

```json

[
   // {"memo": "更多历史消息"},
    {
      "content": [
        {
          "content": "warning: LF will be replaced by CRLF in docs/superpowers/specs/2026-05-01-client-naming-design.md.\nThe file will have its original line endings in your working directory\n[master 95ccf8a9] docs(spec): add client naming \u0026 address tracking design\n 1 file changed, 49 insertions(+)\n create mode 100644 docs/superpowers/specs/2026-05-01-client-naming-design.md",
          "is_error": false,
          "tool_use_id": "toolu_5862fee7544643348ce991ec",
          "type": "tool_result"
        }
      ],
      "role": "user"
    },
    {
      "content": [
       // 自动补充一条空的thinking消息
        {
          "signature": "",
          "thinking": "",
          "type": "thinking"
        },
        {
          "id": "toolu_9c16f9c821ff435eac6d59b7",
          "input": {
            "status": "completed",
            "taskId": "3"
          },
          "name": "TaskUpdate",
          "type": "tool_use"
        }
      ],
      "role": "assistant"
    },
    {
      "content": [
        {
          "content": "Updated task #3 status",
          "tool_use_id": "toolu_9c16f9c821ff435eac6d59b7",
          "type": "tool_result"
        }
      ],
      "role": "user"
    }
  ],
```

```bash
./test\ copy.sh 
event: message_start
data: {"message":{"model":"deepseek-v4-pro","id":"msg_545486d9-1e4b-4eff-87a4-37476c53b2da","role":"assistant","type":"message","content":[],"usage":{"input_tokens":72770,"output_tokens":0}},"type":"message_start"}


event: ping
data: {"type":"ping"}


event: content_block_start
data: {"type":"content_block_start","content_block":{"type":"thinking","signature":"","thinking":""},"index":0}


event: content_block_delta
data: {"delta":{"type":"thinking_delta","thinking":"Spec"},"type":"content_block_delta","index":0}
```

## 🚀 变更类型 / Type of change
- [X] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

#4515


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the ordering of message components in Claude requests for DeepSeek V4 models, ensuring proper message structure and enhanced compatibility with advanced features.
  * Improved request processing for the Ali channel to automatically apply DeepSeek-specific message formatting adjustments, resulting in better request handling consistency and reduced formatting errors across integrated channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->