### PR TITLE
fix(topup): use theme-aware return URLs for epay and stripe

### DIFF
--- a/controller/topup.go
+++ b/controller/topup.go
@@ -207,7 +207,11 @@ func RequestEpay(c *gin.Context) {
 	}
 
 	callBackAddress := service.GetCallbackAddress()
-	returnUrl, _ := url.Parse(system_setting.ServerAddress + "/console/log")
+	returnPath := "/console/log"
+	if common.GetTheme() == "default" {
+		returnPath = "/usage-logs"
+	}
+	returnUrl, _ := url.Parse(system_setting.ServerAddress + returnPath)
 	notifyUrl, _ := url.Parse(callBackAddress + "/api/user/epay/notify")
 	tradeNo := fmt.Sprintf("%s%d", common.GetRandomString(6), time.Now().Unix())
 	tradeNo = fmt.Sprintf("USR%dNO%s", id, tradeNo)

--- a/controller/topup_stripe.go
+++ b/controller/topup_stripe.go
@@ -346,12 +346,18 @@ func genStripeLink(referenceId string, customerId string, email string, amount i
 
 	stripe.Key = setting.StripeApiSecret
 
-	// Use custom URLs if provided, otherwise use defaults
+	// Use custom URLs if provided, otherwise use defaults based on the active frontend theme
+	successPath := "/console/log"
+	cancelPath := "/console/topup"
+	if common.GetTheme() == "default" {
+		successPath = "/usage-logs"
+		cancelPath = "/wallet"
+	}
 	if successURL == "" {
-		successURL = system_setting.ServerAddress + "/console/log"
+		successURL = system_setting.ServerAddress + successPath
 	}
 	if cancelURL == "" {
-		cancelURL = system_setting.ServerAddress + "/console/topup"
+		cancelURL = system_setting.ServerAddress + cancelPath
 	}
 
 	params := &stripe.CheckoutSessionParams{


### PR DESCRIPTION
## Problem

The default frontend (v1) introduced in `v1.0.0-rc.1` reorganized routes to drop the `/console/` prefix:

| Page          | classic         | default (v1)   |
| ------------- | --------------- | -------------- |
| Usage logs    | `/console/log`  | `/usage-logs`  |
| Topup/wallet  | `/console/topup`| `/wallet`      |

But payment-related controllers (`controller/topup.go`, `controller/topup_stripe.go`) still hardcode the classic paths for return / success / cancel URLs. This causes a 404 in the v1 UI after the user completes payment, since the v1 router does not recognize `/console/log` or `/console/topup`.

**Reproduction (with default frontend active):**
1. Configure epay or Stripe in admin
2. Buy a top-up via the user-facing topup page
3. Complete payment in the provider's flow
4. Land back on the new-api domain → 404

## Fix

Select the appropriate path at request time based on `common.GetTheme()`. Classic paths remain the fallback so existing classic deployments are unaffected.

```go
returnPath := "/console/log"
if common.GetTheme() == "default" {
    returnPath = "/usage-logs"
}
```

`common.GetTheme()` reads an atomic value updated when the admin toggles the frontend in **设置 → 其他设置 → 切换到新版前端**, so the change takes effect immediately without restarting.

## Affected URLs

| Caller                       | Field         | classic         | default       |
| ---------------------------- | ------------- | --------------- | ------------- |
| `controller/topup.go`        | epay return   | `/console/log`  | `/usage-logs` |
| `controller/topup_stripe.go` | stripe success| `/console/log`  | `/usage-logs` |
| `controller/topup_stripe.go` | stripe cancel | `/console/topup`| `/wallet`     |

## Tested

- Deployed to a sandbox environment with `theme.frontend=default`.
- Completed an epay→Alipay-sandbox top-up; browser correctly lands on `/usage-logs` (HTTP 200) showing the new top-up record. Async notify and quota credit work end-to-end.
- Compiles cleanly with `go build ./controller/`.

## Compatibility

- Classic frontend deployments: **no behavior change** (path unchanged).
- Default (v1) frontend deployments: 404 → working page.
- Existing custom `success_url` / `cancel_url` overrides on Stripe still take precedence; the conditional only affects the empty-URL fallback.