### PR TITLE
fix: normalize null Responses input content

### DIFF
--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -948,10 +948,11 @@ func (r *OpenAIResponsesRequest) GetToolsMap() []map[string]any {
 	return toolsMap
 }
 
-// NormalizeInputNullContent rewrites Responses API input items whose `content`
-// is explicitly null into an empty string. Some OpenAI-compatible chat clients
-// emit empty assistant messages as null, while Responses-compatible upstreams
-// reject null content.
+// NormalizeInputNullContent rewrites Responses API message input items whose
+// `content` is explicitly null into an empty string. Some OpenAI-compatible
+// chat clients emit empty assistant messages as null, while Responses-compatible
+// upstreams reject null content. Non-message input items such as reasoning and
+// function_call use different schemas and must be preserved.
 func (r *OpenAIResponsesRequest) NormalizeInputNullContent() error {
 	if r == nil || len(r.Input) == 0 {
 		return nil
@@ -969,6 +970,14 @@ func (r *OpenAIResponsesRequest) NormalizeInputNullContent() error {
 	for _, rawItem := range items {
 		item, ok := rawItem.(map[string]any)
 		if !ok || item == nil {
+			continue
+		}
+		itemType := strings.TrimSpace(common.Interface2String(item["type"]))
+		role := strings.TrimSpace(common.Interface2String(item["role"]))
+		if itemType != "" && itemType != "message" {
+			continue
+		}
+		if itemType == "" && role == "" {
 			continue
 		}
 		content, exists := item["content"]

--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -945,6 +946,49 @@ func (r *OpenAIResponsesRequest) GetToolsMap() []map[string]any {
 		_ = common.Unmarshal(r.Tools, &toolsMap)
 	}
 	return toolsMap
+}
+
+// NormalizeInputNullContent rewrites Responses API input items whose `content`
+// is explicitly null into an empty string. Some OpenAI-compatible chat clients
+// emit empty assistant messages as null, while Responses-compatible upstreams
+// reject null content.
+func (r *OpenAIResponsesRequest) NormalizeInputNullContent() error {
+	if r == nil || len(r.Input) == 0 {
+		return nil
+	}
+	if common.GetJsonType(r.Input) != "array" {
+		return nil
+	}
+
+	var items []any
+	if err := common.Unmarshal(r.Input, &items); err != nil {
+		return err
+	}
+
+	changed := false
+	for _, rawItem := range items {
+		item, ok := rawItem.(map[string]any)
+		if !ok || item == nil {
+			continue
+		}
+		content, exists := item["content"]
+		if !exists || content != nil {
+			continue
+		}
+		item["content"] = ""
+		changed = true
+	}
+
+	if !changed {
+		return nil
+	}
+
+	normalized, err := common.Marshal(items)
+	if err != nil {
+		return err
+	}
+	r.Input = json.RawMessage(bytes.TrimSpace(normalized))
+	return nil
 }
 
 type Reasoning struct {

--- a/dto/openai_request_zero_value_test.go
+++ b/dto/openai_request_zero_value_test.go
@@ -71,3 +71,25 @@ func TestOpenAIResponsesRequestPreserveExplicitZeroValues(t *testing.T) {
 	require.True(t, gjson.GetBytes(encoded, "stream").Exists())
 	require.True(t, gjson.GetBytes(encoded, "top_p").Exists())
 }
+
+func TestOpenAIResponsesRequestNormalizeInputNullContent(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"input":[
+			{"role":"user","content":"hello"},
+			{"role":"assistant","content":null},
+			{"type":"function_call","call_id":"call_1","name":"demo","arguments":"{}"}
+		]
+	}`)
+
+	var req OpenAIResponsesRequest
+	err := common.Unmarshal(raw, &req)
+	require.NoError(t, err)
+
+	err = req.NormalizeInputNullContent()
+	require.NoError(t, err)
+
+	require.Equal(t, "\"\"", gjson.GetBytes(req.Input, "1.content").Raw)
+	require.Equal(t, "", gjson.GetBytes(req.Input, "1.content").String())
+	require.Equal(t, "hello", gjson.GetBytes(req.Input, "0.content").String())
+}

--- a/dto/openai_request_zero_value_test.go
+++ b/dto/openai_request_zero_value_test.go
@@ -78,7 +78,8 @@ func TestOpenAIResponsesRequestNormalizeInputNullContent(t *testing.T) {
 		"input":[
 			{"role":"user","content":"hello"},
 			{"role":"assistant","content":null},
-			{"type":"function_call","call_id":"call_1","name":"demo","arguments":"{}"}
+			{"type":"function_call","call_id":"call_1","name":"demo","arguments":"{}"},
+			{"type":"reasoning","summary":[],"content":null,"encrypted_content":"secret"}
 		]
 	}`)
 
@@ -92,4 +93,5 @@ func TestOpenAIResponsesRequestNormalizeInputNullContent(t *testing.T) {
 	require.Equal(t, "\"\"", gjson.GetBytes(req.Input, "1.content").Raw)
 	require.Equal(t, "", gjson.GetBytes(req.Input, "1.content").String())
 	require.Equal(t, "hello", gjson.GetBytes(req.Input, "0.content").String())
+	require.Equal(t, "null", gjson.GetBytes(req.Input, "3.content").Raw)
 }

--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -59,6 +59,9 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 	if err != nil {
 		return types.NewError(fmt.Errorf("failed to copy request to GeneralOpenAIRequest: %w", err), types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
 	}
+	if err := request.NormalizeInputNullContent(); err != nil {
+		return types.NewError(err, types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
+	}
 
 	err = helper.ModelMappedHelper(c, info, request)
 	if err != nil {

--- a/service/openaicompat/chat_to_responses.go
+++ b/service/openaicompat/chat_to_responses.go
@@ -398,5 +398,9 @@ func ChatCompletionsRequestToResponsesRequest(req *dto.GeneralOpenAIRequest) (*d
 		}
 	}
 
+	if err := out.NormalizeInputNullContent(); err != nil {
+		return nil, err
+	}
+
 	return out, nil
 }


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
Some OpenAI-compatible clients can send empty assistant messages as `content: null`. When these requests are converted to, or directly sent through, the Responses API path, Responses-compatible upstreams reject them because each input item's `content` must be a string or an array.

This change normalizes explicit `null` content on Responses input items to an empty string before the request is sent upstream. It is applied both to native `/v1/responses` requests and to the `/v1/chat/completions` to `/v1/responses` compatibility conversion path.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (N/A)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
Relevant test passed:

```text
go test ./dto
ok  	github.com/QuantumNous/new-api/dto	0.025s
```

I also attempted broader local test commands. They are currently blocked in this workspace by unrelated existing/local issues:

```text
go test ./...
FAIL github.com/QuantumNous/new-api [setup failed]
main.go:43:12: pattern web/classic/dist: no matching files found

FAIL github.com/QuantumNous/new-api/output [build failed]
output/analytics_paper_bench.go: undefined symbols from local untracked output files
```

A targeted relay command also reaches unrelated existing failures in Claude and stream scanner tests, outside the files changed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize null message content in incoming requests to empty strings, improving robustness and compatibility of API input handling.

* **Tests**
  * Added tests verifying null content is correctly preserved or converted where appropriate, reducing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->