### PR TITLE
修复游乐场默认auto分组403错误

### DIFF
--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -90,7 +90,7 @@ func Distribute() func(c *gin.Context) {
 						return
 					}
 					if playgroundRequest.Group != "" {
-						if !service.GroupInUserUsableGroups(usingGroup, playgroundRequest.Group) && playgroundRequest.Group != usingGroup {
+						if playgroundRequest.Group != "auto" && !service.GroupInUserUsableGroups(usingGroup, playgroundRequest.Group) && playgroundRequest.Group != usingGroup {
 							abortWithOpenAiMessage(c, http.StatusForbidden, i18n.T(c, i18n.MsgDistributorGroupAccessDenied))
 							return
 						}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
新版本UI默认为auto分组
auto分组被默认拒绝为403

## 📝 变更描述 / Description
playgound增加判断允许auto分组通过

## 📸 运行证明 / Proof of Work
修复前:
<img width="1866" height="1148" alt="image" src="https://github.com/user-attachments/assets/d8655e54-978b-49d4-9295-c7f11230058f" />

修复后:
<img width="1798" height="750" alt="image" src="https://github.com/user-attachments/assets/48bca926-3819-4a9e-86b8-80ac0392d16f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified group-access permissions to allow playground requests to bypass standard membership validation while maintaining access controls for other request types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->