### PR TITLE
fix(web/default): adjust DEFAULT_PRICING_PAGE_SIZE to prevent empty grid cell

### DIFF
--- a/web/default/src/features/pricing/constants.ts
+++ b/web/default/src/features/pricing/constants.ts
@@ -123,4 +123,4 @@ export const VIEW_MODES = {
 export type ViewMode = (typeof VIEW_MODES)[keyof typeof VIEW_MODES]
 
 /** Default page size for pricing table */
-export const DEFAULT_PRICING_PAGE_SIZE = 20
+export const DEFAULT_PRICING_PAGE_SIZE = 21


### PR DESCRIPTION
Change page size from 20 to 21 to avoid an empty cell in the last row of the pricing table grid layout.

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
The pricing table uses a grid layout where a page size of 20 leaves the last cell of the final row empty, creating an uneven visual gap. Increasing `DEFAULT_PRICING_PAGE_SIZE` from 20 to 21 ensures the grid fills completely on the last row, resolving the layout inconsistency without affecting data logic or pagination mechanics.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
<img width="1176" height="948" alt="ScreenShot_2026-05-07_125807_327" src="https://github.com/user-attachments/assets/bd23fba1-2968-4e24-b320-4f4c78573be3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Adjusted the default number of items displayed per page on the pricing page from 20 to 21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->