### PR TITLE
fix: qualify column names in PerfMetric upsert to avoid PG ambiguity

### DIFF
--- a/model/perf_metric.go
+++ b/model/perf_metric.go
@@ -37,13 +37,13 @@ func UpsertPerfMetric(metric *PerfMetric) error {
 			{Name: "bucket_ts"},
 		},
 		DoUpdates: clause.Assignments(map[string]interface{}{
-			"request_count":    gorm.Expr("request_count + ?", metric.RequestCount),
-			"success_count":    gorm.Expr("success_count + ?", metric.SuccessCount),
-			"total_latency_ms": gorm.Expr("total_latency_ms + ?", metric.TotalLatencyMs),
-			"ttft_sum_ms":      gorm.Expr("ttft_sum_ms + ?", metric.TtftSumMs),
-			"ttft_count":       gorm.Expr("ttft_count + ?", metric.TtftCount),
-			"output_tokens":    gorm.Expr("output_tokens + ?", metric.OutputTokens),
-			"generation_ms":    gorm.Expr("generation_ms + ?", metric.GenerationMs),
+			"request_count":    gorm.Expr("perf_metrics.request_count + ?", metric.RequestCount),
+			"success_count":    gorm.Expr("perf_metrics.success_count + ?", metric.SuccessCount),
+			"total_latency_ms": gorm.Expr("perf_metrics.total_latency_ms + ?", metric.TotalLatencyMs),
+			"ttft_sum_ms":      gorm.Expr("perf_metrics.ttft_sum_ms + ?", metric.TtftSumMs),
+			"ttft_count":       gorm.Expr("perf_metrics.ttft_count + ?", metric.TtftCount),
+			"output_tokens":    gorm.Expr("perf_metrics.output_tokens + ?", metric.OutputTokens),
+			"generation_ms":    gorm.Expr("perf_metrics.generation_ms + ?", metric.GenerationMs),
 		}),
 	}).Create(metric).Error
 }


### PR DESCRIPTION
## 📝 变更描述 / Description
PostgreSQL 在 `ON CONFLICT DO UPDATE SET` 中将未限定的列名（如 `generation_ms`）视为既可指目标表列，也可指 `EXCLUDED.generation_ms`，触发 `column reference is ambiguous` (SQLSTATE 42702)，导致 `failed to flush perf metric bucket` 日志刷屏，性能指标无法写入。

修复方法：在 `UpsertPerfMetric` 的 `gorm.Expr` 累加表达式中显式使用 `perf_metrics.<col>` 限定符，明确引用目标表的现有值。MySQL 与 SQLite 同样接受 `tablename.column` 形式，无兼容性影响。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- Closes #4683

## ✅ 提交前检查项 / Checklist
- [x] **人工确认**
- [x] **非重复提交**
- [x] **Bug fix 说明**
- [x] **变更理解**
- [x] **范围聚焦**
- [x] **本地验证:** `go build ./model/` 与 `go vet ./model/` 通过
- [x] **安全合规**

## 📸 运行证明 / Proof of Work
```
$ go vet ./model/
$ go build ./model/
(no output)
```

生成的 SQL 片段（PG）由
```
ON CONFLICT (...) DO UPDATE SET generation_ms = generation_ms + 123
```
变为
```
ON CONFLICT (...) DO UPDATE SET generation_ms = perf_metrics.generation_ms + 123
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of performance metric aggregation in database operations by ensuring proper column reference handling during conflict resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->