### PR TITLE
Fix BT tutorial links in READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -376,7 +376,7 @@ docker run --name new-api -d --restart always \
 2. Search for **New-API** in the application store
 3. One-click installation
 
-📖 [Tutorial with images](./docs/BT.md)
+📖 [Tutorial with images](./docs/installation/BT.md)
 
 </details>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -383,7 +383,7 @@ docker run --name new-api -d --restart always \
 2. Recherchez **New-API** dans le magasin d'applications
 3. Installation en un clic
 
-📖 [Tutoriel avec des images](./docs/BT.md)
+📖 [Tutoriel avec des images](./docs/installation/BT.md)
 
 </details>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -383,7 +383,7 @@ docker run --name new-api -d --restart always \
 
 1. 宝塔パネル（**9.2.0バージョン**以上）をインストールし、アプリケーションストアで**New-API**を検索してインストールします。
 
-📖 [画像付きチュートリアル](./docs/BT.md)
+📖 [画像付きチュートリアル](./docs/installation/BT.md)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ docker run --name new-api -d --restart always \
 2. Search for **New-API** in the application store
 3. One-click installation
 
-📖 [Tutorial with images](./docs/BT.md)
+📖 [Tutorial with images](./docs/installation/BT.md)
 
 </details>
 

--- a/README.zh_TW.md
+++ b/README.zh_TW.md
@@ -383,7 +383,7 @@ docker run --name new-api -d --restart always \
 2. 在應用商店搜尋 **New-API**
 3. 一鍵安裝
 
-📖 [圖文教學](./docs/BT.md)
+📖 [圖文教學](./docs/installation/BT.md)
 
 </details>
 


### PR DESCRIPTION
## Summary
- update BT tutorial links across localized READMEs to point to the existing docs/installation/BT.md file

## Verification
- checked local Markdown links in the changed README files
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated BaoTa Panel installation guide links across multiple language versions of README files (English, French, Japanese, and Traditional Chinese) to reflect the reorganized documentation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->