### PR TITLE
feat(setup): add options to disable registration settings in init SelfUseMode

### DIFF
--- a/controller/setup.go
+++ b/controller/setup.go
@@ -152,6 +152,26 @@ func PostSetup(c *gin.Context) {
 		return
 	}
 
+	if req.SelfUseModeEnabled {
+		err = model.UpdateOption("RegisterEnabled", "false")
+		if err != nil {
+			c.JSON(200, gin.H{
+				"success": false,
+				"message": "保存注册设置失败: " + err.Error(),
+			})
+			return
+		}
+
+		err = model.UpdateOption("PasswordRegisterEnabled", "false")
+		if err != nil {
+			c.JSON(200, gin.H{
+				"success": false,
+				"message": "保存密码注册设置失败: " + err.Error(),
+			})
+			return
+		}
+	}
+
 	// Update setup status
 	constant.Setup = true
 

--- a/web/classic/src/components/setup/components/steps/UsageModeStep.jsx
+++ b/web/classic/src/components/setup/components/steps/UsageModeStep.jsx
@@ -50,7 +50,9 @@ const UsageModeStep = ({
         </Radio>
         <Radio
           value='self'
-          extra={t('适用于个人使用的场景，不需要设置模型价格')}
+          extra={t(
+            '适用于个人使用，无需设置模型价格；初始化默认关闭注册，可在设置中开启',
+          )}
           style={{ width: '30%', minWidth: 200 }}
         >
           {t('自用模式')}

--- a/web/default/src/features/setup/components/usage-mode-step.tsx
+++ b/web/default/src/features/setup/components/usage-mode-step.tsx
@@ -53,7 +53,7 @@ const USAGE_MODE_OPTIONS: Array<{
     value: 'self',
     titleKey: 'Personal use',
     descriptionKey:
-      'Best for single-tenant deployments. Pricing and billing options stay hidden.',
+      'Best for personal use. No need to configure model pricing; registration is off by default and can be enabled later in settings.',
     icon: Home,
   },
   {

--- a/web/default/src/i18n/locales/en.json
+++ b/web/default/src/i18n/locales/en.json
@@ -509,7 +509,7 @@
     "Batch enable failed": "Batch enable failed",
     "Batch processing failed": "Batch processing failed",
     "Batch upstream model updates applied: {{channels}} channels, {{added}} added, {{removed}} removed, {{fails}} failed": "Batch upstream model updates applied: {{channels}} channels, {{added}} added, {{removed}} removed, {{fails}} failed",
-    "Best for single-tenant deployments. Pricing and billing options stay hidden.": "Best for single-tenant deployments. Pricing and billing options stay hidden.",
+    "Best for personal use. No need to configure model pricing; registration is off by default and can be enabled later in settings.": "Best for personal use. No need to configure model pricing; registration is off by default and can be enabled later in settings.",
     "Best TTFT": "Best TTFT",
     "Billable input tokens": "Billable input tokens",
     "Billable output tokens": "Billable output tokens",

--- a/web/default/src/i18n/locales/fr.json
+++ b/web/default/src/i18n/locales/fr.json
@@ -509,7 +509,7 @@
     "Batch enable failed": "Échec de l'activation par lots",
     "Batch processing failed": "Échec du traitement par lot",
     "Batch upstream model updates applied: {{channels}} channels, {{added}} added, {{removed}} removed, {{fails}} failed": "Mises à jour par lot des modèles en amont appliquées : {{channels}} canaux, {{added}} ajoutés, {{removed}} supprimés, {{fails}} échoués",
-    "Best for single-tenant deployments. Pricing and billing options stay hidden.": "Idéal pour les déploiements mono-utilisateur. Les options de tarification et de facturation restent masquées.",
+    "Best for personal use. No need to configure model pricing; registration is off by default and can be enabled later in settings.": "Idéal pour un usage personnel. Aucun prix de modèle à configurer ; l'inscription est désactivée par défaut et peut être réactivée plus tard dans les paramètres.",
     "Best TTFT": "Meilleur TTFT",
     "Billable input tokens": "Tokens d’entrée facturables",
     "Billable output tokens": "Tokens de sortie facturables",

--- a/web/default/src/i18n/locales/ja.json
+++ b/web/default/src/i18n/locales/ja.json
@@ -509,7 +509,7 @@
     "Batch enable failed": "一括有効化に失敗しました",
     "Batch processing failed": "一括処理に失敗しました",
     "Batch upstream model updates applied: {{channels}} channels, {{added}} added, {{removed}} removed, {{fails}} failed": "一括上流モデル更新を処理しました：{{channels}} チャネル、{{added}} 個追加、{{removed}} 個削除、{{fails}} 個失敗",
-    "Best for single-tenant deployments. Pricing and billing options stay hidden.": "シングルテナント環境に最適です。料金設定や請求オプションは非表示になります。",
+    "Best for personal use. No need to configure model pricing; registration is off by default and can be enabled later in settings.": "個人利用に最適です。モデル価格の設定は不要です。登録は既定でオフになり、後で設定から有効にできます。",
     "Best TTFT": "最良 TTFT",
     "Billable input tokens": "課金対象の入力トークン",
     "Billable output tokens": "課金対象の出力トークン",

--- a/web/default/src/i18n/locales/ru.json
+++ b/web/default/src/i18n/locales/ru.json
@@ -509,7 +509,7 @@
     "Batch enable failed": "Пакетное включение не удалось",
     "Batch processing failed": "Пакетная обработка не удалась",
     "Batch upstream model updates applied: {{channels}} channels, {{added}} added, {{removed}} removed, {{fails}} failed": "Пакетное обновление моделей: {{channels}} каналов, {{added}} добавлено, {{removed}} удалено, {{fails}} ошибок",
-    "Best for single-tenant deployments. Pricing and billing options stay hidden.": "Лучший вариант для однопользовательских развёртываний. Опции ценообразования и биллинга будут скрыты.",
+    "Best for personal use. No need to configure model pricing; registration is off by default and can be enabled later in settings.": "Подходит для личного использования. Настраивать цены моделей не нужно; регистрация по умолчанию отключена, её можно включить позже в настройках.",
     "Best TTFT": "Лучший TTFT",
     "Billable input tokens": "Оплачиваемые входные токены",
     "Billable output tokens": "Оплачиваемые выходные токены",

--- a/web/default/src/i18n/locales/vi.json
+++ b/web/default/src/i18n/locales/vi.json
@@ -509,7 +509,7 @@
     "Batch enable failed": "Kích hoạt hàng loạt thất bại",
     "Batch processing failed": "Xử lý hàng loạt thất bại",
     "Batch upstream model updates applied: {{channels}} channels, {{added}} added, {{removed}} removed, {{fails}} failed": "Đã áp dụng cập nhật hàng loạt mô hình upstream: {{channels}} kênh, {{added}} đã thêm, {{removed}} đã xóa, {{fails}} thất bại",
-    "Best for single-tenant deployments. Pricing and billing options stay hidden.": "Phù hợp nhất cho triển khai đơn người dùng. Các tùy chọn giá và thanh toán sẽ được ẩn.",
+    "Best for personal use. No need to configure model pricing; registration is off by default and can be enabled later in settings.": "Phù hợp cho sử dụng cá nhân. Không cần cấu hình giá mô hình; đăng ký mặc định tắt và có thể bật lại sau trong cài đặt.",
     "Best TTFT": "TTFT tốt nhất",
     "Billable input tokens": "Token đầu vào tính phí",
     "Billable output tokens": "Token đầu ra tính phí",

--- a/web/default/src/i18n/locales/zh.json
+++ b/web/default/src/i18n/locales/zh.json
@@ -509,7 +509,7 @@
     "Batch enable failed": "批量启用失败",
     "Batch processing failed": "批量处理失败",
     "Batch upstream model updates applied: {{channels}} channels, {{added}} added, {{removed}} removed, {{fails}} failed": "已批量处理上游模型更新：渠道 {{channels}} 个，加入 {{added}} 个，删除 {{removed}} 个，失败 {{fails}} 个",
-    "Best for single-tenant deployments. Pricing and billing options stay hidden.": "适合单用户部署。定价和计费选项将被隐藏。",
+    "Best for personal use. No need to configure model pricing; registration is off by default and can be enabled later in settings.": "适用于个人使用，无需设置模型价格；注册默认关闭，可稍后在设置中开启。",
     "Best TTFT": "最优 TTFT",
     "Billable input tokens": "计费输入 token",
     "Billable output tokens": "计费输出 token",

--- a/web/default/src/i18n/static-keys.ts
+++ b/web/default/src/i18n/static-keys.ts
@@ -185,7 +185,7 @@ export const STATIC_I18N_KEYS = [
   'External operations',
   'Serve multiple users or teams with billing and quota control.',
   'Personal use',
-  'Best for single-tenant deployments. Pricing and billing options stay hidden.',
+  'Best for personal use. No need to configure model pricing; registration is off by default and can be enabled later in settings.',
   'Demo site',
   'Showcase core capabilities with demo credentials and limited access.',
 


### PR DESCRIPTION

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

如果用户启用的自用模式，自动关闭密码注册和注册开关，。如果用户要开启可以初始化后在
面板手动开启勾选。 避免大量小白自用情况被网络上的扫描器自动注册（目前密码注册方面没有做任何反自动化措施）


## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x]**Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Registration is now automatically disabled when self-use mode is selected during initial setup, keeping setup defaults consistent.

* **UI Copy**
  * Clarified the "Personal use" description in the setup flow to explain default registration behavior and model pricing expectations.

* **Localization**
  * Updated translations for the revised "Personal use" plan description across multiple locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->