### PR TITLE
fix(creem): fix manual refill and billing log for Creem orders(#4179)

### DIFF
--- a/controller/misc.go
+++ b/controller/misc.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/logger"
 	"github.com/QuantumNous/new-api/middleware"
 	"github.com/QuantumNous/new-api/model"
@@ -283,10 +284,15 @@ func SendEmailVerification(c *gin.Context) {
 	}
 	code := common.GenerateVerificationCode(6)
 	common.RegisterVerificationCodeWithKey(email, code, common.EmailVerificationPurpose)
-	subject := fmt.Sprintf("%s邮箱验证邮件", common.SystemName)
-	content := fmt.Sprintf("<p>您好，你正在进行%s邮箱验证。</p>"+
-		"<p>您的验证码为: <strong>%s</strong></p>"+
-		"<p>验证码 %d 分钟内有效，如果不是本人操作，请忽略。</p>", common.SystemName, code, common.VerificationValidMinutes)
+	lang := i18n.GetLangFromContext(c)
+	subject := i18n.Translate(lang, i18n.MsgEmailVerificationSubject, map[string]any{
+		"SystemName": common.SystemName,
+	})
+	content := i18n.Translate(lang, i18n.MsgEmailVerificationContent, map[string]any{
+		"SystemName": common.SystemName,
+		"Code":       code,
+		"Minutes":    common.VerificationValidMinutes,
+	})
 	err := common.SendEmail(subject, email, content)
 	if err != nil {
 		common.ApiError(c, err)
@@ -312,11 +318,15 @@ func SendPasswordResetEmail(c *gin.Context) {
 		code := common.GenerateVerificationCode(0)
 		common.RegisterVerificationCodeWithKey(email, code, common.PasswordResetPurpose)
 		link := fmt.Sprintf("%s/user/reset?email=%s&token=%s", system_setting.ServerAddress, email, code)
-		subject := fmt.Sprintf("%s密码重置", common.SystemName)
-		content := fmt.Sprintf("<p>您好，你正在进行%s密码重置。</p>"+
-			"<p>点击 <a href='%s'>此处</a> 进行密码重置。</p>"+
-			"<p>如果链接无法点击，请尝试点击下面的链接或将其复制到浏览器中打开：<br> %s </p>"+
-			"<p>重置链接 %d 分钟内有效，如果不是本人操作，请忽略。</p>", common.SystemName, link, link, common.VerificationValidMinutes)
+		lang := i18n.GetLangFromContext(c)
+		subject := i18n.Translate(lang, i18n.MsgEmailPasswordResetSubject, map[string]any{
+			"SystemName": common.SystemName,
+		})
+		content := i18n.Translate(lang, i18n.MsgEmailPasswordResetContent, map[string]any{
+			"SystemName": common.SystemName,
+			"Link":       link,
+			"Minutes":    common.VerificationValidMinutes,
+		})
 		err := common.SendEmail(subject, email, content)
 		if err != nil {
 			logger.LogError(c.Request.Context(), fmt.Sprintf("failed to send password reset email to %s: %s", email, err.Error()))

--- a/i18n/keys.go
+++ b/i18n/keys.go
@@ -329,3 +329,15 @@ const (
 	MsgCustomOAuthBindingNotFound   = "custom_oauth.binding_not_found"
 	MsgCustomOAuthProviderIdInvalid = "custom_oauth.provider_id_field_invalid"
 )
+
+// Email related messages
+const (
+	MsgEmailVerificationSubject    = "email.verification.subject"
+	MsgEmailVerificationContent    = "email.verification.content"
+	MsgEmailPasswordResetSubject   = "email.password_reset.subject"
+	MsgEmailPasswordResetContent   = "email.password_reset.content"
+	MsgEmailChannelDisabledSubject = "email.channel_disabled.subject"
+	MsgEmailChannelDisabledContent = "email.channel_disabled.content"
+	MsgEmailChannelEnabledSubject  = "email.channel_enabled.subject"
+	MsgEmailChannelEnabledContent  = "email.channel_enabled.content"
+)

--- a/i18n/locales/en.yaml
+++ b/i18n/locales/en.yaml
@@ -276,3 +276,13 @@ custom_oauth.name_empty: "Provider name cannot be empty"
 custom_oauth.has_bindings: "Cannot delete provider with existing user bindings"
 custom_oauth.binding_not_found: "OAuth binding not found"
 custom_oauth.provider_id_field_invalid: "Could not extract user ID from provider response"
+
+# Email messages
+email.verification.subject: "{{.SystemName}} Email Verification"
+email.verification.content: "<p>Hello,</p><p>You are verifying your email for <strong>{{.SystemName}}</strong>.</p><p>Your verification code is: <strong>{{.Code}}</strong></p><p>This code is valid for {{.Minutes}} minutes. If you did not request this, please ignore this email.</p>"
+email.password_reset.subject: "{{.SystemName}} Password Reset"
+email.password_reset.content: "<p>Hello,</p><p>You are resetting your password for <strong>{{.SystemName}}</strong>.</p><p>Click <a href='{{.Link}}'>here</a> to reset your password.</p><p>If the link does not work, copy and paste the URL below into your browser:<br>{{.Link}}</p><p>This reset link is valid for {{.Minutes}} minutes. If you did not request this, please ignore this email.</p>"
+email.channel_disabled.subject: "Channel \"{{.ChannelName}}\" (#{{.ChannelId}}) Disabled"
+email.channel_disabled.content: "Channel \"{{.ChannelName}}\" (#{{.ChannelId}}) has been automatically disabled. Reason: {{.Reason}}"
+email.channel_enabled.subject: "Channel \"{{.ChannelName}}\" (#{{.ChannelId}}) Enabled"
+email.channel_enabled.content: "Channel \"{{.ChannelName}}\" (#{{.ChannelId}}) has been automatically re-enabled."

--- a/i18n/locales/zh-CN.yaml
+++ b/i18n/locales/zh-CN.yaml
@@ -277,3 +277,13 @@ custom_oauth.name_empty: "提供商名称不能为空"
 custom_oauth.has_bindings: "无法删除已有用户绑定的提供商"
 custom_oauth.binding_not_found: "OAuth 绑定不存在"
 custom_oauth.provider_id_field_invalid: "无法从提供商响应中提取用户 ID"
+
+# Email messages
+email.verification.subject: "{{.SystemName}} 邮箱验证"
+email.verification.content: "<p>您好，</p><p>您正在进行 <strong>{{.SystemName}}</strong> 邮箱验证。</p><p>您的验证码为：<strong>{{.Code}}</strong></p><p>验证码 {{.Minutes}} 分钟内有效，如果不是本人操作，请忽略此邮件。</p>"
+email.password_reset.subject: "{{.SystemName}} 密码重置"
+email.password_reset.content: "<p>您好，</p><p>您正在进行 <strong>{{.SystemName}}</strong> 密码重置。</p><p>点击 <a href='{{.Link}}'>此处</a> 进行密码重置。</p><p>如果链接无法点击，请将以下链接复制到浏览器中打开：<br>{{.Link}}</p><p>重置链接 {{.Minutes}} 分钟内有效，如果不是本人操作，请忽略此邮件。</p>"
+email.channel_disabled.subject: "通道「{{.ChannelName}}」（#{{.ChannelId}}）已被禁用"
+email.channel_disabled.content: "通道「{{.ChannelName}}」（#{{.ChannelId}}）已被禁用，原因：{{.Reason}}"
+email.channel_enabled.subject: "通道「{{.ChannelName}}」（#{{.ChannelId}}）已被启用"
+email.channel_enabled.content: "通道「{{.ChannelName}}」（#{{.ChannelId}}）已被启用"

--- a/i18n/locales/zh-TW.yaml
+++ b/i18n/locales/zh-TW.yaml
@@ -277,3 +277,13 @@ custom_oauth.name_empty: "供應者名稱不能為空"
 custom_oauth.has_bindings: "無法刪除已有使用者綁定的供應者"
 custom_oauth.binding_not_found: "OAuth 綁定不存在"
 custom_oauth.provider_id_field_invalid: "無法從供應者響應中提取使用者 ID"
+
+# Email messages
+email.verification.subject: "{{.SystemName}} 郵箱驗證"
+email.verification.content: "<p>您好，</p><p>您正在進行 <strong>{{.SystemName}}</strong> 郵箱驗證。</p><p>您的驗證碼為：<strong>{{.Code}}</strong></p><p>驗證碼 {{.Minutes}} 分鐘內有效，如果不是本人操作，請忽略此郵件。</p>"
+email.password_reset.subject: "{{.SystemName}} 密碼重置"
+email.password_reset.content: "<p>您好，</p><p>您正在進行 <strong>{{.SystemName}}</strong> 密碼重置。</p><p>點擊 <a href='{{.Link}}'>此處</a> 進行密碼重置。</p><p>如果連結無法點擊，請將以下連結複製到瀏覽器中打開：<br>{{.Link}}</p><p>重置連結 {{.Minutes}} 分鐘內有效，如果不是本人操作，請忽略此郵件。</p>"
+email.channel_disabled.subject: "通道「{{.ChannelName}}」（#{{.ChannelId}}）已被禁用"
+email.channel_disabled.content: "通道「{{.ChannelName}}」（#{{.ChannelId}}）已被禁用，原因：{{.Reason}}"
+email.channel_enabled.subject: "通道「{{.ChannelName}}」（#{{.ChannelId}}）已被啟用"
+email.channel_enabled.content: "通道「{{.ChannelName}}」（#{{.ChannelId}}）已被啟用"

--- a/model/topup.go
+++ b/model/topup.go
@@ -421,8 +421,10 @@ func RechargeCreem(referenceId string, customerEmail string, customerName string
 			return err
 		}
 
-		// Creem 直接使用 Amount 作为充值额度（整数）
-		quota = topUp.Amount
+		// Creem 产品配置的 quota 字段与 Stripe/Waffo 语义一致，
+		// 存储的是美元等价单位数（如 50 表示 $50 额度），
+		// 需乘以 QuotaPerUnit 换算为系统内部 raw quota 值。
+		quota = int64(decimal.NewFromInt(topUp.Amount).Mul(decimal.NewFromFloat(common.QuotaPerUnit)).IntPart())
 
 		// 构建更新字段，优先使用邮箱，如果邮箱为空则使用用户名
 		updateFields := map[string]interface{}{

--- a/model/topup.go
+++ b/model/topup.go
@@ -348,10 +348,13 @@ func ManualCompleteTopUp(tradeNo string, callerIp string) error {
 
 		// 计算应充值额度：
 		// - Stripe 订单：Money 代表经分组倍率换算后的美元数量，直接 * QuotaPerUnit
+		// - Creem 订单：Amount 直接存储 raw quota 值，无需换算
 		// - 其他订单（如易支付）：Amount 为美元数量，* QuotaPerUnit
 		if topUp.PaymentProvider == PaymentProviderStripe {
 			dQuotaPerUnit := decimal.NewFromFloat(common.QuotaPerUnit)
 			quotaToAdd = int(decimal.NewFromFloat(topUp.Money).Mul(dQuotaPerUnit).IntPart())
+		} else if topUp.PaymentProvider == PaymentProviderCreem {
+			quotaToAdd = int(topUp.Amount)
 		} else {
 			dAmount := decimal.NewFromInt(topUp.Amount)
 			dQuotaPerUnit := decimal.NewFromFloat(common.QuotaPerUnit)
@@ -421,10 +424,10 @@ func RechargeCreem(referenceId string, customerEmail string, customerName string
 			return err
 		}
 
-		// Creem 产品配置的 quota 字段与 Stripe/Waffo 语义一致，
-		// 存储的是美元等价单位数（如 50 表示 $50 额度），
-		// 需乘以 QuotaPerUnit 换算为系统内部 raw quota 值。
-		quota = int64(decimal.NewFromInt(topUp.Amount).Mul(decimal.NewFromFloat(common.QuotaPerUnit)).IntPart())
+		// Creem 产品配置的 quota 字段存储的是系统内部 raw quota 值，
+		// 由管理员在产品配置中直接填写（如填 25000000 表示 $50 额度），
+		// 直接使用，不需要再乘以 QuotaPerUnit。
+		quota = topUp.Amount
 
 		// 构建更新字段，优先使用邮箱，如果邮箱为空则使用用户名
 		updateFields := map[string]interface{}{
@@ -459,7 +462,7 @@ func RechargeCreem(referenceId string, customerEmail string, customerName string
 		return errors.New("充值失败，请稍后重试")
 	}
 
-	RecordTopupLog(topUp.UserId, fmt.Sprintf("使用Creem充值成功，充值额度: %v，支付金额：%.2f", quota, topUp.Money), callerIp, topUp.PaymentMethod, PaymentMethodCreem)
+	RecordTopupLog(topUp.UserId, fmt.Sprintf("使用Creem充值成功，充值金额: %v，支付金额：%.2f", logger.FormatQuota(int(quota)), topUp.Money), callerIp, topUp.PaymentMethod, PaymentMethodCreem)
 
 	return nil
 }
@@ -580,7 +583,6 @@ func RechargeWaffoPancake(tradeNo string) (err error) {
 		common.SysError("waffo pancake topup failed: " + err.Error())
 		return errors.New("充值失败，请稍后重试")
 	}
-
 	if quotaToAdd > 0 {
 		RecordLog(topUp.UserId, LogTypeTopup, fmt.Sprintf("Waffo Pancake充值成功，充值额度: %v，支付金额: %.2f", logger.FormatQuota(quotaToAdd), topUp.Money))
 	}

--- a/service/channel.go
+++ b/service/channel.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/setting/operation_setting"
 	"github.com/QuantumNous/new-api/types"
@@ -13,6 +14,20 @@ import (
 
 func formatNotifyType(channelId int, status int) string {
 	return fmt.Sprintf("%s_%d_%d", dto.NotifyTypeChannelUpdate, channelId, status)
+}
+
+// getRootUserLang returns the language preference of the root user,
+// falling back to the default language if not set.
+func getRootUserLang() string {
+	rootUser := model.GetRootUser()
+	if rootUser == nil {
+		return i18n.DefaultLang
+	}
+	setting := rootUser.GetSetting()
+	if setting.Language != "" {
+		return setting.Language
+	}
+	return i18n.DefaultLang
 }
 
 // disable & notify
@@ -27,8 +42,16 @@ func DisableChannel(channelError types.ChannelError, reason string) {
 
 	success := model.UpdateChannelStatus(channelError.ChannelId, channelError.UsingKey, common.ChannelStatusAutoDisabled, reason)
 	if success {
-		subject := fmt.Sprintf("通道「%s」（#%d）已被禁用", channelError.ChannelName, channelError.ChannelId)
-		content := fmt.Sprintf("通道「%s」（#%d）已被禁用，原因：%s", channelError.ChannelName, channelError.ChannelId, reason)
+		lang := getRootUserLang()
+		subject := i18n.Translate(lang, i18n.MsgEmailChannelDisabledSubject, map[string]any{
+			"ChannelName": channelError.ChannelName,
+			"ChannelId":   channelError.ChannelId,
+		})
+		content := i18n.Translate(lang, i18n.MsgEmailChannelDisabledContent, map[string]any{
+			"ChannelName": channelError.ChannelName,
+			"ChannelId":   channelError.ChannelId,
+			"Reason":      reason,
+		})
 		NotifyRootUser(formatNotifyType(channelError.ChannelId, common.ChannelStatusAutoDisabled), subject, content)
 	}
 }
@@ -36,8 +59,15 @@ func DisableChannel(channelError types.ChannelError, reason string) {
 func EnableChannel(channelId int, usingKey string, channelName string) {
 	success := model.UpdateChannelStatus(channelId, usingKey, common.ChannelStatusEnabled, "")
 	if success {
-		subject := fmt.Sprintf("通道「%s」（#%d）已被启用", channelName, channelId)
-		content := fmt.Sprintf("通道「%s」（#%d）已被启用", channelName, channelId)
+		lang := getRootUserLang()
+		subject := i18n.Translate(lang, i18n.MsgEmailChannelEnabledSubject, map[string]any{
+			"ChannelName": channelName,
+			"ChannelId":   channelId,
+		})
+		content := i18n.Translate(lang, i18n.MsgEmailChannelEnabledContent, map[string]any{
+			"ChannelName": channelName,
+			"ChannelId":   channelId,
+		})
 		NotifyRootUser(formatNotifyType(channelId, common.ChannelStatusEnabled), subject, content)
 	}
 }

--- a/web/classic/src/components/topup/modals/TopupHistoryModal.jsx
+++ b/web/classic/src/components/topup/modals/TopupHistoryModal.jsx
@@ -35,6 +35,7 @@ import {
 import { Coins } from 'lucide-react';
 import { IconSearch } from '@douyinfe/semi-icons';
 import { API, timestamp2string } from '../../../helpers';
+import { renderQuota, renderQuotaWithAmount } from '../../../helpers/render';
 import { isAdmin } from '../../../helpers/utils';
 import { useIsMobile } from '../../../hooks/common/useIsMobile';
 const { Text } = Typography;
@@ -163,13 +164,13 @@ const TopupHistoryModal = ({ visible, onCancel, t }) => {
     const baseColumns = [
       ...(userIsAdmin
         ? [
-            {
-              title: t('用户ID'),
-              dataIndex: 'user_id',
-              key: 'user_id',
-              render: (userId) => <Text>{userId ?? '-'}</Text>,
-            },
-          ]
+          {
+            title: t('用户ID'),
+            dataIndex: 'user_id',
+            key: 'user_id',
+            render: (userId) => <Text>{userId ?? '-'}</Text>,
+          },
+        ]
         : []),
       {
         title: t('订单号'),
@@ -195,10 +196,15 @@ const TopupHistoryModal = ({ visible, onCancel, t }) => {
               </Tag>
             );
           }
+          // Creem 的 amount 存的是 raw quota，其他支付方式存的是 USD 数量
+          const formatted =
+            record.payment_method === 'creem'
+              ? renderQuota(amount)
+              : renderQuotaWithAmount(amount);
           return (
             <span className='flex items-center gap-1'>
               <Coins size={16} />
-              <Text>{amount}</Text>
+              <Text>{formatted}</Text>
             </span>
           );
         },

--- a/web/default/src/features/wallet/components/dialogs/billing-history-dialog.tsx
+++ b/web/default/src/features/wallet/components/dialogs/billing-history-dialog.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Search, Copy, Check, ChevronLeft, ChevronRight } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { formatCurrencyFromUSD } from '@/lib/currency'
+import { formatCurrencyFromUSD, formatQuotaWithCurrency } from '@/lib/currency'
 import { formatNumber } from '@/lib/format'
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard'
 import {
@@ -226,11 +226,17 @@ export function BillingHistoryDialog({
                               Amount
                             </Label>
                             <div className='text-sm font-semibold'>
-                              {formatCurrencyFromUSD(record.amount, {
-                                digitsLarge: 2,
-                                digitsSmall: 2,
-                                abbreviate: false,
-                              })}
+                              {record.payment_method === 'creem'
+                                ? formatQuotaWithCurrency(record.amount, {
+                                    digitsLarge: 2,
+                                    digitsSmall: 2,
+                                    abbreviate: false,
+                                  })
+                                : formatCurrencyFromUSD(record.amount, {
+                                    digitsLarge: 2,
+                                    digitsSmall: 2,
+                                    abbreviate: false,
+                                  })}
                             </div>
                           </div>
                           <div className='space-y-1'>


### PR DESCRIPTION

### 问题背景

Creem 支付通道的产品配置中，`quota` 字段由管理员**直接填写系统内部 raw quota 值**（例如填 `25000000` 表示给用户充值 $50 额度），与 Stripe/Waffo 等通道的 `Amount` 语义不同（后者存的是美元数量，需乘以 `QuotaPerUnit` 换算）。

### 修复内容

**Bug 1：管理员补单（`ManualCompleteTopUp`）给 Creem 订单额度错误**

原代码对所有非 Stripe 通道统一执行 `Amount × QuotaPerUnit`，Creem 订单会被错误地再乘以 500,000：

```
补单实际到账 = 25,000,000 × 500,000 = 12,500,000,000,000（约 $25 亿！）
```
修复：为 Creem 单独分支，直接使用 `topUp.Amount`，不做换算。

**Bug 2：账单日志显示原始数字而非可读金额**

Creem 充值成功的账单记录使用 `%v, quota` 直接打印原始数字（如 `25000000`），而 Stripe、Waffo 等通道使用 `logger.FormatQuota()` 格式化为 `$50.00`，用户体验不一致。

修复：改用 `logger.FormatQuota(int(quota))` 与其他通道保持一致。

### 变更文件

- `model/topup.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed top-up quota calculation so credits are computed correctly per payment provider (Stripe, Creem, others).

* **Improvements**
  * Clarified recharge logging for clearer transaction amounts.
  * Improved quota formatting in top-up and billing history views so amounts display appropriately by payment method.

* **New Features**
  * Localized email templates for verification, password reset, and channel enable/disable notifications (subject and HTML content adapt to recipient language).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4708)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->