### PR TITLE
feat: per-model channel testing with test history and model-level enable/disable

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -901,40 +901,119 @@ func testAllChannels(notify bool) error {
 				continue
 			}
 			isChannelEnabled := channel.Status == common.ChannelStatusEnabled
-			tik := time.Now()
-			result := testChannel(channel, "", "", shouldUseStreamForAutomaticChannelTest(channel))
-			tok := time.Now()
-			milliseconds := tok.Sub(tik).Milliseconds()
 
-			shouldBanChannel := false
-			newAPIError := result.newAPIError
-			// request error disables the channel
-			if newAPIError != nil {
-				shouldBanChannel = service.ShouldDisableChannel(result.newAPIError)
+			models := channel.GetModels()
+			if len(models) == 0 {
+				continue
 			}
 
-			// 当错误检查通过，才检查响应时间
-			if common.AutomaticDisableChannelEnabled && !shouldBanChannel {
-				if milliseconds > disableThreshold {
-					err := fmt.Errorf("响应时间 %.2fs 超过阈值 %.2fs", float64(milliseconds)/1000.0, float64(disableThreshold)/1000.0)
-					newAPIError = types.NewOpenAIError(err, types.ErrorCodeChannelResponseTimeExceeded, http.StatusRequestTimeout)
-					shouldBanChannel = true
+			var totalMs int64
+			var testedCount int64
+			channelLevelErrorOccurred := false
+
+			for _, testModelName := range models {
+				testModelName = strings.TrimSpace(testModelName)
+				if testModelName == "" {
+					continue
+				}
+
+				testTimeout := 120 * time.Second
+				tik := time.Now()
+				resultCh := make(chan testResult, 1)
+				go func() {
+					resultCh <- testChannel(channel, testModelName, "", shouldUseStreamForAutomaticChannelTest(channel))
+				}()
+				var result testResult
+				select {
+				case result = <-resultCh:
+				case <-time.After(testTimeout):
+					result = testResult{
+						localErr:    fmt.Errorf("测试超时（%ds），模型「%s」未在限定时间内响应", int(testTimeout.Seconds()), testModelName),
+						newAPIError: types.NewOpenAIError(fmt.Errorf("test timeout after %ds", int(testTimeout.Seconds())), types.ErrorCodeChannelResponseTimeExceeded, http.StatusRequestTimeout),
+					}
+				}
+				tok := time.Now()
+				milliseconds := tok.Sub(tik).Milliseconds()
+				totalMs += milliseconds
+				testedCount++
+
+				shouldBanModel := false
+				newAPIError := result.newAPIError
+				errMsg := ""
+				testStatus := "operational"
+
+				if result.localErr != nil {
+					errMsg = result.localErr.Error()
+					if strings.Contains(errMsg, "not supported") ||
+						strings.Contains(errMsg, "invalid image request type") ||
+						strings.Contains(errMsg, "invalid embedding request type") ||
+						strings.Contains(errMsg, "invalid rerank request type") {
+						testStatus = "unsupported"
+					}
+				}
+
+				if newAPIError != nil {
+					shouldBanModel = service.ShouldDisableChannel(newAPIError)
+
+					if shouldBanModel && service.IsChannelLevelError(newAPIError) {
+						if isChannelEnabled && channel.GetAutoBan() {
+							processChannelError(result.context, *types.NewChannelError(channel.Id, channel.Type, channel.Name, channel.ChannelInfo.IsMultiKey, common.GetContextKeyString(result.context, constant.ContextKeyChannelKey), channel.GetAutoBan()), newAPIError)
+						}
+						channelLevelErrorOccurred = true
+						testStatus = "failed"
+						model.RecordChannelTestHistory(channel.Id, channel.Name, testModelName, testStatus, milliseconds, errMsg)
+						break
+					}
+				}
+
+				if common.AutomaticDisableChannelEnabled && !shouldBanModel {
+					if milliseconds > disableThreshold {
+						err := fmt.Errorf("响应时间 %.2fs 超过阈值 %.2fs", float64(milliseconds)/1000.0, float64(disableThreshold)/1000.0)
+						newAPIError = types.NewOpenAIError(err, types.ErrorCodeChannelResponseTimeExceeded, http.StatusRequestTimeout)
+						shouldBanModel = true
+						testStatus = "timeout"
+						errMsg = err.Error()
+					}
+				}
+
+				if common.AutomaticDisableChannelEnabled && isChannelEnabled && shouldBanModel && channel.GetAutoBan() && testStatus != "unsupported" {
+					reason := "测试失败"
+					if newAPIError != nil {
+						reason = newAPIError.ErrorWithStatusCode()
+					}
+					service.DisableChannelModel(channel.Id, channel.Name, testModelName, reason)
+					testStatus = "failed"
+				}
+
+				if common.AutomaticEnableChannelEnabled && newAPIError == nil && testStatus == "operational" {
+					if !model.IsAbilityModelEnabled(channel.Id, testModelName) {
+						service.EnableChannelModel(channel.Id, channel.Name, testModelName)
+					}
+				}
+
+				model.RecordChannelTestHistory(channel.Id, channel.Name, testModelName, testStatus, milliseconds, errMsg)
+				time.Sleep(common.RequestInterval)
+			}
+
+			if common.AutomaticEnableChannelEnabled && !channelLevelErrorOccurred && !isChannelEnabled && channel.Status == common.ChannelStatusAutoDisabled {
+				allModelsOk := true
+				for _, m := range models {
+					if !model.IsAbilityModelEnabled(channel.Id, strings.TrimSpace(m)) {
+						allModelsOk = false
+						break
+					}
+				}
+				if allModelsOk {
+					service.EnableChannel(channel.Id, "", channel.Name)
 				}
 			}
 
-			// disable channel
-			if isChannelEnabled && shouldBanChannel && channel.GetAutoBan() {
-				processChannelError(result.context, *types.NewChannelError(channel.Id, channel.Type, channel.Name, channel.ChannelInfo.IsMultiKey, common.GetContextKeyString(result.context, constant.ContextKeyChannelKey), channel.GetAutoBan()), newAPIError)
+			if testedCount > 0 {
+				channel.UpdateResponseTime(totalMs / testedCount)
 			}
-
-			// enable channel
-			if !isChannelEnabled && service.ShouldEnableChannel(newAPIError, channel.Status) {
-				service.EnableChannel(channel.Id, common.GetContextKeyString(result.context, constant.ContextKeyChannelKey), channel.Name)
-			}
-
-			channel.UpdateResponseTime(milliseconds)
-			time.Sleep(common.RequestInterval)
 		}
+
+		model.PruneChannelTestHistory(30)
 
 		if notify {
 			service.NotifyRootUser(dto.NotifyTypeChannelTest, "通道测试完成", "所有通道测试已完成")

--- a/model/ability.go
+++ b/model/ability.go
@@ -264,6 +264,22 @@ func UpdateAbilityStatus(channelId int, status bool) error {
 	return DB.Model(&Ability{}).Where("channel_id = ?", channelId).Select("enabled").Update("enabled", status).Error
 }
 
+// UpdateAbilityModelStatus updates the enabled status of a specific model within a channel.
+func UpdateAbilityModelStatus(channelId int, modelName string, status bool) error {
+	err := DB.Model(&Ability{}).Where("channel_id = ? AND model = ?", channelId, modelName).Select("enabled").Update("enabled", status).Error
+	if err == nil {
+		InitChannelCache()
+	}
+	return err
+}
+
+// IsAbilityModelEnabled checks whether a specific model within a channel is enabled.
+func IsAbilityModelEnabled(channelId int, modelName string) bool {
+	var count int64
+	DB.Model(&Ability{}).Where("channel_id = ? AND model = ? AND enabled = ?", channelId, modelName, true).Count(&count)
+	return count > 0
+}
+
 func UpdateAbilityStatusByTag(tag string, status bool) error {
 	return DB.Model(&Ability{}).Where("tag = ?", tag).Select("enabled").Update("enabled", status).Error
 }

--- a/model/channel_cache.go
+++ b/model/channel_cache.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -30,28 +29,25 @@ func InitChannelCache() {
 	}
 	var abilities []*Ability
 	DB.Find(&abilities)
-	groups := make(map[string]bool)
-	for _, ability := range abilities {
-		groups[ability.Group] = true
-	}
 	newGroup2model2channels := make(map[string]map[string][]int)
-	for group := range groups {
-		newGroup2model2channels[group] = make(map[string][]int)
-	}
-	for _, channel := range channels {
-		if channel.Status != common.ChannelStatusEnabled {
-			continue // skip disabled channels
+	for _, ability := range abilities {
+		if !ability.Enabled {
+			continue
 		}
-		groups := strings.Split(channel.Group, ",")
-		for _, group := range groups {
-			models := strings.Split(channel.Models, ",")
-			for _, model := range models {
-				if _, ok := newGroup2model2channels[group][model]; !ok {
-					newGroup2model2channels[group][model] = make([]int, 0)
-				}
-				newGroup2model2channels[group][model] = append(newGroup2model2channels[group][model], channel.Id)
-			}
+		channel, ok := newChannelId2channel[ability.ChannelId]
+		if !ok || channel.Status != common.ChannelStatusEnabled {
+			continue
 		}
+		if _, ok := newGroup2model2channels[ability.Group]; !ok {
+			newGroup2model2channels[ability.Group] = make(map[string][]int)
+		}
+		if _, ok := newGroup2model2channels[ability.Group][ability.Model]; !ok {
+			newGroup2model2channels[ability.Group][ability.Model] = make([]int, 0)
+		}
+		newGroup2model2channels[ability.Group][ability.Model] = append(
+			newGroup2model2channels[ability.Group][ability.Model],
+			ability.ChannelId,
+		)
 	}
 
 	// sort by priority

--- a/model/channel_test_history.go
+++ b/model/channel_test_history.go
@@ -1,0 +1,39 @@
+package model
+
+import (
+	"time"
+
+	"github.com/bytedance/gopkg/util/gopool"
+)
+
+type ChannelTestHistory struct {
+	Id           int       `json:"id" gorm:"primaryKey;autoIncrement"`
+	ChannelId    int       `json:"channel_id" gorm:"index"`
+	ChannelName  string    `json:"channel_name"`
+	TestModel    string    `json:"test_model"`
+	Status       string    `json:"status"`        // operational, failed, timeout, unsupported
+	ResponseTime int64     `json:"response_time"` // ms
+	ErrorMessage string    `json:"error_message"`
+	TestedAt     time.Time `json:"tested_at" gorm:"index"`
+}
+
+func RecordChannelTestHistory(channelId int, channelName, testModel, status string, responseTime int64, errMsg string) {
+	gopool.Go(func() {
+		history := ChannelTestHistory{
+			ChannelId:    channelId,
+			ChannelName:  channelName,
+			TestModel:    testModel,
+			Status:       status,
+			ResponseTime: responseTime,
+			ErrorMessage: errMsg,
+			TestedAt:     time.Now(),
+		}
+		DB.Create(&history)
+	})
+}
+
+func PruneChannelTestHistory(retentionDays int) int64 {
+	cutoff := time.Now().AddDate(0, 0, -retentionDays)
+	result := DB.Where("tested_at < ?", cutoff).Delete(&ChannelTestHistory{})
+	return result.RowsAffected
+}

--- a/model/main.go
+++ b/model/main.go
@@ -281,6 +281,7 @@ func migrateDB() error {
 		&CustomOAuthProvider{},
 		&UserOAuthBinding{},
 		&PerfMetric{},
+		&ChannelTestHistory{},
 	)
 	if err != nil {
 		return err

--- a/service/channel.go
+++ b/service/channel.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
@@ -13,6 +14,10 @@ import (
 
 func formatNotifyType(channelId int, status int) string {
 	return fmt.Sprintf("%s_%d_%d", dto.NotifyTypeChannelUpdate, channelId, status)
+}
+
+func formatModelNotifyType(channelId int, modelName string, status int) string {
+	return fmt.Sprintf("%s_%d_%s_%d", dto.NotifyTypeChannelUpdate, channelId, modelName, status)
 }
 
 // disable & notify
@@ -62,6 +67,57 @@ func ShouldDisableChannel(err *types.NewAPIError) bool {
 	lowerMessage := strings.ToLower(err.Error())
 	search, _ := AcSearch(lowerMessage, operation_setting.AutomaticDisableKeywords, true)
 	return search
+}
+
+// IsChannelLevelError checks if the error is a channel-level issue
+// (e.g. invalid API key, account deactivated, insufficient quota).
+// Channel-level errors affect all models on the channel and should
+// disable the entire channel rather than individual models.
+func IsChannelLevelError(err *types.NewAPIError) bool {
+	if err == nil {
+		return false
+	}
+	if types.IsChannelError(err) {
+		return true
+	}
+	if err.StatusCode == http.StatusUnauthorized || err.StatusCode == http.StatusForbidden {
+		return true
+	}
+	oaiErr := err.ToOpenAIError()
+	switch oaiErr.Code {
+	case "invalid_api_key", "account_deactivated", "billing_not_active", "Arrearage":
+		return true
+	}
+	switch oaiErr.Type {
+	case "insufficient_quota", "insufficient_user_quota", "authentication_error", "permission_error", "forbidden":
+		return true
+	}
+	return false
+}
+
+// DisableChannelModel disables a single model's ability within a channel and sends notification.
+func DisableChannelModel(channelId int, channelName string, modelName string, reason string) {
+	common.SysLog(fmt.Sprintf("通道「%s」（#%d）的模型「%s」发生错误，准备禁用，原因：%s", channelName, channelId, modelName, reason))
+	err := model.UpdateAbilityModelStatus(channelId, modelName, false)
+	if err != nil {
+		common.SysError(fmt.Sprintf("failed to disable model ability: channel=%d, model=%s, error=%v", channelId, modelName, err))
+		return
+	}
+	subject := fmt.Sprintf("通道「%s」（#%d）的模型「%s」已被禁用", channelName, channelId, modelName)
+	content := fmt.Sprintf("通道「%s」（#%d）的模型「%s」已被禁用，原因：%s", channelName, channelId, modelName, reason)
+	NotifyRootUser(formatModelNotifyType(channelId, modelName, common.ChannelStatusAutoDisabled), subject, content)
+}
+
+// EnableChannelModel enables a single model's ability within a channel and sends notification.
+func EnableChannelModel(channelId int, channelName string, modelName string) {
+	err := model.UpdateAbilityModelStatus(channelId, modelName, true)
+	if err != nil {
+		common.SysError(fmt.Sprintf("failed to enable model ability: channel=%d, model=%s, error=%v", channelId, modelName, err))
+		return
+	}
+	subject := fmt.Sprintf("通道「%s」（#%d）的模型「%s」已被启用", channelName, channelId, modelName)
+	content := fmt.Sprintf("通道「%s」（#%d）的模型「%s」已被启用", channelName, channelId, modelName)
+	NotifyRootUser(formatModelNotifyType(channelId, modelName, common.ChannelStatusEnabled), subject, content)
 }
 
 func ShouldEnableChannel(newAPIError *types.NewAPIError, status int) bool {


### PR DESCRIPTION
## Summary

- Upgrade `testAllChannels` to test each model within a channel individually (instead of testing the channel as a single unit), with a 120s per-model timeout
- Record per-model test results in a new `ChannelTestHistory` table for availability tracking (7/15/30 day stats)
- Distinguish **channel-level errors** (invalid API key, account deactivated, insufficient quota) from **model-level errors** — channel-level errors disable the entire channel, model-level errors only disable the affected model
- Add `DisableChannelModel` / `EnableChannelModel` / `IsChannelLevelError` to `service/channel.go`
- Add `UpdateAbilityModelStatus` / `IsAbilityModelEnabled` to `model/ability.go`
- Rebuild channel cache from abilities table (instead of parsing channel.Models string) so per-model disables take effect immediately
- Auto-prune test history older than 30 days
- Auto-re-enable individual models when they pass testing, and re-enable the whole channel when all models recover

## Motivation

The current `testAllChannels` tests each channel with a single model (usually the first one). If a specific model is down but the channel's API key is valid, the whole channel stays enabled — users hitting the broken model get errors. Conversely, if one model fails, the entire channel gets disabled, taking all healthy models offline.

Per-model testing solves both problems: broken models are individually disabled while healthy models continue serving traffic.

## Test plan

- [ ] Run "Test All Channels" from admin UI and verify each model is tested individually
- [ ] Verify `channel_test_histories` table is populated with per-model results
- [ ] Simulate a model-level error (e.g., unsupported model) and verify only that model's ability is disabled
- [ ] Simulate a channel-level error (e.g., invalid API key) and verify the entire channel is disabled
- [ ] Verify auto-recovery: fix a disabled model and run test again — model should be re-enabled
- [ ] Verify test history pruning (records older than 30 days are cleaned up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced channel testing to evaluate each model individually, providing granular reliability assessment instead of single-shot testing.
  * Models can now be automatically enabled or disabled based on test results with improved error classification.
  * Channel test history is now tracked and retained for performance monitoring over time.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4729)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->