### PR TITLE
fix(claude): convert web_search tools for Claude relay

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -46,8 +46,18 @@ func maybeMarkClaudeRefusal(c *gin.Context, stopReason string) {
 
 func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRequest) (*dto.ClaudeRequest, error) {
 	claudeTools := make([]any, 0, len(textRequest.Tools))
+	hasWebSearchTool := false
 
 	for _, tool := range textRequest.Tools {
+		if isClaudeWebSearchTool(tool) {
+			claudeTools = append(claudeTools, &dto.ClaudeWebSearchTool{
+				Type: "web_search_20250305",
+				Name: "web_search",
+			})
+			hasWebSearchTool = true
+			continue
+		}
+
 		if params, ok := tool.Function.Parameters.(map[string]any); ok {
 			claudeTool := dto.Tool{
 				Name:        tool.Function.Name,
@@ -71,7 +81,7 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 
 	// Web search tool
 	// https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search-tool
-	if textRequest.WebSearchOptions != nil {
+	if textRequest.WebSearchOptions != nil && !hasWebSearchTool {
 		webSearchTool := dto.ClaudeWebSearchTool{
 			Type: "web_search_20250305",
 			Name: "web_search",
@@ -432,6 +442,15 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 	claudeRequest.Prompt = ""
 	claudeRequest.Messages = claudeMessages
 	return &claudeRequest, nil
+}
+
+func isClaudeWebSearchTool(tool dto.ToolCallRequest) bool {
+	switch strings.TrimSpace(tool.Type) {
+	case "web_search", "web_search_20250305", dto.BuildInToolWebSearchPreview:
+		return true
+	default:
+		return strings.HasPrefix(strings.TrimSpace(tool.Type), "web_search_preview")
+	}
 }
 
 func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.ChatCompletionsStreamResponse {

--- a/relay/channel/claude/relay_claude_test.go
+++ b/relay/channel/claude/relay_claude_test.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -273,6 +274,96 @@ func TestBuildOpenAIStyleUsageFromClaudeUsageDefaultsAggregateCacheCreationTo5m(
 
 	require.Equal(t, 50, openAIUsage.ClaudeCacheCreation5mTokens)
 	require.Equal(t, 0, openAIUsage.ClaudeCacheCreation1hTokens)
+}
+
+func TestRequestOpenAI2ClaudeMessage_ConvertsClaudeWebSearchTool(t *testing.T) {
+	request := dto.GeneralOpenAIRequest{
+		Model: "claude-3-5-sonnet",
+		Tools: []dto.ToolCallRequest{
+			{
+				Type: "web_search_20250305",
+			},
+		},
+		Messages: []dto.Message{
+			{
+				Role:    "user",
+				Content: "search the web",
+			},
+		},
+	}
+
+	claudeRequest, err := RequestOpenAI2ClaudeMessage(nil, request)
+	require.NoError(t, err)
+
+	tools, ok := claudeRequest.Tools.([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 1)
+
+	webSearchTool, ok := tools[0].(*dto.ClaudeWebSearchTool)
+	require.True(t, ok)
+	require.Equal(t, "web_search_20250305", webSearchTool.Type)
+	require.Equal(t, "web_search", webSearchTool.Name)
+}
+
+func TestRequestOpenAI2ClaudeMessage_ConvertsWebSearchOptions(t *testing.T) {
+	request := dto.GeneralOpenAIRequest{
+		Model: "claude-3-5-sonnet",
+		WebSearchOptions: &dto.WebSearchOptions{
+			SearchContextSize: "high",
+			UserLocation:      json.RawMessage(`{"approximate":{"country":"US","timezone":"America/Los_Angeles"}}`),
+		},
+		Messages: []dto.Message{
+			{
+				Role:    "user",
+				Content: "search the web",
+			},
+		},
+	}
+
+	claudeRequest, err := RequestOpenAI2ClaudeMessage(nil, request)
+	require.NoError(t, err)
+
+	tools, ok := claudeRequest.Tools.([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 1)
+
+	webSearchTool, ok := tools[0].(*dto.ClaudeWebSearchTool)
+	require.True(t, ok)
+	require.Equal(t, WebSearchMaxUsesHigh, webSearchTool.MaxUses)
+	require.NotNil(t, webSearchTool.UserLocation)
+	require.Equal(t, "US", webSearchTool.UserLocation.Country)
+	require.Equal(t, "America/Los_Angeles", webSearchTool.UserLocation.Timezone)
+}
+
+func TestRequestOpenAI2ClaudeMessage_DoesNotDuplicateWebSearchTool(t *testing.T) {
+	request := dto.GeneralOpenAIRequest{
+		Model: "claude-3-5-sonnet",
+		Tools: []dto.ToolCallRequest{
+			{
+				Type: "web_search_preview",
+			},
+		},
+		WebSearchOptions: &dto.WebSearchOptions{
+			SearchContextSize: "medium",
+		},
+		Messages: []dto.Message{
+			{
+				Role:    "user",
+				Content: "search the web",
+			},
+		},
+	}
+
+	claudeRequest, err := RequestOpenAI2ClaudeMessage(nil, request)
+	require.NoError(t, err)
+
+	tools, ok := claudeRequest.Tools.([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 1)
+
+	webSearchTool, ok := tools[0].(*dto.ClaudeWebSearchTool)
+	require.True(t, ok)
+	require.Equal(t, 0, webSearchTool.MaxUses)
 }
 
 func TestRequestOpenAI2ClaudeMessage_IgnoresUnsupportedFileContent(t *testing.T) {

--- a/relay/channel/vertex/dto_test.go
+++ b/relay/channel/vertex/dto_test.go
@@ -1,0 +1,34 @@
+package vertex
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyRequestPreservesClaudeWebSearchTools(t *testing.T) {
+	maxUses := 2
+	request := &dto.ClaudeRequest{
+		Tools: []any{
+			&dto.ClaudeWebSearchTool{
+				Type:    "web_search_20250305",
+				Name:    "web_search",
+				MaxUses: maxUses,
+			},
+		},
+	}
+
+	vertexRequest := copyRequest(request, "vertex-2023-10-16")
+
+	require.Equal(t, "vertex-2023-10-16", vertexRequest.AnthropicVersion)
+	tools, ok := vertexRequest.Tools.([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 1)
+
+	webSearchTool, ok := tools[0].(*dto.ClaudeWebSearchTool)
+	require.True(t, ok)
+	require.Equal(t, "web_search_20250305", webSearchTool.Type)
+	require.Equal(t, "web_search", webSearchTool.Name)
+	require.Equal(t, maxUses, webSearchTool.MaxUses)
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
修复 OpenAI 兼容 Chat Completions 请求里直接传入 Claude web search tool 时没有被转换的问题。

当前 `RequestOpenAI2ClaudeMessage` 只处理 function tool 和 `web_search_options`。如果客户端传 `tools: [{"type":"web_search"}]`、`web_search_preview` 或 `web_search_20250305`，这些 tool 会被当作非 function tool 跳过，最终没有传给 Claude。

这个 PR 只做最小转换：
- 识别 OpenAI 兼容请求里的 Claude web search tool type。
- 转成 Anthropic `web_search_20250305` server tool。
- 已显式提供 web search tool 时，不再额外从 `web_search_options` 注入第二个搜索工具，避免重复。
- 不扩展 `ToolCallRequest` DTO 结构。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #3320

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过相关测试；全量测试的既有失败已在下方列出。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
本地 Go 版本：`go version go1.25.1 linux/amd64`

通过：
- `git diff --check`
- `go test ./relay/channel/claude -run 'TestRequestOpenAI2ClaudeMessage_(ConvertsClaudeWebSearchTool|ConvertsWebSearchOptions|DoesNotDuplicateWebSearchTool)' -count=1 -v`
- `go test ./relay/channel/vertex -run TestCopyRequestPreservesClaudeWebSearchTools -count=1 -v`
- `go test ./dto ./service -count=1`

真实端到端验证：
- 启动本地 New API 服务，使用临时 SQLite DB 和真实 Vertex AI service account JSON key 配置临时 VertexAI channel；测试完成后已停止服务并删除临时数据。
- `claude-sonnet-4-6` 普通 `/v1/chat/completions`：HTTP 200，返回 `NEW_API_VERTEX_CLAUDE_OK`。
- `claude-sonnet-4-6` + `tools: [{"type":"web_search"}]`：HTTP 200；本地 New API 计费日志记录 `web_search=true`、`web_search_call_count=1`。
- `claude-sonnet-4-6` + `web_search_options`：HTTP 200；本地 New API 计费日志记录 `web_search_call_count=1`。
- `claude-sonnet-4-6` 同时带 `tools: [{"type":"web_search_preview"}]` 和 `web_search_options`：HTTP 200；本地 New API 计费日志记录 `web_search_call_count=1`，确认不会重复注入搜索工具。
- `claude-opus-4-7` 普通请求：HTTP 200，返回 `NEW_API_VERTEX_OPUS_OK`。
- `claude-opus-4-7` + `tools: [{"type":"web_search"}]` + `tool_choice: "required"`：HTTP 200；本地 New API 计费日志记录 `web_search=true`、`web_search_call_count=1`。
- 补充可见结果验证：`claude-sonnet-4-6` + `tool_choice: "required"` 返回正文包含 `searched=yes; source=GitHub - QuantumNous/new-api...; url=https://github.com/QuantumNous/new-api`，同时日志记录 `web_search_call_count=1`。

补充说明：
- `claude-opus-4-7` 如果传 `temperature`，Vertex Claude 返回 `temperature is deprecated for this model`；去掉 `temperature` 后正常。这是模型参数约束，不是本 PR 引入的问题。
- `go test ./...` 已运行，当前失败项为既有测试状态：`relay/channel/claude` 下 3 条文件内容转换测试，以及 `relay/helper` 的 `TestStreamScannerHandler_StreamStatus_PreInitialized`。本 PR 新增和相关测试均已单独通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude web search tool handling to prevent duplicate tools when both explicit tool definitions and web search options are provided.
  * Enhanced web search configuration merging to ensure proper priority when multiple sources define web search settings.

* **Tests**
  * Added comprehensive test coverage for web search tool conversion and deduplication scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4771)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
