### PR TITLE
perf(relay): 短路参数覆盖条件判断以提升复杂条件的性能

### DIFF
--- a/relay/common/override.go
+++ b/relay/common/override.go
@@ -502,19 +502,22 @@ func checkConditions(jsonStr, contextJSON string, conditions []ConditionOperatio
 	if len(conditions) == 0 {
 		return true, nil // 没有条件，直接通过
 	}
-	results := make([]bool, len(conditions))
-	for i, condition := range conditions {
+
+	isAND := strings.ToUpper(logic) == "AND"
+	for _, condition := range conditions {
 		result, err := checkSingleCondition(jsonStr, contextJSON, condition)
 		if err != nil {
 			return false, err
 		}
-		results[i] = result
+		if isAND && !result {
+			return false, nil
+		}
+		if !isAND && result {
+			return true, nil
+		}
 	}
 
-	if strings.ToUpper(logic) == "AND" {
-		return lo.EveryBy(results, func(item bool) bool { return item }), nil
-	}
-	return lo.SomeBy(results, func(item bool) bool { return item }), nil
+	return isAND, nil
 }
 
 func checkSingleCondition(jsonStr, contextJSON string, condition ConditionOperation) (bool, error) {

--- a/relay/common/override_test.go
+++ b/relay/common/override_test.go
@@ -1125,6 +1125,81 @@ func TestApplyParamOverrideReturnError(t *testing.T) {
 	}
 }
 
+func TestCheckConditionsShortCircuitAND(t *testing.T) {
+	conditions := []ConditionOperation{
+		{Path: "model", Mode: "full", Value: "gpt-3.5-turbo"},
+		{Path: "temperature", Mode: "gt", Value: 0},
+	}
+
+	ok, err := checkConditions(`{"model":"gpt-4","temperature":"not-a-number"}`, "", conditions, "AND")
+	if err != nil {
+		t.Fatalf("expected short-circuit to skip invalid numeric comparison, got error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected AND conditions to be false")
+	}
+}
+
+func TestCheckConditionsShortCircuitOR(t *testing.T) {
+	conditions := []ConditionOperation{
+		{Path: "model", Mode: "full", Value: "gpt-4"},
+		{Path: "temperature", Mode: "gt", Value: 0},
+	}
+
+	ok, err := checkConditions(`{"model":"gpt-4","temperature":"not-a-number"}`, "", conditions, "OR")
+	if err != nil {
+		t.Fatalf("expected short-circuit to skip invalid numeric comparison, got error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected OR conditions to be true")
+	}
+}
+
+func TestCheckConditionsShortCircuitDefaultOR(t *testing.T) {
+	conditions := []ConditionOperation{
+		{Path: "model", Mode: "full", Value: "gpt-4"},
+		{Path: "temperature", Mode: "gt", Value: 0},
+	}
+
+	ok, err := checkConditions(`{"model":"gpt-4","temperature":"not-a-number"}`, "", conditions, "")
+	if err != nil {
+		t.Fatalf("expected default OR short-circuit to skip invalid numeric comparison, got error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected default OR conditions to be true")
+	}
+}
+
+func TestCheckConditionsANDAllTrue(t *testing.T) {
+	conditions := []ConditionOperation{
+		{Path: "model", Mode: "full", Value: "gpt-4"},
+		{Path: "temperature", Mode: "gt", Value: 0},
+	}
+
+	ok, err := checkConditions(`{"model":"gpt-4","temperature":0.7}`, "", conditions, "AND")
+	if err != nil {
+		t.Fatalf("expected AND conditions to evaluate without error, got: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected AND conditions to be true")
+	}
+}
+
+func TestCheckConditionsORAllFalse(t *testing.T) {
+	conditions := []ConditionOperation{
+		{Path: "model", Mode: "full", Value: "gpt-3.5-turbo"},
+		{Path: "temperature", Mode: "lt", Value: 0},
+	}
+
+	ok, err := checkConditions(`{"model":"gpt-4","temperature":0.7}`, "", conditions, "OR")
+	if err != nil {
+		t.Fatalf("expected OR conditions to evaluate without error, got: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected OR conditions to be false")
+	}
+}
+
 func TestApplyParamOverridePruneObjectsByTypeString(t *testing.T) {
 	input := []byte(`{
 		"messages":[


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
本 PR 优化了参数覆盖（param override）中多条件判断的执行方式。

原实现会先执行同一条规则下的所有 `conditions`，再根据 `logic` 执行 `AND` / `OR` 聚合。这样即使前面的条件已经能确定最终结果，后续条件仍会继续执行，例如较重的 GJSON 数组查询或 wildcard path 查询。

本次改为标准短路语义：

- `AND`：遇到第一个不满足的条件后立即返回 `false`
- `OR`：遇到第一个满足的条件后立即返回 `true`
- 非 `AND` 的 `logic` 仍保持原有行为，按 `OR` 处理
- 空条件列表仍保持原行为，返回 `true`

这样可以减少不必要的 JSON path 查询和中间结果分配。

需要注意的是：短路后，被跳过的后续条件不会再执行；如果这些被跳过的条件本身配置有误，也不会再返回对应错误。这与常见 `AND` / `OR` 短路语义一致，但属于行为上的细微变化。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [x] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (无)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

本地测试通过：

```bash
go test ./relay/common
```

Benchmark 环境：

```text
goos: darwin
goarch: arm64
cpu: Apple M3
```

Benchmark setup：

- 直接 benchmark `relay/common/override.go` 中的 `checkConditions`。
- 构造一个请求 JSON：
  - `model: "gpt-4"`
  - `messages` 包含一条简单 user 消息
  - `tools` 包含 64 个 function tool
- 构造 3 组 conditions：
  1. **AND 可短路场景**
     - 第 1 个条件：`model == "gpt-5.3-codex-spark"`，实际为 false
     - 第 2 个条件：`tools.#(type=="image_generation").type == "image_generation"`
     - 预期：修改后在第 1 个条件处短路，不再执行 tools 数组查询
  2. **OR 可短路场景**
     - 第 1 个条件：`model == "gpt-4"`，实际为 true
     - 第 2 个条件：`tools.#(type=="image_generation").type == "image_generation"`
     - 预期：修改后在第 1 个条件处短路，不再执行 tools 数组查询
  3. **无法短路场景**
     - 第 1 个条件：`model == "gpt-4"`，实际为 true
     - 第 2 个条件：`tools.#(type=="function").type == "function"`，实际为 true
     - 预期：两个条件都需要执行，用于确认无明显性能回退

Benchmark 对比：

| 场景 | 修改前 | 修改后 | 变化 |
|---|---:|---:|---:|
| AND 可短路，后续包含 GJSON 数组查询 | ~6,900 ns/op | ~182 ns/op | 约 97.4% 降低 |
| OR 可短路，后续包含 GJSON 数组查询 | ~6,800 ns/op | ~170 ns/op | 约 97.5% 降低 |
| 所有条件都需要执行 | ~592 ns/op | ~594 ns/op | 基本持平 |

说明：可短路场景下性能提升明显；无法短路时性能基本持平。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized condition evaluation logic with improved short-circuit performance for AND/OR operations.

* **Tests**
  * Added unit tests covering condition evaluation behavior and edge cases with various input scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4785)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->