### PR TITLE
fix(auth): submit forgot password form

### DIFF
--- a/web/default/src/features/auth/forgot-password/components/forgot-password-form.tsx
+++ b/web/default/src/features/auth/forgot-password/components/forgot-password-form.tsx
@@ -107,7 +107,7 @@ export function ForgotPasswordForm({
           )}
         />
 
-        <Button className='mt-2' disabled={isLoading || isActive}>
+        <Button type='submit' className='mt-2' disabled={isLoading || isActive}>
           {isActive ? `Resend (${secondsLeft}s)` : 'Send reset email'}
           {isLoading ? <Loader2 className='animate-spin' /> : <ArrowRight />}
         </Button>


### PR DESCRIPTION
## 📝 变更描述 / Description

Default 前端忘记密码页的主按钮点击后不会触发表单提交。原因是该按钮位于 `<form onSubmit={...}>` 内，但没有显式设置 `type="submit"`；同一 auth 模块里的登录、OTP、注册表单提交按钮均显式使用 `type="submit"`。

此 PR 只为忘记密码页的 `Send reset email` 按钮补上 `type="submit"`，让点击按钮时执行现有的 `react-hook-form` submit handler，不改变 API、表单校验、倒计时或 Turnstile 逻辑。

Closes #4793.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #4793

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

Base: `QuantumNous/new-api@ba474393`

本地验证：

```bash
cd web/default
bun run typecheck
bunx eslint src/features/auth/forgot-password/components/forgot-password-form.tsx
```

验证结果：

- `bun run typecheck` 通过
- `bunx eslint src/features/auth/forgot-password/components/forgot-password-form.tsx` 通过

变更范围：

- `web/default/src/features/auth/forgot-password/components/forgot-password-form.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed submit button behavior in the forgot password form to ensure proper form submission.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4794)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->