### PR TITLE
fix(web/default/playground): hide image-generation models from chat dropdown

### DIFF
--- a/web/default/src/features/playground/index.tsx
+++ b/web/default/src/features/playground/index.tsx
@@ -25,6 +25,33 @@ import { usePlaygroundState, useChatHandler } from './hooks'
 import { createUserMessage, createLoadingAssistantMessage } from './lib'
 import type { Message as MessageType } from './types'
 
+// Image-generation-only models that don't accept chat/completions requests.
+// Filtered out of the chat playground's model dropdown so users aren't presented
+// with options that produce confusing upstream errors when "sent". Aligned with
+// upstream PR #4701's image-workbench detection. Drop this list once #4701 lands.
+const IMAGE_MODEL_KEYWORDS = [
+  'gpt-image',
+  'chatgpt-image',
+  'dall-e',
+  'imagen',
+  'flux',
+  'qwen-image',
+  'z-image',
+  'nano-banana',
+  'gemini-2.5-flash-image',
+  'gemini-3-pro-image',
+  'gemini-3.1-flash-image',
+  'gemini-2.0-flash-exp-image',
+  'midjourney',
+  'stable-diffusion',
+  'wanx',
+  'grok-imagine',
+]
+function isImageOnlyModel(model: string): boolean {
+  const normalized = model.toLowerCase()
+  return IMAGE_MODEL_KEYWORDS.some((k) => normalized.includes(k))
+}
+
 export function Playground() {
   const {
     config,
@@ -65,12 +92,18 @@ export function Playground() {
   useEffect(() => {
     if (!modelsData) return
 
-    setModels(modelsData)
+    // Chat playground sends /v1/chat/completions; image-generation models reject
+    // that request shape. Filter them out so users don't pick one and hit an
+    // upstream "not supported" error. See PR #4701 for the proper image
+    // workbench that handles these on /v1/images/generations.
+    const chatModels = modelsData.filter((m) => !isImageOnlyModel(m.value))
+
+    setModels(chatModels)
 
     // Set default model if current model is not available
-    const isCurrentModelValid = modelsData.some((m) => m.value === config.model)
-    if (modelsData.length > 0 && !isCurrentModelValid) {
-      updateConfig('model', modelsData[0].value)
+    const isCurrentModelValid = chatModels.some((m) => m.value === config.model)
+    if (chatModels.length > 0 && !isCurrentModelValid) {
+      updateConfig('model', chatModels[0].value)
     }
   }, [modelsData, config.model, setModels, updateConfig])
 


### PR DESCRIPTION
## Problem

The chat playground (`features/playground/`) hardcodes `/v1/chat/completions` as its only endpoint (`API_ENDPOINTS.CHAT_COMPLETIONS` in `constants.ts`). Image-generation-only models like `gpt-image-2`, `dall-e-3`, `imagen-*`, `flux-*` etc. reject chat/completions request shape upstream — they expect `/v1/images/generations`.

**Current UX**: a user with image models available picks `gpt-image-2` in the model dropdown, types a prompt, hits Send, and gets a confusing 400 from upstream like:

> The 'gpt-image-2' model is not supported when using Codex with a ChatGPT account.

Looks like an infrastructure bug to the user but it's actually a fundamental playground/model mismatch.

## Fix

Filter image-only models out of the chat playground's model dropdown via a name-keyword match. List aligned with the `IMAGE_MODEL_KEYWORDS` introduced in #4701 (image workbench PR) for clean drop-in once that lands. Backend `GET /api/user/models` is unchanged — image models still appear in API key creation, image-aware clients, etc.

This is a temporary frontend-only fix until #4701 (or equivalent) ships a proper image workbench page that routes image models through `/v1/images/generations`. When that lands, this filter can be removed (image models would show in the image workbench instead).

## Verification

- Verified locally on a deployment with `gpt-image-1`, `gpt-image-2`, `nano-banana-2` channels: those models no longer appear in playground dropdown; chat-capable models (`gpt-5.3-codex`, `claude-haiku-4-5`, etc.) still appear normally.
- No backend changes — pure frontend filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image-generation-only models no longer appear in the chat model dropdown, preventing invalid model selections in the playground.
  * The playground now automatically validates the selected model and falls back to an available model if the current selection becomes invalid.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4808)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->