### PR TITLE
feat(ali): support happyhorse 1.0/1.1 video generation models

### DIFF
--- a/dto/values.go
+++ b/dto/values.go
@@ -30,20 +30,20 @@ func (s StringValue) MarshalJSON() ([]byte, error) {
 type IntValue int
 
 func (i *IntValue) UnmarshalJSON(b []byte) error {
-	var n int
-	if err := json.Unmarshal(b, &n); err == nil {
-		*i = IntValue(n)
+	var f float64
+	if err := json.Unmarshal(b, &f); err == nil {
+		*i = IntValue(int(f))
 		return nil
 	}
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	v, err := strconv.Atoi(s)
+	v, err := strconv.ParseFloat(s, 64)
 	if err != nil {
 		return err
 	}
-	*i = IntValue(v)
+	*i = IntValue(int(v))
 	return nil
 }
 

--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -213,23 +213,23 @@ func sizeToResolution(size string) (string, error) {
 
 func ProcessAliOtherRatios(aliReq *AliVideoRequest) (map[string]float64, error) {
 	otherRatios := make(map[string]float64)
+	wan27Ratio := map[string]float64{
+		"720P":  1,
+		"1080P": 1 / 0.6,
+	}
+	happyhorseRatio := map[string]float64{
+		"720P":  1,
+		"1080P": 1.6 / 0.9,
+	}
 	aliRatios := map[string]map[string]float64{
-		"wan2.7-t2v": {
-			"720P":  1,
-			"1080P": 1 / 0.6,
-		},
-		"wan2.7-i2v": {
-			"720P":  1,
-			"1080P": 1 / 0.6,
-		},
-		"wan2.7-r2v": {
-			"720P":  1,
-			"1080P": 1 / 0.6,
-		},
-		"wan2.7-videoedit": {
-			"720P":  1,
-			"1080P": 1 / 0.6,
-		},
+		"wan2.7-t2v":                wan27Ratio,
+		"wan2.7-i2v":                wan27Ratio,
+		"wan2.7-r2v":                wan27Ratio,
+		"wan2.7-videoedit":          wan27Ratio,
+		"happyhorse-1.0-t2v":        happyhorseRatio,
+		"happyhorse-1.0-i2v":        happyhorseRatio,
+		"happyhorse-1.0-r2v":        happyhorseRatio,
+		"happyhorse-1.0-video-edit": happyhorseRatio,
 		"wan2.6-i2v": {
 			"720P":  1,
 			"1080P": 1 / 0.6,
@@ -391,7 +391,11 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 			Watermark:    false,
 		},
 	}
-	if len(req.Images) > 1 {
+	if isWan27I2VModel(aliReq.Model) {
+		// wan2.7-i2v 由 normalizeWan27I2VInput 从 req 构建 input.media（含首尾帧分型与 trim）
+	} else if isNewFormatModel(aliReq.Model) {
+		appendImageURLsAsMedia(aliReq, imageMediaType(aliReq.Model), req.Images)
+	} else if len(req.Images) > 1 {
 		aliReq.Input.FirstFrameURL = req.Images[0]
 		aliReq.Input.LastFrameURL = req.Images[1]
 	} else {
@@ -409,30 +413,28 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 			}
 			aliReq.Parameters.Resolution = resolution
 		}
-	} else {
-		// 根据模型设置默认分辨率
-		if strings.HasPrefix(req.Model, "wan2.7") {
-			// wan2.7 服务端有默认值（resolution=720P, ratio=16:9），不设则用服务端默认
-		} else if strings.Contains(req.Model, "t2v") { // image to video
-			if strings.HasPrefix(req.Model, "wan2.5") {
-				aliReq.Parameters.Size = "1920*1080"
-			} else if strings.HasPrefix(req.Model, "wan2.2") {
-				aliReq.Parameters.Size = "1920*1080"
-			} else {
-				aliReq.Parameters.Size = "1280*720"
-			}
+	} else if resolution, ok := newFormatDefaultResolution(aliReq.Model); ok {
+		aliReq.Parameters.Resolution = resolution
+	} else if strings.Contains(req.Model, "t2v") { // 旧版 t2v 默认 size
+		if strings.HasPrefix(req.Model, "wan2.5") {
+			aliReq.Parameters.Size = "1920*1080"
+		} else if strings.HasPrefix(req.Model, "wan2.2") {
+			aliReq.Parameters.Size = "1920*1080"
 		} else {
-			if strings.HasPrefix(req.Model, "wan2.6") {
-				aliReq.Parameters.Resolution = "1080P"
-			} else if strings.HasPrefix(req.Model, "wan2.5") {
-				aliReq.Parameters.Resolution = "1080P"
-			} else if strings.HasPrefix(req.Model, "wan2.2-i2v-flash") {
-				aliReq.Parameters.Resolution = "720P"
-			} else if strings.HasPrefix(req.Model, "wan2.2-i2v-plus") {
-				aliReq.Parameters.Resolution = "1080P"
-			} else {
-				aliReq.Parameters.Resolution = "720P"
-			}
+			aliReq.Parameters.Size = "1280*720"
+		}
+	} else {
+		// 旧版 i2v 默认 resolution
+		if strings.HasPrefix(req.Model, "wan2.6") {
+			aliReq.Parameters.Resolution = "1080P"
+		} else if strings.HasPrefix(req.Model, "wan2.5") {
+			aliReq.Parameters.Resolution = "1080P"
+		} else if strings.HasPrefix(req.Model, "wan2.2-i2v-flash") {
+			aliReq.Parameters.Resolution = "720P"
+		} else if strings.HasPrefix(req.Model, "wan2.2-i2v-plus") {
+			aliReq.Parameters.Resolution = "1080P"
+		} else {
+			aliReq.Parameters.Resolution = "720P"
 		}
 	}
 

--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/logger"
 	"github.com/QuantumNous/new-api/model"
@@ -41,25 +42,30 @@ type AliVideoMedia struct {
 
 // AliVideoInput 视频输入参数
 type AliVideoInput struct {
-	Prompt         string          `json:"prompt,omitempty"`          // 文本提示词
-	ImgURL         string          `json:"img_url,omitempty"`         // 首帧图像URL或Base64（图生视频）
-	FirstFrameURL  string          `json:"first_frame_url,omitempty"` // 首帧图片URL（首尾帧生视频）
-	LastFrameURL   string          `json:"last_frame_url,omitempty"`  // 尾帧图片URL（首尾帧生视频）
-	AudioURL       string          `json:"audio_url,omitempty"`       // 音频URL（wan2.5支持）
-	Media          []AliVideoMedia `json:"media,omitempty"`           // 媒体列表（wan2.7-i2v新协议）
-	NegativePrompt string          `json:"negative_prompt,omitempty"` // 反向提示词
-	Template       string          `json:"template,omitempty"`        // 视频特效模板
+	Prompt             string          `json:"prompt,omitempty"`               // 文本提示词
+	ImgURL             string          `json:"img_url,omitempty"`              // 首帧图像URL或Base64（图生视频）
+	FirstFrameURL      string          `json:"first_frame_url,omitempty"`      // 首帧图片URL（首尾帧生视频）
+	LastFrameURL       string          `json:"last_frame_url,omitempty"`       // 尾帧图片URL（首尾帧生视频）
+	AudioURL           string          `json:"audio_url,omitempty"`            // 音频URL（wan2.5支持）
+	Media              []AliVideoMedia `json:"media,omitempty"`                // 媒体列表（wan2.7新协议）
+	NegativePrompt     string          `json:"negative_prompt,omitempty"`      // 反向提示词
+	Template           string          `json:"template,omitempty"`             // 视频特效模板
+	ReferenceVideoURLs []string        `json:"reference_video_urls,omitempty"` // 参考视频URL数组（wan2.6-r2v）
+	ReferenceVoice     string          `json:"reference_voice,omitempty"`      // 参考声音URL（wan2.7-r2v）
 }
 
 // AliVideoParameters 视频参数
 type AliVideoParameters struct {
-	Resolution   string `json:"resolution,omitempty"`    // 分辨率: 480P/720P/1080P（图生视频、首尾帧生视频）
-	Size         string `json:"size,omitempty"`          // 尺寸: 如 "832*480"（文生视频）
-	Duration     int    `json:"duration,omitempty"`      // 时长: 3-10秒
+	Resolution   string `json:"resolution,omitempty"`    // 分辨率: 480P/720P/1080P
+	Size         string `json:"size,omitempty"`          // 尺寸: 如 "832*480"（wan2.6及更早文生视频）
+	Ratio        string `json:"ratio,omitempty"`         // 比例: 16:9/9:16/1:1/4:3/3:4（wan2.7）
+	Duration     int    `json:"duration,omitempty"`      // 时长（秒）
 	PromptExtend bool   `json:"prompt_extend,omitempty"` // 是否开启prompt智能改写
 	Watermark    bool   `json:"watermark,omitempty"`     // 是否添加水印
-	Audio        *bool  `json:"audio,omitempty"`         // 是否添加音频（wan2.5）
+	Audio        *bool  `json:"audio,omitempty"`         // 是否添加音频（wan2.5/2.6）
+	AudioSetting string `json:"audio_setting,omitempty"` // 音频处理方式: auto/origin（wan2.7-videoedit）
 	Seed         int    `json:"seed,omitempty"`          // 随机数种子
+	ShotType     string `json:"shot_type,omitempty"`     // 镜头类型: single/multi（wan2.6-r2v）
 }
 
 // AliVideoResponse 阿里通义万相响应
@@ -87,29 +93,38 @@ type AliVideoOutput struct {
 
 // AliUsage 使用统计
 type AliUsage struct {
-	Duration   dto.IntValue `json:"duration,omitempty"`
-	VideoCount dto.IntValue `json:"video_count,omitempty"`
-	SR         dto.IntValue `json:"SR,omitempty"`
+	Duration            dto.IntValue `json:"duration,omitempty"`              // 总视频时长（秒），计费按此时长计算
+	Size                string       `json:"size,omitempty"`                  // 生成视频的分辨率，格式为"宽*高"
+	Ratio               string       `json:"ratio,omitempty"`                 // 生成视频的比例（wan2.7），如 "16:9"
+	InputVideoDuration  int          `json:"input_video_duration,omitempty"`  // 输入的参考视频的时长（秒）
+	OutputVideoDuration int          `json:"output_video_duration,omitempty"` // 输出视频的时长（秒）
+	VideoCount          dto.IntValue `json:"video_count,omitempty"`           // 生成视频的数量
+	SR                  dto.IntValue `json:"SR,omitempty"`                    // 生成视频的分辨率档位
 }
 
 type AliMetadata struct {
 	// Input 相关
-	AudioURL       string          `json:"audio_url,omitempty"`       // 音频URL
-	ImgURL         string          `json:"img_url,omitempty"`         // 图片URL（图生视频）
-	FirstFrameURL  string          `json:"first_frame_url,omitempty"` // 首帧图片URL（首尾帧生视频）
-	LastFrameURL   string          `json:"last_frame_url,omitempty"`  // 尾帧图片URL（首尾帧生视频）
-	Media          []AliVideoMedia `json:"media,omitempty"`           // 媒体列表（wan2.7-i2v新协议）
-	NegativePrompt string          `json:"negative_prompt,omitempty"` // 反向提示词
-	Template       string          `json:"template,omitempty"`        // 视频特效模板
+	AudioURL           string          `json:"audio_url,omitempty"`            // 音频URL
+	ImgURL             string          `json:"img_url,omitempty"`              // 图片URL（图生视频）
+	FirstFrameURL      string          `json:"first_frame_url,omitempty"`      // 首帧图片URL（首尾帧生视频）
+	LastFrameURL       string          `json:"last_frame_url,omitempty"`       // 尾帧图片URL（首尾帧生视频）
+	Media              []AliVideoMedia `json:"media,omitempty"`                // 媒体列表（wan2.7新协议）
+	NegativePrompt     string          `json:"negative_prompt,omitempty"`      // 反向提示词
+	Template           string          `json:"template,omitempty"`             // 视频特效模板
+	ReferenceVideoURLs []string        `json:"reference_video_urls,omitempty"` // 参考视频URL数组（wan2.6-r2v）
+	ReferenceVoice     *string         `json:"reference_voice,omitempty"`      // 参考声音URL（wan2.7-r2v）
 
 	// Parameters 相关
 	Resolution   *string `json:"resolution,omitempty"`    // 分辨率: 480P/720P/1080P
 	Size         *string `json:"size,omitempty"`          // 尺寸: 如 "832*480"
+	Ratio        *string `json:"ratio,omitempty"`         // 比例: 16:9/9:16/1:1/4:3/3:4（wan2.7）
 	Duration     *int    `json:"duration,omitempty"`      // 时长
 	PromptExtend *bool   `json:"prompt_extend,omitempty"` // 是否开启prompt智能改写
 	Watermark    *bool   `json:"watermark,omitempty"`     // 是否添加水印
 	Audio        *bool   `json:"audio,omitempty"`         // 是否添加音频
+	AudioSetting *string `json:"audio_setting,omitempty"` // 音频处理方式（wan2.7-videoedit）
 	Seed         *int    `json:"seed,omitempty"`          // 随机数种子
+	ShotType     *string `json:"shot_type,omitempty"`     // 镜头类型: single/multi（wan2.6-r2v）
 }
 
 // ============================
@@ -130,8 +145,7 @@ func (a *TaskAdaptor) Init(info *relaycommon.RelayInfo) {
 }
 
 func (a *TaskAdaptor) ValidateRequestAndSetAction(c *gin.Context, info *relaycommon.RelayInfo) (taskErr *dto.TaskError) {
-	// ValidateMultipartDirect 负责解析并将原始 TaskSubmitReq 存入 context
-	return relaycommon.ValidateMultipartDirect(c, info)
+	return relaycommon.ValidateBasicTaskRequest(c, info, constant.TaskActionGenerate)
 }
 
 func (a *TaskAdaptor) BuildRequestURL(info *relaycommon.RelayInfo) (string, error) {
@@ -149,15 +163,14 @@ func (a *TaskAdaptor) BuildRequestHeader(c *gin.Context, req *http.Request, info
 func (a *TaskAdaptor) BuildRequestBody(c *gin.Context, info *relaycommon.RelayInfo) (io.Reader, error) {
 	taskReq, err := relaycommon.GetTaskRequest(c)
 	if err != nil {
-		return nil, errors.Wrap(err, "get_task_request_failed")
+		return nil, err
 	}
-
 	aliReq, err := a.convertToAliRequest(info, taskReq)
 	if err != nil {
-		return nil, errors.Wrap(err, "convert_to_ali_request_failed")
+		return nil, err
 	}
+	appendMultipartMediaToRequest(c, aliReq)
 	logger.LogJson(c, "ali video request body", aliReq)
-
 	bodyBytes, err := common.Marshal(aliReq)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal_ali_request_failed")
@@ -201,6 +214,22 @@ func sizeToResolution(size string) (string, error) {
 func ProcessAliOtherRatios(aliReq *AliVideoRequest) (map[string]float64, error) {
 	otherRatios := make(map[string]float64)
 	aliRatios := map[string]map[string]float64{
+		"wan2.7-t2v": {
+			"720P":  1,
+			"1080P": 1 / 0.6,
+		},
+		"wan2.7-i2v": {
+			"720P":  1,
+			"1080P": 1 / 0.6,
+		},
+		"wan2.7-r2v": {
+			"720P":  1,
+			"1080P": 1 / 0.6,
+		},
+		"wan2.7-videoedit": {
+			"720P":  1,
+			"1080P": 1 / 0.6,
+		},
 		"wan2.6-i2v": {
 			"720P":  1,
 			"1080P": 1 / 0.6,
@@ -356,20 +385,20 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 		Model: upstreamModel,
 		Input: AliVideoInput{
 			Prompt: req.Prompt,
-			ImgURL: firstTaskImage(req),
 		},
 		Parameters: &AliVideoParameters{
 			PromptExtend: true, // 默认开启智能改写
 			Watermark:    false,
 		},
 	}
-
+	if len(req.Images) > 1 {
+		aliReq.Input.FirstFrameURL = req.Images[0]
+		aliReq.Input.LastFrameURL = req.Images[1]
+	} else {
+		aliReq.Input.ImgURL = firstTaskImage(req)
+	}
 	// 处理分辨率映射
 	if req.Size != "" {
-		// text to video size must be contained *
-		if strings.Contains(req.Model, "t2v") && !strings.Contains(req.Size, "*") {
-			return nil, fmt.Errorf("invalid size: %s, example: %s", req.Size, "1920*1080")
-		}
 		if strings.Contains(req.Size, "*") {
 			aliReq.Parameters.Size = req.Size
 		} else {
@@ -382,7 +411,9 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 		}
 	} else {
 		// 根据模型设置默认分辨率
-		if strings.Contains(req.Model, "t2v") { // image to video
+		if strings.HasPrefix(req.Model, "wan2.7") {
+			// wan2.7 服务端有默认值（resolution=720P, ratio=16:9），不设则用服务端默认
+		} else if strings.Contains(req.Model, "t2v") { // image to video
 			if strings.HasPrefix(req.Model, "wan2.5") {
 				aliReq.Parameters.Size = "1920*1080"
 			} else if strings.HasPrefix(req.Model, "wan2.2") {
@@ -594,16 +625,7 @@ func (a *TaskAdaptor) ConvertToOpenAIVideo(task *model.Task) ([]byte, error) {
 		return nil, errors.Wrap(err, "unmarshal ali response failed")
 	}
 
-	openAIResp := dto.NewOpenAIVideo()
-	openAIResp.ID = task.TaskID
-	openAIResp.Status = convertAliStatus(aliResp.Output.TaskStatus)
-	openAIResp.Model = task.Properties.OriginModelName
-	openAIResp.SetProgressStr(task.Progress)
-	openAIResp.CreatedAt = task.CreatedAt
-	openAIResp.CompletedAt = task.UpdatedAt
-
-	// 设置视频URL（核心字段）
-	openAIResp.SetMetadata("url", aliResp.Output.VideoURL)
+	openAIResp := task.ToOpenAIVideo()
 
 	// 错误处理
 	if aliResp.Code != "" {

--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -96,8 +96,8 @@ type AliUsage struct {
 	Duration            dto.IntValue `json:"duration,omitempty"`              // 总视频时长（秒），计费按此时长计算
 	Size                string       `json:"size,omitempty"`                  // 生成视频的分辨率，格式为"宽*高"
 	Ratio               string       `json:"ratio,omitempty"`                 // 生成视频的比例（wan2.7），如 "16:9"
-	InputVideoDuration  int          `json:"input_video_duration,omitempty"`  // 输入的参考视频的时长（秒）
-	OutputVideoDuration int          `json:"output_video_duration,omitempty"` // 输出视频的时长（秒）
+	InputVideoDuration  dto.IntValue `json:"input_video_duration,omitempty"`  // 输入的参考视频的时长（秒）
+	OutputVideoDuration dto.IntValue `json:"output_video_duration,omitempty"` // 输出视频的时长（秒）
 	VideoCount          dto.IntValue `json:"video_count,omitempty"`           // 生成视频的数量
 	SR                  dto.IntValue `json:"SR,omitempty"`                    // 生成视频的分辨率档位
 }

--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -221,6 +221,10 @@ func ProcessAliOtherRatios(aliReq *AliVideoRequest) (map[string]float64, error) 
 		"720P":  1,
 		"1080P": 1.6 / 0.9,
 	}
+	happyhorse11Ratio := map[string]float64{
+		"720P":  1,
+		"1080P": 1.2 / 0.9,
+	}
 	aliRatios := map[string]map[string]float64{
 		"wan2.7-t2v":                wan27Ratio,
 		"wan2.7-i2v":                wan27Ratio,
@@ -230,6 +234,9 @@ func ProcessAliOtherRatios(aliReq *AliVideoRequest) (map[string]float64, error) 
 		"happyhorse-1.0-i2v":        happyhorseRatio,
 		"happyhorse-1.0-r2v":        happyhorseRatio,
 		"happyhorse-1.0-video-edit": happyhorseRatio,
+		"happyhorse-1.1-t2v":        happyhorse11Ratio,
+		"happyhorse-1.1-i2v":        happyhorse11Ratio,
+		"happyhorse-1.1-r2v":        happyhorse11Ratio,
 		"wan2.6-i2v": {
 			"720P":  1,
 			"1080P": 1 / 0.6,

--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -94,12 +94,12 @@ type AliVideoOutput struct {
 // AliUsage 使用统计
 type AliUsage struct {
 	Duration            dto.IntValue `json:"duration,omitempty"`              // 总视频时长（秒），计费按此时长计算
-	Size                string  `json:"size,omitempty"`                  // 生成视频的分辨率，格式为"宽*高"
-	Ratio               string  `json:"ratio,omitempty"`                 // 生成视频的比例（wan2.7），如 "16:9"
-	InputVideoDuration  int     `json:"input_video_duration,omitempty"`  // 输入的参考视频的时长（秒）
-	OutputVideoDuration int     `json:"output_video_duration,omitempty"` // 输出视频的时长（秒）
-	VideoCount          dto.IntValue     `json:"video_count,omitempty"`           // 生成视频的数量
-	SR                  dto.IntValue     `json:"SR,omitempty"`                    // 生成视频的分辨率档位
+	Size                string       `json:"size,omitempty"`                  // 生成视频的分辨率，格式为"宽*高"
+	Ratio               string       `json:"ratio,omitempty"`                 // 生成视频的比例（wan2.7），如 "16:9"
+	InputVideoDuration  int          `json:"input_video_duration,omitempty"`  // 输入的参考视频的时长（秒）
+	OutputVideoDuration int          `json:"output_video_duration,omitempty"` // 输出视频的时长（秒）
+	VideoCount          dto.IntValue `json:"video_count,omitempty"`           // 生成视频的数量
+	SR                  dto.IntValue `json:"SR,omitempty"`                    // 生成视频的分辨率档位
 }
 
 type AliMetadata struct {
@@ -213,23 +213,23 @@ func sizeToResolution(size string) (string, error) {
 
 func ProcessAliOtherRatios(aliReq *AliVideoRequest) (map[string]float64, error) {
 	otherRatios := make(map[string]float64)
+	wan27Ratio := map[string]float64{
+		"720P":  1,
+		"1080P": 1 / 0.6,
+	}
+	happyhorseRatio := map[string]float64{
+		"720P":  1,
+		"1080P": 1.6 / 0.9,
+	}
 	aliRatios := map[string]map[string]float64{
-		"wan2.7-t2v": {
-			"720P":  1,
-			"1080P": 1 / 0.6,
-		},
-		"wan2.7-i2v": {
-			"720P":  1,
-			"1080P": 1 / 0.6,
-		},
-		"wan2.7-r2v": {
-			"720P":  1,
-			"1080P": 1 / 0.6,
-		},
-		"wan2.7-videoedit": {
-			"720P":  1,
-			"1080P": 1 / 0.6,
-		},
+		"wan2.7-t2v":         wan27Ratio,
+		"wan2.7-i2v":         wan27Ratio,
+		"wan2.7-r2v":         wan27Ratio,
+		"wan2.7-videoedit":   wan27Ratio,
+		"happyhorse-1.0-t2v":        happyhorseRatio,
+		"happyhorse-1.0-i2v":        happyhorseRatio,
+		"happyhorse-1.0-r2v":        happyhorseRatio,
+		"happyhorse-1.0-video-edit": happyhorseRatio,
 		"wan2.6-i2v": {
 			"720P":  1,
 			"1080P": 1 / 0.6,
@@ -304,11 +304,8 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 			Watermark:    false,
 		},
 	}
-	if len(req.Images) > 1 {
-		aliReq.Input.FirstFrameURL = req.Images[0]
-		aliReq.Input.LastFrameURL = req.Images[1]
-	} else if len(req.Images) > 0 {
-		aliReq.Input.ImgURL = req.Images[0]
+	if isNewFormatModel(aliReq.Model) {
+		appendImageURLsAsMedia(aliReq, imageMediaType(aliReq.Model), req.Images)
 	}
 	// 处理分辨率映射
 	if req.Size != "" {
@@ -322,30 +319,28 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 			}
 			aliReq.Parameters.Resolution = resolution
 		}
-	} else {
-		// 根据模型设置默认分辨率
-		if strings.HasPrefix(req.Model, "wan2.7") {
-			// wan2.7 服务端有默认值（resolution=720P, ratio=16:9），不设则用服务端默认
-		} else if strings.Contains(req.Model, "t2v") { // image to video
-			if strings.HasPrefix(req.Model, "wan2.5") {
-				aliReq.Parameters.Size = "1920*1080"
-			} else if strings.HasPrefix(req.Model, "wan2.2") {
-				aliReq.Parameters.Size = "1920*1080"
-			} else {
-				aliReq.Parameters.Size = "1280*720"
-			}
+	} else if resolution, ok := newFormatDefaultResolution(aliReq.Model); ok {
+		aliReq.Parameters.Resolution = resolution
+	} else if strings.Contains(req.Model, "t2v") { // 旧版 t2v 默认 size
+		if strings.HasPrefix(req.Model, "wan2.5") {
+			aliReq.Parameters.Size = "1920*1080"
+		} else if strings.HasPrefix(req.Model, "wan2.2") {
+			aliReq.Parameters.Size = "1920*1080"
 		} else {
-			if strings.HasPrefix(req.Model, "wan2.6") {
-				aliReq.Parameters.Resolution = "1080P"
-			} else if strings.HasPrefix(req.Model, "wan2.5") {
-				aliReq.Parameters.Resolution = "1080P"
-			} else if strings.HasPrefix(req.Model, "wan2.2-i2v-flash") {
-				aliReq.Parameters.Resolution = "720P"
-			} else if strings.HasPrefix(req.Model, "wan2.2-i2v-plus") {
-				aliReq.Parameters.Resolution = "1080P"
-			} else {
-				aliReq.Parameters.Resolution = "720P"
-			}
+			aliReq.Parameters.Size = "1280*720"
+		}
+	} else {
+		// 旧版 i2v 默认 resolution
+		if strings.HasPrefix(req.Model, "wan2.6") {
+			aliReq.Parameters.Resolution = "1080P"
+		} else if strings.HasPrefix(req.Model, "wan2.5") {
+			aliReq.Parameters.Resolution = "1080P"
+		} else if strings.HasPrefix(req.Model, "wan2.2-i2v-flash") {
+			aliReq.Parameters.Resolution = "720P"
+		} else if strings.HasPrefix(req.Model, "wan2.2-i2v-plus") {
+			aliReq.Parameters.Resolution = "1080P"
+		} else {
+			aliReq.Parameters.Resolution = "720P"
 		}
 	}
 

--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/logger"
 	"github.com/QuantumNous/new-api/model"
@@ -33,26 +34,38 @@ type AliVideoRequest struct {
 	Parameters *AliVideoParameters `json:"parameters,omitempty"`
 }
 
+// AliVideoMedia wan2.7 媒体数组元素
+type AliVideoMedia struct {
+	Type string `json:"type"` // first_frame/last_frame/driving_audio/first_clip/reference_video/reference_image/video
+	URL  string `json:"url"`
+}
+
 // AliVideoInput 视频输入参数
 type AliVideoInput struct {
-	Prompt         string `json:"prompt,omitempty"`          // 文本提示词
-	ImgURL         string `json:"img_url,omitempty"`         // 首帧图像URL或Base64（图生视频）
-	FirstFrameURL  string `json:"first_frame_url,omitempty"` // 首帧图片URL（首尾帧生视频）
-	LastFrameURL   string `json:"last_frame_url,omitempty"`  // 尾帧图片URL（首尾帧生视频）
-	AudioURL       string `json:"audio_url,omitempty"`       // 音频URL（wan2.5支持）
-	NegativePrompt string `json:"negative_prompt,omitempty"` // 反向提示词
-	Template       string `json:"template,omitempty"`        // 视频特效模板
+	Prompt             string          `json:"prompt,omitempty"`               // 文本提示词
+	NegativePrompt     string          `json:"negative_prompt,omitempty"`      // 反向提示词
+	ImgURL             string          `json:"img_url,omitempty"`              // 首帧图像URL或Base64（图生视频，wan2.6及更早）
+	FirstFrameURL      string          `json:"first_frame_url,omitempty"`      // 首帧图片URL（首尾帧生视频，wan2.6及更早）
+	LastFrameURL       string          `json:"last_frame_url,omitempty"`       // 尾帧图片URL（首尾帧生视频，wan2.6及更早）
+	AudioURL           string          `json:"audio_url,omitempty"`            // 音频URL（wan2.5/2.6）
+	Template           string          `json:"template,omitempty"`             // 视频特效模板
+	ReferenceVideoURLs []string        `json:"reference_video_urls,omitempty"` // 参考视频URL数组（wan2.6-r2v）
+	Media              []AliVideoMedia `json:"media,omitempty"`                // 媒体数组（wan2.7 i2v/r2v/videoedit 新格式）
+	ReferenceVoice     string          `json:"reference_voice,omitempty"`      // 参考声音URL（wan2.7-r2v）
 }
 
 // AliVideoParameters 视频参数
 type AliVideoParameters struct {
-	Resolution   string `json:"resolution,omitempty"`    // 分辨率: 480P/720P/1080P（图生视频、首尾帧生视频）
-	Size         string `json:"size,omitempty"`          // 尺寸: 如 "832*480"（文生视频）
-	Duration     int    `json:"duration,omitempty"`      // 时长: 3-10秒
+	Resolution   string `json:"resolution,omitempty"`    // 分辨率: 480P/720P/1080P
+	Size         string `json:"size,omitempty"`          // 尺寸: 如 "832*480"（wan2.6及更早文生视频）
+	Ratio        string `json:"ratio,omitempty"`         // 比例: 16:9/9:16/1:1/4:3/3:4（wan2.7）
+	Duration     int    `json:"duration,omitempty"`      // 时长（秒）
 	PromptExtend bool   `json:"prompt_extend,omitempty"` // 是否开启prompt智能改写
 	Watermark    bool   `json:"watermark,omitempty"`     // 是否添加水印
-	Audio        *bool  `json:"audio,omitempty"`         // 是否添加音频（wan2.5）
+	Audio        *bool  `json:"audio,omitempty"`         // 是否添加音频（wan2.5/2.6）
+	AudioSetting string `json:"audio_setting,omitempty"` // 音频处理方式: auto/origin（wan2.7-videoedit）
 	Seed         int    `json:"seed,omitempty"`          // 随机数种子
+	ShotType     string `json:"shot_type,omitempty"`     // 镜头类型: single/multi（wan2.6-r2v）
 }
 
 // AliVideoResponse 阿里通义万相响应
@@ -80,28 +93,38 @@ type AliVideoOutput struct {
 
 // AliUsage 使用统计
 type AliUsage struct {
-	Duration   dto.IntValue `json:"duration,omitempty"`
-	VideoCount dto.IntValue `json:"video_count,omitempty"`
-	SR         dto.IntValue `json:"SR,omitempty"`
+	Duration            dto.IntValue `json:"duration,omitempty"`              // 总视频时长（秒），计费按此时长计算
+	Size                string  `json:"size,omitempty"`                  // 生成视频的分辨率，格式为"宽*高"
+	Ratio               string  `json:"ratio,omitempty"`                 // 生成视频的比例（wan2.7），如 "16:9"
+	InputVideoDuration  int     `json:"input_video_duration,omitempty"`  // 输入的参考视频的时长（秒）
+	OutputVideoDuration int     `json:"output_video_duration,omitempty"` // 输出视频的时长（秒）
+	VideoCount          dto.IntValue     `json:"video_count,omitempty"`           // 生成视频的数量
+	SR                  dto.IntValue     `json:"SR,omitempty"`                    // 生成视频的分辨率档位
 }
 
 type AliMetadata struct {
 	// Input 相关
-	AudioURL       string `json:"audio_url,omitempty"`       // 音频URL
-	ImgURL         string `json:"img_url,omitempty"`         // 图片URL（图生视频）
-	FirstFrameURL  string `json:"first_frame_url,omitempty"` // 首帧图片URL（首尾帧生视频）
-	LastFrameURL   string `json:"last_frame_url,omitempty"`  // 尾帧图片URL（首尾帧生视频）
-	NegativePrompt string `json:"negative_prompt,omitempty"` // 反向提示词
-	Template       string `json:"template,omitempty"`        // 视频特效模板
+	AudioURL           string          `json:"audio_url,omitempty"`            // 音频URL（wan2.6及更早）
+	ImgURL             string          `json:"img_url,omitempty"`              // 图片URL（图生视频，wan2.6及更早）
+	FirstFrameURL      string          `json:"first_frame_url,omitempty"`      // 首帧图片URL（wan2.6及更早）
+	LastFrameURL       string          `json:"last_frame_url,omitempty"`       // 尾帧图片URL（wan2.6及更早）
+	NegativePrompt     string          `json:"negative_prompt,omitempty"`      // 反向提示词
+	Template           string          `json:"template,omitempty"`             // 视频特效模板
+	ReferenceVideoURLs []string        `json:"reference_video_urls,omitempty"` // 参考视频URL数组（wan2.6-r2v）
+	Media              []AliVideoMedia `json:"media,omitempty"`                // 媒体数组（wan2.7）
+	ReferenceVoice     *string         `json:"reference_voice,omitempty"`      // 参考声音URL（wan2.7-r2v）
 
 	// Parameters 相关
 	Resolution   *string `json:"resolution,omitempty"`    // 分辨率: 480P/720P/1080P
 	Size         *string `json:"size,omitempty"`          // 尺寸: 如 "832*480"
+	Ratio        *string `json:"ratio,omitempty"`         // 比例: 16:9/9:16/1:1/4:3/3:4（wan2.7）
 	Duration     *int    `json:"duration,omitempty"`      // 时长
 	PromptExtend *bool   `json:"prompt_extend,omitempty"` // 是否开启prompt智能改写
 	Watermark    *bool   `json:"watermark,omitempty"`     // 是否添加水印
 	Audio        *bool   `json:"audio,omitempty"`         // 是否添加音频
+	AudioSetting *string `json:"audio_setting,omitempty"` // 音频处理方式（wan2.7-videoedit）
 	Seed         *int    `json:"seed,omitempty"`          // 随机数种子
+	ShotType     *string `json:"shot_type,omitempty"`     // 镜头类型: single/multi（wan2.6-r2v）
 }
 
 // ============================
@@ -122,8 +145,7 @@ func (a *TaskAdaptor) Init(info *relaycommon.RelayInfo) {
 }
 
 func (a *TaskAdaptor) ValidateRequestAndSetAction(c *gin.Context, info *relaycommon.RelayInfo) (taskErr *dto.TaskError) {
-	// ValidateMultipartDirect 负责解析并将原始 TaskSubmitReq 存入 context
-	return relaycommon.ValidateMultipartDirect(c, info)
+	return relaycommon.ValidateBasicTaskRequest(c, info, constant.TaskActionGenerate)
 }
 
 func (a *TaskAdaptor) BuildRequestURL(info *relaycommon.RelayInfo) (string, error) {
@@ -141,15 +163,14 @@ func (a *TaskAdaptor) BuildRequestHeader(c *gin.Context, req *http.Request, info
 func (a *TaskAdaptor) BuildRequestBody(c *gin.Context, info *relaycommon.RelayInfo) (io.Reader, error) {
 	taskReq, err := relaycommon.GetTaskRequest(c)
 	if err != nil {
-		return nil, errors.Wrap(err, "get_task_request_failed")
+		return nil, err
 	}
-
 	aliReq, err := a.convertToAliRequest(info, taskReq)
 	if err != nil {
-		return nil, errors.Wrap(err, "convert_to_ali_request_failed")
+		return nil, err
 	}
+	appendMultipartMediaToRequest(c, aliReq)
 	logger.LogJson(c, "ali video request body", aliReq)
-
 	bodyBytes, err := common.Marshal(aliReq)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal_ali_request_failed")
@@ -193,6 +214,22 @@ func sizeToResolution(size string) (string, error) {
 func ProcessAliOtherRatios(aliReq *AliVideoRequest) (map[string]float64, error) {
 	otherRatios := make(map[string]float64)
 	aliRatios := map[string]map[string]float64{
+		"wan2.7-t2v": {
+			"720P":  1,
+			"1080P": 1 / 0.6,
+		},
+		"wan2.7-i2v": {
+			"720P":  1,
+			"1080P": 1 / 0.6,
+		},
+		"wan2.7-r2v": {
+			"720P":  1,
+			"1080P": 1 / 0.6,
+		},
+		"wan2.7-videoedit": {
+			"720P":  1,
+			"1080P": 1 / 0.6,
+		},
 		"wan2.6-i2v": {
 			"720P":  1,
 			"1080P": 1 / 0.6,
@@ -261,20 +298,20 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 		Model: upstreamModel,
 		Input: AliVideoInput{
 			Prompt: req.Prompt,
-			ImgURL: req.InputReference,
 		},
 		Parameters: &AliVideoParameters{
 			PromptExtend: true, // 默认开启智能改写
 			Watermark:    false,
 		},
 	}
-
+	if len(req.Images) > 1 {
+		aliReq.Input.FirstFrameURL = req.Images[0]
+		aliReq.Input.LastFrameURL = req.Images[1]
+	} else if len(req.Images) > 0 {
+		aliReq.Input.ImgURL = req.Images[0]
+	}
 	// 处理分辨率映射
 	if req.Size != "" {
-		// text to video size must be contained *
-		if strings.Contains(req.Model, "t2v") && !strings.Contains(req.Size, "*") {
-			return nil, fmt.Errorf("invalid size: %s, example: %s", req.Size, "1920*1080")
-		}
 		if strings.Contains(req.Size, "*") {
 			aliReq.Parameters.Size = req.Size
 		} else {
@@ -287,7 +324,9 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 		}
 	} else {
 		// 根据模型设置默认分辨率
-		if strings.Contains(req.Model, "t2v") { // image to video
+		if strings.HasPrefix(req.Model, "wan2.7") {
+			// wan2.7 服务端有默认值（resolution=720P, ratio=16:9），不设则用服务端默认
+		} else if strings.Contains(req.Model, "t2v") { // image to video
 			if strings.HasPrefix(req.Model, "wan2.5") {
 				aliReq.Parameters.Size = "1920*1080"
 			} else if strings.HasPrefix(req.Model, "wan2.2") {
@@ -492,16 +531,7 @@ func (a *TaskAdaptor) ConvertToOpenAIVideo(task *model.Task) ([]byte, error) {
 		return nil, errors.Wrap(err, "unmarshal ali response failed")
 	}
 
-	openAIResp := dto.NewOpenAIVideo()
-	openAIResp.ID = task.TaskID
-	openAIResp.Status = convertAliStatus(aliResp.Output.TaskStatus)
-	openAIResp.Model = task.Properties.OriginModelName
-	openAIResp.SetProgressStr(task.Progress)
-	openAIResp.CreatedAt = task.CreatedAt
-	openAIResp.CompletedAt = task.UpdatedAt
-
-	// 设置视频URL（核心字段）
-	openAIResp.SetMetadata("url", aliResp.Output.VideoURL)
+	openAIResp := task.ToOpenAIVideo()
 
 	// 错误处理
 	if aliResp.Code != "" {

--- a/relay/channel/task/ali/constants.go
+++ b/relay/channel/task/ali/constants.go
@@ -1,6 +1,10 @@
 package ali
 
 var ModelList = []string{
+	"wan2.7-t2v",         // 万相2.7 文生视频（有声）推荐
+	"wan2.7-i2v",         // 万相2.7 图生视频（有声）推荐
+	"wan2.7-r2v",         // 万相2.7 参考生视频
+	"wan2.7-videoedit",   // 万相2.7 视频编辑
 	"wan2.5-i2v-preview", // 万相2.5 preview（有声视频）推荐
 	"wan2.2-i2v-flash",   // 万相2.2极速版（无声视频）
 	"wan2.2-i2v-plus",    // 万相2.2专业版（无声视频）

--- a/relay/channel/task/ali/constants.go
+++ b/relay/channel/task/ali/constants.go
@@ -3,6 +3,8 @@ package ali
 var ModelList = []string{
 	"wan2.7-i2v",         // 万相2.7图生视频（新input.media协议）
 	"wan2.7-t2v",         // 万相2.7文生视频
+	"wan2.7-r2v",         // 万相2.7参考生视频
+	"wan2.7-videoedit",   // 万相2.7视频编辑
 	"wan2.5-i2v-preview", // 万相2.5 preview（有声视频）推荐
 	"wan2.2-i2v-flash",   // 万相2.2极速版（无声视频）
 	"wan2.2-i2v-plus",    // 万相2.2专业版（无声视频）

--- a/relay/channel/task/ali/constants.go
+++ b/relay/channel/task/ali/constants.go
@@ -1,15 +1,19 @@
 package ali
 
 var ModelList = []string{
-	"wan2.7-i2v",         // 万相2.7图生视频（新input.media协议）
-	"wan2.7-t2v",         // 万相2.7文生视频
-	"wan2.7-r2v",         // 万相2.7参考生视频
-	"wan2.7-videoedit",   // 万相2.7视频编辑
-	"wan2.5-i2v-preview", // 万相2.5 preview（有声视频）推荐
-	"wan2.2-i2v-flash",   // 万相2.2极速版（无声视频）
-	"wan2.2-i2v-plus",    // 万相2.2专业版（无声视频）
-	"wanx2.1-i2v-plus",   // 万相2.1专业版（无声视频）
-	"wanx2.1-i2v-turbo",  // 万相2.1极速版（无声视频）
+	"wan2.7-i2v",                // 万相2.7图生视频（新input.media协议）
+	"wan2.7-t2v",                // 万相2.7文生视频
+	"wan2.7-r2v",                // 万相2.7参考生视频
+	"wan2.7-videoedit",          // 万相2.7视频编辑
+	"happyhorse-1.0-t2v",        // HappyHorse 1.0 文生视频
+	"happyhorse-1.0-i2v",        // HappyHorse 1.0 图生视频（首帧）
+	"happyhorse-1.0-r2v",        // HappyHorse 1.0 参考生视频
+	"happyhorse-1.0-video-edit", // HappyHorse 1.0 视频编辑
+	"wan2.5-i2v-preview",        // 万相2.5 preview（有声视频）推荐
+	"wan2.2-i2v-flash",          // 万相2.2极速版（无声视频）
+	"wan2.2-i2v-plus",           // 万相2.2专业版（无声视频）
+	"wanx2.1-i2v-plus",          // 万相2.1专业版（无声视频）
+	"wanx2.1-i2v-turbo",         // 万相2.1极速版（无声视频）
 }
 
 var ChannelName = "ali"

--- a/relay/channel/task/ali/constants.go
+++ b/relay/channel/task/ali/constants.go
@@ -9,6 +9,9 @@ var ModelList = []string{
 	"happyhorse-1.0-i2v",        // HappyHorse 1.0 图生视频（首帧）
 	"happyhorse-1.0-r2v",        // HappyHorse 1.0 参考生视频
 	"happyhorse-1.0-video-edit", // HappyHorse 1.0 视频编辑
+	"happyhorse-1.1-t2v",        // HappyHorse 1.1 文生视频
+	"happyhorse-1.1-i2v",        // HappyHorse 1.1 图生视频（首帧）
+	"happyhorse-1.1-r2v",        // HappyHorse 1.1 参考生视频
 	"wan2.5-i2v-preview",        // 万相2.5 preview（有声视频）推荐
 	"wan2.2-i2v-flash",          // 万相2.2极速版（无声视频）
 	"wan2.2-i2v-plus",           // 万相2.2专业版（无声视频）

--- a/relay/channel/task/ali/constants.go
+++ b/relay/channel/task/ali/constants.go
@@ -5,6 +5,10 @@ var ModelList = []string{
 	"wan2.7-i2v",         // 万相2.7 图生视频（有声）推荐
 	"wan2.7-r2v",         // 万相2.7 参考生视频
 	"wan2.7-videoedit",   // 万相2.7 视频编辑
+	"happyhorse-1.0-t2v",        // HappyHorse 1.0 文生视频
+	"happyhorse-1.0-i2v",        // HappyHorse 1.0 图生视频（首帧）
+	"happyhorse-1.0-r2v",        // HappyHorse 1.0 参考生视频
+	"happyhorse-1.0-video-edit", // HappyHorse 1.0 视频编辑
 	"wan2.5-i2v-preview", // 万相2.5 preview（有声视频）推荐
 	"wan2.2-i2v-flash",   // 万相2.2极速版（无声视频）
 	"wan2.2-i2v-plus",    // 万相2.2专业版（无声视频）

--- a/relay/channel/task/ali/multipart.go
+++ b/relay/channel/task/ali/multipart.go
@@ -6,6 +6,42 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+func newFormatDefaultResolution(model string) (string, bool) {
+	switch {
+	case strings.HasPrefix(model, "wan2.7"):
+		return "720P", true
+	case strings.HasPrefix(model, "happyhorse-1.0"):
+		return "1080P", true
+	}
+	return "", false
+}
+
+func isNewFormatModel(model string) bool {
+	_, ok := newFormatDefaultResolution(model)
+	return ok
+}
+
+// isVideoEditModel 同时匹配 wan2.7-videoedit（无连字符）与 happyhorse-1.0-video-edit（有连字符）。
+func isVideoEditModel(model string) bool {
+	return strings.Contains(model, "videoedit") || strings.Contains(model, "video-edit")
+}
+
+func imageMediaType(model string) string {
+	if strings.Contains(model, "r2v") || isVideoEditModel(model) {
+		return "reference_image"
+	}
+	return "first_frame"
+}
+
+func appendImageURLsAsMedia(aliReq *AliVideoRequest, mediaType string, urls []string) {
+	for _, u := range urls {
+		aliReq.Input.Media = append(aliReq.Input.Media, AliVideoMedia{
+			Type: mediaType,
+			URL:  u,
+		})
+	}
+}
+
 type mediaFieldDef struct {
 	fieldName   string
 	mediaTypeFn func(model string) string
@@ -13,18 +49,13 @@ type mediaFieldDef struct {
 
 var mediaFields = []mediaFieldDef{
 	{
-		fieldName: "image_url",
-		mediaTypeFn: func(model string) string {
-			if strings.Contains(model, "r2v") {
-				return "reference_image"
-			}
-			return "first_frame"
-		},
+		fieldName:   "image_url",
+		mediaTypeFn: imageMediaType,
 	},
 	{
 		fieldName: "video_url",
 		mediaTypeFn: func(model string) string {
-			if strings.Contains(model, "videoedit") {
+			if isVideoEditModel(model) {
 				return "video"
 			}
 			return "reference_video"
@@ -39,21 +70,14 @@ var mediaFields = []mediaFieldDef{
 }
 
 func appendMultipartMediaToRequest(c *gin.Context, aliReq *AliVideoRequest) {
-	if !strings.HasPrefix(aliReq.Model, "wan2.7") {
+	if !isNewFormatModel(aliReq.Model) {
 		return
 	}
-
 	for _, mf := range mediaFields {
 		urls := c.PostFormArray(mf.fieldName)
 		if len(urls) == 0 {
 			continue
 		}
-		mediaType := mf.mediaTypeFn(aliReq.Model)
-		for _, u := range urls {
-			aliReq.Input.Media = append(aliReq.Input.Media, AliVideoMedia{
-				Type: mediaType,
-				URL:  u,
-			})
-		}
+		appendImageURLsAsMedia(aliReq, mf.mediaTypeFn(aliReq.Model), urls)
 	}
 }

--- a/relay/channel/task/ali/multipart.go
+++ b/relay/channel/task/ali/multipart.go
@@ -1,0 +1,59 @@
+package ali
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+type mediaFieldDef struct {
+	fieldName   string
+	mediaTypeFn func(model string) string
+}
+
+var mediaFields = []mediaFieldDef{
+	{
+		fieldName: "image_url",
+		mediaTypeFn: func(model string) string {
+			if strings.Contains(model, "r2v") {
+				return "reference_image"
+			}
+			return "first_frame"
+		},
+	},
+	{
+		fieldName: "video_url",
+		mediaTypeFn: func(model string) string {
+			if strings.Contains(model, "videoedit") {
+				return "video"
+			}
+			return "reference_video"
+		},
+	},
+	{
+		fieldName: "audio_url",
+		mediaTypeFn: func(_ string) string {
+			return "driving_audio"
+		},
+	},
+}
+
+func appendMultipartMediaToRequest(c *gin.Context, aliReq *AliVideoRequest) {
+	if !strings.HasPrefix(aliReq.Model, "wan2.7") {
+		return
+	}
+
+	for _, mf := range mediaFields {
+		urls := c.PostFormArray(mf.fieldName)
+		if len(urls) == 0 {
+			continue
+		}
+		mediaType := mf.mediaTypeFn(aliReq.Model)
+		for _, u := range urls {
+			aliReq.Input.Media = append(aliReq.Input.Media, AliVideoMedia{
+				Type: mediaType,
+				URL:  u,
+			})
+		}
+	}
+}

--- a/relay/channel/task/ali/multipart.go
+++ b/relay/channel/task/ali/multipart.go
@@ -10,7 +10,7 @@ func newFormatDefaultResolution(model string) (string, bool) {
 	switch {
 	case strings.HasPrefix(model, "wan2.7"):
 		return "720P", true
-	case strings.HasPrefix(model, "happyhorse-1.0"):
+	case strings.HasPrefix(model, "happyhorse"):
 		return "1080P", true
 	}
 	return "", false


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

支持阿里百炼快乐马 happyhorse-1.0 / happyhorse-1.1 系列视频模型(含 video-edit)，1.1 的 1080P 档单独定价。同时补齐 wan2.6/2.7 协议字段(reference_video_urls、ratio、audio_setting、shot_type 等)、multipart 媒体字段映射，新增 wan2.7-r2v / wan2.7-videoedit。

原 PR 里的 wan2.7 基础支持已由 #4984 合入。分支已基于当前 main 重建，移除了重复实现，现在零冲突可直接合并。线上已稳定运行两个月。

usage.duration 浮点解析的修复为了尽快解决 #6166 拆成了单独 PR(#6174)，先合哪个都不冲突。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- #6166(浮点解析部分，独立修复见 #6174)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

提交示例:
<img width="2814" height="2280" alt="image" src="https://github.com/user-attachments/assets/43ecc88e-b3e6-489e-9402-8f1c3a19655f" />
轮询成功:
<img width="4592" height="348" alt="image" src="https://github.com/user-attachments/assets/69890765-c673-49b1-8b51-03f8c41c8de3" />
查询成功:
<img width="2832" height="1090" alt="image" src="https://github.com/user-attachments/assets/af4078cd-3e5e-4546-b873-eb266e744c9c" />
生成视频:
<img width="2940" height="1654" alt="image" src="https://github.com/user-attachments/assets/c153cec5-9378-46b8-9ce3-4286ee2e9aaa" />

