### PR TITLE
fix(web/default): api-info save silently fails when color is invalid or result unchecked

### DIFF
--- a/setting/console_setting/validation.go
+++ b/setting/console_setting/validation.go
@@ -17,7 +17,7 @@ var (
 		"blue": true, "green": true, "cyan": true, "purple": true, "pink": true,
 		"red": true, "orange": true, "amber": true, "yellow": true, "lime": true,
 		"light-green": true, "teal": true, "light-blue": true, "indigo": true,
-		"violet": true, "grey": true,
+		"violet": true, "grey": true, "slate": true,
 	}
 	slugRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 )

--- a/web/default/src/features/system-settings/content/api-info-section.tsx
+++ b/web/default/src/features/system-settings/content/api-info-section.tsx
@@ -249,12 +249,13 @@ export function ApiInfoSection({ enabled, data }: ApiInfoSectionProps) {
 
   const handleSaveAll = async () => {
     try {
-      await updateOption.mutateAsync({
+      const result = await updateOption.mutateAsync({
         key: 'console_setting.api_info',
         value: JSON.stringify(apiInfoList),
       })
-      setHasChanges(false)
-      toast.success(t('API info saved successfully'))
+      if (result.success) {
+        setHasChanges(false)
+      }
     } catch {
       toast.error(t('Failed to save API info'))
     }


### PR DESCRIPTION
## 问题描述

系统管理 → 内容 → API 地址页面，添加条目后点击「保存设置」，提示保存成功，但刷新页面后新添加的条目消失。

## 根本原因

**问题一：前端不检查后端返回值**

`handleSaveAll` 使用 `mutateAsync` 但不检查返回的 `success` 字段：

```ts
// 修复前：无论后端返回 success: true 还是 false，都执行 setHasChanges(false) 和 toast.success
await updateOption.mutateAsync({ key: 'console_setting.api_info', value: ... })
setHasChanges(false)
toast.success(t('API info saved successfully'))  // 无条件显示成功
```

当后端返回 `{ success: false, message: ... }` 时（HTTP 200），`mutateAsync` 不会 throw，catch 块不触发，用户看到保存成功但数据实际未写入。

**问题二：`slate` 颜色不在后端白名单**

前端颜色选项包含 `slate`，但后端 `validColors` 白名单不包含 `slate`，导致选择 `slate` 颜色时后端校验失败返回 `success: false`，触发上述问题一。

## 修复方案

1. `handleSaveAll` 检查 `result.success`，只有成功时才清除 `hasChanges` 标记（错误提示已由 `useUpdateOption` 的 `onSuccess` 统一处理）
2. 后端 `validColors` 白名单加入 `slate`，与前端颜色选项保持一致

## 影响范围

- 仅影响 API 地址设置页面的保存逻辑
- 不影响其他设置项

Signed-off-by: Micah-Zheng <102610064+Micah-Zheng@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "slate" color in console settings.

* **Bug Fixes**
  * Updated success notification handling for API settings updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4823)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->