### PR TITLE
fix(oauth): return stable error codes

### DIFF
--- a/controller/discord.go
+++ b/controller/discord.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/setting/system_setting"
 
@@ -33,9 +34,9 @@ type DiscordUser struct {
 	Name string `json:"global_name"`
 }
 
-func getDiscordUserInfoByCode(code string) (*DiscordUser, error) {
+func getDiscordUserInfoByCode(c *gin.Context, code string) (*DiscordUser, error) {
 	if code == "" {
-		return nil, errors.New("无效的参数")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthInvalidCode))
 	}
 
 	values := url.Values{}
@@ -57,7 +58,7 @@ func getDiscordUserInfoByCode(code string) (*DiscordUser, error) {
 	res, err := client.Do(req)
 	if err != nil {
 		common.SysLog(err.Error())
-		return nil, errors.New("无法连接至 Discord 服务器，请稍后重试！")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthConnectFailed, providerParams("Discord")))
 	}
 	defer res.Body.Close()
 	var discordResponse DiscordResponse
@@ -68,7 +69,7 @@ func getDiscordUserInfoByCode(code string) (*DiscordUser, error) {
 
 	if discordResponse.AccessToken == "" {
 		common.SysError("Discord 获取 Token 失败，请检查设置！")
-		return nil, errors.New("Discord 获取 Token 失败，请检查设置！")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthTokenFailed, providerParams("Discord")))
 	}
 
 	req, err = http.NewRequest("GET", "https://discord.com/api/v10/users/@me", nil)
@@ -79,12 +80,12 @@ func getDiscordUserInfoByCode(code string) (*DiscordUser, error) {
 	res2, err := client.Do(req)
 	if err != nil {
 		common.SysLog(err.Error())
-		return nil, errors.New("无法连接至 Discord 服务器，请稍后重试！")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthConnectFailed, providerParams("Discord")))
 	}
 	defer res2.Body.Close()
 	if res2.StatusCode != http.StatusOK {
 		common.SysError("Discord 获取用户信息失败！请检查设置！")
-		return nil, errors.New("Discord 获取用户信息失败！请检查设置！")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthGetUserErr))
 	}
 
 	var discordUser DiscordUser
@@ -94,7 +95,7 @@ func getDiscordUserInfoByCode(code string) (*DiscordUser, error) {
 	}
 	if discordUser.UID == "" || discordUser.ID == "" {
 		common.SysError("Discord 获取用户信息为空！请检查设置！")
-		return nil, errors.New("Discord 获取用户信息为空！请检查设置！")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthUserInfoEmpty, providerParams("Discord")))
 	}
 	return &discordUser, nil
 }
@@ -115,14 +116,11 @@ func DiscordOAuth(c *gin.Context) {
 		return
 	}
 	if !system_setting.GetDiscordSettings().Enabled {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "管理员未开启通过 Discord 登录以及注册",
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthNotEnabled, providerParams("Discord"))
 		return
 	}
 	code := c.Query("code")
-	discordUser, err := getDiscordUserInfoByCode(code)
+	discordUser, err := getDiscordUserInfoByCode(c, code)
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -160,19 +158,13 @@ func DiscordOAuth(c *gin.Context) {
 				return
 			}
 		} else {
-			c.JSON(http.StatusOK, gin.H{
-				"success": false,
-				"message": "管理员关闭了新用户注册",
-			})
+			common.ApiErrorI18n(c, i18n.MsgUserRegisterDisabled)
 			return
 		}
 	}
 
 	if user.Status != common.UserStatusEnabled {
-		c.JSON(http.StatusOK, gin.H{
-			"message": "用户已被封禁",
-			"success": false,
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthUserBanned)
 		return
 	}
 	setupLogin(&user, c)
@@ -180,14 +172,11 @@ func DiscordOAuth(c *gin.Context) {
 
 func DiscordBind(c *gin.Context) {
 	if !system_setting.GetDiscordSettings().Enabled {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "管理员未开启通过 Discord 登录以及注册",
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthNotEnabled, providerParams("Discord"))
 		return
 	}
 	code := c.Query("code")
-	discordUser, err := getDiscordUserInfoByCode(code)
+	discordUser, err := getDiscordUserInfoByCode(c, code)
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -196,10 +185,7 @@ func DiscordBind(c *gin.Context) {
 		DiscordId: discordUser.UID,
 	}
 	if model.IsDiscordIdAlreadyTaken(user.DiscordId) {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "该 Discord 账户已被绑定",
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthAlreadyBound, providerParams("Discord"))
 		return
 	}
 	session := sessions.Default(c)

--- a/controller/discord.go
+++ b/controller/discord.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -13,6 +11,7 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/oauth"
 	"github.com/QuantumNous/new-api/setting/system_setting"
 
 	"github.com/gin-contrib/sessions"
@@ -36,7 +35,7 @@ type DiscordUser struct {
 
 func getDiscordUserInfoByCode(c *gin.Context, code string) (*DiscordUser, error) {
 	if code == "" {
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthInvalidCode))
+		return nil, oauth.NewOAuthError(i18n.MsgOAuthInvalidCode, nil)
 	}
 
 	values := url.Values{}
@@ -58,18 +57,18 @@ func getDiscordUserInfoByCode(c *gin.Context, code string) (*DiscordUser, error)
 	res, err := client.Do(req)
 	if err != nil {
 		common.SysLog(err.Error())
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthConnectFailed, providerParams("Discord")))
+		return nil, oauth.NewOAuthErrorWithRaw(i18n.MsgOAuthConnectFailed, providerParams("Discord"), err.Error())
 	}
 	defer res.Body.Close()
 	var discordResponse DiscordResponse
-	err = json.NewDecoder(res.Body).Decode(&discordResponse)
+	err = common.DecodeJson(res.Body, &discordResponse)
 	if err != nil {
 		return nil, err
 	}
 
 	if discordResponse.AccessToken == "" {
 		common.SysError("Discord 获取 Token 失败，请检查设置！")
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthTokenFailed, providerParams("Discord")))
+		return nil, oauth.NewOAuthError(i18n.MsgOAuthTokenFailed, providerParams("Discord"))
 	}
 
 	req, err = http.NewRequest("GET", "https://discord.com/api/v10/users/@me", nil)
@@ -80,22 +79,22 @@ func getDiscordUserInfoByCode(c *gin.Context, code string) (*DiscordUser, error)
 	res2, err := client.Do(req)
 	if err != nil {
 		common.SysLog(err.Error())
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthConnectFailed, providerParams("Discord")))
+		return nil, oauth.NewOAuthErrorWithRaw(i18n.MsgOAuthConnectFailed, providerParams("Discord"), err.Error())
 	}
 	defer res2.Body.Close()
 	if res2.StatusCode != http.StatusOK {
 		common.SysError("Discord 获取用户信息失败！请检查设置！")
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthGetUserErr))
+		return nil, oauth.NewOAuthError(i18n.MsgOAuthGetUserErr, nil)
 	}
 
 	var discordUser DiscordUser
-	err = json.NewDecoder(res2.Body).Decode(&discordUser)
+	err = common.DecodeJson(res2.Body, &discordUser)
 	if err != nil {
 		return nil, err
 	}
 	if discordUser.UID == "" || discordUser.ID == "" {
 		common.SysError("Discord 获取用户信息为空！请检查设置！")
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthUserInfoEmpty, providerParams("Discord")))
+		return nil, oauth.NewOAuthError(i18n.MsgOAuthUserInfoEmpty, providerParams("Discord"))
 	}
 	return &discordUser, nil
 }
@@ -122,7 +121,7 @@ func DiscordOAuth(c *gin.Context) {
 	code := c.Query("code")
 	discordUser, err := getDiscordUserInfoByCode(c, code)
 	if err != nil {
-		common.ApiError(c, err)
+		handleOAuthError(c, err)
 		return
 	}
 	user := model.User{
@@ -178,7 +177,7 @@ func DiscordBind(c *gin.Context) {
 	code := c.Query("code")
 	discordUser, err := getDiscordUserInfoByCode(c, code)
 	if err != nil {
-		common.ApiError(c, err)
+		handleOAuthError(c, err)
 		return
 	}
 	user := model.User{

--- a/controller/github.go
+++ b/controller/github.go
@@ -2,8 +2,6 @@ package controller
 
 import (
 	"bytes"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -12,6 +10,7 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/oauth"
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
@@ -31,10 +30,10 @@ type GitHubUser struct {
 
 func getGitHubUserInfoByCode(c *gin.Context, code string) (*GitHubUser, error) {
 	if code == "" {
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthInvalidCode))
+		return nil, oauth.NewOAuthError(i18n.MsgOAuthInvalidCode, nil)
 	}
 	values := map[string]string{"client_id": common.GitHubClientId, "client_secret": common.GitHubClientSecret, "code": code}
-	jsonData, err := json.Marshal(values)
+	jsonData, err := common.Marshal(values)
 	if err != nil {
 		return nil, err
 	}
@@ -50,11 +49,11 @@ func getGitHubUserInfoByCode(c *gin.Context, code string) (*GitHubUser, error) {
 	res, err := client.Do(req)
 	if err != nil {
 		common.SysLog(err.Error())
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthConnectFailed, providerParams("GitHub")))
+		return nil, oauth.NewOAuthErrorWithRaw(i18n.MsgOAuthConnectFailed, providerParams("GitHub"), err.Error())
 	}
 	defer res.Body.Close()
 	var oAuthResponse GitHubOAuthResponse
-	err = json.NewDecoder(res.Body).Decode(&oAuthResponse)
+	err = common.DecodeJson(res.Body, &oAuthResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -66,16 +65,16 @@ func getGitHubUserInfoByCode(c *gin.Context, code string) (*GitHubUser, error) {
 	res2, err := client.Do(req)
 	if err != nil {
 		common.SysLog(err.Error())
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthConnectFailed, providerParams("GitHub")))
+		return nil, oauth.NewOAuthErrorWithRaw(i18n.MsgOAuthConnectFailed, providerParams("GitHub"), err.Error())
 	}
 	defer res2.Body.Close()
 	var githubUser GitHubUser
-	err = json.NewDecoder(res2.Body).Decode(&githubUser)
+	err = common.DecodeJson(res2.Body, &githubUser)
 	if err != nil {
 		return nil, err
 	}
 	if githubUser.Login == "" {
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthUserInfoEmpty, providerParams("GitHub")))
+		return nil, oauth.NewOAuthError(i18n.MsgOAuthUserInfoEmpty, providerParams("GitHub"))
 	}
 	return &githubUser, nil
 }
@@ -103,7 +102,7 @@ func GitHubOAuth(c *gin.Context) {
 	code := c.Query("code")
 	githubUser, err := getGitHubUserInfoByCode(c, code)
 	if err != nil {
-		common.ApiError(c, err)
+		handleOAuthError(c, err)
 		return
 	}
 	user := model.User{
@@ -170,7 +169,7 @@ func GitHubBind(c *gin.Context) {
 	code := c.Query("code")
 	githubUser, err := getGitHubUserInfoByCode(c, code)
 	if err != nil {
-		common.ApiError(c, err)
+		handleOAuthError(c, err)
 		return
 	}
 	user := model.User{

--- a/controller/github.go
+++ b/controller/github.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
 
 	"github.com/gin-contrib/sessions"
@@ -28,9 +29,9 @@ type GitHubUser struct {
 	Email string `json:"email"`
 }
 
-func getGitHubUserInfoByCode(code string) (*GitHubUser, error) {
+func getGitHubUserInfoByCode(c *gin.Context, code string) (*GitHubUser, error) {
 	if code == "" {
-		return nil, errors.New("无效的参数")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthInvalidCode))
 	}
 	values := map[string]string{"client_id": common.GitHubClientId, "client_secret": common.GitHubClientSecret, "code": code}
 	jsonData, err := json.Marshal(values)
@@ -49,7 +50,7 @@ func getGitHubUserInfoByCode(code string) (*GitHubUser, error) {
 	res, err := client.Do(req)
 	if err != nil {
 		common.SysLog(err.Error())
-		return nil, errors.New("无法连接至 GitHub 服务器，请稍后重试！")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthConnectFailed, providerParams("GitHub")))
 	}
 	defer res.Body.Close()
 	var oAuthResponse GitHubOAuthResponse
@@ -65,7 +66,7 @@ func getGitHubUserInfoByCode(code string) (*GitHubUser, error) {
 	res2, err := client.Do(req)
 	if err != nil {
 		common.SysLog(err.Error())
-		return nil, errors.New("无法连接至 GitHub 服务器，请稍后重试！")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthConnectFailed, providerParams("GitHub")))
 	}
 	defer res2.Body.Close()
 	var githubUser GitHubUser
@@ -74,7 +75,7 @@ func getGitHubUserInfoByCode(code string) (*GitHubUser, error) {
 		return nil, err
 	}
 	if githubUser.Login == "" {
-		return nil, errors.New("返回值非法，用户字段为空，请稍后重试！")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthUserInfoEmpty, providerParams("GitHub")))
 	}
 	return &githubUser, nil
 }
@@ -96,14 +97,11 @@ func GitHubOAuth(c *gin.Context) {
 	}
 
 	if !common.GitHubOAuthEnabled {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "管理员未开启通过 GitHub 登录以及注册",
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthNotEnabled, providerParams("GitHub"))
 		return
 	}
 	code := c.Query("code")
-	githubUser, err := getGitHubUserInfoByCode(code)
+	githubUser, err := getGitHubUserInfoByCode(c, code)
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -124,10 +122,7 @@ func GitHubOAuth(c *gin.Context) {
 		}
 		// if user.Id == 0 , user has been deleted
 		if user.Id == 0 {
-			c.JSON(http.StatusOK, gin.H{
-				"success": false,
-				"message": "用户已注销",
-			})
+			common.ApiErrorI18n(c, i18n.MsgOAuthUserDeleted)
 			return
 		}
 	} else {
@@ -155,19 +150,13 @@ func GitHubOAuth(c *gin.Context) {
 				return
 			}
 		} else {
-			c.JSON(http.StatusOK, gin.H{
-				"success": false,
-				"message": "管理员关闭了新用户注册",
-			})
+			common.ApiErrorI18n(c, i18n.MsgUserRegisterDisabled)
 			return
 		}
 	}
 
 	if user.Status != common.UserStatusEnabled {
-		c.JSON(http.StatusOK, gin.H{
-			"message": "用户已被封禁",
-			"success": false,
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthUserBanned)
 		return
 	}
 	setupLogin(&user, c)
@@ -175,14 +164,11 @@ func GitHubOAuth(c *gin.Context) {
 
 func GitHubBind(c *gin.Context) {
 	if !common.GitHubOAuthEnabled {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "管理员未开启通过 GitHub 登录以及注册",
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthNotEnabled, providerParams("GitHub"))
 		return
 	}
 	code := c.Query("code")
-	githubUser, err := getGitHubUserInfoByCode(code)
+	githubUser, err := getGitHubUserInfoByCode(c, code)
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -191,10 +177,7 @@ func GitHubBind(c *gin.Context) {
 		GitHubId: githubUser.Login,
 	}
 	if model.IsGitHubIdAlreadyTaken(user.GitHubId) {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "该 GitHub 账户已被绑定",
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthAlreadyBound, providerParams("GitHub"))
 		return
 	}
 	session := sessions.Default(c)

--- a/controller/linuxdo.go
+++ b/controller/linuxdo.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
 
 	"github.com/gin-contrib/sessions"
@@ -29,10 +30,7 @@ type LinuxdoUser struct {
 
 func LinuxDoBind(c *gin.Context) {
 	if !common.LinuxDOOAuthEnabled {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "管理员未开启通过 Linux DO 登录以及注册",
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthNotEnabled, providerParams("Linux DO"))
 		return
 	}
 
@@ -48,10 +46,7 @@ func LinuxDoBind(c *gin.Context) {
 	}
 
 	if model.IsLinuxDOIdAlreadyTaken(user.LinuxDOId) {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "该 Linux DO 账户已被绑定",
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthAlreadyBound, providerParams("Linux DO"))
 		return
 	}
 
@@ -80,7 +75,7 @@ func LinuxDoBind(c *gin.Context) {
 
 func getLinuxdoUserInfoByCode(code string, c *gin.Context) (*LinuxdoUser, error) {
 	if code == "" {
-		return nil, errors.New("invalid code")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthInvalidCode))
 	}
 
 	// Get access token using Basic auth
@@ -112,7 +107,7 @@ func getLinuxdoUserInfoByCode(code string, c *gin.Context) (*LinuxdoUser, error)
 	client := http.Client{Timeout: 5 * time.Second}
 	res, err := client.Do(req)
 	if err != nil {
-		return nil, errors.New("failed to connect to Linux DO server")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthConnectFailed, providerParams("Linux DO")))
 	}
 	defer res.Body.Close()
 
@@ -125,7 +120,7 @@ func getLinuxdoUserInfoByCode(code string, c *gin.Context) (*LinuxdoUser, error)
 	}
 
 	if tokenRes.AccessToken == "" {
-		return nil, fmt.Errorf("failed to get access token: %s", tokenRes.Message)
+		return nil, fmt.Errorf("%s: %s", i18n.T(c, i18n.MsgOAuthTokenFailed, providerParams("Linux DO")), tokenRes.Message)
 	}
 
 	// Get user info
@@ -139,7 +134,7 @@ func getLinuxdoUserInfoByCode(code string, c *gin.Context) (*LinuxdoUser, error)
 
 	res2, err := client.Do(req)
 	if err != nil {
-		return nil, errors.New("failed to get user info from Linux DO")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthGetUserErr))
 	}
 	defer res2.Body.Close()
 
@@ -149,7 +144,7 @@ func getLinuxdoUserInfoByCode(code string, c *gin.Context) (*LinuxdoUser, error)
 	}
 
 	if linuxdoUser.Id == 0 {
-		return nil, errors.New("invalid user info returned")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthUserInfoEmpty, providerParams("Linux DO")))
 	}
 
 	return &linuxdoUser, nil
@@ -184,10 +179,7 @@ func LinuxdoOAuth(c *gin.Context) {
 	}
 
 	if !common.LinuxDOOAuthEnabled {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "管理员未开启通过 Linux DO 登录以及注册",
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthNotEnabled, providerParams("Linux DO"))
 		return
 	}
 
@@ -213,10 +205,7 @@ func LinuxdoOAuth(c *gin.Context) {
 			return
 		}
 		if user.Id == 0 {
-			c.JSON(http.StatusOK, gin.H{
-				"success": false,
-				"message": "用户已注销",
-			})
+			common.ApiErrorI18n(c, i18n.MsgOAuthUserDeleted)
 			return
 		}
 	} else {
@@ -241,26 +230,17 @@ func LinuxdoOAuth(c *gin.Context) {
 					return
 				}
 			} else {
-				c.JSON(http.StatusOK, gin.H{
-					"success": false,
-					"message": "Linux DO 信任等级未达到管理员设置的最低信任等级",
-				})
+				common.ApiErrorI18n(c, i18n.MsgOAuthTrustLevelLow)
 				return
 			}
 		} else {
-			c.JSON(http.StatusOK, gin.H{
-				"success": false,
-				"message": "管理员关闭了新用户注册",
-			})
+			common.ApiErrorI18n(c, i18n.MsgUserRegisterDisabled)
 			return
 		}
 	}
 
 	if user.Status != common.UserStatusEnabled {
-		c.JSON(http.StatusOK, gin.H{
-			"message": "用户已被封禁",
-			"success": false,
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthUserBanned)
 		return
 	}
 

--- a/controller/linuxdo.go
+++ b/controller/linuxdo.go
@@ -2,8 +2,6 @@ package controller
 
 import (
 	"encoding/base64"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -14,6 +12,7 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/oauth"
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
@@ -37,7 +36,7 @@ func LinuxDoBind(c *gin.Context) {
 	code := c.Query("code")
 	linuxdoUser, err := getLinuxdoUserInfoByCode(code, c)
 	if err != nil {
-		common.ApiError(c, err)
+		handleOAuthError(c, err)
 		return
 	}
 
@@ -75,7 +74,7 @@ func LinuxDoBind(c *gin.Context) {
 
 func getLinuxdoUserInfoByCode(code string, c *gin.Context) (*LinuxdoUser, error) {
 	if code == "" {
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthInvalidCode))
+		return nil, oauth.NewOAuthError(i18n.MsgOAuthInvalidCode, nil)
 	}
 
 	// Get access token using Basic auth
@@ -107,7 +106,7 @@ func getLinuxdoUserInfoByCode(code string, c *gin.Context) (*LinuxdoUser, error)
 	client := http.Client{Timeout: 5 * time.Second}
 	res, err := client.Do(req)
 	if err != nil {
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthConnectFailed, providerParams("Linux DO")))
+		return nil, oauth.NewOAuthErrorWithRaw(i18n.MsgOAuthConnectFailed, providerParams("Linux DO"), err.Error())
 	}
 	defer res.Body.Close()
 
@@ -115,12 +114,12 @@ func getLinuxdoUserInfoByCode(code string, c *gin.Context) (*LinuxdoUser, error)
 		AccessToken string `json:"access_token"`
 		Message     string `json:"message"`
 	}
-	if err := json.NewDecoder(res.Body).Decode(&tokenRes); err != nil {
+	if err := common.DecodeJson(res.Body, &tokenRes); err != nil {
 		return nil, err
 	}
 
 	if tokenRes.AccessToken == "" {
-		return nil, fmt.Errorf("%s: %s", i18n.T(c, i18n.MsgOAuthTokenFailed, providerParams("Linux DO")), tokenRes.Message)
+		return nil, oauth.NewOAuthErrorWithRaw(i18n.MsgOAuthTokenFailed, providerParams("Linux DO"), tokenRes.Message)
 	}
 
 	// Get user info
@@ -134,17 +133,17 @@ func getLinuxdoUserInfoByCode(code string, c *gin.Context) (*LinuxdoUser, error)
 
 	res2, err := client.Do(req)
 	if err != nil {
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthGetUserErr))
+		return nil, oauth.NewOAuthErrorWithRaw(i18n.MsgOAuthConnectFailed, providerParams("Linux DO"), err.Error())
 	}
 	defer res2.Body.Close()
 
 	var linuxdoUser LinuxdoUser
-	if err := json.NewDecoder(res2.Body).Decode(&linuxdoUser); err != nil {
+	if err := common.DecodeJson(res2.Body, &linuxdoUser); err != nil {
 		return nil, err
 	}
 
 	if linuxdoUser.Id == 0 {
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthUserInfoEmpty, providerParams("Linux DO")))
+		return nil, oauth.NewOAuthError(i18n.MsgOAuthUserInfoEmpty, providerParams("Linux DO"))
 	}
 
 	return &linuxdoUser, nil
@@ -186,7 +185,7 @@ func LinuxdoOAuth(c *gin.Context) {
 	code := c.Query("code")
 	linuxdoUser, err := getLinuxdoUserInfoByCode(code, c)
 	if err != nil {
-		common.ApiError(c, err)
+		handleOAuthError(c, err)
 		return
 	}
 

--- a/controller/oauth.go
+++ b/controller/oauth.go
@@ -19,6 +19,18 @@ func providerParams(name string) map[string]any {
 	return map[string]any{"Provider": name}
 }
 
+func apiOAuthErrorI18n(c *gin.Context, key string, args ...map[string]any) {
+	writeOAuthErrorI18n(c, http.StatusOK, key, args...)
+}
+
+func writeOAuthErrorI18n(c *gin.Context, status int, key string, args ...map[string]any) {
+	c.JSON(status, gin.H{
+		"success": false,
+		"message": i18n.T(c, key, args...),
+		"code":    key,
+	})
+}
+
 // GenerateOAuthCode generates a state code for OAuth CSRF protection
 func GenerateOAuthCode(c *gin.Context) {
 	session := sessions.Default(c)
@@ -45,10 +57,7 @@ func HandleOAuth(c *gin.Context) {
 	providerName := c.Param("provider")
 	provider := oauth.GetProvider(providerName)
 	if provider == nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"success": false,
-			"message": i18n.T(c, i18n.MsgOAuthUnknownProvider),
-		})
+		writeOAuthErrorI18n(c, http.StatusBadRequest, i18n.MsgOAuthUnknownProvider)
 		return
 	}
 
@@ -57,10 +66,7 @@ func HandleOAuth(c *gin.Context) {
 	// 1. Validate state (CSRF protection)
 	state := c.Query("state")
 	if state == "" || session.Get("oauth_state") == nil || state != session.Get("oauth_state").(string) {
-		c.JSON(http.StatusForbidden, gin.H{
-			"success": false,
-			"message": i18n.T(c, i18n.MsgOAuthStateInvalid),
-		})
+		writeOAuthErrorI18n(c, http.StatusForbidden, i18n.MsgOAuthStateInvalid)
 		return
 	}
 
@@ -73,7 +79,7 @@ func HandleOAuth(c *gin.Context) {
 
 	// 3. Check if provider is enabled
 	if !provider.IsEnabled() {
-		common.ApiErrorI18n(c, i18n.MsgOAuthNotEnabled, providerParams(provider.GetName()))
+		apiOAuthErrorI18n(c, i18n.MsgOAuthNotEnabled, providerParams(provider.GetName()))
 		return
 	}
 
@@ -108,9 +114,9 @@ func HandleOAuth(c *gin.Context) {
 	if err != nil {
 		switch err.(type) {
 		case *OAuthUserDeletedError:
-			common.ApiErrorI18n(c, i18n.MsgOAuthUserDeleted)
+			apiOAuthErrorI18n(c, i18n.MsgOAuthUserDeleted)
 		case *OAuthRegistrationDisabledError:
-			common.ApiErrorI18n(c, i18n.MsgUserRegisterDisabled)
+			apiOAuthErrorI18n(c, i18n.MsgUserRegisterDisabled)
 		default:
 			common.ApiError(c, err)
 		}
@@ -119,7 +125,7 @@ func HandleOAuth(c *gin.Context) {
 
 	// 8. Check user status
 	if user.Status != common.UserStatusEnabled {
-		common.ApiErrorI18n(c, i18n.MsgOAuthUserBanned)
+		apiOAuthErrorI18n(c, i18n.MsgOAuthUserBanned)
 		return
 	}
 
@@ -130,7 +136,7 @@ func HandleOAuth(c *gin.Context) {
 // handleOAuthBind handles binding OAuth account to existing user
 func handleOAuthBind(c *gin.Context, provider oauth.Provider) {
 	if !provider.IsEnabled() {
-		common.ApiErrorI18n(c, i18n.MsgOAuthNotEnabled, providerParams(provider.GetName()))
+		apiOAuthErrorI18n(c, i18n.MsgOAuthNotEnabled, providerParams(provider.GetName()))
 		return
 	}
 
@@ -151,13 +157,13 @@ func handleOAuthBind(c *gin.Context, provider oauth.Provider) {
 
 	// Check if this OAuth account is already bound (check both new ID and legacy ID)
 	if provider.IsUserIDTaken(oauthUser.ProviderUserID) {
-		common.ApiErrorI18n(c, i18n.MsgOAuthAlreadyBound, providerParams(provider.GetName()))
+		apiOAuthErrorI18n(c, i18n.MsgOAuthAlreadyBound, providerParams(provider.GetName()))
 		return
 	}
 	// Also check legacy ID to prevent duplicate bindings during migration period
 	if legacyID, ok := oauthUser.Extra["legacy_id"].(string); ok && legacyID != "" {
 		if provider.IsUserIDTaken(legacyID) {
-			common.ApiErrorI18n(c, i18n.MsgOAuthAlreadyBound, providerParams(provider.GetName()))
+			apiOAuthErrorI18n(c, i18n.MsgOAuthAlreadyBound, providerParams(provider.GetName()))
 			return
 		}
 	}
@@ -348,14 +354,14 @@ func handleOAuthError(c *gin.Context, err error) {
 	switch e := err.(type) {
 	case *oauth.OAuthError:
 		if e.Params != nil {
-			common.ApiErrorI18n(c, e.MsgKey, e.Params)
+			apiOAuthErrorI18n(c, e.MsgKey, e.Params)
 		} else {
-			common.ApiErrorI18n(c, e.MsgKey)
+			apiOAuthErrorI18n(c, e.MsgKey)
 		}
 	case *oauth.AccessDeniedError:
 		common.ApiErrorMsg(c, e.Message)
 	case *oauth.TrustLevelError:
-		common.ApiErrorI18n(c, i18n.MsgOAuthTrustLevelLow)
+		apiOAuthErrorI18n(c, i18n.MsgOAuthTrustLevelLow)
 	default:
 		common.ApiError(c, err)
 	}

--- a/controller/oidc.go
+++ b/controller/oidc.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -13,6 +11,7 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/oauth"
 	"github.com/QuantumNous/new-api/setting/system_setting"
 
 	"github.com/gin-contrib/sessions"
@@ -38,7 +37,7 @@ type OidcUser struct {
 
 func getOidcUserInfoByCode(c *gin.Context, code string) (*OidcUser, error) {
 	if code == "" {
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthInvalidCode))
+		return nil, oauth.NewOAuthError(i18n.MsgOAuthInvalidCode, nil)
 	}
 
 	values := url.Values{}
@@ -60,18 +59,18 @@ func getOidcUserInfoByCode(c *gin.Context, code string) (*OidcUser, error) {
 	res, err := client.Do(req)
 	if err != nil {
 		common.SysLog(err.Error())
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthConnectFailed, providerParams("OIDC")))
+		return nil, oauth.NewOAuthErrorWithRaw(i18n.MsgOAuthConnectFailed, providerParams("OIDC"), err.Error())
 	}
 	defer res.Body.Close()
 	var oidcResponse OidcResponse
-	err = json.NewDecoder(res.Body).Decode(&oidcResponse)
+	err = common.DecodeJson(res.Body, &oidcResponse)
 	if err != nil {
 		return nil, err
 	}
 
 	if oidcResponse.AccessToken == "" {
 		common.SysLog("OIDC 获取 Token 失败，请检查设置！")
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthTokenFailed, providerParams("OIDC")))
+		return nil, oauth.NewOAuthError(i18n.MsgOAuthTokenFailed, providerParams("OIDC"))
 	}
 
 	req, err = http.NewRequest("GET", system_setting.GetOIDCSettings().UserInfoEndpoint, nil)
@@ -82,22 +81,22 @@ func getOidcUserInfoByCode(c *gin.Context, code string) (*OidcUser, error) {
 	res2, err := client.Do(req)
 	if err != nil {
 		common.SysLog(err.Error())
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthConnectFailed, providerParams("OIDC")))
+		return nil, oauth.NewOAuthErrorWithRaw(i18n.MsgOAuthConnectFailed, providerParams("OIDC"), err.Error())
 	}
 	defer res2.Body.Close()
 	if res2.StatusCode != http.StatusOK {
 		common.SysLog("OIDC 获取用户信息失败！请检查设置！")
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthGetUserErr))
+		return nil, oauth.NewOAuthError(i18n.MsgOAuthGetUserErr, nil)
 	}
 
 	var oidcUser OidcUser
-	err = json.NewDecoder(res2.Body).Decode(&oidcUser)
+	err = common.DecodeJson(res2.Body, &oidcUser)
 	if err != nil {
 		return nil, err
 	}
 	if oidcUser.OpenID == "" || oidcUser.Email == "" {
 		common.SysLog("OIDC 获取用户信息为空！请检查设置！")
-		return nil, errors.New(i18n.T(c, i18n.MsgOAuthUserInfoEmpty, providerParams("OIDC")))
+		return nil, oauth.NewOAuthError(i18n.MsgOAuthUserInfoEmpty, providerParams("OIDC"))
 	}
 	return &oidcUser, nil
 }
@@ -124,7 +123,7 @@ func OidcAuth(c *gin.Context) {
 	code := c.Query("code")
 	oidcUser, err := getOidcUserInfoByCode(c, code)
 	if err != nil {
-		common.ApiError(c, err)
+		handleOAuthError(c, err)
 		return
 	}
 	user := model.User{
@@ -181,7 +180,7 @@ func OidcBind(c *gin.Context) {
 	code := c.Query("code")
 	oidcUser, err := getOidcUserInfoByCode(c, code)
 	if err != nil {
-		common.ApiError(c, err)
+		handleOAuthError(c, err)
 		return
 	}
 	user := model.User{

--- a/controller/oidc.go
+++ b/controller/oidc.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/setting/system_setting"
 
@@ -35,9 +36,9 @@ type OidcUser struct {
 	Picture           string `json:"picture"`
 }
 
-func getOidcUserInfoByCode(code string) (*OidcUser, error) {
+func getOidcUserInfoByCode(c *gin.Context, code string) (*OidcUser, error) {
 	if code == "" {
-		return nil, errors.New("无效的参数")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthInvalidCode))
 	}
 
 	values := url.Values{}
@@ -59,7 +60,7 @@ func getOidcUserInfoByCode(code string) (*OidcUser, error) {
 	res, err := client.Do(req)
 	if err != nil {
 		common.SysLog(err.Error())
-		return nil, errors.New("无法连接至 OIDC 服务器，请稍后重试！")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthConnectFailed, providerParams("OIDC")))
 	}
 	defer res.Body.Close()
 	var oidcResponse OidcResponse
@@ -70,7 +71,7 @@ func getOidcUserInfoByCode(code string) (*OidcUser, error) {
 
 	if oidcResponse.AccessToken == "" {
 		common.SysLog("OIDC 获取 Token 失败，请检查设置！")
-		return nil, errors.New("OIDC 获取 Token 失败，请检查设置！")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthTokenFailed, providerParams("OIDC")))
 	}
 
 	req, err = http.NewRequest("GET", system_setting.GetOIDCSettings().UserInfoEndpoint, nil)
@@ -81,12 +82,12 @@ func getOidcUserInfoByCode(code string) (*OidcUser, error) {
 	res2, err := client.Do(req)
 	if err != nil {
 		common.SysLog(err.Error())
-		return nil, errors.New("无法连接至 OIDC 服务器，请稍后重试！")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthConnectFailed, providerParams("OIDC")))
 	}
 	defer res2.Body.Close()
 	if res2.StatusCode != http.StatusOK {
 		common.SysLog("OIDC 获取用户信息失败！请检查设置！")
-		return nil, errors.New("OIDC 获取用户信息失败！请检查设置！")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthGetUserErr))
 	}
 
 	var oidcUser OidcUser
@@ -96,7 +97,7 @@ func getOidcUserInfoByCode(code string) (*OidcUser, error) {
 	}
 	if oidcUser.OpenID == "" || oidcUser.Email == "" {
 		common.SysLog("OIDC 获取用户信息为空！请检查设置！")
-		return nil, errors.New("OIDC 获取用户信息为空！请检查设置！")
+		return nil, errors.New(i18n.T(c, i18n.MsgOAuthUserInfoEmpty, providerParams("OIDC")))
 	}
 	return &oidcUser, nil
 }
@@ -117,14 +118,11 @@ func OidcAuth(c *gin.Context) {
 		return
 	}
 	if !system_setting.GetOIDCSettings().Enabled {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "管理员未开启通过 OIDC 登录以及注册",
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthNotEnabled, providerParams("OIDC"))
 		return
 	}
 	code := c.Query("code")
-	oidcUser, err := getOidcUserInfoByCode(code)
+	oidcUser, err := getOidcUserInfoByCode(c, code)
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -163,19 +161,13 @@ func OidcAuth(c *gin.Context) {
 				return
 			}
 		} else {
-			c.JSON(http.StatusOK, gin.H{
-				"success": false,
-				"message": "管理员关闭了新用户注册",
-			})
+			common.ApiErrorI18n(c, i18n.MsgUserRegisterDisabled)
 			return
 		}
 	}
 
 	if user.Status != common.UserStatusEnabled {
-		c.JSON(http.StatusOK, gin.H{
-			"message": "用户已被封禁",
-			"success": false,
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthUserBanned)
 		return
 	}
 	setupLogin(&user, c)
@@ -183,14 +175,11 @@ func OidcAuth(c *gin.Context) {
 
 func OidcBind(c *gin.Context) {
 	if !system_setting.GetOIDCSettings().Enabled {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "管理员未开启通过 OIDC 登录以及注册",
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthNotEnabled, providerParams("OIDC"))
 		return
 	}
 	code := c.Query("code")
-	oidcUser, err := getOidcUserInfoByCode(code)
+	oidcUser, err := getOidcUserInfoByCode(c, code)
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -199,10 +188,7 @@ func OidcBind(c *gin.Context) {
 		OidcId: oidcUser.OpenID,
 	}
 	if model.IsOidcIdAlreadyTaken(user.OidcId) {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "该 OIDC 账户已被绑定",
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthAlreadyBound, providerParams("OIDC"))
 		return
 	}
 	session := sessions.Default(c)

--- a/controller/telegram.go
+++ b/controller/telegram.go
@@ -5,10 +5,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"net/http"
 	"sort"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
 
 	"github.com/gin-contrib/sessions"
@@ -17,26 +17,17 @@ import (
 
 func TelegramBind(c *gin.Context) {
 	if !common.TelegramOAuthEnabled {
-		c.JSON(200, gin.H{
-			"message": "管理员未开启通过 Telegram 登录以及注册",
-			"success": false,
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthNotEnabled, providerParams("Telegram"))
 		return
 	}
 	params := c.Request.URL.Query()
 	if !checkTelegramAuthorization(params, common.TelegramBotToken) {
-		c.JSON(200, gin.H{
-			"message": "无效的请求",
-			"success": false,
-		})
+		common.ApiErrorI18n(c, i18n.MsgInvalidParams)
 		return
 	}
 	telegramId := params["id"][0]
 	if model.IsTelegramIdAlreadyTaken(telegramId) {
-		c.JSON(200, gin.H{
-			"message": "该 Telegram 账户已被绑定",
-			"success": false,
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthAlreadyBound, providerParams("Telegram"))
 		return
 	}
 
@@ -44,25 +35,16 @@ func TelegramBind(c *gin.Context) {
 	id := session.Get("id")
 	user := model.User{Id: id.(int)}
 	if err := user.FillUserById(); err != nil {
-		c.JSON(200, gin.H{
-			"message": err.Error(),
-			"success": false,
-		})
+		common.ApiErrorI18n(c, i18n.MsgAuthUserInfoInvalid)
 		return
 	}
 	if user.Id == 0 {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "用户已注销",
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthUserDeleted)
 		return
 	}
 	user.TelegramId = telegramId
 	if err := user.Update(false); err != nil {
-		c.JSON(200, gin.H{
-			"message": err.Error(),
-			"success": false,
-		})
+		common.ApiError(c, err)
 		return
 	}
 
@@ -71,28 +53,23 @@ func TelegramBind(c *gin.Context) {
 
 func TelegramLogin(c *gin.Context) {
 	if !common.TelegramOAuthEnabled {
-		c.JSON(200, gin.H{
-			"message": "管理员未开启通过 Telegram 登录以及注册",
-			"success": false,
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthNotEnabled, providerParams("Telegram"))
 		return
 	}
 	params := c.Request.URL.Query()
 	if !checkTelegramAuthorization(params, common.TelegramBotToken) {
-		c.JSON(200, gin.H{
-			"message": "无效的请求",
-			"success": false,
-		})
+		common.ApiErrorI18n(c, i18n.MsgInvalidParams)
 		return
 	}
 
 	telegramId := params["id"][0]
+	if !model.IsTelegramIdAlreadyTaken(telegramId) {
+		common.ApiErrorI18n(c, i18n.MsgUserTelegramNotBound)
+		return
+	}
 	user := model.User{TelegramId: telegramId}
 	if err := user.FillUserByTelegramId(); err != nil {
-		c.JSON(200, gin.H{
-			"message": err.Error(),
-			"success": false,
-		})
+		common.ApiErrorI18n(c, i18n.MsgOAuthUserDeleted)
 		return
 	}
 	setupLogin(&user, c)

--- a/controller/telegram.go
+++ b/controller/telegram.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"sort"
 
@@ -13,6 +14,7 @@ import (
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 func TelegramBind(c *gin.Context) {
@@ -69,7 +71,12 @@ func TelegramLogin(c *gin.Context) {
 	}
 	user := model.User{TelegramId: telegramId}
 	if err := user.FillUserByTelegramId(); err != nil {
-		common.ApiErrorI18n(c, i18n.MsgOAuthUserDeleted)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			common.ApiErrorI18n(c, i18n.MsgOAuthUserDeleted)
+			return
+		}
+		common.SysError("Telegram login failed to load user: " + err.Error())
+		common.ApiError(c, err)
 		return
 	}
 	setupLogin(&user, c)

--- a/model/user.go
+++ b/model/user.go
@@ -677,10 +677,7 @@ func (user *User) FillUserByTelegramId() error {
 		return errors.New("Telegram id 为空！")
 	}
 	err := DB.Where(User{TelegramId: user.TelegramId}).First(user).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return errors.New("该 Telegram 账户未绑定")
-	}
-	return nil
+	return err
 }
 
 func IsEmailAlreadyTaken(email string) bool {

--- a/web/default/src/routes/oauth/$provider.tsx
+++ b/web/default/src/routes/oauth/$provider.tsx
@@ -207,7 +207,7 @@ function OAuthCallback() {
           return
         }
         const message = res?.data?.message || 'OAuth failed'
-        const code = res?.data?.code
+        const code: string | undefined = res?.data?.code
         if (!res?.data?.success && !isBindingFlow) {
           // Backend returns stable i18n keys in code for OAuth business errors.
           if (code === OAUTH_ALREADY_BOUND_CODE) {

--- a/web/default/src/routes/oauth/$provider.tsx
+++ b/web/default/src/routes/oauth/$provider.tsx
@@ -31,6 +31,8 @@ import { api, getSelf } from '@/lib/api'
 import { OAuthCallbackScreen } from '@/features/auth/components/oauth-callback-screen'
 import { OAUTH_BIND_STORAGE_KEY } from '@/features/auth/constants'
 
+const OAUTH_ALREADY_BOUND_CODE = 'oauth.already_bound'
+
 type OAuthRequestConfig = AxiosRequestConfig & {
   skipBusinessError?: boolean
 }
@@ -205,9 +207,10 @@ function OAuthCallback() {
           return
         }
         const message = res?.data?.message || 'OAuth failed'
+        const code = res?.data?.code
         if (!res?.data?.success && !isBindingFlow) {
-          // When logging in with an already bound GitHub account, backend may return this message
-          if (message === '该 GitHub 账户已被绑定') {
+          // Backend returns stable i18n keys in code for OAuth business errors.
+          if (code === OAUTH_ALREADY_BOUND_CODE) {
             if (await finalizeLogin()) {
               redirectAfterLogin()
               return


### PR DESCRIPTION
## 变更描述 / Description
OAuth 登录和绑定流程里，部分业务错误之前只能从本地化 message 判断。这个改动让后端 OAuth 业务错误同时返回稳定的 i18n key `code`，default 前端在 GitHub 已绑定账号的兼容登录分支中改为匹配 `code`，不再依赖中文文案。

变更不改变 OAuth 登录、绑定、注册、session 写入流程，只调整错误响应结构和前端判断条件。

## 变更类型 / Type of change
- [x] Bug 修复 (Bug fix)
- [ ] 新功能 (New feature)
- [ ] 性能优化 / 重构 (Refactor)
- [ ] 文档更新 (Documentation)

## 关联任务 / Related Issue
- Part of #3490
- Related to #1906

## 提交前检查项 / Checklist
- [x] 人工确认: 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] 非重复提交: 我已搜索现有 Issues 与 PRs，确认不是重复提交。
- [x] Bug fix 说明: 此 PR 修复 OAuth callback 中依赖中文错误文案判断的问题。
- [x] 变更理解: 我已理解这些更改的工作原理及可能影响。
- [x] 范围聚焦: 本 PR 未包含任何与当前任务无关的代码改动。
- [x] 本地验证: 已在本地运行可用检查；前端 typecheck 因本地 node_modules 缺失 TypeScript 文件无法启动，见下方说明。
- [x] 安全合规: 代码中无敏感凭据，且符合项目代码规范。

## 运行证明 / Proof of Work
```bash
docker run --rm -v "$PWD":/src -w /src golang:1.26.1-alpine gofmt -w controller/discord.go controller/github.go controller/linuxdo.go controller/oauth.go controller/oidc.go controller/telegram.go

git diff --cached --check

git diff --cached -U0 -- controller/discord.go controller/github.go controller/linuxdo.go controller/oauth.go controller/oidc.go controller/telegram.go web/default/src/routes/oauth/\$provider.tsx | rg "^\+.*[\p{Han}]" || true

docker run --rm -v "$PWD":/src -w /src -e GOCACHE=/tmp/go-cache -e GOMODCACHE=/tmp/go-mod-cache golang:1.26.1-alpine go test ./controller
```

结果：
```text
ok  github.com/QuantumNous/new-api/controller
```

前端检查说明：
```text
bun run typecheck
# failed before type checking because local node_modules/typescript/bin/tsc cannot find ../lib/tsc.js
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * OAuth/OIDC error messages are now localized across providers (Discord, GitHub, Linux DO, Telegram, OIDC).
  * Authentication flows use standardized, translated error responses for clearer guidance.

* **Bug Fixes**
  * OAuth callback now reliably detects and handles "already bound" accounts, improving login/bind UX.
  * Telegram login/bind now returns consistent translated errors when an account isn't bound or is deleted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4825)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->