### PR TITLE
fix(quota): localize user-facing errors

### DIFF
--- a/controller/codex_oauth.go
+++ b/controller/codex_oauth.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/relay/channel/codex"
 	"github.com/QuantumNous/new-api/service"
@@ -133,7 +134,7 @@ func completeCodexOAuthWithChannelID(c *gin.Context, channelID int) {
 	code, state, err := parseCodexAuthorizationInput(req.Input)
 	if err != nil {
 		common.SysError("failed to parse codex authorization input: " + err.Error())
-		c.JSON(http.StatusOK, gin.H{"success": false, "message": "Failed to parse authorization information. Please check the input format."})
+		common.ApiErrorI18n(c, i18n.MsgCodexAuthorizationParseFailed)
 		return
 	}
 	if strings.TrimSpace(code) == "" {
@@ -181,7 +182,7 @@ func completeCodexOAuthWithChannelID(c *gin.Context, channelID int) {
 	tokenRes, err := service.ExchangeCodexAuthorizationCodeWithProxy(ctx, code, verifier, channelProxy)
 	if err != nil {
 		common.SysError("failed to exchange codex authorization code: " + err.Error())
-		c.JSON(http.StatusOK, gin.H{"success": false, "message": "Failed to exchange authorization code. Please try again."})
+		common.ApiErrorI18n(c, i18n.MsgCodexAuthorizationExchangeFailed)
 		return
 	}
 

--- a/controller/codex_oauth.go
+++ b/controller/codex_oauth.go
@@ -133,7 +133,7 @@ func completeCodexOAuthWithChannelID(c *gin.Context, channelID int) {
 	code, state, err := parseCodexAuthorizationInput(req.Input)
 	if err != nil {
 		common.SysError("failed to parse codex authorization input: " + err.Error())
-		c.JSON(http.StatusOK, gin.H{"success": false, "message": "解析授权信息失败，请检查输入格式"})
+		c.JSON(http.StatusOK, gin.H{"success": false, "message": "Failed to parse authorization information. Please check the input format."})
 		return
 	}
 	if strings.TrimSpace(code) == "" {
@@ -181,7 +181,7 @@ func completeCodexOAuthWithChannelID(c *gin.Context, channelID int) {
 	tokenRes, err := service.ExchangeCodexAuthorizationCodeWithProxy(ctx, code, verifier, channelProxy)
 	if err != nil {
 		common.SysError("failed to exchange codex authorization code: " + err.Error())
-		c.JSON(http.StatusOK, gin.H{"success": false, "message": "授权码交换失败，请重试"})
+		c.JSON(http.StatusOK, gin.H{"success": false, "message": "Failed to exchange authorization code. Please try again."})
 		return
 	}
 

--- a/controller/codex_usage.go
+++ b/controller/codex_usage.go
@@ -45,7 +45,7 @@ func GetCodexChannelUsage(c *gin.Context) {
 	oauthKey, err := codex.ParseOAuthKey(strings.TrimSpace(ch.Key))
 	if err != nil {
 		common.SysError("failed to parse oauth key: " + err.Error())
-		c.JSON(http.StatusOK, gin.H{"success": false, "message": "解析凭证失败，请检查渠道配置"})
+		c.JSON(http.StatusOK, gin.H{"success": false, "message": "Failed to parse credentials. Please check the channel configuration."})
 		return
 	}
 	accessToken := strings.TrimSpace(oauthKey.AccessToken)
@@ -71,7 +71,7 @@ func GetCodexChannelUsage(c *gin.Context) {
 	statusCode, body, err := service.FetchCodexWhamUsage(ctx, client, ch.GetBaseURL(), accessToken, accountID)
 	if err != nil {
 		common.SysError("failed to fetch codex usage: " + err.Error())
-		c.JSON(http.StatusOK, gin.H{"success": false, "message": "获取用量信息失败，请稍后重试"})
+		c.JSON(http.StatusOK, gin.H{"success": false, "message": "Failed to fetch usage information. Please try again later."})
 		return
 	}
 
@@ -101,7 +101,7 @@ func GetCodexChannelUsage(c *gin.Context) {
 			statusCode, body, err = service.FetchCodexWhamUsage(ctx2, client, ch.GetBaseURL(), oauthKey.AccessToken, accountID)
 			if err != nil {
 				common.SysError("failed to fetch codex usage after refresh: " + err.Error())
-				c.JSON(http.StatusOK, gin.H{"success": false, "message": "获取用量信息失败，请稍后重试"})
+				c.JSON(http.StatusOK, gin.H{"success": false, "message": "Failed to fetch usage information. Please try again later."})
 				return
 			}
 		}

--- a/controller/codex_usage.go
+++ b/controller/codex_usage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/relay/channel/codex"
 	"github.com/QuantumNous/new-api/service"
@@ -45,7 +46,7 @@ func GetCodexChannelUsage(c *gin.Context) {
 	oauthKey, err := codex.ParseOAuthKey(strings.TrimSpace(ch.Key))
 	if err != nil {
 		common.SysError("failed to parse oauth key: " + err.Error())
-		c.JSON(http.StatusOK, gin.H{"success": false, "message": "Failed to parse credentials. Please check the channel configuration."})
+		common.ApiErrorI18n(c, i18n.MsgCodexCredentialParseFailed)
 		return
 	}
 	accessToken := strings.TrimSpace(oauthKey.AccessToken)
@@ -71,7 +72,7 @@ func GetCodexChannelUsage(c *gin.Context) {
 	statusCode, body, err := service.FetchCodexWhamUsage(ctx, client, ch.GetBaseURL(), accessToken, accountID)
 	if err != nil {
 		common.SysError("failed to fetch codex usage: " + err.Error())
-		c.JSON(http.StatusOK, gin.H{"success": false, "message": "Failed to fetch usage information. Please try again later."})
+		common.ApiErrorI18n(c, i18n.MsgCodexUsageFetchFailed)
 		return
 	}
 
@@ -101,7 +102,7 @@ func GetCodexChannelUsage(c *gin.Context) {
 			statusCode, body, err = service.FetchCodexWhamUsage(ctx2, client, ch.GetBaseURL(), oauthKey.AccessToken, accountID)
 			if err != nil {
 				common.SysError("failed to fetch codex usage after refresh: " + err.Error())
-				c.JSON(http.StatusOK, gin.H{"success": false, "message": "Failed to fetch usage information. Please try again later."})
+				common.ApiErrorI18n(c, i18n.MsgCodexUsageFetchFailed)
 				return
 			}
 		}

--- a/i18n/keys.go
+++ b/i18n/keys.go
@@ -118,11 +118,27 @@ const (
 
 // Quota related messages
 const (
-	MsgQuotaNegative        = "quota.negative"
-	MsgQuotaExceedMax       = "quota.exceed_max"
-	MsgQuotaInsufficient    = "quota.insufficient"
-	MsgQuotaWarningInvalid  = "quota.warning_invalid"
-	MsgQuotaThresholdGtZero = "quota.threshold_gt_zero"
+	MsgQuotaNegative                 = "quota.negative"
+	MsgQuotaExceedMax                = "quota.exceed_max"
+	MsgQuotaInsufficient             = "quota.insufficient"
+	MsgQuotaWarningInvalid           = "quota.warning_invalid"
+	MsgQuotaThresholdGtZero          = "quota.threshold_gt_zero"
+	MsgQuotaInsufficientRemaining    = "quota.insufficient_remaining"
+	MsgQuotaReserveFailed            = "quota.reserve_failed"
+	MsgQuotaSubscriptionInsufficient = "quota.subscription_insufficient"
+	MsgQuotaNotifyWalletPrompt       = "quota.notify.wallet_prompt"
+	MsgQuotaNotifySubscriptionPrompt = "quota.notify.subscription_prompt"
+	MsgQuotaNotifyShortContent       = "quota.notify.short_content"
+	MsgQuotaNotifyPlainContent       = "quota.notify.plain_content"
+	MsgQuotaNotifyHTMLContent        = "quota.notify.html_content"
+)
+
+// Codex related messages
+const (
+	MsgCodexAuthorizationParseFailed    = "codex.authorization_parse_failed"
+	MsgCodexAuthorizationExchangeFailed = "codex.authorization_exchange_failed"
+	MsgCodexCredentialParseFailed       = "codex.credential_parse_failed"
+	MsgCodexUsageFetchFailed            = "codex.usage_fetch_failed"
 )
 
 // Subscription related messages

--- a/i18n/locales/en.yaml
+++ b/i18n/locales/en.yaml
@@ -109,6 +109,20 @@ quota.exceed_max: "Quota value exceeds valid range"
 quota.insufficient: "Insufficient quota"
 quota.warning_invalid: "Invalid warning type"
 quota.threshold_gt_zero: "Warning threshold must be greater than 0"
+quota.insufficient_remaining: "Insufficient quota, remaining quota: {{.Remaining}}"
+quota.reserve_failed: "Failed to reserve quota, remaining quota: {{.Remaining}}, required quota: {{.Required}}"
+quota.subscription_insufficient: "Subscription quota is insufficient or no subscription is configured: {{.Error}}"
+quota.notify.wallet_prompt: "Your quota is running low"
+quota.notify.subscription_prompt: "Your subscription quota is running low"
+quota.notify.short_content: "{{.Prompt}}. Remaining quota: {{.Remaining}}. Please top up soon."
+quota.notify.plain_content: "{{.Prompt}}. Current remaining quota: {{.Remaining}}. Please top up soon."
+quota.notify.html_content: "{{.Prompt}}. Current remaining quota: {{.Remaining}}. To avoid service interruption, please top up soon.<br/>Top-up link: <a href='{{.TopUpLink}}'>{{.TopUpLink}}</a>"
+
+# Codex messages
+codex.authorization_parse_failed: "Failed to parse authorization information. Please check the input format."
+codex.authorization_exchange_failed: "Failed to exchange authorization code. Please try again."
+codex.credential_parse_failed: "Failed to parse credentials. Please check the channel configuration."
+codex.usage_fetch_failed: "Failed to fetch usage information. Please try again later."
 
 # Subscription messages
 subscription.not_enabled: "Subscription plan is not enabled"

--- a/i18n/locales/zh-CN.yaml
+++ b/i18n/locales/zh-CN.yaml
@@ -110,6 +110,20 @@ quota.exceed_max: "额度值超出有效范围"
 quota.insufficient: "额度不足"
 quota.warning_invalid: "无效的预警类型"
 quota.threshold_gt_zero: "预警阈值必须大于0"
+quota.insufficient_remaining: "用户额度不足，剩余额度：{{.Remaining}}"
+quota.reserve_failed: "预扣费额度失败，用户剩余额度：{{.Remaining}}，需要预扣费额度：{{.Required}}"
+quota.subscription_insufficient: "订阅额度不足或未配置订阅：{{.Error}}"
+quota.notify.wallet_prompt: "您的额度即将用尽"
+quota.notify.subscription_prompt: "您的订阅额度即将用尽"
+quota.notify.short_content: "{{.Prompt}}，剩余额度：{{.Remaining}}，请及时充值"
+quota.notify.plain_content: "{{.Prompt}}，当前剩余额度为 {{.Remaining}}，请及时充值。"
+quota.notify.html_content: "{{.Prompt}}，当前剩余额度为 {{.Remaining}}，为了不影响您的使用，请及时充值。<br/>充值链接：<a href='{{.TopUpLink}}'>{{.TopUpLink}}</a>"
+
+# Codex messages
+codex.authorization_parse_failed: "解析授权信息失败，请检查输入格式"
+codex.authorization_exchange_failed: "授权码交换失败，请重试"
+codex.credential_parse_failed: "解析凭证失败，请检查渠道配置"
+codex.usage_fetch_failed: "获取用量信息失败，请稍后重试"
 
 # Subscription messages
 subscription.not_enabled: "套餐未启用"

--- a/i18n/locales/zh-TW.yaml
+++ b/i18n/locales/zh-TW.yaml
@@ -110,6 +110,20 @@ quota.exceed_max: "額度值超出有效範圍"
 quota.insufficient: "額度不足"
 quota.warning_invalid: "無效的預警類型"
 quota.threshold_gt_zero: "預警閾值必須大於0"
+quota.insufficient_remaining: "使用者額度不足，剩餘額度：{{.Remaining}}"
+quota.reserve_failed: "預扣費額度失敗，使用者剩餘額度：{{.Remaining}}，需要預扣費額度：{{.Required}}"
+quota.subscription_insufficient: "訂閱額度不足或未設定訂閱：{{.Error}}"
+quota.notify.wallet_prompt: "您的額度即將用盡"
+quota.notify.subscription_prompt: "您的訂閱額度即將用盡"
+quota.notify.short_content: "{{.Prompt}}，剩餘額度：{{.Remaining}}，請及時充值"
+quota.notify.plain_content: "{{.Prompt}}，目前剩餘額度為 {{.Remaining}}，請及時充值。"
+quota.notify.html_content: "{{.Prompt}}，目前剩餘額度為 {{.Remaining}}，為了不影響您的使用，請及時充值。<br/>充值連結：<a href='{{.TopUpLink}}'>{{.TopUpLink}}</a>"
+
+# Codex messages
+codex.authorization_parse_failed: "解析授權資訊失敗，請檢查輸入格式"
+codex.authorization_exchange_failed: "授權碼交換失敗，請重試"
+codex.credential_parse_failed: "解析憑證失敗，請檢查管道設定"
+codex.usage_fetch_failed: "取得用量資訊失敗，請稍後重試"
 
 # Subscription messages
 subscription.not_enabled: "訂閱方案未啟用"

--- a/service/billing_session.go
+++ b/service/billing_session.go
@@ -216,7 +216,7 @@ func (s *BillingSession) preConsume(c *gin.Context, quota int) *types.NewAPIErro
 		// TODO: model 层应定义哨兵错误（如 ErrNoActiveSubscription），用 errors.Is 替代字符串匹配
 		errMsg := err.Error()
 		if strings.Contains(errMsg, "no active subscription") || strings.Contains(errMsg, "subscription quota insufficient") {
-			return types.NewErrorWithStatusCode(fmt.Errorf("订阅额度不足或未配置订阅: %s", errMsg), types.ErrorCodeInsufficientUserQuota, http.StatusForbidden, types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
+			return types.NewErrorWithStatusCode(fmt.Errorf("subscription quota is insufficient or no subscription is configured: %s", errMsg), types.ErrorCodeInsufficientUserQuota, http.StatusForbidden, types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
 		}
 		return types.NewError(err, types.ErrorCodeUpdateDataError, types.ErrOptionWithSkipRetry())
 	}
@@ -240,7 +240,7 @@ func (s *BillingSession) reserveFunding(delta int) error {
 	case *SubscriptionFunding:
 		if err := model.PostConsumeUserSubscriptionDelta(funding.subscriptionId, int64(delta)); err != nil {
 			return types.NewErrorWithStatusCode(
-				fmt.Errorf("订阅额度不足或未配置订阅: %s", err.Error()),
+				fmt.Errorf("subscription quota is insufficient or no subscription is configured: %s", err.Error()),
 				types.ErrorCodeInsufficientUserQuota,
 				http.StatusForbidden,
 				types.ErrOptionWithSkipRetry(),
@@ -354,13 +354,13 @@ func NewBillingSession(c *gin.Context, relayInfo *relaycommon.RelayInfo, preCons
 		}
 		if userQuota <= 0 {
 			return nil, types.NewErrorWithStatusCode(
-				fmt.Errorf("用户额度不足, 剩余额度: %s", logger.FormatQuota(userQuota)),
+				fmt.Errorf("insufficient quota, remaining quota: %s", logger.FormatQuota(userQuota)),
 				types.ErrorCodeInsufficientUserQuota, http.StatusForbidden,
 				types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
 		}
 		if userQuota-preConsumedQuota < 0 {
 			return nil, types.NewErrorWithStatusCode(
-				fmt.Errorf("预扣费额度失败, 用户剩余额度: %s, 需要预扣费额度: %s", logger.FormatQuota(userQuota), logger.FormatQuota(preConsumedQuota)),
+				fmt.Errorf("failed to reserve quota, remaining quota: %s, required quota: %s", logger.FormatQuota(userQuota), logger.FormatQuota(preConsumedQuota)),
 				types.ErrorCodeInsufficientUserQuota, http.StatusForbidden,
 				types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
 		}

--- a/service/billing_session.go
+++ b/service/billing_session.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/logger"
 	"github.com/QuantumNous/new-api/model"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
@@ -216,7 +217,7 @@ func (s *BillingSession) preConsume(c *gin.Context, quota int) *types.NewAPIErro
 		// TODO: model 层应定义哨兵错误（如 ErrNoActiveSubscription），用 errors.Is 替代字符串匹配
 		errMsg := err.Error()
 		if strings.Contains(errMsg, "no active subscription") || strings.Contains(errMsg, "subscription quota insufficient") {
-			return types.NewErrorWithStatusCode(fmt.Errorf("subscription quota is insufficient or no subscription is configured: %s", errMsg), types.ErrorCodeInsufficientUserQuota, http.StatusForbidden, types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
+			return types.NewErrorWithStatusCode(fmt.Errorf("%s", i18n.T(c, i18n.MsgQuotaSubscriptionInsufficient, map[string]any{"Error": errMsg})), types.ErrorCodeInsufficientUserQuota, http.StatusForbidden, types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
 		}
 		return types.NewError(err, types.ErrorCodeUpdateDataError, types.ErrOptionWithSkipRetry())
 	}
@@ -240,7 +241,7 @@ func (s *BillingSession) reserveFunding(delta int) error {
 	case *SubscriptionFunding:
 		if err := model.PostConsumeUserSubscriptionDelta(funding.subscriptionId, int64(delta)); err != nil {
 			return types.NewErrorWithStatusCode(
-				fmt.Errorf("subscription quota is insufficient or no subscription is configured: %s", err.Error()),
+				fmt.Errorf("%s", i18n.Translate(s.relayInfo.UserSetting.Language, i18n.MsgQuotaSubscriptionInsufficient, map[string]any{"Error": err.Error()})),
 				types.ErrorCodeInsufficientUserQuota,
 				http.StatusForbidden,
 				types.ErrOptionWithSkipRetry(),
@@ -354,13 +355,13 @@ func NewBillingSession(c *gin.Context, relayInfo *relaycommon.RelayInfo, preCons
 		}
 		if userQuota <= 0 {
 			return nil, types.NewErrorWithStatusCode(
-				fmt.Errorf("insufficient quota, remaining quota: %s", logger.FormatQuota(userQuota)),
+				fmt.Errorf("%s", i18n.T(c, i18n.MsgQuotaInsufficientRemaining, map[string]any{"Remaining": logger.FormatQuota(userQuota)})),
 				types.ErrorCodeInsufficientUserQuota, http.StatusForbidden,
 				types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
 		}
 		if userQuota-preConsumedQuota < 0 {
 			return nil, types.NewErrorWithStatusCode(
-				fmt.Errorf("failed to reserve quota, remaining quota: %s, required quota: %s", logger.FormatQuota(userQuota), logger.FormatQuota(preConsumedQuota)),
+				fmt.Errorf("%s", i18n.T(c, i18n.MsgQuotaReserveFailed, map[string]any{"Remaining": logger.FormatQuota(userQuota), "Required": logger.FormatQuota(preConsumedQuota)})),
 				types.ErrorCodeInsufficientUserQuota, http.StatusForbidden,
 				types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
 		}

--- a/service/pre_consume_quota.go
+++ b/service/pre_consume_quota.go
@@ -36,10 +36,10 @@ func PreConsumeQuota(c *gin.Context, preConsumedQuota int, relayInfo *relaycommo
 		return types.NewError(err, types.ErrorCodeQueryDataError, types.ErrOptionWithSkipRetry())
 	}
 	if userQuota <= 0 {
-		return types.NewErrorWithStatusCode(fmt.Errorf("用户额度不足, 剩余额度: %s", logger.FormatQuota(userQuota)), types.ErrorCodeInsufficientUserQuota, http.StatusForbidden, types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
+		return types.NewErrorWithStatusCode(fmt.Errorf("insufficient quota, remaining quota: %s", logger.FormatQuota(userQuota)), types.ErrorCodeInsufficientUserQuota, http.StatusForbidden, types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
 	}
 	if userQuota-preConsumedQuota < 0 {
-		return types.NewErrorWithStatusCode(fmt.Errorf("预扣费额度失败, 用户剩余额度: %s, 需要预扣费额度: %s", logger.FormatQuota(userQuota), logger.FormatQuota(preConsumedQuota)), types.ErrorCodeInsufficientUserQuota, http.StatusForbidden, types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
+		return types.NewErrorWithStatusCode(fmt.Errorf("failed to reserve quota, remaining quota: %s, required quota: %s", logger.FormatQuota(userQuota), logger.FormatQuota(preConsumedQuota)), types.ErrorCodeInsufficientUserQuota, http.StatusForbidden, types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
 	}
 
 	trustQuota := common.GetTrustQuota()

--- a/service/pre_consume_quota.go
+++ b/service/pre_consume_quota.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/logger"
 	"github.com/QuantumNous/new-api/model"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
@@ -36,10 +37,10 @@ func PreConsumeQuota(c *gin.Context, preConsumedQuota int, relayInfo *relaycommo
 		return types.NewError(err, types.ErrorCodeQueryDataError, types.ErrOptionWithSkipRetry())
 	}
 	if userQuota <= 0 {
-		return types.NewErrorWithStatusCode(fmt.Errorf("insufficient quota, remaining quota: %s", logger.FormatQuota(userQuota)), types.ErrorCodeInsufficientUserQuota, http.StatusForbidden, types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
+		return types.NewErrorWithStatusCode(fmt.Errorf("%s", i18n.T(c, i18n.MsgQuotaInsufficientRemaining, map[string]any{"Remaining": logger.FormatQuota(userQuota)})), types.ErrorCodeInsufficientUserQuota, http.StatusForbidden, types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
 	}
 	if userQuota-preConsumedQuota < 0 {
-		return types.NewErrorWithStatusCode(fmt.Errorf("failed to reserve quota, remaining quota: %s, required quota: %s", logger.FormatQuota(userQuota), logger.FormatQuota(preConsumedQuota)), types.ErrorCodeInsufficientUserQuota, http.StatusForbidden, types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
+		return types.NewErrorWithStatusCode(fmt.Errorf("%s", i18n.T(c, i18n.MsgQuotaReserveFailed, map[string]any{"Remaining": logger.FormatQuota(userQuota), "Required": logger.FormatQuota(preConsumedQuota)})), types.ErrorCodeInsufficientUserQuota, http.StatusForbidden, types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
 	}
 
 	trustQuota := common.GetTrustQuota()

--- a/service/quota.go
+++ b/service/quota.go
@@ -472,7 +472,6 @@ func checkAndSendQuotaNotify(relayInfo *relaycommon.RelayInfo, quota int, preCon
 
 			// 根据通知方式生成不同的内容格式
 			var content string
-			var values []interface{}
 
 			notifyType := userSetting.NotifyType
 			if notifyType == "" {
@@ -489,7 +488,7 @@ func checkAndSendQuotaNotify(relayInfo *relaycommon.RelayInfo, quota int, preCon
 				content = i18n.Translate(lang, i18n.MsgQuotaNotifyHTMLContent, map[string]any{"Prompt": prompt, "Remaining": logger.FormatQuota(relayInfo.UserQuota), "TopUpLink": topUpLink})
 			}
 
-			err := NotifyUser(relayInfo.UserId, relayInfo.UserEmail, relayInfo.UserSetting, dto.NewNotify(dto.NotifyTypeQuotaExceed, prompt, content, values))
+			err := NotifyUser(relayInfo.UserId, relayInfo.UserEmail, relayInfo.UserSetting, dto.NewNotify(dto.NotifyTypeQuotaExceed, prompt, content, nil))
 			if err != nil {
 				common.SysError(fmt.Sprintf("failed to send quota notify to user %d: %s", relayInfo.UserId, err.Error()))
 			}
@@ -523,7 +522,6 @@ func checkAndSendSubscriptionQuotaNotify(relayInfo *relaycommon.RelayInfo) {
 		topUpLink := PaymentReturnURL("/console/topup")
 
 		var content string
-		var values []interface{}
 		notifyType := userSetting.NotifyType
 		if notifyType == "" {
 			notifyType = dto.NotifyTypeEmail
@@ -537,7 +535,7 @@ func checkAndSendSubscriptionQuotaNotify(relayInfo *relaycommon.RelayInfo) {
 			content = i18n.Translate(lang, i18n.MsgQuotaNotifyHTMLContent, map[string]any{"Prompt": prompt, "Remaining": logger.FormatQuota(int(remaining)), "TopUpLink": topUpLink})
 		}
 
-		if err := NotifyUser(relayInfo.UserId, relayInfo.UserEmail, relayInfo.UserSetting, dto.NewNotify(dto.NotifyTypeQuotaExceed, prompt, content, values)); err != nil {
+		if err := NotifyUser(relayInfo.UserId, relayInfo.UserEmail, relayInfo.UserSetting, dto.NewNotify(dto.NotifyTypeQuotaExceed, prompt, content, nil)); err != nil {
 			common.SysError(fmt.Sprintf("failed to send subscription quota notify to user %d: %s", relayInfo.UserId, err.Error()))
 		}
 	})

--- a/service/quota.go
+++ b/service/quota.go
@@ -382,7 +382,7 @@ func PostAudioConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, u
 
 func PreConsumeTokenQuota(relayInfo *relaycommon.RelayInfo, quota int) error {
 	if quota < 0 {
-		return errors.New("quota 不能为负数！")
+		return errors.New("quota cannot be negative")
 	}
 	if relayInfo.IsPlayground {
 		return nil
@@ -465,7 +465,7 @@ func checkAndSendQuotaNotify(relayInfo *relaycommon.RelayInfo, quota int, preCon
 			quotaTooLow = true
 		}
 		if quotaTooLow {
-			prompt := "您的额度即将用尽"
+			prompt := "Your quota is running low"
 			topUpLink := PaymentReturnURL("/console/topup")
 
 			// 根据通知方式生成不同的内容格式
@@ -479,14 +479,14 @@ func checkAndSendQuotaNotify(relayInfo *relaycommon.RelayInfo, quota int, preCon
 
 			if notifyType == dto.NotifyTypeBark {
 				// Bark推送使用简短文本，不支持HTML
-				content = "{{value}}，剩余额度：{{value}}，请及时充值"
+				content = "{{value}}. Remaining quota: {{value}}. Please top up soon."
 				values = []interface{}{prompt, logger.FormatQuota(relayInfo.UserQuota)}
 			} else if notifyType == dto.NotifyTypeGotify {
-				content = "{{value}}，当前剩余额度为 {{value}}，请及时充值。"
+				content = "{{value}}. Current remaining quota: {{value}}. Please top up soon."
 				values = []interface{}{prompt, logger.FormatQuota(relayInfo.UserQuota)}
 			} else {
 				// 默认内容格式，适用于Email和Webhook（支持HTML）
-				content = "{{value}}，当前剩余额度为 {{value}}，为了不影响您的使用，请及时充值。<br/>充值链接：<a href='{{value}}'>{{value}}</a>"
+				content = "{{value}}. Current remaining quota: {{value}}. To avoid service interruption, please top up soon.<br/>Top-up link: <a href='{{value}}'>{{value}}</a>"
 				values = []interface{}{prompt, logger.FormatQuota(relayInfo.UserQuota), topUpLink, topUpLink}
 			}
 
@@ -519,7 +519,7 @@ func checkAndSendSubscriptionQuotaNotify(relayInfo *relaycommon.RelayInfo) {
 			return
 		}
 
-		prompt := "您的订阅额度即将用尽"
+		prompt := "Your subscription quota is running low"
 		topUpLink := PaymentReturnURL("/console/topup")
 
 		var content string
@@ -530,13 +530,13 @@ func checkAndSendSubscriptionQuotaNotify(relayInfo *relaycommon.RelayInfo) {
 		}
 
 		if notifyType == dto.NotifyTypeBark {
-			content = "{{value}}，剩余额度：{{value}}，请及时充值"
+			content = "{{value}}. Remaining quota: {{value}}. Please top up soon."
 			values = []interface{}{prompt, logger.FormatQuota(int(remaining))}
 		} else if notifyType == dto.NotifyTypeGotify {
-			content = "{{value}}，当前剩余额度为 {{value}}，请及时充值。"
+			content = "{{value}}. Current remaining quota: {{value}}. Please top up soon."
 			values = []interface{}{prompt, logger.FormatQuota(int(remaining))}
 		} else {
-			content = "{{value}}，当前剩余额度为 {{value}}，为了不影响您的使用，请及时充值。<br/>充值链接：<a href='{{value}}'>{{value}}</a>"
+			content = "{{value}}. Current remaining quota: {{value}}. To avoid service interruption, please top up soon.<br/>Top-up link: <a href='{{value}}'>{{value}}</a>"
 			values = []interface{}{prompt, logger.FormatQuota(int(remaining)), topUpLink, topUpLink}
 		}
 

--- a/service/quota.go
+++ b/service/quota.go
@@ -11,6 +11,7 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/logger"
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/pkg/billingexpr"
@@ -382,7 +383,7 @@ func PostAudioConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, u
 
 func PreConsumeTokenQuota(relayInfo *relaycommon.RelayInfo, quota int) error {
 	if quota < 0 {
-		return errors.New("quota cannot be negative")
+		return errors.New(i18n.Translate(relayInfo.UserSetting.Language, i18n.MsgQuotaNegative))
 	}
 	if relayInfo.IsPlayground {
 		return nil
@@ -465,7 +466,8 @@ func checkAndSendQuotaNotify(relayInfo *relaycommon.RelayInfo, quota int, preCon
 			quotaTooLow = true
 		}
 		if quotaTooLow {
-			prompt := "Your quota is running low"
+			lang := relayInfo.UserSetting.Language
+			prompt := i18n.Translate(lang, i18n.MsgQuotaNotifyWalletPrompt)
 			topUpLink := PaymentReturnURL("/console/topup")
 
 			// 根据通知方式生成不同的内容格式
@@ -479,15 +481,12 @@ func checkAndSendQuotaNotify(relayInfo *relaycommon.RelayInfo, quota int, preCon
 
 			if notifyType == dto.NotifyTypeBark {
 				// Bark推送使用简短文本，不支持HTML
-				content = "{{value}}. Remaining quota: {{value}}. Please top up soon."
-				values = []interface{}{prompt, logger.FormatQuota(relayInfo.UserQuota)}
+				content = i18n.Translate(lang, i18n.MsgQuotaNotifyShortContent, map[string]any{"Prompt": prompt, "Remaining": logger.FormatQuota(relayInfo.UserQuota)})
 			} else if notifyType == dto.NotifyTypeGotify {
-				content = "{{value}}. Current remaining quota: {{value}}. Please top up soon."
-				values = []interface{}{prompt, logger.FormatQuota(relayInfo.UserQuota)}
+				content = i18n.Translate(lang, i18n.MsgQuotaNotifyPlainContent, map[string]any{"Prompt": prompt, "Remaining": logger.FormatQuota(relayInfo.UserQuota)})
 			} else {
 				// 默认内容格式，适用于Email和Webhook（支持HTML）
-				content = "{{value}}. Current remaining quota: {{value}}. To avoid service interruption, please top up soon.<br/>Top-up link: <a href='{{value}}'>{{value}}</a>"
-				values = []interface{}{prompt, logger.FormatQuota(relayInfo.UserQuota), topUpLink, topUpLink}
+				content = i18n.Translate(lang, i18n.MsgQuotaNotifyHTMLContent, map[string]any{"Prompt": prompt, "Remaining": logger.FormatQuota(relayInfo.UserQuota), "TopUpLink": topUpLink})
 			}
 
 			err := NotifyUser(relayInfo.UserId, relayInfo.UserEmail, relayInfo.UserSetting, dto.NewNotify(dto.NotifyTypeQuotaExceed, prompt, content, values))
@@ -519,7 +518,8 @@ func checkAndSendSubscriptionQuotaNotify(relayInfo *relaycommon.RelayInfo) {
 			return
 		}
 
-		prompt := "Your subscription quota is running low"
+		lang := relayInfo.UserSetting.Language
+		prompt := i18n.Translate(lang, i18n.MsgQuotaNotifySubscriptionPrompt)
 		topUpLink := PaymentReturnURL("/console/topup")
 
 		var content string
@@ -530,14 +530,11 @@ func checkAndSendSubscriptionQuotaNotify(relayInfo *relaycommon.RelayInfo) {
 		}
 
 		if notifyType == dto.NotifyTypeBark {
-			content = "{{value}}. Remaining quota: {{value}}. Please top up soon."
-			values = []interface{}{prompt, logger.FormatQuota(int(remaining))}
+			content = i18n.Translate(lang, i18n.MsgQuotaNotifyShortContent, map[string]any{"Prompt": prompt, "Remaining": logger.FormatQuota(int(remaining))})
 		} else if notifyType == dto.NotifyTypeGotify {
-			content = "{{value}}. Current remaining quota: {{value}}. Please top up soon."
-			values = []interface{}{prompt, logger.FormatQuota(int(remaining))}
+			content = i18n.Translate(lang, i18n.MsgQuotaNotifyPlainContent, map[string]any{"Prompt": prompt, "Remaining": logger.FormatQuota(int(remaining))})
 		} else {
-			content = "{{value}}. Current remaining quota: {{value}}. To avoid service interruption, please top up soon.<br/>Top-up link: <a href='{{value}}'>{{value}}</a>"
-			values = []interface{}{prompt, logger.FormatQuota(int(remaining)), topUpLink, topUpLink}
+			content = i18n.Translate(lang, i18n.MsgQuotaNotifyHTMLContent, map[string]any{"Prompt": prompt, "Remaining": logger.FormatQuota(int(remaining)), "TopUpLink": topUpLink})
 		}
 
 		if err := NotifyUser(relayInfo.UserId, relayInfo.UserEmail, relayInfo.UserSetting, dto.NewNotify(dto.NotifyTypeQuotaExceed, prompt, content, values)); err != nil {


### PR DESCRIPTION
## 变更描述 / Description
将 Codex OAuth/usage、预扣费、订阅扣费、quota 通知中普通用户可能直接看到的中文文案改为英文。

这个 PR 只替换错误和通知文本，不改变 quota 计算、预扣费、订阅回退、通知发送或充值链接生成逻辑。冲突处理时保留了当前 main 的 `PaymentReturnURL("/console/topup")` 行为。

## 变更类型 / Type of change
- [x] Bug 修复 (Bug fix)
- [ ] 新功能 (New feature)
- [ ] 性能优化 / 重构 (Refactor)
- [ ] 文档更新 (Documentation)

## 关联任务 / Related Issue
- Part of #3490
- Related to #1906

## 提交前检查项 / Checklist
- [x] 人工确认: 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] 非重复提交: 我已搜索现有 Issues 与 PRs，确认不是重复提交。
- [x] Bug fix 说明: 此 PR 修复英文用户侧 quota/Codex 相关流程仍可能返回中文文案的问题。
- [x] 变更理解: 我已理解这些更改的工作原理及可能影响。
- [x] 范围聚焦: 本 PR 未包含任何与当前任务无关的代码改动。
- [x] 本地验证: 已在本地运行并通过测试。
- [x] 安全合规: 代码中无敏感凭据，且符合项目代码规范。

## 运行证明 / Proof of Work
```bash
docker run --rm -v "$PWD":/src -w /src golang:1.26.1-alpine gofmt -w controller/codex_oauth.go controller/codex_usage.go service/billing_session.go service/pre_consume_quota.go service/quota.go

git diff --cached --check

git diff --cached -U0 -- controller/codex_oauth.go controller/codex_usage.go service/billing_session.go service/pre_consume_quota.go service/quota.go | rg "^\+.*[\p{Han}]" || true

docker run --rm -v "$PWD":/src -w /src -e GOCACHE=/tmp/go-cache -e GOMODCACHE=/tmp/go-mod-cache golang:1.26.1-alpine go test ./controller ./service
```

结果：
```text
ok  github.com/QuantumNous/new-api/controller
ok  github.com/QuantumNous/new-api/service
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced hardcoded Chinese error messages with localized i18n messages across OAuth, usage retrieval, billing, and quota flows to provide consistent user-facing messaging.
* **New Features**
  * Added new translation keys and English/Chinese/Traditional Chinese messages for quota notifications and Codex-related errors (authorization, credential parsing, exchange, and usage fetch).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->