### PR TITLE
fix: GetAllChannels ignores group filter parameter

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -85,6 +85,8 @@ func GetAllChannels(c *gin.Context) {
 			typeFilter = t
 		}
 	}
+	// group filter
+	groupFilter := c.Query("group")
 
 	var total int64
 
@@ -114,6 +116,11 @@ func GetAllChannels(c *gin.Context) {
 				if typeFilter >= 0 && ch.Type != typeFilter {
 					continue
 				}
+				if groupFilter != "" && groupFilter != "null" {
+					if !strings.Contains(","+ch.Group+",", ","+groupFilter+",") {
+						continue
+					}
+				}
 				filtered = append(filtered, ch)
 			}
 			channelData = append(channelData, filtered...)
@@ -128,6 +135,14 @@ func GetAllChannels(c *gin.Context) {
 			baseQuery = baseQuery.Where("status = ?", common.ChannelStatusEnabled)
 		} else if statusFilter == 0 {
 			baseQuery = baseQuery.Where("status != ?", common.ChannelStatusEnabled)
+		}
+		if groupFilter != "" && groupFilter != "null" {
+			if common.UsingMySQL {
+				baseQuery = baseQuery.Where("CONCAT(',', `group`, ',') LIKE ?", "%,"+groupFilter+",%")
+			} else {
+				// SQLite, PostgreSQL
+				baseQuery = baseQuery.Where("(',' || \"group\" || ',') LIKE ?", "%,"+groupFilter+",%")
+			}
 		}
 
 		baseQuery.Count(&total)


### PR DESCRIPTION
## Problem

When users filter channels by group without entering a search keyword, the group filter has no effect.

**Root cause:** The frontend determines whether to call `GetAllChannels` (GET /api/channel/) or `SearchChannels` (GET /api/channel/search) based on whether a keyword/model filter is present. When only the group filter is selected, `GetAllChannels` is called, but it completely ignores the `group` query parameter.

## Fix

Added group filtering logic to `GetAllChannels()` in `controller/channel.go`:
- Normal mode: Added SQL WHERE clause using `CONCAT(',', group, ',') LIKE ?` (MySQL) / `(',' || "group" || ',') LIKE ?` (PostgreSQL/SQLite)
- Tag mode: Added in-memory filtering with `strings.Contains`

This matches the existing pattern used in `SearchChannels()` and `model.SearchChannels()`.

## Testing

- Filter by group without keyword → now correctly returns only channels in that group
- Filter by group + status/type → works correctly with combined filters
- Tag mode + group filter → works correctly
- No group filter → behavior unchanged (returns all channels)


---
## 问题

用户在渠道列表页面仅按分组筛选（不输入搜索关键词）时，筛选无效，返回全部渠道。

**根因：** 前端根据是否有关键词/模型筛选来决定调用 `GetAllChannels`（GET /api/channel/）还是 `SearchChannels`（GET /api/channel/search）。当只选择了分组筛选时，走的是 `GetAllChannels`，但该函数完全忽略了 `group` 查询参数。

## 修复

在 `controller/channel.go` 的 `GetAllChannels()` 中补充了分组筛选逻辑：

- **普通模式：** 添加 SQL WHERE 条件，使用 `CONCAT(',', group, ',') LIKE ?`（MySQL）/ `(',' || "group" || ',') LIKE ?`（PostgreSQL/SQLite），兼容三种数据库
- **标签模式：** 添加内存过滤，使用 `strings.Contains` 匹配逗号分隔的分组字段

实现方式与已有的 `SearchChannels()` 和 `model.SearchChannels()` 保持一致。

## 测试

- 仅按分组筛选（无关键词）→ 正确返回该分组下的渠道
- 分组 + 状态/类型组合筛选 → 正常工作
- 标签模式 + 分组筛选 → 正常工作
- 不选分组 → 行为不变，返回全部渠道

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering channels by group using a query parameter in the channels API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4847)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->