### PR TITLE
fix: 修复多个关键生产问题 — 数据库兼容性、安全超时与 HTTP 响应体泄漏

### DIFF
--- a/common/init.go
+++ b/common/init.go
@@ -101,7 +101,7 @@ func InitEnv() {
 	// Initialize variables with GetEnvOrDefault
 	SyncFrequency = GetEnvOrDefault("SYNC_FREQUENCY", 60)
 	BatchUpdateInterval = GetEnvOrDefault("BATCH_UPDATE_INTERVAL", 5)
-	RelayTimeout = GetEnvOrDefault("RELAY_TIMEOUT", 0)
+	RelayTimeout = GetEnvOrDefault("RELAY_TIMEOUT", 60)
 	RelayMaxIdleConns = GetEnvOrDefault("RELAY_MAX_IDLE_CONNS", 500)
 	RelayMaxIdleConnsPerHost = GetEnvOrDefault("RELAY_MAX_IDLE_CONNS_PER_HOST", 100)
 

--- a/model/log.go
+++ b/model/log.go
@@ -500,7 +500,7 @@ func SumUsedQuota(logType int, startTimestamp int64, endTimestamp int64, modelNa
 }
 
 func SumUsedToken(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string) (token int) {
-	tx := LOG_DB.Table("logs").Select("ifnull(sum(prompt_tokens),0) + ifnull(sum(completion_tokens),0)")
+	tx := LOG_DB.Table("logs").Select("coalesce(sum(prompt_tokens),0) + coalesce(sum(completion_tokens),0)")
 	if username != "" {
 		tx = tx.Where("username = ?", username)
 	}

--- a/model/main.go
+++ b/model/main.go
@@ -195,6 +195,18 @@ func InitDB() (err error) {
 		sqlDB.SetMaxOpenConns(common.GetEnvOrDefault("SQL_MAX_OPEN_CONNS", 1000))
 		sqlDB.SetConnMaxLifetime(time.Second * time.Duration(common.GetEnvOrDefault("SQL_MAX_LIFETIME", 60)))
 
+		if common.UsingSQLite {
+			if _, err := sqlDB.Exec("PRAGMA journal_mode=WAL"); err != nil {
+				common.SysLog("Warning: failed to set SQLite journal_mode=WAL: " + err.Error())
+			}
+			if _, err := sqlDB.Exec("PRAGMA busy_timeout=5000"); err != nil {
+				common.SysLog("Warning: failed to set SQLite busy_timeout: " + err.Error())
+			}
+			if _, err := sqlDB.Exec("PRAGMA synchronous=NORMAL"); err != nil {
+				common.SysLog("Warning: failed to set SQLite synchronous=NORMAL: " + err.Error())
+			}
+		}
+
 		if !common.IsMasterNode {
 			return nil
 		}
@@ -234,6 +246,18 @@ func InitLogDB() (err error) {
 		sqlDB.SetMaxIdleConns(common.GetEnvOrDefault("SQL_MAX_IDLE_CONNS", 100))
 		sqlDB.SetMaxOpenConns(common.GetEnvOrDefault("SQL_MAX_OPEN_CONNS", 1000))
 		sqlDB.SetConnMaxLifetime(time.Second * time.Duration(common.GetEnvOrDefault("SQL_MAX_LIFETIME", 60)))
+
+		if common.UsingSQLite {
+			if _, err := sqlDB.Exec("PRAGMA journal_mode=WAL"); err != nil {
+				common.SysLog("Warning: failed to set SQLite journal_mode=WAL: " + err.Error())
+			}
+			if _, err := sqlDB.Exec("PRAGMA busy_timeout=5000"); err != nil {
+				common.SysLog("Warning: failed to set SQLite busy_timeout: " + err.Error())
+			}
+			if _, err := sqlDB.Exec("PRAGMA synchronous=NORMAL"); err != nil {
+				common.SysLog("Warning: failed to set SQLite synchronous=NORMAL: " + err.Error())
+			}
+		}
 
 		if !common.IsMasterNode {
 			return nil

--- a/model/main.go
+++ b/model/main.go
@@ -247,7 +247,7 @@ func InitLogDB() (err error) {
 		sqlDB.SetMaxOpenConns(common.GetEnvOrDefault("SQL_MAX_OPEN_CONNS", 1000))
 		sqlDB.SetConnMaxLifetime(time.Second * time.Duration(common.GetEnvOrDefault("SQL_MAX_LIFETIME", 60)))
 
-		if common.UsingSQLite {
+		if common.LogSqlType == common.DatabaseTypeSQLite {
 			if _, err := sqlDB.Exec("PRAGMA journal_mode=WAL"); err != nil {
 				common.SysLog("Warning: failed to set SQLite journal_mode=WAL: " + err.Error())
 			}

--- a/relay/channel/replicate/adaptor.go
+++ b/relay/channel/replicate/adaptor.go
@@ -180,11 +180,11 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycom
 		return nil, types.NewError(errors.New("replicate adaptor: empty response"), types.ErrorCodeBadResponse)
 	}
 
+	defer resp.Body.Close()
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, types.NewError(err, types.ErrorCodeReadResponseBodyFailed)
 	}
-	_ = resp.Body.Close()
 
 	var prediction PredictionResponse
 	if err := common.Unmarshal(responseBody, &prediction); err != nil {

--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -376,12 +376,12 @@ func (a *TaskAdaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, req
 
 // DoResponse handles upstream response
 func (a *TaskAdaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (taskID string, taskData []byte, taskErr *dto.TaskError) {
+	defer resp.Body.Close()
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		taskErr = service.TaskErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError)
 		return
 	}
-	_ = resp.Body.Close()
 
 	// 解析阿里响应
 	var aliResp AliVideoResponse

--- a/relay/channel/task/doubao/adaptor.go
+++ b/relay/channel/task/doubao/adaptor.go
@@ -205,12 +205,12 @@ func (a *TaskAdaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, req
 
 // DoResponse handles upstream response, returns taskID etc.
 func (a *TaskAdaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (taskID string, taskData []byte, taskErr *dto.TaskError) {
+	defer resp.Body.Close()
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		taskErr = service.TaskErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError)
 		return
 	}
-	_ = resp.Body.Close()
 
 	// Parse Doubao response
 	var dResp responsePayload

--- a/relay/channel/task/gemini/adaptor.go
+++ b/relay/channel/task/gemini/adaptor.go
@@ -121,11 +121,11 @@ func (a *TaskAdaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, req
 
 // DoResponse handles upstream response, returns taskID etc.
 func (a *TaskAdaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (taskID string, taskData []byte, taskErr *dto.TaskError) {
+	defer resp.Body.Close()
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", nil, service.TaskErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError)
 	}
-	_ = resp.Body.Close()
 
 	var s submitResponse
 	if err := common.Unmarshal(responseBody, &s); err != nil {

--- a/relay/channel/task/hailuo/adaptor.go
+++ b/relay/channel/task/hailuo/adaptor.go
@@ -79,12 +79,12 @@ func (a *TaskAdaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, req
 }
 
 func (a *TaskAdaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (taskID string, taskData []byte, taskErr *dto.TaskError) {
+	defer resp.Body.Close()
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		taskErr = service.TaskErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError)
 		return
 	}
-	_ = resp.Body.Close()
 
 	var hResp VideoResponse
 	if err := common.Unmarshal(responseBody, &hResp); err != nil {
@@ -264,8 +264,8 @@ func (a *TaskAdaptor) buildVideoURL(_, fileID string) string {
 	if err != nil {
 		return ""
 	}
-	defer resp.Body.Close()
 
+	defer resp.Body.Close()
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return ""

--- a/relay/channel/task/jimeng/adaptor.go
+++ b/relay/channel/task/jimeng/adaptor.go
@@ -183,12 +183,12 @@ func (a *TaskAdaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, req
 
 // DoResponse handles upstream response, returns taskID etc.
 func (a *TaskAdaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (taskID string, taskData []byte, taskErr *dto.TaskError) {
+	defer resp.Body.Close()
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		taskErr = service.TaskErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError)
 		return
 	}
-	_ = resp.Body.Close()
 
 	// Parse Jimeng response
 	var jResp responsePayload

--- a/relay/channel/task/sora/adaptor.go
+++ b/relay/channel/task/sora/adaptor.go
@@ -226,12 +226,12 @@ func (a *TaskAdaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, req
 
 // DoResponse handles upstream response, returns taskID etc.
 func (a *TaskAdaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (taskID string, taskData []byte, taskErr *dto.TaskError) {
+	defer resp.Body.Close()
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		taskErr = service.TaskErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError)
 		return
 	}
-	_ = resp.Body.Close()
 
 	// Parse Sora response
 	var dResp responseTask

--- a/relay/channel/task/vertex/adaptor.go
+++ b/relay/channel/task/vertex/adaptor.go
@@ -192,11 +192,11 @@ func (a *TaskAdaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, req
 
 // DoResponse handles upstream response, returns taskID etc.
 func (a *TaskAdaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (taskID string, taskData []byte, taskErr *dto.TaskError) {
+	defer resp.Body.Close()
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", nil, service.TaskErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError)
 	}
-	_ = resp.Body.Close()
 
 	var s submitResponse
 	if err := common.Unmarshal(responseBody, &s); err != nil {


### PR DESCRIPTION
## 摘要

本次 PR 修复了多个关键生产问题：

### 数据库兼容性
- **`model/log.go`**：将 `ifnull()` 替换为 `coalesce()`，修复 PostgreSQL 兼容性问题。PostgreSQL 不支持 `IFNULL` 函数，使用标准 SQL 的 `COALESCE` 替代。
- **`model/main.go`**：为 SQLite 数据库连接添加 `PRAGMA journal_mode=WAL`、`PRAGMA busy_timeout=5000` 和 `PRAGMA synchronous=NORMAL`。解决高并发场景下 SQLite 数据库锁死（`database is locked`）问题（ref: #4266、#4263）。

### 超时安全
- **`common/init.go`**：将 `RELAY_TIMEOUT` 默认值从 `0`（无超时）改为 60 秒，防止上游无响应时 HTTP 连接永久占用导致连接池耗尽。

### HTTP 响应体泄漏
- **`relay/channel/replicate/adaptor.go`**：使用 `defer resp.Body.Close()` 替代 `_ = resp.Body.Close()`
- **`relay/channel/task/{sora,gemini,vertex,hailuo,doubao,jimeng,ali}/adaptor.go`**：同上，确保即使发生 panic 也能正确释放 HTTP 连接，防止高并发下文件描述符耗尽。

## 变更文件

11 个文件，+35 行，-11 行

## 测试

- 所有变更均为独立的 Bug 修复，无破坏性改动
- `ifnull()` → `coalesce()` 在 SQLite/MySQL/PostgreSQL 上均有相同行为
- SQLite WAL PRAGMA 设置使用 SysLog 记录失败，不会阻塞数据库初始化
- `defer resp.Body.Close()` 在所有异常路径（包括 panic）中均能正确释放资源

---

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured HTTP responses are reliably closed across channels to prevent resource leaks.
  * Corrected token summation in logs so null totals are treated as zero.

* **Performance**
  * Applied SQLite runtime optimizations (WAL, timeout and synchronous settings) for better concurrency and stability.

* **Bug Fixes**
  * Increased default relay timeout to 60 seconds for improved request stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->