### PR TITLE
 feat(vertex): bypass Base64 conversion and support native FileData for HTTP/GCS URLs

### DIFF
--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -594,14 +596,19 @@ func CovertOpenAI2Gemini(c *gin.Context, textRequest dto.GeneralOpenAIRequest, i
 				if info.ChannelType == constant.ChannelTypeVertexAi {
 					if urlSource, ok := source.(*types.URLSource); ok && (strings.HasPrefix(urlSource.URL, "http") || strings.HasPrefix(urlSource.URL, "gs://")) {
 						mimeType := "image/jpeg"
-						urlLower := strings.ToLower(urlSource.URL)
-						if strings.HasSuffix(urlLower, ".png") {
-							mimeType = "image/png"
-						} else if strings.HasSuffix(urlLower, ".webp") {
-							mimeType = "image/webp"
-						} else if strings.HasSuffix(urlLower, ".gif") {
-							mimeType = "image/gif"
+						parsedUrl, err := url.Parse(urlSource.URL)
+						if err == nil {
+							ext := strings.ToLower(path.Ext(parsedUrl.Path))
+							switch ext {
+							case ".png":
+								mimeType = "image/png"
+							case ".webp":
+								mimeType = "image/webp"
+							case ".gif":
+								mimeType = "image/gif"
+							}
 						}
+						
 						parts = append(parts, dto.GeminiPart{
 							FileData: &dto.GeminiFileData{
 								MimeType: mimeType,

--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -590,6 +590,28 @@ func CovertOpenAI2Gemini(c *gin.Context, textRequest dto.GeneralOpenAIRequest, i
 				if source == nil {
 					continue
 				}
+
+				if info.ChannelType == constant.ChannelTypeVertexAi {
+					if urlSource, ok := source.(*types.URLSource); ok && (strings.HasPrefix(urlSource.URL, "http") || strings.HasPrefix(urlSource.URL, "gs://")) {
+						mimeType := "image/jpeg"
+						urlLower := strings.ToLower(urlSource.URL)
+						if strings.HasSuffix(urlLower, ".png") {
+							mimeType = "image/png"
+						} else if strings.HasSuffix(urlLower, ".webp") {
+							mimeType = "image/webp"
+						} else if strings.HasSuffix(urlLower, ".gif") {
+							mimeType = "image/gif"
+						}
+						parts = append(parts, dto.GeminiPart{
+							FileData: &dto.GeminiFileData{
+								MimeType: mimeType,
+								FileUri:  urlSource.URL,
+							},
+						})
+						continue
+					}
+				}
+
 				base64Data, mimeType, err := service.GetBase64Data(c, source, "formatting image for Gemini")
 				if err != nil {
 					return nil, fmt.Errorf("get file data from '%s' failed: %w", source.GetIdentifier(), err)


### PR DESCRIPTION

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
**做了什么：**
为 Vertex AI 渠道增加了原生 URL (`http`/`gs://`) 透传支持。当检测到 `ChannelTypeVertexAi` 时，对于 OpenAI 格式传来的 URL 图片，不再强制下载为 Base64，而是组装为 `dto.GeminiFileData` 结构体发给上游。

**为什么这样改能生效：**
当前在 `relay/channel/gemini/relay-gemini.go` 中，Vertex 渠道（调用 Gemini 模型时）复用了普通 AI Studio 免费版通道的代码。旧逻辑对于任何 `image_url` 请求，都会调用 `service.GetBase64Data` 在服务器端物理下载图片并强制进行 Base64 编码 (`InlineData`)。
实际上，Vertex AI 官方原生支持直接读取公网 `http` 及 GCS 内网的 `gs://` 链接。
此修改在 `GetBase64Data` 前增加了白名单拦截：针对 Vertex 渠道且是 URL 源的情况，直接提取 URL 并使用 `net/url` + `path.Ext` 安全推断 MimeType，构建为 `FileData` 透传。这彻底释放了网关的带宽和 CPU 开销，并且将首字延迟 (TTFT) 降低了秒级。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [x] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

*逻辑验证点:* 在修改前的网关日志中，无论是否配置了 Vertex 渠道，传入 `gs://` 都会引发下载失败报错，传入 `http://` 会导致网关出口流量激增；修改后，传入上述 URL 将直接完成请求流转，日志无本地下载记录，且上游正常吐字。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced file handling in Gemini integration. Remote file URLs (HTTP and Google Cloud Storage) are now processed more efficiently with automatic image format detection for PNG, WebP, and GIF formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4855)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->