### PR TITLE
fix: preserve images in Claude tool_result when converting to OpenAI chat completions

### DIFF
--- a/service/convert.go
+++ b/service/convert.go
@@ -14,6 +14,12 @@ import (
 	"github.com/samber/lo"
 )
 
+// ClaudeToOpenAIRequest converts a Claude Messages API request into an
+// equivalent OpenAI Chat Completions request. It handles system prompts,
+// message content (text, images), tool calls, and tool results.
+// In particular, tool_result content blocks are parsed recursively:
+// text blocks become role:"tool" messages, while image blocks are
+// split into a following role:"user" message with image_url content parts.
 func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.RelayInfo) (*dto.GeneralOpenAIRequest, error) {
 	openAIRequest := dto.GeneralOpenAIRequest{
 		Model:       claudeRequest.Model,

--- a/service/convert.go
+++ b/service/convert.go
@@ -176,25 +176,103 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 					}
 					toolCalls = append(toolCalls, toolCall)
 				case "tool_result":
-					// Add tool result as a separate message
 					toolName := mediaMsg.Name
 					if toolName == "" {
 						toolName = claudeRequest.SearchToolNameByToolCallId(mediaMsg.ToolUseId)
 					}
+
 					oaiToolMessage := dto.Message{
 						Role:       "tool",
 						Name:       &toolName,
 						ToolCallId: mediaMsg.ToolUseId,
 					}
-					//oaiToolMessage.SetStringContent(*mediaMsg.GetMediaContent().Text)
+
 					if mediaMsg.IsStringContent() {
 						oaiToolMessage.SetStringContent(mediaMsg.GetStringContent())
+						openAIMessages = append(openAIMessages, oaiToolMessage)
+						break
+					}
+
+					mediaContents := mediaMsg.ParseMediaContent()
+
+					toolTextParts := make([]string, 0)
+					imageUserContents := make([]dto.MediaContent, 0)
+
+					for _, mc := range mediaContents {
+						switch mc.Type {
+						case "text":
+							if text := strings.TrimSpace(mc.GetText()); text != "" {
+								toolTextParts = append(toolTextParts, text)
+							}
+
+						case "image":
+							if mc.Source == nil {
+								continue
+							}
+
+							if mc.Source.Url != "" {
+								imageUserContents = append(imageUserContents, dto.MediaContent{
+									Type:     dto.ContentTypeImageURL,
+									ImageUrl: &dto.MessageImageUrl{Url: mc.Source.Url},
+								})
+								continue
+							}
+
+							data := common.Interface2String(mc.Source.Data)
+							if data == "" {
+								continue
+							}
+
+							mediaType := mc.Source.MediaType
+							if mediaType == "" {
+								mediaType = "image/png"
+							}
+
+							imageData := fmt.Sprintf("data:%s;base64,%s", mediaType, data)
+							imageUserContents = append(imageUserContents, dto.MediaContent{
+								Type:     dto.ContentTypeImageURL,
+								ImageUrl: &dto.MessageImageUrl{Url: imageData},
+							})
+
+						default:
+							textBytes, _ := common.Marshal(mc)
+							if len(textBytes) > 0 {
+								toolTextParts = append(toolTextParts, string(textBytes))
+							}
+						}
+					}
+
+					if len(imageUserContents) > 0 {
+						toolTextParts = append(
+							toolTextParts,
+							"[Tool result contained image content. The image content is provided in the following user message.]",
+						)
+					}
+
+					if len(toolTextParts) > 0 {
+						oaiToolMessage.SetStringContent(strings.Join(toolTextParts, "\n"))
 					} else {
-						mediaContents := mediaMsg.ParseMediaContent()
 						encodeJson, _ := common.Marshal(mediaContents)
 						oaiToolMessage.SetStringContent(string(encodeJson))
 					}
+
 					openAIMessages = append(openAIMessages, oaiToolMessage)
+
+					if len(imageUserContents) > 0 {
+						imageUserContents = append([]dto.MediaContent{
+							{
+								Type: dto.ContentTypeText,
+								Text: fmt.Sprintf("Image content returned by tool %s:", mediaMsg.ToolUseId),
+							},
+						}, imageUserContents...)
+
+						imageUserMessage := dto.Message{
+							Role: "user",
+						}
+						imageUserMessage.SetMediaContent(imageUserContents)
+
+						openAIMessages = append(openAIMessages, imageUserMessage)
+					}
 				}
 			}
 

--- a/service/convert_test.go
+++ b/service/convert_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestClaudeToOpenAIRequest_ToolResultImages verifies that Claude tool_result
+// content blocks are correctly converted to OpenAI format. It covers text-only,
+// image-only, mixed text+image, multiple images, URL sources, empty data,
+// and unknown block type serialization.
 func TestClaudeToOpenAIRequest_ToolResultImages(t *testing.T) {
 	t.Parallel()
 

--- a/service/convert_test.go
+++ b/service/convert_test.go
@@ -1,0 +1,181 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaudeToOpenAIRequest_ToolResultImages(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name               string
+		messages           []dto.ClaudeMessage
+		expectToolContent  string
+		expectImageURL     string
+		expectUserImageMsg bool
+	}{
+		{
+			name: "pure string tool_result stays as tool text",
+			messages: []dto.ClaudeMessage{
+				{
+					Role:    "assistant",
+					Content: []any{map[string]any{"type": "tool_use", "id": "toolu_1", "name": "Read"}},
+				},
+				{
+					Role:    "user",
+					Content: []any{map[string]any{"type": "tool_result", "tool_use_id": "toolu_1", "content": "hello from tool"}},
+				},
+			},
+			expectToolContent: "hello from tool",
+		},
+		{
+			name: "text block tool_result becomes tool text",
+			messages: []dto.ClaudeMessage{
+				{
+					Role:    "assistant",
+					Content: []any{map[string]any{"type": "tool_use", "id": "toolu_1", "name": "Read"}},
+				},
+				{
+					Role: "user",
+					Content: []any{
+						map[string]any{
+							"type":        "tool_result",
+							"tool_use_id": "toolu_1",
+							"content": []any{
+								map[string]any{"type": "text", "text": "hello from tool"},
+							},
+						},
+					},
+				},
+			},
+			expectToolContent: "hello from tool",
+		},
+		{
+			name: "image block tool_result splits into tool+user",
+			messages: []dto.ClaudeMessage{
+				{
+					Role:    "assistant",
+					Content: []any{map[string]any{"type": "tool_use", "id": "toolu_1", "name": "Read"}},
+				},
+				{
+					Role: "user",
+					Content: []any{
+						map[string]any{
+							"type":        "tool_result",
+							"tool_use_id": "toolu_1",
+							"content": []any{
+								map[string]any{
+									"type": "image",
+									"source": map[string]any{
+										"type":       "base64",
+										"media_type": "image/png",
+										"data":       "abc123",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectToolContent:  "[Tool result contained image content. The image content is provided in the following user message.]",
+			expectImageURL:     "data:image/png;base64,abc123",
+			expectUserImageMsg: true,
+		},
+		{
+			name: "mixed text and image preserves text in tool and image in user",
+			messages: []dto.ClaudeMessage{
+				{
+					Role:    "assistant",
+					Content: []any{map[string]any{"type": "tool_use", "id": "toolu_1", "name": "Read"}},
+				},
+				{
+					Role: "user",
+					Content: []any{
+						map[string]any{
+							"type":        "tool_result",
+							"tool_use_id": "toolu_1",
+							"content": []any{
+								map[string]any{"type": "text", "text": "screenshot output"},
+								map[string]any{
+									"type": "image",
+									"source": map[string]any{
+										"type":       "base64",
+										"media_type": "image/png",
+										"data":       "xyz789",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectToolContent:  "screenshot output\n[Tool result contained image content. The image content is provided in the following user message.]",
+			expectImageURL:     "data:image/png;base64,xyz789",
+			expectUserImageMsg: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			claudeReq := dto.ClaudeRequest{
+				Model:    "claude-3-5-sonnet",
+				Messages: tc.messages,
+			}
+
+			info := &common.RelayInfo{
+				ChannelMeta: &common.ChannelMeta{
+					ChannelType: 1,
+				},
+			}
+
+			oaiReq, err := ClaudeToOpenAIRequest(claudeReq, info)
+			require.NoError(t, err)
+
+			var toolMsg *dto.Message
+			var imgUserMsg *dto.Message
+			for i := range oaiReq.Messages {
+				msg := &oaiReq.Messages[i]
+				if msg.Role == "tool" {
+					toolMsg = msg
+				}
+				if msg.Role == "user" {
+					content := msg.ParseContent()
+					for _, block := range content {
+						if block.Type == dto.ContentTypeImageURL {
+							imgUserMsg = msg
+							break
+						}
+					}
+				}
+			}
+
+			require.NotNil(t, toolMsg, "tool message should exist")
+			require.Equal(t, tc.expectToolContent, toolMsg.StringContent())
+
+			if tc.expectUserImageMsg {
+				require.NotNil(t, imgUserMsg, "user message with image_url should exist")
+				content := imgUserMsg.ParseContent()
+				var foundURL string
+				for _, block := range content {
+					if block.Type == dto.ContentTypeImageURL && block.ImageUrl != nil {
+						if url, ok := block.ImageUrl.(*dto.MessageImageUrl); ok {
+							foundURL = url.Url
+						} else if urlMap, ok := block.ImageUrl.(map[string]any); ok {
+							foundURL, _ = urlMap["url"].(string)
+						}
+					}
+				}
+				require.Equal(t, tc.expectImageURL, foundURL)
+			} else {
+				require.Nil(t, imgUserMsg, "user message with image_url should not exist for text-only")
+			}
+		})
+	}
+}

--- a/service/convert_test.go
+++ b/service/convert_test.go
@@ -15,6 +15,7 @@ func TestClaudeToOpenAIRequest_ToolResultImages(t *testing.T) {
 		name               string
 		messages           []dto.ClaudeMessage
 		expectToolContent  string
+		expectToolContains string
 		expectImageURL     string
 		expectUserImageMsg bool
 	}{
@@ -117,6 +118,129 @@ func TestClaudeToOpenAIRequest_ToolResultImages(t *testing.T) {
 			expectImageURL:     "data:image/png;base64,xyz789",
 			expectUserImageMsg: true,
 		},
+		{
+			name: "multiple images in tool_result",
+			messages: []dto.ClaudeMessage{
+				{
+					Role:    "assistant",
+					Content: []any{map[string]any{"type": "tool_use", "id": "toolu_1", "name": "Read"}},
+				},
+				{
+					Role: "user",
+					Content: []any{
+						map[string]any{
+							"type":        "tool_result",
+							"tool_use_id": "toolu_1",
+							"content": []any{
+								map[string]any{
+									"type": "image",
+									"source": map[string]any{
+										"type":       "base64",
+										"media_type": "image/png",
+										"data":       "image1",
+									},
+								},
+								map[string]any{
+									"type": "image",
+									"source": map[string]any{
+										"type":       "base64",
+										"media_type": "image/jpeg",
+										"data":       "image2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectToolContent:  "[Tool result contained image content. The image content is provided in the following user message.]",
+			expectImageURL:     "data:image/jpeg;base64,image2",
+			expectUserImageMsg: true,
+		},
+		{
+			name: "image with url instead of data",
+			messages: []dto.ClaudeMessage{
+				{
+					Role:    "assistant",
+					Content: []any{map[string]any{"type": "tool_use", "id": "toolu_1", "name": "Read"}},
+				},
+				{
+					Role: "user",
+					Content: []any{
+						map[string]any{
+							"type":        "tool_result",
+							"tool_use_id": "toolu_1",
+							"content": []any{
+								map[string]any{
+									"type": "image",
+									"source": map[string]any{
+										"type": "url",
+										"url":  "https://example.com/img.png",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectToolContent:  "[Tool result contained image content. The image content is provided in the following user message.]",
+			expectImageURL:     "https://example.com/img.png",
+			expectUserImageMsg: true,
+		},
+		{
+			name: "empty data image is skipped",
+			messages: []dto.ClaudeMessage{
+				{
+					Role:    "assistant",
+					Content: []any{map[string]any{"type": "tool_use", "id": "toolu_1", "name": "Read"}},
+				},
+				{
+					Role: "user",
+					Content: []any{
+						map[string]any{
+							"type":        "tool_result",
+							"tool_use_id": "toolu_1",
+							"content": []any{
+								map[string]any{
+									"type": "image",
+									"source": map[string]any{
+										"type":       "base64",
+										"media_type": "image/png",
+										"data":       "",
+									},
+								},
+								map[string]any{"type": "text", "text": "no image available"},
+							},
+						},
+					},
+				},
+			},
+			expectToolContent: "no image available",
+		},
+		{
+			name: "unknown block type serializes as text alongside real text",
+			messages: []dto.ClaudeMessage{
+				{
+					Role:    "assistant",
+					Content: []any{map[string]any{"type": "tool_use", "id": "toolu_1", "name": "Read"}},
+				},
+				{
+					Role: "user",
+					Content: []any{
+						map[string]any{
+							"type":        "tool_result",
+							"tool_use_id": "toolu_1",
+							"content": []any{
+								map[string]any{"type": "text", "text": "result"},
+								map[string]any{"type": "doc", "content": "doc content here"},
+							},
+						},
+					},
+				},
+			},
+			expectToolContent: "result\n",
+			expectToolContains: `{"type":"doc"`,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -157,7 +281,12 @@ func TestClaudeToOpenAIRequest_ToolResultImages(t *testing.T) {
 			}
 
 			require.NotNil(t, toolMsg, "tool message should exist")
-			require.Equal(t, tc.expectToolContent, toolMsg.StringContent())
+			if tc.expectToolContains != "" {
+				require.Contains(t, toolMsg.StringContent(), tc.expectToolContent)
+				require.Contains(t, toolMsg.StringContent(), tc.expectToolContains)
+			} else {
+				require.Equal(t, tc.expectToolContent, toolMsg.StringContent())
+			}
 
 			if tc.expectUserImageMsg {
 				require.NotNil(t, imgUserMsg, "user message with image_url should exist")


### PR DESCRIPTION
## 变更描述

修复 Claude tool_result 中的图片在转换为 OpenAI Chat Completions 格式时丢失的问题。

根因：service/convert.go 的 ClaudeToOpenAIRequest 处理 tool_result 时，把非字符串内容直接 Marshal 成 JSON 字符串塞进 tool message 的 content 字段。上游收到的 tool 消息里 content 是一段 JSON 文本，模型拿不到图片输入，只能靠文本猜测，产生幻觉。

修复：按 OpenAI Chat Completions 规范拆分：
- tool_result 的文本内容 -> role:tool，字符串 content
- tool_result 的图片内容 -> 拆成 role:tool（文本说明）+ role:user（image_url content part）

OpenAI 规范里 role:tool 只支持 text content part，图片必须放在 user message 中。

## 变更类型

- [x] Bug 修复

## 提交前检查项

- [x] 确认：已亲自整理描述，未直接粘贴 AI 输出
- [x] 已搜索 Issues 和 PRs，确认非重复提交
- [x] Bug fix 说明：已通过 curl 实验和端到端复现验证
- [x] 变更范围仅限 service/convert.go 的 tool_result 分支
- [x] 无无关代码改动
- [x] 本地测试 8 个用例全部通过，curl 最小复现和 Claude Code 端到端均验证通过
- [x] 代码中无凭据泄露

## 运行证明

修复前 dump（outbound JSON）：
- role=tool, content=[{"type":"image","source":{"type":"base64",...}}]
- 模型回答：\u0022像素风格樱桃/水果图标\u0022

修复后 dump：
- role=tool, content=\u0022[Tool result contained image content...]\u0022
- role=user, type=image_url, len=24234
- 模型回答：\u0022Windows Recycle Bin icon\u0022

测试命令：go test ./service -run TestClaudeToOpenAIRequest_ToolResultImages -v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved conversion of tool-result content: non-text media are parsed so text remains in tool messages while images are emitted as separate follow-up user messages.
  * Supports both direct image URLs and base64 image data (converted to data: URIs), preserves text alongside images, and skips empty image data.
  * Unknown block types are serialized into tool message content.

* **Tests**
  * Added comprehensive tests covering mixed text/image tool results, base64 and URL images, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4873)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->