### PR TITLE
feat: make channel test follow global OpenAI completions via responses rules

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -96,40 +96,32 @@ func testChannel(channel *model.Channel, testModel string, endpointType string, 
 
 	requestPath := "/v1/chat/completions"
 
-	// 如果指定了端点类型，使用指定的端点类型
+	// Use the specified endpoint type if specified
 	if endpointType != "" {
 		if endpointInfo, ok := common.GetDefaultEndpointInfo(constant.EndpointType(endpointType)); ok {
 			requestPath = endpointInfo.Path
 		}
-	} else {
-		// 如果没有指定端点类型，使用原有的自动检测逻辑
-
+	} else { // auto detect
 		if strings.Contains(strings.ToLower(testModel), "rerank") {
 			requestPath = "/v1/rerank"
-		}
-
-		// 先判断是否为 Embedding 模型
-		if strings.Contains(strings.ToLower(testModel), "embedding") ||
-			strings.HasPrefix(testModel, "m3e") || // m3e 系列模型
-			strings.Contains(testModel, "bge-") || // bge 系列模型
+		} else if strings.Contains(strings.ToLower(testModel), "embedding") || // embedding models
+			strings.HasPrefix(testModel, "m3e") || // m3e series
+			strings.Contains(testModel, "bge-") || // bge series
 			strings.Contains(testModel, "embed") ||
-			channel.Type == constant.ChannelTypeMokaAI { // 其他 embedding 模型
-			requestPath = "/v1/embeddings" // 修改请求路径
-		}
-
-		// VolcEngine 图像生成模型
-		if channel.Type == constant.ChannelTypeVolcEngine && strings.Contains(testModel, "seedream") {
+			channel.Type == constant.ChannelTypeMokaAI { // other embedding models
+			requestPath = "/v1/embeddings"
+		} else if channel.Type == constant.ChannelTypeVolcEngine && strings.Contains(testModel, "seedream") {
+			// VolcEngine image gen models
 			requestPath = "/v1/images/generations"
-		}
-
-		// responses-only models
-		if strings.Contains(strings.ToLower(testModel), "codex") {
-			requestPath = "/v1/responses"
-		}
-
-		// responses compaction models (must use /v1/responses/compact)
-		if strings.HasSuffix(testModel, ratio_setting.CompactModelSuffix) {
+		} else if strings.HasSuffix(testModel, ratio_setting.CompactModelSuffix) {
+			// responses compaction models (must use /v1/responses/compact)
 			requestPath = "/v1/responses/compact"
+		} else if strings.Contains(strings.ToLower(testModel), "codex") {
+			// responses-only models
+			requestPath = "/v1/responses"
+		} else if service.ShouldChatCompletionsUseResponsesGlobal(channel.Id, channel.Type, testModel) {
+			// follow the global setting for using responses instead of completions
+			requestPath = "/v1/responses"
 		}
 	}
 	if strings.HasPrefix(requestPath, "/v1/responses/compact") {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

当前渠道测试代码里，自动检测部分对 Codex 模型自动使用 Responses API，但是仍有其他模型（并且未来可能会有更多）仍只通过 Responses API 提供，如 gpt-5.4-pro。

为了使其与系统其他部分更加直观统一，可以在自动检测逻辑中应用全局设置里的 Chat Completions API -> Responses API 转换规则，按规则直接改为使用 Responses API。

另：我们是否需要给 gpt-pro 系列也如同 codex 系列一样，硬编码使用 Responses API？

## 📝 变更描述 / Description

1. 将自动检测逻辑从多个 if 转为 if-else 链，以进行优先级覆盖
2. 满足 ShouldChatCompletionsUseResponsesGlobal 时将端点设置为 Responses API。
3. 简化注释并改为英文注释。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined endpoint auto-detection with a prioritized conditional chain, improving selection among rerank, embeddings, image generation, and response endpoints; refined fallback behavior for global response switching to apply only when earlier checks don't match.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4888)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->