### PR TITLE
feat: support gemini imagen 4 generate model

### DIFF
--- a/dto/gemini.go
+++ b/dto/gemini.go
@@ -483,6 +483,26 @@ type GeminiImageRequest struct {
 	Parameters GeminiImageParameters `json:"parameters"`
 }
 
+func (r *GeminiImageRequest) GetTokenCountMeta() *types.TokenCountMeta {
+	inputTexts := make([]string, 0, len(r.Instances))
+	for _, instance := range r.Instances {
+		if strings.TrimSpace(instance.Prompt) != "" {
+			inputTexts = append(inputTexts, strings.TrimSpace(instance.Prompt))
+		}
+	}
+	return &types.TokenCountMeta{
+		CombineText: strings.Join(inputTexts, "\n"),
+	}
+}
+
+func (r *GeminiImageRequest) IsStream(c *gin.Context) bool {
+	return false
+}
+
+func (r *GeminiImageRequest) SetModelName(modelName string) {
+	// Gemini image request carries model in URL path, not in body.
+}
+
 type GeminiImageInstance struct {
 	Prompt string `json:"prompt"`
 }

--- a/dto/gemini.go
+++ b/dto/gemini.go
@@ -483,6 +483,7 @@ type GeminiImageRequest struct {
 	Parameters GeminiImageParameters `json:"parameters"`
 }
 
+// GetTokenCountMeta returns prompt text metadata for Gemini image requests.
 func (r *GeminiImageRequest) GetTokenCountMeta() *types.TokenCountMeta {
 	inputTexts := make([]string, 0, len(r.Instances))
 	for _, instance := range r.Instances {
@@ -495,10 +496,12 @@ func (r *GeminiImageRequest) GetTokenCountMeta() *types.TokenCountMeta {
 	}
 }
 
+// IsStream reports whether the Gemini image request uses streaming.
 func (r *GeminiImageRequest) IsStream(c *gin.Context) bool {
 	return false
 }
 
+// SetModelName keeps Gemini image model names in the request URL path.
 func (r *GeminiImageRequest) SetModelName(modelName string) {
 	// Gemini image request carries model in URL path, not in body.
 }

--- a/relay/channel/gemini/adaptor.go
+++ b/relay/channel/gemini/adaptor.go
@@ -57,6 +57,7 @@ func (a *Adaptor) ConvertAudioRequest(c *gin.Context, info *relaycommon.RelayInf
 	return nil, errors.New("not implemented")
 }
 
+// ConvertImageRequest converts OpenAI image requests into Gemini Imagen requests.
 func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.ImageRequest) (any, error) {
 	if !strings.HasPrefix(info.UpstreamModelName, "imagen") {
 		return nil, errors.New("not supported model for image generation, only imagen models are supported")
@@ -268,6 +269,7 @@ func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, request
 	return channel.DoApiRequest(a, c, info, requestBody)
 }
 
+// DoResponse converts Gemini upstream responses into relay usage data.
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
 	if info.RelayMode == constant.RelayModeGemini {
 		if strings.HasPrefix(info.UpstreamModelName, "imagen") && strings.Contains(info.RequestURLPath, ":predict") {

--- a/relay/channel/gemini/adaptor.go
+++ b/relay/channel/gemini/adaptor.go
@@ -61,12 +61,13 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 	if !strings.HasPrefix(info.UpstreamModelName, "imagen") {
 		return nil, errors.New("not supported model for image generation, only imagen models are supported")
 	}
-
 	// convert size to aspect ratio but allow user to specify aspect ratio
 	aspectRatio := "1:1" // default aspect ratio
 	size := strings.TrimSpace(request.Size)
 	if size != "" {
-		if strings.Contains(size, ":") {
+		if info.UpstreamModelName == "imagen-4.0-generate-001" {
+			aspectRatio = convertImagen4SizeToAspectRatio(size)
+		} else if strings.Contains(size, ":") {
 			aspectRatio = size
 		} else {
 			switch size {
@@ -121,6 +122,26 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 	}
 
 	return geminiRequest, nil
+}
+
+func convertImagen4SizeToAspectRatio(size string) string {
+	if strings.Contains(size, ":") {
+		return size
+	}
+	switch strings.ToLower(strings.TrimSpace(size)) {
+	case "1024x1024", "2048x2048":
+		return "1:1"
+	case "896x1280", "1792x2560":
+		return "3:4"
+	case "1280x896", "2560x1792":
+		return "4:3"
+	case "768x1408", "1536x2816", "1024x1792":
+		return "9:16"
+	case "1408x768", "2816x1536", "1792x1024":
+		return "16:9"
+	default:
+		return "1:1"
+	}
 }
 
 func (a *Adaptor) Init(info *relaycommon.RelayInfo) {
@@ -248,6 +269,9 @@ func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, request
 
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
 	if info.RelayMode == constant.RelayModeGemini {
+		if strings.HasPrefix(info.UpstreamModelName, "imagen") && strings.Contains(info.RequestURLPath, ":predict") {
+			return GeminiNativeImagePredictHandler(c, info, resp)
+		}
 		if strings.Contains(info.RequestURLPath, ":embedContent") ||
 			strings.Contains(info.RequestURLPath, ":batchEmbedContents") {
 			return NativeGeminiEmbeddingHandler(c, resp, info)

--- a/relay/channel/gemini/adaptor.go
+++ b/relay/channel/gemini/adaptor.go
@@ -124,6 +124,7 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 	return geminiRequest, nil
 }
 
+// convertImagen4SizeToAspectRatio maps OpenAI image sizes to Imagen 4 aspect ratios.
 func convertImagen4SizeToAspectRatio(size string) string {
 	if strings.Contains(size, ":") {
 		return size

--- a/relay/channel/gemini/relay-gemini-native.go
+++ b/relay/channel/gemini/relay-gemini-native.go
@@ -95,3 +95,34 @@ func GeminiTextGenerationStreamHandler(c *gin.Context, info *relaycommon.RelayIn
 		return true
 	})
 }
+
+func GeminiNativeImagePredictHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
+	defer service.CloseResponseBodyGracefully(resp)
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+
+	if common.DebugEnabled {
+		println(string(responseBody))
+	}
+
+	var geminiResponse dto.GeminiImageResponse
+	if err = common.Unmarshal(responseBody, &geminiResponse); err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+
+	generatedImages := 0
+	for _, prediction := range geminiResponse.Predictions {
+		if prediction.RaiFilteredReason != "" {
+			continue
+		}
+		if prediction.BytesBase64Encoded != "" {
+			generatedImages++
+		}
+	}
+
+	service.IOCopyBytesGracefully(c, resp, responseBody)
+	return buildGeminiImageUsage(generatedImages), nil
+}

--- a/relay/channel/gemini/relay-gemini-native.go
+++ b/relay/channel/gemini/relay-gemini-native.go
@@ -96,6 +96,7 @@ func GeminiTextGenerationStreamHandler(c *gin.Context, info *relaycommon.RelayIn
 	})
 }
 
+// GeminiNativeImagePredictHandler relays native Gemini Imagen predict responses.
 func GeminiNativeImagePredictHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
 	defer service.CloseResponseBodyGracefully(resp)
 

--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -1581,6 +1581,7 @@ func GeminiImageHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.
 	return buildGeminiImageUsage(len(openAIResponse.Data)), nil
 }
 
+// buildGeminiImageUsage returns usage for generated Gemini images.
 func buildGeminiImageUsage(generatedImages int) *dto.Usage {
 	// https://github.com/google-gemini/cookbook/blob/719a27d752aac33f39de18a8d3cb42a70874917e/quickstarts/Counting_Tokens.ipynb
 	// each image has fixed 258 tokens.

--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -1578,18 +1578,19 @@ func GeminiImageHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.
 	c.Writer.WriteHeader(resp.StatusCode)
 	_, _ = c.Writer.Write(jsonResponse)
 
+	return buildGeminiImageUsage(len(openAIResponse.Data)), nil
+}
+
+func buildGeminiImageUsage(generatedImages int) *dto.Usage {
 	// https://github.com/google-gemini/cookbook/blob/719a27d752aac33f39de18a8d3cb42a70874917e/quickstarts/Counting_Tokens.ipynb
-	// each image has fixed 258 tokens
+	// each image has fixed 258 tokens.
 	const imageTokens = 258
-	generatedImages := len(openAIResponse.Data)
-
-	usage := &dto.Usage{
-		PromptTokens:     imageTokens * generatedImages, // each generated image has fixed 258 tokens
-		CompletionTokens: 0,                             // image generation does not calculate completion tokens
-		TotalTokens:      imageTokens * generatedImages,
+	imageTokenCount := imageTokens * generatedImages
+	return &dto.Usage{
+		PromptTokens:     imageTokenCount,
+		CompletionTokens: 0,
+		TotalTokens:      imageTokenCount,
 	}
-
-	return usage, nil
 }
 
 type GeminiModelsResponse struct {

--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -1538,6 +1538,7 @@ func GeminiEmbeddingHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *h
 	return usage, nil
 }
 
+// GeminiImageHandler converts Gemini Imagen responses to OpenAI image responses.
 func GeminiImageHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
 	responseBody, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {

--- a/relay/channel/vertex/adaptor.go
+++ b/relay/channel/vertex/adaptor.go
@@ -1,7 +1,6 @@
 package vertex
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -266,7 +265,7 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 		}
 		if len(request.ExtraBody) > 0 {
 			var extra map[string]any
-			if err := json.Unmarshal(request.ExtraBody, &extra); err == nil {
+			if err := common.Unmarshal(request.ExtraBody, &extra); err == nil {
 				if n, ok := extra["n"].(float64); ok && n > 0 {
 					imgReq.N = lo.ToPtr(uint(n))
 				}
@@ -348,6 +347,9 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycom
 			return claudeAdaptor.DoResponse(c, resp, info)
 		case RequestModeGemini:
 			if info.RelayMode == constant.RelayModeGemini {
+				if strings.HasPrefix(info.UpstreamModelName, "imagen") && strings.Contains(info.RequestURLPath, ":predict") {
+					return gemini.GeminiNativeImagePredictHandler(c, info, resp)
+				}
 				return gemini.GeminiTextGenerationHandler(c, info, resp)
 			} else {
 				if strings.HasPrefix(info.UpstreamModelName, "imagen") {

--- a/relay/channel/vertex/adaptor.go
+++ b/relay/channel/vertex/adaptor.go
@@ -228,6 +228,7 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *rel
 	return nil
 }
 
+// ConvertOpenAIRequest converts OpenAI-compatible requests for Vertex upstreams.
 func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeneralOpenAIRequest) (any, error) {
 	if request == nil {
 		return nil, errors.New("request is nil")
@@ -326,6 +327,7 @@ func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, request
 	return channel.DoApiRequest(a, c, info, requestBody)
 }
 
+// DoResponse converts Vertex upstream responses into relay usage data.
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
 	claudeAdaptor := claude.Adaptor{}
 	if info.IsStream {

--- a/relay/gemini_handler.go
+++ b/relay/gemini_handler.go
@@ -53,6 +53,7 @@ func trimModelThinking(modelName string) string {
 	return modelName
 }
 
+// GeminiHelper handles native Gemini relay requests.
 func GeminiHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
 	info.InitChannelMeta(c)
 

--- a/relay/gemini_handler.go
+++ b/relay/gemini_handler.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -54,6 +55,10 @@ func trimModelThinking(modelName string) string {
 
 func GeminiHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
 	info.InitChannelMeta(c)
+
+	if strings.HasPrefix(info.OriginModelName, "imagen") && strings.Contains(info.RequestURLPath, ":predict") {
+		return geminiImagePredictHelper(c, info)
+	}
 
 	geminiReq, ok := info.Request.(*dto.GeminiChatRequest)
 	if !ok {
@@ -189,6 +194,70 @@ func GeminiHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 	}
 
 	usage, openaiErr := adaptor.DoResponse(c, resp.(*http.Response), info)
+	if openaiErr != nil {
+		service.ResetStatusCode(openaiErr, statusCodeMappingStr)
+		return openaiErr
+	}
+
+	service.PostTextConsumeQuota(c, info, usage.(*dto.Usage), nil)
+	return nil
+}
+
+func geminiImagePredictHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
+	imageReq, ok := info.Request.(*dto.GeminiImageRequest)
+	if !ok {
+		return types.NewErrorWithStatusCode(
+			fmt.Errorf("invalid request type for imagen predict, got %T", info.Request),
+			types.ErrorCodeInvalidRequest,
+			http.StatusBadRequest,
+			types.ErrOptionWithSkipRetry(),
+		)
+	}
+
+	if err := helper.ModelMappedHelper(c, info, imageReq); err != nil {
+		return types.NewError(err, types.ErrorCodeChannelModelMappedError, types.ErrOptionWithSkipRetry())
+	}
+
+	adaptor := GetAdaptor(info.ApiType)
+	if adaptor == nil {
+		return types.NewError(fmt.Errorf("invalid api type: %d", info.ApiType), types.ErrorCodeInvalidApiType, types.ErrOptionWithSkipRetry())
+	}
+	adaptor.Init(info)
+
+	storage, err := common.GetBodyStorage(c)
+	if err != nil {
+		return types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+	}
+	body, err := storage.Bytes()
+	if err != nil {
+		return types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+	}
+	if len(info.ParamOverride) > 0 {
+		body, err = relaycommon.ApplyParamOverride(body, info.ParamOverride, relaycommon.BuildParamOverrideContext(info))
+		if err != nil {
+			return types.NewError(err, types.ErrorCodeChannelParamOverrideInvalid, types.ErrOptionWithSkipRetry())
+		}
+	}
+	logger.LogDebug(c, "Gemini imagen predict request body: "+string(body))
+
+	resp, err := adaptor.DoRequest(c, info, bytes.NewReader(body))
+	if err != nil {
+		logger.LogError(c, "Do gemini imagen predict request failed: "+err.Error())
+		return types.NewOpenAIError(err, types.ErrorCodeDoRequestFailed, http.StatusInternalServerError)
+	}
+
+	statusCodeMappingStr := c.GetString("status_code_mapping")
+	if resp == nil {
+		return types.NewErrorWithStatusCode(errors.New("empty upstream response"), types.ErrorCodeBadResponse, http.StatusInternalServerError)
+	}
+	httpResp := resp.(*http.Response)
+	if httpResp.StatusCode != http.StatusOK {
+		newAPIError = service.RelayErrorHandler(c.Request.Context(), httpResp, false)
+		service.ResetStatusCode(newAPIError, statusCodeMappingStr)
+		return newAPIError
+	}
+
+	usage, openaiErr := adaptor.DoResponse(c, httpResp, info)
 	if openaiErr != nil {
 		service.ResetStatusCode(openaiErr, statusCodeMappingStr)
 		return openaiErr

--- a/relay/gemini_handler.go
+++ b/relay/gemini_handler.go
@@ -203,6 +203,7 @@ func GeminiHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 	return nil
 }
 
+// geminiImagePredictHelper forwards native Gemini Imagen predict requests.
 func geminiImagePredictHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
 	imageReq, ok := info.Request.(*dto.GeminiImageRequest)
 	if !ok {

--- a/relay/helper/valid_request.go
+++ b/relay/helper/valid_request.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// GetAndValidateRequest parses and validates requests for the relay format.
 func GetAndValidateRequest(c *gin.Context, format types.RelayFormat) (request dto.Request, err error) {
 	relayMode := relayconstant.Path2RelayMode(c.Request.URL.Path)
 

--- a/relay/helper/valid_request.go
+++ b/relay/helper/valid_request.go
@@ -27,6 +27,8 @@ func GetAndValidateRequest(c *gin.Context, format types.RelayFormat) (request dt
 			request, err = GetAndValidateGeminiEmbeddingRequest(c)
 		} else if strings.Contains(c.Request.URL.Path, ":batchEmbedContents") {
 			request, err = GetAndValidateGeminiBatchEmbeddingRequest(c)
+		} else if isGeminiImagePredictPath(c.Request.URL.Path) {
+			request, err = GetAndValidateGeminiImageRequest(c)
 		} else {
 			request, err = GetAndValidateGeminiRequest(c)
 		}
@@ -246,6 +248,31 @@ func GetAndValidateClaudeRequest(c *gin.Context) (textRequest *dto.ClaudeRequest
 	return textRequest, nil
 }
 
+func isGeminiImagePredictPath(path string) bool {
+	if !strings.Contains(path, ":predict") {
+		return false
+	}
+	modelName := extractGeminiModelNameFromPath(path)
+	return strings.HasPrefix(modelName, "imagen")
+}
+
+func extractGeminiModelNameFromPath(path string) string {
+	const modelsPrefix = "/models/"
+	modelsIndex := strings.Index(path, modelsPrefix)
+	if modelsIndex == -1 {
+		return ""
+	}
+	startIndex := modelsIndex + len(modelsPrefix)
+	if startIndex >= len(path) {
+		return ""
+	}
+	colonIndex := strings.Index(path[startIndex:], ":")
+	if colonIndex == -1 {
+		return path[startIndex:]
+	}
+	return path[startIndex : startIndex+colonIndex]
+}
+
 func GetAndValidateTextRequest(c *gin.Context, relayMode int) (*dto.GeneralOpenAIRequest, error) {
 	textRequest := &dto.GeneralOpenAIRequest{}
 	err := common.UnmarshalBodyReusable(c, textRequest)
@@ -318,6 +345,17 @@ func GetAndValidateGeminiRequest(c *gin.Context) (*dto.GeminiChatRequest, error)
 	//	relayInfo.IsStream = true
 	//}
 
+	return request, nil
+}
+
+func GetAndValidateGeminiImageRequest(c *gin.Context) (*dto.GeminiImageRequest, error) {
+	request := &dto.GeminiImageRequest{}
+	if err := common.UnmarshalBodyReusable(c, request); err != nil {
+		return nil, err
+	}
+	if len(request.Instances) == 0 {
+		return nil, errors.New("instances is required")
+	}
 	return request, nil
 }
 

--- a/relay/helper/valid_request.go
+++ b/relay/helper/valid_request.go
@@ -248,6 +248,7 @@ func GetAndValidateClaudeRequest(c *gin.Context) (textRequest *dto.ClaudeRequest
 	return textRequest, nil
 }
 
+// isGeminiImagePredictPath reports whether a Gemini path targets Imagen predict.
 func isGeminiImagePredictPath(path string) bool {
 	if !strings.Contains(path, ":predict") {
 		return false
@@ -256,6 +257,7 @@ func isGeminiImagePredictPath(path string) bool {
 	return strings.HasPrefix(modelName, "imagen")
 }
 
+// extractGeminiModelNameFromPath extracts the model segment from a Gemini URL path.
 func extractGeminiModelNameFromPath(path string) string {
 	const modelsPrefix = "/models/"
 	modelsIndex := strings.Index(path, modelsPrefix)
@@ -348,6 +350,7 @@ func GetAndValidateGeminiRequest(c *gin.Context) (*dto.GeminiChatRequest, error)
 	return request, nil
 }
 
+// GetAndValidateGeminiImageRequest parses and validates a native Gemini image request.
 func GetAndValidateGeminiImageRequest(c *gin.Context) (*dto.GeminiImageRequest, error) {
 	request := &dto.GeminiImageRequest{}
 	if err := common.UnmarshalBodyReusable(c, request); err != nil {

--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -281,6 +281,7 @@ var defaultModelPrice = map[string]float64{
 	"suno_lyrics":                    0.01,
 	"dall-e-3":                       0.04,
 	"imagen-3.0-generate-002":        0.03,
+	"imagen-4.0-generate-001":        0.04,
 	"black-forest-labs/flux-1.1-pro": 0.04,
 	"gpt-4-gizmo-*":                  0.1,
 	"mj_video":                       0.8,


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
本 PR 为 Gemini Imagen 4 模型接入支持，目标模型为 `imagen-4.0-generate-001`。

主要变更：
- 为 `imagen-4.0-generate-001` 补充默认模型价格。
- 复用现有 Gemini Imagen 图片生成链路，针对 Imagen 4 支持的尺寸比例做最小映射适配。
- 补充 Gemini 原生 `:predict` 图片请求的解析、转发、响应处理与用量统计。
- 让 `GeminiImageRequest` 满足现有 relay 请求接口，保证模型映射、参数覆盖和配额消费流程可以复用原有逻辑。
- Vertex Gemini 原生 `:predict` 图片响应复用同一处理逻辑。

这样可以同时支持：
- OpenAI-compatible `/v1/images/generations`
- Gemini native `/v1/models/imagen-4.0-generate-001:predict`



## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- [1460](https://github.com/QuantumNous/new-api/issues/1460)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
验证 curl
`curl http://localhost:3000/v1/images/generations \
  --request POST \
  --header 'Authorization: Bearer YOUR_API_KEY' \
  --header 'Content-Type: application/json' \
  --data '{
    "model": "imagen-4.0-generate-001",
    "prompt": "A clean product photo of a ceramic coffee mug on a walnut desk, soft daylight, realistic",
    "n": 1,
    "size": "1024x1024",
    "quality": "standard",
    "response_format": "b64_json"
  }'
`
`curl http://localhost:3000/v1/models/imagen-4.0-generate-001:predict \
  --request POST \
  --header 'Authorization: Bearer YOUR_API_KEY' \
  --header 'Content-Type: application/json' \
  --data '{
    "instances": [
      {
        "prompt": "A clean product photo of a ceramic coffee mug on a walnut desk, soft daylight, realistic"
      }
    ],
    "parameters": {
      "sampleCount": 1,
      "aspectRatio": "1:1",
      "personGeneration": "allow_adult"
    }
  }'
`
本地验证通过：
<img width="1733" height="587" alt="屏幕截图 2026-05-15 175731" src="https://github.com/user-attachments/assets/296ada20-be99-4679-9922-03378836e423" />

<img width="1708" height="332" alt="屏幕截图 2026-05-15 180115" src="https://github.com/user-attachments/assets/d715dfb4-c3c6-4e22-933e-4fbe18b9d91a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Gemini/Imagen native image prediction flows with a dedicated predict handler.
  * Automatic size-to-aspect-ratio conversion for Imagen 4.0 model.
  * Added pricing entry for Imagen 4.0 image generation.

* **Bug Fixes / Validation**
  * Reject empty image-generation requests and ensure image requests are not treated as streaming.
  * Improved image-generation usage reporting for accurate quota accounting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4890)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->