### PR TITLE
fix(web/default/wallet): make recharge preset selection visible in dark mode

### DIFF
--- a/web/default/src/features/wallet/components/recharge-form-card.tsx
+++ b/web/default/src/features/wallet/components/recharge-form-card.tsx
@@ -240,7 +240,7 @@ export function RechargeFormCard({
                           className={cn(
                             'hover:border-foreground flex min-h-16 flex-col items-start rounded-lg px-3 py-2.5 text-left whitespace-normal sm:min-h-[72px] sm:p-4',
                             selectedPreset === preset.value
-                              ? 'border-foreground bg-foreground/5'
+                              ? 'border-foreground bg-foreground/5 dark:border-foreground dark:bg-foreground/10'
                               : 'border-muted'
                           )}
                           onClick={() => onSelectPreset(preset)}


### PR DESCRIPTION
## Summary

On the recharge page (`web/default/src/features/wallet/components/recharge-form-card.tsx`), the selected preset-amount button is nearly indistinguishable from unselected buttons in dark mode — users cannot tell which amount they have chosen.

## Root cause

The selected-state override only sets light-mode utilities:

```tsx
selectedPreset === preset.value
  ? 'border-foreground bg-foreground/5'   // <-- no dark: variants
  : 'border-muted'
```

while `<Button variant='outline'>` (`web/default/src/components/ui/button.tsx`) sets dark-only utilities in its base style:

```ts
outline:
  'border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50'
```

`tailwind-merge` keeps both `border-foreground` (no variant) and `dark:border-input` (dark variant) because they belong to different variant groups. At runtime, CSS specificity decides: `.dark .border-input` (compound selector, specificity 0,2,0) wins over `.border-foreground` (single class, specificity 0,1,0). Same story for `bg-foreground/5` vs `dark:bg-input/30`.

Result in dark mode: selected = unselected, both rendered with the variant's `dark:border-input` border and `dark:bg-input/30` background.

## Fix

Add `dark:` variants to the override so tailwind-merge resolves the dark-variant conflict in favor of the override:

```diff
-  ? 'border-foreground bg-foreground/5'
+  ? 'border-foreground bg-foreground/5 dark:border-foreground dark:bg-foreground/10'
```

After this, in dark mode the selected preset shows a bright `--foreground` border and a 10% foreground-tint background — clearly visible against the card surface. Light mode behavior is unchanged.

The bump from `/5` to `/10` for the dark-mode background offsets the fact that `--foreground` in dark mode is near-white and a 5% tint is too subtle against the dark card.

## Test plan

- [x] `cd web/default && bun run typecheck` passes
- [x] `cd web/default && bun run build` succeeds (via the project's `scripts/dev-build.sh`)
- [ ] Open `/topup` in dark mode → click a preset amount → verify bright border + visible tinted background on the selected card, and that the difference vs. unselected is clearly distinguishable
- [ ] Same page in light mode → confirm visual is unchanged from before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode styling for preset amount buttons in the recharge form when selected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->