### PR TITLE
fix(auth): localize WeChat OAuth messages

### DIFF
--- a/controller/custom_oauth.go
+++ b/controller/custom_oauth.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/oauth"
 	"github.com/gin-gonic/gin"
@@ -469,7 +470,7 @@ func buildUserOAuthBindingsResponse(userId int) ([]UserOAuthBindingResponse, err
 func GetUserOAuthBindings(c *gin.Context) {
 	userId := c.GetInt("id")
 	if userId == 0 {
-		common.ApiErrorMsg(c, "未登录")
+		common.ApiErrorI18n(c, i18n.MsgUnauthorized)
 		return
 	}
 
@@ -523,14 +524,14 @@ func GetUserOAuthBindingsByAdmin(c *gin.Context) {
 func UnbindCustomOAuth(c *gin.Context) {
 	userId := c.GetInt("id")
 	if userId == 0 {
-		common.ApiErrorMsg(c, "未登录")
+		common.ApiErrorI18n(c, i18n.MsgUnauthorized)
 		return
 	}
 
 	providerIdStr := c.Param("provider_id")
 	providerId, err := strconv.Atoi(providerIdStr)
 	if err != nil {
-		common.ApiErrorMsg(c, "无效的提供商 ID")
+		common.ApiErrorI18n(c, i18n.MsgInvalidId)
 		return
 	}
 
@@ -541,7 +542,7 @@ func UnbindCustomOAuth(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"message": "解绑成功",
+		"message": i18n.T(c, i18n.MsgCustomOAuthUnbindSuccess),
 	})
 }
 

--- a/controller/wechat.go
+++ b/controller/wechat.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -46,7 +45,7 @@ func getWeChatIdByCode(code string) (string, error) {
 	}
 	defer httpResponse.Body.Close()
 	var res wechatLoginResponse
-	err = json.NewDecoder(httpResponse.Body).Decode(&res)
+	err = common.DecodeJson(httpResponse.Body, &res)
 	if err != nil {
 		return "", err
 	}

--- a/controller/wechat.go
+++ b/controller/wechat.go
@@ -10,10 +10,16 @@ import (
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
+)
+
+var (
+	errWeChatInvalidCode        = errors.New("wechat code is empty")
+	errWeChatVerificationFailed = errors.New("wechat verification failed")
 )
 
 type wechatLoginResponse struct {
@@ -24,7 +30,7 @@ type wechatLoginResponse struct {
 
 func getWeChatIdByCode(code string) (string, error) {
 	if code == "" {
-		return "", errors.New("无效的参数")
+		return "", errWeChatInvalidCode
 	}
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/wechat/user?code=%s", common.WeChatServerAddress, url.QueryEscape(code)), nil)
 	if err != nil {
@@ -45,29 +51,35 @@ func getWeChatIdByCode(code string) (string, error) {
 		return "", err
 	}
 	if !res.Success {
-		return "", errors.New(res.Message)
+		return "", errWeChatVerificationFailed
 	}
 	if res.Data == "" {
-		return "", errors.New("验证码错误或已过期")
+		return "", errWeChatVerificationFailed
 	}
 	return res.Data, nil
 }
 
+func apiWeChatError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, errWeChatInvalidCode):
+		common.ApiErrorI18n(c, i18n.MsgInvalidParams)
+	case errors.Is(err, errWeChatVerificationFailed):
+		common.ApiErrorI18n(c, i18n.MsgUserVerificationCodeError)
+	default:
+		common.SysError("wechat auth failed: " + err.Error())
+		common.ApiErrorI18n(c, i18n.MsgOAuthConnectFailed, map[string]any{"Provider": "WeChat"})
+	}
+}
+
 func WeChatAuth(c *gin.Context) {
 	if !common.WeChatAuthEnabled {
-		c.JSON(http.StatusOK, gin.H{
-			"message": "管理员未开启通过微信登录以及注册",
-			"success": false,
-		})
+		common.ApiErrorI18n(c, i18n.MsgWeChatNotEnabled)
 		return
 	}
 	code := c.Query("code")
 	wechatId, err := getWeChatIdByCode(code)
 	if err != nil {
-		c.JSON(http.StatusOK, gin.H{
-			"message": err.Error(),
-			"success": false,
-		})
+		apiWeChatError(c, err)
 		return
 	}
 	user := model.User{
@@ -76,17 +88,11 @@ func WeChatAuth(c *gin.Context) {
 	if model.IsWeChatIdAlreadyTaken(wechatId) {
 		err := user.FillUserByWeChatId()
 		if err != nil {
-			c.JSON(http.StatusOK, gin.H{
-				"success": false,
-				"message": err.Error(),
-			})
+			common.ApiError(c, err)
 			return
 		}
 		if user.Id == 0 {
-			c.JSON(http.StatusOK, gin.H{
-				"success": false,
-				"message": "用户已注销",
-			})
+			common.ApiErrorI18n(c, i18n.MsgOAuthUserDeleted)
 			return
 		}
 	} else {
@@ -97,26 +103,17 @@ func WeChatAuth(c *gin.Context) {
 			user.Status = common.UserStatusEnabled
 
 			if err := user.Insert(0); err != nil {
-				c.JSON(http.StatusOK, gin.H{
-					"success": false,
-					"message": err.Error(),
-				})
+				common.ApiError(c, err)
 				return
 			}
 		} else {
-			c.JSON(http.StatusOK, gin.H{
-				"success": false,
-				"message": "管理员关闭了新用户注册",
-			})
+			common.ApiErrorI18n(c, i18n.MsgUserRegisterDisabled)
 			return
 		}
 	}
 
 	if user.Status != common.UserStatusEnabled {
-		c.JSON(http.StatusOK, gin.H{
-			"message": "用户已被封禁",
-			"success": false,
-		})
+		common.ApiErrorI18n(c, i18n.MsgUserDisabled)
 		return
 	}
 	setupLogin(&user, c)
@@ -128,34 +125,22 @@ type wechatBindRequest struct {
 
 func WeChatBind(c *gin.Context) {
 	if !common.WeChatAuthEnabled {
-		c.JSON(http.StatusOK, gin.H{
-			"message": "管理员未开启通过微信登录以及注册",
-			"success": false,
-		})
+		common.ApiErrorI18n(c, i18n.MsgWeChatNotEnabled)
 		return
 	}
 	var req wechatBindRequest
 	if err := common.DecodeJson(c.Request.Body, &req); err != nil {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "无效的请求",
-		})
+		common.ApiErrorI18n(c, i18n.MsgInvalidParams)
 		return
 	}
 	code := req.Code
 	wechatId, err := getWeChatIdByCode(code)
 	if err != nil {
-		c.JSON(http.StatusOK, gin.H{
-			"message": err.Error(),
-			"success": false,
-		})
+		apiWeChatError(c, err)
 		return
 	}
 	if model.IsWeChatIdAlreadyTaken(wechatId) {
-		c.JSON(http.StatusOK, gin.H{
-			"success": false,
-			"message": "该微信账号已被绑定",
-		})
+		common.ApiErrorI18n(c, i18n.MsgWeChatAccountUsed)
 		return
 	}
 	session := sessions.Default(c)

--- a/i18n/keys.go
+++ b/i18n/keys.go
@@ -329,4 +329,11 @@ const (
 	MsgCustomOAuthHasBindings       = "custom_oauth.has_bindings"
 	MsgCustomOAuthBindingNotFound   = "custom_oauth.binding_not_found"
 	MsgCustomOAuthProviderIdInvalid = "custom_oauth.provider_id_field_invalid"
+	MsgCustomOAuthUnbindSuccess     = "custom_oauth.unbind_success"
+)
+
+// WeChat auth related messages
+const (
+	MsgWeChatNotEnabled  = "wechat.not_enabled"
+	MsgWeChatAccountUsed = "wechat.account_used"
 )

--- a/i18n/locales/en.yaml
+++ b/i18n/locales/en.yaml
@@ -277,3 +277,8 @@ custom_oauth.name_empty: "Provider name cannot be empty"
 custom_oauth.has_bindings: "Cannot delete provider with existing user bindings"
 custom_oauth.binding_not_found: "OAuth binding not found"
 custom_oauth.provider_id_field_invalid: "Could not extract user ID from provider response"
+custom_oauth.unbind_success: "OAuth account unbound successfully"
+
+# WeChat auth messages
+wechat.not_enabled: "WeChat login and registration are not enabled"
+wechat.account_used: "This WeChat account has already been bound"

--- a/i18n/locales/zh-CN.yaml
+++ b/i18n/locales/zh-CN.yaml
@@ -278,3 +278,8 @@ custom_oauth.name_empty: "提供商名称不能为空"
 custom_oauth.has_bindings: "无法删除已有用户绑定的提供商"
 custom_oauth.binding_not_found: "OAuth 绑定不存在"
 custom_oauth.provider_id_field_invalid: "无法从提供商响应中提取用户 ID"
+custom_oauth.unbind_success: "OAuth 账户解绑成功"
+
+# WeChat auth messages
+wechat.not_enabled: "管理员未开启通过微信登录以及注册"
+wechat.account_used: "该微信账户已被绑定"

--- a/i18n/locales/zh-TW.yaml
+++ b/i18n/locales/zh-TW.yaml
@@ -278,3 +278,8 @@ custom_oauth.name_empty: "供應者名稱不能為空"
 custom_oauth.has_bindings: "無法刪除已有使用者綁定的供應者"
 custom_oauth.binding_not_found: "OAuth 綁定不存在"
 custom_oauth.provider_id_field_invalid: "無法從供應者響應中提取使用者 ID"
+custom_oauth.unbind_success: "OAuth 帳號解除綁定成功"
+
+# WeChat auth messages
+wechat.not_enabled: "管理員未開啟透過微信登入以及註冊"
+wechat.account_used: "該微信帳號已被綁定"


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
Localize user-facing WeChat OAuth login/bind responses and current-user custom OAuth binding responses through the existing backend i18n layer.

This removes hardcoded Chinese responses from ordinary user auth flows, adds matching `en`, `zh-CN`, and `zh-TW` locale keys, and keeps admin custom OAuth provider management endpoints unchanged.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- N/A, small i18n follow-up for existing auth endpoints.

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- `gofmt -w controller/custom_oauth.go controller/wechat.go i18n/keys.go`
- `go test ./controller ./i18n`
- `git diff --check`
- Parsed `i18n/locales/en.yaml`, `zh-CN.yaml`, and `zh-TW.yaml`
- Confirmed the added locale keys are present in all three locale files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication flows (WeChat and custom OAuth) now show localized messages in English, Simplified Chinese, and Traditional Chinese.
  * Success and error notifications for bind/unbind, auth failures, and account-in-use scenarios are translated and presented consistently.
  * Added new localized messages for OAuth unbind success and WeChat-specific errors to improve user-facing clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4907?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->