### PR TITLE
fix: add type="submit" to forgot password form button

### DIFF
--- a/web/default/src/features/auth/forgot-password/components/forgot-password-form.tsx
+++ b/web/default/src/features/auth/forgot-password/components/forgot-password-form.tsx
@@ -107,7 +107,7 @@ export function ForgotPasswordForm({
           )}
         />
 
-        <Button className='mt-2' disabled={isLoading || isActive}>
+        <Button type='submit' className='mt-2' disabled={isLoading || isActive}>
           {isActive ? `Resend (${secondsLeft}s)` : 'Send reset email'}
           {isLoading ? <Loader2 className='animate-spin' /> : <ArrowRight />}
         </Button>


### PR DESCRIPTION
## Summary

- Adds `type="submit"` to the primary "Send reset email" `<Button>` in the forgot password form, enabling form submission when the button is clicked.
- All other auth forms (sign-in, sign-up, OTP, reset-password-confirm) already have this attribute set correctly on their submit buttons.

Closes #4793

## Root Cause

The `<Button>` component defaults to `type="button"`, which does not trigger form submission. Since the `<form>` element uses `onSubmit={form.handleSubmit(onSubmit)}`, clicking the button without `type="submit"` fires a click event but never invokes the form's submit handler.

## Test Plan

- [x] Code change is a single attribute addition, consistent with other auth forms
- [ ] Manual test: navigate to `/forgot-password`, enter email, click "Send reset email", verify XHR request fires and success toast appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the forgot password form's submit button to properly function as a form submission trigger.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->