### PR TITLE
fix(i18n): default API responses to English

### DIFF
--- a/constant/context_key.go
+++ b/constant/context_key.go
@@ -66,4 +66,5 @@ const (
 	// ContextKeyLanguage stores the user's language preference for i18n
 	ContextKeyLanguage ContextKey = "language"
 	ContextKeyIsStream ContextKey = "is_stream"
+	ContextKeyRouteTag ContextKey = "route_tag"
 )

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -121,12 +121,18 @@ func SetUserLangLoader(loader func(userId int) string) {
 	userLangLoaderFunc = loader
 }
 
+func usesExplicitLanguageOnly(c *gin.Context) bool {
+	routeTag := c.GetString(string(constant.ContextKeyRouteTag))
+	return routeTag == "relay" || routeTag == "old_api"
+}
+
 // GetLangFromContext extracts the language setting from gin context
 // It checks multiple sources in priority order:
 // 1. User settings (ContextKeyUserSetting) - if already loaded (e.g., by TokenAuth)
 // 2. Lazy load user language from cache/DB using user ID
-// 3. Language set by middleware (ContextKeyLanguage) - from Accept-Language header
-// 4. Default language (English)
+// 3. For API-client routes, default to English instead of Accept-Language
+// 4. Language set by middleware (ContextKeyLanguage) - from Accept-Language header
+// 5. Default language (English)
 func GetLangFromContext(c *gin.Context) string {
 	if c == nil {
 		return DefaultLang
@@ -157,7 +163,12 @@ func GetLangFromContext(c *gin.Context) string {
 		}
 	}
 
-	// 3. Try to get language from context (set by I18n middleware from Accept-Language)
+	// API clients should receive stable English errors unless the user explicitly saved a language preference.
+	if usesExplicitLanguageOnly(c) {
+		return DefaultLang
+	}
+
+	// 4. Try to get language from context (set by I18n middleware from Accept-Language)
 	if lang := c.GetString(string(constant.ContextKeyLanguage)); lang != "" {
 		normalized := normalizeLang(lang)
 		if IsSupported(normalized) {
@@ -165,7 +176,7 @@ func GetLangFromContext(c *gin.Context) string {
 		}
 	}
 
-	// 4. Try Accept-Language header directly (fallback if middleware didn't run)
+	// 5. Try Accept-Language header directly (fallback if middleware didn't run)
 	if acceptLang := c.GetHeader("Accept-Language"); acceptLang != "" {
 		lang := ParseAcceptLanguage(acceptLang)
 		if IsSupported(lang) {

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -1,0 +1,54 @@
+package i18n
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+)
+
+func TestGetLangFromContextAPIRoutesDefaultEnglish(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []string{"relay", "old_api"}
+
+	for _, routeTag := range tests {
+		t.Run(routeTag, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest("GET", "/v1/chat/completions", nil)
+			c.Request.Header.Set("Accept-Language", "zh-CN,zh;q=0.9")
+			c.Set(string(constant.ContextKeyRouteTag), routeTag)
+
+			if got := GetLangFromContext(c); got != LangEn {
+				t.Fatalf("expected API route to default to %q, got %q", LangEn, got)
+			}
+		})
+	}
+}
+
+func TestGetLangFromContextAPIRoutesUseExplicitUserLanguage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("GET", "/v1/chat/completions", nil)
+	c.Request.Header.Set("Accept-Language", "en")
+	c.Set(string(constant.ContextKeyRouteTag), "relay")
+	common.SetContextKey(c, constant.ContextKeyUserSetting, dto.UserSetting{Language: LangZhCN})
+
+	if got := GetLangFromContext(c); got != LangZhCN {
+		t.Fatalf("expected explicit user language %q, got %q", LangZhCN, got)
+	}
+}
+
+func TestGetLangFromContextWebRoutesUseAcceptLanguage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("GET", "/api/user/login", nil)
+	c.Request.Header.Set("Accept-Language", "zh-CN,zh;q=0.9")
+
+	if got := GetLangFromContext(c); got != LangZhCN {
+		t.Fatalf("expected web route to use Accept-Language %q, got %q", LangZhCN, got)
+	}
+}

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/gin-gonic/gin"
 )
 
-const RouteTagKey = "route_tag"
+const RouteTagKey = string(constant.ContextKeyRouteTag)
 
 func RouteTag(tag string) gin.HandlerFunc {
 	return func(c *gin.Context) {


### PR DESCRIPTION
# PR Notice

## Description
API-style routes should not inherit `Accept-Language` from generic clients by default. This keeps relay and old API responses in English unless the user has explicitly configured a language.

The change stores the route tag in context and lets `i18n.GetLangFromContext` skip browser language detection for `relay` and `old_api` routes. Web-facing routes still use the existing `Accept-Language` fallback.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation

## Related Issue
- N/A

## Checklist
- [x] I manually reviewed and wrote this description.
- [x] I searched existing issues and PRs and did not find a duplicate.
- [x] Bug fix note: this PR is not marked as a bug fix.
- [x] I understand how this change works and its impact.
- [x] This PR only includes changes related to API language selection.
- [x] I ran local validation.
- [x] No secrets or credentials are included.

## Proof of Work
- `gofmt -w constant/context_key.go middleware/logger.go i18n/i18n.go i18n/i18n_test.go`
- `go test ./i18n ./middleware`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * API client routes now consistently default to English language. User language preferences and browser language settings no longer affect language behavior for API requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->