### PR TITLE
fix(middleware): detect and handle gzip/zstd automatically and return 415 for invalid encodings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/middleware/gzip.go
+++ b/middleware/gzip.go
@@ -1,13 +1,16 @@
 package middleware
 
 import (
+	"bufio"
 	"compress/gzip"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/andybalholm/brotli"
 	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
 )
 
 type readCloser struct {
@@ -38,16 +41,39 @@ func DecompressRequestMiddleware() gin.HandlerFunc {
 		wrapMaxBytes := func(body io.ReadCloser) io.ReadCloser {
 			return http.MaxBytesReader(c.Writer, body, maxBytes)
 		}
+		clearContentLength := func() {
+			c.Request.ContentLength = -1
+			c.Request.Header.Del("Content-Length")
+		}
 
-		switch c.GetHeader("Content-Encoding") {
+		encoding := strings.ToLower(c.GetHeader("Content-Encoding"))
+		encoding = strings.TrimSpace(encoding)
+
+		// Use bufio.Reader to peek without consuming
+		br := bufio.NewReader(origBody)
+		peek, _ := br.Peek(4)
+
+		if encoding == "" || encoding == "identity" {
+			if len(peek) >= 2 && peek[0] == 0x1f && peek[1] == 0x8b {
+				encoding = "gzip"
+			} else if len(peek) >= 4 && peek[0] == 0x28 && peek[1] == 0xb5 && peek[2] == 0x2f && peek[3] == 0xfd {
+				encoding = "zstd"
+			}
+		}
+
+		switch encoding {
 		case "gzip":
-			gzipReader, err := gzip.NewReader(origBody)
+			gzipReader, err := gzip.NewReader(br)
 			if err != nil {
 				_ = origBody.Close()
-				c.AbortWithStatus(http.StatusBadRequest)
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+					"error": gin.H{
+						"message": "invalid gzip body",
+						"type":    "invalid_request_error",
+					},
+				})
 				return
 			}
-			// Replace the request body with the decompressed data, and enforce a max size (post-decompression).
 			c.Request.Body = wrapMaxBytes(&readCloser{
 				Reader: gzipReader,
 				closeFn: func() error {
@@ -55,19 +81,55 @@ func DecompressRequestMiddleware() gin.HandlerFunc {
 					return origBody.Close()
 				},
 			})
+			clearContentLength()
 			c.Request.Header.Del("Content-Encoding")
 		case "br":
-			reader := brotli.NewReader(origBody)
+			reader := brotli.NewReader(br)
 			c.Request.Body = wrapMaxBytes(&readCloser{
 				Reader: reader,
 				closeFn: func() error {
 					return origBody.Close()
 				},
 			})
+			clearContentLength()
 			c.Request.Header.Del("Content-Encoding")
+		case "zstd":
+			decoder, err := zstd.NewReader(br)
+			if err != nil {
+				_ = origBody.Close()
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+					"error": gin.H{
+						"message": "invalid zstd body",
+						"type":    "invalid_request_error",
+					},
+				})
+				return
+			}
+			c.Request.Body = wrapMaxBytes(&readCloser{
+				Reader: decoder,
+				closeFn: func() error {
+					decoder.Close()
+					return origBody.Close()
+				},
+			})
+			clearContentLength()
+			c.Request.Header.Del("Content-Encoding")
+		case "", "identity":
+			c.Request.Body = wrapMaxBytes(&readCloser{
+				Reader: br,
+				closeFn: func() error {
+					return origBody.Close()
+				},
+			})
 		default:
-			// Even for uncompressed bodies, enforce a max size to avoid huge request allocations.
-			c.Request.Body = wrapMaxBytes(origBody)
+			_ = origBody.Close()
+			c.AbortWithStatusJSON(http.StatusUnsupportedMediaType, gin.H{
+				"error": gin.H{
+					"message": "unsupported content encoding: " + encoding,
+					"type":    "invalid_request_error",
+				},
+			})
+			return
 		}
 
 		// Continue processing the request


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

## 📝 变更描述 / Description
* OpenAI Codex 在开启远程控制后会使用 zstd 来压缩body，于是支援了zstd
* 当客户端发来的请求头没有声明压缩时会判断body的前4个字节是否符合gzip或zstd然后使用对应方式解压
* 现在在请求头中遇到不支持的编码会拒绝 而不是直接不处理，防止一些意义不明的错误
* 修改了错误响应

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- closes #4914 

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
```
[INFO] 2026/05/18 - 15:44:42 | 20260518064426450124000G6bjpudSQlpdDP3d | record consume log: userId=1, params={"channel_id":1,"prompt_tokens":143230,"completion_tokens":51,"model_name":"gpt-5.5","token_name":"default","quota":5382600,"content":"","token_id":1,"use_time_seconds":16,"is_stream":true,"group":"default","other":{"admin_info":{"channel_affinity":{"channel_id":1,"key_fp":"34407c4d","key_hint":"019e...66b1","key_key":"","key_path":"prompt_cache_key","key_source":"gjson","model":"gpt-5.5","override_template":{"applied":true,"param_override_keys":1,"rule_name":"codex cli trace"},"reason":"codex cli trace","request_path":"/v1/responses","rule_name":"codex cli trace","selected_group":"default","using_group":"default"},"use_channel":["1"]},"billing_source":"wallet","cache_ratio":1,"cache_tokens":142720,"completion_ratio":6,"frt":10952,"group_ratio":1,"model_price":-1,"model_ratio":37.5,"reasoning_effort":"high","request_conversion":["OpenAI Responses"],"request_path":"/v1/responses","stream_status":{"end_reason":"eof","status":"ok"},"user_group_ratio":-1}} 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request decompression with auto-detection for gzip and zstd payloads.
  * Enhanced error handling that returns structured JSON for invalid compressed data.
  * Returns HTTP 415 with detected encoding for unsupported content encodings.
  * Ensures decoded request streams enforce configured size limits and properly manage content headers.

* **Chores**
  * Promoted a compression library dependency from indirect to direct in module declarations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4936?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->