### PR TITLE
fix: close Claude stream when final usage is estimated

### DIFF
--- a/service/convert.go
+++ b/service/convert.go
@@ -465,9 +465,7 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 		doneChunk := chosenChoice.FinishReason != nil && *chosenChoice.FinishReason != ""
 		if doneChunk {
 			info.FinishReason = *chosenChoice.FinishReason
-			oaiUsage := openAIResponse.Usage
-			if oaiUsage == nil {
-				oaiUsage = info.ClaudeConvertInfo.Usage
+			if openAIResponse.Usage == nil && info.ClaudeConvertInfo.Usage == nil {
 				// Some upstreams emit finish_reason first, then send a final usage-only chunk.
 				// Defer closing until usage is available so the final message_delta carries it.
 				return claudeResponses

--- a/service/convert_test.go
+++ b/service/convert_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamResponseOpenAI2ClaudeClosesStopChunkWithoutUpstreamUsage(t *testing.T) {
+	info := &relaycommon.RelayInfo{
+		ClaudeConvertInfo: &relaycommon.ClaudeConvertInfo{
+			LastMessagesType: relaycommon.LastMessageTypeNone,
+			Usage: &dto.Usage{
+				PromptTokens:     10,
+				CompletionTokens: 20,
+			},
+		},
+	}
+
+	content := func(text string) *dto.ChatCompletionsStreamResponse {
+		return &dto.ChatCompletionsStreamResponse{
+			Id:      "chatcmpl-test",
+			Object:  "chat.completion.chunk",
+			Model:   "qwen3.6-plus",
+			Choices: []dto.ChatCompletionsStreamResponseChoice{{Delta: dto.ChatCompletionsStreamResponseChoiceDelta{Content: common.GetPointer(text)}}},
+		}
+	}
+	reasoning := func(text string) *dto.ChatCompletionsStreamResponse {
+		return &dto.ChatCompletionsStreamResponse{
+			Id:      "chatcmpl-test",
+			Object:  "chat.completion.chunk",
+			Model:   "qwen3.6-plus",
+			Choices: []dto.ChatCompletionsStreamResponseChoice{{Delta: dto.ChatCompletionsStreamResponseChoiceDelta{ReasoningContent: common.GetPointer(text)}}},
+		}
+	}
+
+	info.SendResponseCount = 1
+	responses := StreamResponseOpenAI2Claude(reasoning("thinking"), info)
+	require.Len(t, responses, 3)
+	require.Equal(t, "message_start", responses[0].Type)
+	require.Equal(t, "content_block_start", responses[1].Type)
+	require.Equal(t, "content_block_delta", responses[2].Type)
+
+	info.SendResponseCount = 2
+	responses = StreamResponseOpenAI2Claude(content("hello"), info)
+	require.Len(t, responses, 3)
+	require.Equal(t, "content_block_stop", responses[0].Type)
+	require.Equal(t, 0, responses[0].GetIndex())
+	require.Equal(t, "content_block_start", responses[1].Type)
+	require.Equal(t, 1, responses[1].GetIndex())
+	require.Equal(t, "content_block_delta", responses[2].Type)
+
+	finishReason := constant.FinishReasonStop
+	responses = StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Id:     "chatcmpl-test",
+		Object: "chat.completion.chunk",
+		Model:  "qwen3.6-plus",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{{
+			Delta:        dto.ChatCompletionsStreamResponseChoiceDelta{Content: common.GetPointer("")},
+			FinishReason: &finishReason,
+		}},
+	}, info)
+
+	require.Len(t, responses, 3)
+	require.Equal(t, "content_block_stop", responses[0].Type)
+	require.Equal(t, 1, responses[0].GetIndex())
+	require.Equal(t, "message_delta", responses[1].Type)
+	require.NotNil(t, responses[1].Usage)
+	require.Equal(t, 10, responses[1].Usage.InputTokens)
+	require.Equal(t, 20, responses[1].Usage.OutputTokens)
+	require.NotNil(t, responses[1].Delta)
+	require.NotNil(t, responses[1].Delta.StopReason)
+	require.Equal(t, "end_turn", *responses[1].Delta.StopReason)
+	require.Equal(t, "message_stop", responses[2].Type)
+	require.True(t, info.ClaudeConvertInfo.Done)
+}


### PR DESCRIPTION
## 📝 变更描述 / Description

修复 OpenAI-compatible stream 转 Anthropic `/v1/messages` 时的结束事件丢失问题。

此前当上游最后一个 chunk 只有 `finish_reason: "stop"`、没有 `usage` 时，转换器会提前返回等待 usage-only chunk。对于已经在最终处理阶段写入本地估算 usage 的请求，这会跳过 `content_block_stop`、`message_delta` 和 `message_stop`，导致 Claude Code 等客户端一直等待流结束。

本次改动只在当前 chunk 和 `ClaudeConvertInfo.Usage` 都没有 usage 时继续等待；如果已有估算 usage，则正常关闭当前 content block 并输出 Anthropic 结束事件。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #4697

## ✅ 提交前检查项 / Checklist

- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```bash
docker run --rm -v /Users/yimingshi/Documents/new-api:/workspace -w /workspace golang:1.25 go test ./service -run TestStreamResponseOpenAI2ClaudeClosesStopChunkWithoutUpstreamUsage -count=1
docker run --rm -v /Users/yimingshi/Documents/new-api:/workspace -w /workspace golang:1.25 go test ./service -count=1
docker run --rm -v /Users/yimingshi/Documents/new-api:/workspace -w /workspace golang:1.25 go test ./relay/channel/openai -run TestNonexistent -count=1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incorrect completion/usage emission when upstream usage data is missing, ensuring stop reasons and final message signals are handled correctly during stream conversion.

* **Tests**
  * Added unit tests covering streaming behavior across reasoning, content, and finish-reason scenarios to validate correct stop-reason mapping, usage propagation, and finalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->