### PR TITLE
fix: preserve DeepSeek V4 reasoning history

### DIFF
--- a/service/convert.go
+++ b/service/convert.go
@@ -146,6 +146,7 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 			contents := content
 			var toolCalls []dto.ToolCallRequest
 			mediaMessages := make([]dto.MediaContent, 0, len(contents))
+			var reasoningContent strings.Builder
 
 			for _, mediaMsg := range contents {
 				switch mediaMsg.Type {
@@ -165,6 +166,10 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 						ImageUrl: &dto.MessageImageUrl{Url: imageData},
 					}
 					mediaMessages = append(mediaMessages, mediaMessage)
+				case "thinking":
+					if shouldPreserveClaudeThinkingAsOpenAIReasoning(info, claudeRequest.Model) && mediaMsg.Thinking != nil {
+						reasoningContent.WriteString(*mediaMsg.Thinking)
+					}
 				case "tool_use":
 					toolCall := dto.ToolCallRequest{
 						ID:   mediaMsg.Id,
@@ -201,12 +206,15 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 			if len(toolCalls) > 0 {
 				openAIMessage.SetToolCalls(toolCalls)
 			}
+			if reasoningContent.Len() > 0 {
+				openAIMessage.ReasoningContent = common.GetPointer[string](reasoningContent.String())
+			}
 
 			if len(mediaMessages) > 0 && len(toolCalls) == 0 {
 				openAIMessage.SetMediaContent(mediaMessages)
 			}
 		}
-		if len(openAIMessage.ParseContent()) > 0 || len(openAIMessage.ToolCalls) > 0 {
+		if len(openAIMessage.ParseContent()) > 0 || len(openAIMessage.ToolCalls) > 0 || openAIMessage.GetReasoningContent() != "" {
 			openAIMessages = append(openAIMessages, openAIMessage)
 		}
 	}
@@ -214,6 +222,14 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 	openAIRequest.Messages = openAIMessages
 
 	return &openAIRequest, nil
+}
+
+func shouldPreserveClaudeThinkingAsOpenAIReasoning(info *relaycommon.RelayInfo, requestModel string) bool {
+	modelName := requestModel
+	if info != nil && info.ChannelMeta != nil && info.UpstreamModelName != "" {
+		modelName = info.UpstreamModelName
+	}
+	return strings.HasPrefix(modelName, "deepseek-v4-")
 }
 
 func generateStopBlock(index int) *dto.ClaudeResponse {

--- a/service/convert.go
+++ b/service/convert.go
@@ -226,8 +226,8 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 
 func shouldPreserveClaudeThinkingAsOpenAIReasoning(info *relaycommon.RelayInfo, requestModel string) bool {
 	modelName := requestModel
-	if info != nil && info.ChannelMeta != nil && info.UpstreamModelName != "" {
-		modelName = info.UpstreamModelName
+	if info != nil && info.ChannelMeta != nil && info.ChannelMeta.UpstreamModelName != "" {
+		modelName = info.ChannelMeta.UpstreamModelName
 	}
 	return strings.HasPrefix(modelName, "deepseek-v4-")
 }

--- a/service/convert_test.go
+++ b/service/convert_test.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaudeToOpenAIRequestPreservesThinkingForDeepSeekV4(t *testing.T) {
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "deepseek-v4-flash",
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "deepseek-v4-flash",
+		},
+	}
+	req := dto.ClaudeRequest{
+		Model: "deepseek-v4-flash",
+		Messages: []dto.ClaudeMessage{
+			{
+				Role: "assistant",
+				Content: []dto.ClaudeMediaMessage{
+					{
+						Type:     "thinking",
+						Thinking: common.GetPointer("checked context"),
+					},
+					{
+						Type: "text",
+						Text: common.GetPointer("I will call the tool."),
+					},
+					{
+						Type:  "tool_use",
+						Id:    "toolu_1",
+						Name:  "search",
+						Input: map[string]any{"query": "deepseek"},
+					},
+				},
+			},
+		},
+	}
+
+	converted, err := ClaudeToOpenAIRequest(req, info)
+	require.NoError(t, err)
+	require.Len(t, converted.Messages, 1)
+	require.Equal(t, "checked context", converted.Messages[0].GetReasoningContent())
+	require.Len(t, converted.Messages[0].ParseToolCalls(), 1)
+}
+
+func TestClaudeToOpenAIRequestDropsThinkingForOtherModels(t *testing.T) {
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "gpt-4.1",
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "gpt-4.1",
+		},
+	}
+	req := dto.ClaudeRequest{
+		Model: "gpt-4.1",
+		Messages: []dto.ClaudeMessage{
+			{
+				Role: "assistant",
+				Content: []dto.ClaudeMediaMessage{
+					{
+						Type:     "thinking",
+						Thinking: common.GetPointer("internal reasoning"),
+					},
+					{
+						Type: "text",
+						Text: common.GetPointer("visible answer"),
+					},
+				},
+			},
+		},
+	}
+
+	converted, err := ClaudeToOpenAIRequest(req, info)
+	require.NoError(t, err)
+	require.Len(t, converted.Messages, 1)
+	require.Empty(t, converted.Messages[0].GetReasoningContent())
+	require.Len(t, converted.Messages[0].ParseContent(), 1)
+	require.Equal(t, "visible answer", converted.Messages[0].ParseContent()[0].Text)
+}

--- a/service/convert_test.go
+++ b/service/convert_test.go
@@ -48,6 +48,34 @@ func TestClaudeToOpenAIRequestPreservesThinkingForDeepSeekV4(t *testing.T) {
 	require.Len(t, converted.Messages[0].ParseToolCalls(), 1)
 }
 
+func TestClaudeToOpenAIRequestPreservesThinkingForMappedDeepSeekV4(t *testing.T) {
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "deepseek-v4",
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "deepseek-v4-flash",
+		},
+	}
+	req := dto.ClaudeRequest{
+		Model: "deepseek-v4",
+		Messages: []dto.ClaudeMessage{
+			{
+				Role: "assistant",
+				Content: []dto.ClaudeMediaMessage{
+					{
+						Type:     "thinking",
+						Thinking: common.GetPointer("mapped model context"),
+					},
+				},
+			},
+		},
+	}
+
+	converted, err := ClaudeToOpenAIRequest(req, info)
+	require.NoError(t, err)
+	require.Len(t, converted.Messages, 1)
+	require.Equal(t, "mapped model context", converted.Messages[0].GetReasoningContent())
+}
+
 func TestClaudeToOpenAIRequestDropsThinkingForOtherModels(t *testing.T) {
 	info := &relaycommon.RelayInfo{
 		OriginModelName: "gpt-4.1",


### PR DESCRIPTION
## 📝 变更描述 / Description

DeepSeek V4 thinking 模式在多轮对话中要求把上一轮 assistant 的 reasoning 历史继续传给上游。Claude Code 这类 Anthropic 客户端会把这段内容保存为 Claude `thinking` content block；当前 Claude -> OpenAI 转换会跳过该 block，导致第二轮请求缺少 `reasoning_content`，触发上游 400。

本次改动在目标上游模型为 `deepseek-v4-*` 时，将 Claude `thinking` block 保留为 OpenAI 消息的 `reasoning_content`。其他模型继续丢弃 thinking block，避免影响普通 OpenAI-compatible 渠道。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #4543

## ✅ 提交前检查项 / Checklist

- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```bash
docker run --rm -v /Users/yimingshi/Documents/new-api:/workspace -w /workspace golang:1.25 go test ./service -run 'TestClaudeToOpenAIRequestPreservesThinkingForDeepSeekV4|TestClaudeToOpenAIRequestDropsThinkingForOtherModels' -count=1
docker run --rm -v /Users/yimingshi/Documents/new-api:/workspace -w /workspace golang:1.25 go test ./service -count=1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Convert Claude "thinking" segments into OpenAI "reasoning" content for the deepseek-v4 model family, allowing reasoning-only messages to be emitted where applicable.

* **Tests**
  * Added unit tests verifying preservation of thinking-as-reasoning for deepseek-v4 variants and correct dropping of thinking for other models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->