### PR TITLE
fix: 修复 OpenRouter 令牌余额查询 403 错误

### DIFF
--- a/controller/channel-billing.go
+++ b/controller/channel-billing.go
@@ -121,6 +121,13 @@ type OpenRouterCreditResponse struct {
 	} `json:"data"`
 }
 
+type OpenRouterKeyResponse struct {
+	Data struct {
+		LimitRemaining float64 `json:"limit_remaining"`
+		TotalUsage     float64 `json:"usage"`
+	}
+}
+
 // GetAuthHeader get auth header
 func GetAuthHeader(token string) http.Header {
 	h := http.Header{}
@@ -307,19 +314,34 @@ func updateChannelAIGC2DBalance(channel *model.Channel) (float64, error) {
 }
 
 func updateChannelOpenRouterBalance(channel *model.Channel) (float64, error) {
+	authHeader := GetAuthHeader(channel.Key)
+
 	url := "https://openrouter.ai/api/v1/credits"
-	body, err := GetResponseBody("GET", url, channel, GetAuthHeader(channel.Key))
-	if err != nil {
-		return 0, err
+	body, err := GetResponseBody("GET", url, channel, authHeader)
+	if err == nil {
+		response := OpenRouterCreditResponse{}
+		err = json.Unmarshal(body, &response)
+		if err != nil {
+			return 0, err
+		}
+		balance := response.Data.TotalCredits - response.Data.TotalUsage
+		channel.UpdateBalance(balance)
+		return balance, nil
 	}
-	response := OpenRouterCreditResponse{}
-	err = json.Unmarshal(body, &response)
-	if err != nil {
-		return 0, err
+
+	url = "https://openrouter.ai/api/v1/key"
+	body, err = GetResponseBody("GET", url, channel, authHeader)
+	if err == nil {
+		response := OpenRouterKeyResponse{}
+		err = json.Unmarshal(body, &response)
+		if err != nil {
+			return 0, err
+		}
+		balance := response.Data.LimitRemaining
+		channel.UpdateBalance(balance)
+		return balance, nil
 	}
-	balance := response.Data.TotalCredits - response.Data.TotalUsage
-	channel.UpdateBalance(balance)
-	return balance, nil
+	return 0, err
 }
 
 func updateChannelMoonshotBalance(channel *model.Channel) (float64, error) {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
默认 `/api/v1/credits` 接口需要管理秘钥才能获取余额，403 错误时降级使用 `/api/v1/key` 让普通秘钥也能正确获取余额。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
失败截图：
<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/b85dc271-bf71-45bc-a7f8-cd6923d19c9e" />

成功截图：
<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/089a208a-2d31-49bd-b555-da389070cd1f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced OpenRouter balance retrieval with improved reliability. The system now includes a fallback mechanism: if the primary endpoint for account credits is unavailable, it automatically retrieves balance and credit limit information from an alternative source, ensuring continuous and uninterrupted access to billing data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->