### PR TITLE
fix: remove deleted Anthropic beta header for AWS

### DIFF
--- a/relay/channel/aws/relay-aws.go
+++ b/relay/channel/aws/relay-aws.go
@@ -116,6 +116,11 @@ func doAwsClientRequest(c *gin.Context, info *relaycommon.RelayInfo, a *Adaptor,
 	if err != nil {
 		return nil, err
 	}
+	if info.UseRuntimeHeadersOverride {
+		if _, ok := headerOverride["anthropic-beta"]; !ok {
+			requestHeader.Del("anthropic-beta")
+		}
+	}
 	for key, value := range headerOverride {
 		requestHeader.Set(key, value)
 	}

--- a/relay/channel/aws/relay_aws_test.go
+++ b/relay/channel/aws/relay_aws_test.go
@@ -182,6 +182,40 @@ func TestDoAwsClientRequest_AppliesRuntimeHeaderOverrideToAnthropicBeta(t *testi
 	require.Equal(t, []any{"computer-use-2025-01-24"}, values)
 }
 
+func TestDoAwsClientRequest_RemovesAnthropicBetaWhenRuntimeOverrideDeletesIt(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/messages", nil)
+	ctx.Request.Header.Set("anthropic-beta", "claude-code-20250219,effort-2025-11-24")
+
+	info := &relaycommon.RelayInfo{
+		OriginModelName:           "claude-3-5-sonnet-20240620",
+		IsStream:                  false,
+		UseRuntimeHeadersOverride: true,
+		RuntimeHeadersOverride:    map[string]any{},
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ApiKey:            "access-key|secret-key|us-east-1",
+			UpstreamModelName: "claude-3-5-sonnet-20240620",
+		},
+	}
+
+	requestBody := bytes.NewBufferString(`{"messages":[{"role":"user","content":"hello"}],"max_tokens":128}`)
+	adaptor := &Adaptor{}
+
+	_, err := doAwsClientRequest(ctx, info, adaptor, requestBody)
+	require.NoError(t, err)
+
+	awsReq, ok := adaptor.AwsReq.(*bedrockruntime.InvokeModelInput)
+	require.True(t, ok)
+
+	var payload map[string]any
+	require.NoError(t, common.Unmarshal(awsReq.Body, &payload))
+	require.NotContains(t, payload, "anthropic_beta")
+}
+
 func TestNewAwsInvokeContextInheritsParent(t *testing.T) {
 	originalRelayTimeout := common.RelayTimeout
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary
- Remove the inherited `anthropic-beta` header when runtime header overrides are enabled but no replacement `anthropic-beta` is provided.
- Add AWS relay coverage for deleting the beta header from Bedrock Claude requests.

## Why
Runtime header overrides can intentionally remove request headers. The AWS relay copied the incoming `anthropic-beta` header into the Bedrock payload even when the override map omitted it, so removed beta flags could still be forwarded upstream.

## Tests
- `go test ./relay/channel/aws -run 'TestDoAwsClientRequest_(AppliesRuntimeHeaderOverrideToAnthropicBeta|RemovesAnthropicBetaWhenRuntimeOverrideDeletesIt)'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request header handling so the `anthropic-beta` header is removed from outgoing requests when runtime header overrides do not include it.
  * Prevented unintended beta feature flags from being forwarded to downstream services.

* **Tests**
  * Added coverage verifying correct header removal when incoming requests contain `anthropic-beta` but runtime overrides are empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->