### PR TITLE
fix(channels): apply group filter in GetAllChannels (#4951)

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -85,6 +85,12 @@ func GetAllChannels(c *gin.Context) {
 			typeFilter = t
 		}
 	}
+	// group filter: matches CSV `group` column using the same semantics as SearchChannels
+	groupFilter := c.Query("group")
+	if groupFilter == "null" {
+		groupFilter = ""
+	}
+	groupCondition, groupArg := model.BuildChannelGroupCondition(groupFilter)
 
 	var total int64
 
@@ -114,6 +120,9 @@ func GetAllChannels(c *gin.Context) {
 				if typeFilter >= 0 && ch.Type != typeFilter {
 					continue
 				}
+				if groupFilter != "" && !model.ChannelGroupMatches(ch.Group, groupFilter) {
+					continue
+				}
 				filtered = append(filtered, ch)
 			}
 			channelData = append(channelData, filtered...)
@@ -128,6 +137,9 @@ func GetAllChannels(c *gin.Context) {
 			baseQuery = baseQuery.Where("status = ?", common.ChannelStatusEnabled)
 		} else if statusFilter == 0 {
 			baseQuery = baseQuery.Where("status != ?", common.ChannelStatusEnabled)
+		}
+		if groupCondition != "" {
+			baseQuery = baseQuery.Where(groupCondition, groupArg)
 		}
 
 		baseQuery.Count(&total)
@@ -149,6 +161,9 @@ func GetAllChannels(c *gin.Context) {
 		countQuery = countQuery.Where("status = ?", common.ChannelStatusEnabled)
 	} else if statusFilter == 0 {
 		countQuery = countQuery.Where("status != ?", common.ChannelStatusEnabled)
+	}
+	if groupCondition != "" {
+		countQuery = countQuery.Where(groupCondition, groupArg)
 	}
 	var results []struct {
 		Type  int64

--- a/model/channel.go
+++ b/model/channel.go
@@ -827,6 +827,37 @@ func DeleteDisabledChannel() (int64, error) {
 	return result.RowsAffected, result.Error
 }
 
+// BuildChannelGroupCondition returns a SQL fragment and arg that matches a single
+// group token inside the CSV `group` column. Returns ("", nil) when group is empty,
+// which means no filter should be applied. The semantics match SearchChannels so
+// frontend filtering behaves consistently across both endpoints.
+func BuildChannelGroupCondition(group string) (string, interface{}) {
+	if group == "" || group == "null" {
+		return "", nil
+	}
+	var groupCondition string
+	if common.UsingMySQL {
+		groupCondition = `CONCAT(',', ` + commonGroupCol + `, ',') LIKE ?`
+	} else {
+		// sqlite, PostgreSQL
+		groupCondition = `(',' || ` + commonGroupCol + ` || ',') LIKE ?`
+	}
+	return groupCondition, "%," + group + ",%"
+}
+
+// ChannelGroupMatches reports whether a CSV `group` column value contains the
+// given group token. Used for in-memory filtering when SQL filtering is not
+// applicable (e.g. tag-mode pagination loads channels per tag in Go).
+func ChannelGroupMatches(channelGroups string, group string) bool {
+	if group == "" {
+		return true
+	}
+	if channelGroups == "" {
+		return false
+	}
+	return strings.Contains(","+channelGroups+",", ","+group+",")
+}
+
 func GetPaginatedTags(offset int, limit int) ([]*string, error) {
 	var tags []*string
 	err := DB.Model(&Channel{}).Select("DISTINCT tag").Where("tag != ''").Offset(offset).Limit(limit).Find(&tags).Error


### PR DESCRIPTION
## Summary

Fixes the new UI's channel-page group dropdown that has been silently doing nothing whenever no keyword/model filter is also set.

`GetAllChannels` (used for the default channel listing) never read the `group` query parameter, while `SearchChannels` (only hit when a keyword/model is also set) did. The frontend group filter therefore worked only by accident in combined searches and was a no-op everywhere else.

### Changes

- `controller/channel.go`: read `group` from the query and apply the same CSV `LIKE` condition that `SearchChannels` uses; apply it to both the page query and the `type_counts` aggregation so the badges stay consistent with the visible list.
- Tag-mode listing now filters per-tag channels in memory using the same matching semantics.
- `model/channel.go`: extract `BuildChannelGroupCondition` and `ChannelGroupMatches` helpers so the SQL/string logic is not duplicated. Uses `commonGroupCol` so PostgreSQL / MySQL / SQLite all work.

### Test plan

- [ ] SQLite local: pick a non-default group on the channel page; list and type-count badges only show channels in that group.
- [ ] Combined keyword + group still works as before (regression check on `SearchChannels`).
- [ ] Tag mode still groups by tag and now respects the group filter too.

Closes #4951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channels can now be filtered by group using a query parameter. This allows users to retrieve only channels associated with a specific group, improving channel management and organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->