### PR TITLE
fix(auth): use aff_code field name in registration payload (#4945)

### DIFF
--- a/web/default/src/features/auth/sign-up/components/sign-up-form.tsx
+++ b/web/default/src/features/auth/sign-up/components/sign-up-form.tsx
@@ -155,7 +155,7 @@ export function SignUpForm({
         password: data.password,
         email: data.email || undefined,
         verification_code: verificationCode || undefined,
-        aff: getAffiliateCode(),
+        aff_code: getAffiliateCode(),
         turnstile: turnstileToken,
       })
 

--- a/web/default/src/features/auth/types.ts
+++ b/web/default/src/features/auth/types.ts
@@ -37,7 +37,7 @@ export interface RegisterPayload {
   password: string
   email?: string
   verification_code?: string
-  aff?: string
+  aff_code?: string
   turnstile?: string
 }
 


### PR DESCRIPTION
## Summary

The new UI's sign-up form posts the invite code under key `aff`, but the backend `Register` controller binds it to `User.AffCode`, whose JSON tag is `aff_code` (`model/user.go`). Every invited sign-up therefore landed with `inviter_id = 0` and the affiliate flow was effectively broken.

### Changes

- `web/default/src/features/auth/types.ts`: `RegisterPayload.aff?` → `RegisterPayload.aff_code?`.
- `web/default/src/features/auth/sign-up/components/sign-up-form.tsx`: send `aff_code: getAffiliateCode()` instead of `aff`.

URL query parameter (`/sign-up?aff=...`), localStorage key (`aff`) and OAuth state (`?aff=`) continue to use `aff` and are unchanged — only the registration request payload is renamed to match the backend contract.

### Test plan

- [ ] Visit `/sign-up?aff=<existing user's aff_code>`, complete registration; verify `inviter_id` on the new user equals the affiliate's id.
- [ ] OAuth sign-up with affiliate still binds the inviter (unchanged path, but worth re-checking).

Closes #4945

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated affiliate code field in the sign-up process to properly capture and transmit affiliate information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->