### PR TITLE
fix(data-table): make faceted filter popover width adaptive (#4905)

### DIFF
--- a/web/default/src/components/data-table/faceted-filter.tsx
+++ b/web/default/src/components/data-table/faceted-filter.tsx
@@ -107,7 +107,10 @@ export function DataTableFacetedFilter<TData, TValue>({
           </>
         )}
       </PopoverTrigger>
-      <PopoverContent className='w-[200px] p-0' align='start'>
+      <PopoverContent
+        className='min-w-[200px] max-w-[360px] p-0'
+        align='start'
+      >
         <Command>
           <CommandInput placeholder={title} />
           <CommandList>
@@ -159,7 +162,10 @@ export function DataTableFacetedFilter<TData, TValue>({
                     ) : option.icon ? (
                       <option.icon className='text-muted-foreground size-4' />
                     ) : null}
-                    <span className='min-w-0 flex-1 truncate'>
+                    <span
+                      className='min-w-0 flex-1 truncate'
+                      title={t(option.label)}
+                    >
                       {t(option.label)}
                     </span>
                     {typeof option.count === 'number' ? (


### PR DESCRIPTION
## Summary

The shared faceted filter (used by group / status / type filters on the channels page and elsewhere) hard-coded its popover width to 200px, so longer option labels — most visibly user-defined channel groups — were truncated with no way to see the full value.

### Changes

- `web/default/src/components/data-table/faceted-filter.tsx`
  - `PopoverContent`: `w-[200px]` → `min-w-[200px] max-w-[360px]` so the popover keeps its current footprint for short lists but can grow up to 360px before the existing `truncate` kicks in.
  - Add `title={t(option.label)}` to the truncated label span so users can still hover to read the full text in extreme cases.

### Test plan

- [ ] Channel page: create a group with a long name (e.g. `super-long-group-name-for-testing`); open the group filter — text is readable, hover shows full label.
- [ ] Status / type filters with short labels look unchanged.

Closes #4905

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added tooltips to reveal full filter option labels on hover when text is truncated

* **Style**
  * Enhanced filter panel layout with responsive width sizing for improved usability across different screen sizes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->