### PR TITLE
fix(keys): call submit handler directly to avoid stale form linkage (#4858)

### DIFF
--- a/web/default/src/features/keys/components/api-keys-mutate-drawer.tsx
+++ b/web/default/src/features/keys/components/api-keys-mutate-drawer.tsx
@@ -605,8 +605,8 @@ export function ApiKeysMutateDrawer({
             {t('Close')}
           </SheetClose>
           <Button
-            form='api-key-form'
-            type='submit'
+            type='button'
+            onClick={form.handleSubmit(onSubmit)}
             disabled={isSubmitting}
             className='w-full sm:w-auto'
           >


### PR DESCRIPTION
## Summary

Users reported the API key edit drawer's "Save changes" button becomes unresponsive after the drawer has been open / idle for a while — no loading state, no request, no error. Reopening the drawer restores it because a fresh DOM is created.

The button lived inside `SheetFooter` (Base UI Sheet, portaled) and submitted the form via the HTML `form="api-key-form"` attribute. Once the portal/DOM linkage gets stale, the click no longer triggers the form's submit event, hence the silent failure.

### Changes (defensive)

- `web/default/src/features/keys/components/api-keys-mutate-drawer.tsx`: drop the cross-DOM `form="api-key-form"` + `type="submit"` and switch to `type="button"` + `onClick={form.handleSubmit(onSubmit)}`. The native submit path (`<form onSubmit>` for Enter key etc.) is preserved.

### Test plan

- [ ] Open the edit drawer, change a field, click save — works as before.
- [ ] Open the edit drawer, switch tabs / idle ~30 minutes, return and click save — still works (was previously the failure case).
- [ ] Enter-to-submit inside the form still works.

Marked as a defensive fix — if the underlying cause is something else (e.g. stale Turnstile token, react-query mutation), this still removes the most suspicious code path; awaiting reporter re-confirmation.

Closes #4858

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form submission behavior in API key management to ensure the "Save changes" button reliably persists updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->