### PR TITLE
fix: expose param override audits for sensitive message fields

### DIFF
--- a/relay/common/override.go
+++ b/relay/common/override.go
@@ -26,13 +26,20 @@ const (
 
 var errSourceHeaderNotFound = errors.New("source header does not exist")
 
-var paramOverrideKeyAuditPaths = map[string]struct{}{
-	"model":          {},
-	"original_model": {},
-	"upstream_model": {},
-	"service_tier":   {},
-	"inference_geo":  {},
-	"speed":          {},
+var paramOverrideSensitivePathPrefixes = []string{
+	"model",
+	"original_model",
+	"upstream_model",
+	"service_tier",
+	"inference_geo",
+	"speed",
+	"messages",
+	"input",
+	"instructions",
+	"system",
+	"contents",
+	"systemInstruction",
+	"system_instruction",
 }
 
 type paramOverrideAuditRecorder struct {
@@ -206,6 +213,7 @@ func shouldEnableParamOverrideAudit(paramOverride map[string]interface{}) bool {
 	if operations, ok := tryParseOperations(paramOverride); ok {
 		for _, operation := range operations {
 			if shouldAuditParamPath(strings.TrimSpace(operation.Path)) ||
+				shouldAuditParamPath(strings.TrimSpace(operation.From)) ||
 				shouldAuditParamPath(strings.TrimSpace(operation.To)) {
 				return true
 			}
@@ -255,15 +263,19 @@ func shouldAuditParamPath(path string) bool {
 	if common.DebugEnabled {
 		return true
 	}
-	_, ok := paramOverrideKeyAuditPaths[path]
-	return ok
+	for _, prefix := range paramOverrideSensitivePathPrefixes {
+		if path == prefix || strings.HasPrefix(path, prefix+".") {
+			return true
+		}
+	}
+	return false
 }
 
 func shouldAuditOperation(mode, path, from, to string) bool {
 	if common.DebugEnabled {
 		return true
 	}
-	for _, candidate := range []string{path, to} {
+	for _, candidate := range []string{path, from, to} {
 		if shouldAuditParamPath(candidate) {
 			return true
 		}

--- a/relay/common/override_test.go
+++ b/relay/common/override_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/setting/model_setting"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
 )
 
 func TestApplyParamOverrideTrimPrefix(t *testing.T) {
@@ -2182,6 +2183,95 @@ func TestApplyParamOverrideWithRelayInfoRecordsOnlyKeyOperationsWhenDebugDisable
 	if !reflect.DeepEqual(info.ParamOverrideAudit, expected) {
 		t.Fatalf("unexpected param override audit, got %#v", info.ParamOverrideAudit)
 	}
+}
+
+func TestApplyParamOverrideWithRelayInfoRecordsConversationBodyOperationsWhenDebugDisabled(t *testing.T) {
+	originalDebugEnabled := common2.DebugEnabled
+	common2.DebugEnabled = false
+	t.Cleanup(func() {
+		common2.DebugEnabled = originalDebugEnabled
+	})
+
+	info := &RelayInfo{
+		ChannelMeta: &ChannelMeta{
+			ParamOverride: map[string]interface{}{
+				"operations": []interface{}{
+					map[string]interface{}{
+						"mode": "replace",
+						"path": "messages.0.content",
+						"from": "hello",
+						"to":   "hi",
+					},
+					map[string]interface{}{
+						"mode":  "set",
+						"path":  "input.0.content.0.text",
+						"value": "rewritten response input",
+					},
+					map[string]interface{}{
+						"mode":  "set",
+						"path":  "instructions",
+						"value": "new instruction",
+					},
+					map[string]interface{}{
+						"mode":  "append",
+						"path":  "contents.0.parts",
+						"value": map[string]interface{}{"text": "new gemini part"},
+					},
+					map[string]interface{}{
+						"mode": "copy",
+						"from": "system",
+						"to":   "metadata.system_copy",
+					},
+					map[string]interface{}{
+						"mode":  "set",
+						"path":  "temperature",
+						"value": 0.1,
+					},
+				},
+			},
+		},
+	}
+
+	out, err := ApplyParamOverrideWithRelayInfo([]byte(`{
+		"messages":[{"role":"user","content":"hello world"}],
+		"input":[{"role":"user","content":[{"type":"input_text","text":"original response input"}]}],
+		"instructions":"old instruction",
+		"system":"old system",
+		"contents":[{"role":"user","parts":[{"text":"hello gemini"}]}],
+		"temperature":0.7
+	}`), info)
+	require.NoError(t, err)
+	assertJSONEqual(t, `{
+		"messages":[{"role":"user","content":"hi world"}],
+		"input":[{"role":"user","content":[{"type":"input_text","text":"rewritten response input"}]}],
+		"instructions":"new instruction",
+		"system":"old system",
+		"contents":[{"role":"user","parts":[{"text":"hello gemini"},{"text":"new gemini part"}]}],
+		"temperature":0.1,
+		"metadata":{"system_copy":"old system"}
+	}`, string(out))
+
+	require.Equal(t, []string{
+		"replace messages.0.content from hello to hi",
+		"set input.0.content.0.text = rewritten response input",
+		"set instructions = new instruction",
+		"append contents.0.parts with {\"text\":\"new gemini part\"}",
+		"copy system -> metadata.system_copy",
+	}, info.ParamOverrideAudit)
+}
+
+func TestShouldAuditParamPathUsesFieldBoundaryPrefixMatching(t *testing.T) {
+	originalDebugEnabled := common2.DebugEnabled
+	common2.DebugEnabled = false
+	t.Cleanup(func() {
+		common2.DebugEnabled = originalDebugEnabled
+	})
+
+	require.True(t, shouldAuditParamPath("messages"))
+	require.True(t, shouldAuditParamPath("messages.0.content"))
+	require.True(t, shouldAuditParamPath("systemInstruction.parts.0.text"))
+	require.False(t, shouldAuditParamPath("model_name"))
+	require.False(t, shouldAuditParamPath("message"))
 }
 
 func assertJSONEqual(t *testing.T, want, got string) {

--- a/web/default/src/features/usage-logs/components/dialogs/details-dialog.tsx
+++ b/web/default/src/features/usage-logs/components/dialogs/details-dialog.tsx
@@ -985,9 +985,8 @@ export function DetailsDialog(props: DetailsDialogProps) {
               </DetailSection>
             )}
 
-            {/* Param override (admin only) */}
-            {props.isAdmin &&
-              other?.po &&
+            {/* Param override */}
+            {other?.po &&
               Array.isArray(other.po) &&
               other.po.length > 0 && (
                 <DetailSection


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

完善参数覆盖记录的字段

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parameter override details in usage logs are now visible to all users, previously restricted to administrators only.

* **Refactor**
  * Parameter override audit detection logic updated to improve accuracy in identifying sensitive operation paths through enhanced prefix matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->