### PR TITLE
feat: support Wan2.7 i2v media mapping

### DIFF
--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -33,15 +33,22 @@ type AliVideoRequest struct {
 	Parameters *AliVideoParameters `json:"parameters,omitempty"`
 }
 
+// AliVideoMedia describes Wan2.7 image-to-video media inputs.
+type AliVideoMedia struct {
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}
+
 // AliVideoInput 视频输入参数
 type AliVideoInput struct {
-	Prompt         string `json:"prompt,omitempty"`          // 文本提示词
-	ImgURL         string `json:"img_url,omitempty"`         // 首帧图像URL或Base64（图生视频）
-	FirstFrameURL  string `json:"first_frame_url,omitempty"` // 首帧图片URL（首尾帧生视频）
-	LastFrameURL   string `json:"last_frame_url,omitempty"`  // 尾帧图片URL（首尾帧生视频）
-	AudioURL       string `json:"audio_url,omitempty"`       // 音频URL（wan2.5支持）
-	NegativePrompt string `json:"negative_prompt,omitempty"` // 反向提示词
-	Template       string `json:"template,omitempty"`        // 视频特效模板
+	Prompt         string          `json:"prompt,omitempty"`          // 文本提示词
+	ImgURL         string          `json:"img_url,omitempty"`         // 首帧图像URL或Base64（图生视频）
+	FirstFrameURL  string          `json:"first_frame_url,omitempty"` // 首帧图片URL（首尾帧生视频）
+	LastFrameURL   string          `json:"last_frame_url,omitempty"`  // 尾帧图片URL（首尾帧生视频）
+	AudioURL       string          `json:"audio_url,omitempty"`       // 音频URL（wan2.5支持）
+	Media          []AliVideoMedia `json:"media,omitempty"`           // 媒体列表（wan2.7-i2v新协议）
+	NegativePrompt string          `json:"negative_prompt,omitempty"` // 反向提示词
+	Template       string          `json:"template,omitempty"`        // 视频特效模板
 }
 
 // AliVideoParameters 视频参数
@@ -87,12 +94,13 @@ type AliUsage struct {
 
 type AliMetadata struct {
 	// Input 相关
-	AudioURL       string `json:"audio_url,omitempty"`       // 音频URL
-	ImgURL         string `json:"img_url,omitempty"`         // 图片URL（图生视频）
-	FirstFrameURL  string `json:"first_frame_url,omitempty"` // 首帧图片URL（首尾帧生视频）
-	LastFrameURL   string `json:"last_frame_url,omitempty"`  // 尾帧图片URL（首尾帧生视频）
-	NegativePrompt string `json:"negative_prompt,omitempty"` // 反向提示词
-	Template       string `json:"template,omitempty"`        // 视频特效模板
+	AudioURL       string          `json:"audio_url,omitempty"`       // 音频URL
+	ImgURL         string          `json:"img_url,omitempty"`         // 图片URL（图生视频）
+	FirstFrameURL  string          `json:"first_frame_url,omitempty"` // 首帧图片URL（首尾帧生视频）
+	LastFrameURL   string          `json:"last_frame_url,omitempty"`  // 尾帧图片URL（首尾帧生视频）
+	Media          []AliVideoMedia `json:"media,omitempty"`           // 媒体列表（wan2.7-i2v新协议）
+	NegativePrompt string          `json:"negative_prompt,omitempty"` // 反向提示词
+	Template       string          `json:"template,omitempty"`        // 视频特效模板
 
 	// Parameters 相关
 	Resolution   *string `json:"resolution,omitempty"`    // 分辨率: 480P/720P/1080P
@@ -252,6 +260,82 @@ func ProcessAliOtherRatios(aliReq *AliVideoRequest) (map[string]float64, error) 
 	return otherRatios, nil
 }
 
+func isWan27I2VModel(model string) bool {
+	return strings.HasPrefix(model, "wan2.7-i2v")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstTaskImage(req relaycommon.TaskSubmitReq) string {
+	if req.InputReference != "" {
+		return req.InputReference
+	}
+	if req.Image != "" {
+		return req.Image
+	}
+	if len(req.Images) > 0 {
+		return req.Images[0]
+	}
+	return ""
+}
+
+func secondTaskImage(req relaycommon.TaskSubmitReq) string {
+	if len(req.Images) > 1 {
+		return req.Images[1]
+	}
+	return ""
+}
+
+func normalizeWan27I2VInput(aliReq *AliVideoRequest, req relaycommon.TaskSubmitReq) error {
+	if !isWan27I2VModel(aliReq.Model) {
+		return nil
+	}
+
+	if len(aliReq.Input.Media) == 0 {
+		firstFrameURL := firstNonEmpty(aliReq.Input.FirstFrameURL, aliReq.Input.ImgURL, firstTaskImage(req))
+		lastFrameURL := firstNonEmpty(aliReq.Input.LastFrameURL, secondTaskImage(req))
+		audioURL := aliReq.Input.AudioURL
+
+		if firstFrameURL != "" {
+			aliReq.Input.Media = append(aliReq.Input.Media, AliVideoMedia{
+				Type: "first_frame",
+				URL:  firstFrameURL,
+			})
+		}
+		if lastFrameURL != "" {
+			aliReq.Input.Media = append(aliReq.Input.Media, AliVideoMedia{
+				Type: "last_frame",
+				URL:  lastFrameURL,
+			})
+		}
+		if audioURL != "" {
+			aliReq.Input.Media = append(aliReq.Input.Media, AliVideoMedia{
+				Type: "driving_audio",
+				URL:  audioURL,
+			})
+		}
+	}
+
+	if len(aliReq.Input.Media) == 0 {
+		return fmt.Errorf("wan2.7-i2v requires image, images, input_reference, or input.media")
+	}
+
+	// Wan2.7 image-to-video uses the new input.media protocol. Avoid sending
+	// legacy fields that belong to wan2.6 and earlier image-to-video APIs.
+	aliReq.Input.ImgURL = ""
+	aliReq.Input.FirstFrameURL = ""
+	aliReq.Input.LastFrameURL = ""
+	aliReq.Input.AudioURL = ""
+	return nil
+}
+
 func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relaycommon.TaskSubmitReq) (*AliVideoRequest, error) {
 	upstreamModel := req.Model
 	if info.IsModelMapped {
@@ -261,7 +345,7 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 		Model: upstreamModel,
 		Input: AliVideoInput{
 			Prompt: req.Prompt,
-			ImgURL: req.InputReference,
+			ImgURL: firstTaskImage(req),
 		},
 		Parameters: &AliVideoParameters{
 			PromptExtend: true, // 默认开启智能改写
@@ -338,6 +422,10 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 
 	if aliReq.Model != upstreamModel {
 		return nil, errors.New("can't change model with metadata")
+	}
+
+	if err := normalizeWan27I2VInput(aliReq, req); err != nil {
+		return nil, err
 	}
 
 	return aliReq, nil

--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -266,29 +266,40 @@ func isWan27I2VModel(model string) bool {
 
 func firstNonEmpty(values ...string) string {
 	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			return trimmed
 		}
 	}
 	return ""
 }
 
 func firstTaskImage(req relaycommon.TaskSubmitReq) string {
-	if req.InputReference != "" {
-		return req.InputReference
+	if image := strings.TrimSpace(req.Image); image != "" {
+		return image
 	}
-	if req.Image != "" {
-		return req.Image
+	for _, image := range req.Images {
+		if trimmed := strings.TrimSpace(image); trimmed != "" {
+			return trimmed
+		}
 	}
-	if len(req.Images) > 0 {
-		return req.Images[0]
+	if inputReference := strings.TrimSpace(req.InputReference); inputReference != "" {
+		return inputReference
 	}
 	return ""
 }
 
 func secondTaskImage(req relaycommon.TaskSubmitReq) string {
-	if len(req.Images) > 1 {
-		return req.Images[1]
+	nonEmptyImages := 0
+	for _, image := range req.Images {
+		trimmed := strings.TrimSpace(image)
+		if trimmed == "" {
+			continue
+		}
+		nonEmptyImages++
+		if nonEmptyImages == 2 {
+			return trimmed
+		}
 	}
 	return ""
 }

--- a/relay/channel/task/ali/adaptor_test.go
+++ b/relay/channel/task/ali/adaptor_test.go
@@ -62,11 +62,56 @@ func TestConvertToAliRequestWan27I2VBuildsFirstAndLastFrameFromImages(t *testing
 	}, aliReq.Input.Media)
 }
 
-func TestConvertToAliRequestWan27I2VKeepsExplicitMetadataMedia(t *testing.T) {
+func TestConvertToAliRequestWan27I2VPrefersImageBeforeImagesAndInputReference(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	req := relaycommon.TaskSubmitReq{
+		Model:          "wan2.7-i2v",
+		Prompt:         "use the direct image",
+		Image:          " https://example.com/direct.png ",
+		Images:         []string{"https://example.com/images-first.png", " https://example.com/images-last.png "},
+		InputReference: "https://example.com/input-reference.png",
+	}
+
+	aliReq, err := adaptor.convertToAliRequest(testRelayInfo(), req)
+
+	require.NoError(t, err)
+	require.Equal(t, []AliVideoMedia{
+		{Type: "first_frame", URL: "https://example.com/direct.png"},
+		{Type: "last_frame", URL: "https://example.com/images-last.png"},
+	}, aliReq.Input.Media)
+}
+
+func TestConvertToAliRequestWan27I2VFallsBackToFirstNonEmptyImage(t *testing.T) {
 	adaptor := &TaskAdaptor{}
 	req := relaycommon.TaskSubmitReq{
 		Model:  "wan2.7-i2v",
-		Prompt: "continue the clip",
+		Prompt: "skip blank images",
+		Image:  " ",
+		Images: []string{
+			" ",
+			" https://example.com/first.png ",
+			" https://example.com/last.png ",
+		},
+		InputReference: "https://example.com/input-reference.png",
+	}
+
+	aliReq, err := adaptor.convertToAliRequest(testRelayInfo(), req)
+
+	require.NoError(t, err)
+	require.Equal(t, []AliVideoMedia{
+		{Type: "first_frame", URL: "https://example.com/first.png"},
+		{Type: "last_frame", URL: "https://example.com/last.png"},
+	}, aliReq.Input.Media)
+}
+
+func TestConvertToAliRequestWan27I2VKeepsExplicitMetadataMedia(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	req := relaycommon.TaskSubmitReq{
+		Model:          "wan2.7-i2v",
+		Prompt:         "continue the clip",
+		Image:          "https://example.com/direct.png",
+		Images:         []string{"https://example.com/images-first.png", "https://example.com/images-last.png"},
+		InputReference: "https://example.com/input-reference.png",
 		Metadata: map[string]interface{}{
 			"input": map[string]interface{}{
 				"media": []interface{}{
@@ -85,6 +130,12 @@ func TestConvertToAliRequestWan27I2VKeepsExplicitMetadataMedia(t *testing.T) {
 	require.Equal(t, []AliVideoMedia{
 		{Type: "first_clip", URL: "https://example.com/input.mp4"},
 	}, aliReq.Input.Media)
+	require.Empty(t, aliReq.Input.ImgURL)
+
+	body, err := common.Marshal(aliReq)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"media"`)
+	require.NotContains(t, string(body), `"img_url"`)
 }
 
 func TestConvertToAliRequestWan27I2VRequiresMedia(t *testing.T) {

--- a/relay/channel/task/ali/adaptor_test.go
+++ b/relay/channel/task/ali/adaptor_test.go
@@ -1,0 +1,121 @@
+package ali
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/require"
+)
+
+func testRelayInfo() *relaycommon.RelayInfo {
+	return &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{},
+	}
+}
+
+func TestConvertToAliRequestWan27I2VBuildsMediaFromImage(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	req := relaycommon.TaskSubmitReq{
+		Model:    "wan2.7-i2v",
+		Prompt:   "animate the first frame",
+		Image:    "https://example.com/first.png",
+		Size:     "720p",
+		Duration: 10,
+	}
+
+	aliReq, err := adaptor.convertToAliRequest(testRelayInfo(), req)
+
+	require.NoError(t, err)
+	require.Equal(t, "wan2.7-i2v", aliReq.Model)
+	require.Equal(t, "720P", aliReq.Parameters.Resolution)
+	require.Equal(t, 10, aliReq.Parameters.Duration)
+	require.Equal(t, []AliVideoMedia{
+		{Type: "first_frame", URL: "https://example.com/first.png"},
+	}, aliReq.Input.Media)
+	require.Empty(t, aliReq.Input.ImgURL)
+
+	body, err := common.Marshal(aliReq)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"media"`)
+	require.NotContains(t, string(body), `"img_url"`)
+}
+
+func TestConvertToAliRequestWan27I2VBuildsFirstAndLastFrameFromImages(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	req := relaycommon.TaskSubmitReq{
+		Model:  "wan2.7-i2v",
+		Prompt: "interpolate between frames",
+		Images: []string{
+			"https://example.com/first.png",
+			"https://example.com/last.png",
+		},
+	}
+
+	aliReq, err := adaptor.convertToAliRequest(testRelayInfo(), req)
+
+	require.NoError(t, err)
+	require.Equal(t, []AliVideoMedia{
+		{Type: "first_frame", URL: "https://example.com/first.png"},
+		{Type: "last_frame", URL: "https://example.com/last.png"},
+	}, aliReq.Input.Media)
+}
+
+func TestConvertToAliRequestWan27I2VKeepsExplicitMetadataMedia(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	req := relaycommon.TaskSubmitReq{
+		Model:  "wan2.7-i2v",
+		Prompt: "continue the clip",
+		Metadata: map[string]interface{}{
+			"input": map[string]interface{}{
+				"media": []interface{}{
+					map[string]interface{}{
+						"type": "first_clip",
+						"url":  "https://example.com/input.mp4",
+					},
+				},
+			},
+		},
+	}
+
+	aliReq, err := adaptor.convertToAliRequest(testRelayInfo(), req)
+
+	require.NoError(t, err)
+	require.Equal(t, []AliVideoMedia{
+		{Type: "first_clip", URL: "https://example.com/input.mp4"},
+	}, aliReq.Input.Media)
+}
+
+func TestConvertToAliRequestWan27I2VRequiresMedia(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	req := relaycommon.TaskSubmitReq{
+		Model:  "wan2.7-i2v",
+		Prompt: "animate without a frame",
+	}
+
+	_, err := adaptor.convertToAliRequest(testRelayInfo(), req)
+
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "requires image"))
+}
+
+func TestConvertToAliRequestWan25I2VKeepsLegacyImgURL(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	req := relaycommon.TaskSubmitReq{
+		Model:  "wan2.5-i2v-preview",
+		Prompt: "animate the first frame",
+		Image:  "https://example.com/first.png",
+	}
+
+	aliReq, err := adaptor.convertToAliRequest(testRelayInfo(), req)
+
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/first.png", aliReq.Input.ImgURL)
+	require.Empty(t, aliReq.Input.Media)
+
+	body, err := common.Marshal(aliReq)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"img_url"`)
+	require.NotContains(t, string(body), `"media"`)
+}

--- a/relay/channel/task/ali/constants.go
+++ b/relay/channel/task/ali/constants.go
@@ -1,6 +1,8 @@
 package ali
 
 var ModelList = []string{
+	"wan2.7-i2v",         // 万相2.7图生视频（新input.media协议）
+	"wan2.7-t2v",         // 万相2.7文生视频
 	"wan2.5-i2v-preview", // 万相2.5 preview（有声视频）推荐
 	"wan2.2-i2v-flash",   // 万相2.2极速版（无声视频）
 	"wan2.2-i2v-plus",    // 万相2.2专业版（无声视频）

--- a/relay/common/relay_utils.go
+++ b/relay/common/relay_utils.go
@@ -141,7 +141,7 @@ func ValidateMultipartDirect(c *gin.Context, info *RelayInfo) *dto.TaskError {
 		req.Images = []string{req.InputReference}
 	} else if len(req.Images) == 0 && strings.TrimSpace(req.Image) != "" {
 		// 兼容单图上传
-		req.Images = []string{req.Image}
+		req.Images = []string{strings.TrimSpace(req.Image)}
 	}
 
 	if strings.TrimSpace(req.Model) == "" {

--- a/relay/common/relay_utils.go
+++ b/relay/common/relay_utils.go
@@ -139,6 +139,9 @@ func ValidateMultipartDirect(c *gin.Context, info *RelayInfo) *dto.TaskError {
 	}
 	if req.InputReference != "" {
 		req.Images = []string{req.InputReference}
+	} else if len(req.Images) == 0 && strings.TrimSpace(req.Image) != "" {
+		// 兼容单图上传
+		req.Images = []string{req.Image}
 	}
 
 	if strings.TrimSpace(req.Model) == "" {

--- a/relay/common/relay_utils_test.go
+++ b/relay/common/relay_utils_test.go
@@ -1,0 +1,33 @@
+package common
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateMultipartDirectNormalizesImageField(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := strings.NewReader(`{"model":"wan2.7-i2v","prompt":"animate","image":"https://example.com/first.png"}`)
+	request := httptest.NewRequest(http.MethodPost, "/v1/video/generations", body)
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	context.Request = request
+	info := &RelayInfo{
+		TaskRelayInfo: &TaskRelayInfo{},
+	}
+
+	taskErr := ValidateMultipartDirect(context, info)
+
+	require.Nil(t, taskErr)
+	storedReq, err := GetTaskRequest(context)
+	require.NoError(t, err)
+	require.Equal(t, []string{"https://example.com/first.png"}, storedReq.Images)
+	require.Equal(t, constant.TaskActionGenerate, info.Action)
+}

--- a/relay/common/relay_utils_test.go
+++ b/relay/common/relay_utils_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestValidateMultipartDirectNormalizesImageField(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	body := strings.NewReader(`{"model":"wan2.7-i2v","prompt":"animate","image":"https://example.com/first.png"}`)
+	body := strings.NewReader(`{"model":"wan2.7-i2v","prompt":"animate","image":" https://example.com/first.png "}`)
 	request := httptest.NewRequest(http.MethodPost, "/v1/video/generations", body)
 	request.Header.Set("Content-Type", "application/json")
 	recorder := httptest.NewRecorder()


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

本次为 Ali 视频生成渠道补充 Wan2.7 图生视频协议适配。

Wan2.7 I2V 使用的是新的 `input.media` 入参格式，而当前 Ali adaptor 仍主要按旧版 `img_url` / `first_frame_url` / `last_frame_url` 字段组织请求。这个改动在 `wan2.7-i2v` 场景下将通用视频请求里的 `image`、`images`、`input_reference` 映射为 DashScope 所需的 `input.media`：

- 单图会映射为 `type: first_frame`
- 双图会映射为 `first_frame` + `last_frame`
- 显式传入的 `metadata.input.media` 会被保留
- 旧版 Wan I2V 模型仍继续使用原有 `img_url` 逻辑

同时补充了 `wan2.7-i2v`、`wan2.7-t2v` 到 Ali task model list，并让 direct video request 路径兼容单图 `image` 字段，避免图生视频请求没有被识别为带图任务。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- N/A

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```bash
go test ./relay/channel/task/ali ./relay/common

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the “wan2.7-i2v” image-to-video model using a media-based input protocol.
* **Bug Fixes**
  * Improved request normalization for wan2.7-i2v by deriving required frame media from provided images/metadata and returning clearer errors when missing.
  * Enhanced multipart/direct handling so a single `image` value is accepted and normalized consistently.
* **Tests**
  * Expanded unit tests for wan2.7-i2v media derivation, legacy wan2.5 behavior, image precedence, and direct upload normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->