### PR TITLE
fix(volcengine): support multimodal embedding models

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -758,6 +758,24 @@ func buildTestRequest(model string, endpointType string, channel *model.Channel,
 	if strings.Contains(strings.ToLower(model), "embedding") ||
 		strings.HasPrefix(model, "m3e") ||
 		strings.Contains(model, "bge-") {
+		// Volcengine multimodal embedding endpoint (/api/v3/embeddings/multimodal)
+		// requires input to be an array of typed parts (e.g. [{type:"text",text:"..."}]),
+		// not a plain string array. Sending the standard `["hello world"]` shape
+		// against vision/multimodal models triggers a 400 from the upstream
+		// "we could not parse the JSON body of your request" — so emit the
+		// multimodal-compatible shape when the model name signals it.
+		lower := strings.ToLower(model)
+		if strings.Contains(lower, "vision") || strings.Contains(lower, "multimodal") {
+			return &dto.EmbeddingRequest{
+				Model: model,
+				Input: []any{
+					map[string]any{
+						"type": "text",
+						"text": "hello world",
+					},
+				},
+			}
+		}
 		// 返回 EmbeddingRequest
 		return &dto.EmbeddingRequest{
 			Model: model,

--- a/relay/channel/volcengine/adaptor.go
+++ b/relay/channel/volcengine/adaptor.go
@@ -263,6 +263,15 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 			}
 			return fmt.Sprintf("%s/api/v3/chat/completions", baseUrl), nil
 		case constant.RelayModeEmbeddings:
+			// Volcengine multimodal embedding models (e.g. doubao-embedding-vision-*)
+			// require the dedicated /api/v3/embeddings/multimodal endpoint and reject
+			// the standard /embeddings path with a 400 InvalidParameter error.
+			// Heuristic: route by model name keywords. Both the request model and the
+			// upstream model name are checked so model_mapping aliases still work.
+			if isVolcengineMultimodalEmbedding(info.UpstreamModelName) ||
+				isVolcengineMultimodalEmbedding(info.OriginModelName) {
+				return fmt.Sprintf("%s/api/v3/embeddings/multimodal", baseUrl), nil
+			}
 			return fmt.Sprintf("%s/api/v3/embeddings", baseUrl), nil
 		//豆包的图生图也走generations接口: https://www.volcengine.com/docs/82379/1824121
 		case constant.RelayModeImagesGenerations, constant.RelayModeImagesEdits:
@@ -399,4 +408,23 @@ func (a *Adaptor) GetModelList() []string {
 
 func (a *Adaptor) GetChannelName() string {
 	return ChannelName
+}
+
+// isVolcengineMultimodalEmbedding reports whether the given model name targets
+// Volcengine's multimodal (image+text) embedding endpoint, which requires the
+// `/api/v3/embeddings/multimodal` path instead of the standard `/embeddings`.
+//
+// The detection is keyword-based on the model name. We accept both the original
+// "vision" series (e.g. doubao-embedding-vision-241215, doubao-embedding-vision-251215)
+// and any future "multimodal" naming. Matching is case-insensitive so user-supplied
+// model_mapping aliases work even with mixed case.
+func isVolcengineMultimodalEmbedding(modelName string) bool {
+	if modelName == "" {
+		return false
+	}
+	lower := strings.ToLower(modelName)
+	if !strings.Contains(lower, "embedding") {
+		return false
+	}
+	return strings.Contains(lower, "vision") || strings.Contains(lower, "multimodal")
 }


### PR DESCRIPTION
## Related Issue

Closes #4997

## Summary

This PR makes Volcengine multimodal embedding models (e.g. `doubao-embedding-vision-251215`) work end-to-end in new-api by fixing two independent bugs.

## Changes

### 1. Route vision/multimodal models to dedicated endpoint

`relay/channel/volcengine/adaptor.go`:

- `GetRequestURL` for `RelayModeEmbeddings` now routes vision/multimodal models to `/api/v3/embeddings/multimodal` and keeps text-only models on `/embeddings`.
- New helper `isVolcengineMultimodalEmbedding(modelName)` does the keyword match (case-insensitive: must contain `embedding` AND `vision`/`multimodal`).
- Both `UpstreamModelName` and `OriginModelName` are checked so `model_mapping` aliases keep working.

### 2. Use multimodal input shape in dashboard "Test channel" button

`controller/channel-test.go`:

- Hard-coded `Input=[\"hello world\"]` was rejected by the multimodal endpoint with `\"we could not parse the JSON body of your request\"`.
- Now emits `Input=[{type:\"text\", text:\"hello world\"}]` for vision/multimodal models, matching the endpoint contract.
- Plain-text embedding models (`Doubao-embedding`, `text-embedding-3-*`, `m3e`, `bge-*`, etc.) keep the legacy string-array shape.

## Behavior Matrix

| Model name | Path before | Test btn before | Path after | Test btn after |
|---|---|---|---|---|
| `Doubao-embedding` (text) | `/embeddings` ✅ | ✅ | (unchanged) | (unchanged) |
| `doubao-embedding-text-240715` | `/embeddings` ✅ | ✅ | (unchanged) | (unchanged) |
| `doubao-embedding-large-text-240915` | `/embeddings` ✅ | ✅ | (unchanged) | (unchanged) |
| `doubao-embedding-vision-241215` | `/embeddings` ❌ 400 | ❌ 400 | `/embeddings/multimodal` ✅ | ✅ multimodal input |
| `doubao-embedding-vision-251215` | `/embeddings` ❌ 400 | ❌ 400 | `/embeddings/multimodal` ✅ | ✅ multimodal input |
| `*-multimodal*` (future) | `/embeddings` ❌ | ❌ | `/embeddings/multimodal` ✅ | ✅ |

## Tests

Validated locally with a real Volcengine multimodal endpoint:

```bash
# Direct call: 200 + full embedding vector
curl http://newapi/v1/embeddings \
  -H \"Authorization: Bearer <token>\" -H \"Content-Type: application/json\" \
  -d '{\"model\":\"doubao-embedding-vision-251215\",\"input\":[{\"type\":\"text\",\"text\":\"测试\"}]}'

# Dashboard \"Test channel\" button: ✅ 200
```

Plain-text embedding channels (Doubao-embedding, OpenAI text-embedding-3-small, m3e) verified unchanged.

## Compatibility

- ✅ No breaking changes for existing text embedding channels
- ✅ No DB migration required — detection is by model name only
- ✅ Works with `model_mapping` aliases (both `OriginModelName` and `UpstreamModelName` are checked)
- ✅ "Test channel" button auto-adapts based on model name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic detection and enhanced support for multimodal and vision-capable embedding models.

* **Bug Fixes**
  * Improved request handling and endpoint routing for specialized embedding model types to ensure proper processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4998?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->