### PR TITLE
修复 切换新版前端Turnstile 开启后注册页未显示验证的问题

### DIFF
--- a/web/default/src/features/auth/sign-up/components/sign-up-form.tsx
+++ b/web/default/src/features/auth/sign-up/components/sign-up-form.tsx
@@ -148,6 +148,8 @@ export function SignUpForm({
       }
     }
 
+    if (!validateTurnstile()) return
+
     setIsLoading(true)
     try {
       const res = await register({
@@ -318,16 +320,17 @@ export function SignUpForm({
               </Button>
             </div>
 
-            {/* Turnstile */}
-            {isTurnstileEnabled && (
-              <div className='mt-2'>
-                <Turnstile
-                  siteKey={turnstileSiteKey}
-                  onVerify={setTurnstileToken}
-                />
-              </div>
-            )}
           </>
+        )}
+
+        {/* Turnstile */}
+        {isTurnstileEnabled && (
+          <div className='mt-2'>
+            <Turnstile
+              siteKey={turnstileSiteKey}
+              onVerify={setTurnstileToken}
+            />
+          </div>
         )}
 
         <LegalConsent


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

修复新版前端注册页在开启 Cloudflare Turnstile 后，部分场景不显示验证组件的问题。

问题原因是新版前端的注册表单中，Turnstile 组件被放在“邮箱验证码”区域内部。这样当系统开启 Turnstile，但未开启邮箱验证时，注册页不会渲染 Turnstile 验证组件；用户提交注册时，前端仍会向后端提交空的 `turnstile` 参数，导致后端提示缺少 Turnstile ID。

本次改动将 Turnstile 组件移动到邮箱验证码条件判断之外，使其只受 Turnstile 开关控制。同时在注册提交前补充 `validateTurnstile()` 校验，和登录流程保持一致，避免验证未完成时继续提交注册请求。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #4714

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
<img width="548" height="559" alt="image" src="https://github.com/user-attachments/assets/ebd1692a-645f-4b54-b046-0d121a27d807" />

已在服务器环境完成 Docker 镜像构建验证：

```bash
docker build -t new-api:turnstile-register-fix .
```
构建结果：
BUILD_OK
REPOSITORY   TAG                      IMAGE ID       SIZE
new-api      turnstile-register-fix   70d6a0515d6f   260MB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-up form now blocks submission when security verification fails and consistently shows the verification widget regardless of email verification.
  * Codex-style response handling now reliably enables streaming for the affected response mode so streamed replies are delivered consistently.

* **Tests**
  * Added tests covering the enforced streaming behavior and the conversion logic for response handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->