### PR TITLE
feat: add tenant ownership and admin tenant isolation

### DIFF
--- a/constant/context_key.go
+++ b/constant/context_key.go
@@ -52,6 +52,11 @@ const (
 	ContextKeyUsingGroup  ContextKey = "group"
 	ContextKeyUserName    ContextKey = "username"
 
+	ContextKeyTenantId              ContextKey = "tenant_id"
+	ContextKeyOrganizationId        ContextKey = "organization_id"
+	ContextKeyDepartmentId          ContextKey = "department_id"
+	ContextKeyDistributionChannelId ContextKey = "distribution_channel_id"
+
 	ContextKeyLocalCountTokens ContextKey = "local_count_tokens"
 
 	ContextKeySystemPromptOverride ContextKey = "system_prompt_override"

--- a/controller/channel-billing.go
+++ b/controller/channel-billing.go
@@ -432,6 +432,9 @@ func UpdateChannelBalance(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	if !requireChannelTenantAccess(c, channel) {
+		return
+	}
 	if channel.ChannelInfo.IsMultiKey {
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,
@@ -451,12 +454,19 @@ func UpdateChannelBalance(c *gin.Context) {
 	})
 }
 
-func updateAllChannelsBalance() error {
+func updateAllChannelsBalance(scopes ...model.TenantScope) error {
 	channels, err := model.GetAllChannels(0, 0, true, false)
 	if err != nil {
 		return err
 	}
+	scope := model.TenantScope{IsRoot: true}
+	if len(scopes) > 0 {
+		scope = scopes[0]
+	}
 	for _, channel := range channels {
+		if !scope.AllowsTenant(channel.TenantId) {
+			continue
+		}
 		if channel.Status != common.ChannelStatusEnabled {
 			continue
 		}
@@ -483,7 +493,7 @@ func updateAllChannelsBalance() error {
 
 func UpdateAllChannelsBalance(c *gin.Context) {
 	// TODO: make it async
-	err := updateAllChannelsBalance()
+	err := updateAllChannelsBalance(model.TenantScopeFromContext(c))
 	if err != nil {
 		common.ApiError(c, err)
 		return

--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -826,6 +826,9 @@ func TestChannel(c *gin.Context) {
 			return
 		}
 	}
+	if !requireChannelTenantAccess(c, channel) {
+		return
+	}
 	//defer func() {
 	//	if channel.ChannelInfo.IsMultiKey {
 	//		go func() { _ = channel.SaveChannelInfo() }()
@@ -871,7 +874,7 @@ func TestChannel(c *gin.Context) {
 var testAllChannelsLock sync.Mutex
 var testAllChannelsRunning bool = false
 
-func testAllChannels(notify bool) error {
+func testAllChannels(notify bool, scopes ...model.TenantScope) error {
 
 	testAllChannelsLock.Lock()
 	if testAllChannelsRunning {
@@ -883,6 +886,10 @@ func testAllChannels(notify bool) error {
 	channels, getChannelErr := model.GetAllChannels(0, 0, true, false)
 	if getChannelErr != nil {
 		return getChannelErr
+	}
+	scope := model.TenantScope{IsRoot: true}
+	if len(scopes) > 0 {
+		scope = scopes[0]
 	}
 	var disableThreshold = int64(common.ChannelDisableThreshold * 1000)
 	if disableThreshold == 0 {
@@ -897,6 +904,9 @@ func testAllChannels(notify bool) error {
 		}()
 
 		for _, channel := range channels {
+			if !scope.AllowsTenant(channel.TenantId) {
+				continue
+			}
 			if channel.Status == common.ChannelStatusManuallyDisabled {
 				continue
 			}
@@ -944,7 +954,7 @@ func testAllChannels(notify bool) error {
 }
 
 func TestAllChannels(c *gin.Context) {
-	err := testAllChannels(true)
+	err := testAllChannels(true, model.TenantScopeFromContext(c))
 	if err != nil {
 		common.ApiError(c, err)
 		return

--- a/controller/channel.go
+++ b/controller/channel.go
@@ -71,6 +71,7 @@ func clearChannelInfo(channel *model.Channel) {
 func GetAllChannels(c *gin.Context) {
 	pageInfo := common.GetPageQuery(c)
 	channelData := make([]*model.Channel, 0)
+	scope := model.TenantScopeFromContext(c)
 	idSort, _ := strconv.ParseBool(c.Query("id_sort"))
 	sortOptions := model.NewChannelSortOptions(c.Query("sort_by"), c.Query("sort_order"), idSort)
 	enableTagMode, _ := strconv.ParseBool(c.Query("tag_mode"))
@@ -89,7 +90,7 @@ func GetAllChannels(c *gin.Context) {
 	var total int64
 
 	if enableTagMode {
-		tags, err := model.GetPaginatedTags(pageInfo.GetStartIdx(), pageInfo.GetPageSize())
+		tags, err := model.GetPaginatedTags(pageInfo.GetStartIdx(), pageInfo.GetPageSize(), scope)
 		if err != nil {
 			common.SysError("failed to get paginated tags: " + err.Error())
 			c.JSON(http.StatusOK, gin.H{"success": false, "message": "获取标签失败，请稍后重试"})
@@ -99,7 +100,7 @@ func GetAllChannels(c *gin.Context) {
 			if tag == nil || *tag == "" {
 				continue
 			}
-			tagChannels, err := model.GetChannelsByTag(*tag, idSort, false, sortOptions)
+			tagChannels, err := model.GetChannelsByTagScoped(*tag, idSort, false, scope, sortOptions)
 			if err != nil {
 				continue
 			}
@@ -118,9 +119,10 @@ func GetAllChannels(c *gin.Context) {
 			}
 			channelData = append(channelData, filtered...)
 		}
-		total, _ = model.CountAllTags()
+		total, _ = model.CountAllTags(scope)
 	} else {
 		baseQuery := model.DB.Model(&model.Channel{})
+		baseQuery = scope.Apply(baseQuery, "channels")
 		if typeFilter >= 0 {
 			baseQuery = baseQuery.Where("type = ?", typeFilter)
 		}
@@ -145,6 +147,7 @@ func GetAllChannels(c *gin.Context) {
 	}
 
 	countQuery := model.DB.Model(&model.Channel{})
+	countQuery = scope.Apply(countQuery, "channels")
 	if statusFilter == common.ChannelStatusEnabled {
 		countQuery = countQuery.Where("status = ?", common.ChannelStatusEnabled)
 	} else if statusFilter == 0 {
@@ -251,8 +254,9 @@ func SearchChannels(c *gin.Context) {
 	sortOptions := model.NewChannelSortOptions(c.Query("sort_by"), c.Query("sort_order"), idSort)
 	enableTagMode, _ := strconv.ParseBool(c.Query("tag_mode"))
 	channelData := make([]*model.Channel, 0)
+	scope := model.TenantScopeFromContext(c)
 	if enableTagMode {
-		tags, err := model.SearchTags(keyword, group, modelKeyword, idSort)
+		tags, err := model.SearchTags(keyword, group, modelKeyword, idSort, scope)
 		if err != nil {
 			c.JSON(http.StatusOK, gin.H{
 				"success": false,
@@ -262,14 +266,14 @@ func SearchChannels(c *gin.Context) {
 		}
 		for _, tag := range tags {
 			if tag != nil && *tag != "" {
-				tagChannel, err := model.GetChannelsByTag(*tag, idSort, false, sortOptions)
+				tagChannel, err := model.GetChannelsByTagScoped(*tag, idSort, false, scope, sortOptions)
 				if err == nil {
 					channelData = append(channelData, tagChannel...)
 				}
 			}
 		}
 	} else {
-		channels, err := model.SearchChannels(keyword, group, modelKeyword, idSort, sortOptions)
+		channels, err := model.SearchChannelsScoped(keyword, group, modelKeyword, idSort, scope, sortOptions)
 		if err != nil {
 			c.JSON(http.StatusOK, gin.H{
 				"success": false,
@@ -1121,7 +1125,7 @@ func GetTagModels(c *gin.Context) {
 		return
 	}
 
-	channels, err := model.GetChannelsByTag(tag, false, false) // idSort=false, selectAll=false
+	channels, err := model.GetChannelsByTagScoped(tag, false, false, model.TenantScopeFromContext(c)) // idSort=false, selectAll=false
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"success": false,

--- a/controller/channel.go
+++ b/controller/channel.go
@@ -211,6 +211,9 @@ func FetchUpstreamModels(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	if !requireChannelTenantAccess(c, channel) {
+		return
+	}
 
 	ids, err := fetchChannelUpstreamModelIDs(channel)
 	if err != nil {
@@ -370,6 +373,9 @@ func GetChannel(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	if !requireChannelTenantAccess(c, channel) {
+		return
+	}
 	if channel != nil {
 		clearChannelInfo(channel)
 	}
@@ -500,6 +506,15 @@ func RefreshCodexChannelCredential(c *gin.Context) {
 		return
 	}
 
+	channel, err := model.GetChannelById(channelId, false)
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	if !requireChannelTenantAccess(c, channel) {
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
 	defer cancel()
 
@@ -507,6 +522,9 @@ func RefreshCodexChannelCredential(c *gin.Context) {
 	if err != nil {
 		common.SysError("failed to refresh codex channel credential: " + err.Error())
 		c.JSON(http.StatusOK, gin.H{"success": false, "message": "刷新凭证失败，请稍后重试"})
+		return
+	}
+	if !requireChannelTenantAccess(c, ch) {
 		return
 	}
 
@@ -666,8 +684,15 @@ func AddChannel(c *gin.Context) {
 
 func DeleteChannel(c *gin.Context) {
 	id, _ := strconv.Atoi(c.Param("id"))
-	channel := model.Channel{Id: id}
-	err := channel.Delete()
+	channel, err := model.GetChannelById(id, true)
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	if !requireChannelTenantAccess(c, channel) {
+		return
+	}
+	err = channel.Delete()
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -681,7 +706,7 @@ func DeleteChannel(c *gin.Context) {
 }
 
 func DeleteDisabledChannel(c *gin.Context) {
-	rows, err := model.DeleteDisabledChannel()
+	rows, err := model.DeleteDisabledChannel(model.TenantScopeFromContext(c))
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -717,7 +742,7 @@ func DisableTagChannels(c *gin.Context) {
 		})
 		return
 	}
-	err = model.DisableChannelByTag(channelTag.Tag)
+	err = model.DisableChannelByTag(channelTag.Tag, model.TenantScopeFromContext(c))
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -740,7 +765,7 @@ func EnableTagChannels(c *gin.Context) {
 		})
 		return
 	}
-	err = model.EnableChannelByTag(channelTag.Tag)
+	err = model.EnableChannelByTag(channelTag.Tag, model.TenantScopeFromContext(c))
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -792,7 +817,7 @@ func EditTagChannels(c *gin.Context) {
 		}
 		channelTag.HeaderOverride = common.GetPointer[string](trimmed)
 	}
-	err = model.EditChannelByTag(channelTag.Tag, channelTag.NewTag, channelTag.ModelMapping, channelTag.Models, channelTag.Groups, channelTag.Priority, channelTag.Weight, channelTag.ParamOverride, channelTag.HeaderOverride)
+	err = model.EditChannelByTag(channelTag.Tag, channelTag.NewTag, channelTag.ModelMapping, channelTag.Models, channelTag.Groups, channelTag.Priority, channelTag.Weight, channelTag.ParamOverride, channelTag.HeaderOverride, model.TenantScopeFromContext(c))
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -818,6 +843,14 @@ func DeleteChannelBatch(c *gin.Context) {
 			"success": false,
 			"message": "参数错误",
 		})
+		return
+	}
+	channels, err := model.GetChannelsByIds(channelBatch.Ids)
+	if err != nil || len(channels) != len(channelBatch.Ids) {
+		common.ApiErrorMsg(c, tenantAccessDeniedMessage)
+		return
+	}
+	if !requireChannelsTenantAccess(c, channels) {
 		return
 	}
 	err = model.BatchDeleteChannels(channelBatch.Ids)
@@ -863,6 +896,9 @@ func UpdateChannel(c *gin.Context) {
 			"success": false,
 			"message": err.Error(),
 		})
+		return
+	}
+	if !requireChannelTenantAccess(c, originChannel) {
 		return
 	}
 
@@ -1101,6 +1137,14 @@ func BatchSetChannelTag(c *gin.Context) {
 		})
 		return
 	}
+	channels, err := model.GetChannelsByIds(channelBatch.Ids)
+	if err != nil || len(channels) != len(channelBatch.Ids) {
+		common.ApiErrorMsg(c, tenantAccessDeniedMessage)
+		return
+	}
+	if !requireChannelsTenantAccess(c, channels) {
+		return
+	}
 	err = model.BatchSetChannelTag(channelBatch.Ids, channelBatch.Tag)
 	if err != nil {
 		common.ApiError(c, err)
@@ -1184,6 +1228,9 @@ func CopyChannel(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"success": false, "message": "获取渠道信息失败，请稍后重试"})
 		return
 	}
+	if !requireChannelTenantAccess(c, origin) {
+		return
+	}
 
 	// clone channel
 	clone := *origin // shallow copy is sufficient as we will overwrite primitives
@@ -1254,6 +1301,9 @@ func ManageMultiKeys(c *gin.Context) {
 			"success": false,
 			"message": "渠道不存在",
 		})
+		return
+	}
+	if !requireChannelTenantAccess(c, channel) {
 		return
 	}
 
@@ -1730,6 +1780,9 @@ func OllamaPullModel(c *gin.Context) {
 		})
 		return
 	}
+	if !requireChannelTenantAccess(c, channel) {
+		return
+	}
 
 	// 检查是否是 Ollama 渠道
 	if channel.Type != constant.ChannelTypeOllama {
@@ -1791,6 +1844,9 @@ func OllamaPullModelStream(c *gin.Context) {
 			"success": false,
 			"message": "Channel not found",
 		})
+		return
+	}
+	if !requireChannelTenantAccess(c, channel) {
 		return
 	}
 
@@ -1875,6 +1931,9 @@ func OllamaDeleteModel(c *gin.Context) {
 		})
 		return
 	}
+	if !requireChannelTenantAccess(c, channel) {
+		return
+	}
 
 	// 检查是否是 Ollama 渠道
 	if channel.Type != constant.ChannelTypeOllama {
@@ -1923,6 +1982,9 @@ func OllamaVersion(c *gin.Context) {
 			"success": false,
 			"message": "Channel not found",
 		})
+		return
+	}
+	if !requireChannelTenantAccess(c, channel) {
 		return
 	}
 

--- a/controller/channel_upstream_update.go
+++ b/controller/channel_upstream_update.go
@@ -699,6 +699,9 @@ func ApplyChannelUpstreamModelUpdates(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	if !requireChannelTenantAccess(c, channel) {
+		return
+	}
 	beforeSettings := channel.GetOtherSettings()
 	ignoredModels := intersectModelNames(req.IgnoreModels, beforeSettings.UpstreamModelUpdateLastDetectedModels)
 
@@ -750,6 +753,9 @@ func DetectChannelUpstreamModelUpdates(c *gin.Context) {
 	channel, err := model.GetChannelById(req.ID, true)
 	if err != nil {
 		common.ApiError(c, err)
+		return
+	}
+	if !requireChannelTenantAccess(c, channel) {
 		return
 	}
 
@@ -850,6 +856,7 @@ func ApplyAllChannelUpstreamModelUpdates(c *gin.Context) {
 	refreshNeeded := false
 	addedModelCount := 0
 	removedModelCount := 0
+	scope := model.TenantScopeFromContext(c)
 
 	lastID := 0
 	for {
@@ -865,6 +872,9 @@ func ApplyAllChannelUpstreamModelUpdates(c *gin.Context) {
 
 		for _, channel := range channels {
 			if channel == nil {
+				continue
+			}
+			if !scope.AllowsTenant(channel.TenantId) {
 				continue
 			}
 
@@ -931,6 +941,7 @@ func DetectAllChannelUpstreamModelUpdates(c *gin.Context) {
 	detectedAddCount := 0
 	detectedRemoveCount := 0
 	refreshNeeded := false
+	scope := model.TenantScopeFromContext(c)
 
 	lastID := 0
 	for {
@@ -946,6 +957,9 @@ func DetectAllChannelUpstreamModelUpdates(c *gin.Context) {
 
 		for _, channel := range channels {
 			if channel == nil {
+				continue
+			}
+			if !scope.AllowsTenant(channel.TenantId) {
 				continue
 			}
 			settings := channel.GetOtherSettings()

--- a/controller/codex_oauth.go
+++ b/controller/codex_oauth.go
@@ -83,6 +83,9 @@ func startCodexOAuthWithChannelID(c *gin.Context, channelID int) {
 			c.JSON(http.StatusOK, gin.H{"success": false, "message": "channel not found"})
 			return
 		}
+		if !requireChannelTenantAccess(c, ch) {
+			return
+		}
 		if ch.Type != constant.ChannelTypeCodex {
 			c.JSON(http.StatusOK, gin.H{"success": false, "message": "channel type is not Codex"})
 			return
@@ -154,6 +157,9 @@ func completeCodexOAuthWithChannelID(c *gin.Context, channelID int) {
 		}
 		if ch == nil {
 			c.JSON(http.StatusOK, gin.H{"success": false, "message": "channel not found"})
+			return
+		}
+		if !requireChannelTenantAccess(c, ch) {
 			return
 		}
 		if ch.Type != constant.ChannelTypeCodex {

--- a/controller/codex_usage.go
+++ b/controller/codex_usage.go
@@ -33,6 +33,9 @@ func GetCodexChannelUsage(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"success": false, "message": "channel not found"})
 		return
 	}
+	if !requireChannelTenantAccess(c, ch) {
+		return
+	}
 	if ch.Type != constant.ChannelTypeCodex {
 		c.JSON(http.StatusOK, gin.H{"success": false, "message": "channel type is not Codex"})
 		return

--- a/controller/custom_oauth.go
+++ b/controller/custom_oauth.go
@@ -499,6 +499,9 @@ func GetUserOAuthBindingsByAdmin(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	if !requireUserTenantAccess(c, targetUser) {
+		return
+	}
 
 	myRole := c.GetInt("role")
 	if myRole <= targetUser.Role && myRole != common.RoleRootUser {
@@ -556,6 +559,9 @@ func UnbindCustomOAuthByAdmin(c *gin.Context) {
 	targetUser, err := model.GetUserById(userId, false)
 	if err != nil {
 		common.ApiError(c, err)
+		return
+	}
+	if !requireUserTenantAccess(c, targetUser) {
 		return
 	}
 

--- a/controller/log.go
+++ b/controller/log.go
@@ -21,7 +21,7 @@ func GetAllLogs(c *gin.Context) {
 	channel, _ := strconv.Atoi(c.Query("channel"))
 	group := c.Query("group")
 	requestId := c.Query("request_id")
-	logs, total, err := model.GetAllLogs(logType, startTimestamp, endTimestamp, modelName, username, tokenName, pageInfo.GetStartIdx(), pageInfo.GetPageSize(), channel, group, requestId)
+	logs, total, err := model.GetAllLogs(model.TenantScopeFromContext(c), logType, startTimestamp, endTimestamp, modelName, username, tokenName, pageInfo.GetStartIdx(), pageInfo.GetPageSize(), channel, group, requestId)
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -102,7 +102,7 @@ func GetLogsStat(c *gin.Context) {
 	modelName := c.Query("model_name")
 	channel, _ := strconv.Atoi(c.Query("channel"))
 	group := c.Query("group")
-	stat, err := model.SumUsedQuota(logType, startTimestamp, endTimestamp, modelName, username, tokenName, channel, group)
+	stat, err := model.SumUsedQuota(logType, startTimestamp, endTimestamp, modelName, username, tokenName, channel, group, model.TenantScopeFromContext(c))
 	if err != nil {
 		common.ApiError(c, err)
 		return

--- a/controller/midjourney.go
+++ b/controller/midjourney.go
@@ -265,8 +265,9 @@ func GetAllMidjourney(c *gin.Context) {
 		EndTimestamp:   c.Query("end_timestamp"),
 	}
 
-	items := model.GetAllTasks(pageInfo.GetStartIdx(), pageInfo.GetPageSize(), queryParams)
-	total := model.CountAllTasks(queryParams)
+	scope := model.TenantScopeFromContext(c)
+	items := model.GetAllTasks(pageInfo.GetStartIdx(), pageInfo.GetPageSize(), queryParams, scope)
+	total := model.CountAllTasks(queryParams, scope)
 
 	if setting.MjForwardUrlEnabled {
 		for i, midjourney := range items {

--- a/controller/passkey.go
+++ b/controller/passkey.go
@@ -350,6 +350,9 @@ func AdminResetPasskey(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	if !requireUserTenantAccess(c, user) {
+		return
+	}
 
 	if _, err := model.GetPasskeyByUserID(user.Id); err != nil {
 		if errors.Is(err, model.ErrPasskeyNotFound) {

--- a/controller/redemption.go
+++ b/controller/redemption.go
@@ -14,7 +14,7 @@ import (
 
 func GetAllRedemptions(c *gin.Context) {
 	pageInfo := common.GetPageQuery(c)
-	redemptions, total, err := model.GetAllRedemptions(pageInfo.GetStartIdx(), pageInfo.GetPageSize())
+	redemptions, total, err := model.GetAllRedemptions(pageInfo.GetStartIdx(), pageInfo.GetPageSize(), model.TenantScopeFromContext(c))
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -28,7 +28,7 @@ func GetAllRedemptions(c *gin.Context) {
 func SearchRedemptions(c *gin.Context) {
 	keyword := c.Query("keyword")
 	pageInfo := common.GetPageQuery(c)
-	redemptions, total, err := model.SearchRedemptions(keyword, pageInfo.GetStartIdx(), pageInfo.GetPageSize())
+	redemptions, total, err := model.SearchRedemptions(keyword, pageInfo.GetStartIdx(), pageInfo.GetPageSize(), model.TenantScopeFromContext(c))
 	if err != nil {
 		common.ApiError(c, err)
 		return

--- a/controller/redemption.go
+++ b/controller/redemption.go
@@ -50,6 +50,9 @@ func GetRedemption(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	if !requireRedemptionTenantAccess(c, redemption) {
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",
@@ -115,7 +118,15 @@ func AddRedemption(c *gin.Context) {
 
 func DeleteRedemption(c *gin.Context) {
 	id, _ := strconv.Atoi(c.Param("id"))
-	err := model.DeleteRedemptionById(id)
+	redemption, err := model.GetRedemptionById(id)
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	if !requireRedemptionTenantAccess(c, redemption) {
+		return
+	}
+	err = model.DeleteRedemptionById(id)
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -138,6 +149,9 @@ func UpdateRedemption(c *gin.Context) {
 	cleanRedemption, err := model.GetRedemptionById(redemption.Id)
 	if err != nil {
 		common.ApiError(c, err)
+		return
+	}
+	if !requireRedemptionTenantAccess(c, cleanRedemption) {
 		return
 	}
 	if statusOnly == "" {
@@ -167,7 +181,7 @@ func UpdateRedemption(c *gin.Context) {
 }
 
 func DeleteInvalidRedemption(c *gin.Context) {
-	rows, err := model.DeleteInvalidRedemptions()
+	rows, err := model.DeleteInvalidRedemptions(model.TenantScopeFromContext(c))
 	if err != nil {
 		common.ApiError(c, err)
 		return

--- a/controller/redemption.go
+++ b/controller/redemption.go
@@ -92,6 +92,7 @@ func AddRedemption(c *gin.Context) {
 			Quota:       redemption.Quota,
 			ExpiredTime: redemption.ExpiredTime,
 		}
+		model.ApplyOwnershipFromContext(c, &cleanRedemption)
 		err = cleanRedemption.Insert()
 		if err != nil {
 			common.SysError("failed to insert redemption: " + err.Error())

--- a/controller/subscription.go
+++ b/controller/subscription.go
@@ -288,6 +288,10 @@ func AdminBindSubscription(c *gin.Context) {
 		common.ApiErrorMsg(c, "参数错误")
 		return
 	}
+	scope := model.TenantScopeFromContext(c)
+	if !ensureAdminTargetUserInTenant(c, req.UserId, scope) {
+		return
+	}
 	msg, err := model.AdminBindSubscription(req.UserId, req.PlanId, "")
 	if err != nil {
 		common.ApiError(c, err)
@@ -311,11 +315,23 @@ func ensureAdminTargetUserInTenant(c *gin.Context, userId int, scope model.Tenan
 		common.ApiErrorMsg(c, "用户不存在或无权访问")
 		return false
 	}
-	userTenantId := user.TenantId
-	if userTenantId == 0 {
-		userTenantId = 1
+	if !scope.AllowsTenant(user.TenantId) {
+		common.ApiErrorMsg(c, "用户不存在或无权访问")
+		return false
 	}
-	if userTenantId != scope.TenantId {
+	return true
+}
+
+func ensureAdminSubscriptionInTenant(c *gin.Context, subId int, scope model.TenantScope) bool {
+	if scope.IsRoot {
+		return true
+	}
+	var sub model.UserSubscription
+	if err := model.DB.Where("id = ?", subId).First(&sub).Error; err != nil {
+		common.ApiErrorMsg(c, "用户不存在或无权访问")
+		return false
+	}
+	if !scope.AllowsTenant(sub.TenantId) {
 		common.ApiErrorMsg(c, "用户不存在或无权访问")
 		return false
 	}
@@ -356,6 +372,10 @@ func AdminCreateUserSubscription(c *gin.Context) {
 		common.ApiErrorMsg(c, "参数错误")
 		return
 	}
+	scope := model.TenantScopeFromContext(c)
+	if !ensureAdminTargetUserInTenant(c, userId, scope) {
+		return
+	}
 	msg, err := model.AdminBindSubscription(userId, req.PlanId, "")
 	if err != nil {
 		common.ApiError(c, err)
@@ -375,6 +395,9 @@ func AdminInvalidateUserSubscription(c *gin.Context) {
 		common.ApiErrorMsg(c, "无效的订阅ID")
 		return
 	}
+	if !ensureAdminSubscriptionInTenant(c, subId, model.TenantScopeFromContext(c)) {
+		return
+	}
 	msg, err := model.AdminInvalidateUserSubscription(subId)
 	if err != nil {
 		common.ApiError(c, err)
@@ -392,6 +415,9 @@ func AdminDeleteUserSubscription(c *gin.Context) {
 	subId, _ := strconv.Atoi(c.Param("id"))
 	if subId <= 0 {
 		common.ApiErrorMsg(c, "无效的订阅ID")
+		return
+	}
+	if !ensureAdminSubscriptionInTenant(c, subId, model.TenantScopeFromContext(c)) {
 		return
 	}
 	msg, err := model.AdminDeleteUserSubscription(subId)

--- a/controller/subscription.go
+++ b/controller/subscription.go
@@ -302,13 +302,37 @@ func AdminBindSubscription(c *gin.Context) {
 
 // ---- Admin: user subscription management ----
 
+func ensureAdminTargetUserInTenant(c *gin.Context, userId int, scope model.TenantScope) bool {
+	if scope.IsRoot {
+		return true
+	}
+	user, err := model.GetUserById(userId, true)
+	if err != nil {
+		common.ApiErrorMsg(c, "用户不存在或无权访问")
+		return false
+	}
+	userTenantId := user.TenantId
+	if userTenantId == 0 {
+		userTenantId = 1
+	}
+	if userTenantId != scope.TenantId {
+		common.ApiErrorMsg(c, "用户不存在或无权访问")
+		return false
+	}
+	return true
+}
+
 func AdminListUserSubscriptions(c *gin.Context) {
 	userId, _ := strconv.Atoi(c.Param("id"))
 	if userId <= 0 {
 		common.ApiErrorMsg(c, "无效的用户ID")
 		return
 	}
-	subs, err := model.GetAllUserSubscriptions(userId)
+	scope := model.TenantScopeFromContext(c)
+	if !ensureAdminTargetUserInTenant(c, userId, scope) {
+		return
+	}
+	subs, err := model.GetAllUserSubscriptions(userId, scope)
 	if err != nil {
 		common.ApiError(c, err)
 		return

--- a/controller/subscription_payment_creem.go
+++ b/controller/subscription_payment_creem.go
@@ -92,6 +92,7 @@ func SubscriptionRequestCreemPay(c *gin.Context) {
 		CreateTime:      time.Now().Unix(),
 		Status:          common.TopUpStatusPending,
 	}
+	model.ApplyOwnershipFromContext(c, order)
 	if err := order.Insert(); err != nil {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "创建订单失败"})
 		return

--- a/controller/subscription_payment_epay.go
+++ b/controller/subscription_payment_epay.go
@@ -90,6 +90,7 @@ func SubscriptionRequestEpay(c *gin.Context) {
 		CreateTime:      time.Now().Unix(),
 		Status:          common.TopUpStatusPending,
 	}
+	model.ApplyOwnershipFromContext(c, order)
 	if err := order.Insert(); err != nil {
 		common.ApiErrorMsg(c, "创建订单失败")
 		return

--- a/controller/subscription_payment_stripe.go
+++ b/controller/subscription_payment_stripe.go
@@ -92,6 +92,7 @@ func SubscriptionRequestStripePay(c *gin.Context) {
 		CreateTime:      time.Now().Unix(),
 		Status:          common.TopUpStatusPending,
 	}
+	model.ApplyOwnershipFromContext(c, order)
 	if err := order.Insert(); err != nil {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "创建订单失败"})
 		return

--- a/controller/task.go
+++ b/controller/task.go
@@ -21,6 +21,7 @@ func UpdateTaskBulk() {
 
 func GetAllTask(c *gin.Context) {
 	pageInfo := common.GetPageQuery(c)
+	scope := model.TenantScopeFromContext(c)
 
 	startTimestamp, _ := strconv.ParseInt(c.Query("start_timestamp"), 10, 64)
 	endTimestamp, _ := strconv.ParseInt(c.Query("end_timestamp"), 10, 64)
@@ -35,8 +36,8 @@ func GetAllTask(c *gin.Context) {
 		ChannelID:      c.Query("channel_id"),
 	}
 
-	items := model.TaskGetAllTasks(pageInfo.GetStartIdx(), pageInfo.GetPageSize(), queryParams)
-	total := model.TaskCountAllTasks(queryParams)
+	items := model.TaskGetAllTasks(pageInfo.GetStartIdx(), pageInfo.GetPageSize(), queryParams, scope)
+	total := model.TaskCountAllTasks(queryParams, scope)
 	pageInfo.SetTotal(int(total))
 	pageInfo.SetItems(tasksToDto(items, true))
 	common.ApiSuccess(c, pageInfo)

--- a/controller/tenant_access.go
+++ b/controller/tenant_access.go
@@ -50,3 +50,11 @@ func requireRedemptionTenantAccess(c *gin.Context, redemption *model.Redemption)
 	}
 	return requireTenantAccess(c, redemption.TenantId)
 }
+
+func requireTopUpTenantAccess(c *gin.Context, topUp *model.TopUp) bool {
+	if topUp == nil {
+		common.ApiErrorMsg(c, tenantAccessDeniedMessage)
+		return false
+	}
+	return requireTenantAccess(c, topUp.TenantId)
+}

--- a/controller/tenant_access.go
+++ b/controller/tenant_access.go
@@ -1,0 +1,52 @@
+package controller
+
+import (
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/gin-gonic/gin"
+)
+
+const tenantAccessDeniedMessage = "用户不存在或无权访问"
+
+func requireTenantAccess(c *gin.Context, tenantId int) bool {
+	if model.TenantScopeFromContext(c).AllowsTenant(tenantId) {
+		return true
+	}
+	common.ApiErrorMsg(c, tenantAccessDeniedMessage)
+	return false
+}
+
+func requireUserTenantAccess(c *gin.Context, user *model.User) bool {
+	if user == nil {
+		common.ApiErrorMsg(c, tenantAccessDeniedMessage)
+		return false
+	}
+	return requireTenantAccess(c, user.TenantId)
+}
+
+func requireChannelTenantAccess(c *gin.Context, channel *model.Channel) bool {
+	if channel == nil {
+		common.ApiErrorMsg(c, tenantAccessDeniedMessage)
+		return false
+	}
+	return requireTenantAccess(c, channel.TenantId)
+}
+
+func requireChannelsTenantAccess(c *gin.Context, channels []*model.Channel) bool {
+	scope := model.TenantScopeFromContext(c)
+	for _, channel := range channels {
+		if channel == nil || !scope.AllowsTenant(channel.TenantId) {
+			common.ApiErrorMsg(c, tenantAccessDeniedMessage)
+			return false
+		}
+	}
+	return true
+}
+
+func requireRedemptionTenantAccess(c *gin.Context, redemption *model.Redemption) bool {
+	if redemption == nil {
+		common.ApiErrorMsg(c, tenantAccessDeniedMessage)
+		return false
+	}
+	return requireTenantAccess(c, redemption.TenantId)
+}

--- a/controller/topup.go
+++ b/controller/topup.go
@@ -458,6 +458,7 @@ func GetUserTopUps(c *gin.Context) {
 func GetAllTopUps(c *gin.Context) {
 	pageInfo := common.GetPageQuery(c)
 	keyword := c.Query("keyword")
+	scope := model.TenantScopeFromContext(c)
 
 	var (
 		topups []*model.TopUp
@@ -465,9 +466,9 @@ func GetAllTopUps(c *gin.Context) {
 		err    error
 	)
 	if keyword != "" {
-		topups, total, err = model.SearchAllTopUps(keyword, pageInfo)
+		topups, total, err = model.SearchAllTopUps(keyword, pageInfo, scope)
 	} else {
-		topups, total, err = model.GetAllTopUps(pageInfo)
+		topups, total, err = model.GetAllTopUps(pageInfo, scope)
 	}
 	if err != nil {
 		common.ApiError(c, err)

--- a/controller/topup.go
+++ b/controller/topup.go
@@ -496,6 +496,11 @@ func AdminCompleteTopUp(c *gin.Context) {
 	LockOrder(req.TradeNo)
 	defer UnlockOrder(req.TradeNo)
 
+	topUp := model.GetTopUpByTradeNo(req.TradeNo)
+	if !requireTopUpTenantAccess(c, topUp) {
+		return
+	}
+
 	if err := model.ManualCompleteTopUp(req.TradeNo, c.ClientIP()); err != nil {
 		common.ApiError(c, err)
 		return

--- a/controller/topup.go
+++ b/controller/topup.go
@@ -246,6 +246,7 @@ func RequestEpay(c *gin.Context) {
 		CreateTime:      time.Now().Unix(),
 		Status:          common.TopUpStatusPending,
 	}
+	model.ApplyOwnershipFromContext(c, topUp)
 	err = topUp.Insert()
 	if err != nil {
 		logger.LogError(c.Request.Context(), fmt.Sprintf("易支付 创建充值订单失败 user_id=%d trade_no=%s payment_method=%s amount=%d error=%q", id, tradeNo, req.PaymentMethod, req.Amount, err.Error()))

--- a/controller/topup_creem.go
+++ b/controller/topup_creem.go
@@ -115,6 +115,7 @@ func (*CreemAdaptor) RequestPay(c *gin.Context, req *CreemPayRequest) {
 		CreateTime:      time.Now().Unix(),
 		Status:          common.TopUpStatusPending,
 	}
+	model.ApplyOwnershipFromContext(c, topUp)
 	err = topUp.Insert()
 	if err != nil {
 		logger.LogError(c.Request.Context(), fmt.Sprintf("Creem 创建充值订单失败 user_id=%d trade_no=%s product_id=%s error=%q", id, referenceId, selectedProduct.ProductId, err.Error()))

--- a/controller/topup_stripe.go
+++ b/controller/topup_stripe.go
@@ -109,6 +109,7 @@ func (*StripeAdaptor) RequestPay(c *gin.Context, req *StripePayRequest) {
 		CreateTime:      time.Now().Unix(),
 		Status:          common.TopUpStatusPending,
 	}
+	model.ApplyOwnershipFromContext(c, topUp)
 	err = topUp.Insert()
 	if err != nil {
 		logger.LogError(c.Request.Context(), fmt.Sprintf("Stripe 创建充值订单失败 user_id=%d trade_no=%s amount=%d error=%q", id, referenceId, req.Amount, err.Error()))

--- a/controller/topup_waffo.go
+++ b/controller/topup_waffo.go
@@ -216,6 +216,7 @@ func RequestWaffoPay(c *gin.Context) {
 		CreateTime:      time.Now().Unix(),
 		Status:          common.TopUpStatusPending,
 	}
+	model.ApplyOwnershipFromContext(c, topUp)
 	if err := topUp.Insert(); err != nil {
 		logger.LogError(c.Request.Context(), fmt.Sprintf("Waffo 创建充值订单失败 user_id=%d trade_no=%s amount=%d error=%q", id, merchantOrderId, req.Amount, err.Error()))
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "创建订单失败"})

--- a/controller/topup_waffo_pancake.go
+++ b/controller/topup_waffo_pancake.go
@@ -167,6 +167,7 @@ func RequestWaffoPancakePay(c *gin.Context) {
 		CreateTime:      time.Now().Unix(),
 		Status:          common.TopUpStatusPending,
 	}
+	model.ApplyOwnershipFromContext(c, topUp)
 	if err := topUp.Insert(); err != nil {
 		logger.LogError(c.Request.Context(), fmt.Sprintf("Waffo Pancake 创建充值订单失败 user_id=%d trade_no=%s amount=%d error=%q", id, tradeNo, req.Amount, err.Error()))
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "创建订单失败"})

--- a/controller/twofa.go
+++ b/controller/twofa.go
@@ -518,6 +518,9 @@ func AdminDisable2FA(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	if !requireUserTenantAccess(c, targetUser) {
+		return
+	}
 
 	myRole := c.GetInt("role")
 	if myRole <= targetUser.Role && myRole != common.RoleRootUser {

--- a/controller/user.go
+++ b/controller/user.go
@@ -274,6 +274,9 @@ func GetUser(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	if !requireUserTenantAccess(c, user) {
+		return
+	}
 	myRole := c.GetInt("role")
 	if myRole <= user.Role && myRole != common.RoleRootUser {
 		common.ApiErrorI18n(c, i18n.MsgUserNoPermissionSameLevel)
@@ -561,6 +564,9 @@ func UpdateUser(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	if !requireUserTenantAccess(c, originUser) {
+		return
+	}
 	myRole := c.GetInt("role")
 	if myRole <= originUser.Role && myRole != common.RoleRootUser {
 		common.ApiErrorI18n(c, i18n.MsgUserNoPermissionHigherLevel)
@@ -766,6 +772,9 @@ func DeleteUser(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	if !requireUserTenantAccess(c, originUser) {
+		return
+	}
 	myRole := c.GetInt("role")
 	if myRole <= originUser.Role {
 		common.ApiErrorI18n(c, i18n.MsgUserNoPermissionHigherLevel)
@@ -864,6 +873,9 @@ func ManageUser(c *gin.Context) {
 	model.DB.Unscoped().Where(&user).First(&user)
 	if user.Id == 0 {
 		common.ApiErrorI18n(c, i18n.MsgUserNotExists)
+		return
+	}
+	if !requireUserTenantAccess(c, &user) {
 		return
 	}
 	myRole := c.GetInt("role")

--- a/controller/user.go
+++ b/controller/user.go
@@ -609,6 +609,9 @@ func AdminClearUserBinding(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	if !requireUserTenantAccess(c, user) {
+		return
+	}
 
 	myRole := c.GetInt("role")
 	if myRole <= user.Role && myRole != common.RoleRootUser {

--- a/controller/user.go
+++ b/controller/user.go
@@ -234,7 +234,7 @@ func Register(c *gin.Context) {
 
 func GetAllUsers(c *gin.Context) {
 	pageInfo := common.GetPageQuery(c)
-	users, total, err := model.GetAllUsers(pageInfo)
+	users, total, err := model.GetAllUsers(pageInfo, model.TenantScopeFromContext(c))
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -251,7 +251,7 @@ func SearchUsers(c *gin.Context) {
 	keyword := c.Query("keyword")
 	group := c.Query("group")
 	pageInfo := common.GetPageQuery(c)
-	users, total, err := model.SearchUsers(keyword, group, pageInfo.GetStartIdx(), pageInfo.GetPageSize())
+	users, total, err := model.SearchUsers(keyword, group, pageInfo.GetStartIdx(), pageInfo.GetPageSize(), model.TenantScopeFromContext(c))
 	if err != nil {
 		common.ApiError(c, err)
 		return

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -152,6 +152,15 @@ func authHelper(c *gin.Context, minRole int) {
 	c.Set("group", session.Get("group"))
 	c.Set("user_group", session.Get("group"))
 	c.Set("use_access_token", useAccessToken)
+	if userCache, err := model.GetUserCache(id.(int)); err == nil {
+		userCache.WriteContext(c)
+	} else {
+		common.SysLog(fmt.Sprintf("authHelper GetUserCache error for user %d: %v", id.(int), err))
+		common.SetContextKey(c, constant.ContextKeyTenantId, 1)
+		common.SetContextKey(c, constant.ContextKeyOrganizationId, 0)
+		common.SetContextKey(c, constant.ContextKeyDepartmentId, 0)
+		common.SetContextKey(c, constant.ContextKeyDistributionChannelId, 0)
+	}
 
 	c.Next()
 }
@@ -269,6 +278,7 @@ func TokenAuthReadOnly() func(c *gin.Context) {
 		c.Set("id", token.UserId)
 		c.Set("token_id", token.Id)
 		c.Set("token_key", token.Key)
+		userCache.WriteContext(c)
 		c.Next()
 	}
 }

--- a/model/ability.go
+++ b/model/ability.go
@@ -14,13 +14,17 @@ import (
 )
 
 type Ability struct {
-	Group     string  `json:"group" gorm:"type:varchar(64);primaryKey;autoIncrement:false"`
-	Model     string  `json:"model" gorm:"type:varchar(255);primaryKey;autoIncrement:false"`
-	ChannelId int     `json:"channel_id" gorm:"primaryKey;autoIncrement:false;index"`
-	Enabled   bool    `json:"enabled"`
-	Priority  *int64  `json:"priority" gorm:"bigint;default:0;index"`
-	Weight    uint    `json:"weight" gorm:"default:0;index"`
-	Tag       *string `json:"tag" gorm:"index"`
+	TenantId              int     `json:"tenant_id" gorm:"index;default:1"`
+	OrganizationId        int     `json:"organization_id" gorm:"index;default:0"`
+	DepartmentId          int     `json:"department_id" gorm:"index;default:0"`
+	DistributionChannelId int     `json:"distribution_channel_id" gorm:"index;default:0"`
+	Group                 string  `json:"group" gorm:"type:varchar(64);primaryKey;autoIncrement:false"`
+	Model                 string  `json:"model" gorm:"type:varchar(255);primaryKey;autoIncrement:false"`
+	ChannelId             int     `json:"channel_id" gorm:"primaryKey;autoIncrement:false;index"`
+	Enabled               bool    `json:"enabled"`
+	Priority              *int64  `json:"priority" gorm:"bigint;default:0;index"`
+	Weight                uint    `json:"weight" gorm:"default:0;index"`
+	Tag                   *string `json:"tag" gorm:"index"`
 }
 
 type AbilityWithChannel struct {

--- a/model/ability.go
+++ b/model/ability.go
@@ -268,11 +268,15 @@ func UpdateAbilityStatus(channelId int, status bool) error {
 	return DB.Model(&Ability{}).Where("channel_id = ?", channelId).Select("enabled").Update("enabled", status).Error
 }
 
-func UpdateAbilityStatusByTag(tag string, status bool) error {
-	return DB.Model(&Ability{}).Where("tag = ?", tag).Select("enabled").Update("enabled", status).Error
+func UpdateAbilityStatusByTag(tag string, status bool, scopes ...TenantScope) error {
+	query := DB.Model(&Ability{}).Where("tag = ?", tag)
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "abilities")
+	}
+	return query.Select("enabled").Update("enabled", status).Error
 }
 
-func UpdateAbilityByTag(tag string, newTag *string, priority *int64, weight *uint) error {
+func UpdateAbilityByTag(tag string, newTag *string, priority *int64, weight *uint, scopes ...TenantScope) error {
 	ability := Ability{}
 	if newTag != nil {
 		ability.Tag = newTag
@@ -283,7 +287,11 @@ func UpdateAbilityByTag(tag string, newTag *string, priority *int64, weight *uin
 	if weight != nil {
 		ability.Weight = *weight
 	}
-	return DB.Model(&Ability{}).Where("tag = ?", tag).Updates(ability).Error
+	query := DB.Model(&Ability{}).Where("tag = ?", tag)
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "abilities")
+	}
+	return query.Updates(ability).Error
 }
 
 var fixLock = sync.Mutex{}

--- a/model/channel.go
+++ b/model/channel.go
@@ -338,9 +338,21 @@ func GetAllChannels(startIdx int, num int, selectAll bool, idSort bool, sortOpti
 }
 
 func GetChannelsByTag(tag string, idSort bool, selectAll bool, sortOptions ...ChannelSortOptions) ([]*Channel, error) {
+	return getChannelsByTag(tag, idSort, selectAll, nil, sortOptions...)
+}
+
+func GetChannelsByTagScoped(tag string, idSort bool, selectAll bool, scope TenantScope, sortOptions ...ChannelSortOptions) ([]*Channel, error) {
+	return getChannelsByTag(tag, idSort, selectAll, &scope, sortOptions...)
+}
+
+func getChannelsByTag(tag string, idSort bool, selectAll bool, scope *TenantScope, sortOptions ...ChannelSortOptions) ([]*Channel, error) {
 	var channels []*Channel
 	order := resolveChannelSortOptions(idSort, sortOptions)
-	query := order.Apply(DB.Where("tag = ?", tag))
+	query := DB.Where("tag = ?", tag)
+	if scope != nil {
+		query = scope.Apply(query, "channels")
+	}
+	query = order.Apply(query)
 	if !selectAll {
 		query = query.Omit("key")
 	}
@@ -349,6 +361,14 @@ func GetChannelsByTag(tag string, idSort bool, selectAll bool, sortOptions ...Ch
 }
 
 func SearchChannels(keyword string, group string, model string, idSort bool, sortOptions ...ChannelSortOptions) ([]*Channel, error) {
+	return searchChannels(keyword, group, model, idSort, nil, sortOptions...)
+}
+
+func SearchChannelsScoped(keyword string, group string, model string, idSort bool, scope TenantScope, sortOptions ...ChannelSortOptions) ([]*Channel, error) {
+	return searchChannels(keyword, group, model, idSort, &scope, sortOptions...)
+}
+
+func searchChannels(keyword string, group string, model string, idSort bool, scope *TenantScope, sortOptions ...ChannelSortOptions) ([]*Channel, error) {
 	var channels []*Channel
 	modelsCol := "`models`"
 
@@ -367,6 +387,9 @@ func SearchChannels(keyword string, group string, model string, idSort bool, sor
 
 	// 构造基础查询
 	baseQuery := DB.Model(&Channel{}).Omit("key")
+	if scope != nil {
+		baseQuery = scope.Apply(baseQuery, "channels")
+	}
 
 	// 构造WHERE子句
 	var whereClause string
@@ -831,13 +854,17 @@ func DeleteDisabledChannel() (int64, error) {
 	return result.RowsAffected, result.Error
 }
 
-func GetPaginatedTags(offset int, limit int) ([]*string, error) {
+func GetPaginatedTags(offset int, limit int, scopes ...TenantScope) ([]*string, error) {
 	var tags []*string
-	err := DB.Model(&Channel{}).Select("DISTINCT tag").Where("tag != ''").Offset(offset).Limit(limit).Find(&tags).Error
+	query := DB.Model(&Channel{})
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "channels")
+	}
+	err := query.Select("DISTINCT tag").Where("tag != ''").Offset(offset).Limit(limit).Find(&tags).Error
 	return tags, err
 }
 
-func SearchTags(keyword string, group string, model string, idSort bool) ([]*string, error) {
+func SearchTags(keyword string, group string, model string, idSort bool, scopes ...TenantScope) ([]*string, error) {
 	var tags []*string
 	modelsCol := "`models`"
 
@@ -859,6 +886,9 @@ func SearchTags(keyword string, group string, model string, idSort bool) ([]*str
 
 	// 构造基础查询
 	baseQuery := DB.Model(&Channel{}).Omit("key")
+	if len(scopes) > 0 {
+		baseQuery = scopes[0].Apply(baseQuery, "channels")
+	}
 
 	// 构造WHERE子句
 	var whereClause string
@@ -1018,9 +1048,13 @@ func CountAllChannels() (int64, error) {
 }
 
 // CountAllTags returns number of non-empty distinct tags
-func CountAllTags() (int64, error) {
+func CountAllTags(scopes ...TenantScope) (int64, error) {
 	var total int64
-	err := DB.Model(&Channel{}).Where("tag is not null AND tag != ''").Distinct("tag").Count(&total).Error
+	query := DB.Model(&Channel{})
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "channels")
+	}
+	err := query.Where("tag is not null AND tag != ''").Distinct("tag").Count(&total).Error
 	return total, err
 }
 

--- a/model/channel.go
+++ b/model/channel.go
@@ -20,25 +20,29 @@ import (
 )
 
 type Channel struct {
-	Id                 int     `json:"id"`
-	Type               int     `json:"type" gorm:"default:0"`
-	Key                string  `json:"key" gorm:"not null"`
-	OpenAIOrganization *string `json:"openai_organization"`
-	TestModel          *string `json:"test_model"`
-	Status             int     `json:"status" gorm:"default:1"`
-	Name               string  `json:"name" gorm:"index"`
-	Weight             *uint   `json:"weight" gorm:"default:0"`
-	CreatedTime        int64   `json:"created_time" gorm:"bigint"`
-	TestTime           int64   `json:"test_time" gorm:"bigint"`
-	ResponseTime       int     `json:"response_time"` // in milliseconds
-	BaseURL            *string `json:"base_url" gorm:"column:base_url;default:''"`
-	Other              string  `json:"other"`
-	Balance            float64 `json:"balance"` // in USD
-	BalanceUpdatedTime int64   `json:"balance_updated_time" gorm:"bigint"`
-	Models             string  `json:"models"`
-	Group              string  `json:"group" gorm:"type:varchar(64);default:'default'"`
-	UsedQuota          int64   `json:"used_quota" gorm:"bigint;default:0"`
-	ModelMapping       *string `json:"model_mapping" gorm:"type:text"`
+	Id                    int     `json:"id"`
+	TenantId              int     `json:"tenant_id" gorm:"index;default:1"`
+	OrganizationId        int     `json:"organization_id" gorm:"index;default:0"`
+	DepartmentId          int     `json:"department_id" gorm:"index;default:0"`
+	DistributionChannelId int     `json:"distribution_channel_id" gorm:"index;default:0"`
+	Type                  int     `json:"type" gorm:"default:0"`
+	Key                   string  `json:"key" gorm:"not null"`
+	OpenAIOrganization    *string `json:"openai_organization"`
+	TestModel             *string `json:"test_model"`
+	Status                int     `json:"status" gorm:"default:1"`
+	Name                  string  `json:"name" gorm:"index"`
+	Weight                *uint   `json:"weight" gorm:"default:0"`
+	CreatedTime           int64   `json:"created_time" gorm:"bigint"`
+	TestTime              int64   `json:"test_time" gorm:"bigint"`
+	ResponseTime          int     `json:"response_time"` // in milliseconds
+	BaseURL               *string `json:"base_url" gorm:"column:base_url;default:''"`
+	Other                 string  `json:"other"`
+	Balance               float64 `json:"balance"` // in USD
+	BalanceUpdatedTime    int64   `json:"balance_updated_time" gorm:"bigint"`
+	Models                string  `json:"models"`
+	Group                 string  `json:"group" gorm:"type:varchar(64);default:'default'"`
+	UsedQuota             int64   `json:"used_quota" gorm:"bigint;default:0"`
+	ModelMapping          *string `json:"model_mapping" gorm:"type:text"`
 	//MaxInputTokens     *int    `json:"max_input_tokens" gorm:"default:0"`
 	StatusCodeMapping *string `json:"status_code_mapping" gorm:"type:varchar(1024);default:''"`
 	Priority          *int64  `json:"priority" gorm:"bigint;default:0"`

--- a/model/channel.go
+++ b/model/channel.go
@@ -755,25 +755,33 @@ func UpdateChannelStatus(channelId int, usingKey string, status int, reason stri
 	return true
 }
 
-func EnableChannelByTag(tag string) error {
-	err := DB.Model(&Channel{}).Where("tag = ?", tag).Update("status", common.ChannelStatusEnabled).Error
+func EnableChannelByTag(tag string, scopes ...TenantScope) error {
+	query := DB.Model(&Channel{}).Where("tag = ?", tag)
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "channels")
+	}
+	err := query.Update("status", common.ChannelStatusEnabled).Error
 	if err != nil {
 		return err
 	}
-	err = UpdateAbilityStatusByTag(tag, true)
+	err = UpdateAbilityStatusByTag(tag, true, scopes...)
 	return err
 }
 
-func DisableChannelByTag(tag string) error {
-	err := DB.Model(&Channel{}).Where("tag = ?", tag).Update("status", common.ChannelStatusManuallyDisabled).Error
+func DisableChannelByTag(tag string, scopes ...TenantScope) error {
+	query := DB.Model(&Channel{}).Where("tag = ?", tag)
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "channels")
+	}
+	err := query.Update("status", common.ChannelStatusManuallyDisabled).Error
 	if err != nil {
 		return err
 	}
-	err = UpdateAbilityStatusByTag(tag, false)
+	err = UpdateAbilityStatusByTag(tag, false, scopes...)
 	return err
 }
 
-func EditChannelByTag(tag string, newTag *string, modelMapping *string, models *string, group *string, priority *int64, weight *uint, paramOverride *string, headerOverride *string) error {
+func EditChannelByTag(tag string, newTag *string, modelMapping *string, models *string, group *string, priority *int64, weight *uint, paramOverride *string, headerOverride *string, scopes ...TenantScope) error {
 	updateData := Channel{}
 	shouldReCreateAbilities := false
 	updatedTag := tag
@@ -806,12 +814,22 @@ func EditChannelByTag(tag string, newTag *string, modelMapping *string, models *
 		updateData.HeaderOverride = headerOverride
 	}
 
-	err := DB.Model(&Channel{}).Where("tag = ?", tag).Updates(updateData).Error
+	query := DB.Model(&Channel{}).Where("tag = ?", tag)
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "channels")
+	}
+	err := query.Updates(updateData).Error
 	if err != nil {
 		return err
 	}
 	if shouldReCreateAbilities {
-		channels, err := GetChannelsByTag(updatedTag, false, false)
+		var channels []*Channel
+		var err error
+		if len(scopes) > 0 {
+			channels, err = GetChannelsByTagScoped(updatedTag, false, false, scopes[0])
+		} else {
+			channels, err = GetChannelsByTag(updatedTag, false, false)
+		}
 		if err == nil {
 			for _, channel := range channels {
 				err = channel.UpdateAbilities(nil)
@@ -821,7 +839,7 @@ func EditChannelByTag(tag string, newTag *string, modelMapping *string, models *
 			}
 		}
 	} else {
-		err := UpdateAbilityByTag(tag, newTag, priority, weight)
+		err := UpdateAbilityByTag(tag, newTag, priority, weight, scopes...)
 		if err != nil {
 			return err
 		}
@@ -849,8 +867,12 @@ func DeleteChannelByStatus(status int64) (int64, error) {
 	return result.RowsAffected, result.Error
 }
 
-func DeleteDisabledChannel() (int64, error) {
-	result := DB.Where("status = ? or status = ?", common.ChannelStatusAutoDisabled, common.ChannelStatusManuallyDisabled).Delete(&Channel{})
+func DeleteDisabledChannel(scopes ...TenantScope) (int64, error) {
+	query := DB.Where("status = ? or status = ?", common.ChannelStatusAutoDisabled, common.ChannelStatusManuallyDisabled)
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "channels")
+	}
+	result := query.Delete(&Channel{})
 	return result.RowsAffected, result.Error
 }
 

--- a/model/department.go
+++ b/model/department.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/QuantumNous/new-api/common"
+	"gorm.io/gorm"
+)
+
+type Department struct {
+	Id                    int            `json:"id"`
+	TenantId              int            `json:"tenant_id" gorm:"index;default:1"`
+	OrganizationId        int            `json:"organization_id" gorm:"index;default:0"`
+	ParentId              int            `json:"parent_id" gorm:"index;default:0"`
+	Name                  string         `json:"name" gorm:"type:varchar(128);not null;index"`
+	Status                int            `json:"status" gorm:"type:int;default:1;index"`
+	DistributionChannelId int            `json:"distribution_channel_id" gorm:"index;default:0"`
+	Remark                string         `json:"remark,omitempty" gorm:"type:varchar(255)"`
+	CreatedAt             int64          `json:"created_at" gorm:"bigint"`
+	UpdatedAt             int64          `json:"updated_at" gorm:"bigint"`
+	DeletedAt             gorm.DeletedAt `gorm:"index"`
+}
+
+func (department *Department) BeforeCreate(tx *gorm.DB) error {
+	now := common.GetTimestamp()
+	department.CreatedAt = now
+	department.UpdatedAt = now
+	return nil
+}
+
+func (department *Department) BeforeUpdate(tx *gorm.DB) error {
+	department.UpdatedAt = common.GetTimestamp()
+	return nil
+}

--- a/model/distribution_channel.go
+++ b/model/distribution_channel.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"github.com/QuantumNous/new-api/common"
+	"gorm.io/gorm"
+)
+
+type DistributionChannel struct {
+	Id             int            `json:"id"`
+	TenantId       int            `json:"tenant_id" gorm:"index;default:1"`
+	Name           string         `json:"name" gorm:"type:varchar(128);not null;index"`
+	Code           string         `json:"code" gorm:"type:varchar(64);not null;uniqueIndex"`
+	Status         int            `json:"status" gorm:"type:int;default:1;index"`
+	ParentId       int            `json:"parent_id" gorm:"index;default:0"`
+	OwnerUserId    int            `json:"owner_user_id" gorm:"index;default:0"`
+	CommissionRate float64        `json:"commission_rate" gorm:"type:decimal(10,6);default:0"`
+	Remark         string         `json:"remark,omitempty" gorm:"type:varchar(255)"`
+	CreatedAt      int64          `json:"created_at" gorm:"bigint"`
+	UpdatedAt      int64          `json:"updated_at" gorm:"bigint"`
+	DeletedAt      gorm.DeletedAt `gorm:"index"`
+}
+
+func (channel *DistributionChannel) BeforeCreate(tx *gorm.DB) error {
+	now := common.GetTimestamp()
+	channel.CreatedAt = now
+	channel.UpdatedAt = now
+	return nil
+}
+
+func (channel *DistributionChannel) BeforeUpdate(tx *gorm.DB) error {
+	channel.UpdatedAt = common.GetTimestamp()
+	return nil
+}

--- a/model/log.go
+++ b/model/log.go
@@ -88,6 +88,7 @@ func RecordLog(userId int, logType int, content string) {
 		Type:      logType,
 		Content:   content,
 	}
+	ApplyOwnershipFromUser(userId, log)
 	err := LOG_DB.Create(log).Error
 	if err != nil {
 		common.SysLog("failed to record log: " + err.Error())
@@ -107,6 +108,7 @@ func RecordLogWithAdminInfo(userId int, logType int, content string, adminInfo m
 		Type:      logType,
 		Content:   content,
 	}
+	ApplyOwnershipFromUser(userId, log)
 	if len(adminInfo) > 0 {
 		other := map[string]interface{}{
 			"admin_info": adminInfo,
@@ -140,6 +142,7 @@ func RecordTopupLog(userId int, content string, callerIp string, paymentMethod s
 		Ip:        callerIp,
 		Other:     common.MapToJsonStr(other),
 	}
+	ApplyOwnershipFromUser(userId, log)
 	err := LOG_DB.Create(log).Error
 	if err != nil {
 		common.SysLog("failed to record topup log: " + err.Error())
@@ -184,6 +187,7 @@ func RecordErrorLog(c *gin.Context, userId int, channelId int, modelName string,
 		RequestId: requestId,
 		Other:     otherStr,
 	}
+	OwnershipFromContext(c).ApplyTo(log)
 	err := LOG_DB.Create(log).Error
 	if err != nil {
 		logger.LogError(c, "failed to record log: "+err.Error())
@@ -245,6 +249,7 @@ func RecordConsumeLog(c *gin.Context, userId int, params RecordConsumeLogParams)
 		RequestId: requestId,
 		Other:     otherStr,
 	}
+	OwnershipFromContext(c).ApplyTo(log)
 	err := LOG_DB.Create(log).Error
 	if err != nil {
 		logger.LogError(c, "failed to record log: "+err.Error())
@@ -293,6 +298,7 @@ func RecordTaskBillingLog(params RecordTaskBillingLogParams) {
 		Group:     params.Group,
 		Other:     common.MapToJsonStr(params.Other),
 	}
+	ApplyOwnershipFromUser(params.UserId, log)
 	err := LOG_DB.Create(log).Error
 	if err != nil {
 		common.SysLog("failed to record task billing log: " + err.Error())

--- a/model/log.go
+++ b/model/log.go
@@ -305,13 +305,14 @@ func RecordTaskBillingLog(params RecordTaskBillingLogParams) {
 	}
 }
 
-func GetAllLogs(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string, startIdx int, num int, channel int, group string, requestId string) (logs []*Log, total int64, err error) {
+func GetAllLogs(scope TenantScope, logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string, startIdx int, num int, channel int, group string, requestId string) (logs []*Log, total int64, err error) {
 	var tx *gorm.DB
 	if logType == LogTypeUnknown {
 		tx = LOG_DB
 	} else {
 		tx = LOG_DB.Where("logs.type = ?", logType)
 	}
+	tx = scope.Apply(tx, "logs")
 
 	if modelName != "" {
 		tx = tx.Where("logs.model_name like ?", modelName)
@@ -442,11 +443,15 @@ type Stat struct {
 	Tpm   int `json:"tpm"`
 }
 
-func SumUsedQuota(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string, channel int, group string) (stat Stat, err error) {
+func SumUsedQuota(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string, channel int, group string, scopes ...TenantScope) (stat Stat, err error) {
 	tx := LOG_DB.Table("logs").Select("sum(quota) quota")
 
 	// 为rpm和tpm创建单独的查询
 	rpmTpmQuery := LOG_DB.Table("logs").Select("count(*) rpm, sum(prompt_tokens) + sum(completion_tokens) tpm")
+	if len(scopes) > 0 {
+		tx = scopes[0].Apply(tx, "logs")
+		rpmTpmQuery = scopes[0].Apply(rpmTpmQuery, "logs")
+	}
 
 	if username != "" {
 		tx = tx.Where("username = ?", username)

--- a/model/log.go
+++ b/model/log.go
@@ -17,26 +17,30 @@ import (
 )
 
 type Log struct {
-	Id               int    `json:"id" gorm:"index:idx_created_at_id,priority:1;index:idx_user_id_id,priority:2"`
-	UserId           int    `json:"user_id" gorm:"index;index:idx_user_id_id,priority:1"`
-	CreatedAt        int64  `json:"created_at" gorm:"bigint;index:idx_created_at_id,priority:2;index:idx_created_at_type"`
-	Type             int    `json:"type" gorm:"index:idx_created_at_type"`
-	Content          string `json:"content"`
-	Username         string `json:"username" gorm:"index;index:index_username_model_name,priority:2;default:''"`
-	TokenName        string `json:"token_name" gorm:"index;default:''"`
-	ModelName        string `json:"model_name" gorm:"index;index:index_username_model_name,priority:1;default:''"`
-	Quota            int    `json:"quota" gorm:"default:0"`
-	PromptTokens     int    `json:"prompt_tokens" gorm:"default:0"`
-	CompletionTokens int    `json:"completion_tokens" gorm:"default:0"`
-	UseTime          int    `json:"use_time" gorm:"default:0"`
-	IsStream         bool   `json:"is_stream"`
-	ChannelId        int    `json:"channel" gorm:"index"`
-	ChannelName      string `json:"channel_name" gorm:"->"`
-	TokenId          int    `json:"token_id" gorm:"default:0;index"`
-	Group            string `json:"group" gorm:"index"`
-	Ip               string `json:"ip" gorm:"index;default:''"`
-	RequestId        string `json:"request_id,omitempty" gorm:"type:varchar(64);index:idx_logs_request_id;default:''"`
-	Other            string `json:"other"`
+	Id                    int    `json:"id" gorm:"index:idx_created_at_id,priority:1;index:idx_user_id_id,priority:2"`
+	TenantId              int    `json:"tenant_id" gorm:"index;default:1"`
+	OrganizationId        int    `json:"organization_id" gorm:"index;default:0"`
+	DepartmentId          int    `json:"department_id" gorm:"index;default:0"`
+	DistributionChannelId int    `json:"distribution_channel_id" gorm:"index;default:0"`
+	UserId                int    `json:"user_id" gorm:"index;index:idx_user_id_id,priority:1"`
+	CreatedAt             int64  `json:"created_at" gorm:"bigint;index:idx_created_at_id,priority:2;index:idx_created_at_type"`
+	Type                  int    `json:"type" gorm:"index:idx_created_at_type"`
+	Content               string `json:"content"`
+	Username              string `json:"username" gorm:"index;index:index_username_model_name,priority:2;default:''"`
+	TokenName             string `json:"token_name" gorm:"index;default:''"`
+	ModelName             string `json:"model_name" gorm:"index;index:index_username_model_name,priority:1;default:''"`
+	Quota                 int    `json:"quota" gorm:"default:0"`
+	PromptTokens          int    `json:"prompt_tokens" gorm:"default:0"`
+	CompletionTokens      int    `json:"completion_tokens" gorm:"default:0"`
+	UseTime               int    `json:"use_time" gorm:"default:0"`
+	IsStream              bool   `json:"is_stream"`
+	ChannelId             int    `json:"channel" gorm:"index"`
+	ChannelName           string `json:"channel_name" gorm:"->"`
+	TokenId               int    `json:"token_id" gorm:"default:0;index"`
+	Group                 string `json:"group" gorm:"index"`
+	Ip                    string `json:"ip" gorm:"index;default:''"`
+	RequestId             string `json:"request_id,omitempty" gorm:"type:varchar(64);index:idx_logs_request_id;default:''"`
+	Other                 string `json:"other"`
 }
 
 // don't use iota, avoid change log type value

--- a/model/main.go
+++ b/model/main.go
@@ -256,6 +256,10 @@ func migrateDB() error {
 	}
 
 	err := DB.AutoMigrate(
+		&Tenant{},
+		&DistributionChannel{},
+		&Organization{},
+		&Department{},
 		&Channel{},
 		&Token{},
 		&User{},
@@ -305,6 +309,10 @@ func migrateDBFast() error {
 		model interface{}
 		name  string
 	}{
+		{&Tenant{}, "Tenant"},
+		{&DistributionChannel{}, "DistributionChannel"},
+		{&Organization{}, "Organization"},
+		{&Department{}, "Department"},
 		{&Channel{}, "Channel"},
 		{&Token{}, "Token"},
 		{&User{}, "User"},

--- a/model/midjourney.go
+++ b/model/midjourney.go
@@ -1,28 +1,32 @@
 package model
 
 type Midjourney struct {
-	Id          int    `json:"id"`
-	Code        int    `json:"code"`
-	UserId      int    `json:"user_id" gorm:"index"`
-	Action      string `json:"action" gorm:"type:varchar(40);index"`
-	MjId        string `json:"mj_id" gorm:"index"`
-	Prompt      string `json:"prompt"`
-	PromptEn    string `json:"prompt_en"`
-	Description string `json:"description"`
-	State       string `json:"state"`
-	SubmitTime  int64  `json:"submit_time" gorm:"index"`
-	StartTime   int64  `json:"start_time" gorm:"index"`
-	FinishTime  int64  `json:"finish_time" gorm:"index"`
-	ImageUrl    string `json:"image_url"`
-	VideoUrl    string `json:"video_url"`
-	VideoUrls   string `json:"video_urls"`
-	Status      string `json:"status" gorm:"type:varchar(20);index"`
-	Progress    string `json:"progress" gorm:"type:varchar(30);index"`
-	FailReason  string `json:"fail_reason"`
-	ChannelId   int    `json:"channel_id"`
-	Quota       int    `json:"quota"`
-	Buttons     string `json:"buttons"`
-	Properties  string `json:"properties"`
+	Id                    int    `json:"id"`
+	TenantId              int    `json:"tenant_id" gorm:"index;default:1"`
+	OrganizationId        int    `json:"organization_id" gorm:"index;default:0"`
+	DepartmentId          int    `json:"department_id" gorm:"index;default:0"`
+	DistributionChannelId int    `json:"distribution_channel_id" gorm:"index;default:0"`
+	Code                  int    `json:"code"`
+	UserId                int    `json:"user_id" gorm:"index"`
+	Action                string `json:"action" gorm:"type:varchar(40);index"`
+	MjId                  string `json:"mj_id" gorm:"index"`
+	Prompt                string `json:"prompt"`
+	PromptEn              string `json:"prompt_en"`
+	Description           string `json:"description"`
+	State                 string `json:"state"`
+	SubmitTime            int64  `json:"submit_time" gorm:"index"`
+	StartTime             int64  `json:"start_time" gorm:"index"`
+	FinishTime            int64  `json:"finish_time" gorm:"index"`
+	ImageUrl              string `json:"image_url"`
+	VideoUrl              string `json:"video_url"`
+	VideoUrls             string `json:"video_urls"`
+	Status                string `json:"status" gorm:"type:varchar(20);index"`
+	Progress              string `json:"progress" gorm:"type:varchar(30);index"`
+	FailReason            string `json:"fail_reason"`
+	ChannelId             int    `json:"channel_id"`
+	Quota                 int    `json:"quota"`
+	Buttons               string `json:"buttons"`
+	Properties            string `json:"properties"`
 }
 
 // TaskQueryParams 用于包含所有搜索条件的结构体，可以根据需求添加更多字段
@@ -60,12 +64,15 @@ func GetAllUserTask(userId int, startIdx int, num int, queryParams TaskQueryPara
 	return tasks
 }
 
-func GetAllTasks(startIdx int, num int, queryParams TaskQueryParams) []*Midjourney {
+func GetAllTasks(startIdx int, num int, queryParams TaskQueryParams, scopes ...TenantScope) []*Midjourney {
 	var tasks []*Midjourney
 	var err error
 
 	// 初始化查询构建器
-	query := DB
+	query := DB.Model(&Midjourney{})
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "midjourneys")
+	}
 
 	// 添加过滤条件
 	if queryParams.ChannelID != "" {
@@ -147,6 +154,9 @@ func UpdateProgress(id int, progress string) error {
 
 func (midjourney *Midjourney) Insert() error {
 	var err error
+	if midjourney.TenantId == 0 {
+		ApplyOwnershipFromUser(midjourney.UserId, midjourney)
+	}
 	err = DB.Create(midjourney).Error
 	return err
 }
@@ -183,9 +193,12 @@ func MjBulkUpdateByTaskIds(taskIDs []int, params map[string]any) error {
 }
 
 // CountAllTasks returns total midjourney tasks for admin query
-func CountAllTasks(queryParams TaskQueryParams) int64 {
+func CountAllTasks(queryParams TaskQueryParams, scopes ...TenantScope) int64 {
 	var total int64
 	query := DB.Model(&Midjourney{})
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "midjourneys")
+	}
 	if queryParams.ChannelID != "" {
 		query = query.Where("channel_id = ?", queryParams.ChannelID)
 	}

--- a/model/organization.go
+++ b/model/organization.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"github.com/QuantumNous/new-api/common"
+	"gorm.io/gorm"
+)
+
+type Organization struct {
+	Id                    int            `json:"id"`
+	TenantId              int            `json:"tenant_id" gorm:"index;default:1"`
+	Name                  string         `json:"name" gorm:"type:varchar(128);not null;index"`
+	Status                int            `json:"status" gorm:"type:int;default:1;index"`
+	DistributionChannelId int            `json:"distribution_channel_id" gorm:"index;default:0"`
+	Remark                string         `json:"remark,omitempty" gorm:"type:varchar(255)"`
+	CreatedAt             int64          `json:"created_at" gorm:"bigint"`
+	UpdatedAt             int64          `json:"updated_at" gorm:"bigint"`
+	DeletedAt             gorm.DeletedAt `gorm:"index"`
+}
+
+func (organization *Organization) BeforeCreate(tx *gorm.DB) error {
+	now := common.GetTimestamp()
+	organization.CreatedAt = now
+	organization.UpdatedAt = now
+	return nil
+}
+
+func (organization *Organization) BeforeUpdate(tx *gorm.DB) error {
+	organization.UpdatedAt = common.GetTimestamp()
+	return nil
+}

--- a/model/ownership.go
+++ b/model/ownership.go
@@ -1,0 +1,117 @@
+package model
+
+import (
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/gin-gonic/gin"
+)
+
+type OwnershipSnapshot struct {
+	TenantId              int
+	OrganizationId        int
+	DepartmentId          int
+	DistributionChannelId int
+}
+
+func NormalizeOwnership(snapshot OwnershipSnapshot) OwnershipSnapshot {
+	if snapshot.TenantId == 0 {
+		snapshot.TenantId = 1
+	}
+	return snapshot
+}
+
+func OwnershipFromContext(c *gin.Context) OwnershipSnapshot {
+	if c == nil {
+		return NormalizeOwnership(OwnershipSnapshot{})
+	}
+	return NormalizeOwnership(OwnershipSnapshot{
+		TenantId:              common.GetContextKeyInt(c, constant.ContextKeyTenantId),
+		OrganizationId:        common.GetContextKeyInt(c, constant.ContextKeyOrganizationId),
+		DepartmentId:          common.GetContextKeyInt(c, constant.ContextKeyDepartmentId),
+		DistributionChannelId: common.GetContextKeyInt(c, constant.ContextKeyDistributionChannelId),
+	})
+}
+
+func OwnershipByUserId(userId int) OwnershipSnapshot {
+	if userId <= 0 {
+		return NormalizeOwnership(OwnershipSnapshot{})
+	}
+	userCache, err := GetUserCache(userId)
+	if err != nil || userCache == nil {
+		return NormalizeOwnership(OwnershipSnapshot{})
+	}
+	return NormalizeOwnership(OwnershipSnapshot{
+		TenantId:              userCache.TenantId,
+		OrganizationId:        userCache.OrganizationId,
+		DepartmentId:          userCache.DepartmentId,
+		DistributionChannelId: userCache.DistributionChannelId,
+	})
+}
+
+func ownershipFromSubscriptionOrder(order *SubscriptionOrder) OwnershipSnapshot {
+	if order == nil {
+		return NormalizeOwnership(OwnershipSnapshot{})
+	}
+	return NormalizeOwnership(OwnershipSnapshot{
+		TenantId:              order.TenantId,
+		OrganizationId:        order.OrganizationId,
+		DepartmentId:          order.DepartmentId,
+		DistributionChannelId: order.DistributionChannelId,
+	})
+}
+
+func ownershipFromUserSubscription(subscription *UserSubscription) OwnershipSnapshot {
+	if subscription == nil {
+		return NormalizeOwnership(OwnershipSnapshot{})
+	}
+	return NormalizeOwnership(OwnershipSnapshot{
+		TenantId:              subscription.TenantId,
+		OrganizationId:        subscription.OrganizationId,
+		DepartmentId:          subscription.DepartmentId,
+		DistributionChannelId: subscription.DistributionChannelId,
+	})
+}
+
+func ApplyOwnershipFromContext(c *gin.Context, target any) {
+	OwnershipFromContext(c).ApplyTo(target)
+}
+
+func ApplyOwnershipFromUser(userId int, target any) {
+	OwnershipByUserId(userId).ApplyTo(target)
+}
+
+func (snapshot OwnershipSnapshot) ApplyTo(target any) {
+	snapshot = NormalizeOwnership(snapshot)
+	switch v := target.(type) {
+	case *Log:
+		v.TenantId = snapshot.TenantId
+		v.OrganizationId = snapshot.OrganizationId
+		v.DepartmentId = snapshot.DepartmentId
+		v.DistributionChannelId = snapshot.DistributionChannelId
+	case *TopUp:
+		v.TenantId = snapshot.TenantId
+		v.OrganizationId = snapshot.OrganizationId
+		v.DepartmentId = snapshot.DepartmentId
+		v.DistributionChannelId = snapshot.DistributionChannelId
+	case *Redemption:
+		v.TenantId = snapshot.TenantId
+		v.OrganizationId = snapshot.OrganizationId
+		v.DepartmentId = snapshot.DepartmentId
+		v.DistributionChannelId = snapshot.DistributionChannelId
+	case *SubscriptionOrder:
+		v.TenantId = snapshot.TenantId
+		v.OrganizationId = snapshot.OrganizationId
+		v.DepartmentId = snapshot.DepartmentId
+		v.DistributionChannelId = snapshot.DistributionChannelId
+	case *UserSubscription:
+		v.TenantId = snapshot.TenantId
+		v.OrganizationId = snapshot.OrganizationId
+		v.DepartmentId = snapshot.DepartmentId
+		v.DistributionChannelId = snapshot.DistributionChannelId
+	case *SubscriptionPreConsumeRecord:
+		v.TenantId = snapshot.TenantId
+		v.OrganizationId = snapshot.OrganizationId
+		v.DepartmentId = snapshot.DepartmentId
+		v.DistributionChannelId = snapshot.DistributionChannelId
+	}
+}

--- a/model/ownership.go
+++ b/model/ownership.go
@@ -113,5 +113,10 @@ func (snapshot OwnershipSnapshot) ApplyTo(target any) {
 		v.OrganizationId = snapshot.OrganizationId
 		v.DepartmentId = snapshot.DepartmentId
 		v.DistributionChannelId = snapshot.DistributionChannelId
+	case *Midjourney:
+		v.TenantId = snapshot.TenantId
+		v.OrganizationId = snapshot.OrganizationId
+		v.DepartmentId = snapshot.DepartmentId
+		v.DistributionChannelId = snapshot.DistributionChannelId
 	}
 }

--- a/model/redemption.go
+++ b/model/redemption.go
@@ -161,6 +161,9 @@ func Redeem(key string, userId int) (quota int, err error) {
 
 func (redemption *Redemption) Insert() error {
 	var err error
+	if redemption.TenantId == 0 {
+		ApplyOwnershipFromUser(redemption.UserId, redemption)
+	}
 	err = DB.Create(redemption).Error
 	return err
 }

--- a/model/redemption.go
+++ b/model/redemption.go
@@ -30,7 +30,7 @@ type Redemption struct {
 	ExpiredTime           int64          `json:"expired_time" gorm:"bigint"` // 过期时间，0 表示不过期
 }
 
-func GetAllRedemptions(startIdx int, num int) (redemptions []*Redemption, total int64, err error) {
+func GetAllRedemptions(startIdx int, num int, scopes ...TenantScope) (redemptions []*Redemption, total int64, err error) {
 	// 开始事务
 	tx := DB.Begin()
 	if tx.Error != nil {
@@ -42,15 +42,20 @@ func GetAllRedemptions(startIdx int, num int) (redemptions []*Redemption, total 
 		}
 	}()
 
+	query := tx.Model(&Redemption{})
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "redemptions")
+	}
+
 	// 获取总数
-	err = tx.Model(&Redemption{}).Count(&total).Error
+	err = query.Count(&total).Error
 	if err != nil {
 		tx.Rollback()
 		return nil, 0, err
 	}
 
 	// 获取分页数据
-	err = tx.Order("id desc").Limit(num).Offset(startIdx).Find(&redemptions).Error
+	err = query.Order("id desc").Limit(num).Offset(startIdx).Find(&redemptions).Error
 	if err != nil {
 		tx.Rollback()
 		return nil, 0, err
@@ -64,7 +69,7 @@ func GetAllRedemptions(startIdx int, num int) (redemptions []*Redemption, total 
 	return redemptions, total, nil
 }
 
-func SearchRedemptions(keyword string, startIdx int, num int) (redemptions []*Redemption, total int64, err error) {
+func SearchRedemptions(keyword string, startIdx int, num int, scopes ...TenantScope) (redemptions []*Redemption, total int64, err error) {
 	tx := DB.Begin()
 	if tx.Error != nil {
 		return nil, 0, tx.Error
@@ -77,6 +82,9 @@ func SearchRedemptions(keyword string, startIdx int, num int) (redemptions []*Re
 
 	// Build query based on keyword type
 	query := tx.Model(&Redemption{})
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "redemptions")
+	}
 
 	// Only try to convert to ID if the string represents a valid integer
 	if id, err := strconv.Atoi(keyword); err == nil {

--- a/model/redemption.go
+++ b/model/redemption.go
@@ -206,8 +206,12 @@ func DeleteRedemptionById(id int) (err error) {
 	return redemption.Delete()
 }
 
-func DeleteInvalidRedemptions() (int64, error) {
+func DeleteInvalidRedemptions(scopes ...TenantScope) (int64, error) {
 	now := common.GetTimestamp()
-	result := DB.Where("status IN ? OR (status = ? AND expired_time != 0 AND expired_time < ?)", []int{common.RedemptionCodeStatusUsed, common.RedemptionCodeStatusDisabled}, common.RedemptionCodeStatusEnabled, now).Delete(&Redemption{})
+	query := DB.Where("status IN ? OR (status = ? AND expired_time != 0 AND expired_time < ?)", []int{common.RedemptionCodeStatusUsed, common.RedemptionCodeStatusDisabled}, common.RedemptionCodeStatusEnabled, now)
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "redemptions")
+	}
+	result := query.Delete(&Redemption{})
 	return result.RowsAffected, result.Error
 }

--- a/model/redemption.go
+++ b/model/redemption.go
@@ -12,18 +12,22 @@ import (
 )
 
 type Redemption struct {
-	Id           int            `json:"id"`
-	UserId       int            `json:"user_id"`
-	Key          string         `json:"key" gorm:"type:char(32);uniqueIndex"`
-	Status       int            `json:"status" gorm:"default:1"`
-	Name         string         `json:"name" gorm:"index"`
-	Quota        int            `json:"quota" gorm:"default:100"`
-	CreatedTime  int64          `json:"created_time" gorm:"bigint"`
-	RedeemedTime int64          `json:"redeemed_time" gorm:"bigint"`
-	Count        int            `json:"count" gorm:"-:all"` // only for api request
-	UsedUserId   int            `json:"used_user_id"`
-	DeletedAt    gorm.DeletedAt `gorm:"index"`
-	ExpiredTime  int64          `json:"expired_time" gorm:"bigint"` // 过期时间，0 表示不过期
+	Id                    int            `json:"id"`
+	TenantId              int            `json:"tenant_id" gorm:"index;default:1"`
+	OrganizationId        int            `json:"organization_id" gorm:"index;default:0"`
+	DepartmentId          int            `json:"department_id" gorm:"index;default:0"`
+	DistributionChannelId int            `json:"distribution_channel_id" gorm:"index;default:0"`
+	UserId                int            `json:"user_id"`
+	Key                   string         `json:"key" gorm:"type:char(32);uniqueIndex"`
+	Status                int            `json:"status" gorm:"default:1"`
+	Name                  string         `json:"name" gorm:"index"`
+	Quota                 int            `json:"quota" gorm:"default:100"`
+	CreatedTime           int64          `json:"created_time" gorm:"bigint"`
+	RedeemedTime          int64          `json:"redeemed_time" gorm:"bigint"`
+	Count                 int            `json:"count" gorm:"-:all"` // only for api request
+	UsedUserId            int            `json:"used_user_id"`
+	DeletedAt             gorm.DeletedAt `gorm:"index"`
+	ExpiredTime           int64          `json:"expired_time" gorm:"bigint"` // 过期时间，0 表示不过期
 }
 
 func GetAllRedemptions(startIdx int, num int) (redemptions []*Redemption, total int64, err error) {

--- a/model/subscription.go
+++ b/model/subscription.go
@@ -216,6 +216,9 @@ func (o *SubscriptionOrder) Insert() error {
 	if o.CreateTime == 0 {
 		o.CreateTime = common.GetTimestamp()
 	}
+	if o.TenantId == 0 {
+		ApplyOwnershipFromUser(o.UserId, o)
+	}
 	return DB.Create(o).Error
 }
 
@@ -444,6 +447,10 @@ func downgradeUserGroupForSubscriptionTx(tx *gorm.DB, sub *UserSubscription, now
 }
 
 func CreateUserSubscriptionFromPlanTx(tx *gorm.DB, userId int, plan *SubscriptionPlan, source string) (*UserSubscription, error) {
+	return createUserSubscriptionFromPlanTx(tx, userId, plan, source, OwnershipByUserId(userId))
+}
+
+func createUserSubscriptionFromPlanTx(tx *gorm.DB, userId int, plan *SubscriptionPlan, source string, ownership OwnershipSnapshot) (*UserSubscription, error) {
 	if tx == nil {
 		return nil, errors.New("tx is nil")
 	}
@@ -507,6 +514,7 @@ func CreateUserSubscriptionFromPlanTx(tx *gorm.DB, userId int, plan *Subscriptio
 		CreatedAt:     common.GetTimestamp(),
 		UpdatedAt:     common.GetTimestamp(),
 	}
+	ownership.ApplyTo(sub)
 	if err := tx.Create(sub).Error; err != nil {
 		return nil, err
 	}
@@ -551,7 +559,7 @@ func CompleteSubscriptionOrder(tradeNo string, providerPayload string, expectedP
 			// still allow completion for already purchased orders
 		}
 		upgradeGroup = strings.TrimSpace(plan.UpgradeGroup)
-		_, err = CreateUserSubscriptionFromPlanTx(tx, order.UserId, plan, "order")
+		_, err = createUserSubscriptionFromPlanTx(tx, order.UserId, plan, "order", ownershipFromSubscriptionOrder(&order))
 		if err != nil {
 			return err
 		}
@@ -597,20 +605,25 @@ func upsertSubscriptionTopUpTx(tx *gorm.DB, order *SubscriptionOrder) error {
 	if err := tx.Where("trade_no = ?", order.TradeNo).First(&topup).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			topup = TopUp{
-				UserId:        order.UserId,
-				Amount:        0,
-				Money:         order.Money,
-				TradeNo:       order.TradeNo,
-				PaymentMethod: order.PaymentMethod,
-				CreateTime:    order.CreateTime,
-				CompleteTime:  now,
-				Status:        common.TopUpStatusSuccess,
+				UserId:                order.UserId,
+				TenantId:              order.TenantId,
+				OrganizationId:        order.OrganizationId,
+				DepartmentId:          order.DepartmentId,
+				DistributionChannelId: order.DistributionChannelId,
+				Amount:                0,
+				Money:                 order.Money,
+				TradeNo:               order.TradeNo,
+				PaymentMethod:         order.PaymentMethod,
+				CreateTime:            order.CreateTime,
+				CompleteTime:          now,
+				Status:                common.TopUpStatusSuccess,
 			}
 			return tx.Create(&topup).Error
 		}
 		return err
 	}
 	topup.Money = order.Money
+	ownershipFromSubscriptionOrder(order).ApplyTo(&topup)
 	if topup.PaymentMethod == "" {
 		topup.PaymentMethod = order.PaymentMethod
 	} else if topup.PaymentMethod != order.PaymentMethod {
@@ -1048,6 +1061,7 @@ func PreConsumeUserSubscription(requestId string, userId int, modelName string, 
 				PreConsumed:        amount,
 				Status:             "consumed",
 			}
+			ownershipFromUserSubscription(&sub).ApplyTo(record)
 			if err := tx.Create(record).Error; err != nil {
 				var dup SubscriptionPreConsumeRecord
 				if err2 := tx.Where("request_id = ?", requestId).First(&dup).Error; err2 == nil {

--- a/model/subscription.go
+++ b/model/subscription.go
@@ -193,10 +193,14 @@ func (p *SubscriptionPlan) BeforeUpdate(tx *gorm.DB) error {
 
 // Subscription order (payment -> webhook -> create UserSubscription)
 type SubscriptionOrder struct {
-	Id     int     `json:"id"`
-	UserId int     `json:"user_id" gorm:"index"`
-	PlanId int     `json:"plan_id" gorm:"index"`
-	Money  float64 `json:"money"`
+	Id                    int     `json:"id"`
+	TenantId              int     `json:"tenant_id" gorm:"index;default:1"`
+	OrganizationId        int     `json:"organization_id" gorm:"index;default:0"`
+	DepartmentId          int     `json:"department_id" gorm:"index;default:0"`
+	DistributionChannelId int     `json:"distribution_channel_id" gorm:"index;default:0"`
+	UserId                int     `json:"user_id" gorm:"index"`
+	PlanId                int     `json:"plan_id" gorm:"index"`
+	Money                 float64 `json:"money"`
 
 	TradeNo         string `json:"trade_no" gorm:"unique;type:varchar(255);index"`
 	PaymentMethod   string `json:"payment_method" gorm:"type:varchar(50)"`
@@ -232,9 +236,13 @@ func GetSubscriptionOrderByTradeNo(tradeNo string) *SubscriptionOrder {
 
 // User subscription instance
 type UserSubscription struct {
-	Id     int `json:"id"`
-	UserId int `json:"user_id" gorm:"index;index:idx_user_sub_active,priority:1"`
-	PlanId int `json:"plan_id" gorm:"index"`
+	Id                    int `json:"id"`
+	TenantId              int `json:"tenant_id" gorm:"index;default:1"`
+	OrganizationId        int `json:"organization_id" gorm:"index;default:0"`
+	DepartmentId          int `json:"department_id" gorm:"index;default:0"`
+	DistributionChannelId int `json:"distribution_channel_id" gorm:"index;default:0"`
+	UserId                int `json:"user_id" gorm:"index;index:idx_user_sub_active,priority:1"`
+	PlanId                int `json:"plan_id" gorm:"index"`
 
 	AmountTotal int64 `json:"amount_total" gorm:"type:bigint;not null;default:0"`
 	AmountUsed  int64 `json:"amount_used" gorm:"type:bigint;not null;default:0"`
@@ -908,14 +916,18 @@ func ExpireDueSubscriptions(limit int) (int, error) {
 
 // SubscriptionPreConsumeRecord stores idempotent pre-consume operations per request.
 type SubscriptionPreConsumeRecord struct {
-	Id                 int    `json:"id"`
-	RequestId          string `json:"request_id" gorm:"type:varchar(64);uniqueIndex"`
-	UserId             int    `json:"user_id" gorm:"index"`
-	UserSubscriptionId int    `json:"user_subscription_id" gorm:"index"`
-	PreConsumed        int64  `json:"pre_consumed" gorm:"type:bigint;not null;default:0"`
-	Status             string `json:"status" gorm:"type:varchar(32);index"` // consumed/refunded
-	CreatedAt          int64  `json:"created_at" gorm:"bigint"`
-	UpdatedAt          int64  `json:"updated_at" gorm:"bigint;index"`
+	Id                    int    `json:"id"`
+	TenantId              int    `json:"tenant_id" gorm:"index;default:1"`
+	OrganizationId        int    `json:"organization_id" gorm:"index;default:0"`
+	DepartmentId          int    `json:"department_id" gorm:"index;default:0"`
+	DistributionChannelId int    `json:"distribution_channel_id" gorm:"index;default:0"`
+	RequestId             string `json:"request_id" gorm:"type:varchar(64);uniqueIndex"`
+	UserId                int    `json:"user_id" gorm:"index"`
+	UserSubscriptionId    int    `json:"user_subscription_id" gorm:"index"`
+	PreConsumed           int64  `json:"pre_consumed" gorm:"type:bigint;not null;default:0"`
+	Status                string `json:"status" gorm:"type:varchar(32);index"` // consumed/refunded
+	CreatedAt             int64  `json:"created_at" gorm:"bigint"`
+	UpdatedAt             int64  `json:"updated_at" gorm:"bigint;index"`
 }
 
 func (r *SubscriptionPreConsumeRecord) BeforeCreate(tx *gorm.DB) error {

--- a/model/subscription.go
+++ b/model/subscription.go
@@ -718,12 +718,16 @@ func HasActiveUserSubscription(userId int) (bool, error) {
 }
 
 // GetAllUserSubscriptions returns all subscriptions (active and expired) for a user.
-func GetAllUserSubscriptions(userId int) ([]SubscriptionSummary, error) {
+func GetAllUserSubscriptions(userId int, scopes ...TenantScope) ([]SubscriptionSummary, error) {
 	if userId <= 0 {
 		return nil, errors.New("invalid userId")
 	}
 	var subs []UserSubscription
-	err := DB.Where("user_id = ?", userId).
+	query := DB.Where("user_id = ?", userId)
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "user_subscriptions")
+	}
+	err := query.
 		Order("end_time desc, id desc").
 		Find(&subs).Error
 	if err != nil {

--- a/model/task.go
+++ b/model/task.go
@@ -248,12 +248,15 @@ func TaskGetAllUserTask(userId int, startIdx int, num int, queryParams SyncTaskQ
 	return tasks
 }
 
-func TaskGetAllTasks(startIdx int, num int, queryParams SyncTaskQueryParams) []*Task {
+func TaskGetAllTasks(startIdx int, num int, queryParams SyncTaskQueryParams, scopes ...TenantScope) []*Task {
 	var tasks []*Task
 	var err error
 
 	// 初始化查询构建器
-	query := DB
+	query := DB.Model(&Task{})
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "tasks")
+	}
 
 	// 添加过滤条件
 	if queryParams.ChannelID != "" {
@@ -451,9 +454,12 @@ type TaskQuotaUsage struct {
 }
 
 // TaskCountAllTasks returns total tasks that match the given query params (admin usage)
-func TaskCountAllTasks(queryParams SyncTaskQueryParams) int64 {
+func TaskCountAllTasks(queryParams SyncTaskQueryParams, scopes ...TenantScope) int64 {
 	var total int64
 	query := DB.Model(&Task{})
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "tasks")
+	}
 	if queryParams.ChannelID != "" {
 		query = query.Where("channel_id = ?", queryParams.ChannelID)
 	}

--- a/model/task.go
+++ b/model/task.go
@@ -42,24 +42,28 @@ const (
 )
 
 type Task struct {
-	ID         int64                 `json:"id" gorm:"primary_key;AUTO_INCREMENT"`
-	CreatedAt  int64                 `json:"created_at" gorm:"index"`
-	UpdatedAt  int64                 `json:"updated_at"`
-	TaskID     string                `json:"task_id" gorm:"type:varchar(191);index"` // 第三方id，不一定有/ song id\ Task id
-	Platform   constant.TaskPlatform `json:"platform" gorm:"type:varchar(30);index"` // 平台
-	UserId     int                   `json:"user_id" gorm:"index"`
-	Group      string                `json:"group" gorm:"type:varchar(50)"` // 修正计费用
-	ChannelId  int                   `json:"channel_id" gorm:"index"`
-	Quota      int                   `json:"quota"`
-	Action     string                `json:"action" gorm:"type:varchar(40);index"` // 任务类型, song, lyrics, description-mode
-	Status     TaskStatus            `json:"status" gorm:"type:varchar(20);index"` // 任务状态
-	FailReason string                `json:"fail_reason"`
-	SubmitTime int64                 `json:"submit_time" gorm:"index"`
-	StartTime  int64                 `json:"start_time" gorm:"index"`
-	FinishTime int64                 `json:"finish_time" gorm:"index"`
-	Progress   string                `json:"progress" gorm:"type:varchar(20);index"`
-	Properties Properties            `json:"properties" gorm:"type:json"`
-	Username   string                `json:"username,omitempty" gorm:"-"`
+	ID                    int64                 `json:"id" gorm:"primary_key;AUTO_INCREMENT"`
+	TenantId              int                   `json:"tenant_id" gorm:"index;default:1"`
+	OrganizationId        int                   `json:"organization_id" gorm:"index;default:0"`
+	DepartmentId          int                   `json:"department_id" gorm:"index;default:0"`
+	DistributionChannelId int                   `json:"distribution_channel_id" gorm:"index;default:0"`
+	CreatedAt             int64                 `json:"created_at" gorm:"index"`
+	UpdatedAt             int64                 `json:"updated_at"`
+	TaskID                string                `json:"task_id" gorm:"type:varchar(191);index"` // 第三方id，不一定有/ song id\ Task id
+	Platform              constant.TaskPlatform `json:"platform" gorm:"type:varchar(30);index"` // 平台
+	UserId                int                   `json:"user_id" gorm:"index"`
+	Group                 string                `json:"group" gorm:"type:varchar(50)"` // 修正计费用
+	ChannelId             int                   `json:"channel_id" gorm:"index"`
+	Quota                 int                   `json:"quota"`
+	Action                string                `json:"action" gorm:"type:varchar(40);index"` // 任务类型, song, lyrics, description-mode
+	Status                TaskStatus            `json:"status" gorm:"type:varchar(20);index"` // 任务状态
+	FailReason            string                `json:"fail_reason"`
+	SubmitTime            int64                 `json:"submit_time" gorm:"index"`
+	StartTime             int64                 `json:"start_time" gorm:"index"`
+	FinishTime            int64                 `json:"finish_time" gorm:"index"`
+	Progress              string                `json:"progress" gorm:"type:varchar(20);index"`
+	Properties            Properties            `json:"properties" gorm:"type:json"`
+	Username              string                `json:"username,omitempty" gorm:"-"`
 	// 禁止返回给用户，内部可能包含key等隐私信息
 	PrivateData TaskPrivateData `json:"-" gorm:"column:private_data;type:json"`
 	Data        json.RawMessage `json:"data" gorm:"type:json"`

--- a/model/tenant.go
+++ b/model/tenant.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/QuantumNous/new-api/common"
+	"gorm.io/gorm"
+)
+
+type Tenant struct {
+	Id        int            `json:"id"`
+	Name      string         `json:"name" gorm:"type:varchar(128);not null;uniqueIndex"`
+	Status    int            `json:"status" gorm:"type:int;default:1;index"`
+	Remark    string         `json:"remark,omitempty" gorm:"type:varchar(255)"`
+	CreatedAt int64          `json:"created_at" gorm:"bigint"`
+	UpdatedAt int64          `json:"updated_at" gorm:"bigint"`
+	DeletedAt gorm.DeletedAt `gorm:"index"`
+}
+
+func (tenant *Tenant) BeforeCreate(tx *gorm.DB) error {
+	now := common.GetTimestamp()
+	tenant.CreatedAt = now
+	tenant.UpdatedAt = now
+	return nil
+}
+
+func (tenant *Tenant) BeforeUpdate(tx *gorm.DB) error {
+	tenant.UpdatedAt = common.GetTimestamp()
+	return nil
+}

--- a/model/tenant_scope.go
+++ b/model/tenant_scope.go
@@ -14,24 +14,34 @@ type TenantScope struct {
 	IsRoot   bool
 }
 
+func normalizeTenantId(tenantId int) int {
+	if tenantId == 0 {
+		return 1
+	}
+	return tenantId
+}
+
 func TenantScopeFromContext(c *gin.Context) TenantScope {
 	scope := TenantScope{
 		TenantId: common.GetContextKeyInt(c, constant.ContextKeyTenantId),
 		IsRoot:   c.GetInt("role") == common.RoleRootUser,
 	}
-	if scope.TenantId == 0 {
-		scope.TenantId = 1
-	}
+	scope.TenantId = normalizeTenantId(scope.TenantId)
 	return scope
+}
+
+func (scope TenantScope) AllowsTenant(tenantId int) bool {
+	if scope.IsRoot {
+		return true
+	}
+	return normalizeTenantId(scope.TenantId) == normalizeTenantId(tenantId)
 }
 
 func (scope TenantScope) Apply(db *gorm.DB, tableAliasOrName string) *gorm.DB {
 	if scope.IsRoot {
 		return db
 	}
-	if scope.TenantId == 0 {
-		scope.TenantId = 1
-	}
+	scope.TenantId = normalizeTenantId(scope.TenantId)
 	column := "tenant_id"
 	if tableAliasOrName != "" {
 		column = fmt.Sprintf("%s.tenant_id", tableAliasOrName)

--- a/model/tenant_scope.go
+++ b/model/tenant_scope.go
@@ -1,0 +1,40 @@
+package model
+
+import (
+	"fmt"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type TenantScope struct {
+	TenantId int
+	IsRoot   bool
+}
+
+func TenantScopeFromContext(c *gin.Context) TenantScope {
+	scope := TenantScope{
+		TenantId: common.GetContextKeyInt(c, constant.ContextKeyTenantId),
+		IsRoot:   c.GetInt("role") == common.RoleRootUser,
+	}
+	if scope.TenantId == 0 {
+		scope.TenantId = 1
+	}
+	return scope
+}
+
+func (scope TenantScope) Apply(db *gorm.DB, tableAliasOrName string) *gorm.DB {
+	if scope.IsRoot {
+		return db
+	}
+	if scope.TenantId == 0 {
+		scope.TenantId = 1
+	}
+	column := "tenant_id"
+	if tableAliasOrName != "" {
+		column = fmt.Sprintf("%s.tenant_id", tableAliasOrName)
+	}
+	return db.Where(column+" = ?", scope.TenantId)
+}

--- a/model/token.go
+++ b/model/token.go
@@ -12,23 +12,27 @@ import (
 )
 
 type Token struct {
-	Id                 int            `json:"id"`
-	UserId             int            `json:"user_id" gorm:"index"`
-	Key                string         `json:"key" gorm:"type:varchar(128);uniqueIndex"`
-	Status             int            `json:"status" gorm:"default:1"`
-	Name               string         `json:"name" gorm:"index" `
-	CreatedTime        int64          `json:"created_time" gorm:"bigint"`
-	AccessedTime       int64          `json:"accessed_time" gorm:"bigint"`
-	ExpiredTime        int64          `json:"expired_time" gorm:"bigint;default:-1"` // -1 means never expired
-	RemainQuota        int            `json:"remain_quota" gorm:"default:0"`
-	UnlimitedQuota     bool           `json:"unlimited_quota"`
-	ModelLimitsEnabled bool           `json:"model_limits_enabled"`
-	ModelLimits        string         `json:"model_limits" gorm:"type:text"`
-	AllowIps           *string        `json:"allow_ips" gorm:"default:''"`
-	UsedQuota          int            `json:"used_quota" gorm:"default:0"` // used quota
-	Group              string         `json:"group" gorm:"default:''"`
-	CrossGroupRetry    bool           `json:"cross_group_retry"` // 跨分组重试，仅auto分组有效
-	DeletedAt          gorm.DeletedAt `gorm:"index"`
+	Id                    int            `json:"id"`
+	TenantId              int            `json:"tenant_id" gorm:"index;default:1"`
+	OrganizationId        int            `json:"organization_id" gorm:"index;default:0"`
+	DepartmentId          int            `json:"department_id" gorm:"index;default:0"`
+	DistributionChannelId int            `json:"distribution_channel_id" gorm:"index;default:0"`
+	UserId                int            `json:"user_id" gorm:"index"`
+	Key                   string         `json:"key" gorm:"type:varchar(128);uniqueIndex"`
+	Status                int            `json:"status" gorm:"default:1"`
+	Name                  string         `json:"name" gorm:"index" `
+	CreatedTime           int64          `json:"created_time" gorm:"bigint"`
+	AccessedTime          int64          `json:"accessed_time" gorm:"bigint"`
+	ExpiredTime           int64          `json:"expired_time" gorm:"bigint;default:-1"` // -1 means never expired
+	RemainQuota           int            `json:"remain_quota" gorm:"default:0"`
+	UnlimitedQuota        bool           `json:"unlimited_quota"`
+	ModelLimitsEnabled    bool           `json:"model_limits_enabled"`
+	ModelLimits           string         `json:"model_limits" gorm:"type:text"`
+	AllowIps              *string        `json:"allow_ips" gorm:"default:''"`
+	UsedQuota             int            `json:"used_quota" gorm:"default:0"` // used quota
+	Group                 string         `json:"group" gorm:"default:''"`
+	CrossGroupRetry       bool           `json:"cross_group_retry"` // 跨分组重试，仅auto分组有效
+	DeletedAt             gorm.DeletedAt `gorm:"index"`
 }
 
 func (token *Token) Clean() {

--- a/model/topup.go
+++ b/model/topup.go
@@ -12,16 +12,20 @@ import (
 )
 
 type TopUp struct {
-	Id              int     `json:"id"`
-	UserId          int     `json:"user_id" gorm:"index"`
-	Amount          int64   `json:"amount"`
-	Money           float64 `json:"money"`
-	TradeNo         string  `json:"trade_no" gorm:"unique;type:varchar(255);index"`
-	PaymentMethod   string  `json:"payment_method" gorm:"type:varchar(50)"`
-	PaymentProvider string  `json:"payment_provider" gorm:"type:varchar(50);default:''"`
-	CreateTime      int64   `json:"create_time"`
-	CompleteTime    int64   `json:"complete_time"`
-	Status          string  `json:"status"`
+	Id                    int     `json:"id"`
+	TenantId              int     `json:"tenant_id" gorm:"index;default:1"`
+	OrganizationId        int     `json:"organization_id" gorm:"index;default:0"`
+	DepartmentId          int     `json:"department_id" gorm:"index;default:0"`
+	DistributionChannelId int     `json:"distribution_channel_id" gorm:"index;default:0"`
+	UserId                int     `json:"user_id" gorm:"index"`
+	Amount                int64   `json:"amount"`
+	Money                 float64 `json:"money"`
+	TradeNo               string  `json:"trade_no" gorm:"unique;type:varchar(255);index"`
+	PaymentMethod         string  `json:"payment_method" gorm:"type:varchar(50)"`
+	PaymentProvider       string  `json:"payment_provider" gorm:"type:varchar(50);default:''"`
+	CreateTime            int64   `json:"create_time"`
+	CompleteTime          int64   `json:"complete_time"`
+	Status                string  `json:"status"`
 }
 
 const (

--- a/model/topup.go
+++ b/model/topup.go
@@ -209,7 +209,7 @@ func GetUserTopUps(userId int, pageInfo *common.PageInfo) (topups []*TopUp, tota
 }
 
 // GetAllTopUps 获取全平台的充值记录（管理员使用，不限制时间窗口）
-func GetAllTopUps(pageInfo *common.PageInfo) (topups []*TopUp, total int64, err error) {
+func GetAllTopUps(pageInfo *common.PageInfo, scopes ...TenantScope) (topups []*TopUp, total int64, err error) {
 	tx := DB.Begin()
 	if tx.Error != nil {
 		return nil, 0, tx.Error
@@ -220,12 +220,17 @@ func GetAllTopUps(pageInfo *common.PageInfo) (topups []*TopUp, total int64, err 
 		}
 	}()
 
-	if err = tx.Model(&TopUp{}).Count(&total).Error; err != nil {
+	query := tx.Model(&TopUp{})
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "top_ups")
+	}
+
+	if err = query.Count(&total).Error; err != nil {
 		tx.Rollback()
 		return nil, 0, err
 	}
 
-	if err = tx.Order("id desc").Limit(pageInfo.GetPageSize()).Offset(pageInfo.GetStartIdx()).Find(&topups).Error; err != nil {
+	if err = query.Order("id desc").Limit(pageInfo.GetPageSize()).Offset(pageInfo.GetStartIdx()).Find(&topups).Error; err != nil {
 		tx.Rollback()
 		return nil, 0, err
 	}
@@ -282,7 +287,7 @@ func SearchUserTopUps(userId int, keyword string, pageInfo *common.PageInfo) (to
 }
 
 // SearchAllTopUps 按订单号搜索全平台充值记录（管理员使用，不限制时间窗口）
-func SearchAllTopUps(keyword string, pageInfo *common.PageInfo) (topups []*TopUp, total int64, err error) {
+func SearchAllTopUps(keyword string, pageInfo *common.PageInfo, scopes ...TenantScope) (topups []*TopUp, total int64, err error) {
 	tx := DB.Begin()
 	if tx.Error != nil {
 		return nil, 0, tx.Error
@@ -294,6 +299,9 @@ func SearchAllTopUps(keyword string, pageInfo *common.PageInfo) (topups []*TopUp
 	}()
 
 	query := tx.Model(&TopUp{})
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "top_ups")
+	}
 	if keyword != "" {
 		pattern, perr := sanitizeLikePattern(keyword)
 		if perr != nil {

--- a/model/topup.go
+++ b/model/topup.go
@@ -51,6 +51,9 @@ var (
 
 func (topUp *TopUp) Insert() error {
 	var err error
+	if topUp.TenantId == 0 {
+		ApplyOwnershipFromUser(topUp.UserId, topUp)
+	}
 	err = DB.Create(topUp).Error
 	return err
 }

--- a/model/user.go
+++ b/model/user.go
@@ -60,13 +60,17 @@ type User struct {
 
 func (user *User) ToBaseUser() *UserBase {
 	cache := &UserBase{
-		Id:       user.Id,
-		Group:    user.Group,
-		Quota:    user.Quota,
-		Status:   user.Status,
-		Username: user.Username,
-		Setting:  user.Setting,
-		Email:    user.Email,
+		Id:                    user.Id,
+		TenantId:              user.TenantId,
+		OrganizationId:        user.OrganizationId,
+		DepartmentId:          user.DepartmentId,
+		DistributionChannelId: user.DistributionChannelId,
+		Group:                 user.Group,
+		Quota:                 user.Quota,
+		Status:                user.Status,
+		Username:              user.Username,
+		Setting:               user.Setting,
+		Email:                 user.Email,
 	}
 	return cache
 }

--- a/model/user.go
+++ b/model/user.go
@@ -198,7 +198,7 @@ func GetMaxUserId() int {
 	return user.Id
 }
 
-func GetAllUsers(pageInfo *common.PageInfo) (users []*User, total int64, err error) {
+func GetAllUsers(pageInfo *common.PageInfo, scopes ...TenantScope) (users []*User, total int64, err error) {
 	// Start transaction
 	tx := DB.Begin()
 	if tx.Error != nil {
@@ -210,15 +210,20 @@ func GetAllUsers(pageInfo *common.PageInfo) (users []*User, total int64, err err
 		}
 	}()
 
+	query := tx.Unscoped().Model(&User{})
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "users")
+	}
+
 	// Get total count within transaction
-	err = tx.Unscoped().Model(&User{}).Count(&total).Error
+	err = query.Count(&total).Error
 	if err != nil {
 		tx.Rollback()
 		return nil, 0, err
 	}
 
 	// Get paginated users within same transaction
-	err = tx.Unscoped().Order("id desc").Limit(pageInfo.GetPageSize()).Offset(pageInfo.GetStartIdx()).Omit("password").Find(&users).Error
+	err = query.Order("id desc").Limit(pageInfo.GetPageSize()).Offset(pageInfo.GetStartIdx()).Omit("password").Find(&users).Error
 	if err != nil {
 		tx.Rollback()
 		return nil, 0, err
@@ -232,7 +237,7 @@ func GetAllUsers(pageInfo *common.PageInfo) (users []*User, total int64, err err
 	return users, total, nil
 }
 
-func SearchUsers(keyword string, group string, startIdx int, num int) ([]*User, int64, error) {
+func SearchUsers(keyword string, group string, startIdx int, num int, scopes ...TenantScope) ([]*User, int64, error) {
 	var users []*User
 	var total int64
 	var err error
@@ -250,6 +255,9 @@ func SearchUsers(keyword string, group string, startIdx int, num int) ([]*User, 
 
 	// 构建基础查询
 	query := tx.Unscoped().Model(&User{})
+	if len(scopes) > 0 {
+		query = scopes[0].Apply(query, "users")
+	}
 
 	// 构建搜索条件
 	likeCondition := "username LIKE ? OR email LIKE ? OR display_name LIKE ?"

--- a/model/user.go
+++ b/model/user.go
@@ -21,37 +21,41 @@ const UserNameMaxLength = 20
 // User if you add sensitive fields, don't forget to clean them in setupLogin function.
 // Otherwise, the sensitive information will be saved on local storage in plain text!
 type User struct {
-	Id               int            `json:"id"`
-	Username         string         `json:"username" gorm:"unique;index" validate:"max=20"`
-	Password         string         `json:"password" gorm:"not null;" validate:"min=8,max=20"`
-	OriginalPassword string         `json:"original_password" gorm:"-:all"` // this field is only for Password change verification, don't save it to database!
-	DisplayName      string         `json:"display_name" gorm:"index" validate:"max=20"`
-	Role             int            `json:"role" gorm:"type:int;default:1"`   // admin, common
-	Status           int            `json:"status" gorm:"type:int;default:1"` // enabled, disabled
-	Email            string         `json:"email" gorm:"index" validate:"max=50"`
-	GitHubId         string         `json:"github_id" gorm:"column:github_id;index"`
-	DiscordId        string         `json:"discord_id" gorm:"column:discord_id;index"`
-	OidcId           string         `json:"oidc_id" gorm:"column:oidc_id;index"`
-	WeChatId         string         `json:"wechat_id" gorm:"column:wechat_id;index"`
-	TelegramId       string         `json:"telegram_id" gorm:"column:telegram_id;index"`
-	VerificationCode string         `json:"verification_code" gorm:"-:all"`                                    // this field is only for Email verification, don't save it to database!
-	AccessToken      *string        `json:"access_token" gorm:"type:char(32);column:access_token;uniqueIndex"` // this token is for system management
-	Quota            int            `json:"quota" gorm:"type:int;default:0"`
-	UsedQuota        int            `json:"used_quota" gorm:"type:int;default:0;column:used_quota"` // used quota
-	RequestCount     int            `json:"request_count" gorm:"type:int;default:0;"`               // request number
-	Group            string         `json:"group" gorm:"type:varchar(64);default:'default'"`
-	AffCode          string         `json:"aff_code" gorm:"type:varchar(32);column:aff_code;uniqueIndex"`
-	AffCount         int            `json:"aff_count" gorm:"type:int;default:0;column:aff_count"`
-	AffQuota         int            `json:"aff_quota" gorm:"type:int;default:0;column:aff_quota"`           // 邀请剩余额度
-	AffHistoryQuota  int            `json:"aff_history_quota" gorm:"type:int;default:0;column:aff_history"` // 邀请历史额度
-	InviterId        int            `json:"inviter_id" gorm:"type:int;column:inviter_id;index"`
-	DeletedAt        gorm.DeletedAt `gorm:"index"`
-	LinuxDOId        string         `json:"linux_do_id" gorm:"column:linux_do_id;index"`
-	Setting          string         `json:"setting" gorm:"type:text;column:setting"`
-	Remark           string         `json:"remark,omitempty" gorm:"type:varchar(255)" validate:"max=255"`
-	StripeCustomer   string         `json:"stripe_customer" gorm:"type:varchar(64);column:stripe_customer;index"`
-	CreatedAt        int64          `json:"created_at" gorm:"autoCreateTime;column:created_at"`
-	LastLoginAt      int64          `json:"last_login_at" gorm:"default:0;column:last_login_at"`
+	Id                    int            `json:"id"`
+	TenantId              int            `json:"tenant_id" gorm:"index;default:1"`
+	OrganizationId        int            `json:"organization_id" gorm:"index;default:0"`
+	DepartmentId          int            `json:"department_id" gorm:"index;default:0"`
+	DistributionChannelId int            `json:"distribution_channel_id" gorm:"index;default:0"`
+	Username              string         `json:"username" gorm:"unique;index" validate:"max=20"`
+	Password              string         `json:"password" gorm:"not null;" validate:"min=8,max=20"`
+	OriginalPassword      string         `json:"original_password" gorm:"-:all"` // this field is only for Password change verification, don't save it to database!
+	DisplayName           string         `json:"display_name" gorm:"index" validate:"max=20"`
+	Role                  int            `json:"role" gorm:"type:int;default:1"`   // admin, common
+	Status                int            `json:"status" gorm:"type:int;default:1"` // enabled, disabled
+	Email                 string         `json:"email" gorm:"index" validate:"max=50"`
+	GitHubId              string         `json:"github_id" gorm:"column:github_id;index"`
+	DiscordId             string         `json:"discord_id" gorm:"column:discord_id;index"`
+	OidcId                string         `json:"oidc_id" gorm:"column:oidc_id;index"`
+	WeChatId              string         `json:"wechat_id" gorm:"column:wechat_id;index"`
+	TelegramId            string         `json:"telegram_id" gorm:"column:telegram_id;index"`
+	VerificationCode      string         `json:"verification_code" gorm:"-:all"`                                    // this field is only for Email verification, don't save it to database!
+	AccessToken           *string        `json:"access_token" gorm:"type:char(32);column:access_token;uniqueIndex"` // this token is for system management
+	Quota                 int            `json:"quota" gorm:"type:int;default:0"`
+	UsedQuota             int            `json:"used_quota" gorm:"type:int;default:0;column:used_quota"` // used quota
+	RequestCount          int            `json:"request_count" gorm:"type:int;default:0;"`               // request number
+	Group                 string         `json:"group" gorm:"type:varchar(64);default:'default'"`
+	AffCode               string         `json:"aff_code" gorm:"type:varchar(32);column:aff_code;uniqueIndex"`
+	AffCount              int            `json:"aff_count" gorm:"type:int;default:0;column:aff_count"`
+	AffQuota              int            `json:"aff_quota" gorm:"type:int;default:0;column:aff_quota"`           // 邀请剩余额度
+	AffHistoryQuota       int            `json:"aff_history_quota" gorm:"type:int;default:0;column:aff_history"` // 邀请历史额度
+	InviterId             int            `json:"inviter_id" gorm:"type:int;column:inviter_id;index"`
+	DeletedAt             gorm.DeletedAt `gorm:"index"`
+	LinuxDOId             string         `json:"linux_do_id" gorm:"column:linux_do_id;index"`
+	Setting               string         `json:"setting" gorm:"type:text;column:setting"`
+	Remark                string         `json:"remark,omitempty" gorm:"type:varchar(255)" validate:"max=255"`
+	StripeCustomer        string         `json:"stripe_customer" gorm:"type:varchar(64);column:stripe_customer;index"`
+	CreatedAt             int64          `json:"created_at" gorm:"autoCreateTime;column:created_at"`
+	LastLoginAt           int64          `json:"last_login_at" gorm:"default:0;column:last_login_at"`
 }
 
 func (user *User) ToBaseUser() *UserBase {

--- a/model/user_cache.go
+++ b/model/user_cache.go
@@ -15,16 +15,28 @@ import (
 
 // UserBase struct remains the same as it represents the cached data structure
 type UserBase struct {
-	Id       int    `json:"id"`
-	Group    string `json:"group"`
-	Email    string `json:"email"`
-	Quota    int    `json:"quota"`
-	Status   int    `json:"status"`
-	Username string `json:"username"`
-	Setting  string `json:"setting"`
+	Id                    int    `json:"id"`
+	TenantId              int    `json:"tenant_id"`
+	OrganizationId        int    `json:"organization_id"`
+	DepartmentId          int    `json:"department_id"`
+	DistributionChannelId int    `json:"distribution_channel_id"`
+	Group                 string `json:"group"`
+	Email                 string `json:"email"`
+	Quota                 int    `json:"quota"`
+	Status                int    `json:"status"`
+	Username              string `json:"username"`
+	Setting               string `json:"setting"`
 }
 
 func (user *UserBase) WriteContext(c *gin.Context) {
+	tenantId := user.TenantId
+	if tenantId == 0 {
+		tenantId = 1
+	}
+	common.SetContextKey(c, constant.ContextKeyTenantId, tenantId)
+	common.SetContextKey(c, constant.ContextKeyOrganizationId, user.OrganizationId)
+	common.SetContextKey(c, constant.ContextKeyDepartmentId, user.DepartmentId)
+	common.SetContextKey(c, constant.ContextKeyDistributionChannelId, user.DistributionChannelId)
 	common.SetContextKey(c, constant.ContextKeyUserGroup, user.Group)
 	common.SetContextKey(c, constant.ContextKeyUserQuota, user.Quota)
 	common.SetContextKey(c, constant.ContextKeyUserStatus, user.Status)
@@ -106,13 +118,17 @@ func GetUserCache(userId int) (userCache *UserBase, err error) {
 
 	// Create cache object from user data
 	userCache = &UserBase{
-		Id:       user.Id,
-		Group:    user.Group,
-		Quota:    user.Quota,
-		Status:   user.Status,
-		Username: user.Username,
-		Setting:  user.Setting,
-		Email:    user.Email,
+		Id:                    user.Id,
+		TenantId:              user.TenantId,
+		OrganizationId:        user.OrganizationId,
+		DepartmentId:          user.DepartmentId,
+		DistributionChannelId: user.DistributionChannelId,
+		Group:                 user.Group,
+		Quota:                 user.Quota,
+		Status:                user.Status,
+		Username:              user.Username,
+		Setting:               user.Setting,
+		Email:                 user.Email,
 	}
 
 	return userCache, nil

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -85,16 +85,20 @@ type TokenCountMeta struct {
 }
 
 type RelayInfo struct {
-	TokenId           int
-	TokenKey          string
-	TokenGroup        string
-	UserId            int
-	UsingGroup        string // 使用的分组，当auto跨分组重试时，会变动
-	UserGroup         string // 用户所在分组
-	TokenUnlimited    bool
-	StartTime         time.Time
-	FirstResponseTime time.Time
-	isFirstResponse   bool
+	TokenId               int
+	TokenKey              string
+	TokenGroup            string
+	UserId                int
+	TenantId              int
+	OrganizationId        int
+	DepartmentId          int
+	DistributionChannelId int
+	UsingGroup            string // 使用的分组，当auto跨分组重试时，会变动
+	UserGroup             string // 用户所在分组
+	TokenUnlimited        bool
+	StartTime             time.Time
+	FirstResponseTime     time.Time
+	isFirstResponse       bool
 	//SendLastReasoningResponse bool
 	IsStream               bool
 	IsGeminiBatchEmbedding bool
@@ -452,15 +456,23 @@ func genBaseRelayInfo(c *gin.Context, request dto.Request) *RelayInfo {
 	if reqId == "" {
 		reqId = common.GetTimeString() + common.GetRandomString(8)
 	}
+	tenantId := common.GetContextKeyInt(c, constant.ContextKeyTenantId)
+	if tenantId == 0 {
+		tenantId = 1
+	}
 	info := &RelayInfo{
 		Request: request,
 
-		RequestId:  reqId,
-		UserId:     common.GetContextKeyInt(c, constant.ContextKeyUserId),
-		UsingGroup: common.GetContextKeyString(c, constant.ContextKeyUsingGroup),
-		UserGroup:  common.GetContextKeyString(c, constant.ContextKeyUserGroup),
-		UserQuota:  common.GetContextKeyInt(c, constant.ContextKeyUserQuota),
-		UserEmail:  common.GetContextKeyString(c, constant.ContextKeyUserEmail),
+		RequestId:             reqId,
+		UserId:                common.GetContextKeyInt(c, constant.ContextKeyUserId),
+		TenantId:              tenantId,
+		OrganizationId:        common.GetContextKeyInt(c, constant.ContextKeyOrganizationId),
+		DepartmentId:          common.GetContextKeyInt(c, constant.ContextKeyDepartmentId),
+		DistributionChannelId: common.GetContextKeyInt(c, constant.ContextKeyDistributionChannelId),
+		UsingGroup:            common.GetContextKeyString(c, constant.ContextKeyUsingGroup),
+		UserGroup:             common.GetContextKeyString(c, constant.ContextKeyUserGroup),
+		UserQuota:             common.GetContextKeyInt(c, constant.ContextKeyUserQuota),
+		UserEmail:             common.GetContextKeyString(c, constant.ContextKeyUserEmail),
 
 		OriginModelName: common.GetContextKeyString(c, constant.ContextKeyOriginalModel),
 

--- a/relay/mjproxy_handler.go
+++ b/relay/mjproxy_handler.go
@@ -266,6 +266,7 @@ func RelaySwapFace(c *gin.Context, info *relaycommon.RelayInfo) *dto.MidjourneyR
 		ChannelId:   c.GetInt("channel_id"),
 		Quota:       priceData.Quota,
 	}
+	model.ApplyOwnershipFromContext(c, midjourneyTask)
 	err = midjourneyTask.Insert()
 	if err != nil {
 		return service.MidjourneyErrorWrapper(constant.MjRequestError, "insert_midjourney_task_failed")
@@ -579,6 +580,7 @@ func RelayMidjourneySubmit(c *gin.Context, relayInfo *relaycommon.RelayInfo) *dt
 		ChannelId:   c.GetInt("channel_id"),
 		Quota:       priceData.Quota,
 	}
+	model.ApplyOwnershipFromContext(c, midjourneyTask)
 	if midjResponse.Code == 3 {
 		//无实例账号自动禁用渠道（No available account instance）
 		channel, err := model.GetChannelById(midjourneyTask.ChannelId, true)


### PR DESCRIPTION
## 变更描述

本 PR 为 New API 增加第一阶段多租户数据归属和后台租户隔离能力，目标是支持后续将系统改造为多租户 AI API 中转站。

主要改动包括：

- 新增 tenant / organization / department / distribution channel 基础模型；
- 在 users、tokens、channels、abilities、logs、top_ups、redemptions、tasks、subscriptions、midjourney 等核心模型中增加归属字段；
- 将用户归属字段注入 Gin Context 和 RelayInfo；
- 在 logs、topups、redemptions、subscriptions、tasks、midjourney 等业务写入时保存 ownership 快照；
- 增加 TenantScope，用于后台列表按 tenant_id 过滤；
- 增加后台详情、更新、删除、批量操作、用户安全绑定、人工补单等接口的 tenant access check；
- root 用户保留平台全局视角；
- 普通用户 self 接口仍保持原有 user_id 限制。

## 变更类型

- ✨ 新功能：多租户数据归属与后台租户隔离基础能力
- ⚡ 重构：抽象 ownership / TenantScope / tenant access check

## 测试

本地已运行：

```bash
PATH=/usr/local/go/bin:$PATH GOCACHE=/tmp/go-build go test ./model ./controller ./service