### PR TITLE
修复 Codex Responses 非流式请求被上游拒绝

### DIFF
--- a/relay/channel/codex/adaptor.go
+++ b/relay/channel/codex/adaptor.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/relay/channel"
 	"github.com/QuantumNous/new-api/relay/channel/openai"
@@ -19,6 +20,18 @@ import (
 )
 
 type Adaptor struct {
+}
+
+func forceCodexResponsesStream(c *gin.Context, info *relaycommon.RelayInfo, request *dto.OpenAIResponsesRequest) {
+	if request != nil {
+		request.Stream = common.GetPointer(true)
+	}
+	if info != nil {
+		info.IsStream = true
+	}
+	if c != nil {
+		c.Set(string(constant.ContextKeyIsStream), true)
+	}
 }
 
 func (a *Adaptor) ConvertGeminiRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeminiChatRequest) (any, error) {
@@ -101,6 +114,9 @@ func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommo
 	}
 	// codex: store must be false
 	request.Store = json.RawMessage("false")
+	// Codex backend requires streaming responses. Keep RelayInfo in sync so
+	// the downstream response is handled as SSE too.
+	forceCodexResponsesStream(c, info, &request)
 	// rm max_output_tokens
 	request.MaxOutputTokens = nil
 	request.Temperature = nil

--- a/relay/channel/codex/adaptor_test.go
+++ b/relay/channel/codex/adaptor_test.go
@@ -1,0 +1,58 @@
+package codex
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertOpenAIResponsesRequestForcesStream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	info := &relaycommon.RelayInfo{RelayMode: relayconstant.RelayModeResponses, ChannelMeta: &relaycommon.ChannelMeta{}}
+	stream := false
+
+	converted, err := (&Adaptor{}).ConvertOpenAIResponsesRequest(c, info, dto.OpenAIResponsesRequest{
+		Model:  "gpt-5.3-codex",
+		Input:  json.RawMessage(`"hi"`),
+		Stream: &stream,
+	})
+
+	require.NoError(t, err)
+	req, ok := converted.(dto.OpenAIResponsesRequest)
+	require.True(t, ok)
+	require.NotNil(t, req.Stream)
+	require.True(t, *req.Stream)
+	require.True(t, info.IsStream)
+	require.True(t, c.GetBool(string(constant.ContextKeyIsStream)))
+	require.Equal(t, json.RawMessage("false"), req.Store)
+}
+
+func TestConvertOpenAIResponsesCompactDoesNotForceStream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	info := &relaycommon.RelayInfo{RelayMode: relayconstant.RelayModeResponsesCompact, ChannelMeta: &relaycommon.ChannelMeta{}}
+	stream := false
+
+	converted, err := (&Adaptor{}).ConvertOpenAIResponsesRequest(c, info, dto.OpenAIResponsesRequest{
+		Model:  "gpt-5.3-codex",
+		Input:  json.RawMessage(`"hi"`),
+		Stream: &stream,
+	})
+
+	require.NoError(t, err)
+	req, ok := converted.(dto.OpenAIResponsesRequest)
+	require.True(t, ok)
+	require.NotNil(t, req.Stream)
+	require.False(t, *req.Stream)
+	require.False(t, info.IsStream)
+	require.False(t, c.GetBool(string(constant.ContextKeyIsStream)))
+}

--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -77,7 +77,15 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 		if err != nil {
 			return types.NewError(err, types.ErrorCodeReadRequestBodyFailed, types.ErrOptionWithSkipRetry())
 		}
-		requestBody = common.ReaderOnly(storage)
+		if info.ApiType == appconstant.APITypeCodex && info.RelayMode == relayconstant.RelayModeResponses {
+			jsonData, err := normalizeCodexResponsesPassthroughBody(c, info, storage)
+			if err != nil {
+				return types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
+			}
+			requestBody = bytes.NewBuffer(jsonData)
+		} else {
+			requestBody = common.ReaderOnly(storage)
+		}
 	} else {
 		convertedRequest, err := adaptor.ConvertOpenAIResponsesRequest(c, info, *request)
 		if err != nil {
@@ -157,4 +165,26 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 		service.PostTextConsumeQuota(c, info, usageDto, nil)
 	}
 	return nil
+}
+
+func normalizeCodexResponsesPassthroughBody(c *gin.Context, info *relaycommon.RelayInfo, storage common.BodyStorage) ([]byte, error) {
+	body, err := storage.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	reqBody := make(map[string]interface{})
+	if err := common.Unmarshal(body, &reqBody); err != nil {
+		return nil, err
+	}
+
+	reqBody["stream"] = true
+	reqBody["store"] = false
+	if info != nil {
+		info.IsStream = true
+	}
+	if c != nil {
+		c.Set(string(appconstant.ContextKeyIsStream), true)
+	}
+
+	return common.Marshal(reqBody)
 }

--- a/relay/responses_handler_test.go
+++ b/relay/responses_handler_test.go
@@ -1,0 +1,33 @@
+package relay
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	appconstant "github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeCodexResponsesPassthroughBodyForcesStream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	info := &relaycommon.RelayInfo{}
+	storage, err := common.CreateBodyStorage([]byte(`{"model":"gpt-5.3-codex","input":"hi","stream":false,"store":true}`))
+	require.NoError(t, err)
+	defer storage.Close()
+
+	body, err := normalizeCodexResponsesPassthroughBody(c, info, storage)
+
+	require.NoError(t, err)
+	var req map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &req))
+	require.Equal(t, true, req["stream"])
+	require.Equal(t, false, req["store"])
+	require.True(t, info.IsStream)
+	require.True(t, c.GetBool(string(appconstant.ContextKeyIsStream)))
+}


### PR DESCRIPTION

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

修复 Codex 渠道在 Responses 普通接口下，入口请求未开启流式时被上游拒绝的问题。

Codex 后端的 `/backend-api/codex/responses` 要求请求必须使用流式模式。此前当调用方没有显式传入 `stream=true`，或渠道测试默认使用非流式请求时，new-api 会把非流式请求继续转发给 Codex 上游，并且内部也会按非流式响应处理，最终触发上游返回 `400 Stream must be set to true`。

本次改动在 Codex Responses 请求转换阶段统一强制设置 `stream=true`，同时同步更新 `RelayInfo` 和 gin context 中的流式状态，使后续响应处理按 SSE 流式逻辑执行。对于开启请求体透传的场景，也会在转发前修正请求体中的 `stream=true` 和 `store=false`，避免透传模式绕过 Codex adaptor 的转换逻辑。

该修复与 #3303 的方向不同：#3303 主要是在渠道测试失败后尝试用流式重试；本 PR 则是在 Codex Responses relay 路径中保证请求和内部响应处理状态始终符合 Codex 上游要求，因此同时覆盖普通调用、渠道测试以及请求体透传场景。

`/v1/responses/compact` 路径保持原有行为，不强制改为流式。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Refs #3298

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、理解偏差或预期不一致直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

已在服务器环境运行并通过相关单元测试：

```bash
go test ./relay/channel/codex ./relay
```

测试结果：

```text
ok  	github.com/QuantumNous/new-api/relay/channel/codex
ok  	github.com/QuantumNous/new-api/relay
```

已完成 Docker 镜像构建验证：

```bash
docker build -t new-api:codex-stream-turnstile .
```
构建结果：成功。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Codex API responses now consistently enforce streaming mode to ensure proper response handling across all relay configurations.

* **Tests**
  * Added tests verifying streaming behavior enforcement for Codex responses and request body normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5031?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->