### PR TITLE
feat: add PATCH /api/user/:id/group for safe group-only updates

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -1282,3 +1282,45 @@ func UpdateUserSetting(c *gin.Context) {
 
 	common.ApiSuccessI18n(c, i18n.MsgSettingSaved, nil)
 }
+
+// UpdateUserGroup 只更新用户的分组字段，不影响其他字段
+func UpdateUserGroup(c *gin.Context) {
+	userId, err := strconv.Atoi(c.Param("id"))
+	if err != nil || userId <= 0 {
+		common.ApiErrorI18n(c, i18n.MsgInvalidParams)
+		return
+	}
+
+	var req struct {
+		Group string `json:"group"`
+	}
+	if err := json.NewDecoder(c.Request.Body).Decode(&req); err != nil {
+		common.ApiErrorI18n(c, i18n.MsgInvalidParams)
+		return
+	}
+
+	if req.Group == "" {
+		common.ApiErrorI18n(c, i18n.MsgInvalidParams)
+		return
+	}
+
+	// 检查用户是否存在
+	var user model.User
+	err = model.DB.Where("id = ?", userId).First(&user).Error
+	if err != nil {
+		common.ApiErrorI18n(c, i18n.MsgUserNotExists)
+		return
+	}
+
+	// 只更新 group 字段，不影响其他任何字段
+	err = model.UpdateUserGroup(userId, req.Group)
+	if err != nil {
+		common.ApiErrorI18n(c, i18n.MsgOperationFailed)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "",
+	})
+}

--- a/model/user.go
+++ b/model/user.go
@@ -1055,3 +1055,15 @@ func RootUserExists() bool {
 	}
 	return true
 }
+
+// UpdateUserGroup 只更新用户的分组字段，不影响其他任何字段
+func UpdateUserGroup(userId int, newGroup string) error {
+	err := DB.Model(&User{}).Where("id = ?", userId).Update(commonGroupCol, newGroup).Error
+	if err != nil {
+		return err
+	}
+	// 更新缓存
+	var user User
+	DB.Where("id = ?", userId).First(&user)
+	return updateUserCache(user)
+}

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -137,6 +137,7 @@ func SetApiRouter(router *gin.Engine) {
 				adminRoute.POST("/", controller.CreateUser)
 				adminRoute.POST("/manage", controller.ManageUser)
 				adminRoute.PUT("/", controller.UpdateUser)
+				adminRoute.PATCH("/:id/group", controller.UpdateUserGroup)
 				adminRoute.DELETE("/:id", controller.DeleteUser)
 				adminRoute.DELETE("/:id/reset_passkey", controller.AdminResetPasskey)
 


### PR DESCRIPTION
## Summary

Add a dedicated `PATCH /api/user/:id/group` endpoint that updates **only the `group` field** without touching other user attributes.

### Problem

The existing `PUT /api/user/` endpoint uses GORM `Updates()` with a map, which unconditionally overwrites `username`, `display_name`, `group`, and `remark`. Passing `{"id": 5, "group": "vip"}` clears the username to an empty string, effectively making the user disappear.

### Solution

- `model.UpdateUserGroup()` — single-column update via `DB.Model(&User{}).Where("id = ?", userId).Update(commonGroupCol, newGroup)` + cache invalidation
- `controller.UpdateUserGroup()` — validates user ID and group name from request body
- Route: `PATCH /api/user/:id/group`

### Changes

- `model/user.go` — new `UpdateUserGroup()` function
- `controller/user.go` — new `UpdateUserGroup()` handler
- `router/api-router.go` — register the new route

### Testing

```bash
curl -X PATCH https://host/api/user/5/group \
  -H "Authorization: Bearer sk-xxx" \
  -H "New-Api-User: 1" \
  -H "Content-Type: application/json" \
  -d '{"group": "vip"}'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new capability to update user group assignments. The feature includes input validation, user verification, and automatic system-wide cache synchronization to ensure consistent group data across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->