### PR TITLE
feat: AdminAuth middleware supports API token for bot management

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -84,12 +84,31 @@ func authHelper(c *gin.Context, minRole int) {
 			status = user.Status
 			useAccessToken = true
 		} else {
-			c.JSON(http.StatusOK, gin.H{
-				"success": false,
-				"message": common.TranslateMessage(c, i18n.MsgAuthAccessTokenInvalid),
-			})
-			c.Abort()
-			return
+			// Access token not found — try API token (sk-xxx from tokens table)
+			apiKey := strings.TrimPrefix(accessToken, "Bearer ")
+			apiKey = strings.TrimPrefix(apiKey, "sk-")
+			apiToken, tokenErr := model.ValidateUserToken(apiKey)
+			if apiToken != nil {
+				tokenUser, tokenUserErr := model.GetUserById(apiToken.UserId, false)
+				if tokenUserErr == nil && tokenUser != nil && tokenUser.Username != "" {
+					username = tokenUser.Username
+					role = tokenUser.Role
+					id = tokenUser.Id
+					status = tokenUser.Status
+					useAccessToken = true
+				}
+			}
+			if username == nil {
+				if tokenErr != nil {
+					common.SysLog("AdminAuth API token validation error: " + tokenErr.Error())
+				}
+				c.JSON(http.StatusOK, gin.H{
+					"success": false,
+					"message": common.TranslateMessage(c, i18n.MsgAuthAccessTokenInvalid),
+				})
+				c.Abort()
+				return
+			}
 		}
 	}
 	// get header New-Api-User


### PR DESCRIPTION
## Summary

Allow management bots to call admin endpoints using `Authorization: Bearer sk-xxx` + `New-Api-User: <user_id>` headers, without needing a session cookie.

### Changes

- `middleware/auth.go` — `AdminAuth()` now checks for API token when session cookie is absent
- Falls back to token lookup via `model.ValidateAccessToken()` + verifies the token belongs to an admin user

### Use Case

Bots like AstrBot can manage users, channels, and quotas via the API using a long-lived token instead of a session that expires.

```bash
curl https://host/api/user/ \
  -H "Authorization: Bearer sk-xxx" \
  -H "New-Api-User: 1"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API token-based authentication as an alternative to session authentication. Users can now authenticate using API tokens provided via the Authorization header using Bearer token format. When session authentication fails, the system automatically attempts token validation. Invalid tokens are rejected with clear error messages and validation errors are logged for troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5052?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->