### PR TITLE
fix: redemptions page 500 — missing REDEMPTION_STATUS import

### DIFF
--- a/web/default/src/features/redemption-codes/components/redemptions-columns.tsx
+++ b/web/default/src/features/redemption-codes/components/redemptions-columns.tsx
@@ -28,7 +28,7 @@ import {
 import { DataTableColumnHeader } from '@/components/data-table'
 import { MaskedValueDisplay } from '@/components/masked-value-display'
 import { StatusBadge } from '@/components/status-badge'
-import { REDEMPTION_FILTER_EXPIRED, REDEMPTION_STATUSES } from '../constants'
+import { REDEMPTION_FILTER_EXPIRED, REDEMPTION_STATUS, REDEMPTION_STATUSES } from '../constants'
 import { isRedemptionExpired, isTimestampExpired } from '../lib'
 import { type Redemption } from '../types'
 import { DataTableRowActions } from './data-table-row-actions'


### PR DESCRIPTION
## Summary

Fix a runtime crash on the redemption codes page caused by a missing import.

### Problem

`redemptions-columns.tsx` references `REDEMPTION_STATUS.ENABLED` (singular) but only imports `REDEMPTION_STATUSES` (plural). This causes a `ReferenceError` at runtime, crashing the entire page with a 500 error.

### Fix

Add the missing `REDEMPTION_STATUS` to the import statement.

### Changes

- `web/default/src/features/redemption-codes/components/redemptions-columns.tsx` — 1 line import fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized internal imports for improved code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->