### PR TITLE
fix: unregister stale ServiceWorkers + lazy import retry for WebView

### DIFF
--- a/web/classic/index.html
+++ b/web/classic/index.html
@@ -25,5 +25,14 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script type="module" src="/src/index.jsx"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.getRegistrations().then(function(registrations) {
+          for (var i = 0; i < registrations.length; i++) {
+            registrations[i].unregister();
+          }
+        });
+      }
+    </script>
   </body>
 </html>

--- a/web/classic/src/App.jsx
+++ b/web/classic/src/App.jsx
@@ -50,11 +50,25 @@ import PersonalSetting from './components/settings/PersonalSetting';
 import Setup from './pages/Setup';
 import SetupCheck from './components/layout/SetupCheck';
 
-const Home = lazy(() => import('./pages/Home'));
-const Dashboard = lazy(() => import('./pages/Dashboard'));
-const About = lazy(() => import('./pages/About'));
-const UserAgreement = lazy(() => import('./pages/UserAgreement'));
-const PrivacyPolicy = lazy(() => import('./pages/PrivacyPolicy'));
+// Retry wrapper for lazy imports (fixes WebView chunk loading failures)
+function lazyWithRetry(factory, retries = 3, delay = 1000) {
+  return lazy(() => {
+    const attempt = (remaining) =>
+      factory().catch((err) => {
+        if (remaining <= 0) throw err;
+        return new Promise((resolve) =>
+          setTimeout(() => resolve(attempt(remaining - 1)), delay)
+        );
+      });
+    return attempt(retries);
+  });
+}
+
+const Home = lazyWithRetry(() => import('./pages/Home'));
+const Dashboard = lazyWithRetry(() => import('./pages/Dashboard'));
+const About = lazyWithRetry(() => import('./pages/About'));
+const UserAgreement = lazyWithRetry(() => import('./pages/UserAgreement'));
+const PrivacyPolicy = lazyWithRetry(() => import('./pages/PrivacyPolicy'));
 
 function DynamicOAuth2Callback() {
   const { provider } = useParams();

--- a/web/classic/vite.config.js
+++ b/web/classic/vite.config.js
@@ -65,6 +65,7 @@ export default defineConfig({
     },
   },
   build: {
+    target: 'es2018',
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
## Summary

Fix 404 and dynamic import errors in WebView browsers caused by stale ServiceWorker registrations and chunk loading failures.

### Changes

1. **SW unregistration** (`web/classic/index.html`): Script that unregisters all existing ServiceWorkers on page load, preventing stale SW from serving cached responses
2. **Lazy import retry** (`web/classic/src/App.jsx`): Retry mechanism (3 attempts with backoff) for dynamic `import()` calls that fail in WebView
3. **Build target** (`web/classic/vite.config.js`): Lower build target for broader WebView compatibility

### Problem

When switching from default to classic theme, the previously registered ServiceWorker persists in WebView browsers. This causes "page not found" errors. Additionally, dynamic imports can fail intermittently in WebView environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Service worker cleanup improved on application initialization for better resource management
  * Lazy-loaded page components enhanced with automatic retry mechanism to improve loading resilience
  * Build configuration updated to target ES2018 for improved JavaScript compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5054?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->