### PR TITLE
fix: auto-disable channels on 5xx errors

### DIFF
--- a/setting/operation_setting/status_code_ranges.go
+++ b/setting/operation_setting/status_code_ranges.go
@@ -14,7 +14,7 @@ type StatusCodeRange struct {
 	End   int
 }
 
-var AutomaticDisableStatusCodeRanges = []StatusCodeRange{{Start: 401, End: 401}}
+var AutomaticDisableStatusCodeRanges = []StatusCodeRange{{Start: 401, End: 401}, {Start: 500, End: 599}}
 
 // Default behavior matches legacy hardcoded retry rules in controller/relay.go shouldRetry:
 // retry for 1xx, 3xx, 4xx(except 400/408), 5xx(except 504/524), and no retry for 2xx.

--- a/setting/operation_setting/status_code_ranges_test.go
+++ b/setting/operation_setting/status_code_ranges_test.go
@@ -75,9 +75,18 @@ func TestShouldRetryByStatusCode_DefaultMatchesLegacyBehavior(t *testing.T) {
 	require.False(t, ShouldRetryByStatusCode(408))
 	require.True(t, ShouldRetryByStatusCode(429))
 	require.True(t, ShouldRetryByStatusCode(500))
+	require.True(t, ShouldRetryByStatusCode(502))
 	require.False(t, ShouldRetryByStatusCode(504))
 	require.False(t, ShouldRetryByStatusCode(524))
 	require.True(t, ShouldRetryByStatusCode(599))
+}
+
+func TestShouldDisableByStatusCode_DefaultDisables5xx(t *testing.T) {
+	require.True(t, ShouldDisableByStatusCode(401))
+	require.True(t, ShouldDisableByStatusCode(500))
+	require.True(t, ShouldDisableByStatusCode(502))
+	require.True(t, ShouldDisableByStatusCode(599))
+	require.False(t, ShouldDisableByStatusCode(400))
 }
 
 func TestIsAlwaysSkipRetryStatusCode(t *testing.T) {


### PR DESCRIPTION
## Summary
- Include 500-599 in the default automatic channel-disable status codes so failed 5xx channels are removed from future selection, not only retried within the current request.
- Add regression coverage that default retry includes 502 and default auto-disable includes 500/502/599 while excluding client-side 400.

## Test Plan
- go test ./setting/operation_setting ./service -run "TestShould|TestSelectFailover" -count=1

## Production notes
- Runtime options should also include AutomaticDisableStatusCodes=401,500-599 and AutomaticRetryStatusCodes=100-199,300-399,401-407,409-499,500-503,505-523,525-599.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded automatic error handling to disable operations when encountering server errors (5xx status codes) alongside existing 401 error behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->