### PR TITLE
fix: apply group ratio in channel test billing

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -528,16 +528,17 @@ func settleTestQuota(info *relaycommon.RelayInfo, priceData types.PriceData, usa
 	}
 
 	quota := 0
+	groupRatio := priceData.GroupRatioInfo.GroupRatio
 	if !priceData.UsePrice {
 		quota = usage.PromptTokens + int(math.Round(float64(usage.CompletionTokens)*priceData.CompletionRatio))
-		quota = int(math.Round(float64(quota) * priceData.ModelRatio))
-		if priceData.ModelRatio != 0 && quota <= 0 {
+		quota = int(math.Round(float64(quota) * priceData.ModelRatio * groupRatio))
+		if priceData.ModelRatio*groupRatio != 0 && quota <= 0 {
 			quota = 1
 		}
 		return quota, nil
 	}
 
-	return int(priceData.ModelPrice * common.QuotaPerUnit), nil
+	return int(math.Round(priceData.ModelPrice * common.QuotaPerUnit * groupRatio)), nil
 }
 
 func buildTestLogOther(c *gin.Context, info *relaycommon.RelayInfo, priceData types.PriceData, usage *dto.Usage, tieredResult *billingexpr.TieredResult) map[string]interface{} {

--- a/controller/channel_test_internal_test.go
+++ b/controller/channel_test_internal_test.go
@@ -41,6 +41,31 @@ func TestSettleTestQuotaUsesTieredBilling(t *testing.T) {
 	require.Equal(t, "stream", result.MatchedTier)
 }
 
+func TestSettleTestQuotaAppliesGroupRatioForTokenBilling(t *testing.T) {
+	quota, result := settleTestQuota(nil, types.PriceData{
+		ModelRatio:      2,
+		CompletionRatio: 3,
+		GroupRatioInfo:  types.GroupRatioInfo{GroupRatio: 1.5},
+	}, &dto.Usage{
+		PromptTokens:     100,
+		CompletionTokens: 50,
+	})
+
+	require.Equal(t, 750, quota)
+	require.Nil(t, result)
+}
+
+func TestSettleTestQuotaAppliesGroupRatioForFixedPriceBilling(t *testing.T) {
+	quota, result := settleTestQuota(nil, types.PriceData{
+		UsePrice:       true,
+		ModelPrice:     0.002,
+		GroupRatioInfo: types.GroupRatioInfo{GroupRatio: 1.5},
+	}, &dto.Usage{})
+
+	require.Equal(t, 1500, quota)
+	require.Nil(t, result)
+}
+
 func TestBuildTestLogOtherInjectsTieredInfo(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())


### PR DESCRIPTION
## 📝 变更描述 / Description
Channel test settlement already includes the group ratio in log metadata, but the fallback quota calculation did not apply it. This change applies `GroupRatioInfo.GroupRatio` to both token-based and fixed-price channel test quota paths so test billing matches the configured group pricing.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5064

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```bash
GOCACHE=/private/tmp/new-api-go-cache GOMODCACHE=/private/tmp/new-api-go-mod go test ./controller -run 'TestSettleTestQuota|TestBuildTestLogOther' -count=1
```

Result:
```text
ok  	github.com/QuantumNous/new-api/controller	0.902s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quota calculation to properly apply group ratio adjustments in token-based and fixed-price billing scenarios.

* **Tests**
  * Added test coverage to verify group ratio is correctly applied during quota settlement for both token and fixed-price billing methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->