### PR TITLE
fix: preserve Claude tool block indexes

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -442,10 +442,7 @@ func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.ChatCo
 	tools := make([]dto.ToolCallResponse, 0)
 	fcIdx := 0
 	if claudeResponse.Index != nil {
-		fcIdx = *claudeResponse.Index - 1
-		if fcIdx < 0 {
-			fcIdx = 0
-		}
+		fcIdx = *claudeResponse.Index
 	}
 	var choice dto.ChatCompletionsStreamResponseChoice
 	if claudeResponse.Type == "message_start" {

--- a/relay/channel/claude/relay_claude_test.go
+++ b/relay/channel/claude/relay_claude_test.go
@@ -48,6 +48,40 @@ func TestFormatClaudeResponseInfo_MessageStart(t *testing.T) {
 	}
 }
 
+func TestStreamResponseClaude2OpenAIUsesClaudeBlockIndexForToolCalls(t *testing.T) {
+	firstIndex := 0
+	first := StreamResponseClaude2OpenAI(&dto.ClaudeResponse{
+		Type:  "content_block_start",
+		Index: &firstIndex,
+		ContentBlock: &dto.ClaudeMediaMessage{
+			Id:   "toolu_1",
+			Type: "tool_use",
+			Name: "first_tool",
+		},
+	})
+	require.NotNil(t, first)
+	require.Len(t, first.Choices, 1)
+	require.Len(t, first.Choices[0].Delta.ToolCalls, 1)
+	require.NotNil(t, first.Choices[0].Delta.ToolCalls[0].Index)
+	require.Equal(t, 0, *first.Choices[0].Delta.ToolCalls[0].Index)
+
+	secondIndex := 1
+	second := StreamResponseClaude2OpenAI(&dto.ClaudeResponse{
+		Type:  "content_block_start",
+		Index: &secondIndex,
+		ContentBlock: &dto.ClaudeMediaMessage{
+			Id:   "toolu_2",
+			Type: "tool_use",
+			Name: "second_tool",
+		},
+	})
+	require.NotNil(t, second)
+	require.Len(t, second.Choices, 1)
+	require.Len(t, second.Choices[0].Delta.ToolCalls, 1)
+	require.NotNil(t, second.Choices[0].Delta.ToolCalls[0].Index)
+	require.Equal(t, 1, *second.Choices[0].Delta.ToolCalls[0].Index)
+}
+
 func TestFormatClaudeResponseInfo_MessageDelta_FullUsage(t *testing.T) {
 	// message_start 先积累 usage
 	claudeInfo := &ClaudeResponseInfo{


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
Anthropic content block indexes identify which stream block a `tool_use` or `input_json_delta` belongs to. The OpenAI-compatible stream response previously subtracted one and clamped to zero, so Claude tool blocks with indexes `0` and `1` could both be emitted as OpenAI tool call index `0`. This keeps Claude's original block index when emitting tool calls and adds a regression test for two sequential tool blocks.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5018

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```bash
GOCACHE=/private/tmp/new-api-go-cache GOMODCACHE=/private/tmp/new-api-go-mod go test ./relay/channel/claude -run 'TestStreamResponseClaude2OpenAIUsesClaudeBlockIndexForToolCalls' -count=1
```

Result:
```text
ok   github.com/QuantumNous/new-api/relay/channel/claude   0.820s
```
