### PR TITLE
fix: preserve Gemini thought and content in same chunk

### DIFF
--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -1079,12 +1079,8 @@ func responseGeminiChat2OpenAI(c *gin.Context, response *dto.GeminiChatResponse)
 			FinishReason: constant.FinishReasonStop,
 		}
 		if len(candidate.Content.Parts) > 0 {
-			// 使用 strings.Builder 直接累积最终 content，避免:
-			//   1) 每张 inline image 生成一次中间 "![image](...)" 字符串
-			//   2) 末尾 strings.Join 再分配一份等大缓冲
-			// Gemini 图片返回时 InlineData.Data 可能是数 MB 的 base64，
-			// 上述两份临时分配在高并发下会显著放大堆驻留。
 			var content strings.Builder
+			var reasoning strings.Builder
 			var inlineGrow int
 			for _, part := range candidate.Content.Parts {
 				if part.InlineData != nil {
@@ -1094,32 +1090,24 @@ func responseGeminiChat2OpenAI(c *gin.Context, response *dto.GeminiChatResponse)
 			if inlineGrow > 0 {
 				content.Grow(inlineGrow)
 			}
-			appended := 0
-			writeSep := func() {
-				if appended > 0 {
-					content.WriteByte('\n')
+			contentAppended := 0
+			reasoningAppended := 0
+			writeSeparated := func(builder *strings.Builder, appended *int, s string) {
+				if *appended > 0 {
+					builder.WriteByte('\n')
 				}
-				appended++
+				builder.WriteString(s)
+				*appended += 1
 			}
 			var toolCalls []dto.ToolCallResponse
 			for _, part := range candidate.Content.Parts {
 				if part.InlineData != nil {
 					// 媒体内容
 					if strings.HasPrefix(part.InlineData.MimeType, "image") {
-						writeSep()
-						content.WriteString("![image](data:")
-						content.WriteString(part.InlineData.MimeType)
-						content.WriteString(";base64,")
-						content.WriteString(part.InlineData.Data)
-						content.WriteByte(')')
+						writeSeparated(&content, &contentAppended, "![image](data:"+part.InlineData.MimeType+";base64,"+part.InlineData.Data+")")
 					} else {
 						// 其他媒体类型，直接显示链接
-						writeSep()
-						content.WriteString("[media](data:")
-						content.WriteString(part.InlineData.MimeType)
-						content.WriteString(";base64,")
-						content.WriteString(part.InlineData.Data)
-						content.WriteByte(')')
+						writeSeparated(&content, &contentAppended, "[media](data:"+part.InlineData.MimeType+";base64,"+part.InlineData.Data+")")
 					}
 				} else if part.FunctionCall != nil {
 					choice.FinishReason = constant.FinishReasonToolCalls
@@ -1127,25 +1115,18 @@ func responseGeminiChat2OpenAI(c *gin.Context, response *dto.GeminiChatResponse)
 						toolCalls = append(toolCalls, *call)
 					}
 				} else if part.Thought {
-					choice.Message.ReasoningContent = &part.Text
+					if part.Text != "" {
+						writeSeparated(&reasoning, &reasoningAppended, part.Text)
+					}
 				} else {
 					if part.ExecutableCode != nil {
-						writeSep()
-						content.WriteString("```")
-						content.WriteString(part.ExecutableCode.Language)
-						content.WriteByte('\n')
-						content.WriteString(part.ExecutableCode.Code)
-						content.WriteString("\n```")
+						writeSeparated(&content, &contentAppended, "```"+part.ExecutableCode.Language+"\n"+part.ExecutableCode.Code+"\n```")
 					} else if part.CodeExecutionResult != nil {
-						writeSep()
-						content.WriteString("```output\n")
-						content.WriteString(part.CodeExecutionResult.Output)
-						content.WriteString("\n```")
+						writeSeparated(&content, &contentAppended, "```output\n"+part.CodeExecutionResult.Output+"\n```")
 					} else {
 						// 过滤掉空行
 						if part.Text != "\n" {
-							writeSep()
-							content.WriteString(part.Text)
+							writeSeparated(&content, &contentAppended, part.Text)
 						}
 					}
 				}
@@ -1153,6 +1134,10 @@ func responseGeminiChat2OpenAI(c *gin.Context, response *dto.GeminiChatResponse)
 			if len(toolCalls) > 0 {
 				choice.Message.SetToolCalls(toolCalls)
 				isToolCall = true
+			}
+			if reasoningAppended > 0 {
+				reasoningText := reasoning.String()
+				choice.Message.ReasoningContent = &reasoningText
 			}
 			choice.Message.SetStringContent(content.String())
 
@@ -1208,9 +1193,8 @@ func streamResponseGeminiChat2OpenAI(geminiResponse *dto.GeminiChatResponse) (*d
 				//Role: "assistant",
 			},
 		}
-		// 使用 strings.Builder 直接累积 delta content，避免每张 image / 每个
-		// 文本片段都先 `+` 拼出一份临时 string，再 strings.Join 再拷贝一遍。
 		var content strings.Builder
+		var reasoning strings.Builder
 		var inlineGrow int
 		for _, part := range candidate.Content.Parts {
 			if part.InlineData != nil {
@@ -1220,15 +1204,16 @@ func streamResponseGeminiChat2OpenAI(geminiResponse *dto.GeminiChatResponse) (*d
 		if inlineGrow > 0 {
 			content.Grow(inlineGrow)
 		}
-		appended := 0
-		writeSep := func() {
-			if appended > 0 {
-				content.WriteByte('\n')
+		contentAppended := 0
+		reasoningAppended := 0
+		writeSeparated := func(builder *strings.Builder, appended *int, s string) {
+			if *appended > 0 {
+				builder.WriteByte('\n')
 			}
-			appended++
+			builder.WriteString(s)
+			*appended += 1
 		}
 		isTools := false
-		isThought := false
 		if candidate.FinishReason != nil {
 			// Map Gemini FinishReason to OpenAI finish_reason
 			switch *candidate.FinishReason {
@@ -1264,12 +1249,7 @@ func streamResponseGeminiChat2OpenAI(geminiResponse *dto.GeminiChatResponse) (*d
 		for _, part := range candidate.Content.Parts {
 			if part.InlineData != nil {
 				if strings.HasPrefix(part.InlineData.MimeType, "image") {
-					writeSep()
-					content.WriteString("![image](data:")
-					content.WriteString(part.InlineData.MimeType)
-					content.WriteString(";base64,")
-					content.WriteString(part.InlineData.Data)
-					content.WriteByte(')')
+					writeSeparated(&content, &contentAppended, "![image](data:"+part.InlineData.MimeType+";base64,"+part.InlineData.Data+")")
 				}
 			} else if part.FunctionCall != nil {
 				isTools = true
@@ -1279,33 +1259,25 @@ func streamResponseGeminiChat2OpenAI(geminiResponse *dto.GeminiChatResponse) (*d
 				}
 
 			} else if part.Thought {
-				isThought = true
-				writeSep()
-				content.WriteString(part.Text)
+				if part.Text != "" {
+					writeSeparated(&reasoning, &reasoningAppended, part.Text)
+				}
 			} else {
 				if part.ExecutableCode != nil {
-					writeSep()
-					content.WriteString("```")
-					content.WriteString(part.ExecutableCode.Language)
-					content.WriteByte('\n')
-					content.WriteString(part.ExecutableCode.Code)
-					content.WriteString("\n```\n")
+					writeSeparated(&content, &contentAppended, "```"+part.ExecutableCode.Language+"\n"+part.ExecutableCode.Code+"\n```\n")
 				} else if part.CodeExecutionResult != nil {
-					writeSep()
-					content.WriteString("```output\n")
-					content.WriteString(part.CodeExecutionResult.Output)
-					content.WriteString("\n```\n")
+					writeSeparated(&content, &contentAppended, "```output\n"+part.CodeExecutionResult.Output+"\n```\n")
 				} else {
 					if part.Text != "\n" {
-						writeSep()
-						content.WriteString(part.Text)
+						writeSeparated(&content, &contentAppended, part.Text)
 					}
 				}
 			}
 		}
-		if isThought {
-			choice.Delta.SetReasoningContent(content.String())
-		} else {
+		if reasoningAppended > 0 {
+			choice.Delta.SetReasoningContent(reasoning.String())
+		}
+		if contentAppended > 0 {
 			choice.Delta.SetContentString(content.String())
 		}
 		if isTools {

--- a/relay/channel/gemini/relay_gemini_reasoning_test.go
+++ b/relay/channel/gemini/relay_gemini_reasoning_test.go
@@ -1,0 +1,58 @@
+package gemini
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamResponseGeminiChat2OpenAISeparatesThoughtAndAnswer(t *testing.T) {
+	t.Parallel()
+
+	resp, isStop := streamResponseGeminiChat2OpenAI(&dto.GeminiChatResponse{
+		Candidates: []dto.GeminiChatCandidate{
+			{
+				Content: dto.GeminiChatContent{
+					Parts: []dto.GeminiPart{
+						{Thought: true, Text: "reasoning"},
+						{Text: "answer"},
+					},
+				},
+			},
+		},
+	})
+
+	require.False(t, isStop)
+	require.Len(t, resp.Choices, 1)
+	require.Equal(t, "reasoning", resp.Choices[0].Delta.GetReasoningContent())
+	require.Equal(t, "answer", resp.Choices[0].Delta.GetContentString())
+}
+
+func TestResponseGeminiChat2OpenAIAccumulatesMultipleThoughtParts(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	resp := responseGeminiChat2OpenAI(c, &dto.GeminiChatResponse{
+		Candidates: []dto.GeminiChatCandidate{
+			{
+				Content: dto.GeminiChatContent{
+					Parts: []dto.GeminiPart{
+						{Thought: true, Text: "first"},
+						{Thought: true, Text: "second"},
+						{Text: "final answer"},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, resp.Choices, 1)
+	require.NotNil(t, resp.Choices[0].Message.ReasoningContent)
+	require.Equal(t, "first\nsecond", *resp.Choices[0].Message.ReasoningContent)
+	require.Equal(t, "final answer", resp.Choices[0].Message.StringContent())
+}

--- a/service/convert.go
+++ b/service/convert.go
@@ -296,6 +296,60 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 		}
 		info.ClaudeConvertInfo.LastMessagesType = relaycommon.LastMessageTypeNone
 	}
+	emitThinkingDelta := func(reasoning string) {
+		if reasoning == "" {
+			return
+		}
+		if info.ClaudeConvertInfo.LastMessagesType != relaycommon.LastMessageTypeThinking {
+			stopOpenBlocksAndAdvance()
+			idx := info.ClaudeConvertInfo.Index
+			claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
+				Index: &idx,
+				Type:  "content_block_start",
+				ContentBlock: &dto.ClaudeMediaMessage{
+					Type:     "thinking",
+					Thinking: common.GetPointer[string](""),
+				},
+			})
+		}
+		idx := info.ClaudeConvertInfo.Index
+		claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
+			Index: &idx,
+			Type:  "content_block_delta",
+			Delta: &dto.ClaudeMediaMessage{
+				Type:     "thinking_delta",
+				Thinking: &reasoning,
+			},
+		})
+		info.ClaudeConvertInfo.LastMessagesType = relaycommon.LastMessageTypeThinking
+	}
+	emitTextDelta := func(content string) {
+		if content == "" {
+			return
+		}
+		if info.ClaudeConvertInfo.LastMessagesType != relaycommon.LastMessageTypeText {
+			stopOpenBlocksAndAdvance()
+			idx := info.ClaudeConvertInfo.Index
+			claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
+				Index: &idx,
+				Type:  "content_block_start",
+				ContentBlock: &dto.ClaudeMediaMessage{
+					Type: "text",
+					Text: common.GetPointer[string](""),
+				},
+			})
+		}
+		idx := info.ClaudeConvertInfo.Index
+		claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
+			Index: &idx,
+			Type:  "content_block_delta",
+			Delta: &dto.ClaudeMediaMessage{
+				Type: "text_delta",
+				Text: common.GetPointer[string](content),
+			},
+		})
+		info.ClaudeConvertInfo.LastMessagesType = relaycommon.LastMessageTypeText
+	}
 	if info.SendResponseCount == 1 {
 		msg := &dto.ClaudeMediaMessage{
 			Id:    openAIResponse.Id,
@@ -360,54 +414,8 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 		if len(openAIResponse.Choices) > 0 {
 			reasoning := openAIResponse.Choices[0].Delta.GetReasoningContent()
 			content := openAIResponse.Choices[0].Delta.GetContentString()
-
-			if reasoning != "" {
-				if info.ClaudeConvertInfo.LastMessagesType != relaycommon.LastMessageTypeThinking {
-					stopOpenBlocksAndAdvance()
-				}
-				idx := info.ClaudeConvertInfo.Index
-				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
-					Index: &idx,
-					Type:  "content_block_start",
-					ContentBlock: &dto.ClaudeMediaMessage{
-						Type:     "thinking",
-						Thinking: common.GetPointer[string](""),
-					},
-				})
-				idx2 := idx
-				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
-					Index: &idx2,
-					Type:  "content_block_delta",
-					Delta: &dto.ClaudeMediaMessage{
-						Type:     "thinking_delta",
-						Thinking: &reasoning,
-					},
-				})
-				info.ClaudeConvertInfo.LastMessagesType = relaycommon.LastMessageTypeThinking
-			} else if content != "" {
-				if info.ClaudeConvertInfo.LastMessagesType != relaycommon.LastMessageTypeText {
-					stopOpenBlocksAndAdvance()
-				}
-				idx := info.ClaudeConvertInfo.Index
-				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
-					Index: &idx,
-					Type:  "content_block_start",
-					ContentBlock: &dto.ClaudeMediaMessage{
-						Type: "text",
-						Text: common.GetPointer[string](""),
-					},
-				})
-				idx2 := idx
-				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
-					Index: &idx2,
-					Type:  "content_block_delta",
-					Delta: &dto.ClaudeMediaMessage{
-						Type: "text_delta",
-						Text: common.GetPointer[string](content),
-					},
-				})
-				info.ClaudeConvertInfo.LastMessagesType = relaycommon.LastMessageTypeText
-			}
+			emitThinkingDelta(reasoning)
+			emitTextDelta(content)
 		}
 
 		// 如果首块就带 finish_reason，需要立即发送停止块
@@ -474,9 +482,6 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 			}
 		}
 
-		var claudeResponse dto.ClaudeResponse
-		var isEmpty bool
-		claudeResponse.Type = "content_block_delta"
 		if len(chosenChoice.Delta.ToolCalls) > 0 {
 			toolCalls := chosenChoice.Delta.ToolCalls
 			if info.ClaudeConvertInfo.LastMessagesType != relaycommon.LastMessageTypeTools {
@@ -530,52 +535,8 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 		} else {
 			reasoning := chosenChoice.Delta.GetReasoningContent()
 			textContent := chosenChoice.Delta.GetContentString()
-			if reasoning != "" || textContent != "" {
-				if reasoning != "" {
-					if info.ClaudeConvertInfo.LastMessagesType != relaycommon.LastMessageTypeThinking {
-						stopOpenBlocksAndAdvance()
-						idx := info.ClaudeConvertInfo.Index
-						claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
-							Index: &idx,
-							Type:  "content_block_start",
-							ContentBlock: &dto.ClaudeMediaMessage{
-								Type:     "thinking",
-								Thinking: common.GetPointer[string](""),
-							},
-						})
-					}
-					info.ClaudeConvertInfo.LastMessagesType = relaycommon.LastMessageTypeThinking
-					claudeResponse.Delta = &dto.ClaudeMediaMessage{
-						Type:     "thinking_delta",
-						Thinking: &reasoning,
-					}
-				} else {
-					if info.ClaudeConvertInfo.LastMessagesType != relaycommon.LastMessageTypeText {
-						stopOpenBlocksAndAdvance()
-						idx := info.ClaudeConvertInfo.Index
-						claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
-							Index: &idx,
-							Type:  "content_block_start",
-							ContentBlock: &dto.ClaudeMediaMessage{
-								Type: "text",
-								Text: common.GetPointer[string](""),
-							},
-						})
-					}
-					info.ClaudeConvertInfo.LastMessagesType = relaycommon.LastMessageTypeText
-					claudeResponse.Delta = &dto.ClaudeMediaMessage{
-						Type: "text_delta",
-						Text: common.GetPointer[string](textContent),
-					}
-				}
-			} else {
-				isEmpty = true
-			}
-		}
-
-		claudeResponse.Index = common.GetPointer[int](info.ClaudeConvertInfo.Index)
-		if !isEmpty && claudeResponse.Delta != nil {
-			claudeResponses = append(claudeResponses, &claudeResponse)
+			emitThinkingDelta(reasoning)
+			emitTextDelta(textContent)
 		}
 
 		if doneChunk || info.ClaudeConvertInfo.Done {

--- a/service/convert_stream_claude_test.go
+++ b/service/convert_stream_claude_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamResponseOpenAI2ClaudeFirstChunkKeepsThinkingAndText(t *testing.T) {
+	t.Parallel()
+
+	info := &relaycommon.RelayInfo{
+		SendResponseCount: 1,
+		ClaudeConvertInfo: &relaycommon.ClaudeConvertInfo{
+			LastMessagesType: relaycommon.LastMessageTypeNone,
+		},
+	}
+	resp := &dto.ChatCompletionsStreamResponse{
+		Id:    "resp_1",
+		Model: "gemini-test",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{Index: 0},
+		},
+	}
+	resp.Choices[0].Delta.SetReasoningContent("thinking")
+	resp.Choices[0].Delta.SetContentString("answer")
+
+	out := StreamResponseOpenAI2Claude(resp, info)
+
+	require.Len(t, out, 6)
+	require.Equal(t, "message_start", out[0].Type)
+	require.Equal(t, "content_block_start", out[1].Type)
+	require.Equal(t, "thinking", out[1].ContentBlock.Type)
+	require.Equal(t, "content_block_delta", out[2].Type)
+	require.Equal(t, "thinking_delta", out[2].Delta.Type)
+	require.Equal(t, "thinking", *out[2].Delta.Thinking)
+	require.Equal(t, "content_block_stop", out[3].Type)
+	require.Equal(t, 0, *out[3].Index)
+	require.Equal(t, "content_block_start", out[4].Type)
+	require.Equal(t, "text", out[4].ContentBlock.Type)
+	require.Equal(t, "content_block_delta", out[5].Type)
+	require.Equal(t, "text_delta", out[5].Delta.Type)
+	require.Equal(t, "answer", *out[5].Delta.Text)
+}
+
+func TestStreamResponseOpenAI2ClaudeMidStreamKeepsThinkingAndText(t *testing.T) {
+	t.Parallel()
+
+	info := &relaycommon.RelayInfo{
+		SendResponseCount: 2,
+		ClaudeConvertInfo: &relaycommon.ClaudeConvertInfo{
+			LastMessagesType: relaycommon.LastMessageTypeNone,
+		},
+	}
+	resp := &dto.ChatCompletionsStreamResponse{
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{Index: 0},
+		},
+	}
+	resp.Choices[0].Delta.SetReasoningContent("thinking")
+	resp.Choices[0].Delta.SetContentString("answer")
+
+	out := StreamResponseOpenAI2Claude(resp, info)
+
+	require.Len(t, out, 5)
+	require.Equal(t, "content_block_start", out[0].Type)
+	require.Equal(t, "thinking", out[0].ContentBlock.Type)
+	require.Equal(t, "content_block_delta", out[1].Type)
+	require.Equal(t, "thinking_delta", out[1].Delta.Type)
+	require.Equal(t, "thinking", *out[1].Delta.Thinking)
+	require.Equal(t, "content_block_stop", out[2].Type)
+	require.Equal(t, 0, *out[2].Index)
+	require.Equal(t, "content_block_start", out[3].Type)
+	require.Equal(t, "text", out[3].ContentBlock.Type)
+	require.Equal(t, "content_block_delta", out[4].Type)
+	require.Equal(t, "text_delta", out[4].Delta.Type)
+	require.Equal(t, "answer", *out[4].Delta.Text)
+}


### PR DESCRIPTION
## Summary
- split Gemini `thought` parts from normal text parts when building `reasoning_content`
- allow `thinking_delta` and `text_delta` to both emit from the same OpenAI delta during Claude SSE conversion
- add regression tests for both the Gemini relay and the OpenAI -> Claude stream conversion

## Root cause
When a Gemini chunk contained both `part.Thought=true` and normal answer text, `new-api` currently mixed the two behaviors:

1. `relay/channel/gemini/relay-gemini.go` treated the whole chunk as reasoning once any thought part appeared, so final answer text could be folded into `reasoning_content`.
2. `service/convert.go` used mutually exclusive reasoning/content emission for Claude SSE, so a chunk with both fields could drop the final `text_delta`.

This change keeps reasoning and answer text separate all the way through the relay/conversion pipeline.

## Tests
- `go test ./relay/channel/gemini ./service`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Gemini integration response formatting to properly separate reasoning content from main answers
  * Improved Claude streaming response handling to correctly manage both reasoning and text content

* **Tests**
  * Added test coverage validating proper separation of reasoning and answer content in Gemini responses
  * Added test coverage validating reasoning and text handling in Claude streaming responses

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5094?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->