### PR TITLE
fix: 移除 fcIdx -1 偏移，修复并发工具调用撞键问题

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -442,10 +442,7 @@ func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.ChatCo
 	tools := make([]dto.ToolCallResponse, 0)
 	fcIdx := 0
 	if claudeResponse.Index != nil {
-		fcIdx = *claudeResponse.Index - 1
-		if fcIdx < 0 {
-			fcIdx = 0
-		}
+		fcIdx = *claudeResponse.Index
 	}
 	var choice dto.ChatCompletionsStreamResponseChoice
 	if claudeResponse.Type == "message_start" {


### PR DESCRIPTION
当 Claude 直接以多个 tool_use 块起始（无文本前导，index=0）时，
-1 偏移导致 index=0 和 index=1 同时映射到 fcIdx=0：
- index=0 的工具 args 先流完，发出一次合法调用 ✓
- index=1 的 args 追加到同一 map 槽位，污染后为非法 JSON，该工具丢失 ✗
- index=2 以后的工具各自独占唯一 fcIdx，正常发出 ✓

结果：每轮并发调用中第 2 个工具必然丢失，
模型收不到对应的工具结果后重试剩余工具，
产生雪球效应（10个→9个→8个...逐轮收缩）。

修复：直接使用 Claude 的 block index 作为 fcIdx，不做偏移。
fcIdx 仅作为本地 map 的 key，只需保证唯一性，无需从 0 开始。

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

## 🚀 变更类型 / Type of change
- [ ✅] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5018 

## ✅ 提交前检查项 / Checklist
- [ ✅] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [✅ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ✅] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ ✅] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [✅ ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [ ✅] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)

修复前（fcIdx -1 偏移，撞键）：             
  场景 2：并发工具调用（同时写两个文件）      
    模型: aws.claude-opus-4.6                 
    收到 SSE chunk 共 2 个                                                                                                                    
    其中包含 functionCall 的 chunk: 1 个                                                                                                      
    ✅ functionCall[0]: name=write_file  args={'content': 'AAA', 'path': 'a.txt'}                                                             
    ⚠️   预期 2 个并发调用，实际只收到 1 个                                                                                                    
                                                                                                                                              
修复后（直接映射，无撞键）：                                                                                                                
  场景 2：并发工具调用（同时写两个文件）                                                                                                      
    模型: aws.claude-opus-4.6                                                                                                                 
    收到 SSE chunk 共 3 个                                                                                                                    
    其中包含 functionCall 的 chunk: 2 个                                                                                                      
    ✅ functionCall[0]: name=write_file  args={'content': 'AAA', 'path': 'a.txt'}                                                             
    ✅ functionCall[1]: name=write_file  args={'content': 'BBB', 'path': 'b.txt'}                                                             
  ✅ 全部通过                                                                                                                                 
                                                                                                                                                                                                                                                       
  复现环境：                                                                                                                                  
  - 渠道：Anthropic(14) / AWS Bedrock                                                                                                         
  - 模型：aws.claude-opus-4.6（该模型倾向于直接 tool_use 起始，无文本前导）                                                                   
  - 请求：Gemini 客户端格式，并发调用 ≥ 2 个工具                                                                                              
                                                                                                                                              
  验证方法：                                                                                                                                  
  发送 streamGenerateContent 请求，要求模型同时调用两次 write_file，                                                                          
  统计收到的 functionCall 数量。                                                                                                              
  修复前：2 个并发工具调用只收到 1 个（index=1 工具丢失）。                                                                                   
  修复后：2 个均正确到达。                                                                                                                    
                                                                                                                                              



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool call indexing in streaming responses to ensure proper index assignment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5095?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->