### PR TITLE
fix(web)修复新版前端首页iframe注入url时的导航栏遮盖问题；  feat(web): 支持自定义iframe导航高度并同步主…

### DIFF
--- a/web/default/src/components/layout/components/public-header.tsx
+++ b/web/default/src/components/layout/components/public-header.tsx
@@ -63,6 +63,7 @@ export interface PublicHeaderProps {
   showNavigation?: boolean
   showAuthButtons?: boolean
   showNotifications?: boolean
+  navHeight?: string | null
   className?: string
 }
 
@@ -76,6 +77,7 @@ export function PublicHeader(props: PublicHeaderProps) {
     homeUrl = '/',
     showAuthButtons = true,
     showNotifications = true,
+    navHeight,
   } = props
 
   const { t } = useTranslation()
@@ -184,16 +186,17 @@ export function PublicHeader(props: PublicHeaderProps) {
         <div
           className={cn(
             'pointer-events-auto mx-auto transition-all duration-700 ease-[cubic-bezier(0.16,1,0.3,1)]',
-            scrolled ? 'max-w-[52rem] px-3 pt-3' : 'max-w-7xl px-4 pt-0 md:px-6'
+            scrolled ? 'max-w-[52rem] px-3 pt-3' : 'max-w-full px-0 pt-0'
           )}
         >
           <nav
             className={cn(
               'flex items-center justify-between transition-all duration-700 ease-[cubic-bezier(0.16,1,0.3,1)]',
               scrolled
-                ? 'bg-background/60 ring-border/50 h-12 rounded-2xl pr-1.5 pl-4 shadow-[0_2px_16px_-6px_rgba(0,0,0,0.08),0_0_0_0.5px_rgba(0,0,0,0.02)] ring-[0.5px] backdrop-blur-2xl dark:shadow-[0_2px_16px_-6px_rgba(0,0,0,0.4)]'
-                : 'h-16 px-2'
+                ? 'bg-background ring-border/50 h-12 rounded-2xl pr-1.5 pl-4 shadow-[0_2px_16px_-6px_rgba(0,0,0,0.08),0_0_0_0.5px_rgba(0,0,0,0.02)] ring-[0.5px] dark:shadow-[0_2px_16px_-6px_rgba(0,0,0,0.4)]'
+                : 'bg-background ring-border/40 h-16 px-4 shadow-[0_2px_16px_-6px_rgba(0,0,0,0.06),0_0_0_0.5px_rgba(0,0,0,0.02)] ring-[0.5px] dark:shadow-[0_2px_16px_-6px_rgba(0,0,0,0.35)] md:px-8'
             )}
+            style={!scrolled && navHeight ? { height: navHeight } : undefined}
           >
             {/* Logo */}
             <Link
@@ -214,7 +217,7 @@ export function PublicHeader(props: PublicHeaderProps) {
                   />
                 )}
               </div>
-              <span className='text-sm font-semibold tracking-tight'>
+              <span className='text-sm font-semibold tracking-tight sm:text-base'>
                 {loading ? <Skeleton className='h-4 w-16' /> : displaySiteName}
               </span>
             </Link>
@@ -234,7 +237,7 @@ export function PublicHeader(props: PublicHeaderProps) {
                       tabIndex={link.disabled ? -1 : undefined}
                       onClick={(event) => handleNavLinkClick(event, link)}
                       className={cn(
-                        'text-muted-foreground hover:text-foreground rounded-lg px-3 py-1.5 text-[13px] font-medium transition-colors duration-200',
+                        'text-muted-foreground hover:text-foreground rounded-lg px-3 py-1.5 text-[15px] font-medium transition-colors duration-200',
                         link.disabled && 'pointer-events-none opacity-50'
                       )}
                     >
@@ -249,7 +252,7 @@ export function PublicHeader(props: PublicHeaderProps) {
                     disabled={link.disabled}
                     onClick={(event) => handleNavLinkClick(event, link)}
                     className={cn(
-                      'rounded-lg px-3 py-1.5 text-[13px] font-medium transition-colors duration-200',
+                      'rounded-lg px-3 py-1.5 text-[15px] font-medium transition-colors duration-200',
                       isActive
                         ? 'text-foreground'
                         : 'text-muted-foreground hover:text-foreground',
@@ -292,7 +295,7 @@ export function PublicHeader(props: PublicHeaderProps) {
                   ) : (
                     <Button
                       size='sm'
-                      className='h-8 rounded-lg px-3.5 text-xs font-medium'
+                      className='h-8 rounded-lg px-3.5 text-sm font-medium'
                       render={<Link to='/sign-in' />}
                     >
                       {t('Sign in')}

--- a/web/default/src/components/layout/components/public-layout.tsx
+++ b/web/default/src/components/layout/components/public-layout.tsx
@@ -22,6 +22,7 @@ import { PublicHeader, type PublicHeaderProps } from './public-header'
 type PublicLayoutProps = {
   children: React.ReactNode
   showMainContainer?: boolean
+  navHeight?: string | null
   navContent?: React.ReactNode
   headerProps?: Omit<PublicHeaderProps, 'navContent'>
   navLinks?: TopNavLink[]
@@ -41,6 +42,7 @@ export function PublicLayout(props: PublicLayoutProps) {
         showThemeSwitch={props.showThemeSwitch}
         showAuthButtons={props.showAuthButtons}
         showNotifications={props.showNotifications}
+        navHeight={props.navHeight}
         logo={props.logo}
         siteName={props.siteName}
         {...props.headerProps}

--- a/web/default/src/features/about/index.tsx
+++ b/web/default/src/features/about/index.tsx
@@ -156,8 +156,16 @@ export function About() {
   }
 
   if (isUrl) {
+    let iframeNavHeight: string | null = null
+    try {
+      const url = new URL(rawContent)
+      iframeNavHeight = url.searchParams.get('navHeight')
+    } catch {
+      // ignore
+    }
+
     return (
-      <PublicLayout showMainContainer={false}>
+      <PublicLayout showMainContainer={false} navHeight={iframeNavHeight}>
         <iframe
           src={rawContent}
           className='h-[calc(100vh-3.5rem)] w-full border-0'

--- a/web/default/src/features/home/index.tsx
+++ b/web/default/src/features/home/index.tsx
@@ -16,8 +16,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAuthStore } from '@/stores/auth-store'
+import { useTheme } from '@/context/theme-provider'
 import { Markdown } from '@/components/ui/markdown'
 import { PublicLayout } from '@/components/layout'
 import { Footer } from '@/components/layout/components/footer'
@@ -25,10 +27,40 @@ import { CTA, Features, Hero, HowItWorks, Stats } from './components'
 import { useHomePageContent } from './hooks'
 
 export function Home() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { auth } = useAuthStore()
+  const { resolvedTheme } = useTheme()
   const isAuthenticated = !!auth.user
   const { content, isLoaded, isUrl } = useHomePageContent()
+
+  let iframeNavHeight: string | null = null
+  if (isUrl && content) {
+    try {
+      const url = new URL(content)
+      iframeNavHeight = url.searchParams.get('navHeight')
+    } catch {
+      // ignore
+    }
+  }
+
+  const handleIframeLoad = (e: React.SyntheticEvent<HTMLIFrameElement>) => {
+    const iframe = e.currentTarget
+    if (iframe && iframe.contentWindow) {
+      iframe.contentWindow.postMessage({ themeMode: resolvedTheme }, '*')
+      iframe.contentWindow.postMessage({ lang: i18n.language }, '*')
+    }
+  }
+
+  // Handle theme or language changes for the already loaded iframe
+  useEffect(() => {
+    if (isUrl && content) {
+      const iframe = document.querySelector('iframe')
+      if (iframe && iframe.contentWindow) {
+        iframe.contentWindow.postMessage({ themeMode: resolvedTheme }, '*')
+        iframe.contentWindow.postMessage({ lang: i18n.language }, '*')
+      }
+    }
+  }, [resolvedTheme, i18n.language, isUrl, content])
 
   if (!isLoaded) {
     return (
@@ -42,16 +74,19 @@ export function Home() {
 
   if (content) {
     return (
-      <PublicLayout showMainContainer={false}>
-        <main className='overflow-x-hidden'>
+      <PublicLayout showMainContainer={false} navHeight={iframeNavHeight}>
+        <main className='relative overflow-x-hidden'>
           {isUrl ? (
-            <iframe
-              src={content}
-              className='h-screen w-full border-none'
-              title={t('Custom Home Page')}
-            />
+            <div className='h-screen w-full'>
+              <iframe
+                src={content}
+                className='block h-full w-full border-none'
+                title={t('Custom Home Page')}
+                onLoad={handleIframeLoad}
+              />
+            </div>
           ) : (
-            <div className='container mx-auto py-8'>
+            <div className='container mx-auto py-8 pt-24'>
               <Markdown className='custom-home-content'>{content}</Markdown>
             </div>
           )}


### PR DESCRIPTION
…题与语言

- 从iframe目标URL的搜索参数提取navHeight动态调整头部高度
- 为iframe添加加载及状态变更时同步主题模式和界面语言的功能
- 优化公共页面头部的样式，调整内边距、文字大小与阴影效果
- 优化主页自定义内容的容器布局与iframe包裹样式

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 修复新版前端首页iframe注入url时的导航栏遮盖问题、添加iframe注入URL通过?navHeight=48px来调整导航栏高度

## 📝 变更描述 / Description
做了什么： 支持通过 iframe 注入 URL 的查询参数 navHeight 来动态控制顶部导航栏高度。

为什么这样改能生效：

1. 数据源 ：管理员在首页/关于页配置 iframe URL 时（如 https://example.com?navHeight=48px ），Home 和 About 组件在渲染前先用 new URL() 解析该字符串，从中提取 navHeight 参数值。
2. 数据传递 ：提取到的值通过 PublicLayout 的新 navHeight prop 透传至 PublicHeader ，形成 Home/About → PublicLayout → PublicHeader 的单向数据流，无需引入 Context。
3. 样式覆盖 ： PublicHeader 内部在未滚动状态下，如果 navHeight 有值，则通过 inline style { height: navHeight } 覆盖 Tailwind 的 h-16 默认高度；滚动后仍保持 h-12 不受影响。
4. 兼容性 ：不带 navHeight 参数的 iframe URL 或普通内容不受影响，导航栏维持原有行为。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizable navigation height across pages.
  * Improved embedded content integration with automatic theme and language synchronization.

* **Style**
  * Increased text sizing in navigation elements for better readability.
  * Refined header layout and visual hierarchy with updated spacing and styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->