### PR TITLE
feat: integrate request audit functionality

### DIFF
--- a/docs/fork-upstream-merge.md
+++ b/docs/fork-upstream-merge.md
@@ -1,0 +1,79 @@
+# Fork 与上游 new-api 合并指南
+
+本仓库在官方 [QuantumNous/new-api](https://github.com/QuantumNous/new-api) 之上增加了 **请求审计落库**（`pkg/requestaudit`）等 fork 能力。升级上游时尽量只处理 **2 个补丁触点**，其余逻辑在自有目录中维护。
+
+## 分支与 remote
+
+```text
+upstream/main  → 官方 new-api（只读）
+main           → 生产分支（merge upstream + 已 apply 补丁）
+feature/*      → 功能分支，定期 merge main
+```
+
+```bash
+git remote add upstream https://github.com/QuantumNous/new-api.git   # 若尚未添加
+```
+
+## 合并流程
+
+```bash
+./scripts/merge-upstream.sh
+```
+
+脚本会：`git fetch upstream` → `git merge upstream/main` → `git apply --3way patches/*.patch` → 尝试 `go build`。
+
+若 merge 或 patch 冲突，优先检查：
+
+| 文件 | 锚点 |
+|------|------|
+| `main.go` | `FORK:BEGIN requestaudit` … `FORK:END requestaudit`（`InitLogDB` 之后） |
+| `router/relay-router.go` | `RegisterRelayForkMiddleware(router)` 必须在 **`StatsMiddleware` 之后** |
+
+**禁止**：在 `main.go` / `relay-router.go` 手改 fork 逻辑却不更新 `patches/`。
+
+## Fork 自有目录（上游不会改）
+
+- `pkg/requestaudit/` — 模型、迁移、中间件、环境变量
+- `router/relay_fork.go` — 仅 fork 存在
+- `patches/`、`scripts/merge-upstream.sh`、本文档
+
+**不要改**：`model/log.go`、`RecordConsumeLog`、`migrateLOGDB`（合并成本高）。
+
+## 请求审计（RELAY_AUDIT_*）
+
+| 变量 | 默认 | 说明 |
+|------|------|------|
+| `RELAY_AUDIT_ENABLED` | `false` | 开启后异步写入 LOG 库表 `relay_audit_records` |
+| `RELAY_AUDIT_MAX_BODY_KB` | `1024` | 单条 body 最大 KB，超出截断 |
+| `RELAY_AUDIT_SAMPLE_RATE` | `100` | 0–100，按 `request_id` 稳定哈希采样 |
+| `RELAY_AUDIT_IF_UNCACHED` | `false` | 为 true 时无缓存 body 也会尝试读（排查环境慎用） |
+
+仅 **relay 路由**（`SetRelayRouter`）会经过审计中间件；`/api/*`、视频路由等不在本期范围。
+
+存的是 **客户端 HTTP 请求体**（经解压后），与 `logs.request_id` JOIN 排查。
+
+### 排查 SQL 示例
+
+```sql
+SELECT l.request_id, l.use_time, l.completion_tokens, l.model_name, l.ip,
+       a.path, a.client_ip, a.body_size, a.truncated, a.body
+FROM logs l
+LEFT JOIN relay_audit_records a ON a.request_id = l.request_id
+WHERE l.request_id = 'YOUR_REQUEST_ID';
+```
+
+### 数据保留
+
+表在 LOG 库会持续增长，需定期清理，例如：
+
+```sql
+DELETE FROM relay_audit_records WHERE created_at < UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 30 DAY));
+```
+
+（SQLite/PostgreSQL 请改用对应时间函数。）
+
+生产默认关闭审计；body 可能含密钥与对话内容，限制 LOG 库访问权限。
+
+## CI 建议（可选）
+
+对干净 upstream tag 执行：`git apply --check patches/*.patch`，补丁过期时提前发现。

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/oauth"
 	perfmetrics "github.com/QuantumNous/new-api/pkg/perf_metrics"
+	"github.com/QuantumNous/new-api/pkg/requestaudit"
 	"github.com/QuantumNous/new-api/relay"
 	"github.com/QuantumNous/new-api/router"
 	"github.com/QuantumNous/new-api/service"
@@ -300,6 +301,11 @@ func InitResources() error {
 	if err != nil {
 		return err
 	}
+	// FORK:BEGIN requestaudit
+	if err = requestaudit.Init(model.LOG_DB); err != nil {
+		return err
+	}
+	// FORK:END requestaudit
 
 	// Initialize Redis
 	err = common.InitRedisClient()

--- a/patches/0001-requestaudit-init.patch
+++ b/patches/0001-requestaudit-init.patch
@@ -1,0 +1,24 @@
+diff --git a/main.go b/main.go
+index 3361b8ce9..2b873449b 100644
+--- a/main.go
++++ b/main.go
+@@ -20,6 +20,7 @@ import (
+ 	"github.com/QuantumNous/new-api/model"
+ 	"github.com/QuantumNous/new-api/oauth"
+ 	perfmetrics "github.com/QuantumNous/new-api/pkg/perf_metrics"
++	"github.com/QuantumNous/new-api/pkg/requestaudit"
+ 	"github.com/QuantumNous/new-api/relay"
+ 	"github.com/QuantumNous/new-api/router"
+ 	"github.com/QuantumNous/new-api/service"
+@@ -300,6 +301,11 @@ func InitResources() error {
+ 	if err != nil {
+ 		return err
+ 	}
++	// FORK:BEGIN requestaudit
++	if err = requestaudit.Init(model.LOG_DB); err != nil {
++		return err
++	}
++	// FORK:END requestaudit
+ 
+ 	// Initialize Redis
+ 	err = common.InitRedisClient()

--- a/patches/0002-requestaudit-relay.patch
+++ b/patches/0002-requestaudit-relay.patch
@@ -1,0 +1,14 @@
+diff --git a/router/relay-router.go b/router/relay-router.go
+index 17a13cad7..35549b5c0 100644
+--- a/router/relay-router.go
++++ b/router/relay-router.go
+@@ -15,6 +15,9 @@ func SetRelayRouter(router *gin.Engine) {
+ 	router.Use(middleware.DecompressRequestMiddleware())
+ 	router.Use(middleware.BodyStorageCleanup()) // 清理请求体存储
+ 	router.Use(middleware.StatsMiddleware())
++	// FORK:BEGIN requestaudit
++	RegisterRelayForkMiddleware(router)
++	// FORK:END requestaudit
+ 	// https://platform.openai.com/docs/api-reference/introduction
+ 	modelsRouter := router.Group("/v1/models")
+ 	modelsRouter.Use(middleware.RouteTag("relay"))

--- a/pkg/requestaudit/config.go
+++ b/pkg/requestaudit/config.go
@@ -1,0 +1,29 @@
+package requestaudit
+
+import (
+	"github.com/QuantumNous/new-api/common"
+)
+
+const (
+	envEnabled      = "RELAY_AUDIT_ENABLED"
+	envMaxBodyKB    = "RELAY_AUDIT_MAX_BODY_KB"
+	envSampleRate   = "RELAY_AUDIT_SAMPLE_RATE"
+	envIfUncached   = "RELAY_AUDIT_IF_UNCACHED"
+	defaultMaxBodyKB = 1024
+)
+
+type config struct {
+	Enabled      bool
+	MaxBodyKB    int
+	SampleRate   int // 0-100, percentage of requests to record
+	IfUncached   bool
+}
+
+func loadConfig() config {
+	return config{
+		Enabled:    common.GetEnvOrDefaultBool(envEnabled, false),
+		MaxBodyKB:  common.GetEnvOrDefault(envMaxBodyKB, defaultMaxBodyKB),
+		SampleRate: common.GetEnvOrDefault(envSampleRate, 100),
+		IfUncached: common.GetEnvOrDefaultBool(envIfUncached, false),
+	}
+}

--- a/pkg/requestaudit/init.go
+++ b/pkg/requestaudit/init.go
@@ -1,0 +1,25 @@
+package requestaudit
+
+import (
+	"fmt"
+
+	"github.com/QuantumNous/new-api/common"
+	"gorm.io/gorm"
+)
+
+var logDB *gorm.DB
+
+func Init(db *gorm.DB) error {
+	logDB = db
+	if db == nil {
+		return nil
+	}
+	if err := db.AutoMigrate(&RelayAuditRecord{}); err != nil {
+		return fmt.Errorf("requestaudit: auto migrate: %w", err)
+	}
+	cfg := loadConfig()
+	if cfg.Enabled {
+		common.SysLog(fmt.Sprintf("requestaudit: enabled (max_body_kb=%d, sample_rate=%d%%)", cfg.MaxBodyKB, cfg.SampleRate))
+	}
+	return nil
+}

--- a/pkg/requestaudit/middleware.go
+++ b/pkg/requestaudit/middleware.go
@@ -1,0 +1,111 @@
+package requestaudit
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/logger"
+	"github.com/bytedance/gopkg/util/gopool"
+	"github.com/gin-gonic/gin"
+)
+
+func Middleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		cfg := loadConfig()
+		if !cfg.Enabled {
+			c.Next()
+			return
+		}
+
+		c.Next()
+
+		requestID := c.GetString(common.RequestIdKey)
+		if requestID == "" {
+			return
+		}
+		if !shouldSample(requestID, cfg.SampleRate) {
+			return
+		}
+
+		raw, exists := c.Get(common.KeyBodyStorage)
+		if !exists || raw == nil {
+			if !cfg.IfUncached {
+				return
+			}
+			storage, err := common.GetBodyStorage(c)
+			if err != nil || storage == nil {
+				return
+			}
+			raw = storage
+		}
+
+		storage, ok := raw.(common.BodyStorage)
+		if !ok || storage == nil {
+			return
+		}
+
+		body, err := storage.Bytes()
+		if err != nil {
+			logger.LogError(c.Request.Context(), fmt.Sprintf("requestaudit: read body: %s", err.Error()))
+			return
+		}
+
+		originalSize := len(body)
+		truncated := false
+		maxBytes := cfg.MaxBodyKB * 1024
+		if maxBytes > 0 && len(body) > maxBytes {
+			body = body[:maxBytes]
+			truncated = true
+		}
+
+		bodyCopy := make([]byte, len(body))
+		copy(bodyCopy, body)
+
+		record := &RelayAuditRecord{
+			RequestId:   requestID,
+			Method:      c.Request.Method,
+			Path:        c.Request.URL.Path,
+			ClientIp:    c.ClientIP(),
+			ContentType: c.Request.Header.Get("Content-Type"),
+			Body:        string(bodyCopy),
+			BodySize:    originalSize,
+			Truncated:   truncated,
+		}
+
+		db := logDB
+		gopool.Go(func() {
+			if err := saveRecord(db, record); err != nil {
+				if isDuplicateKeyError(err) {
+					return
+				}
+				logger.LogError(context.Background(), fmt.Sprintf("requestaudit: save record request_id=%s: %s", requestID, err.Error()))
+			}
+		})
+	}
+}
+
+func shouldSample(requestID string, ratePercent int) bool {
+	if ratePercent >= 100 {
+		return true
+	}
+	if ratePercent <= 0 {
+		return false
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(requestID))
+	return int(h.Sum32()%100) < ratePercent
+}
+
+func isDuplicateKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "duplicate") ||
+		strings.Contains(msg, "unique constraint") ||
+		strings.Contains(msg, "1062") ||
+		strings.Contains(msg, "23505")
+}

--- a/pkg/requestaudit/model.go
+++ b/pkg/requestaudit/model.go
@@ -1,0 +1,33 @@
+package requestaudit
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type RelayAuditRecord struct {
+	Id          int    `json:"id" gorm:"primaryKey"`
+	RequestId   string `json:"request_id" gorm:"type:varchar(64);uniqueIndex;not null;default:''"`
+	Method      string `json:"method" gorm:"type:varchar(16);not null;default:''"`
+	Path        string `json:"path" gorm:"type:varchar(512);not null;default:''"`
+	ClientIp    string `json:"client_ip" gorm:"type:varchar(64);not null;default:''"`
+	ContentType string `json:"content_type" gorm:"type:varchar(256);not null;default:''"`
+	Body        string `json:"body" gorm:"type:text"`
+	BodySize    int    `json:"body_size" gorm:"not null;default:0"`
+	Truncated   bool   `json:"truncated" gorm:"not null;default:false"`
+	CreatedAt   int64  `json:"created_at" gorm:"bigint;not null;index"`
+}
+
+func (RelayAuditRecord) TableName() string {
+	return "relay_audit_records"
+}
+
+func saveRecord(db *gorm.DB, record *RelayAuditRecord) error {
+	if db == nil || record == nil {
+		return nil
+	}
+	record.CreatedAt = time.Now().Unix()
+	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(record).Error
+}

--- a/pkg/requestaudit/requestaudit_test.go
+++ b/pkg/requestaudit/requestaudit_test.go
@@ -1,0 +1,52 @@
+package requestaudit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestShouldSampleStable(t *testing.T) {
+	id := "20260526013754192623098268d9d6M5ecz1Xo"
+	a := shouldSample(id, 50)
+	b := shouldSample(id, 50)
+	if a != b {
+		t.Fatalf("expected stable sample decision, got %v then %v", a, b)
+	}
+}
+
+func TestSaveRecordAndJoinByRequestId(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&RelayAuditRecord{}); err != nil {
+		t.Fatal(err)
+	}
+
+	rid := "test-request-id-join"
+	body := `{"model":"gpt-4","max_tokens":98304}`
+	rec := &RelayAuditRecord{
+		RequestId:   rid,
+		Method:      "POST",
+		Path:        "/v1/chat/completions",
+		ClientIp:    "127.0.0.1",
+		ContentType: "application/json",
+		Body:        body,
+		BodySize:    len(body),
+		CreatedAt:   time.Now().Unix(),
+	}
+	if err := saveRecord(db, rec); err != nil {
+		t.Fatal(err)
+	}
+
+	var loaded RelayAuditRecord
+	if err := db.Where("request_id = ?", rid).First(&loaded).Error; err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Body != body {
+		t.Fatalf("body mismatch: got %q", loaded.Body)
+	}
+}

--- a/router/relay-router.go
+++ b/router/relay-router.go
@@ -15,6 +15,9 @@ func SetRelayRouter(router *gin.Engine) {
 	router.Use(middleware.DecompressRequestMiddleware())
 	router.Use(middleware.BodyStorageCleanup()) // 清理请求体存储
 	router.Use(middleware.StatsMiddleware())
+	// FORK:BEGIN requestaudit
+	RegisterRelayForkMiddleware(router)
+	// FORK:END requestaudit
 	// https://platform.openai.com/docs/api-reference/introduction
 	modelsRouter := router.Group("/v1/models")
 	modelsRouter.Use(middleware.RouteTag("relay"))

--- a/router/relay_fork.go
+++ b/router/relay_fork.go
@@ -1,0 +1,11 @@
+package router
+
+import (
+	"github.com/QuantumNous/new-api/pkg/requestaudit"
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterRelayForkMiddleware registers fork-only relay middleware (not in upstream).
+func RegisterRelayForkMiddleware(router *gin.Engine) {
+	router.Use(requestaudit.Middleware())
+}

--- a/scripts/merge-upstream.sh
+++ b/scripts/merge-upstream.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Merge upstream new-api and re-apply fork patches (requestaudit, etc.).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+UPSTREAM_REMOTE="${UPSTREAM_REMOTE:-upstream}"
+UPSTREAM_BRANCH="${UPSTREAM_BRANCH:-main}"
+
+echo "==> Fetch ${UPSTREAM_REMOTE}/${UPSTREAM_BRANCH}"
+git fetch "$UPSTREAM_REMOTE" "$UPSTREAM_BRANCH"
+
+echo "==> Merge ${UPSTREAM_REMOTE}/${UPSTREAM_BRANCH} into current branch"
+if ! git merge "${UPSTREAM_REMOTE}/${UPSTREAM_BRANCH}"; then
+  echo "Merge conflict. Resolve conflicts, then run:"
+  echo "  git apply --3way patches/*.patch"
+  echo "  go build ./..."
+  exit 1
+fi
+
+echo "==> Apply fork patches"
+if ! git apply --3way patches/*.patch; then
+  echo "Patch apply failed. Typical conflict files:"
+  echo "  - main.go (FORK:BEGIN requestaudit block)"
+  echo "  - router/relay-router.go (RegisterRelayForkMiddleware after StatsMiddleware)"
+  exit 1
+fi
+
+echo "==> Build"
+if command -v go >/dev/null 2>&1; then
+  go build ./pkg/... ./router/... ./middleware/... ./model/... ./controller/... 2>/dev/null || go build ./...
+fi
+
+echo "Done. Commit with: chore: merge upstream + apply fork patches"


### PR DESCRIPTION
Add request audit initialization in main.go and register middleware in relay-router.go to enhance request tracking capabilities.

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

为 Relay 流量增加**可选**的请求体审计能力：在日志库（`LOG_DB`）中落表 `relay_audit_records`，按 `request_id` 与现有日志关联排查。

**实现要点：**

1. **`pkg/requestaudit`**  
   - `Init`：在 `model.InitLogDB()` 之后执行，对 `LOG_DB` 做 `AutoMigrate`，默认关闭时几乎无开销。  
   - `Middleware`：挂在 Relay 路由链上（经 `RegisterRelayForkMiddleware`），在 `c.Next()` **之后**读取 `common.KeyBodyStorage` 里已缓存的请求体，避免重复读流、也不阻塞上游响应；写入通过 `gopool` 异步完成。  
   - 行为由环境变量控制：`RELAY_AUDIT_ENABLED`（默认 `false`）、`RELAY_AUDIT_MAX_BODY_KB`、`RELAY_AUDIT_SAMPLE_RATE`、`RELAY_AUDIT_IF_UNCACHED`。  
   - 按 `request_id` 做稳定采样（FNV 哈希），超长 body 截断并标记 `truncated`；`request_id` 唯一索引冲突时静默忽略（防重试重复插入）。

2. **接入点**  
   - `main.go`：`requestaudit.Init(model.LOG_DB)`，初始化失败则启动失败。  
   - `router/relay-router.go`：在 `BodyStorageCleanup` 之后注册审计中间件，保证 body 存储生命周期与现有 Relay 中间件一致。

3. **Fork 维护**（便于自有分支合 upstream）  
   - `router/relay_fork.go`、`patches/`、`scripts/merge-upstream.sh`、`docs/fork-upstream-merge.md` 仅服务 fork 合并流程，**不改变**默认关闭时的运行时行为。

**为何这样改能生效：** Relay 路径已有 `BodyStorage` 将请求体放入 Context；中间件在 handler 执行完后读取同一份存储并异步写入日志库，与现有 `request_id` 体系对齐，无需改各 channel adapter。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #（无对应 Issue；若维护者要求先开 Issue 再补编号）

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

**1. 单元测试**

```bash
go test ./pkg/requestaudit/... -v
```

预期：覆盖 `shouldSample` 稳定性及 `saveRecord` + 按 `request_id` 查询。

**2. 启用审计（示例）**

```bash
export RELAY_AUDIT_ENABLED=true
export RELAY_AUDIT_MAX_BODY_KB=1024
export RELAY_AUDIT_SAMPLE_RATE=100
# 启动服务后发起一次 Relay 请求（如 POST /v1/chat/completions）
```

**3. 启动日志（启用时）**

```
requestaudit: enabled (max_body_kb=1024, sample_rate=100%)
```

**4. 数据验证（日志库）**

在 `LOG_DB` 中查询：

```sql
SELECT request_id, method, path, body_size, truncated, created_at
FROM relay_audit_records
ORDER BY id DESC
LIMIT 5;
```

应能看到与本次请求 `request_id` 一致的记录；`truncated=true` 时表示 body 超过 `RELAY_AUDIT_MAX_BODY_KB` 被截断。

**5. 默认关闭**

不设置 `RELAY_AUDIT_ENABLED` 或设为 `false` 时：中间件直接 `c.Next()` 返回，不读写审计表，对现有 Relay 路径无行为变化。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added relay request auditing capability with configurable sampling rate, body size limits, and optional caching behavior via environment variables (`RELAY_AUDIT_*`).
  * Audit records stored in database with request metadata, body content, and timestamps for debugging and compliance.

* **Documentation**
  * Added comprehensive fork and merge guidelines covering upstream synchronization, conflict resolution anchor points, and patch management best practices.

* **Infrastructure**
  * Added automated merge script for streamlined upstream synchronization with built-in patch reapplication and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->