### PR TITLE
perf: order admin logs by created_at to use composite index

### DIFF
--- a/model/log.go
+++ b/model/log.go
@@ -339,7 +339,7 @@ func GetAllLogs(logType int, startTimestamp int64, endTimestamp int64, modelName
 	if err != nil {
 		return nil, 0, err
 	}
-	err = tx.Order("logs.id desc").Limit(num).Offset(startIdx).Find(&logs).Error
+	err = tx.Order("logs.created_at desc, logs.id desc").Limit(num).Offset(startIdx).Find(&logs).Error
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
优化跨时间段按模型查询时执行效率
100w数据量下, 查询模型`gemini-2.5-pro`7天内数据
优化前,需要187s
[187335.418ms] [rows:1] SELECT * FROM `logs` WHERE logs.model_name like 'gemini-2.5-pro' AND logs.created_at >= 1779206400 AND logs.created_at <= 1779811199 ORDER BY logs.id desc LIMIT 10
优化后, 只需要75ms
[75.417ms] [rows:0] SELECT * FROM `logs` WHERE logs.model_name like 'gemini-2.5.pro' AND logs.created_at >= 1779206400 AND logs.created_at <= 1779811199 ORDER BY logs.created_at desc, logs.id desc LIMIT 100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log list sorting to display logs in chronological order by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->