### PR TITLE
fix(web/default): hide sign-up link when password registration disabled

### DIFF
--- a/web/default/src/features/auth/sign-in/index.tsx
+++ b/web/default/src/features/auth/sign-in/index.tsx
@@ -36,7 +36,8 @@ export function SignIn() {
             {t('Sign in')}
           </h2>
           {!status?.self_use_mode_enabled &&
-            status?.register_enabled !== false && (
+            status?.register_enabled !== false &&
+            status?.password_register_enabled !== false && (
               <p className='text-muted-foreground text-left text-sm sm:text-base'>
                 {t("Don't have an account?")}{' '}
                 <Link


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
关闭密码注册后
在登录框上面还会显示注册链接

## 📝 变更描述 / Description
判断如果当前设置是关闭密码注册的, 则隐藏注册链接

## 📸 运行证明 / Proof of Work

后台设置:
<img width="1001" height="307" alt="image" src="https://github.com/user-attachments/assets/89eb0c6f-03ce-4576-8d80-e975933dc3e3" />

修改前:
<img width="533" height="228" alt="image" src="https://github.com/user-attachments/assets/d11004bf-de8b-41f2-8d14-ea5ffd64da39" />

修改后:
<img width="491" height="176" alt="image" src="https://github.com/user-attachments/assets/f688d69c-83af-4fba-954c-cd9c0f0e9a09" />
