### PR TITLE
feat(relay): add timeout controls for streaming and non-streaming relay  requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,10 @@
 # 对话超时设置
 # 所有请求超时时间，单位秒，默认为0，表示不限制
 # RELAY_TIMEOUT=0
+# 流式请求等待上游响应头超时时间，单位秒；默认为0，表示不限制
+# RELAY_RESPONSE_HEADER_TIMEOUT=0
+# 非流式请求总超时时间，单位秒；默认为-1，表示沿用 RELAY_TIMEOUT；大于0时不会超过 RELAY_TIMEOUT
+# RELAY_NON_STREAM_TIMEOUT=-1
 # 流模式无响应超时时间，单位秒，如果出现空补全可以尝试改为更大值
 # STREAMING_TIMEOUT=300
 

--- a/common/constants.go
+++ b/common/constants.go
@@ -168,7 +168,9 @@ var SyncFrequency int // unit is second
 var BatchUpdateEnabled = false
 var BatchUpdateInterval int
 
-var RelayTimeout int // unit is second
+var RelayTimeout int               // unit is second
+var RelayResponseHeaderTimeout int // unit is second
+var RelayNonStreamTimeout int      // unit is second
 
 var RelayMaxIdleConns int
 var RelayMaxIdleConnsPerHost int

--- a/common/init.go
+++ b/common/init.go
@@ -102,6 +102,8 @@ func InitEnv() {
 	SyncFrequency = GetEnvOrDefault("SYNC_FREQUENCY", 60)
 	BatchUpdateInterval = GetEnvOrDefault("BATCH_UPDATE_INTERVAL", 5)
 	RelayTimeout = GetEnvOrDefault("RELAY_TIMEOUT", 0)
+	RelayResponseHeaderTimeout = GetEnvOrDefault("RELAY_RESPONSE_HEADER_TIMEOUT", 0)
+	RelayNonStreamTimeout = GetEnvOrDefault("RELAY_NON_STREAM_TIMEOUT", -1)
 	RelayMaxIdleConns = GetEnvOrDefault("RELAY_MAX_IDLE_CONNS", 500)
 	RelayMaxIdleConnsPerHost = GetEnvOrDefault("RELAY_MAX_IDLE_CONNS_PER_HOST", 100)
 

--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptrace"
 	"regexp"
 	"strings"
 	"sync"
@@ -310,7 +311,7 @@ func DoApiRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody
 		return nil, fmt.Errorf("get request url failed: %w", err)
 	}
 	logger.LogDebug(c, "fullRequestURL: %s", fullRequestURL)
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
@@ -340,7 +341,7 @@ func DoFormRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBod
 		return nil, fmt.Errorf("get request url failed: %w", err)
 	}
 	logger.LogDebug(c, "fullRequestURL: %s", fullRequestURL)
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
@@ -488,12 +489,12 @@ func doRequest(c *gin.Context, req *http.Request, info *common.RelayInfo) (*http
 	var client *http.Client
 	var err error
 	if info.ChannelSetting.Proxy != "" {
-		client, err = service.NewProxyHttpClient(info.ChannelSetting.Proxy)
+		client, err = service.NewProxyHttpClientForRelay(info.ChannelSetting.Proxy, info.IsStream)
 		if err != nil {
 			return nil, fmt.Errorf("new proxy http client failed: %w", err)
 		}
 	} else {
-		client = service.GetHttpClient()
+		client = service.GetHttpClientForRelay(info.IsStream)
 	}
 
 	var stopPinger context.CancelFunc
@@ -514,22 +515,232 @@ func doRequest(c *gin.Context, req *http.Request, info *common.RelayInfo) (*http
 		}
 	}
 
+	reqCtx, cancel := service.WithRelayRequestTimeout(c.Request.Context(), info.IsStream)
+	req = req.WithContext(reqCtx)
+	firstResponseTimeout := newFirstResponseTimeoutControl(req, info)
+	if firstResponseTimeout != nil {
+		req = firstResponseTimeout.request
+	}
+	closeRequestBodies := func() {
+		if req != nil && req.Body != nil {
+			_ = req.Body.Close()
+		}
+		if c != nil && c.Request != nil && c.Request.Body != nil {
+			_ = c.Request.Body.Close()
+		}
+	}
+
+	if firstResponseTimeout != nil {
+		firstResponseTimeout.Start()
+	}
 	resp, err := client.Do(req)
+	doReturn := time.Now()
+	if firstResponseTimeout != nil {
+		firstResponseTimeout.CompleteAt(doReturn)
+	}
 	if err != nil {
+		firstResponseTimedOut := isFirstResponseTimeout(firstResponseTimeout, reqCtx, c)
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		closeRequestBodies()
+		if firstResponseTimeout != nil {
+			firstResponseTimeout.Cancel()
+		}
+		cancel()
+		if firstResponseTimedOut {
+			logger.LogError(c, "do request failed: response header timeout: "+err.Error())
+			return nil, types.NewError(
+				err,
+				types.ErrorCodeDoRequestFailed,
+				types.ErrOptionWithHideErrMsg("upstream error: response header timeout"),
+			)
+		}
+		if isResponseHeaderTimeout(err) {
+			logger.LogError(c, "do request failed: response header timeout: "+err.Error())
+			return nil, types.NewError(
+				err,
+				types.ErrorCodeDoRequestFailed,
+				types.ErrOptionWithHideErrMsg("upstream error: response header timeout"),
+			)
+		}
 		logger.LogError(c, "do request failed: "+err.Error())
 		return nil, types.NewError(err, types.ErrorCodeDoRequestFailed, types.ErrOptionWithHideErrMsg("upstream error: do request failed"))
 	}
+	if isFirstResponseTimeout(firstResponseTimeout, reqCtx, c) {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		closeRequestBodies()
+		cancel()
+		firstResponseTimeout.Cancel()
+		logger.LogError(c, "do request failed: response header timeout")
+		return nil, types.NewError(
+			context.DeadlineExceeded,
+			types.ErrorCodeDoRequestFailed,
+			types.ErrOptionWithHideErrMsg("upstream error: response header timeout"),
+		)
+	}
 	if resp == nil {
+		closeRequestBodies()
+		cancel()
+		if firstResponseTimeout != nil {
+			firstResponseTimeout.Cancel()
+		}
 		return nil, errors.New("resp is nil")
+	}
+	if resp.Body == nil {
+		closeRequestBodies()
+		cancel()
+		if firstResponseTimeout != nil {
+			firstResponseTimeout.Cancel()
+		}
+		return nil, errors.New("resp body is nil")
+	}
+	responseBodyCancel := cancel
+	if firstResponseTimeout != nil {
+		responseBodyCancel = func() {
+			firstResponseTimeout.Cancel()
+			cancel()
+		}
+	}
+	resp.Body = &cancelOnCloseReadCloser{
+		ReadCloser: resp.Body,
+		cancel:     responseBodyCancel,
 	}
 
 	if upID := resp.Header.Get(common2.RequestIdKey); upID != "" {
 		c.Set(common2.UpstreamRequestIdKey, upID)
 	}
 
-	_ = req.Body.Close()
-	_ = c.Request.Body.Close()
+	closeRequestBodies()
 	return resp, nil
+}
+
+func isResponseHeaderTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "timeout awaiting response headers") ||
+		strings.Contains(msg, "response header timeout")
+}
+
+type firstResponseTimeoutControl struct {
+	request  *http.Request
+	timer    *time.Timer
+	cancel   context.CancelFunc
+	timeout  time.Duration
+	deadline time.Time
+	complete bool
+	timedOut bool
+	mu       sync.Mutex
+}
+
+func newFirstResponseTimeoutControl(req *http.Request, info *common.RelayInfo) *firstResponseTimeoutControl {
+	if req == nil || info == nil || !info.IsStream || common2.RelayResponseHeaderTimeout <= 0 {
+		return nil
+	}
+	timeout := time.Duration(common2.RelayResponseHeaderTimeout) * time.Second
+	ctx, cancel := context.WithCancel(req.Context())
+	control := &firstResponseTimeoutControl{
+		cancel:  cancel,
+		timeout: timeout,
+	}
+	control.request = req.WithContext(httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		GotFirstResponseByte: func() {
+			control.CompleteAt(time.Now())
+		},
+	}))
+	return control
+}
+
+func (c *firstResponseTimeoutControl) Start() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if c.complete || c.timedOut || c.timer != nil {
+		c.mu.Unlock()
+		return
+	}
+	c.deadline = time.Now().Add(c.timeout)
+	c.timer = time.AfterFunc(c.timeout, func() {
+		c.mu.Lock()
+		if c.complete {
+			c.mu.Unlock()
+			return
+		}
+		c.timedOut = true
+		cancel := c.cancel
+		c.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
+	})
+	c.mu.Unlock()
+}
+
+func (c *firstResponseTimeoutControl) CompleteAt(t time.Time) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if c.deadline.IsZero() || !t.After(c.deadline) {
+		c.complete = true
+		c.timedOut = false
+	}
+	timer := c.timer
+	c.mu.Unlock()
+	if timer != nil {
+		timer.Stop()
+	}
+}
+
+func (c *firstResponseTimeoutControl) Cancel() {
+	if c == nil || c.cancel == nil {
+		return
+	}
+	c.cancel()
+}
+
+func (c *firstResponseTimeoutControl) TimedOut() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.timedOut || (!c.complete && !c.deadline.IsZero() && time.Now().After(c.deadline))
+}
+
+func isFirstResponseTimeout(control *firstResponseTimeoutControl, parent context.Context, c *gin.Context) bool {
+	if control == nil || !control.TimedOut() {
+		return false
+	}
+	if parent != nil && parent.Err() != nil {
+		return false
+	}
+	if c != nil && c.Request != nil && c.Request.Context().Err() != nil {
+		return false
+	}
+	return true
+}
+
+type cancelOnCloseReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (r *cancelOnCloseReadCloser) Close() error {
+	var err error
+	if r.ReadCloser != nil {
+		err = r.ReadCloser.Close()
+	}
+	if r.cancel != nil {
+		r.once.Do(r.cancel)
+	}
+	return err
 }
 
 func DoTaskApiRequest(a TaskAdaptor, c *gin.Context, info *common.RelayInfo, requestBody io.Reader) (*http.Response, error) {
@@ -537,7 +748,7 @@ func DoTaskApiRequest(a TaskAdaptor, c *gin.Context, info *common.RelayInfo, req
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}

--- a/relay/channel/api_request_test.go
+++ b/relay/channel/api_request_test.go
@@ -1,10 +1,14 @@
 package channel
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
 	"testing"
+	"time"
 
+	common2 "github.com/QuantumNous/new-api/common"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
@@ -190,4 +194,80 @@ func TestProcessHeaderOverride_PassHeadersTemplateSetsRuntimeHeaders(t *testing.
 	require.Equal(t, "Codex CLI", upstreamReq.Header.Get("Originator"))
 	require.Equal(t, "sess-123", upstreamReq.Header.Get("Session_id"))
 	require.Empty(t, upstreamReq.Header.Get("X-Codex-Beta-Features"))
+}
+
+func TestNewFirstResponseTimeoutControlRequiresStreamAndTimeout(t *testing.T) {
+	oldTimeout := common2.RelayResponseHeaderTimeout
+	t.Cleanup(func() {
+		common2.RelayResponseHeaderTimeout = oldTimeout
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "https://example.com/v1/responses", nil)
+
+	common2.RelayResponseHeaderTimeout = 0
+	require.Nil(t, newFirstResponseTimeoutControl(req, &relaycommon.RelayInfo{IsStream: true}))
+
+	common2.RelayResponseHeaderTimeout = 1
+	require.Nil(t, newFirstResponseTimeoutControl(req, &relaycommon.RelayInfo{IsStream: false}))
+
+	control := newFirstResponseTimeoutControl(req, &relaycommon.RelayInfo{IsStream: true})
+	require.NotNil(t, control)
+	t.Cleanup(control.Cancel)
+
+	trace := httptrace.ContextClientTrace(control.request.Context())
+	require.NotNil(t, trace)
+	require.NotNil(t, trace.GotFirstResponseByte)
+}
+
+func TestFirstResponseTimeoutControlMarksTimedOut(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	control := &firstResponseTimeoutControl{
+		cancel:  cancel,
+		timeout: 10 * time.Millisecond,
+	}
+
+	control.Start()
+
+	require.Eventually(t, control.TimedOut, 200*time.Millisecond, 5*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return ctx.Err() != nil
+	}, 200*time.Millisecond, 5*time.Millisecond)
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+	require.True(t, isFirstResponseTimeout(control, context.Background(), nil))
+}
+
+func TestFirstResponseTimeoutControlCompleteStopsTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	control := &firstResponseTimeoutControl{
+		cancel:  cancel,
+		timeout: 20 * time.Millisecond,
+	}
+
+	control.Start()
+	control.CompleteAt(time.Now())
+	time.Sleep(30 * time.Millisecond)
+
+	require.False(t, control.TimedOut())
+	require.NoError(t, ctx.Err())
+}
+
+func TestIsFirstResponseTimeoutIgnoresClientCancellation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+
+	parent, parentCancel := context.WithCancel(context.Background())
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil).WithContext(parent)
+	control := &firstResponseTimeoutControl{
+		timeout: 1 * time.Millisecond,
+		cancel:  func() {},
+	}
+	control.Start()
+	require.Eventually(t, control.TimedOut, 200*time.Millisecond, 5*time.Millisecond)
+
+	parentCancel()
+
+	require.False(t, isFirstResponseTimeout(control, parent, ginCtx))
 }

--- a/relay/channel/aws/relay-aws.go
+++ b/relay/channel/aws/relay-aws.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
@@ -40,11 +39,8 @@ func getAwsErrorStatusCode(err error) int {
 	return http.StatusInternalServerError
 }
 
-func newAwsInvokeContext() (context.Context, context.CancelFunc) {
-	if common.RelayTimeout <= 0 {
-		return context.Background(), func() {}
-	}
-	return context.WithTimeout(context.Background(), time.Duration(common.RelayTimeout)*time.Second)
+func newAwsInvokeContext(parent context.Context, stream bool) (context.Context, context.CancelFunc) {
+	return service.WithRelayRequestTimeout(parent, stream)
 }
 
 func newAwsClient(c *gin.Context, info *relaycommon.RelayInfo) (*bedrockruntime.Client, error) {
@@ -53,12 +49,12 @@ func newAwsClient(c *gin.Context, info *relaycommon.RelayInfo) (*bedrockruntime.
 		err        error
 	)
 	if info.ChannelSetting.Proxy != "" {
-		httpClient, err = service.NewProxyHttpClient(info.ChannelSetting.Proxy)
+		httpClient, err = service.NewProxyHttpClientForRelay(info.ChannelSetting.Proxy, info.IsStream)
 		if err != nil {
 			return nil, fmt.Errorf("new proxy http client failed: %w", err)
 		}
 	} else {
-		httpClient = service.GetHttpClient()
+		httpClient = service.GetHttpClientForRelay(info.IsStream)
 	}
 
 	awsSecret := strings.Split(info.ApiKey, "|")
@@ -223,7 +219,7 @@ func getAwsModelID(requestModel string) string {
 
 func awsHandler(c *gin.Context, info *relaycommon.RelayInfo, a *Adaptor) (*types.NewAPIError, *dto.Usage) {
 
-	ctx, cancel := newAwsInvokeContext()
+	ctx, cancel := newAwsInvokeContext(c.Request.Context(), false)
 	defer cancel()
 
 	awsResp, err := a.AwsClient.InvokeModel(ctx, a.AwsReq.(*bedrockruntime.InvokeModelInput))
@@ -253,7 +249,7 @@ func awsHandler(c *gin.Context, info *relaycommon.RelayInfo, a *Adaptor) (*types
 }
 
 func awsStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, a *Adaptor) (*types.NewAPIError, *dto.Usage) {
-	ctx, cancel := newAwsInvokeContext()
+	ctx, cancel := newAwsInvokeContext(c.Request.Context(), true)
 	defer cancel()
 
 	awsResp, err := a.AwsClient.InvokeModelWithResponseStream(ctx, a.AwsReq.(*bedrockruntime.InvokeModelWithResponseStreamInput))
@@ -296,7 +292,7 @@ func awsStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, a *Adaptor) (
 // Nova模型处理函数
 func handleNovaRequest(c *gin.Context, info *relaycommon.RelayInfo, a *Adaptor) (*types.NewAPIError, *dto.Usage) {
 
-	ctx, cancel := newAwsInvokeContext()
+	ctx, cancel := newAwsInvokeContext(c.Request.Context(), false)
 	defer cancel()
 
 	awsResp, err := a.AwsClient.InvokeModel(ctx, a.AwsReq.(*bedrockruntime.InvokeModelInput))

--- a/service/error.go
+++ b/service/error.go
@@ -85,12 +85,12 @@ func ClaudeErrorWrapperLocal(err error, code string, statusCode int) *dto.Claude
 
 func RelayErrorHandler(ctx context.Context, resp *http.Response, showBodyWhenFail bool) (newApiErr *types.NewAPIError) {
 	newApiErr = types.InitOpenAIError(types.ErrorCodeBadResponseStatusCode, resp.StatusCode)
+	defer CloseResponseBodyGracefully(resp)
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return
 	}
-	CloseResponseBodyGracefully(resp)
 	var errResponse dto.GeneralErrorResponse
 	responseBodyText := string(responseBody)
 	responseBodyPreview := common.LocalLogPreview(responseBodyText)

--- a/service/http_client.go
+++ b/service/http_client.go
@@ -16,9 +16,10 @@ import (
 )
 
 var (
-	httpClient      *http.Client
-	proxyClientLock sync.Mutex
-	proxyClients    = make(map[string]*http.Client)
+	httpClient       *http.Client
+	streamHttpClient *http.Client
+	proxyClientLock  sync.Mutex
+	proxyClients     = make(map[string]*http.Client)
 )
 
 func checkRedirect(req *http.Request, via []*http.Request) error {
@@ -44,21 +45,34 @@ func InitHttpClient() {
 		transport.TLSClientConfig = common.InsecureTLSConfig
 	}
 
-	if common.RelayTimeout == 0 {
-		httpClient = &http.Client{
-			Transport:     transport,
-			CheckRedirect: checkRedirect,
-		}
-	} else {
-		httpClient = &http.Client{
-			Transport:     transport,
-			Timeout:       time.Duration(common.RelayTimeout) * time.Second,
-			CheckRedirect: checkRedirect,
-		}
+	httpClient = newRelayHTTPClient(transport)
+	streamHttpClient = httpClient
+	if shouldUseResponseHeaderTimeout(true) {
+		streamTransport := transport.Clone()
+		applyResponseHeaderTimeout(streamTransport, true)
+		streamHttpClient = newRelayHTTPClient(streamTransport)
 	}
 }
 
+func newRelayHTTPClient(transport http.RoundTripper) *http.Client {
+	client := &http.Client{
+		Transport:     transport,
+		CheckRedirect: checkRedirect,
+	}
+	if common.RelayTimeout > 0 {
+		client.Timeout = time.Duration(common.RelayTimeout) * time.Second
+	}
+	return client
+}
+
 func GetHttpClient() *http.Client {
+	return httpClient
+}
+
+func GetHttpClientForRelay(stream bool) *http.Client {
+	if shouldUseResponseHeaderTimeout(stream) && streamHttpClient != nil {
+		return streamHttpClient
+	}
 	return httpClient
 }
 
@@ -68,6 +82,49 @@ func GetHttpClientWithProxy(proxyURL string) (*http.Client, error) {
 		return GetHttpClient(), nil
 	}
 	return NewProxyHttpClient(proxyURL)
+}
+
+func shouldUseResponseHeaderTimeout(stream bool) bool {
+	return stream && common.RelayResponseHeaderTimeout > 0
+}
+
+func applyResponseHeaderTimeout(transport *http.Transport, stream bool) {
+	if transport != nil && shouldUseResponseHeaderTimeout(stream) {
+		transport.ResponseHeaderTimeout = time.Duration(common.RelayResponseHeaderTimeout) * time.Second
+	}
+}
+
+func relayRequestTimeout(stream bool) time.Duration {
+	if stream {
+		if common.RelayTimeout <= 0 {
+			return 0
+		}
+		return time.Duration(common.RelayTimeout) * time.Second
+	}
+
+	if common.RelayNonStreamTimeout > 0 {
+		timeout := common.RelayNonStreamTimeout
+		if common.RelayTimeout > 0 && timeout > common.RelayTimeout {
+			timeout = common.RelayTimeout
+		}
+		return time.Duration(timeout) * time.Second
+	}
+
+	if common.RelayTimeout <= 0 {
+		return 0
+	}
+	return time.Duration(common.RelayTimeout) * time.Second
+}
+
+func WithRelayRequestTimeout(ctx context.Context, stream bool) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	timeout := relayRequestTimeout(stream)
+	if timeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
 }
 
 // ResetProxyClientCache 清空代理客户端缓存，确保下次使用时重新初始化
@@ -84,15 +141,24 @@ func ResetProxyClientCache() {
 
 // NewProxyHttpClient 创建支持代理的 HTTP 客户端
 func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
+	return NewProxyHttpClientForRelay(proxyURL, false)
+}
+
+func NewProxyHttpClientForRelay(proxyURL string, stream bool) (*http.Client, error) {
 	if proxyURL == "" {
-		if client := GetHttpClient(); client != nil {
+		if client := GetHttpClientForRelay(stream); client != nil {
 			return client, nil
 		}
 		return http.DefaultClient, nil
 	}
 
+	cacheKey := proxyURL
+	if shouldUseResponseHeaderTimeout(stream) {
+		cacheKey += "|stream_response_header_timeout"
+	}
+
 	proxyClientLock.Lock()
-	if client, ok := proxyClients[proxyURL]; ok {
+	if client, ok := proxyClients[cacheKey]; ok {
 		proxyClientLock.Unlock()
 		return client, nil
 	}
@@ -111,16 +177,13 @@ func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
 			ForceAttemptHTTP2:   true,
 			Proxy:               http.ProxyURL(parsedURL),
 		}
+		applyResponseHeaderTimeout(transport, stream)
 		if common.TLSInsecureSkipVerify {
 			transport.TLSClientConfig = common.InsecureTLSConfig
 		}
-		client := &http.Client{
-			Transport:     transport,
-			CheckRedirect: checkRedirect,
-		}
-		client.Timeout = time.Duration(common.RelayTimeout) * time.Second
+		client := newRelayHTTPClient(transport)
 		proxyClientLock.Lock()
-		proxyClients[proxyURL] = client
+		proxyClients[cacheKey] = client
 		proxyClientLock.Unlock()
 		return client, nil
 
@@ -152,14 +215,14 @@ func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
 				return dialer.Dial(network, addr)
 			},
 		}
+		applyResponseHeaderTimeout(transport, stream)
 		if common.TLSInsecureSkipVerify {
 			transport.TLSClientConfig = common.InsecureTLSConfig
 		}
 
-		client := &http.Client{Transport: transport, CheckRedirect: checkRedirect}
-		client.Timeout = time.Duration(common.RelayTimeout) * time.Second
+		client := newRelayHTTPClient(transport)
 		proxyClientLock.Lock()
-		proxyClients[proxyURL] = client
+		proxyClients[cacheKey] = client
 		proxyClientLock.Unlock()
 		return client, nil
 

--- a/service/http_client_test.go
+++ b/service/http_client_test.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelayRequestTimeoutUsesStreamGlobalTimeout(t *testing.T) {
+	oldRelayTimeout := common.RelayTimeout
+	oldRelayNonStreamTimeout := common.RelayNonStreamTimeout
+	t.Cleanup(func() {
+		common.RelayTimeout = oldRelayTimeout
+		common.RelayNonStreamTimeout = oldRelayNonStreamTimeout
+	})
+
+	common.RelayTimeout = 30
+	common.RelayNonStreamTimeout = 5
+
+	require.Equal(t, 30*time.Second, relayRequestTimeout(true))
+}
+
+func TestRelayRequestTimeoutUsesNonStreamOverride(t *testing.T) {
+	oldRelayTimeout := common.RelayTimeout
+	oldRelayNonStreamTimeout := common.RelayNonStreamTimeout
+	t.Cleanup(func() {
+		common.RelayTimeout = oldRelayTimeout
+		common.RelayNonStreamTimeout = oldRelayNonStreamTimeout
+	})
+
+	common.RelayTimeout = 0
+	common.RelayNonStreamTimeout = 5
+
+	require.Equal(t, 5*time.Second, relayRequestTimeout(false))
+}
+
+func TestRelayRequestTimeoutFallsBackAndCapsNonStreamTimeout(t *testing.T) {
+	oldRelayTimeout := common.RelayTimeout
+	oldRelayNonStreamTimeout := common.RelayNonStreamTimeout
+	t.Cleanup(func() {
+		common.RelayTimeout = oldRelayTimeout
+		common.RelayNonStreamTimeout = oldRelayNonStreamTimeout
+	})
+
+	common.RelayTimeout = 10
+	common.RelayNonStreamTimeout = -1
+	require.Equal(t, 10*time.Second, relayRequestTimeout(false))
+
+	common.RelayNonStreamTimeout = 30
+	require.Equal(t, 10*time.Second, relayRequestTimeout(false))
+}
+
+func TestShouldUseResponseHeaderTimeoutOnlyForStream(t *testing.T) {
+	oldRelayResponseHeaderTimeout := common.RelayResponseHeaderTimeout
+	t.Cleanup(func() {
+		common.RelayResponseHeaderTimeout = oldRelayResponseHeaderTimeout
+	})
+
+	common.RelayResponseHeaderTimeout = 0
+	require.False(t, shouldUseResponseHeaderTimeout(true))
+
+	common.RelayResponseHeaderTimeout = 3
+	require.True(t, shouldUseResponseHeaderTimeout(true))
+	require.False(t, shouldUseResponseHeaderTimeout(false))
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)
 - 新增 `RELAY_RESPONSE_HEADER_TIMEOUT`，用于限制流式请求等待上游 HTTP 响应头的时间。例如某些上游在异常情况下可能长时间无响应，设置RELAY_RESPONSE_HEADER_TIMEOUT=30，超时后进入重试逻辑或者打断对话，可有效减缓客户端等待时长
 - 流式请求收到上游响应头后，后续 body/SSE 读取仍由现有 `STREAMING_TIMEOUT` 负责。
  - 新增 `RELAY_NON_STREAM_TIMEOUT`，用于控制非流式请求的总超时时间；当同时设置 `RELAY_TIMEOUT` 时，非流式超
  时不会超过 `RELAY_TIMEOUT`。
  - 补充 `.env.example` 中新增环境变量的说明。
  - 修正 relay 错误响应体在读取失败时也会被关闭，避免异常路径下响应体未关闭。


## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable timeout settings for response headers and non-streaming requests, enabling more granular control over upstream response timing.

* **Bug Fixes**
  * Enhanced resource management by ensuring response bodies are properly closed even when errors occur during processing.

* **Tests**
  * Introduced comprehensive test coverage for timeout behaviors across streaming and non-streaming request types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->