### PR TITLE
fix(relay): preserve reasoning_content and thinking block in playground and Claude conversion

### DIFF
--- a/service/convert.go
+++ b/service/convert.go
@@ -149,6 +149,10 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 
 			for _, mediaMsg := range contents {
 				switch mediaMsg.Type {
+				case "thinking":
+					if mediaMsg.Thinking != nil {
+						openAIMessage.ReasoningContent = mediaMsg.Thinking
+					}
 				case "text", "input_text":
 					message := dto.MediaContent{
 						Type:         "text",

--- a/web/classic/src/helpers/utils.jsx
+++ b/web/classic/src/helpers/utils.jsx
@@ -469,6 +469,7 @@ export const formatMessageForAPI = (message) => {
   return {
     role: message.role,
     content: message.content,
+    reasoning_content: message.reasoningContent || undefined,
   };
 };
 

--- a/web/classic/src/hooks/playground/useSyncMessageAndCustomBody.js
+++ b/web/classic/src/hooks/playground/useSyncMessageAndCustomBody.js
@@ -40,6 +40,7 @@ export const useSyncMessageAndCustomBody = (
         id: msg.id,
         role: msg.role,
         content: msg.content,
+        reasoning_content: msg.reasoningContent || undefined,
       })),
     );
   }, []);
@@ -77,6 +78,7 @@ export const useSyncMessageAndCustomBody = (
       customPayload.messages = message.map((msg) => ({
         role: msg.role,
         content: msg.content,
+        reasoning_content: msg.reasoningContent || undefined,
       }));
 
       const newCustomBody = JSON.stringify(customPayload, null, 2);

--- a/web/default/src/features/playground/lib/message-utils.ts
+++ b/web/default/src/features/playground/lib/message-utils.ts
@@ -134,6 +134,7 @@ export function formatMessageForAPI(message: Message): ChatCompletionMessage {
   return {
     role: message.from,
     content: currentVersion.content,
+    reasoning_content: message.reasoning?.content,
   }
 }
 

--- a/web/default/src/features/playground/types.ts
+++ b/web/default/src/features/playground/types.ts
@@ -46,6 +46,7 @@ export interface Message {
 export interface ChatCompletionMessage {
   role: MessageRole
   content: string | ContentPart[]
+  reasoning_content?: string
 }
 
 export interface ContentPart {


### PR DESCRIPTION
Fixes DeepSeek reasoning_content 400 error in multi-turn conversations for both default/classic playgrounds and Claude-to-OpenAI relay path. Closes #4543. Resolves https://github.com/QuantumNous/new-api/issues/4543

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added support for reasoning content in chat messages across all API integrations.
* Messages now properly include, synchronize, and preserve reasoning text throughout the conversation workflow and custom request bodies.
* Reasoning content is correctly formatted and converted when exchanging messages with different API providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->