### PR TITLE
fix(web): use slug and state token for custom OAuth binding

### DIFF
--- a/web/default/src/features/profile/components/tabs/account-bindings-tab.tsx
+++ b/web/default/src/features/profile/components/tabs/account-bindings-tab.tsx
@@ -118,10 +118,16 @@ export function AccountBindingsTab({
   const handleBindCustomOAuth = async (
     provider: CustomOAuthProviderInfo
   ) => {
-    if (!provider.authorization_endpoint || !provider.client_id) return
+    if (!provider.authorization_endpoint || !provider.client_id) {
+      toast.error(t('OAuth provider is not configured correctly'))
+      return
+    }
 
     const state = await getOAuthState()
-    if (!state) return
+    if (!state) {
+      toast.error(t('Failed to start OAuth binding'))
+      return
+    }
 
     const redirectUri = `${window.location.origin}/oauth/${provider.slug}`
     const url = new URL(provider.authorization_endpoint)

--- a/web/default/src/features/profile/components/tabs/account-bindings-tab.tsx
+++ b/web/default/src/features/profile/components/tabs/account-bindings-tab.tsx
@@ -27,6 +27,7 @@ import {
   handleOIDCOAuth,
   handleDiscordOAuth,
   handleLinuxDOOAuth,
+  getOAuthState,
 } from '@/lib/oauth'
 import { useDialogs } from '@/hooks/use-dialog'
 import { useStatus } from '@/hooks/use-status'
@@ -41,6 +42,7 @@ import {
   type CustomOAuthBinding,
 } from '../../api'
 import type { UserProfile, BindingItem } from '../../types'
+import type { CustomOAuthProviderInfo } from '@/features/auth/types'
 import { EmailBindDialog } from '../dialogs/email-bind-dialog'
 import { TelegramBindDialog } from '../dialogs/telegram-bind-dialog'
 import { WeChatBindDialog } from '../dialogs/wechat-bind-dialog'
@@ -70,7 +72,7 @@ export function AccountBindingsTab({
   const [unbinding, setUnbinding] = useState(false)
 
   const customProviders = status?.custom_oauth_providers as
-    | Array<{ id: string; name: string }>
+    | CustomOAuthProviderInfo[]
     | undefined
 
   const fetchCustomBindings = useCallback(async () => {
@@ -113,9 +115,25 @@ export function AccountBindingsTab({
     }
   }
 
-  const handleBindCustomOAuth = (provider: { id: string; name: string }) => {
-    const redirectUrl = `${window.location.origin}/oauth/${provider.id}?bind=true`
-    window.location.href = `/api/oauth/${provider.id}?redirect=${encodeURIComponent(redirectUrl)}`
+  const handleBindCustomOAuth = async (
+    provider: CustomOAuthProviderInfo
+  ) => {
+    if (!provider.authorization_endpoint || !provider.client_id) return
+
+    const state = await getOAuthState()
+    if (!state) return
+
+    const redirectUri = `${window.location.origin}/oauth/${provider.slug}`
+    const url = new URL(provider.authorization_endpoint)
+    url.searchParams.set('client_id', provider.client_id)
+    url.searchParams.set('redirect_uri', redirectUri)
+    url.searchParams.set('response_type', 'code')
+    url.searchParams.set('state', state)
+    if (provider.scopes) {
+      url.searchParams.set('scope', provider.scopes)
+    }
+
+    window.open(url.toString(), '_blank')
   }
 
   useEffect(() => {
@@ -316,7 +334,7 @@ export function AccountBindingsTab({
           <div className='grid grid-cols-1 gap-2.5 sm:grid-cols-2 sm:gap-3'>
             {customProviders.map((provider) => {
               const binding = customBindings.find(
-                (b) => b.provider_id === provider.id
+                (b) => b.provider_id === String(provider.id)
               )
               const isBound = !!binding
               return (


### PR DESCRIPTION
## Description

`handleBindCustomOAuth` in the profile bindings tab was passing `provider.id` (the database primary key) to the OAuth router, which looks up providers by `slug`. It also never obtained a CSRF state token, so the backend rejected every binding request.

This aligns the bind flow with the already-working login flow (`handleCustomOAuthLogin` in `use-oauth-login.ts`): use `provider.slug`, call `getOAuthState()`, build the authorization URL directly, and open it in a new tab so the callback page detects bind mode via `window.opener`.

## Type of change

- [x] Bug fix

## Checklist

- [x] Scope is focused on this fix
- [x] TypeScript check passes (`tsc -b`)
- [x] No unrelated changes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom OAuth provider binding flow to open the authorization page in a new browser tab for a smoother authentication experience.
  * Made provider binding detection more robust to avoid missed or incorrect matches.
  * Fixed handling of custom providers to reduce errors when connecting external accounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->