### PR TITLE
fix: auto-detect image generation models in channel test

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -139,6 +139,12 @@ func testChannel(channel *model.Channel, testUserID int, testModel string, endpo
 			requestPath = "/v1/images/generations"
 		}
 
+		// 通用图像生成模型（gpt-image-*, dall-e-*, imagen-* 等）
+		if strings.Contains(strings.ToLower(testModel), "image") ||
+		   strings.Contains(strings.ToLower(testModel), "dall-e") {
+			requestPath = "/v1/images/generations"
+		}
+
 		// responses-only models
 		if strings.Contains(strings.ToLower(testModel), "codex") {
 			requestPath = "/v1/responses"


### PR DESCRIPTION
## Summary

Channel auto-test (`controller/channel-test.go`) does not recognize `gpt-image-*` models as image generation models. The only image path detection currently is for VolcEngine + seedream.

This causes image-only channels (e.g. `gpt-image-2`) to be tested via `/v1/chat/completions`, which always fails — even though the code already has a complete `ImageRequest` test template with correct defaults (`prompt: "a cute cat"`, `size: 1024x1024`).

## Fix

Add general image model name detection in the auto-detection logic:

```go
// 通用图像生成模型（gpt-image-*, dall-e-*, imagen-* 等）
if strings.Contains(strings.ToLower(testModel), "image") ||
   strings.Contains(strings.ToLower(testModel), "dall-e") {
    requestPath = "/v1/images/generations"
}
```

This catches `gpt-image-2`, `dall-e-3`, `imagen-*`, and any future models with "image" in their name, routing them to the correct `/v1/images/generations` endpoint with the existing `ImageRequest` test payload.

## Verification

- `go build` passes
- Tested end-to-end: gpt-image-2 channel auto-test now routes to `/v1/images/generations` → uses `ImageRequest{Size: "1024x1024"}` → upstream returns 200 with valid image data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic endpoint detection for image-generation model requests: model names containing "image" or "dall-e" are now recognized and routed to the image-generation endpoint when an endpoint type isn't explicitly specified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->