### PR TITLE
chore: improve new-api maintenance path

### DIFF
--- a/common/json_test.go
+++ b/common/json_test.go
@@ -33,6 +33,36 @@ func TestJsonRawMessageToString(t *testing.T) {
 			data: nil,
 			want: "",
 		},
+		{
+			name: "empty object",
+			data: json.RawMessage(`{}`),
+			want: `{}`,
+		},
+		{
+			name: "array",
+			data: json.RawMessage(`[1,2,3]`),
+			want: `[1,2,3]`,
+		},
+		{
+			name: "boolean",
+			data: json.RawMessage(`true`),
+			want: `true`,
+		},
+		{
+			name: "number",
+			data: json.RawMessage(`123`),
+			want: `123`,
+		},
+		{
+			name: "whitespace padded",
+			data: json.RawMessage(`   {"a":1}   `),
+			want: `{"a":1}`,
+		},
+		{
+			name: "malformed string",
+			data: json.RawMessage(`"unterminated`),
+			want: `"unterminated`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/ionet/types.go
+++ b/pkg/ionet/types.go
@@ -278,6 +278,9 @@ func (e *APIError) Error() string {
 	return e.Message
 }
 
+// Compile-time check that APIError satisfies the error interface.
+var _ error = (*APIError)(nil)
+
 // ListDeploymentsOptions represents options for listing deployments
 type ListDeploymentsOptions struct {
 	Status     string `json:"status,omitempty"`      // filter by status


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in pkg/ionet/types.go, common/json_test.go related to CI, Docker, Kubernetes, build tooling, release automation; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded JSON handling test coverage with additional test cases for various JSON value types and edge cases.

* **Chores**
  * Added compile-time verification to ensure proper interface implementation for improved code reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->