### PR TITLE
fix(web): improve form validation error focus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ data/
 .test
 token_estimator_test.go
 skills-lock.json
+.playwright-mcp

--- a/web/default/src/components/ui/form.tsx
+++ b/web/default/src/components/ui/form.tsx
@@ -31,7 +31,99 @@ import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/utils'
 import { Label } from '@/components/ui/label'
 
-const Form = FormProvider
+type FormRootContextValue = {
+  id: string
+}
+
+const FormRootContext = React.createContext<FormRootContextValue | null>(null)
+
+function getFormScopedSelector(formId: string, selector: string): string {
+  return `[data-form-root="${formId}"]${selector}`
+}
+
+function hasFormErrors(errors: unknown): boolean {
+  return (
+    typeof errors === 'object' &&
+    errors !== null &&
+    Object.keys(errors).length > 0
+  )
+}
+
+function getFirstFormErrorTarget(
+  invalidControl: HTMLElement | null,
+  errorMessage: HTMLElement | null
+): HTMLElement | null {
+  if (!invalidControl) return errorMessage
+  if (!errorMessage) return invalidControl
+
+  const position = invalidControl.compareDocumentPosition(errorMessage)
+  return position & Node.DOCUMENT_POSITION_PRECEDING
+    ? errorMessage
+    : invalidControl
+}
+
+function FormValidationFocus() {
+  const formContext = React.useContext(FormRootContext)
+  const { control } = useFormContext()
+  const { errors, submitCount } = useFormState({ control })
+  const handledSubmitCountRef = React.useRef(0)
+
+  React.useEffect(() => {
+    if (!formContext || submitCount === 0 || !hasFormErrors(errors)) return
+    if (handledSubmitCountRef.current === submitCount) return
+
+    handledSubmitCountRef.current = submitCount
+
+    const animationFrameId = window.requestAnimationFrame(() => {
+      const invalidControl = document.querySelector<HTMLElement>(
+        getFormScopedSelector(formContext.id, '[aria-invalid="true"]')
+      )
+      const errorMessage = document.querySelector<HTMLElement>(
+        getFormScopedSelector(formContext.id, '[data-slot="form-message"]')
+      )
+      const target = getFirstFormErrorTarget(invalidControl, errorMessage)
+      if (!target) return
+
+      const formItem = target.closest<HTMLElement>(
+        getFormScopedSelector(formContext.id, '[data-slot="form-item"]')
+      )
+      const scrollTarget = formItem ?? target
+      const focusTarget =
+        target === invalidControl
+          ? invalidControl
+          : (formItem?.querySelector<HTMLElement>(
+              '[aria-invalid="true"], input, textarea, select, button, [tabindex]:not([tabindex="-1"])'
+            ) ?? null)
+
+      scrollTarget.scrollIntoView({ block: 'center', behavior: 'smooth' })
+      focusTarget?.focus({ preventScroll: true })
+    })
+
+    return () => window.cancelAnimationFrame(animationFrameId)
+  }, [errors, formContext, submitCount])
+
+  return null
+}
+
+function Form<TFieldValues extends FieldValues = FieldValues>({
+  children,
+  ...props
+}: React.ComponentProps<typeof FormProvider<TFieldValues>>) {
+  const reactId = React.useId()
+  const id = React.useMemo(
+    () => `form-${reactId.replaceAll(/[^a-zA-Z0-9_-]/g, '_')}`,
+    [reactId]
+  )
+
+  return (
+    <FormRootContext.Provider value={{ id }}>
+      <FormProvider {...props}>
+        <FormValidationFocus />
+        {children}
+      </FormProvider>
+    </FormRootContext.Provider>
+  )
+}
 
 type FormFieldContextValue<
   TFieldValues extends FieldValues = FieldValues,
@@ -90,11 +182,13 @@ const FormItemContext = React.createContext<FormItemContextValue>(
 
 function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
   const id = React.useId()
+  const formContext = React.useContext(FormRootContext)
 
   return (
     <FormItemContext.Provider value={{ id }}>
       <div
         data-slot='form-item'
+        data-form-root={formContext?.id}
         className={cn('grid gap-2', className)}
         {...props}
       />
@@ -124,11 +218,13 @@ function FormControl({
   ...props
 }: { children: React.ReactElement } & Record<string, unknown>) {
   const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+  const formContext = React.useContext(FormRootContext)
 
   return useRender({
     render: children,
     props: {
       'data-slot': 'form-control',
+      'data-form-root': formContext?.id,
       id: formItemId,
       'aria-describedby': !error
         ? `${formDescriptionId}`
@@ -154,6 +250,7 @@ function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
 
 function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
   const { error, formMessageId } = useFormField()
+  const formContext = React.useContext(FormRootContext)
   const { t } = useTranslation()
   const body = error ? String(error?.message ?? '') : props.children
 
@@ -166,6 +263,7 @@ function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
   return (
     <p
       data-slot='form-message'
+      data-form-root={formContext?.id}
       id={formMessageId}
       className={cn('text-destructive text-sm', className)}
       {...props}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。
- 新建渠道等表单提交失败时，视口外的必填项错误不容易被用户发现。
- 多个字段同时报错后，用户修复第一个字段时焦点可能被自动跳转到剩余错误字段，影响输入。


## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

- 在公共 Form 组件中为同一表单实例标记作用域，并在提交校验失败后按 DOM 顺序定位第一个错误。
- 滚动到对应 FormItem，并优先聚焦可交互控件；对自定义控件通过错误消息兜底定位。
- 按 submitCount 去重，确保同一次失败提交只自动定位一次，不在用户编辑过程中抢焦点。
- 将 `.playwright-mcp` 加入忽略列表，避免本地浏览器验证产物污染工作区。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ ] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [ ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [ ] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved form validation experience: forms now automatically scroll to and focus on the first invalid field after submission attempt, with smooth scrolling for better visibility of validation feedback.

* **Chores**
  * Updated project ignore configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->