### PR TITLE
fix: correct relative time boundaries in notification popover

### DIFF
--- a/web/default/src/components/notification-popover.tsx
+++ b/web/default/src/components/notification-popover.tsx
@@ -82,7 +82,6 @@ function getRelativeTime(publishDate: string | Date, t: TFunction): string {
   const diffDays = Math.floor(diffHours / 24)
   const diffWeeks = Math.floor(diffDays / 7)
   const diffMonths = Math.floor(diffDays / 30)
-  const diffYears = Math.floor(diffDays / 365)
 
   // If future time, show specific date
   if (diffMs < 0) return formatDateTimeObject(pubDate)
@@ -101,15 +100,15 @@ function getRelativeTime(publishDate: string | Date, t: TFunction): string {
     return diffDays === 1
       ? t('1 day ago')
       : t('{{count}} days ago', { count: diffDays })
-  if (diffWeeks < 4)
+  if (diffDays < 30)
     return diffWeeks === 1
       ? t('1 week ago')
       : t('{{count}} weeks ago', { count: diffWeeks })
-  if (diffMonths < 12)
+  if (diffDays < 365)
     return diffMonths === 1
       ? t('1 month ago')
       : t('{{count}} months ago', { count: diffMonths })
-  if (diffYears < 2) return t('1 year ago')
+  if (diffDays < 365 * 2) return t('1 year ago')
 
   // Over 2 years, show specific date
   return formatDateTimeObject(pubDate)


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
week=7天
7*4=28天
当天数为28-29时, 会显示`0个月`前
同理
当天数为360-365时, 会显示`0年前`

## 📝 变更描述 / Description
修复临界值判断


## ✅ 提交前检查项 / Checklist
修复前:
<img width="858" height="662" alt="image" src="https://github.com/user-attachments/assets/e97117a0-875a-4ab7-bc08-fc54fd11ccf2" />


修复后:
<img width="842" height="552" alt="image" src="https://github.com/user-attachments/assets/66eaad14-9fe1-4f55-ae44-ae33d81b5461" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date formatting logic for notification announcements to display relative times using more consistent thresholds for weeks, months, and years.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->