### PR TITLE
fix(dashboard): weight performance summary by request_count

### DIFF
--- a/web/default/src/features/dashboard/components/models/performance-overview.tsx
+++ b/web/default/src/features/dashboard/components/models/performance-overview.tsx
@@ -42,40 +42,53 @@ type PerformanceSummary = {
   successRate: number
 }
 
-function simpleAverage(
+function weightedAverage(
   rows: PerfModelSummary[],
   metric: WeightedMetric,
   isValid: (value: number) => boolean
 ): number {
-  let total = 0
-  let count = 0
+  let weightedTotal = 0
+  let weightSum = 0
+  let fallbackTotal = 0
+  let fallbackCount = 0
 
   for (const row of rows) {
     const value = Number(row[metric])
     if (!isValid(value)) continue
-    total += value
-    count++
+
+    fallbackTotal += value
+    fallbackCount++
+
+    const weight = Number(row.request_count)
+    if (Number.isFinite(weight) && weight > 0) {
+      weightedTotal += value * weight
+      weightSum += weight
+    }
   }
 
-  return count > 0 ? total / count : NaN
+  // Weight each model by its request_count so low-traffic models do not skew
+  // the overall figures. Fall back to an unweighted mean only when no usable
+  // request counts are available (e.g. older backends that omit the field).
+  if (weightSum > 0) return weightedTotal / weightSum
+  return fallbackCount > 0 ? fallbackTotal / fallbackCount : NaN
 }
 
 function buildPerformanceSummary(rows: PerfModelSummary[]): PerformanceSummary {
   return {
     totalRequests: rows.length,
     avgLatencyMs: Math.round(
-      simpleAverage(
+      weightedAverage(
         rows,
         'avg_latency_ms',
         (value) => Number.isFinite(value) && value > 0
       )
     ),
-    avgTps: simpleAverage(
+    avgTps: weightedAverage(
       rows,
       'avg_tps',
       (value) => Number.isFinite(value) && value > 0
     ),
-    successRate: simpleAverage(rows, 'success_rate', Number.isFinite),
+    successRate: weightedAverage(rows, 'success_rate', Number.isFinite),
   }
 }
 


### PR DESCRIPTION
## 📝 变更描述 / Description

仪表盘「性能健康」概览卡片（成功率 / 平均延迟 / 吞吐量）此前对每个模型采用**简单平均**，即每个模型权重相同。结果是：一个只有 1 条失败请求、成功率 0% 的模型，会和承载数百次成功请求的模型同权，严重拉偏整体数字。

本 PR 将 `buildPerformanceSummary()` 改为按各模型的 `request_count` 做**加权平均**；仅当所有行都缺少可用的 `request_count`（例如旧后端不返回该字段）时，才回退到原来的简单平均，以保持兼容。改动仅涉及前端汇总计算，不改变接口与展示组件。

The dashboard "Performance health" summary (success rate, average latency, throughput) averaged every model with equal weight, so a model with a single failed request skewed the headline figures as much as one serving hundreds of successful requests. It now weights each model by `request_count`, falling back to an unweighted mean only when no usable request counts are available.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- Closes #5029

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述由人工撰写整理。
- [x] **非重复提交:** 已搜索 Issues / PRs（weighted average、performance overview 等关键词），未发现重复。
- [x] **Bug fix 说明:** 已关联 Issue #5029；这是客观的聚合算法错误，非设计取舍或预期不一致。
- [x] **变更理解:** 仅调整前端汇总计算逻辑，行为可预测，无副作用。
- [x] **范围聚焦:** 仅改动 `performance-overview.tsx` 单个文件。
- [x] **本地验证:** `tsc -b` 未引入新的类型错误；`prettier --check` 通过（见下）。
- [x] **安全合规:** 无敏感凭据，无信任边界改动，符合代码规范。

## 📸 运行证明 / Proof of Work

以 Issue #5029 给出的样例数据（过去 24h）为例：

| 模型 / Model | 请求数 / Requests | 成功率 / Success rate |
| --- | --- | --- |
| deepseek-v4-flash-max | 549 | 99.53% |
| kimi-for-coding | 1 | 0% |
| deepseek-v4-flash | 1 | 0% |

- 修复前（简单平均 / simple average）：`(99.53 + 0 + 0) / 3 = 33.18%`
- 修复后（按 request_count 加权 / request-weighted）：`(549×99.53 + 1×0 + 1×0) / 551 = 99.17%`

本地验证 / Local validation:

```text
$ bun run typecheck        # tsc -b
# 仅 src/features/usage-logs/components/usage-logs-mobile-card.tsx 报 2 处既有错误，
# 该错误在未改动的 main 上同样存在，与本 PR 无关。

$ bunx prettier --check src/features/dashboard/components/models/performance-overview.tsx
All matched files use Prettier code style!
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard performance metrics now use request-volume weighted calculations for latency, throughput, and success rate, ensuring low-traffic models don't disproportionately skew overall KPIs. System gracefully handles cases with unavailable request volume data by reverting to unweighted averaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->