### PR TITLE
feat(keys/cc-switch-dialog): 修复自定义cc-switch名称失焦后重置问题

### DIFF
--- a/web/default/src/features/keys/components/dialogs/cc-switch-dialog.tsx
+++ b/web/default/src/features/keys/components/dialogs/cc-switch-dialog.tsx
@@ -189,6 +189,7 @@ export function CCSwitchDialog(props: Props) {
               onValueChange={setName}
               placeholder={currentConfig.defaultName}
               emptyText=''
+              allowCustomValue={true}
             />
           </div>
 


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)
问题阐述：用户输入的文字只存在于组件内部的 searchValue 状态中，因为 allowCustomValue 为 false ，这些文字 从未同步到父组件的 name state 。失焦后内部状态清空，显示就恢复成了父组件持有的旧值。
在 cc-switch-dialog.tsx 的 Name 输入框上加 allowCustomValue={true} ，在 cc-switch-dialog.tsx 的 Name 输入框上加 allowCustomValue={true} ：
## 🚀 变更类型 / Type of change
- [✅] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5162 

## ✅ 提交前检查项 / Checklist
- [✅] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [✅] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [✅] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [✅] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [✅] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [✅] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [✅] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
<img width="450" height="484" alt="image" src="https://github.com/user-attachments/assets/88a6ae98-dbfd-4f00-bea1-65ed23725029" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Name field now accepts custom user-provided entries in addition to predefined options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->