### PR TITLE
fix: 修改用户分组时余额被错误清零

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -564,8 +565,13 @@ func GetUserModels(c *gin.Context) {
 }
 
 func UpdateUser(c *gin.Context) {
+	bodyBytes, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		common.ApiErrorI18n(c, i18n.MsgInvalidParams)
+		return
+	}
 	var updatedUser model.User
-	err := json.NewDecoder(c.Request.Body).Decode(&updatedUser)
+	err = common.Unmarshal(bodyBytes, &updatedUser)
 	if err != nil || updatedUser.Id == 0 {
 		common.ApiErrorI18n(c, i18n.MsgInvalidParams)
 		return
@@ -590,6 +596,13 @@ func UpdateUser(c *gin.Context) {
 	if !canManageTargetRole(myRole, updatedUser.Role) {
 		common.ApiErrorI18n(c, i18n.MsgUserCannotCreateHigherLevel)
 		return
+	}
+	// Preserve original quota if not explicitly provided in the request
+	var rawMap map[string]json.RawMessage
+	if common.Unmarshal(bodyBytes, &rawMap) == nil {
+		if _, hasQuota := rawMap["quota"]; !hasQuota {
+			updatedUser.Quota = originUser.Quota
+		}
 	}
 	if updatedUser.Password == "$I_LOVE_U" {
 		updatedUser.Password = "" // rollback to what it should be


### PR DESCRIPTION
## Summary
- 修复管理员在修改用户分组时,如果未传入 `quota` 字段,用户的余额(quota)会被错误清零的问题
- 当请求体中未显式包含 `quota` 字段时,保留数据库中的原始值

## Root Cause
`UpdateUser` 使用 `json.NewDecoder` 解码请求体到 `model.User` 结构体,当 JSON 中未包含 `quota` 字段时,Go 将 `Quota`(int) 设为零值 0,然后 `Edit` 方法无条件将 `quota=0` 写入数据库

## Fix
先读取原始请求体字节,解码后检查 JSON 是否显式包含 `"quota"` 键,若未提供则从数据库原始记录保留 `originUser.Quota`

## Test Plan
- [ ] 修改用户分组(不传 quota 字段),验证余额保持不变
- [ ] 修改用户分组的同时传入 quota 字段,验证余额正常更新
- [ ] 显式传入 `quota: 0`,验证可以清零余额

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User quota is now preserved when updating user information without explicitly specifying a quota value.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->