### PR TITLE
Guard users drawer against stale fetch responses

### DIFF
--- a/web/default/src/features/users/components/users-mutate-drawer.tsx
+++ b/web/default/src/features/users/components/users-mutate-drawer.tsx
@@ -88,6 +88,7 @@ export function UsersMutateDrawer({
 }: UsersMutateDrawerProps) {
   const { t } = useTranslation()
   const isUpdate = !!currentRow
+  const currentRowId = currentRow?.id
   const { triggerRefresh } = useUsers()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [quotaDialogOpen, setQuotaDialogOpen] = useState(false)
@@ -108,18 +109,25 @@ export function UsersMutateDrawer({
 
   // Load existing data when updating
   useEffect(() => {
-    if (open && isUpdate && currentRow) {
+    if (open && isUpdate && currentRowId !== undefined) {
+      let cancelled = false
+      const userId = currentRowId
+
       // For update, fetch fresh data
-      getUser(currentRow.id).then((result) => {
-        if (result.success && result.data) {
+      getUser(userId).then((result) => {
+        if (!cancelled && result.success && result.data?.id === userId) {
           form.reset(transformUserToFormDefaults(result.data))
         }
       })
+
+      return () => {
+        cancelled = true
+      }
     } else if (open && !isUpdate) {
       // For create, reset to defaults
       form.reset(USER_FORM_DEFAULT_VALUES)
     }
-  }, [open, isUpdate, currentRow, form])
+  }, [open, isUpdate, currentRowId, form])
 
   const { meta: currencyMeta } = getCurrencyDisplay()
   const currencyLabel = getCurrencyLabel()

--- a/web/default/src/features/users/components/users-mutate-drawer.tsx
+++ b/web/default/src/features/users/components/users-mutate-drawer.tsx
@@ -114,11 +114,15 @@ export function UsersMutateDrawer({
       const userId = currentRowId
 
       // For update, fetch fresh data
-      getUser(userId).then((result) => {
-        if (!cancelled && result.success && result.data?.id === userId) {
-          form.reset(transformUserToFormDefaults(result.data))
-        }
-      })
+      getUser(userId)
+        .then((result) => {
+          if (!cancelled && result.success && result.data?.id === userId) {
+            form.reset(transformUserToFormDefaults(result.data))
+          }
+        })
+        .catch(() => {
+          // Request failures are already reported by the global API interceptor.
+        })
 
       return () => {
         cancelled = true


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

用户编辑抽屉打开已有用户时会异步拉取最新用户详情。此前请求返回后会直接重置表单，如果管理员快速从用户 A 切到用户 B，A 的慢请求可能覆盖 B 的当前抽屉状态。

本 PR 在 effect 内捕获本次请求的用户 id，并在 cleanup 后标记取消；请求返回时同时检查未取消且响应用户 id 与请求 id 一致，才允许更新表单。这样旧请求返回不会再写入当前抽屉。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #5174

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

- `git diff --check` 通过。
- `npx eslint src/features/users/components/users-mutate-drawer.tsx --quiet` 通过。
- `npm run typecheck` 未通过，失败点在既有 `usage-logs` 类型错误，不在本 PR 改动文件。
- `npm run lint -- --quiet` 未通过，失败点在既有 `system-settings`、`usage-logs` 等规则错误，不在本 PR 改动文件；本 PR 改动文件单独 eslint 已通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the user edit/create drawer by avoiding stale async results during lifecycle changes.
  * Ensured the form only resets when the fetched user matches the expected record, preventing incorrect data from appearing.
  * Reduced unnecessary fetches and state churn by tightening dependency tracking for form initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->