### PR TITLE
feat(channel): 修改编辑渠道状态下修改api地址、类型、api密钥时，无法按照最新的进行获取的问题；

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -224,6 +224,15 @@ func FetchUpstreamModels(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	
+	if typeStr := c.Query("type"); typeStr != "" {
+		if t, err := strconv.Atoi(typeStr); err == nil {
+			channel.Type = t
+		}
+	}
+	if baseURL := c.Query("base_url"); baseURL != "" {
+		channel.BaseURL = &baseURL
+	}
 
 	ids, err := fetchChannelUpstreamModelIDs(channel)
 	if err != nil {

--- a/web/default/src/features/channels/api.ts
+++ b/web/default/src/features/channels/api.ts
@@ -214,11 +214,15 @@ export async function updateChannelBalance(
  * Fetch available models from upstream provider
  */
 export async function fetchUpstreamModels(
-  id: number
+  id: number,
+  overrides?: { type?: number; base_url?: string }
 ): Promise<FetchModelsResponse> {
+  const params: Record<string, string> = {}
+  if (overrides?.type != null) params.type = String(overrides.type)
+  if (overrides?.base_url) params.base_url = overrides.base_url
   const res = await api.get(
     `/api/channel/fetch_models/${id}`,
-    channelActionConfig()
+    channelActionConfig({ params: Object.keys(params).length > 0 ? params : undefined })
   )
   return res.data
 }

--- a/web/default/src/features/channels/components/drawers/channel-mutate-drawer.tsx
+++ b/web/default/src/features/channels/components/drawers/channel-mutate-drawer.tsx
@@ -107,6 +107,7 @@ import {
 } from '@/features/auth/secure-verification'
 import {
   fetchModels,
+  fetchUpstreamModels,
   getAllModels,
   getChannel,
   getChannelKey,
@@ -287,6 +288,9 @@ export function ChannelMutateDrawer({
   const initialModelsRef = useRef<string[]>([])
   const initialModelMappingRef = useRef<string>('')
   const initialStatusCodeMappingRef = useRef<string>('')
+  const initialTypeRef = useRef<number>(0)
+  const initialBaseUrlRef = useRef<string>('')
+  const initialKeyRef = useRef<string>('')
   const [statusCodeRiskOpen, setStatusCodeRiskOpen] = useState(false)
   const [statusCodeRiskDetailItems, setStatusCodeRiskDetailItems] = useState<
     string[]
@@ -592,14 +596,20 @@ export function ChannelMutateDrawer({
       initialModelMappingRef.current = channelData.data.model_mapping || ''
       initialStatusCodeMappingRef.current =
         channelData.data.status_code_mapping || ''
+      initialTypeRef.current = channelData.data.type ?? 0
+      initialBaseUrlRef.current = channelData.data.base_url || ''
+      initialKeyRef.current = channelKey ?? ''
     } else if (!isEditing) {
       form.reset(CHANNEL_FORM_DEFAULT_VALUES)
       setAdvancedSettingsOpen(false)
       initialModelsRef.current = []
       initialModelMappingRef.current = ''
       initialStatusCodeMappingRef.current = ''
+      initialTypeRef.current = 0
+      initialBaseUrlRef.current = ''
+      initialKeyRef.current = ''
     }
-  }, [isEditing, channelData, form])
+  }, [isEditing, channelData, form, channelKey])
 
   // Handle type change - set default values for specific types
   useEffect(() => {
@@ -768,6 +778,38 @@ export function ChannelMutateDrawer({
     }
     throw new Error(response.message || 'No models fetched from upstream')
   }, [form])
+
+  const editModeFetcher = useCallback(async (): Promise<string[]> => {
+    const formKey = form.getValues('key')
+    if (formKey?.trim()) {
+      const response = await fetchModels({
+        type: form.getValues('type'),
+        key: formKey,
+        base_url: form.getValues('base_url') || '',
+      })
+      if (response.success && response.data) {
+        return response.data
+      }
+      throw new Error(response.message || 'No models fetched from upstream')
+    }
+    const overrides: { type?: number; base_url?: string } = {}
+    const currentTypeVal = form.getValues('type')
+    const currentBaseUrlVal = form.getValues('base_url') || ''
+    if (currentTypeVal !== initialTypeRef.current) {
+      overrides.type = currentTypeVal
+    }
+    if (currentBaseUrlVal !== initialBaseUrlRef.current) {
+      overrides.base_url = currentBaseUrlVal
+    }
+    const response = await fetchUpstreamModels(
+      channelId!,
+      Object.keys(overrides).length > 0 ? overrides : undefined
+    )
+    if (response.success && response.data) {
+      return response.data
+    }
+    throw new Error(response.message || 'No models fetched from upstream')
+  }, [form, channelId])
 
   // Handle model operations
   const handleFillRelatedModels = useCallback(() => {
@@ -3419,7 +3461,7 @@ export function ChannelMutateDrawer({
         }}
         redirectModels={redirectModelList}
         redirectSourceModels={redirectModelKeyList}
-        customFetcher={!isEditing ? createModeFetcher : undefined}
+        customFetcher={isEditing ? editModeFetcher : createModeFetcher}
         channelName={!isEditing ? currentName?.trim() : undefined}
         existingModelsOverride={
           !isEditing


### PR DESCRIPTION
后端 FetchUpstreamModels 接口新增处理 type 和 base_url 查询参数 前端调整上游模型获取 API 并更新渠道编辑抽屉，支持编辑模式下自定义参数拉取模型

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)
做了什么：
在编辑渠道时点击"从上游获取"按钮，现在能 根据用户在表单中实际修改的内容 来决定请求方式，而不是一律用数据库里保存的旧配置去请求。

为什么需要改：
原来的逻辑有一个问题：编辑模式下没有传 customFetcher ，所以弹窗打开后直接拿 数据库中保存的渠道信息 去请求上游。这意味着用户在表单里临时改了 type 、 base_url 或 key ，点"从上游获取"时根本感知不到这些修改，拿到的模型列表和预期不符。

改了三处，各解决什么：
第一处：后端 GET /fetch_models/:id 增加可选 query 参数
原来这个接口只认渠道 ID，拿数据库里的 type 和 base_url 去请求上游。现在允许通过 ?type=xx&base_url=xx 覆盖这两个字段，但不传就保持原样，不影响现有调用方。
第二处：前端 API 层 fetchUpstreamModels 支持 overrides 参数
让前端能方便地把 type/base_url 作为 query 参数拼到请求里。
第三处：Drawer 中新增 editModeFetcher ，替代原来编辑模式不传 fetcher 的行为
这是核心改动。 editModeFetcher 做了一个简单判断：
  - 表单的 key 字段有值（用户输入了新 Key）→ 调用 POST 接口，把 type/key/base_url 全传给后端，后端用新 Key 去请求上游
  - 表单的 key 为空（用户没改 Key）→ 调用 GET 接口，仅把变化了的 type 和 base_url 作为 query 参数传过去，后端读数据库中的 Key，用覆盖后的参数去请求上游
  这个判断能成立，是因为编辑模式下后端出于安全考虑 不会把真实 Key 回填到表单 （ transformChannelToFormDefaults 里 key: '' 是写死的），所以表单 key 非空就必然代表用户手动输入了新值。

## 🚀 变更类型 / Type of change
- [] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [✅] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5159 

## ✅ 提交前检查项 / Checklist
- [✅] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [✅] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [✅] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [✅] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [✅] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [✅] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [✅] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Upstream model fetching now supports optional customization of channel type and base configuration parameters during creation and editing workflows.
  * Channel editor intelligently detects configuration changes and only requests model updates when specific fields are modified, reducing unnecessary requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->