### PR TITLE
fix: harden production security defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,18 @@
 # GEMINI_VISION_MAX_IMAGE_NUM=16
 
 # 会话密钥
-# SESSION_SECRET=random_string
+# SESSION_SECRET=generated-secret-value
+# Field encryption secret for stored provider/payment credentials.
+# Keep stable across restarts and rotate with a planned migration.
+# CRYPTO_SECRET=generated-encryption-secret-value
+# Session cookie Secure flag. Set true when serving only over HTTPS.
+# SESSION_COOKIE_SECURE=false
+
+# CORS allowlist. Comma-separated exact origins, no paths.
+# Example: https://app.example.com,http://localhost:3000
+# CORS_ALLOW_ORIGINS=https://app.example.com
+# Explicitly allow every origin. Not recommended for production.
+# CORS_ALLOW_ALL_ORIGINS=false
 
 # 其他配置
 # 生成默认token
@@ -92,3 +103,27 @@ LINUX_DO_USER_ENDPOINT=https://connect.linux.do/api/user
 # 用于验证支付成功/取消回调URL的域名安全性
 # 示例: example.com,myapp.io 将允许 example.com, sub.example.com, myapp.io 等
 # TRUSTED_REDIRECT_DOMAINS=example.com,myapp.io
+
+# Production Docker Compose settings.
+# Copy this file to .env and fill these values before running docker compose.
+# Use an immutable release tag, not "latest".
+NEW_API_IMAGE_TAG=
+
+# PostgreSQL defaults match docker-compose.yml service names.
+POSTGRES_USER=root
+POSTGRES_PASSWORD=
+POSTGRES_DB=new-api
+
+# Redis requires authentication in the production compose file.
+REDIS_PASSWORD=
+
+# Required application session secret for production.
+SESSION_SECRET=
+
+# Required stable encryption secret for production credential storage.
+CRYPTO_SECRET=
+
+# Optional MySQL deployment settings if switching docker-compose.yml from PostgreSQL.
+MYSQL_USER=root
+MYSQL_ROOT_PASSWORD=
+MYSQL_DATABASE=new-api

--- a/common/constants.go
+++ b/common/constants.go
@@ -74,6 +74,10 @@ var DefaultCollapseSidebar = false // default value of collapse sidebar
 
 var SessionSecret = uuid.New().String()
 var CryptoSecret = uuid.New().String()
+var SessionCookieSecure = false
+
+var CorsAllowAllOrigins = false
+var CorsAllowedOrigins []string
 
 var OptionMap map[string]string
 var OptionMapRWMutex sync.RWMutex

--- a/common/init.go
+++ b/common/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -61,6 +62,8 @@ func InitEnv() {
 	} else {
 		CryptoSecret = SessionSecret
 	}
+	SessionCookieSecure = GetEnvOrDefaultBool("SESSION_COOKIE_SECURE", false)
+	initCorsEnv()
 	if os.Getenv("SQLITE_PATH") != "" {
 		SQLitePath = os.Getenv("SQLITE_PATH")
 	}
@@ -126,6 +129,73 @@ func InitEnv() {
 	SearchRateLimitNum = GetEnvOrDefault("SEARCH_RATE_LIMIT", 10)
 	SearchRateLimitDuration = int64(GetEnvOrDefault("SEARCH_RATE_LIMIT_DURATION", 60))
 	initConstantEnv()
+}
+
+func initCorsEnv() {
+	CorsAllowAllOrigins = GetEnvOrDefaultBool("CORS_ALLOW_ALL_ORIGINS", false)
+	originsStr := GetEnvOrDefaultString("CORS_ALLOW_ORIGINS", "")
+	if strings.TrimSpace(originsStr) == "*" {
+		CorsAllowAllOrigins = true
+		CorsAllowedOrigins = nil
+		return
+	}
+
+	origins := strings.Split(originsStr, ",")
+	allowedOrigins := make([]string, 0, len(origins))
+	seenOrigins := make(map[string]struct{}, len(origins))
+	for _, origin := range origins {
+		normalizedOrigin, ok := normalizeCorsOrigin(origin, true)
+		if !ok {
+			continue
+		}
+		if _, exists := seenOrigins[normalizedOrigin]; exists {
+			continue
+		}
+		seenOrigins[normalizedOrigin] = struct{}{}
+		allowedOrigins = append(allowedOrigins, normalizedOrigin)
+	}
+	CorsAllowedOrigins = allowedOrigins
+}
+
+func normalizeCorsOrigin(origin string, logInvalid bool) (string, bool) {
+	origin = strings.TrimSpace(origin)
+	if origin == "" {
+		return "", false
+	}
+	parsedOrigin, err := url.Parse(origin)
+	if err != nil || parsedOrigin.Scheme == "" || parsedOrigin.Host == "" {
+		if logInvalid {
+			SysError(fmt.Sprintf("invalid CORS origin %q, expected scheme://host", origin))
+		}
+		return "", false
+	}
+	if parsedOrigin.RawQuery != "" || parsedOrigin.Fragment != "" || (parsedOrigin.Path != "" && parsedOrigin.Path != "/") {
+		if logInvalid {
+			SysError(fmt.Sprintf("invalid CORS origin %q, paths, queries, and fragments are not allowed", origin))
+		}
+		return "", false
+	}
+	scheme := strings.ToLower(parsedOrigin.Scheme)
+	if scheme != "http" && scheme != "https" {
+		if logInvalid {
+			SysError(fmt.Sprintf("invalid CORS origin %q, only http and https are allowed", origin))
+		}
+		return "", false
+	}
+	return scheme + "://" + strings.ToLower(parsedOrigin.Host), true
+}
+
+func IsCorsOriginAllowed(origin string) bool {
+	normalizedOrigin, ok := normalizeCorsOrigin(origin, false)
+	if !ok {
+		return false
+	}
+	for _, allowedOrigin := range CorsAllowedOrigins {
+		if normalizedOrigin == allowedOrigin {
+			return true
+		}
+	}
+	return false
 }
 
 func initConstantEnv() {

--- a/common/secure_text.go
+++ b/common/secure_text.go
@@ -1,0 +1,73 @@
+package common
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const secureTextPrefix = "enc:v1:"
+
+func IsSecureText(value string) bool {
+	return strings.HasPrefix(value, secureTextPrefix)
+}
+
+func EncryptSecureText(value string) (string, error) {
+	if value == "" || IsSecureText(value) {
+		return value, nil
+	}
+	aead, err := secureTextAEAD()
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("generate nonce: %w", err)
+	}
+	ciphertext := aead.Seal(nil, nonce, []byte(value), nil)
+	payload := append(nonce, ciphertext...)
+	return secureTextPrefix + base64.RawURLEncoding.EncodeToString(payload), nil
+}
+
+func DecryptSecureText(value string) (string, error) {
+	if value == "" || !IsSecureText(value) {
+		return value, nil
+	}
+	aead, err := secureTextAEAD()
+	if err != nil {
+		return "", err
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(value, secureTextPrefix))
+	if err != nil {
+		return "", fmt.Errorf("decode secure text: %w", err)
+	}
+	if len(payload) <= aead.NonceSize() {
+		return "", errors.New("secure text payload is too short")
+	}
+	nonce := payload[:aead.NonceSize()]
+	ciphertext := payload[aead.NonceSize():]
+	plaintext, err := aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", fmt.Errorf("decrypt secure text: %w", err)
+	}
+	return string(plaintext), nil
+}
+
+func secureTextAEAD() (cipher.AEAD, error) {
+	key := sha256.Sum256([]byte(CryptoSecret))
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, fmt.Errorf("create secure text cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create secure text AEAD: %w", err)
+	}
+	return aead, nil
+}

--- a/common/secure_text_test.go
+++ b/common/secure_text_test.go
@@ -1,0 +1,34 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecureTextRoundTrip(t *testing.T) {
+	originalSecret := CryptoSecret
+	CryptoSecret = "test-secret-for-secure-text"
+	t.Cleanup(func() {
+		CryptoSecret = originalSecret
+	})
+
+	encrypted, err := EncryptSecureText("sk-test-secret")
+	require.NoError(t, err)
+	require.True(t, IsSecureText(encrypted))
+	require.NotContains(t, encrypted, "sk-test-secret")
+
+	decrypted, err := DecryptSecureText(encrypted)
+	require.NoError(t, err)
+	require.Equal(t, "sk-test-secret", decrypted)
+}
+
+func TestSecureTextLeavesPlainAndExistingCiphertextUnchanged(t *testing.T) {
+	plain, err := DecryptSecureText("plain")
+	require.NoError(t, err)
+	require.Equal(t, "plain", plain)
+
+	encrypted, err := EncryptSecureText("enc:v1:already")
+	require.NoError(t, err)
+	require.Equal(t, "enc:v1:already", encrypted)
+}

--- a/controller/topup_stripe.go
+++ b/controller/topup_stripe.go
@@ -160,19 +160,20 @@ func StripeWebhook(c *gin.Context) {
 	}
 
 	signature := c.GetHeader("Stripe-Signature")
-	logger.LogInfo(ctx, fmt.Sprintf("Stripe webhook 收到请求 path=%q client_ip=%s signature=%q body=%q", c.Request.RequestURI, c.ClientIP(), signature, string(payload)))
+	logger.LogInfo(ctx, fmt.Sprintf("Stripe webhook 收到请求 path=%q client_ip=%s body_bytes=%d signature_present=%t", c.Request.RequestURI, c.ClientIP(), len(payload), signature != ""))
 	event, err := webhook.ConstructEventWithOptions(payload, signature, setting.StripeWebhookSecret, webhook.ConstructEventOptions{
 		IgnoreAPIVersionMismatch: true,
 	})
 
 	if err != nil {
-		logger.LogWarn(ctx, fmt.Sprintf("Stripe webhook 验签失败 path=%q client_ip=%s error=%q", c.Request.RequestURI, c.ClientIP(), err.Error()))
+		logger.LogWarn(ctx, fmt.Sprintf("Stripe webhook 验签失败 path=%q client_ip=%s body_bytes=%d signature_present=%t error_type=%T", c.Request.RequestURI, c.ClientIP(), len(payload), signature != "", err))
 		c.AbortWithStatus(http.StatusBadRequest)
 		return
 	}
 
 	callerIp := c.ClientIP()
-	logger.LogInfo(ctx, fmt.Sprintf("Stripe webhook 验签成功 event_type=%s client_ip=%s path=%q", string(event.Type), callerIp, c.Request.RequestURI))
+	tradeNo := event.GetObjectValue("client_reference_id")
+	logger.LogInfo(ctx, fmt.Sprintf("Stripe webhook 验签成功 event_id=%s event_type=%s trade_no=%s client_ip=%s path=%q", event.ID, string(event.Type), tradeNo, callerIp, c.Request.RequestURI))
 	switch event.Type {
 	case stripe.EventTypeCheckoutSessionCompleted:
 		sessionCompleted(ctx, event, callerIp)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
 # New-API Docker Compose Configuration
 # 
 # Quick Start:
-#   1. docker-compose up -d
-#   2. Access at http://localhost:3000
+#   1. Copy .env.example to .env and set the required production secrets.
+#   2. Set NEW_API_IMAGE_TAG to an immutable release tag.
+#   3. docker compose up -d
+#   4. Access at http://localhost:3000
 #
 # Using MySQL instead of PostgreSQL:
 #   1. Comment out the postgres service and SQL_DSN line 15
@@ -10,13 +12,11 @@
 #   3. Uncomment mysql in depends_on (line 28)
 #   4. Uncomment mysql_data in volumes section (line 64)
 #
-# ⚠️  IMPORTANT: Change all default passwords before deploying to production!
-
 version: '3.4' # For compatibility with older Docker versions
 
 services:
   new-api:
-    image: calciumion/new-api:latest
+    image: calciumion/new-api:${NEW_API_IMAGE_TAG:?Set NEW_API_IMAGE_TAG to an immutable release tag before deployment}
     container_name: new-api
     restart: always
     command: --log-dir /app/logs
@@ -26,15 +26,16 @@ services:
       - ./data:/data
       - ./logs:/app/logs
     environment:
-      - SQL_DSN=postgresql://root:123456@postgres:5432/new-api # ⚠️ IMPORTANT: Change the password in production!
-#      - SQL_DSN=root:123456@tcp(mysql:3306)/new-api  # Point to the mysql service, uncomment if using MySQL
-      - REDIS_CONN_STRING=redis://:123456@redis:6379 # ⚠️ IMPORTANT: Change the password in production!
+      - SQL_DSN=postgresql://${POSTGRES_USER:-root}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-new-api}
+#      - SQL_DSN=${MYSQL_USER:-root}:${MYSQL_ROOT_PASSWORD:?Set MYSQL_ROOT_PASSWORD in .env}@tcp(mysql:3306)/${MYSQL_DATABASE:-new-api}  # Point to the mysql service, uncomment if using MySQL
+      - REDIS_CONN_STRING=redis://:${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env}@redis:6379
+      - SESSION_SECRET=${SESSION_SECRET:?Set SESSION_SECRET in .env}
+      - CRYPTO_SECRET=${CRYPTO_SECRET:?Set CRYPTO_SECRET in .env}
       - TZ=Asia/Shanghai
       - ERROR_LOG_ENABLED=true # 是否启用错误日志记录 (Whether to enable error log recording)
       - BATCH_UPDATE_ENABLED=true  # 是否启用批量更新 (Whether to enable batch update)
       - NODE_NAME=new-api-node-1  # 节点名称，用于审计日志中标识节点身份；多节点/容器部署时建议设置 (Node name used in audit logs; recommended when running multiple instances or in containers)
 #      - STREAMING_TIMEOUT=300  # 流模式无响应超时时间，单位秒，默认120秒，如果出现空补全可以尝试改为更大值 （Streaming timeout in seconds, default is 120s. Increase if experiencing empty completions）
-#      - SESSION_SECRET=random_string  # 多机部署时设置，必须修改这个随机字符串！！ （multi-node deployment, set this to a random string!!!!!!!）
 #      - SYNC_FREQUENCY=60  # Uncomment if regular database syncing is needed
 #      - GOOGLE_ANALYTICS_ID=G-XXXXXXXXXX  # Google Analytics 的测量 ID (Google Analytics Measurement ID)
 #      - UMAMI_WEBSITE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx  # Umami 网站 ID (Umami Website ID)
@@ -53,10 +54,10 @@ services:
       retries: 3
 
   redis:
-    image: redis:latest
+    image: redis:7-alpine
     container_name: redis
     restart: always
-    command: ["redis-server", "--requirepass", "123456"]  # ⚠️ IMPORTANT: Change this password in production!
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env}"]
     networks:
       - new-api-network
 
@@ -65,9 +66,9 @@ services:
     container_name: postgres
     restart: always
     environment:
-      POSTGRES_USER: root
-      POSTGRES_PASSWORD: 123456  # ⚠️ IMPORTANT: Change this password in production!
-      POSTGRES_DB: new-api
+      POSTGRES_USER: ${POSTGRES_USER:-root}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-new-api}
     volumes:
       - pg_data:/var/lib/postgresql/data
     networks:
@@ -80,8 +81,8 @@ services:
 #    container_name: mysql
 #    restart: always
 #    environment:
-#      MYSQL_ROOT_PASSWORD: 123456  # ⚠️ IMPORTANT: Change this password in production!
-#      MYSQL_DATABASE: new-api
+#      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?Set MYSQL_ROOT_PASSWORD in .env}
+#      MYSQL_DATABASE: ${MYSQL_DATABASE:-new-api}
 #    volumes:
 #      - mysql_data:/var/lib/mysql
 #    networks:

--- a/docs/deployment/PRODUCTION_SECURITY_CONFIG.md
+++ b/docs/deployment/PRODUCTION_SECURITY_CONFIG.md
@@ -1,0 +1,91 @@
+# Production Security Configuration
+
+This guide covers the production Docker Compose security settings for `new-api`.
+
+## Required `.env` Values
+
+Before running `docker compose up -d`, copy `.env.example` to `.env` and set these values:
+
+```dotenv
+NEW_API_IMAGE_TAG=
+POSTGRES_USER=root
+POSTGRES_PASSWORD=
+POSTGRES_DB=new-api
+REDIS_PASSWORD=
+SESSION_SECRET=
+CRYPTO_SECRET=
+```
+
+Use `NEW_API_IMAGE_TAG` with an immutable release tag. Do not use `latest` for commercial or production deployments because it makes upgrades implicit and rollback behavior ambiguous.
+
+Generate unique high-entropy values for:
+
+- `POSTGRES_PASSWORD`
+- `REDIS_PASSWORD`
+- `SESSION_SECRET`
+- `CRYPTO_SECRET`
+- `MYSQL_ROOT_PASSWORD`, if using MySQL instead of PostgreSQL
+
+Use at least 32 random characters for passwords, session secrets, and encryption secrets. Keep `.env` out of source control and restrict filesystem access to deployment operators.
+
+`CRYPTO_SECRET` protects newly stored provider credentials, payment secrets, and other sensitive options. Keep it stable across restarts. Rotating it requires a planned credential migration because existing encrypted values must be decrypted with the previous secret and re-encrypted with the new one.
+
+## Password Encoding
+
+`SQL_DSN` and `REDIS_CONN_STRING` are URL-like connection strings. If a password contains reserved characters such as `@`, `:`, `/`, `?`, `#`, `&`, or `%`, URL-encode the password value before placing it in `.env`, or choose a generated value that avoids URL-reserved characters.
+
+The Redis container password is also passed to `redis-server --requirepass`, so `REDIS_PASSWORD` must match the password embedded in `REDIS_CONN_STRING`.
+
+## PostgreSQL Deployment
+
+The default production compose file uses PostgreSQL:
+
+```yaml
+SQL_DSN=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+```
+
+Do not expose PostgreSQL to the host or public network unless there is a specific operational need. If external database access is required, restrict it with host firewall rules and database-level credentials.
+
+## MySQL Deployment
+
+If switching to MySQL:
+
+1. Comment out the PostgreSQL service and dependency.
+2. Uncomment the MySQL service, dependency, volume, and MySQL `SQL_DSN`.
+3. Set these values in `.env`:
+
+```dotenv
+MYSQL_USER=root
+MYSQL_ROOT_PASSWORD=
+MYSQL_DATABASE=new-api
+```
+
+For production environments with shared database infrastructure, prefer a dedicated least-privilege database user instead of the root account.
+
+## Pre-Deployment Checks
+
+Render the final Compose configuration before deployment:
+
+```bash
+docker compose config
+```
+
+Confirm the rendered output:
+
+- Does not reference `:latest` images.
+- Does not contain example passwords such as `123456`.
+- Contains the intended database and Redis connection strings.
+- Does not expose database or Redis ports unless explicitly required.
+
+Start the stack:
+
+```bash
+docker compose up -d
+docker compose ps
+```
+
+Check application health:
+
+```bash
+curl -fsS http://localhost:3000/api/status
+```

--- a/main.go
+++ b/main.go
@@ -181,7 +181,7 @@ func main() {
 		Path:     "/",
 		MaxAge:   2592000, // 30 days
 		HttpOnly: true,
-		Secure:   false,
+		Secure:   common.SessionCookieSecure,
 		SameSite: http.SameSiteStrictMode,
 	})
 	server.Use(sessions.Sessions("session", store))

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -8,8 +8,13 @@ import (
 
 func CORS() gin.HandlerFunc {
 	config := cors.DefaultConfig()
-	config.AllowAllOrigins = true
-	config.AllowCredentials = true
+	config.AllowAllOrigins = common.CorsAllowAllOrigins
+	if common.CorsAllowAllOrigins {
+		config.AllowCredentials = false
+	} else {
+		config.AllowOriginFunc = common.IsCorsOriginAllowed
+		config.AllowCredentials = true
+	}
 	config.AllowMethods = []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}
 	config.AllowHeaders = []string{"*"}
 	return cors.New(config)

--- a/model/channel.go
+++ b/model/channel.go
@@ -75,6 +75,30 @@ type ChannelSortOptions struct {
 	IDSort    bool
 }
 
+func (channel *Channel) encryptKeyForStorage() error {
+	if channel == nil || channel.Key == "" {
+		return nil
+	}
+	encrypted, err := common.EncryptSecureText(channel.Key)
+	if err != nil {
+		return fmt.Errorf("encrypt channel key: %w", err)
+	}
+	channel.Key = encrypted
+	return nil
+}
+
+func (channel *Channel) decryptKeyForUse() {
+	if channel == nil || channel.Key == "" || !common.IsSecureText(channel.Key) {
+		return
+	}
+	decrypted, err := common.DecryptSecureText(channel.Key)
+	if err != nil {
+		common.SysLog(fmt.Sprintf("failed to decrypt channel key: channel_id=%d, error=%v", channel.Id, err))
+		return
+	}
+	channel.Key = decrypted
+}
+
 var channelSortColumns = map[string]string{
 	"id":            "id",
 	"name":          "name",
@@ -173,6 +197,7 @@ func (c *ChannelInfo) Scan(value interface{}) error {
 }
 
 func (channel *Channel) GetKeys() []string {
+	channel.decryptKeyForUse()
 	if channel.Key == "" {
 		return []string{}
 	}
@@ -197,6 +222,7 @@ func (channel *Channel) GetKeys() []string {
 }
 
 func (channel *Channel) GetNextEnabledKey() (string, int, *types.NewAPIError) {
+	channel.decryptKeyForUse()
 	// If not in multi-key mode, return the original key string directly.
 	if !channel.ChannelInfo.IsMultiKey {
 		return channel.Key, 0, nil
@@ -343,7 +369,11 @@ func (channel *Channel) GetAutoBan() bool {
 }
 
 func (channel *Channel) Save() error {
-	return DB.Save(channel).Error
+	stored := *channel
+	if err := stored.encryptKeyForStorage(); err != nil {
+		return err
+	}
+	return DB.Save(&stored).Error
 }
 
 func (channel *Channel) SaveWithoutKey() error {
@@ -362,6 +392,11 @@ func GetAllChannels(startIdx int, num int, selectAll bool, idSort bool, sortOpti
 	} else {
 		err = order.Apply(DB).Limit(num).Offset(startIdx).Omit("key").Find(&channels).Error
 	}
+	if err == nil && selectAll {
+		for _, channel := range channels {
+			channel.decryptKeyForUse()
+		}
+	}
 	return channels, err
 }
 
@@ -373,6 +408,11 @@ func GetChannelsByTag(tag string, idSort bool, selectAll bool, sortOptions ...Ch
 		query = query.Omit("key")
 	}
 	err := query.Find(&channels).Error
+	if err == nil && selectAll {
+		for _, channel := range channels {
+			channel.decryptKeyForUse()
+		}
+	}
 	return channels, err
 }
 
@@ -420,6 +460,7 @@ func GetChannelById(id int, selectAll bool) (*Channel, error) {
 	if err != nil {
 		return nil, err
 	}
+	channel.decryptKeyForUse()
 	return channel, nil
 }
 
@@ -438,6 +479,12 @@ func BatchInsertChannels(channels []Channel) error {
 	}()
 
 	for _, chunk := range lo.Chunk(channels, 50) {
+		for i := range chunk {
+			if err := chunk[i].encryptKeyForStorage(); err != nil {
+				tx.Rollback()
+				return err
+			}
+		}
 		if err := tx.Create(&chunk).Error; err != nil {
 			tx.Rollback()
 			return err
@@ -514,11 +561,17 @@ func (channel *Channel) GetStatusCodeMapping() string {
 }
 
 func (channel *Channel) Insert() error {
+	stored := *channel
+	if err := stored.encryptKeyForStorage(); err != nil {
+		return err
+	}
 	var err error
-	err = DB.Create(channel).Error
+	err = DB.Create(&stored).Error
 	if err != nil {
 		return err
 	}
+	*channel = stored
+	channel.decryptKeyForUse()
 	err = channel.AddAbilities(nil)
 	return err
 }
@@ -563,11 +616,16 @@ func (channel *Channel) Update() error {
 		}
 	}
 	var err error
-	err = DB.Model(channel).Updates(channel).Error
+	stored := *channel
+	if err := stored.encryptKeyForStorage(); err != nil {
+		return err
+	}
+	err = DB.Model(channel).Updates(&stored).Error
 	if err != nil {
 		return err
 	}
 	DB.Model(channel).First(channel, "id = ?", channel.Id)
+	channel.decryptKeyForUse()
 	err = channel.UpdateAbilities(nil)
 	return err
 }

--- a/model/option.go
+++ b/model/option.go
@@ -187,7 +187,12 @@ func InitOptionMap() {
 func loadOptionsFromDatabase() {
 	options, _ := AllOption()
 	for _, option := range options {
-		err := updateOptionMap(option.Key, option.Value)
+		value, decryptErr := decryptOptionValue(option.Key, option.Value)
+		if decryptErr != nil {
+			common.SysLog("failed to decrypt option value: key=" + option.Key + ", error=" + decryptErr.Error())
+			continue
+		}
+		err := updateOptionMap(option.Key, value)
 		if err != nil {
 			common.SysLog("failed to update option map: " + err.Error())
 		}
@@ -209,11 +214,17 @@ func UpdateOption(key string, value string) error {
 	}
 	// https://gorm.io/docs/update.html#Save-All-Fields
 	DB.FirstOrCreate(&option, Option{Key: key})
-	option.Value = value
+	storedValue, err := encryptOptionValue(key, value)
+	if err != nil {
+		return err
+	}
+	option.Value = storedValue
 	// Save is a combination function.
 	// If save value does not contain primary key, it will execute Create,
 	// otherwise it will execute Update (with all fields).
-	DB.Save(&option)
+	if err := DB.Save(&option).Error; err != nil {
+		return err
+	}
 	// Update OptionMap
 	return updateOptionMap(key, value)
 }
@@ -233,7 +244,11 @@ func UpdateOptionsBulk(values map[string]string) error {
 			if err := tx.FirstOrCreate(&option, Option{Key: k}).Error; err != nil {
 				return err
 			}
-			option.Value = v
+			storedValue, err := encryptOptionValue(k, v)
+			if err != nil {
+				return err
+			}
+			option.Value = storedValue
 			if err := tx.Save(&option).Error; err != nil {
 				return err
 			}
@@ -249,6 +264,49 @@ func UpdateOptionsBulk(values map[string]string) error {
 		}
 	}
 	return nil
+}
+
+func encryptOptionValue(key string, value string) (string, error) {
+	if !isSensitiveOptionKey(key) || value == "" {
+		return value, nil
+	}
+	encrypted, err := common.EncryptSecureText(value)
+	if err != nil {
+		return "", err
+	}
+	return encrypted, nil
+}
+
+func decryptOptionValue(key string, value string) (string, error) {
+	if !isSensitiveOptionKey(key) || value == "" {
+		return value, nil
+	}
+	return common.DecryptSecureText(value)
+}
+
+func isSensitiveOptionKey(key string) bool {
+	switch key {
+	case "SMTPToken",
+		"WorkerValidKey",
+		"EpayKey",
+		"StripeApiSecret",
+		"StripeWebhookSecret",
+		"CreemApiKey",
+		"CreemWebhookSecret",
+		"WaffoApiKey",
+		"WaffoPrivateKey",
+		"WaffoSandboxApiKey",
+		"WaffoSandboxPrivateKey",
+		"WaffoPancakePrivateKey",
+		"GitHubClientSecret",
+		"LinuxDOClientSecret",
+		"WeChatServerToken",
+		"TelegramBotToken",
+		"TurnstileSecretKey":
+		return true
+	default:
+		return false
+	}
 }
 
 func updateOptionMap(key string, value string) (err error) {


### PR DESCRIPTION
## Summary
- Restrict CORS with configurable allowlist and add SESSION_COOKIE_SECURE support
- Redact Stripe webhook payload/signature logging
- Add AES-GCM secure text storage for new channel keys and sensitive options
- Require production Docker secrets and document secure deployment settings

## Verification
- go test ./common ./middleware ./model
- go test ./controller -run 'Stripe|Webhook'
- docker compose config with required production env vars
- docker build -f Dockerfile.dev -t new-api-security-verify:local .
- container smoke test: GET http://localhost:13000/api/status => 200 success=true

## Known existing test failures
Full go test ./... is currently blocked by pre-existing failures unrelated to this change: missing web/classic/dist embed assets in local test mode, controller TestListModelsTokenLimitIncludesTieredBillingModel, Claude file conversion tests, relay/helper stream scanner tests, and service channel affinity usage cache tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CORS origin allowlist configuration for fine-grained cross-origin access control.
  * Added secure text encryption for protecting sensitive data storage.
  * Added session cookie security controls via environment configuration.

* **Security**
  * Channel keys are now encrypted at rest and decrypted at runtime.
  * Sensitive option values are encrypted before database persistence.

* **Documentation**
  * Added comprehensive production security configuration guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->