### PR TITLE
feat: 支持阿里多模态向量化模型qwen3-vl-embedding

### DIFF
--- a/relay/channel/ali/adaptor.go
+++ b/relay/channel/ali/adaptor.go
@@ -100,7 +100,11 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	default:
 		switch info.RelayMode {
 		case constant.RelayModeEmbeddings:
-			fullRequestURL = fmt.Sprintf("%s/compatible-mode/v1/embeddings", info.ChannelBaseUrl)
+			if IsMultimodalEmbeddingModel(info.UpstreamModelName) {
+				fullRequestURL = fmt.Sprintf("%s/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding", info.ChannelBaseUrl)
+			} else {
+				fullRequestURL = fmt.Sprintf("%s/compatible-mode/v1/embeddings", info.ChannelBaseUrl)
+			}
 		case constant.RelayModeRerank:
 			fullRequestURL = fmt.Sprintf("%s/api/v1/services/rerank/text-rerank/text-rerank", info.ChannelBaseUrl)
 		case constant.RelayModeResponses:
@@ -222,6 +226,9 @@ func (a *Adaptor) ConvertRerankRequest(c *gin.Context, relayMode int, request dt
 }
 
 func (a *Adaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.EmbeddingRequest) (any, error) {
+	if IsMultimodalEmbeddingModel(info.UpstreamModelName) {
+		return convertToMultimodalEmbeddingRequest(request)
+	}
 	return request, nil
 }
 
@@ -256,6 +263,13 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycom
 			err, usage = aliImageHandler(a, c, resp, info)
 		case constant.RelayModeRerank:
 			err, usage = RerankHandler(c, resp, info)
+		case constant.RelayModeEmbeddings:
+			if IsMultimodalEmbeddingModel(info.UpstreamModelName) {
+				err, usage = MultimodalEmbeddingHandler(c, resp, info)
+			} else {
+				adaptor := openai.Adaptor{}
+				usage, err = adaptor.DoResponse(c, resp, info)
+			}
 		default:
 			adaptor := openai.Adaptor{}
 			usage, err = adaptor.DoResponse(c, resp, info)

--- a/relay/channel/ali/constants.go
+++ b/relay/channel/ali/constants.go
@@ -8,6 +8,7 @@ var ModelList = []string{
 	"qwq-32b",
 	"qwen3-235b-a22b",
 	"text-embedding-v1",
+	"qwen3-vl-embedding",
 	"gte-rerank-v2",
 }
 

--- a/relay/channel/ali/dto.go
+++ b/relay/channel/ali/dto.go
@@ -73,6 +73,7 @@ type AliUsage struct {
 	OutputTokens int `json:"output_tokens"`
 	TotalTokens  int `json:"total_tokens"`
 	ImageCount   int `json:"image_count,omitempty"`
+	ImageTokens  int `json:"image_tokens,omitempty"`
 }
 
 type TaskResult struct {

--- a/relay/channel/ali/embedding.go
+++ b/relay/channel/ali/embedding.go
@@ -1,0 +1,196 @@
+package ali
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/types"
+
+	"github.com/gin-gonic/gin"
+)
+
+// DashScope 多模态向量不支持 OpenAI 兼容接口,必须走原生 multimodal 端点,故需单独识别。
+var MultimodalEmbeddingModels = map[string]bool{
+	"qwen3-vl-embedding": true,
+}
+
+func IsMultimodalEmbeddingModel(model string) bool {
+	return MultimodalEmbeddingModels[model]
+}
+
+type AliMultimodalContent struct {
+	Text  string `json:"text,omitempty"`
+	Image string `json:"image,omitempty"`
+	Video string `json:"video,omitempty"`
+}
+
+type AliMultimodalEmbeddingRequest struct {
+	Model string `json:"model"`
+	Input struct {
+		Contents []AliMultimodalContent `json:"contents"`
+	} `json:"input"`
+	Parameters *AliMultimodalEmbeddingParameters `json:"parameters,omitempty"`
+}
+
+type AliMultimodalEmbeddingParameters struct {
+	Dimension *int `json:"dimension,omitempty"`
+}
+
+type AliMultimodalEmbeddingItem struct {
+	Index     int       `json:"index"`
+	Embedding []float64 `json:"embedding"`
+}
+
+type AliMultimodalEmbeddingResponse struct {
+	Output struct {
+		Embeddings []AliMultimodalEmbeddingItem `json:"embeddings"`
+	} `json:"output"`
+	Usage     AliUsage `json:"usage"`
+	RequestId string   `json:"request_id"`
+	AliError
+}
+
+func convertToMultimodalEmbeddingRequest(request dto.EmbeddingRequest) (*AliMultimodalEmbeddingRequest, error) {
+	contents, err := convertInputToAliContents(request.Input)
+	if err != nil {
+		return nil, err
+	}
+	aliReq := &AliMultimodalEmbeddingRequest{Model: request.Model}
+	aliReq.Input.Contents = contents
+	if request.Dimensions != nil {
+		aliReq.Parameters = &AliMultimodalEmbeddingParameters{Dimension: request.Dimensions}
+	}
+	return aliReq, nil
+}
+
+func convertInputToAliContents(input any) ([]AliMultimodalContent, error) {
+	if input == nil {
+		return nil, fmt.Errorf("embedding input is empty")
+	}
+	switch v := input.(type) {
+	case string:
+		return []AliMultimodalContent{{Text: v}}, nil
+	case []any:
+		return convertSliceToAliContents(v)
+	default:
+		return nil, fmt.Errorf("unsupported embedding input type: %T", input)
+	}
+}
+
+func convertSliceToAliContents(items []any) ([]AliMultimodalContent, error) {
+	if len(items) == 0 {
+		return nil, fmt.Errorf("embedding input is empty")
+	}
+	result := make([]AliMultimodalContent, 0, len(items))
+	for _, item := range items {
+		switch v := item.(type) {
+		case string:
+			result = append(result, AliMultimodalContent{Text: v})
+		case map[string]any:
+			content, err := parseAliContentItem(v)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, content)
+		default:
+			return nil, fmt.Errorf("unsupported embedding input item type: %T", item)
+		}
+	}
+	return result, nil
+}
+
+func parseAliContentItem(m map[string]any) (AliMultimodalContent, error) {
+	typeStr, ok := m["type"].(string)
+	if !ok || typeStr == "" {
+		return AliMultimodalContent{}, fmt.Errorf("multimodal input item missing required 'type' field")
+	}
+	switch typeStr {
+	case dto.ContentTypeText:
+		text, _ := m[dto.ContentTypeText].(string)
+		return AliMultimodalContent{Text: text}, nil
+	case dto.ContentTypeImageURL:
+		url, err := parseURLField(m, dto.ContentTypeImageURL)
+		if err != nil {
+			return AliMultimodalContent{}, err
+		}
+		return AliMultimodalContent{Image: url}, nil
+	case dto.ContentTypeVideoUrl:
+		url, err := parseURLField(m, dto.ContentTypeVideoUrl)
+		if err != nil {
+			return AliMultimodalContent{}, err
+		}
+		return AliMultimodalContent{Video: url}, nil
+	default:
+		return AliMultimodalContent{}, fmt.Errorf("unsupported multimodal input type: %s", typeStr)
+	}
+}
+
+func parseURLField(m map[string]any, key string) (string, error) {
+	urlObj, ok := m[key].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("invalid %s format", key)
+	}
+	url, _ := urlObj["url"].(string)
+	if url == "" {
+		return "", fmt.Errorf("%s.url is required", key)
+	}
+	return url, nil
+}
+
+func MultimodalEmbeddingHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (*types.NewAPIError, *dto.Usage) {
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return types.NewOpenAIError(err, types.ErrorCodeReadResponseBodyFailed, http.StatusInternalServerError), nil
+	}
+	service.CloseResponseBodyGracefully(resp)
+
+	var aliResponse AliMultimodalEmbeddingResponse
+	if err = common.Unmarshal(responseBody, &aliResponse); err != nil {
+		return types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError), nil
+	}
+	// 原生端点可能返回 200 但 body 带错误码
+	if aliResponse.Code != "" {
+		return types.WithOpenAIError(types.OpenAIError{
+			Message: aliResponse.Message,
+			Type:    aliResponse.Code,
+			Param:   aliResponse.RequestId,
+			Code:    aliResponse.Code,
+		}, resp.StatusCode), nil
+	}
+
+	data := make([]dto.EmbeddingResponseItem, 0, len(aliResponse.Output.Embeddings))
+	for _, embedding := range aliResponse.Output.Embeddings {
+		data = append(data, dto.EmbeddingResponseItem{
+			Object:    "embedding",
+			Index:     embedding.Index,
+			Embedding: embedding.Embedding,
+		})
+	}
+
+	usage := dto.Usage{
+		PromptTokens: aliResponse.Usage.InputTokens,
+		TotalTokens:  aliResponse.Usage.TotalTokens,
+	}
+	if usage.TotalTokens == 0 {
+		usage.TotalTokens = usage.PromptTokens
+	}
+
+	embeddingResponse := dto.EmbeddingResponse{
+		Object: "list",
+		Data:   data,
+		Model:  info.UpstreamModelName,
+		Usage:  usage,
+	}
+
+	jsonResponse, err := common.Marshal(embeddingResponse)
+	if err != nil {
+		return types.NewError(err, types.ErrorCodeBadResponseBody), nil
+	}
+	service.IOCopyBytesGracefully(c, resp, jsonResponse)
+	return nil, &usage
+}

--- a/relay/channel/ali/embedding.go
+++ b/relay/channel/ali/embedding.go
@@ -172,10 +172,13 @@ func MultimodalEmbeddingHandler(c *gin.Context, resp *http.Response, info *relay
 		})
 	}
 
+	u := aliResponse.Usage
 	usage := dto.Usage{
-		PromptTokens: aliResponse.Usage.InputTokens,
-		TotalTokens:  aliResponse.Usage.TotalTokens,
+		PromptTokens: u.InputTokens + u.ImageTokens,
+		TotalTokens:  u.TotalTokens,
 	}
+	usage.PromptTokensDetails.TextTokens = u.InputTokens
+	usage.PromptTokensDetails.ImageTokens = u.ImageTokens
 	if usage.TotalTokens == 0 {
 		usage.TotalTokens = usage.PromptTokens
 	}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
原先阿里渠道只支持文本向量化
增加多模态向量化模型支持
支持图像和视频url
支持文本, 图像和视频token单独计费

## 📝 变更描述 / Description
将阿里的向量化格式转换成openai格式的向量化

## 📸 运行证明 / Proof of Work
```
请求格式:
curl http://localhost:3000/v1/embeddings \
  --request POST \
  --header 'Content-Type: application/json' \
  --data '{
  "model": "qwen3-vl-embedding",
  "input": [
    {
      "type": "text",
      "text": "hello"
    },
    {
      "type": "image_url",
      "image_url": {
        "url": "https://ark-project.tos-cn-beijing.volces.com/doc_image/tower.png"
      }
    }
  ],
  "encoding_format": "float"
}'
```
<img width="2598" height="2248" alt="image" src="https://github.com/user-attachments/assets/a2b0bc1c-05a2-470d-b8cb-f4092976121b" />

计费:
<img width="4578" height="1316" alt="image" src="https://github.com/user-attachments/assets/0c7bfb28-f7ae-4ed4-a631-28b2136d8973" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multimodal embeddings, enabling image and video processing alongside text in embedding requests.
  * Introduced image token usage tracking in embedding responses for improved usage monitoring.
  * Extended model support with a new multimodal embedding model.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/5179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->