### PR TITLE
fix(model): correct idx_created_at_id index column order to (created_at, id)

### DIFF
--- a/model/log.go
+++ b/model/log.go
@@ -32,9 +32,9 @@ func applyExplicitLogTextFilter(tx *gorm.DB, column string, value string) (*gorm
 }
 
 type Log struct {
-	Id                int    `json:"id" gorm:"index:idx_created_at_id,priority:1;index:idx_user_id_id,priority:2"`
+	Id                int    `json:"id" gorm:"index:idx_created_at_id,priority:2;index:idx_user_id_id,priority:2"`
 	UserId            int    `json:"user_id" gorm:"index;index:idx_user_id_id,priority:1"`
-	CreatedAt         int64  `json:"created_at" gorm:"bigint;index:idx_created_at_id,priority:2;index:idx_created_at_type"`
+	CreatedAt         int64  `json:"created_at" gorm:"bigint;index:idx_created_at_id,priority:1;index:idx_created_at_type"`
 	Type              int    `json:"type" gorm:"index:idx_created_at_type"`
 	Content           string `json:"content"`
 	Username          string `json:"username" gorm:"index;index:index_username_model_name,priority:2;default:''"`


### PR DESCRIPTION
## 背景

修复 #5192。

`logs` 表的复合索引 `idx_created_at_id` 因 GORM `priority` 写反,实际生成为 `(id, created_at)`,而非索引名所暗示的 `(created_at, id)`。由于 `id` 是自增主键,以 `id` 打头的二级复合索引与主键高度重复、基本无用,且无法加速日志列表常见的 `WHERE created_at BETWEEN ? AND ? ORDER BY id DESC LIMIT n` 查询,导致大表上退化为接近全表扫描的慢查询。

## 改动

`model/log.go` 中交换 `Id` 与 `CreatedAt` 在 `idx_created_at_id` 上的 `priority`,使列序变为 `(created_at, id)`,与索引名与用途一致。`idx_user_id_id`、`idx_created_at_type` 不受影响。

```diff
- Id        int   `json:"id" gorm:"index:idx_created_at_id,priority:1;index:idx_user_id_id,priority:2"`
+ Id        int   `json:"id" gorm:"index:idx_created_at_id,priority:2;index:idx_user_id_id,priority:2"`
- CreatedAt int64 `json:"created_at" gorm:"bigint;index:idx_created_at_id,priority:2;index:idx_created_at_type"`
+ CreatedAt int64 `json:"created_at" gorm:"bigint;index:idx_created_at_id,priority:1;index:idx_created_at_type"`
```

## ⚠️ 存量部署注意

GORM AutoMigrate **不会**调整"已存在同名索引"的列序,因此本改动仅对**全新初始化**的数据库自动生效。存量部署需手动重建索引:

**MySQL**(8.0 支持在线 DDL,不锁表):
```sql
ALTER TABLE logs
  DROP INDEX idx_created_at_id,
  ADD INDEX idx_created_at_id (created_at, id),
  ALGORITHM=INPLACE, LOCK=NONE;
```

**PostgreSQL**:
```sql
DROP INDEX IF EXISTS idx_created_at_id;
CREATE INDEX CONCURRENTLY idx_created_at_id ON logs (created_at, id);
```

**SQLite**:
```sql
DROP INDEX IF EXISTS idx_created_at_id;
CREATE INDEX idx_created_at_id ON logs (created_at, id);
```

是否在 `migrateDB` 中加入自动重建逻辑,因涉及大表 DROP/CREATE 的风险与三库差异,留待维护者决定,可在本 PR 讨论。

## 验证

- `go build ./...` 通过,`gofmt` 无差异。
- 全新库 AutoMigrate 后,`SHOW INDEX FROM logs`(MySQL)中 `idx_created_at_id` 的列序为 `(created_at, id)`。
