### PR TITLE
fix: preserve settings on invalid json updates

### DIFF
--- a/setting/rate_limit.go
+++ b/setting/rate_limit.go
@@ -1,7 +1,6 @@
 package setting
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
 	"sync"
@@ -20,7 +19,7 @@ func ModelRequestRateLimitGroup2JSONString() string {
 	ModelRequestRateLimitMutex.RLock()
 	defer ModelRequestRateLimitMutex.RUnlock()
 
-	jsonBytes, err := json.Marshal(ModelRequestRateLimitGroup)
+	jsonBytes, err := common.Marshal(ModelRequestRateLimitGroup)
 	if err != nil {
 		common.SysLog("error marshalling model ratio: " + err.Error())
 	}
@@ -28,11 +27,15 @@ func ModelRequestRateLimitGroup2JSONString() string {
 }
 
 func UpdateModelRequestRateLimitGroupByJSONString(jsonStr string) error {
-	ModelRequestRateLimitMutex.RLock()
-	defer ModelRequestRateLimitMutex.RUnlock()
+	nextModelRequestRateLimitGroup := make(map[string][2]int)
+	if err := common.UnmarshalJsonStr(jsonStr, &nextModelRequestRateLimitGroup); err != nil {
+		return err
+	}
 
-	ModelRequestRateLimitGroup = make(map[string][2]int)
-	return json.Unmarshal([]byte(jsonStr), &ModelRequestRateLimitGroup)
+	ModelRequestRateLimitMutex.Lock()
+	defer ModelRequestRateLimitMutex.Unlock()
+	ModelRequestRateLimitGroup = nextModelRequestRateLimitGroup
+	return nil
 }
 
 func GetGroupRateLimit(group string) (totalCount, successCount int, found bool) {
@@ -52,7 +55,7 @@ func GetGroupRateLimit(group string) (totalCount, successCount int, found bool) 
 
 func CheckModelRequestRateLimitGroup(jsonStr string) error {
 	checkModelRequestRateLimitGroup := make(map[string][2]int)
-	err := json.Unmarshal([]byte(jsonStr), &checkModelRequestRateLimitGroup)
+	err := common.UnmarshalJsonStr(jsonStr, &checkModelRequestRateLimitGroup)
 	if err != nil {
 		return err
 	}

--- a/setting/rate_limit_test.go
+++ b/setting/rate_limit_test.go
@@ -1,0 +1,54 @@
+package setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateModelRequestRateLimitGroupByJSONStringPreservesExistingOnInvalidJSON(t *testing.T) {
+	ModelRequestRateLimitMutex.Lock()
+	original := ModelRequestRateLimitGroup
+	ModelRequestRateLimitGroup = map[string][2]int{
+		"default": {10, 8},
+	}
+	ModelRequestRateLimitMutex.Unlock()
+	t.Cleanup(func() {
+		ModelRequestRateLimitMutex.Lock()
+		ModelRequestRateLimitGroup = original
+		ModelRequestRateLimitMutex.Unlock()
+	})
+
+	err := UpdateModelRequestRateLimitGroupByJSONString(`{"default":`)
+	require.Error(t, err)
+
+	total, success, found := GetGroupRateLimit("default")
+	require.True(t, found)
+	require.Equal(t, 10, total)
+	require.Equal(t, 8, success)
+}
+
+func TestUpdateModelRequestRateLimitGroupByJSONStringReplacesExistingOnValidJSON(t *testing.T) {
+	ModelRequestRateLimitMutex.Lock()
+	original := ModelRequestRateLimitGroup
+	ModelRequestRateLimitGroup = map[string][2]int{
+		"default": {10, 8},
+	}
+	ModelRequestRateLimitMutex.Unlock()
+	t.Cleanup(func() {
+		ModelRequestRateLimitMutex.Lock()
+		ModelRequestRateLimitGroup = original
+		ModelRequestRateLimitMutex.Unlock()
+	})
+
+	err := UpdateModelRequestRateLimitGroupByJSONString(`{"vip":[20,15]}`)
+	require.NoError(t, err)
+
+	_, _, found := GetGroupRateLimit("default")
+	require.False(t, found)
+
+	total, success, found := GetGroupRateLimit("vip")
+	require.True(t, found)
+	require.Equal(t, 20, total)
+	require.Equal(t, 15, success)
+}

--- a/setting/user_usable_group.go
+++ b/setting/user_usable_group.go
@@ -1,7 +1,6 @@
 package setting
 
 import (
-	"encoding/json"
 	"sync"
 
 	"github.com/QuantumNous/new-api/common"
@@ -28,7 +27,7 @@ func UserUsableGroups2JSONString() string {
 	userUsableGroupsMutex.RLock()
 	defer userUsableGroupsMutex.RUnlock()
 
-	jsonBytes, err := json.Marshal(userUsableGroups)
+	jsonBytes, err := common.Marshal(userUsableGroups)
 	if err != nil {
 		common.SysLog("error marshalling user groups: " + err.Error())
 	}
@@ -36,11 +35,15 @@ func UserUsableGroups2JSONString() string {
 }
 
 func UpdateUserUsableGroupsByJSONString(jsonStr string) error {
+	nextUserUsableGroups := make(map[string]string)
+	if err := common.UnmarshalJsonStr(jsonStr, &nextUserUsableGroups); err != nil {
+		return err
+	}
+
 	userUsableGroupsMutex.Lock()
 	defer userUsableGroupsMutex.Unlock()
-
-	userUsableGroups = make(map[string]string)
-	return json.Unmarshal([]byte(jsonStr), &userUsableGroups)
+	userUsableGroups = nextUserUsableGroups
+	return nil
 }
 
 func GetUsableGroupDescription(groupName string) string {

--- a/setting/user_usable_group_test.go
+++ b/setting/user_usable_group_test.go
@@ -1,0 +1,46 @@
+package setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateUserUsableGroupsByJSONStringPreservesExistingOnInvalidJSON(t *testing.T) {
+	userUsableGroupsMutex.Lock()
+	original := userUsableGroups
+	userUsableGroups = map[string]string{
+		"default": "Default group",
+	}
+	userUsableGroupsMutex.Unlock()
+	t.Cleanup(func() {
+		userUsableGroupsMutex.Lock()
+		userUsableGroups = original
+		userUsableGroupsMutex.Unlock()
+	})
+
+	err := UpdateUserUsableGroupsByJSONString(`{"default":`)
+	require.Error(t, err)
+
+	require.Equal(t, "Default group", GetUsableGroupDescription("default"))
+}
+
+func TestUpdateUserUsableGroupsByJSONStringReplacesExistingOnValidJSON(t *testing.T) {
+	userUsableGroupsMutex.Lock()
+	original := userUsableGroups
+	userUsableGroups = map[string]string{
+		"default": "Default group",
+	}
+	userUsableGroupsMutex.Unlock()
+	t.Cleanup(func() {
+		userUsableGroupsMutex.Lock()
+		userUsableGroups = original
+		userUsableGroupsMutex.Unlock()
+	})
+
+	err := UpdateUserUsableGroupsByJSONString(`{"vip":"VIP group"}`)
+	require.NoError(t, err)
+
+	require.Equal(t, "default", GetUsableGroupDescription("default"))
+	require.Equal(t, "VIP group", GetUsableGroupDescription("vip"))
+}


### PR DESCRIPTION
## Summary
- parse model request rate limit group updates before replacing the active map
- use a write lock when replacing rate limit group settings
- preserve user usable group settings when invalid JSON is submitted
- switch these settings helpers to the project JSON wrappers

## Tests
- go test ./setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test cases to verify rate limit groups and user group configurations are correctly managed when processing both valid and invalid configuration updates.

* **Chores**
  * Enhanced internal handling of configuration updates for improved reliability and thread-safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->