### PR TITLE
fix: default new claude models to adaptive thinking

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -155,16 +155,14 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 
 	if baseModel, effortLevel, ok := reasoning.TrimEffortSuffix(textRequest.Model); ok && effortLevel != "" &&
 		(strings.HasPrefix(textRequest.Model, "claude-opus-4-6") ||
-			strings.HasPrefix(textRequest.Model, "claude-opus-4-7") ||
-			strings.HasPrefix(textRequest.Model, "claude-opus-4-8")) {
+			(reasoning.IsClaudeModel(baseModel) && !reasoning.IsLegacyClaudeThinkingModel(baseModel))) {
 		claudeRequest.Model = baseModel
 		claudeRequest.Thinking = &dto.Thinking{
 			Type: "adaptive",
 		}
 		claudeRequest.OutputConfig = json.RawMessage(fmt.Sprintf(`{"effort":"%s"}`, effortLevel))
-		if strings.HasPrefix(baseModel, "claude-opus-4-7") ||
-			strings.HasPrefix(baseModel, "claude-opus-4-8") {
-			// Opus 4.7/4.8 reject non-default temperature/top_p/top_k with 400
+		if !reasoning.IsLegacyClaudeThinkingModel(baseModel) {
+			// Newer Claude adaptive thinking rejects non-default temperature/top_p/top_k with 400
 			// and defaults display to "omitted"; restore the 4.6 visible summary.
 			claudeRequest.Thinking.Display = "summarized"
 			claudeRequest.Temperature = nil
@@ -178,9 +176,8 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 		strings.HasSuffix(textRequest.Model, "-thinking") {
 
 		trimmedModel := strings.TrimSuffix(textRequest.Model, "-thinking")
-		if strings.HasPrefix(trimmedModel, "claude-opus-4-7") ||
-			strings.HasPrefix(trimmedModel, "claude-opus-4-8") {
-			// Opus 4.7/4.8 reject thinking.type="enabled"; use adaptive at high effort.
+		if reasoning.IsClaudeModel(trimmedModel) && !reasoning.IsLegacyClaudeThinkingModel(trimmedModel) {
+			// Newer Claude models reject thinking.type="enabled"; use adaptive at high effort.
 			claudeRequest.Thinking = &dto.Thinking{Type: "adaptive", Display: "summarized"}
 			claudeRequest.OutputConfig = json.RawMessage(`{"effort":"high"}`)
 			claudeRequest.Temperature = nil
@@ -208,37 +205,63 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 	}
 
 	if textRequest.ReasoningEffort != "" {
-		switch textRequest.ReasoningEffort {
-		case "low":
-			claudeRequest.Thinking = &dto.Thinking{
-				Type:         "enabled",
-				BudgetTokens: common.GetPointer[int](1280),
+		if reasoning.IsClaudeModel(claudeRequest.Model) && !reasoning.IsLegacyClaudeThinkingModel(claudeRequest.Model) {
+			switch textRequest.ReasoningEffort {
+			case "minimal", "low", "medium", "high", "xhigh", "max":
+				claudeRequest.Thinking = &dto.Thinking{Type: "adaptive", Display: "summarized"}
+				claudeRequest.OutputConfig = json.RawMessage(fmt.Sprintf(`{"effort":"%s"}`, textRequest.ReasoningEffort))
+				claudeRequest.Temperature = nil
+				claudeRequest.TopP = nil
+				claudeRequest.TopK = nil
 			}
-		case "medium":
-			claudeRequest.Thinking = &dto.Thinking{
-				Type:         "enabled",
-				BudgetTokens: common.GetPointer[int](2048),
-			}
-		case "high":
-			claudeRequest.Thinking = &dto.Thinking{
-				Type:         "enabled",
-				BudgetTokens: common.GetPointer[int](4096),
+		} else {
+			switch textRequest.ReasoningEffort {
+			case "low":
+				claudeRequest.Thinking = &dto.Thinking{
+					Type:         "enabled",
+					BudgetTokens: common.GetPointer[int](1280),
+				}
+			case "medium":
+				claudeRequest.Thinking = &dto.Thinking{
+					Type:         "enabled",
+					BudgetTokens: common.GetPointer[int](2048),
+				}
+			case "high":
+				claudeRequest.Thinking = &dto.Thinking{
+					Type:         "enabled",
+					BudgetTokens: common.GetPointer[int](4096),
+				}
 			}
 		}
 	}
 
 	// 指定了 reasoning 参数,覆盖 budgetTokens
 	if textRequest.Reasoning != nil {
-		var reasoning openrouter.RequestReasoning
-		if err := common.Unmarshal(textRequest.Reasoning, &reasoning); err != nil {
+		var requestReasoning openrouter.RequestReasoning
+		if err := common.Unmarshal(textRequest.Reasoning, &requestReasoning); err != nil {
 			return nil, err
 		}
 
-		budgetTokens := reasoning.MaxTokens
-		if budgetTokens > 0 {
-			claudeRequest.Thinking = &dto.Thinking{
-				Type:         "enabled",
-				BudgetTokens: &budgetTokens,
+		if reasoning.IsClaudeModel(claudeRequest.Model) && !reasoning.IsLegacyClaudeThinkingModel(claudeRequest.Model) {
+			effort := requestReasoning.Effort
+			if effort == "" && (requestReasoning.Enabled || requestReasoning.MaxTokens > 0) {
+				effort = "high"
+			}
+			switch effort {
+			case "minimal", "low", "medium", "high", "xhigh", "max":
+				claudeRequest.Thinking = &dto.Thinking{Type: "adaptive", Display: "summarized"}
+				claudeRequest.OutputConfig = json.RawMessage(fmt.Sprintf(`{"effort":"%s"}`, effort))
+				claudeRequest.Temperature = nil
+				claudeRequest.TopP = nil
+				claudeRequest.TopK = nil
+			}
+		} else {
+			budgetTokens := requestReasoning.MaxTokens
+			if budgetTokens > 0 {
+				claudeRequest.Thinking = &dto.Thinking{
+					Type:         "enabled",
+					BudgetTokens: &budgetTokens,
+				}
 			}
 		}
 	}

--- a/relay/channel/claude/relay_claude_test.go
+++ b/relay/channel/claude/relay_claude_test.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -364,6 +365,202 @@ func TestRequestOpenAI2ClaudeMessage_ClaudeOpus48ThinkingUsesAdaptiveHighEffort(
 	require.Nil(t, claudeRequest.Temperature)
 	require.Nil(t, claudeRequest.TopP)
 	require.Nil(t, claudeRequest.TopK)
+}
+
+func TestRequestOpenAI2ClaudeMessage_FutureClaudeModelUsesAdaptiveThinking(t *testing.T) {
+	request := dto.GeneralOpenAIRequest{
+		Model:       "claude-sonnet-4-6-xhigh",
+		Temperature: commonPointer(0.7),
+		TopP:        commonPointer(0.9),
+		TopK:        commonPointer(40),
+		Messages: []dto.Message{
+			{
+				Role:    "user",
+				Content: "hello",
+			},
+		},
+	}
+
+	claudeRequest, err := RequestOpenAI2ClaudeMessage(nil, request)
+	require.NoError(t, err)
+	require.Equal(t, "claude-sonnet-4-6", claudeRequest.Model)
+	require.NotNil(t, claudeRequest.Thinking)
+	require.Equal(t, "adaptive", claudeRequest.Thinking.Type)
+	require.Equal(t, "summarized", claudeRequest.Thinking.Display)
+	require.JSONEq(t, `{"effort":"xhigh"}`, string(claudeRequest.OutputConfig))
+	require.Nil(t, claudeRequest.Temperature)
+	require.Nil(t, claudeRequest.TopP)
+	require.Nil(t, claudeRequest.TopK)
+}
+
+func TestRequestOpenAI2ClaudeMessage_ClaudeOpus46ThinkingKeepsLegacyBudgetThinking(t *testing.T) {
+	maxTokens := uint(2000)
+	request := dto.GeneralOpenAIRequest{
+		Model:       "claude-opus-4-6-thinking",
+		MaxTokens:   &maxTokens,
+		Temperature: commonPointer(0.7),
+		TopP:        commonPointer(0.9),
+		TopK:        commonPointer(40),
+		Messages: []dto.Message{
+			{
+				Role:    "user",
+				Content: "hello",
+			},
+		},
+	}
+
+	claudeRequest, err := RequestOpenAI2ClaudeMessage(nil, request)
+	require.NoError(t, err)
+	require.Equal(t, "claude-opus-4-6", claudeRequest.Model)
+	require.NotNil(t, claudeRequest.Thinking)
+	require.Equal(t, "enabled", claudeRequest.Thinking.Type)
+	require.NotNil(t, claudeRequest.Thinking.BudgetTokens)
+	require.Equal(t, 1600, *claudeRequest.Thinking.BudgetTokens)
+	require.Empty(t, claudeRequest.Thinking.Display)
+	require.Empty(t, claudeRequest.OutputConfig)
+	require.NotNil(t, claudeRequest.Temperature)
+	require.Equal(t, 1.0, *claudeRequest.Temperature)
+	require.Nil(t, claudeRequest.TopP)
+	require.NotNil(t, claudeRequest.TopK)
+	require.Equal(t, 40, *claudeRequest.TopK)
+}
+
+func TestRequestOpenAI2ClaudeMessage_Claude3ThinkingKeepsLegacyBudgetThinking(t *testing.T) {
+	maxTokens := uint(2000)
+	request := dto.GeneralOpenAIRequest{
+		Model:       "claude-3-7-sonnet-20250219-thinking",
+		MaxTokens:   &maxTokens,
+		Temperature: commonPointer(0.7),
+		TopP:        commonPointer(0.9),
+		TopK:        commonPointer(40),
+		Messages: []dto.Message{
+			{
+				Role:    "user",
+				Content: "hello",
+			},
+		},
+	}
+
+	claudeRequest, err := RequestOpenAI2ClaudeMessage(nil, request)
+	require.NoError(t, err)
+	require.Equal(t, "claude-3-7-sonnet-20250219", claudeRequest.Model)
+	require.NotNil(t, claudeRequest.Thinking)
+	require.Equal(t, "enabled", claudeRequest.Thinking.Type)
+	require.NotNil(t, claudeRequest.Thinking.BudgetTokens)
+	require.Equal(t, 1600, *claudeRequest.Thinking.BudgetTokens)
+	require.Empty(t, claudeRequest.Thinking.Display)
+	require.Empty(t, claudeRequest.OutputConfig)
+	require.NotNil(t, claudeRequest.Temperature)
+	require.Equal(t, 1.0, *claudeRequest.Temperature)
+	require.Nil(t, claudeRequest.TopP)
+	require.NotNil(t, claudeRequest.TopK)
+	require.Equal(t, 40, *claudeRequest.TopK)
+}
+
+func TestRequestOpenAI2ClaudeMessage_NewClaudeReasoningEffortUsesAdaptiveThinking(t *testing.T) {
+	request := dto.GeneralOpenAIRequest{
+		Model:           "claude-sonnet-4-6",
+		ReasoningEffort: "high",
+		Temperature:     commonPointer(0.7),
+		TopP:            commonPointer(0.9),
+		TopK:            commonPointer(40),
+		Messages: []dto.Message{
+			{
+				Role:    "user",
+				Content: "hello",
+			},
+		},
+	}
+
+	claudeRequest, err := RequestOpenAI2ClaudeMessage(nil, request)
+	require.NoError(t, err)
+	require.Equal(t, "claude-sonnet-4-6", claudeRequest.Model)
+	require.NotNil(t, claudeRequest.Thinking)
+	require.Equal(t, "adaptive", claudeRequest.Thinking.Type)
+	require.Equal(t, "summarized", claudeRequest.Thinking.Display)
+	require.JSONEq(t, `{"effort":"high"}`, string(claudeRequest.OutputConfig))
+	require.Nil(t, claudeRequest.Temperature)
+	require.Nil(t, claudeRequest.TopP)
+	require.Nil(t, claudeRequest.TopK)
+}
+
+func TestRequestOpenAI2ClaudeMessage_LegacyClaudeReasoningEffortKeepsBudgetThinking(t *testing.T) {
+	request := dto.GeneralOpenAIRequest{
+		Model:           "claude-3-opus-20240229",
+		ReasoningEffort: "high",
+		Temperature:     commonPointer(0.7),
+		Messages: []dto.Message{
+			{
+				Role:    "user",
+				Content: "hello",
+			},
+		},
+	}
+
+	claudeRequest, err := RequestOpenAI2ClaudeMessage(nil, request)
+	require.NoError(t, err)
+	require.Equal(t, "claude-3-opus-20240229", claudeRequest.Model)
+	require.NotNil(t, claudeRequest.Thinking)
+	require.Equal(t, "enabled", claudeRequest.Thinking.Type)
+	require.NotNil(t, claudeRequest.Thinking.BudgetTokens)
+	require.Equal(t, 4096, *claudeRequest.Thinking.BudgetTokens)
+	require.Empty(t, claudeRequest.Thinking.Display)
+	require.Empty(t, claudeRequest.OutputConfig)
+	require.NotNil(t, claudeRequest.Temperature)
+	require.Equal(t, 0.7, *claudeRequest.Temperature)
+}
+
+func TestRequestOpenAI2ClaudeMessage_NewClaudeReasoningJSONUsesAdaptiveThinking(t *testing.T) {
+	request := dto.GeneralOpenAIRequest{
+		Model:       "claude-sonnet-4-6",
+		Reasoning:   json.RawMessage(`{"max_tokens":4096}`),
+		Temperature: commonPointer(0.7),
+		TopP:        commonPointer(0.9),
+		TopK:        commonPointer(40),
+		Messages: []dto.Message{
+			{
+				Role:    "user",
+				Content: "hello",
+			},
+		},
+	}
+
+	claudeRequest, err := RequestOpenAI2ClaudeMessage(nil, request)
+	require.NoError(t, err)
+	require.Equal(t, "claude-sonnet-4-6", claudeRequest.Model)
+	require.NotNil(t, claudeRequest.Thinking)
+	require.Equal(t, "adaptive", claudeRequest.Thinking.Type)
+	require.Equal(t, "summarized", claudeRequest.Thinking.Display)
+	require.JSONEq(t, `{"effort":"high"}`, string(claudeRequest.OutputConfig))
+	require.Nil(t, claudeRequest.Temperature)
+	require.Nil(t, claudeRequest.TopP)
+	require.Nil(t, claudeRequest.TopK)
+}
+
+func TestRequestOpenAI2ClaudeMessage_LegacyClaudeReasoningJSONKeepsBudgetThinking(t *testing.T) {
+	request := dto.GeneralOpenAIRequest{
+		Model:       "claude-3-opus-20240229",
+		Reasoning:   json.RawMessage(`{"max_tokens":4096}`),
+		Temperature: commonPointer(0.7),
+		Messages: []dto.Message{
+			{
+				Role:    "user",
+				Content: "hello",
+			},
+		},
+	}
+
+	claudeRequest, err := RequestOpenAI2ClaudeMessage(nil, request)
+	require.NoError(t, err)
+	require.Equal(t, "claude-3-opus-20240229", claudeRequest.Model)
+	require.NotNil(t, claudeRequest.Thinking)
+	require.Equal(t, "enabled", claudeRequest.Thinking.Type)
+	require.NotNil(t, claudeRequest.Thinking.BudgetTokens)
+	require.Equal(t, 4096, *claudeRequest.Thinking.BudgetTokens)
+	require.Empty(t, claudeRequest.Thinking.Display)
+	require.Empty(t, claudeRequest.OutputConfig)
+	require.NotNil(t, claudeRequest.Temperature)
+	require.Equal(t, 0.7, *claudeRequest.Temperature)
 }
 
 func TestRequestOpenAI2ClaudeMessage_SupportsPDFFileContent(t *testing.T) {

--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -54,16 +54,14 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 
 	if baseModel, effortLevel, ok := reasoning.TrimEffortSuffix(request.Model); ok && effortLevel != "" &&
 		(strings.HasPrefix(request.Model, "claude-opus-4-6") ||
-			strings.HasPrefix(request.Model, "claude-opus-4-7") ||
-			strings.HasPrefix(request.Model, "claude-opus-4-8")) {
+			(reasoning.IsClaudeModel(baseModel) && !reasoning.IsLegacyClaudeThinkingModel(baseModel))) {
 		request.Model = baseModel
 		request.Thinking = &dto.Thinking{
 			Type: "adaptive",
 		}
 		request.OutputConfig = json.RawMessage(fmt.Sprintf(`{"effort":"%s"}`, effortLevel))
-		if strings.HasPrefix(request.Model, "claude-opus-4-7") ||
-			strings.HasPrefix(request.Model, "claude-opus-4-8") {
-			// Opus 4.7/4.8 reject non-default temperature/top_p/top_k with 400
+		if !reasoning.IsLegacyClaudeThinkingModel(request.Model) {
+			// Newer Claude adaptive thinking rejects non-default temperature/top_p/top_k with 400
 			// and defaults display to "omitted"; restore the 4.6 visible summary.
 			request.Thinking.Display = "summarized"
 			request.Temperature = nil
@@ -77,9 +75,8 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 		strings.HasSuffix(request.Model, "-thinking") {
 		if request.Thinking == nil {
 			baseModel := strings.TrimSuffix(request.Model, "-thinking")
-			if strings.HasPrefix(baseModel, "claude-opus-4-7") ||
-				strings.HasPrefix(baseModel, "claude-opus-4-8") {
-				// Opus 4.7/4.8 reject thinking.type="enabled"; use adaptive at high effort.
+			if reasoning.IsClaudeModel(baseModel) && !reasoning.IsLegacyClaudeThinkingModel(baseModel) {
+				// Newer Claude models reject thinking.type="enabled"; use adaptive at high effort.
 				request.Thinking = &dto.Thinking{Type: "adaptive", Display: "summarized"}
 				request.OutputConfig = json.RawMessage(`{"effort":"high"}`)
 				request.Temperature = nil

--- a/setting/reasoning/suffix.go
+++ b/setting/reasoning/suffix.go
@@ -49,3 +49,35 @@ func ParseDeepSeekV4ThinkingSuffix(modelName string) (baseModel string, thinking
 		return modelName, "", "", false
 	}
 }
+
+func IsClaudeModel(modelName string) bool {
+	target := strings.TrimSpace(modelName)
+	return strings.HasPrefix(target, "claude-")
+}
+
+func IsLegacyClaudeThinkingModel(modelName string) bool {
+	target := strings.TrimSpace(modelName)
+	target = strings.TrimSuffix(target, "-thinking")
+	if baseModel, _, ok := TrimEffortSuffix(target); ok {
+		target = baseModel
+	}
+
+	legacyPrefixes := []string{
+		"claude-2",
+		"claude-3-",
+		"claude-instant",
+		"claude-opus-4-20250514",
+		"claude-opus-4-1-",
+		"claude-opus-4-5-",
+		"claude-opus-4-6",
+		"claude-sonnet-4-20250514",
+		"claude-sonnet-4-5-",
+		"claude-haiku-4-5-",
+	}
+	for _, prefix := range legacyPrefixes {
+		if strings.HasPrefix(target, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/setting/reasoning/suffix_test.go
+++ b/setting/reasoning/suffix_test.go
@@ -1,0 +1,45 @@
+package reasoning
+
+import "testing"
+
+func TestIsLegacyClaudeThinkingModel(t *testing.T) {
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{model: "claude-3-opus-20240229", want: true},
+		{model: "claude-3-sonnet-20240229-thinking", want: true},
+		{model: "claude-3-5-sonnet-20241022", want: true},
+		{model: "claude-3-7-sonnet-20250219-high", want: true},
+		{model: "claude-opus-4-20250514", want: true},
+		{model: "claude-opus-4-20250514-thinking", want: true},
+		{model: "claude-opus-4-1-20250805", want: true},
+		{model: "claude-opus-4-5-20251101-thinking", want: true},
+		{model: "claude-opus-4-6", want: true},
+		{model: "claude-opus-4-6-high", want: true},
+		{model: "claude-opus-4-7", want: false},
+		{model: "claude-opus-4-7-high", want: false},
+		{model: "claude-opus-4-8-thinking", want: false},
+		{model: "claude-opus-4-9-high", want: false},
+		{model: "claude-opus-4-10-thinking", want: false},
+		{model: "claude-sonnet-4-6-thinking", want: false},
+		{model: "claude-sonnet-4-8-high", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			if got := IsLegacyClaudeThinkingModel(tt.model); got != tt.want {
+				t.Fatalf("IsLegacyClaudeThinkingModel(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsClaudeModel(t *testing.T) {
+	if !IsClaudeModel("claude-opus-4-8") {
+		t.Fatal("expected Claude model")
+	}
+	if IsClaudeModel("gpt-5") {
+		t.Fatal("expected non-Claude model")
+	}
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

> [!IMPORTANT]
>
> - Please provide a concise, human-written summary. Avoid pasting unreviewed generated output.

## 📝 变更描述 / Description

This PR changes Claude thinking adaptation so that newer Claude models use the newer adaptive thinking format by default, while known legacy Claude models keep the existing budget-token thinking behavior.

Previously, the adaptive thinking path was explicitly tied to model names such as `claude-opus-4-7` and `claude-opus-4-8`. That meant future Claude models would require source changes before they could use the newer thinking behavior.

The new behavior is:

- Known legacy Claude models continue to use `thinking.type = enabled` with `budget_tokens`.
- Newer Claude models use `thinking.type = adaptive` with `output_config.effort`.
- Newer Claude adaptive thinking sets `display = summarized` and clears `temperature`, `top_p`, and `top_k`.
- The same legacy/newer split is applied to model suffixes, `-thinking`, `reasoning_effort`, and OpenRouter-style `reasoning`.

Legacy Claude matching currently covers older families such as Claude 2, Claude 3, Claude Instant, older Opus 4 variants, older Sonnet 4 variants, and Haiku 4.5. Other Claude models default to the newer adaptive thinking path.

## 🚀 变更类型 / Type of change

- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes # (if any)

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** I have personally reviewed and written this description instead of pasting unreviewed generated output.
- [x] **非重复提交:** I have searched existing [Issues](https://github.com/QuantumNous/new-api/issues) and [PRs](https://github.com/QuantumNous/new-api/pulls) and confirmed this is not a duplicate.
- [x] **Bug fix 说明:** This PR is not marked as a bug fix, and does not classify a design choice or expectation difference as a bug.
- [x] **变更理解:** I understand how these changes work and their possible impact.
- [x] **范围聚焦:** This PR does not include unrelated code changes.
- [x] **本地验证:** I have run local tests so maintainers can verify the result.
- [x] **安全合规:** The code contains no sensitive credentials and follows the project coding conventions.

## 📸 运行证明 / Proof of Work

```text
gofmt -w setting/reasoning/suffix.go setting/reasoning/suffix_test.go relay/claude_handler.go relay/channel/claude/relay-claude.go relay/channel/claude/relay_claude_test.go

git diff --check
# passed

go test ./setting/reasoning -count=1
# ok github.com/QuantumNous/new-api/setting/reasoning

go test ./relay/channel/claude -run 'TestRequestOpenAI2ClaudeMessage_(ClaudeOpus48|FutureClaudeModel|ClaudeOpus46Thinking|Claude3Thinking|NewClaudeReasoningEffort|LegacyClaudeReasoningEffort|NewClaudeReasoningJSON|LegacyClaudeReasoningJSON)' -count=1
# ok github.com/QuantumNous/new-api/relay/channel/claude

go test ./relay -run Claude -count=1
# ? github.com/QuantumNous/new-api/relay [no test files]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for newer Claude models' reasoning capabilities with adaptive thinking and configurable effort levels (including extended effort options).
  * Improved model-specific behavior differentiation between newer and legacy Claude models.

* **Tests**
  * Added comprehensive test coverage for Claude model reasoning and effort mapping across model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->