### PR TITLE
feat: improve Claude-OpenAI conversion with 4-tier reasoning_effort and DeepSeek safety guard

### DIFF
--- a/service/convert.go
+++ b/service/convert.go
@@ -115,7 +115,12 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 		// Map Anthropic budget_tokens to OpenAI reasoning_effort (4 tiers)
 		if claudeRequest.Thinking != nil && (claudeRequest.Thinking.Type == "enabled" || claudeRequest.Thinking.Type == "adaptive") {
 			budget := claudeRequest.Thinking.GetBudgetTokens()
-			openAIRequest.ReasoningEffort = budgetTokensToEffort(budget)
+			effort := budgetTokensToEffort(budget)
+			// "max" is invalid for non-DeepSeek OpenAI-compatible models; cap to "high"
+			if effort == "max" && !isDeepSeekModel(info.OriginModelName) {
+				effort = "high"
+			}
+			openAIRequest.ReasoningEffort = effort
 		}
 
 		// DeepSeek safety guard: if history has assistant messages without thinking blocks,
@@ -198,6 +203,9 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 			}
 		}
 	}
+	isDeepSeek := isDeepSeekModel(info.OriginModelName)
+	historyHasThinking := isDeepSeek && hasThinkingBlocksInHistory(claudeRequest.Messages)
+
 	for _, claudeMessage := range claudeRequest.Messages {
 		openAIMessage := dto.Message{
 			Role: claudeMessage.Role,
@@ -268,7 +276,7 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 
 			// DeepSeek reasoning_content placeholder: required when history has thinking blocks
 			if openAIMessage.Role == "assistant" && (openAIMessage.ReasoningContent == nil || *openAIMessage.ReasoningContent == "") {
-				if isDeepSeekModel(info.OriginModelName) && hasThinkingBlocksInHistory(claudeRequest.Messages) {
+				if historyHasThinking {
 					openAIMessage.ReasoningContent = lo.ToPtr(" ")
 				}
 			}
@@ -309,7 +317,7 @@ func buildClaudeUsageFromOpenAIUsage(oaiUsage *dto.Usage) *dto.ClaudeUsage {
 	)
 	usage := &dto.ClaudeUsage{
 			// Subtract cache tokens from input_tokens per Anthropic spec (OpenAI prompt_tokens includes them)
-			InputTokens:              oaiUsage.PromptTokens - oaiUsage.PromptTokensDetails.CachedCreationTokens - oaiUsage.PromptTokensDetails.CachedTokens,
+			InputTokens: max(0, oaiUsage.PromptTokens-oaiUsage.PromptTokensDetails.CachedCreationTokens-oaiUsage.PromptTokensDetails.CachedTokens),
 		OutputTokens:             oaiUsage.CompletionTokens,
 		CacheCreationInputTokens: oaiUsage.PromptTokensDetails.CachedCreationTokens,
 		CacheReadInputTokens:     oaiUsage.PromptTokensDetails.CachedTokens,

--- a/service/convert.go
+++ b/service/convert.go
@@ -14,6 +14,60 @@ import (
 	"github.com/samber/lo"
 )
 
+// isDeepSeekModel returns true for DeepSeek models.
+func isDeepSeekModel(modelID string) bool {
+	return strings.HasPrefix(modelID, "deepseek-")
+}
+
+// hasThinkingBlocksInHistory checks if any assistant message has thinking blocks.
+func hasThinkingBlocksInHistory(messages []dto.ClaudeMessage) bool {
+	for _, msg := range messages {
+		if msg.Role != "assistant" {
+			continue
+		}
+		if msg.IsStringContent() {
+			continue
+		}
+		blocks, err := msg.ParseContent()
+		if err != nil {
+			continue
+		}
+		for _, block := range blocks {
+			if block.Type == "thinking" {
+				return true
+			}
+			if block.Type == "tool_use" && block.Thinking != nil && *block.Thinking != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasAssistantMessages returns true when the conversation contains assistant messages.
+func hasAssistantMessages(messages []dto.ClaudeMessage) bool {
+	for _, msg := range messages {
+		if msg.Role == "assistant" {
+			return true
+		}
+	}
+	return false
+}
+
+// budgetTokensToEffort maps Anthropic budget_tokens to OpenAI reasoning_effort.
+func budgetTokensToEffort(budget int) string {
+	switch {
+	case budget <= 2048:
+		return "low"
+	case budget <= 8192:
+		return "medium"
+	case budget <= 32768:
+		return "high"
+	default:
+		return "max"
+	}
+}
+
 func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.RelayInfo) (*dto.GeneralOpenAIRequest, error) {
 	openAIRequest := dto.GeneralOpenAIRequest{
 		Model:       claudeRequest.Model,
@@ -58,6 +112,20 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 			openAIRequest.Reasoning = reasoningJSON
 		}
 	} else {
+		// Map Anthropic budget_tokens to OpenAI reasoning_effort (4 tiers)
+		if claudeRequest.Thinking != nil && (claudeRequest.Thinking.Type == "enabled" || claudeRequest.Thinking.Type == "adaptive") {
+			budget := claudeRequest.Thinking.GetBudgetTokens()
+			openAIRequest.ReasoningEffort = budgetTokensToEffort(budget)
+		}
+
+		// DeepSeek safety guard: if history has assistant messages without thinking blocks,
+		// disable thinking mode to prevent 400 errors (reasoning_content must be passed back)
+		if isDeepSeekModel(info.OriginModelName) {
+			if hasAssistantMessages(claudeRequest.Messages) && !hasThinkingBlocksInHistory(claudeRequest.Messages) {
+				openAIRequest.ReasoningEffort = ""
+			}
+		}
+
 		thinkingSuffix := "-thinking"
 		if strings.HasSuffix(info.OriginModelName, thinkingSuffix) &&
 			!strings.HasSuffix(openAIRequest.Model, thinkingSuffix) {
@@ -198,6 +266,13 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 				}
 			}
 
+			// DeepSeek reasoning_content placeholder: required when history has thinking blocks
+			if openAIMessage.Role == "assistant" && (openAIMessage.ReasoningContent == nil || *openAIMessage.ReasoningContent == "") {
+				if isDeepSeekModel(info.OriginModelName) && hasThinkingBlocksInHistory(claudeRequest.Messages) {
+					openAIMessage.ReasoningContent = lo.ToPtr(" ")
+				}
+			}
+
 			if len(toolCalls) > 0 {
 				openAIMessage.SetToolCalls(toolCalls)
 			}
@@ -233,7 +308,8 @@ func buildClaudeUsageFromOpenAIUsage(oaiUsage *dto.Usage) *dto.ClaudeUsage {
 		oaiUsage.ClaudeCacheCreation1hTokens,
 	)
 	usage := &dto.ClaudeUsage{
-		InputTokens:              oaiUsage.PromptTokens,
+			// Subtract cache tokens from input_tokens per Anthropic spec (OpenAI prompt_tokens includes them)
+			InputTokens:              oaiUsage.PromptTokens - oaiUsage.PromptTokensDetails.CachedCreationTokens - oaiUsage.PromptTokensDetails.CachedTokens,
 		OutputTokens:             oaiUsage.CompletionTokens,
 		CacheCreationInputTokens: oaiUsage.PromptTokensDetails.CachedCreationTokens,
 		CacheReadInputTokens:     oaiUsage.PromptTokensDetails.CachedTokens,


### PR DESCRIPTION
## Summary

Improves the Claude → OpenAI protocol conversion in `service/convert.go` with better thinking/reasoning support.

## Changes

1. **4-tier reasoning_effort mapping** — Maps Anthropic `budget_tokens` to OpenAI `reasoning_effort`.
2. **DeepSeek thinking safety guard** — Auto-disables thinking mode when history lacks thinking blocks.
3. **reasoning_content placeholder** — For DeepSeek multi-turn conversations.
4. **Cache token subtraction** — Per Anthropic spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced DeepSeek model handling: improved mapping of thinking/reasoning settings and conditional insertion of placeholder reasoning content for assistant replies.

* **Improvements**
  * More accurate token usage accounting to reflect cached-token behavior.
  * Better conversion and mapping of reasoning features between platforms for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->