### PR TITLE
fix: pass form control props to API key inputs

### DIFF
--- a/web/default/src/components/datetime-picker.tsx
+++ b/web/default/src/components/datetime-picker.tsx
@@ -45,6 +45,9 @@ interface DateTimePickerProps {
   onChange?: (date: Date | undefined) => void
   placeholder?: string
   className?: string
+  id?: string
+  'aria-describedby'?: string
+  'aria-invalid'?: boolean
 }
 
 export function DateTimePicker({
@@ -52,6 +55,9 @@ export function DateTimePicker({
   onChange,
   placeholder,
   className,
+  id,
+  'aria-describedby': ariaDescribedBy,
+  'aria-invalid': ariaInvalid,
 }: DateTimePickerProps) {
   const { t, i18n } = useTranslation()
   const placeholderText = placeholder ?? t('Select date')
@@ -114,7 +120,10 @@ export function DateTimePicker({
         <PopoverTrigger
           render={
             <Button
+              id={id}
               variant='outline'
+              aria-describedby={ariaDescribedBy}
+              aria-invalid={ariaInvalid}
               className={cn(
                 'flex-1 justify-between font-normal',
                 !date && 'text-muted-foreground'

--- a/web/default/src/features/keys/components/api-key-group-combobox.tsx
+++ b/web/default/src/features/keys/components/api-key-group-combobox.tsx
@@ -49,6 +49,9 @@ type ApiKeyGroupComboboxProps = {
   onValueChange: (value: string) => void
   placeholder?: string
   disabled?: boolean
+  id?: string
+  'aria-describedby'?: string
+  'aria-invalid'?: boolean
 }
 
 function formatGroupRatio(
@@ -101,6 +104,9 @@ export function ApiKeyGroupCombobox({
   onValueChange,
   placeholder,
   disabled,
+  id,
+  'aria-describedby': ariaDescribedBy,
+  'aria-invalid': ariaInvalid,
 }: ApiKeyGroupComboboxProps) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
@@ -136,7 +142,10 @@ export function ApiKeyGroupCombobox({
             type='button'
             variant='outline'
             role='combobox'
+            id={id}
+            aria-describedby={ariaDescribedBy}
             aria-expanded={open}
+            aria-invalid={ariaInvalid}
             disabled={disabled}
             className='border-input bg-muted/40 hover:bg-muted/55 hover:text-foreground active:bg-background data-popup-open:border-ring data-popup-open:bg-background data-popup-open:ring-ring/20 h-auto min-h-14 w-full justify-between gap-2 rounded-lg px-3 py-2 text-start shadow-none transition-[background-color,border-color,box-shadow] duration-150 data-popup-open:ring-[3px] sm:min-h-20 sm:gap-3 sm:px-4 sm:py-3'
           />


### PR DESCRIPTION
## Description
Forward the form control id and aria attributes from `FormControl` into the API key group combobox and date-time picker trigger buttons. This keeps `FormLabel` htmlFor references connected to focusable controls and removes Chrome label association warnings on the API key form.

## Type of change
- [x] Bug fix

## Related Issue
No existing issue.

## Checklist
- [x] I wrote this description manually and reviewed the changed code.
- [x] I searched existing Issues and PRs for similar API key form-control label issues.
- [x] I understand the change and its impact.
- [x] This PR only includes the API key form-control prop forwarding changes.
- [x] No sensitive credentials are included.

## Proof of Work
Partially verified locally. The patch is limited to forwarding `id`, `aria-describedby`, and `aria-invalid` to the existing trigger buttons.

Local checks on current main are blocked by pre-existing environment/baseline issues:
- `npx tsc -b` fails in `usage-logs-mobile-card.tsx` because `created_at` and `type` are not present on generic `TData`.
- `npx rsbuild build` fails because the local install is missing `@fontsource-variable/lora`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Date/time picker and API key group selection components now support enhanced accessibility attributes, including unique identifiers and ARIA descriptive properties for better compatibility with assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->