### PR TITLE
  fix: 修复 Claude→OpenAI 流式转换中 tool_call index 偏移导致工具调用丢失

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -438,15 +438,18 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 	return &claudeRequest, nil
 }
 
-func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.ChatCompletionsStreamResponse {
+func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse, claudeInfo *ClaudeResponseInfo) *dto.ChatCompletionsStreamResponse {
+	if claudeInfo == nil {
+		claudeInfo = &ClaudeResponseInfo{}
+	}
 	var response dto.ChatCompletionsStreamResponse
 	response.Object = "chat.completion.chunk"
 	response.Model = claudeResponse.Model
 	response.Choices = make([]dto.ChatCompletionsStreamResponseChoice, 0)
 	tools := make([]dto.ToolCallResponse, 0)
-	fcIdx := 0
+	blockIdx := 0
 	if claudeResponse.Index != nil {
-		fcIdx = *claudeResponse.Index
+		blockIdx = *claudeResponse.Index
 	}
 	var choice dto.ChatCompletionsStreamResponseChoice
 	if claudeResponse.Type == "message_start" {
@@ -465,7 +468,7 @@ func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.ChatCo
 			}
 			if claudeResponse.ContentBlock.Type == "tool_use" {
 				tools = append(tools, dto.ToolCallResponse{
-					Index: common.GetPointer(fcIdx),
+					Index: common.GetPointer(claudeInfo.toolCallIndex(blockIdx)),
 					ID:    claudeResponse.ContentBlock.Id,
 					Type:  "function",
 					Function: dto.FunctionResponse{
@@ -484,7 +487,7 @@ func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.ChatCo
 			case "input_json_delta":
 				tools = append(tools, dto.ToolCallResponse{
 					Type:  "function",
-					Index: common.GetPointer(fcIdx),
+					Index: common.GetPointer(claudeInfo.toolCallIndex(blockIdx)),
 					Function: dto.FunctionResponse{
 						Arguments: *claudeResponse.Delta.PartialJson,
 					},
@@ -589,6 +592,23 @@ type ClaudeResponseInfo struct {
 	ResponseText strings.Builder
 	Usage        *dto.Usage
 	Done         bool
+	ToolIndexMap map[int]int
+}
+
+// toolCallIndex maps a Claude content-block index to a 0-based OpenAI tool_call
+// ordinal (Claude counts all blocks; OpenAI counts only tool calls). Call it
+// only for tool_use blocks — for text/thinking blocks it would consume an
+// ordinal and shift later tool indices.
+func (info *ClaudeResponseInfo) toolCallIndex(blockIndex int) int {
+	if info.ToolIndexMap == nil {
+		info.ToolIndexMap = make(map[int]int)
+	}
+	if idx, ok := info.ToolIndexMap[blockIndex]; ok {
+		return idx
+	}
+	idx := len(info.ToolIndexMap)
+	info.ToolIndexMap[blockIndex] = idx
+	return idx
 }
 
 func cacheCreationTokensForOpenAIUsage(usage *dto.Usage) int {
@@ -817,7 +837,7 @@ func HandleStreamResponseData(c *gin.Context, info *relaycommon.RelayInfo, claud
 		}
 		helper.ClaudeChunkData(c, claudeResponse, data)
 	} else if info.RelayFormat == types.RelayFormatOpenAI {
-		response := StreamResponseClaude2OpenAI(&claudeResponse)
+		response := StreamResponseClaude2OpenAI(&claudeResponse, claudeInfo)
 
 		if !FormatClaudeResponseInfo(&claudeResponse, response, claudeInfo) {
 			return nil

--- a/relay/channel/claude/relay_claude_test.go
+++ b/relay/channel/claude/relay_claude_test.go
@@ -13,6 +13,78 @@ func commonPointer[T any](value T) *T {
 	return &value
 }
 
+func mkToolUseStart(i int, id string) *dto.ClaudeResponse {
+	idx := i
+	return &dto.ClaudeResponse{
+		Type:         "content_block_start",
+		Index:        &idx,
+		ContentBlock: &dto.ClaudeMediaMessage{Type: "tool_use", Id: id, Name: "f"},
+	}
+}
+
+// claude-opus-4-8 回归：前导 text 块不得把后续 tool_use 的工具序号顶离 0。
+func TestStreamToolCallIndex_LeadingTextDoesNotShiftToolIndex(t *testing.T) {
+	info := &ClaudeResponseInfo{Usage: &dto.Usage{}}
+
+	text := "好的，我来安排执行。"
+	textIdx := 0
+	resp := StreamResponseClaude2OpenAI(&dto.ClaudeResponse{
+		Type:         "content_block_start",
+		Index:        &textIdx,
+		ContentBlock: &dto.ClaudeMediaMessage{Type: "text", Text: &text},
+	}, info)
+	require.Len(t, resp.Choices[0].Delta.ToolCalls, 0)
+	require.Empty(t, info.ToolIndexMap, "前导文本块不应分配工具序号")
+
+	blk := 1
+	resp = StreamResponseClaude2OpenAI(&dto.ClaudeResponse{
+		Type:         "content_block_start",
+		Index:        &blk,
+		ContentBlock: &dto.ClaudeMediaMessage{Type: "tool_use", Id: "toolu_1", Name: "execute_task"},
+	}, info)
+	require.Len(t, resp.Choices[0].Delta.ToolCalls, 1)
+	require.NotNil(t, resp.Choices[0].Delta.ToolCalls[0].Index)
+	require.Equal(t, 0, *resp.Choices[0].Delta.ToolCalls[0].Index)
+	require.Equal(t, "toolu_1", resp.Choices[0].Delta.ToolCalls[0].ID)
+
+	pj := `{"intent":"x"}` // input_json_delta 复用 start 分配的序号
+	resp = StreamResponseClaude2OpenAI(&dto.ClaudeResponse{
+		Type:  "content_block_delta",
+		Index: &blk,
+		Delta: &dto.ClaudeMediaMessage{Type: "input_json_delta", PartialJson: &pj},
+	}, info)
+	require.Len(t, resp.Choices[0].Delta.ToolCalls, 1)
+	require.Equal(t, 0, *resp.Choices[0].Delta.ToolCalls[0].Index)
+	require.Equal(t, pj, resp.Choices[0].Delta.ToolCalls[0].Function.Arguments)
+}
+
+// 前导 thinking 块同样不应占用工具序号；其后两个工具应得到连续的 0、1。
+func TestStreamToolCallIndex_LeadingThinkingThenTools(t *testing.T) {
+	info := &ClaudeResponseInfo{Usage: &dto.Usage{}}
+
+	think := "let me think"
+	thIdx := 0
+	StreamResponseClaude2OpenAI(&dto.ClaudeResponse{
+		Type:  "content_block_delta",
+		Index: &thIdx,
+		Delta: &dto.ClaudeMediaMessage{Type: "thinking_delta", Thinking: &think},
+	}, info)
+
+	r1 := StreamResponseClaude2OpenAI(mkToolUseStart(1, "a"), info)
+	r2 := StreamResponseClaude2OpenAI(mkToolUseStart(2, "b"), info)
+	require.Equal(t, 0, *r1.Choices[0].Delta.ToolCalls[0].Index)
+	require.Equal(t, 1, *r2.Choices[0].Delta.ToolCalls[0].Index)
+}
+
+// 无前导块、多工具从块 0 起：序号 0、1 不撞键(对应 ff06067a1)。
+func TestStreamToolCallIndex_MultipleToolsFromZeroNoCollision(t *testing.T) {
+	info := &ClaudeResponseInfo{Usage: &dto.Usage{}}
+	r0 := StreamResponseClaude2OpenAI(mkToolUseStart(0, "a"), info)
+	r1 := StreamResponseClaude2OpenAI(mkToolUseStart(1, "b"), info)
+	require.Equal(t, 0, *r0.Choices[0].Delta.ToolCalls[0].Index)
+	require.Equal(t, 1, *r1.Choices[0].Delta.ToolCalls[0].Index)
+}
+
 func TestFormatClaudeResponseInfo_MessageStart(t *testing.T) {
 	claudeInfo := &ClaudeResponseInfo{
 		Usage: &dto.Usage{},


### PR DESCRIPTION
  ## 背景 / 现象

  通过 OpenAI 兼容端点(`/v1/chat/completions`)调用 Claude 渠道(请求转换为 `OpenAI Compatible → Claude Messages`)、流式 + 带 tools 时,客户端会偶发收到:

  - `finish_reason = "tool_calls"`
  - 但 `tool_calls` 为空(toolCallCount = 0),只收到了模型的前导文本

  在 claude-opus-4-8 上尤其容易复现,且**时好时坏**、难以稳定重现。

  ## fix: 移除 fcIdx -1 偏移，修复并发工具调用撞键问题 (#5095) 
  没有彻底修复,  只是把常量偏移从 `-1` 改成 `0`,**两个版本都不正确**:常量偏移无法表达真实映射关系,只是各自"刚好"覆盖了一种场景。

  ## 根因

  `StreamResponseClaude2OpenAI` 直接把 **Claude 的内容块序号** 当作 **OpenAI 的 `tool_calls[].index`**:

  - Claude 的 `index` 对**所有内容块**(text / thinking / tool_use)统一连续计数;
  - OpenAI 的 `tool_calls[].index` 必须**只针对工具调用**、从 0 起连续。

  因此只要 tool_use **前面存在任何非工具块**(一段前导文本,或 thinking 块),tool_use 就落在块 `index ≥ 1`。转换后发出的 OpenAI tool_call delta 携带 `index: 1`(或更大),且不存在 `index: 0`。严格按 0 基下标累积 tool_calls 的客户端无法正确归并,直接丢弃该工具调用;而 `finish_reason=tool_calls`(由 `message_delta` 的
  `stop_reason=tool_use` 映射)仍照常下发——于是出现「有 finish_reason、无 tool_calls」的矛盾。

  - 旧的 `-1` 偏移:刚好修正了「恰好一个前导块」的情况,却在「无前导、多工具从 0 起」时撞键(即 #5095 遇到的问题);
  - #5095 去掉偏移:修了后者,却重新暴露了「前导 text / thinking 块」这一情况。

  claude-opus-4-8 等模型在调用工具前常先输出一句前导文本或先思考,因此高频命中;当模型直接以 tool_use(块 0)起始时则正常——这正是"时好时坏"的原因。

  ## 修复方案

  不再使用常量偏移,改为在 `ClaudeResponseInfo` 中维护一张 **Claude 块序号 → 0 基工具序号** 的映射(首次见到该块时分配下一个序号),并**仅对 tool_use 块**(`content_block_start` 的 tool_use 及其 `input_json_delta`)调用;text / thinking 块不占用序号。

  效果:

  | 上游块序列 | 修复前 | 修复后 |
  |---|---|---|
  | `text(0), tool(1)` | `index=1` → 被客户端丢弃 | `index=0` ✓ |
  | `thinking(0), tool(1), tool(2)` | `1, 2` | `0, 1` ✓ |
  | `tool(0), tool(1)`(#5095 的撞键场景) | `0, 1` | `0, 1` ✓(不撞键) |

  ## 影响范围

  - Claude 原生渠道、流式、`RelayFormat=OpenAI`(即 OpenAI 格式客户端调用 Claude 模型)。
  - AWS Bedrock 的 Claude 流式复用同一处理逻辑,一并受益。
  - 非流式、Claude→Claude 透传路径不受影响。

  ## 测试

  新增回归用例覆盖三种场景并断言 OpenAI `tool_calls[].index` 为 0 基连续:

  - `TestStreamToolCallIndex_LeadingTextDoesNotShiftToolIndex`(前导文本)
  - `TestStreamToolCallIndex_LeadingThinkingThenTools`(前导 thinking + 多工具)
  - `TestStreamToolCallIndex_MultipleToolsFromZeroNoCollision`(#5095 撞键场景回归)

修复前:
<img width="1740" height="918" alt="image" src="https://github.com/user-attachments/assets/46eab8a7-2356-4395-abef-6c6e1c9ed9e3" />
修复后:
<img width="1618" height="1166" alt="image" src="https://github.com/user-attachments/assets/b6692cbb-a6d8-4d60-8e63-fed6c070c69d" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed tool-call index assignment in streaming responses when non-tool content blocks precede tool invocations, ensuring correct and collision-free indices.

* **Tests**
  * Added regression tests for edge cases in tool-call index mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->