### PR TITLE
fix: remove unused Mutex from CustomEvent to fix go vet lock-by-value

### DIFF
--- a/common/custom-event.go
+++ b/common/custom-event.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync"
 )
 
 type stringWriter interface {
@@ -53,8 +52,6 @@ type CustomEvent struct {
 	Id    string
 	Retry uint
 	Data  interface{}
-
-	Mutex sync.Mutex
 }
 
 func encode(writer io.Writer, event CustomEvent) error {
@@ -76,8 +73,6 @@ func (r CustomEvent) Render(w http.ResponseWriter) error {
 }
 
 func (r CustomEvent) WriteContentType(w http.ResponseWriter) {
-	r.Mutex.Lock()
-	defer r.Mutex.Unlock()
 	header := w.Header()
 	header["Content-Type"] = writeContentType
 


### PR DESCRIPTION
### What

CustomEvent embeds a sync.Mutex, but the struct is always passed by value when it is rendered (Gin's render interface is satisfied by value). Copying the struct copies the mutex, so `go vet` reports four "passes lock by value" / "copies lock value" errors in this single file.

### Why removing the mutex is safe

Every CustomEvent is a freshly constructed value that gets rendered exactly once, so the embedded mutex guards no shared state — each copy just locks its own zero-value mutex. It is effectively dead code. Writing the HTTP headers onto the per-request response writer needs no cross-goroutine lock here.

The receiver cannot simply be changed to a pointer either: the value-based render interface is used at every call site, so switching to a pointer receiver would break all of them.

### Fix

Remove the unused Mutex field, its Lock/Unlock calls in WriteContentType, and the now-unused sync import. Nothing else changes.

### Verification

- `go vet ./common/` — previously 4 errors, now clean (exit 0)
- `go build` of every CustomEvent consumer — pass
- No public API change: event construction and the render signatures stay the same


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal custom event processing by removing unnecessary synchronization, improving overall efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->