### PR TITLE
fix(web): correct multi-key dialog width overridden by default max-w

### DIFF
--- a/web/default/src/features/channels/components/dialogs/multi-key-manage-dialog.tsx
+++ b/web/default/src/features/channels/components/dialogs/multi-key-manage-dialog.tsx
@@ -229,7 +229,7 @@ export function MultiKeyManageDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className='flex max-h-[90vh] max-w-5xl flex-col'>
+        <DialogContent className='flex max-h-[90vh] flex-col sm:max-w-5xl'>
           <DialogHeader>
             <DialogTitle className='flex items-center gap-2'>
               {t('Multi-Key Management')}


### PR DESCRIPTION
  ##  变更描述 / Description
  修复 `MultiKeyManageDialog` 弹窗宽度在桌面端被默认样式覆盖的问题。
<img width="1721" height="910" alt="013ae91cfc1e34de3013b04f1e9c8a18" src="https://github.com/user-attachments/assets/5d749fa8-a6ee-43e1-ae73-c083bd518633" />


  `DialogContent` 默认带有 `sm:max-w-sm`，原先传入的 `max-w-5xl` 没有 `sm:` 前缀，二者作用在不同断点上，因此不会被 `tailwind-merge` 合并覆盖。在 `>= 40rem` 屏幕宽度下，
  默认的 `sm:max-w-sm` 仍然生效，导致弹窗被限制为 384px，工具栏操作按钮被挤压或裁切。

  本次将覆盖类名改为 `sm:max-w-5xl`，使其与默认类名处于相同断点，能够正确覆盖默认宽度，恢复预期的 1024px 弹窗宽度。

  ##  变更类型 / Type of change
  - [x]  Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
  - [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
  - [ ] ⚡ 性能优化 / 重构 (Refactor)
  - [ ]  文档更新 (Documentation)

  ##  关联任务 / Related Issue
  - Closes # （如有）

  ## ✅ 提交前检查项 / Checklist
  - [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
  - [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提
  交。
  - [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
  - [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
  - [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
  - [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
  - [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

  ##  运行证明 / Proof of Work
  手动验证 `MultiKeyManageDialog`：

  - 打开多密钥管理弹窗。
  - 在桌面宽度下确认 `DialogContent` 最终应用 `sm:max-w-5xl`。
  - 弹窗宽度恢复为预期的大尺寸布局。
  - 工具栏操作按钮，包括 `Delete Auto-Disabled`，不再因默认 `sm:max-w-sm` 宽度限制而被裁切。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced responsive design for multi-key management dialog to better display across various screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->