### PR TITLE
fix(console-setting): 文本长度按字符数校验而非字节数

### DIFF
--- a/setting/console_setting/validation.go
+++ b/setting/console_setting/validation.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 var (
@@ -110,13 +111,13 @@ func validateApiInfo(apiInfoStr string) error {
 			return err
 		}
 
-		if len(urlStr) > 500 {
+		if utf8.RuneCountInString(urlStr) > 500 {
 			return fmt.Errorf("第%d个API信息的URL长度不能超过500字符", i+1)
 		}
-		if len(route) > 100 {
+		if utf8.RuneCountInString(route) > 100 {
 			return fmt.Errorf("第%d个API信息的线路描述长度不能超过100字符", i+1)
 		}
-		if len(description) > 200 {
+		if utf8.RuneCountInString(description) > 200 {
 			return fmt.Errorf("第%d个API信息的说明长度不能超过200字符", i+1)
 		}
 
@@ -172,11 +173,11 @@ func validateAnnouncements(announcementsStr string) error {
 				}
 			}
 		}
-		if len(content) > 500 {
+		if utf8.RuneCountInString(content) > 500 {
 			return fmt.Errorf("第%d个公告的内容长度不能超过500字符", i+1)
 		}
 		if extra, exists := ann["extra"]; exists {
-			if extraStr, ok := extra.(string); ok && len(extraStr) > 200 {
+			if extraStr, ok := extra.(string); ok && utf8.RuneCountInString(extraStr) > 200 {
 				return fmt.Errorf("第%d个公告的说明长度不能超过200字符", i+1)
 			}
 		}
@@ -201,10 +202,10 @@ func validateFAQ(faqStr string) error {
 		if !ok || answer == "" {
 			return fmt.Errorf("第%d个FAQ缺少答案字段", i+1)
 		}
-		if len(question) > 200 {
+		if utf8.RuneCountInString(question) > 200 {
 			return fmt.Errorf("第%d个FAQ的问题长度不能超过200字符", i+1)
 		}
-		if len(answer) > 1000 {
+		if utf8.RuneCountInString(answer) > 1000 {
 			return fmt.Errorf("第%d个FAQ的答案长度不能超过1000字符", i+1)
 		}
 	}
@@ -272,16 +273,16 @@ func validateUptimeKumaGroups(groupsStr string) error {
 			return err
 		}
 
-		if len(categoryName) > 50 {
+		if utf8.RuneCountInString(categoryName) > 50 {
 			return fmt.Errorf("第%d个分组的分类名称长度不能超过50字符", i+1)
 		}
-		if len(urlStr) > 500 {
+		if utf8.RuneCountInString(urlStr) > 500 {
 			return fmt.Errorf("第%d个分组的URL长度不能超过500字符", i+1)
 		}
-		if len(slug) > 100 {
+		if utf8.RuneCountInString(slug) > 100 {
 			return fmt.Errorf("第%d个分组的Slug长度不能超过100字符", i+1)
 		}
-		if len(description) > 200 {
+		if utf8.RuneCountInString(description) > 200 {
 			return fmt.Errorf("第%d个分组的描述长度不能超过200字符", i+1)
 		}
 


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)
后端validation.go 中所有字符串字段长度校验使用 len() 计算字节数,
导致中文等多字节字符被错误拒绝(如公告约 167 个中文即超 500 字节),
而前端按 Unicode 字符数显示与校验,文案也写的是"N 字符",
前后端口径不一致。

在后端校验时将可能涉及中文字符的地方统一改为 utf8.RuneCountInString 按字符数校验,涉及公告 content/extra、 API 信息、FAQ、分组等字段。数组数量校验保持 len 不变。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
<img width="877" height="471" alt="image" src="https://github.com/user-attachments/assets/55d674dc-13a9-4c37-9ac8-1150aa3462c6" />
<img width="944" height="353" alt="image" src="https://github.com/user-attachments/assets/326d2596-8123-432d-8bcd-2f8439d9f9da" />
<img width="938" height="354" alt="image" src="https://github.com/user-attachments/assets/ffa2c92e-8390-4cf9-b73c-a139bc8ae0a3" />

修改后公告能够成功发布

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed field length validation to accurately count Unicode characters instead of bytes. This improves support for international text and special characters in API descriptions, announcements, FAQs, and group configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->