### PR TITLE
fix：修复异步任务（Task）计费日志未导出统计数据

### DIFF
--- a/model/log.go
+++ b/model/log.go
@@ -57,13 +57,14 @@ type Log struct {
 
 // don't use iota, avoid change log type value
 const (
-	LogTypeUnknown = 0
-	LogTypeTopup   = 1
-	LogTypeConsume = 2
-	LogTypeManage  = 3
-	LogTypeSystem  = 4
-	LogTypeError   = 5
-	LogTypeRefund  = 6
+	LogTypeUnknown    = 0
+	LogTypeTopup      = 1
+	LogTypeConsume    = 2
+	LogTypeManage     = 3
+	LogTypeSystem     = 4
+	LogTypeError      = 5
+	LogTypeRefund     = 6
+	LogTypePreConsume = 7 // 预扣费中间态日志，不计入统计面板
 )
 
 func formatUserLogs(logs []*Log, startIdx int) {
@@ -313,11 +314,10 @@ func RecordTaskBillingLog(params RecordTaskBillingLogParams) {
 	if err != nil {
 		common.SysLog("failed to record task billing log: " + err.Error())
 	}
-	if common.DataExportEnabled {
+	// LogTypePreConsume 是预扣费中间态，统计数据在差额结算时一次性写入，避免虚高。
+	// LogTypeRefund 对应任务失败退款：由于预扣阶段未写 quota_data，退款无需冲销，跳过写入。
+	if common.DataExportEnabled && params.LogType != LogTypePreConsume && params.LogType != LogTypeRefund {
 		quotaForStats := params.Quota
-		if params.LogType == LogTypeRefund {
-			quotaForStats = -quotaForStats
-		}
 		gopool.Go(func() {
 			LogQuotaData(params.UserId, username, params.ModelName, quotaForStats, common.GetTimestamp(), 0)
 		})

--- a/model/log.go
+++ b/model/log.go
@@ -313,6 +313,15 @@ func RecordTaskBillingLog(params RecordTaskBillingLogParams) {
 	if err != nil {
 		common.SysLog("failed to record task billing log: " + err.Error())
 	}
+	if common.DataExportEnabled {
+		quotaForStats := params.Quota
+		if params.LogType == LogTypeRefund {
+			quotaForStats = -quotaForStats
+		}
+		gopool.Go(func() {
+			LogQuotaData(params.UserId, username, params.ModelName, quotaForStats, common.GetTimestamp(), 0)
+		})
+	}
 }
 
 func GetAllLogs(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string, startIdx int, num int, channel int, group string, requestId string, upstreamRequestId string) (logs []*Log, total int64, err error) {

--- a/service/task_billing.go
+++ b/service/task_billing.go
@@ -194,38 +194,34 @@ func RecalculateTaskQuota(ctx context.Context, task *model.Task, actualQuota int
 	if quotaDelta == 0 {
 		logger.LogInfo(ctx, fmt.Sprintf("任务 %s 预扣费准确（%s，%s）",
 			task.TaskID, logger.LogQuota(actualQuota), reason))
-		return
+	} else {
+		logger.LogInfo(ctx, fmt.Sprintf("任务 %s 差额结算：delta=%s（实际：%s，预扣：%s，%s）",
+			task.TaskID,
+			logger.LogQuota(quotaDelta),
+			logger.LogQuota(actualQuota),
+			logger.LogQuota(preConsumedQuota),
+			reason,
+		))
+
+		// 调整资金来源
+		if err := taskAdjustFunding(task, quotaDelta); err != nil {
+			logger.LogError(ctx, fmt.Sprintf("差额结算资金调整失败 task %s: %s", task.TaskID, err.Error()))
+			return
+		}
+
+		// 调整令牌额度
+		taskAdjustTokenQuota(ctx, task, quotaDelta)
 	}
-
-	logger.LogInfo(ctx, fmt.Sprintf("任务 %s 差额结算：delta=%s（实际：%s，预扣：%s，%s）",
-		task.TaskID,
-		logger.LogQuota(quotaDelta),
-		logger.LogQuota(actualQuota),
-		logger.LogQuota(preConsumedQuota),
-		reason,
-	))
-
-	// 调整资金来源
-	if err := taskAdjustFunding(task, quotaDelta); err != nil {
-		logger.LogError(ctx, fmt.Sprintf("差额结算资金调整失败 task %s: %s", task.TaskID, err.Error()))
-		return
-	}
-
-	// 调整令牌额度
-	taskAdjustTokenQuota(ctx, task, quotaDelta)
 
 	task.Quota = actualQuota
 
-	var logType int
-	var logQuota int
+	// Siempre usamos LogTypeConsume con la quota real: el log refleja el consumo efectivo.
+	// La devolución del exceso al usuario ya se hizo vía taskAdjustFunding arriba.
+	// Escribir LogTypeRefund aquí confundiría el panel (sería consumo real, no una cancelación).
+	// UpdateUserUsedQuotaAndRequestCount solo se ajusta por el delta positivo para no duplicar.
 	if quotaDelta > 0 {
-		logType = model.LogTypeConsume
-		logQuota = quotaDelta
 		model.UpdateUserUsedQuotaAndRequestCount(task.UserId, quotaDelta)
 		model.UpdateChannelUsedQuota(task.ChannelId, quotaDelta)
-	} else {
-		logType = model.LogTypeRefund
-		logQuota = -quotaDelta
 	}
 	other := taskBillingOther(task)
 	other["task_id"] = task.TaskID
@@ -233,11 +229,11 @@ func RecalculateTaskQuota(ctx context.Context, task *model.Task, actualQuota int
 	other["actual_quota"] = actualQuota
 	model.RecordTaskBillingLog(model.RecordTaskBillingLogParams{
 		UserId:    task.UserId,
-		LogType:   logType,
+		LogType:   model.LogTypeConsume,
 		Content:   reason,
 		ChannelId: task.ChannelId,
 		ModelName: taskModelName(task),
-		Quota:     logQuota,
+		Quota:     actualQuota,
 		TokenId:   task.PrivateData.TokenId,
 		Group:     task.Group,
 		Other:     other,


### PR DESCRIPTION
### 问题描述

当 `DataExportEnabled` 开启时，异步任务（Task）场景的退款和差额补扣数据不会被导出到 `quota_data` 统计表，导致统计数据偏差。

### 根因

`RecordConsumeLog`（同步场景）在写入日志后会调用 `LogQuotaData` 导出统计数据，但 `RecordTaskBillingLog`（异步任务场景）只写入了 `logs` 表，**缺少 `DataExportEnabled` 检查和 `LogQuotaData` 调用**。

### 影响范围

| 调用路径 | LogType | 是否导出统计（修复前） |
|----------|---------|----------------------|
| `LogTaskConsumption` → `RecordConsumeLog` | Consume（预扣费） | ✅ 是 | | `RefundTaskQuota` → `RecordTaskBillingLog` | Refund（退款） | ❌ 否 | | `RecalculateTaskQuota` → `RecordTaskBillingLog` | Consume/Refund（差额补扣/退还） | ❌ 否 |

### 后果

- `quota_data` 统计表中**只包含预扣金额**，缺少退款和差额补扣数据
- 统计的消费金额**偏高**，Task 场景的退款和差额不会被扣除
- 影响 `DataExportEnabled` 开启时的所有异步任务（如 Midjourney 等）

### 修复

在 `RecordTaskBillingLog` 的 `LOG_DB.Create` 之后，新增 `DataExportEnabled` 检查和 `LogQuotaData` 调用，退款场景将 quota 取反以正确反映扣减方向。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional billing data export when enabled, skipping interim/pre-refund entries.

* **Bug Fixes**
  * Settlement now records accurate consumption amounts and avoids double-counting on refunds by only updating usage counters for net increases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->