### PR TITLE
fix(billing): count tool call tokens when upstream omits usage

### DIFF
--- a/relay/channel/openai/relay-openai.go
+++ b/relay/channel/openai/relay-openai.go
@@ -240,7 +240,12 @@ func OpenaiHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respo
 		completionTokens := simpleResponse.Usage.CompletionTokens
 		if completionTokens == 0 {
 			for _, choice := range simpleResponse.Choices {
-				ctkm := service.CountTextToken(choice.Message.StringContent()+choice.Message.GetReasoningContent(), info.UpstreamModelName)
+				textContent := choice.Message.StringContent() + choice.Message.GetReasoningContent()
+				// Count tool call name/arguments too, otherwise completion tokens are undercounted when upstream omits usage for tool-calling responses.
+				for _, tool := range choice.Message.ParseToolCalls() {
+					textContent += tool.Function.Name + tool.Function.Arguments
+				}
+				ctkm := service.CountTextToken(textContent, info.UpstreamModelName)
 				completionTokens += ctkm
 			}
 		}


### PR DESCRIPTION
## Problem

When an upstream channel returns a tool/function-calling response **without** a `usage` object, `OpenaiHandler` falls back to estimating completion tokens locally via `service.CountTextToken`.

The current estimate only accounts for message content and reasoning content:

```go
ctkm := service.CountTextToken(choice.Message.StringContent()+choice.Message.GetReasoningContent(), info.UpstreamModelName)
```

For tool-calling responses, the actual generated output (the tool call `function.name` and `arguments`) is **not** counted. This **undercounts completion tokens**, which in turn **undercharges** for requests that produce tool calls but whose upstream channel omits usage data.

## Fix

Include each tool call's `function.name` and `arguments` in the text passed to `CountTextToken`, so the local estimate reflects the full generated output:

```go
textContent := choice.Message.StringContent() + choice.Message.GetReasoningContent()
for _, tool := range choice.Message.ParseToolCalls() {
    textContent += tool.Function.Name + tool.Function.Arguments
}
ctkm := service.CountTextToken(textContent, info.UpstreamModelName)
```

## Scope / Safety

- Only affects the **estimation fallback path** (`Usage.PromptTokens == 0 && Usage.CompletionTokens == 0`). Responses where the upstream provides usage are unchanged.
- Uses the existing `Message.ParseToolCalls()` helper; no new API.
- `go build ./relay/channel/openai/` passes; no new lint/type errors.

## Test plan

- Send a tool/function-calling request to a channel that does not return `usage`.
- Before: logged completion tokens omit tool call content.
- After: completion tokens include tool call name + arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved token usage estimation accuracy for OpenAI relay responses. The system now comprehensively includes tool-call function names and arguments in token calculations, providing significantly more precise and accurate completion token counts and better usage estimates for API responses where explicit usage metrics may not be directly available from the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->