### PR TITLE
fix: validate user group exists in UpdateUser (fixes #5236)

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -591,6 +591,10 @@ func UpdateUser(c *gin.Context) {
 		common.ApiErrorI18n(c, i18n.MsgUserCannotCreateHigherLevel)
 		return
 	}
+	if updatedUser.Group != "" && !setting.IsUserUsableGroup(updatedUser.Group) {
+		common.ApiErrorI18n(c, i18n.MsgInvalidParams, map[string]any{"Error": fmt.Sprintf("user group does not exist: %s", updatedUser.Group)})
+		return
+	}
 	if updatedUser.Password == "$I_LOVE_U" {
 		updatedUser.Password = "" // rollback to what it should be
 	}

--- a/controller/user.go
+++ b/controller/user.go
@@ -18,6 +18,7 @@ import (
 	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting"
 	"github.com/QuantumNous/new-api/setting/operation_setting"
+	"github.com/QuantumNous/new-api/setting/ratio_setting"
 
 	"github.com/QuantumNous/new-api/constant"
 
@@ -591,7 +592,7 @@ func UpdateUser(c *gin.Context) {
 		common.ApiErrorI18n(c, i18n.MsgUserCannotCreateHigherLevel)
 		return
 	}
-	if updatedUser.Group != "" && !setting.IsUserUsableGroup(updatedUser.Group) {
+	if updatedUser.Group != "" && !ratio_setting.ContainsGroupRatio(updatedUser.Group) {
 		common.ApiErrorI18n(c, i18n.MsgInvalidParams, map[string]any{"Error": fmt.Sprintf("user group does not exist: %s", updatedUser.Group)})
 		return
 	}

--- a/setting/user_usable_group.go
+++ b/setting/user_usable_group.go
@@ -43,6 +43,14 @@ func UpdateUserUsableGroupsByJSONString(jsonStr string) error {
 	return json.Unmarshal([]byte(jsonStr), &userUsableGroups)
 }
 
+// IsUserUsableGroup checks whether a group name exists in the configured user groups.
+func IsUserUsableGroup(groupName string) bool {
+	userUsableGroupsMutex.RLock()
+	defer userUsableGroupsMutex.RUnlock()
+	_, ok := userUsableGroups[groupName]
+	return ok
+}
+
 func GetUsableGroupDescription(groupName string) string {
 	userUsableGroupsMutex.RLock()
 	defer userUsableGroupsMutex.RUnlock()


### PR DESCRIPTION
fix: validate user group exists in UpdateUser (fixes #5236)

Add group existence validation in UpdateUser to prevent writing
non-existent group names to the database.

- Add IsUserUsableGroup() helper to setting/user_usable_group.go
- Validate updatedUser.Group in controller/user.go UpdateUser handler
- Return error with descriptive message when group does not exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for user group assignments to prevent non-existent groups from being set when updating user accounts.

* **New Features**
  * Added a capability to check which groups are available for users, strengthening group-assignment checks and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->