### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/relay/channel/minimax/constants.go
+++ b/relay/channel/minimax/constants.go
@@ -3,24 +3,20 @@ package minimax
 // https://www.minimaxi.com/document/guides/chat-model/V2?id=65e0736ab2845de20908e2dd
 
 var ModelList = []string{
+	"MiniMax-M3",
+	"MiniMax-M2.7",
+	"MiniMax-M2.7-highspeed",
 	"abab6.5-chat",
 	"abab6.5s-chat",
 	"abab6-chat",
 	"abab5.5-chat",
 	"abab5.5s-chat",
-	"MiniMax-M2.7",
-	"MiniMax-M2.7-highspeed",
 	"speech-2.5-hd-preview",
 	"speech-2.5-turbo-preview",
 	"speech-02-hd",
 	"speech-02-turbo",
 	"speech-01-hd",
 	"speech-01-turbo",
-	"MiniMax-M2.1",
-	"MiniMax-M2.1-highspeed",
-	"MiniMax-M2",
-	"MiniMax-M2.5",
-	"MiniMax-M2.5-highspeed",
 	"image-01",
 	"image-01-live",
 }

--- a/relay/channel/minimax/constants_test.go
+++ b/relay/channel/minimax/constants_test.go
@@ -1,0 +1,80 @@
+package minimax
+
+import "testing"
+
+func TestModelListContainsM3(t *testing.T) {
+	found := false
+	for _, model := range ModelList {
+		if model == "MiniMax-M3" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("ModelList should contain MiniMax-M3")
+	}
+}
+
+func TestModelListKeepsM27Variants(t *testing.T) {
+	required := []string{
+		"MiniMax-M2.7",
+		"MiniMax-M2.7-highspeed",
+	}
+
+	set := make(map[string]bool, len(ModelList))
+	for _, model := range ModelList {
+		set[model] = true
+	}
+
+	for _, name := range required {
+		if !set[name] {
+			t.Errorf("ModelList should still contain %s", name)
+		}
+	}
+}
+
+func TestModelListM3IsDefault(t *testing.T) {
+	if len(ModelList) == 0 {
+		t.Fatal("ModelList is empty")
+	}
+
+	m3Idx := -1
+	m27Idx := -1
+	for i, model := range ModelList {
+		switch model {
+		case "MiniMax-M3":
+			m3Idx = i
+		case "MiniMax-M2.7":
+			m27Idx = i
+		}
+	}
+
+	if m3Idx == -1 {
+		t.Fatal("MiniMax-M3 not found in ModelList")
+	}
+	if m27Idx == -1 {
+		t.Fatal("MiniMax-M2.7 not found in ModelList")
+	}
+	if m3Idx >= m27Idx {
+		t.Errorf("MiniMax-M3 (index %d) should come before MiniMax-M2.7 (index %d)", m3Idx, m27Idx)
+	}
+}
+
+func TestModelListRemovesLegacyModels(t *testing.T) {
+	removed := []string{
+		"MiniMax-M2.5",
+		"MiniMax-M2.5-highspeed",
+		"MiniMax-M2.1",
+		"MiniMax-M2.1-highspeed",
+		"MiniMax-M2",
+		"MiniMax-M1",
+	}
+
+	for _, model := range ModelList {
+		for _, legacy := range removed {
+			if model == legacy {
+				t.Errorf("ModelList should not contain legacy model %s", legacy)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 📝 变更描述 / Description
将 MiniMax 通道的默认聊天模型升级为 `MiniMax-M3`（512K 上下文、128K 最大输出、支持图片输入），并在模型列表中放在最前作为默认。保留上一代 `MiniMax-M2.7` 与 `MiniMax-M2.7-highspeed` 作为可选项，移除更早的 `MiniMax-M2.5` / `M2.5-highspeed` / `M2.1` / `M2.1-highspeed` / `M2`。

为什么生效：`relay/channel/minimax/constants.go` 中的 `ModelList` 是通道暴露给上层的模型集合，调度按数组顺序选取首项作为默认；将 M3 置于首位即让其在通道默认场景下被优先选中，旧条目移除后将不再出现在控制台/调用方可见列表里。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (无)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 非 Bug fix。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 仅修改 `relay/channel/minimax/constants.go` 与新增同包测试文件，未带入无关改动。
- [x] **本地验证:** `go test ./relay/channel/minimax/...` 通过。
- [x] **安全合规:** 不涉及任何凭据或敏感信息。

## 📸 运行证明 / Proof of Work
本地测试输出：
\`\`\`
$ go test ./relay/channel/minimax/...
ok  	github.com/QuantumNous/new-api/relay/channel/minimax	4.401s
\`\`\`

新增 4 个单元测试用例覆盖：
- `TestModelListContainsM3` — 列表包含 `MiniMax-M3`
- `TestModelListKeepsM27Variants` — 仍保留 `MiniMax-M2.7` 与 `MiniMax-M2.7-highspeed`
- `TestModelListM3IsDefault` — `MiniMax-M3` 排在 `MiniMax-M2.7` 之前（默认位）
- `TestModelListRemovesLegacyModels` — 旧版 M2.5 / M2.1 / M2 / M1 已从列表中移除

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for MiniMax-M3, MiniMax-M2.7, and MiniMax-M2.7-highspeed models.

* **Tests**
  * Added comprehensive test coverage for supported MiniMax models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->