### PR TITLE
fix: bill minimax tts by upstream usage_characters

### DIFF
--- a/relay/channel/minimax/tts.go
+++ b/relay/channel/minimax/tts.go
@@ -163,10 +163,16 @@ func handleTTSResponse(c *gin.Context, resp *http.Response, info *relaycommon.Re
 		c.Data(http.StatusOK, contentType, audioData)
 	}
 
+	// MiniMax 按字符计费，优先使用上游返回的真实 usage_characters；
+	// 若上游未返回（成功但字符数缺失），回退到本地预估的输入字符数，避免免费请求
+	billingTokens := int(minimaxResp.ExtraInfo.UsageCharacters)
+	if billingTokens <= 0 {
+		billingTokens = info.GetEstimatePromptTokens()
+	}
 	usage = &dto.Usage{
-		PromptTokens:     info.GetEstimatePromptTokens(),
+		PromptTokens:     billingTokens,
 		CompletionTokens: 0,
-		TotalTokens:      int(minimaxResp.ExtraInfo.UsageCharacters),
+		TotalTokens:      billingTokens,
 	}
 
 	return usage, nil


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
minimax tts上游返回的token和本地预扣的有误差
比如 `你好,世界`, 本地预估是5,  上游官方返回是10

## 🚀 变更类型 / Type of change
优先使用上游返回token计费
上游token缺失才使用本地预扣保底

## 📸 运行证明 / Proof of Work
请求: 
```
{
  "model": "speech-2.8-hd",
  "input": "你好, 世界"
}
```

修复前: 
<img width="1904" height="232" alt="image" src="https://github.com/user-attachments/assets/ac81ae11-986f-4145-a253-d717a97ccc6b" />

修复后:
<img width="1596" height="226" alt="image" src="https://github.com/user-attachments/assets/a058325c-acde-4078-8e05-dfec7ecced66" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced TTS token usage reporting accuracy with improved fallback handling for edge cases where upstream values are missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->