### PR TITLE
feat: 新增阿里千问语音识别ASR - qwen3-asr-flash

### DIFF
--- a/relay/channel/ali/adaptor.go
+++ b/relay/channel/ali/adaptor.go
@@ -119,6 +119,8 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 			} else {
 				fullRequestURL = fmt.Sprintf("%s/api/v1/services/aigc/multimodal-generation/generation", info.ChannelBaseUrl)
 			}
+		case constant.RelayModeAudioTranscription:
+			fullRequestURL = fmt.Sprintf("%s/compatible-mode/v1/chat/completions", info.ChannelBaseUrl)
 		case constant.RelayModeCompletions:
 			fullRequestURL = fmt.Sprintf("%s/compatible-mode/v1/completions", info.ChannelBaseUrl)
 		default:
@@ -132,6 +134,10 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *relaycommon.RelayInfo) error {
 	channel.SetupApiRequestHeader(info, c, req)
 	req.Set("Authorization", "Bearer "+info.ApiKey)
+	if info.RelayMode == constant.RelayModeAudioTranscription {
+		// 基础 header 逻辑对转写模式默认留空（multipart），这里走 chat/completions 发 JSON
+		req.Set("Content-Type", "application/json")
+	}
 	if info.IsStream {
 		req.Set("X-DashScope-SSE", "enable")
 	}
@@ -226,7 +232,9 @@ func (a *Adaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.Rela
 }
 
 func (a *Adaptor) ConvertAudioRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.AudioRequest) (io.Reader, error) {
-	//TODO implement me
+	if info.RelayMode == constant.RelayModeAudioTranscription && isQwenASRModel(info.UpstreamModelName) {
+		return a.convertASRRequest(c, info, request)
+	}
 	return nil, errors.New("not implemented")
 }
 
@@ -250,6 +258,8 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycom
 		return adaptor.DoResponse(c, resp, info)
 	default:
 		switch info.RelayMode {
+		case constant.RelayModeAudioTranscription:
+			usage, err = handleASRResponse(c, resp, info)
 		case constant.RelayModeImagesGenerations:
 			err, usage = aliImageHandler(a, c, resp, info)
 		case constant.RelayModeImagesEdits:

--- a/relay/channel/ali/asr.go
+++ b/relay/channel/ali/asr.go
@@ -1,0 +1,146 @@
+package ali
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/types"
+
+	"github.com/gin-gonic/gin"
+)
+
+// isQwenASRModel 判断是否走 ASR 路径（chat/completions + input_audio，而非标准 whisper 接口）。
+func isQwenASRModel(modelName string) bool {
+	return strings.Contains(strings.ToLower(modelName), "asr")
+}
+
+// asr_options 在请求体顶层（SDK 中通过 extra_body 传入）。
+type qwenASRChatRequest struct {
+	Model      string           `json:"model"`
+	Messages   []qwenASRMessage `json:"messages"`
+	Stream     bool             `json:"stream"`
+	ASROptions *qwenASROptions  `json:"asr_options,omitempty"`
+}
+
+type qwenASRMessage struct {
+	Role    string           `json:"role"`
+	Content []qwenASRContent `json:"content"`
+}
+
+type qwenASRContent struct {
+	Type       string          `json:"type"`
+	InputAudio *qwenInputAudio `json:"input_audio,omitempty"`
+}
+
+type qwenInputAudio struct {
+	Data string `json:"data"`
+}
+
+type qwenASROptions struct {
+	Language  string `json:"language,omitempty"`
+	EnableITN *bool  `json:"enable_itn,omitempty"`
+}
+
+// 未启用对象存储时中间件透传原始文件，回退为 Base64，使 ASR 不硬依赖 OSS。
+func asrAudioData(c *gin.Context) (string, error) {
+	if urls := c.PostFormArray("file"); len(urls) > 0 && urls[0] != "" {
+		return urls[0], nil
+	}
+
+	b64s, err := relaycommon.GetBase64sFromForm(c, "file")
+	if err != nil {
+		return "", err
+	}
+	return b64s[0].String(), nil
+}
+
+func (a *Adaptor) convertASRRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.AudioRequest) (io.Reader, error) {
+	audioData, err := asrAudioData(c)
+	if err != nil {
+		return nil, err
+	}
+
+	asrReq := qwenASRChatRequest{
+		Model:  info.UpstreamModelName,
+		Stream: false,
+		Messages: []qwenASRMessage{
+			{
+				Role: "user",
+				Content: []qwenASRContent{
+					{
+						Type:       "input_audio",
+						InputAudio: &qwenInputAudio{Data: audioData},
+					},
+				},
+			},
+		},
+	}
+
+	var options qwenASROptions
+	hasOptions := false
+	if request.Language != nil {
+		var lang string
+		if err := common.Unmarshal(request.Language, &lang); err == nil && lang != "" {
+			options.Language = lang
+			hasOptions = true
+		}
+	}
+	if v := c.PostForm("enable_itn"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			options.EnableITN = &b
+			hasOptions = true
+		}
+	}
+	if hasOptions {
+		asrReq.ASROptions = &options
+	}
+
+	jsonData, err := common.Marshal(asrReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ASR request: %w", err)
+	}
+	return bytes.NewReader(jsonData), nil
+}
+
+func handleASRResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (any, *types.NewAPIError) {
+	defer service.CloseResponseBodyGracefully(resp)
+
+	var textResp dto.OpenAITextResponse
+	if err := common.DecodeJson(resp.Body, &textResp); err != nil {
+		return nil, types.NewError(fmt.Errorf("failed to parse ASR response: %w", err), types.ErrorCodeBadResponse)
+	}
+
+	resultText := ""
+	if len(textResp.Choices) > 0 {
+		resultText = textResp.Choices[0].Message.StringContent()
+	}
+
+	responseFormat := "json"
+	if audioReq, ok := info.Request.(*dto.AudioRequest); ok && audioReq.ResponseFormat != "" {
+		responseFormat = audioReq.ResponseFormat
+	}
+
+	switch responseFormat {
+	case "text":
+		c.Data(http.StatusOK, "text/plain; charset=utf-8", []byte(resultText))
+	case "verbose_json":
+		c.JSON(http.StatusOK, dto.WhisperVerboseJSONResponse{Task: "transcribe", Text: resultText})
+	default:
+		c.JSON(http.StatusOK, dto.AudioResponse{Text: resultText})
+	}
+
+	usage := &textResp.Usage
+	if usage.TotalTokens == 0 {
+		usage.PromptTokens = info.GetEstimatePromptTokens()
+		usage.TotalTokens = usage.PromptTokens
+	}
+	return usage, nil
+}

--- a/relay/channel/ali/constants.go
+++ b/relay/channel/ali/constants.go
@@ -7,6 +7,7 @@ var ModelList = []string{
 	"qwen-max-longcontext",
 	"qwq-32b",
 	"qwen3-235b-a22b",
+	"qwen3-asr-flash",
 	"text-embedding-v1",
 	"gte-rerank-v2",
 }


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
增加阿里千问ASR模型支持: qwen3-asr-flash
按返回usage token计费

## 📝 变更描述 / Description
支持OAI格式按file传本地文件
也支持file直接传url

## 📸 运行证明 / Proof of Work
url请求格式:
```
curl http://localhost:3000/v1/audio/transcriptions \
  --request POST \
  --header 'Content-Type: multipart/form-data' \
  --form 'file=https://dashscope.oss-cn-beijing.aliyuncs.com/audios/welcome.mp3' \
  --form 'model=qwen3-asr-flash'
```

本地文件请求格式:
```
curl http://localhost:3000/v1/audio/transcriptions \
  --request POST \
  --header 'Content-Type: multipart/form-data' \
  --form 'file=@test.wav' \
  --form 'model=qwen3-asr-flash'
```
 结果:
<img width="1246" height="360" alt="image" src="https://github.com/user-attachments/assets/9ce0b2df-0844-4754-8551-e55686756ebf" />

计费: 
<img width="1448" height="181" alt="image" src="https://github.com/user-attachments/assets/3a589a07-5bca-4e4f-bf2a-c92d7e56679f" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Enabled audio transcription support for Ali channel with Qwen ASR models, including the new `qwen3-asr-flash` model
* Audio input flexibility: support for file uploads and base64-encoded audio data
* Multiple response formats: text output, verbose JSON, and structured audio response format
* Automatic token usage estimation for transcription requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->