### PR TITLE
fix: keep Responses stream pre-consume on missing usage

### DIFF
--- a/constant/context_key.go
+++ b/constant/context_key.go
@@ -64,6 +64,10 @@ const (
 	// It is not returned to end users, but can be persisted into consume/error logs for debugging.
 	ContextKeyAdminRejectReason ContextKey = "admin_reject_reason"
 
+	// ContextKeyResponsesBillableStreamOutput marks a Responses stream that emitted
+	// billable output before its terminal usage event was observed.
+	ContextKeyResponsesBillableStreamOutput ContextKey = "responses_billable_stream_output"
+
 	// ContextKeyLanguage stores the user's language preference for i18n
 	ContextKeyLanguage ContextKey = "language"
 	ContextKeyIsStream ContextKey = "is_stream"

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/logger"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/helper"
@@ -123,6 +124,9 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 							idx := i
 							imageCounter.Observe(&streamResponse.Response.Output[i], &idx)
 						}
+						if imageCounter.Count() > 0 {
+							common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, true)
+						}
 						imageCounter.Commit(info)
 						imageCommitted = true
 					}
@@ -139,19 +143,32 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 			}
 		case "response.output_text.delta":
 			// 处理输出文本
-			responseTextBuilder.WriteString(streamResponse.Delta)
+			if streamResponse.Delta != "" {
+				common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, true)
+				responseTextBuilder.WriteString(streamResponse.Delta)
+			}
 		case dto.ResponsesOutputTypeItemDone:
 			if streamResponse.Item != nil {
 				switch streamResponse.Item.Type {
 				case dto.BuildInCallWebSearchCall:
+					common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, true)
 					info.CountBillableToolCall(dto.BuildInCallWebSearchCall, "")
 				case dto.BuildInCallFileSearchCall:
+					common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, true)
 					info.CountBillableToolCall(dto.BuildInCallFileSearchCall, "")
 				case dto.BuildInCallFunctionCall:
+					before := responseToolCallCount(info)
 					info.CountBillableToolCall(dto.BuildInCallFunctionCall, streamResponse.Item.Name)
+					if responseToolCallCount(info) > before {
+						common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, true)
+					}
 				case dto.ResponsesOutputTypeImageGenerationCall:
+					before := imageCounter.Count()
 					if !imageCommitted {
 						imageCounter.Observe(streamResponse.Item, streamResponse.OutputIndex)
+					}
+					if imageCounter.Count() > before {
+						common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, true)
 					}
 				}
 			}
@@ -175,4 +192,17 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
 
 	return usage, nil
+}
+
+func responseToolCallCount(info *relaycommon.RelayInfo) int {
+	if info == nil || info.ResponsesUsageInfo == nil {
+		return 0
+	}
+	total := 0
+	for _, tool := range info.ResponsesUsageInfo.BuiltInTools {
+		if tool != nil && tool.CallCount > 0 {
+			total += tool.CallCount
+		}
+	}
+	return total
 }

--- a/relay/channel/openai/relay_responses_billing_test.go
+++ b/relay/channel/openai/relay_responses_billing_test.go
@@ -265,3 +265,35 @@ func TestOaiResponsesStreamHandlerDoesNotCountPartialImageEvent(t *testing.T) {
 
 	assert.Equal(t, 0, info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolImageGeneration].CallCount)
 }
+
+func TestOaiResponsesStreamHandlerMarksBillableOutput(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	body := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"hello"}`,
+		`data: {"type":"response.output_item.done","item":{"type":"file_search_call"}}`,
+		`data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "gpt-5.1",
+		DisablePing:     true,
+		ChannelMeta:     &relaycommon.ChannelMeta{UpstreamModelName: "gpt-5.1"},
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+
+	_, apiErr := OaiResponsesStreamHandler(c, info, resp)
+	require.Nil(t, apiErr)
+	assert.True(t, common.GetContextKeyBool(c, constant.ContextKeyResponsesBillableStreamOutput))
+}

--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -66,6 +66,8 @@ type textQuotaSummary struct {
 	AudioInputPrice        float64
 	ToolSurchargeItems     []ToolSurchargeItem
 	ToolCallSurchargeQuota decimal.Decimal
+
+	MissingUsagePreConsumed bool
 }
 
 // hasBillableUsage reports whether this request should incur any charge.
@@ -73,7 +75,46 @@ type textQuotaSummary struct {
 // surcharge (e.g. /v1/alpha/search returns no usage but bills one web_search
 // call), so token count alone is not sufficient to decide.
 func (s *textQuotaSummary) hasBillableUsage() bool {
-	return s.TotalTokens > 0 || !s.ToolCallSurchargeQuota.IsZero()
+	return s.MissingUsagePreConsumed || s.TotalTokens > 0 || !s.ToolCallSurchargeQuota.IsZero()
+}
+
+func preConsumedQuotaForRelay(relayInfo *relaycommon.RelayInfo) int {
+	if relayInfo == nil {
+		return 0
+	}
+	if relayInfo.Billing != nil {
+		// BillingSession is authoritative even when the trusted pre-consume
+		// amount is legitimately zero.
+		return relayInfo.Billing.GetPreConsumedQuota()
+	}
+	return relayInfo.FinalPreConsumedQuota
+}
+
+func shouldKeepPreConsumedQuotaForMissingStreamUsage(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, totalTokens int) (int, bool) {
+	if relayInfo == nil || !relayInfo.IsStream || totalTokens != 0 {
+		return 0, false
+	}
+	if relayInfo.GetFinalRequestRelayFormat() != types.RelayFormatOpenAIResponses {
+		return 0, false
+	}
+	if !common.GetContextKeyBool(ctx, constant.ContextKeyResponsesBillableStreamOutput) {
+		return 0, false
+	}
+	preConsumed := preConsumedQuotaForRelay(relayInfo)
+	if preConsumed <= 0 || relayInfo.StreamStatus == nil {
+		return 0, false
+	}
+
+	switch relayInfo.StreamStatus.EndReason {
+	case relaycommon.StreamEndReasonDone, relaycommon.StreamEndReasonNone:
+		return 0, false
+	case relaycommon.StreamEndReasonHandlerStop:
+		if !relayInfo.StreamStatus.HasErrors() && relayInfo.StreamStatus.EndError == nil {
+			return 0, false
+		}
+	}
+
+	return preConsumed, true
 }
 
 func cacheWriteTokensTotal(summary textQuotaSummary) int {
@@ -375,7 +416,10 @@ func calculateTextQuotaSummary(ctx *gin.Context, relayInfo *relaycommon.RelayInf
 		noteQuotaClamp(relayInfo, clamp)
 	}
 
-	if !summary.hasBillableUsage() {
+	if preConsumed, ok := shouldKeepPreConsumedQuotaForMissingStreamUsage(ctx, relayInfo, summary.TotalTokens); ok {
+		summary.Quota = preConsumed
+		summary.MissingUsagePreConsumed = true
+	} else if !summary.hasBillableUsage() {
 		summary.Quota = 0
 	} else if !ratio.IsZero() && summary.Quota == 0 {
 		summary.Quota = 1
@@ -409,7 +453,7 @@ func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, us
 
 	var tieredResult *billingexpr.TieredResult
 	tieredBillingApplied := false
-	if originUsage != nil {
+	if originUsage != nil && !summary.MissingUsagePreConsumed {
 		var tieredUsedVars map[string]bool
 		if snap := relayInfo.TieredBillingSnapshot; snap != nil {
 			tieredUsedVars = billingexpr.UsedVars(snap.ExprString)
@@ -442,8 +486,12 @@ func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, us
 
 	if !summary.hasBillableUsage() {
 		extraContent = append(extraContent, "上游没有返回计费信息，无法扣费（可能是上游超时）")
-		logger.LogError(ctx, fmt.Sprintf("total tokens is 0, cannot consume quota, userId %d, channelId %d, tokenId %d, model %s， pre-consumed quota %d", relayInfo.UserId, relayInfo.ChannelId, relayInfo.TokenId, summary.ModelName, relayInfo.FinalPreConsumedQuota))
+		logger.LogWarn(ctx, fmt.Sprintf("total tokens is 0, cannot consume quota, userId %d, channelId %d, tokenId %d, model %s, pre-consumed quota %d", relayInfo.UserId, relayInfo.ChannelId, relayInfo.TokenId, summary.ModelName, preConsumedQuotaForRelay(relayInfo)))
 	} else {
+		if summary.MissingUsagePreConsumed {
+			extraContent = append(extraContent, "流式响应已开始但缺少最终计费信息，按预扣额度结算")
+			logger.LogWarn(ctx, fmt.Sprintf("stream usage missing after response chunks, settling pre-consumed quota, userId %d, channelId %d, tokenId %d, model %s, pre-consumed quota %d, received %d, sent %d", relayInfo.UserId, relayInfo.ChannelId, relayInfo.TokenId, summary.ModelName, summary.Quota, relayInfo.ReceivedResponseCount, relayInfo.SendResponseCount))
+		}
 		model.UpdateUserUsedQuotaAndRequestCount(relayInfo.UserId, summary.Quota)
 		model.UpdateChannelUsedQuota(relayInfo.ChannelId, summary.Quota)
 	}
@@ -479,6 +527,10 @@ func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, us
 	appendUsageBillingPathForLog(other, common.GetContextKeyBool(ctx, constant.ContextKeyLocalCountTokens), originUsage)
 	if adminRejectReason != "" {
 		other["reject_reason"] = adminRejectReason
+	}
+	if summary.MissingUsagePreConsumed {
+		other["missing_usage_pre_consumed"] = true
+		other["missing_usage_pre_consumed_quota"] = summary.Quota
 	}
 	if summary.ImageTokens != 0 {
 		other["image"] = true

--- a/service/text_quota_test.go
+++ b/service/text_quota_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"math"
 	"net/http/httptest"
 	"testing"
@@ -352,6 +353,110 @@ func TestCacheWriteTokensTotal(t *testing.T) {
 		}
 		require.Equal(t, 30, cacheWriteTokensTotal(summary))
 	})
+}
+
+func newMissingUsageQuotaTestContext(markOutput bool) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	if markOutput {
+		common.SetContextKey(ctx, constant.ContextKeyResponsesBillableStreamOutput, true)
+	}
+	return ctx
+}
+
+func newMissingUsageRelayInfo(format types.RelayFormat, reason relaycommon.StreamEndReason) *relaycommon.RelayInfo {
+	status := relaycommon.NewStreamStatus()
+	status.SetEndReason(reason, nil)
+	return &relaycommon.RelayInfo{
+		IsStream:        true,
+		RelayFormat:     format,
+		OriginModelName: "gpt-5.5",
+		PriceData: hosttypes.PriceData{
+			ModelRatio:      1,
+			CompletionRatio: 1,
+			GroupRatioInfo:  hosttypes.GroupRatioInfo{GroupRatio: 1},
+		},
+		StartTime:             time.Now(),
+		StreamStatus:          status,
+		FinalPreConsumedQuota: 5000,
+	}
+}
+
+func TestCalculateTextQuotaSummaryKeepsPreConsumedQuotaForInterruptedResponsesStream(t *testing.T) {
+	ctx := newMissingUsageQuotaTestContext(true)
+	relayInfo := newMissingUsageRelayInfo(types.RelayFormatOpenAIResponses, relaycommon.StreamEndReasonClientGone)
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, &dto.Usage{})
+
+	assert.Equal(t, 0, summary.TotalTokens)
+	assert.Equal(t, 5000, summary.Quota)
+	assert.True(t, summary.MissingUsagePreConsumed)
+}
+
+func TestCalculateTextQuotaSummaryDoesNotKeepPreConsumedQuotaForNormalResponsesEnd(t *testing.T) {
+	ctx := newMissingUsageQuotaTestContext(true)
+	relayInfo := newMissingUsageRelayInfo(types.RelayFormatOpenAIResponses, relaycommon.StreamEndReasonDone)
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, &dto.Usage{})
+
+	assert.Equal(t, 0, summary.Quota)
+	assert.False(t, summary.MissingUsagePreConsumed)
+}
+
+func TestCalculateTextQuotaSummaryKeepsPreConsumedQuotaForHandlerStopError(t *testing.T) {
+	ctx := newMissingUsageQuotaTestContext(true)
+	relayInfo := newMissingUsageRelayInfo(types.RelayFormatOpenAIResponses, relaycommon.StreamEndReasonHandlerStop)
+	relayInfo.StreamStatus.EndError = errors.New("client disconnected")
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, &dto.Usage{})
+
+	assert.Equal(t, 5000, summary.Quota)
+	assert.True(t, summary.MissingUsagePreConsumed)
+}
+
+func TestCalculateTextQuotaSummaryDoesNotKeepPreConsumedQuotaWithoutBillableOutputMarker(t *testing.T) {
+	ctx := newMissingUsageQuotaTestContext(false)
+	relayInfo := newMissingUsageRelayInfo(types.RelayFormatOpenAIResponses, relaycommon.StreamEndReasonClientGone)
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, &dto.Usage{})
+
+	assert.Equal(t, 0, summary.Quota)
+	assert.False(t, summary.MissingUsagePreConsumed)
+}
+
+func TestCalculateTextQuotaSummaryActualUsageOverridesMissingUsageFallback(t *testing.T) {
+	ctx := newMissingUsageQuotaTestContext(true)
+	relayInfo := newMissingUsageRelayInfo(types.RelayFormatOpenAIResponses, relaycommon.StreamEndReasonClientGone)
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, &dto.Usage{
+		PromptTokens:     100,
+		CompletionTokens: 20,
+	})
+
+	assert.Equal(t, 120, summary.TotalTokens)
+	assert.Equal(t, 120, summary.Quota)
+	assert.False(t, summary.MissingUsagePreConsumed)
+}
+
+func TestCalculateTextQuotaSummaryDoesNotKeepPreConsumedQuotaForNonResponsesStream(t *testing.T) {
+	ctx := newMissingUsageQuotaTestContext(true)
+	relayInfo := newMissingUsageRelayInfo(types.RelayFormatOpenAI, relaycommon.StreamEndReasonClientGone)
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, &dto.Usage{})
+
+	assert.Equal(t, 0, summary.Quota)
+	assert.False(t, summary.MissingUsagePreConsumed)
+}
+
+func TestCalculateTextQuotaSummaryTreatsBillingSessionPreConsumedQuotaAsAuthoritative(t *testing.T) {
+	ctx := newMissingUsageQuotaTestContext(true)
+	relayInfo := newMissingUsageRelayInfo(types.RelayFormatOpenAIResponses, relaycommon.StreamEndReasonClientGone)
+	relayInfo.Billing = &recordingBillingSettler{}
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, &dto.Usage{})
+
+	assert.Equal(t, 0, summary.Quota)
+	assert.False(t, summary.MissingUsagePreConsumed)
 }
 
 func TestCalculateTextQuotaSummaryHandlesLegacyClaudeDerivedOpenAIUsage(t *testing.T) {


### PR DESCRIPTION
## Summary

When a Responses stream emits billable output but ends without final usage, preserve the already pre-consumed quota only for interrupted streams. Normal completion, empty output, non-Responses streams, and responses with actual usage keep the existing behavior.

The fallback is limited to streaming Responses requests with zero reported tokens and an observed billable output marker. A Billing session's pre-consumed value remains authoritative, including a legitimate zero value. Tiered settlement is skipped when the fallback is used, and the consume log records the reason.

Closes #5235

## Tests

- `go test ./service -count=1`
- `go test ./relay/channel/openai -run Responses -count=1`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved billing accuracy for streamed responses when final usage data is unavailable.
  - Preserved pre-consumed quota for billable response streams and tool calls when appropriate.
  - Refunded or settled quota correctly for aborted, incomplete, metadata-only, and non-response streams.
  - Ensured actual usage takes precedence whenever it is available.

- **Tests**
  - Added coverage for missing usage, stream termination scenarios, tool calls, and quota settlement outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->