### PR TITLE
fix: 收窄 OpenAI o 系列模型适配范围

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -814,7 +814,7 @@ func buildTestRequest(model string, endpointType string, channel *model.Channel,
 		testRequest.StreamOptions = &dto.StreamOptions{IncludeUsage: true}
 	}
 
-	if strings.HasPrefix(model, "o") {
+	if dto.IsOpenAIReasoningOModel(model) {
 		testRequest.MaxCompletionTokens = lo.ToPtr(uint(16))
 	} else if strings.Contains(model, "thinking") {
 		if !strings.Contains(model, "claude") {

--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -213,12 +213,22 @@ func (r *GeneralOpenAIRequest) ToMap() map[string]any {
 	return result
 }
 
+func IsOpenAIReasoningOModel(modelName string) bool {
+	return strings.HasPrefix(modelName, "o1") ||
+		strings.HasPrefix(modelName, "o3") ||
+		strings.HasPrefix(modelName, "o4")
+}
+
+func IsOpenAIGPT5Model(modelName string) bool {
+	return strings.HasPrefix(modelName, "gpt-5")
+}
+
 func (r *GeneralOpenAIRequest) GetSystemRoleName() string {
-	if strings.HasPrefix(r.Model, "o") {
+	if IsOpenAIReasoningOModel(r.Model) {
 		if !strings.HasPrefix(r.Model, "o1-mini") && !strings.HasPrefix(r.Model, "o1-preview") {
 			return "developer"
 		}
-	} else if strings.HasPrefix(r.Model, "gpt-5") {
+	} else if IsOpenAIGPT5Model(r.Model) {
 		return "developer"
 	}
 	return "system"

--- a/dto/openai_request_zero_value_test.go
+++ b/dto/openai_request_zero_value_test.go
@@ -71,3 +71,27 @@ func TestOpenAIResponsesRequestPreserveExplicitZeroValues(t *testing.T) {
 	require.True(t, gjson.GetBytes(encoded, "stream").Exists())
 	require.True(t, gjson.GetBytes(encoded, "top_p").Exists())
 }
+
+func TestGeneralOpenAIRequestGetSystemRoleName(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  string
+	}{
+		{name: "o1 uses developer", model: "o1", want: "developer"},
+		{name: "o3 family uses developer", model: "o3-mini-high", want: "developer"},
+		{name: "o4 family uses developer", model: "o4-mini", want: "developer"},
+		{name: "o1 mini stays system", model: "o1-mini", want: "system"},
+		{name: "o1 preview stays system", model: "o1-preview", want: "system"},
+		{name: "gpt 5 uses developer", model: "gpt-5", want: "developer"},
+		{name: "omni is not o series", model: "omni-moderation-latest", want: "system"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := GeneralOpenAIRequest{Model: tt.model}
+
+			require.Equal(t, tt.want, req.GetSystemRoleName())
+		})
+	}
+}

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -317,7 +317,8 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 		upstreamModelName = upstreamModelName[idx+1:]
 	}
 	isOModel := openAIProvider && len(upstreamModelName) > 1 && upstreamModelName[0] == 'o' && upstreamModelName[1] >= '0' && upstreamModelName[1] <= '9'
-	if isOModel || strings.HasPrefix(upstreamModelName, "gpt-5") {
+	isGPT5Model := openAIProvider && strings.HasPrefix(upstreamModelName, "gpt-5")
+	if isOModel || isGPT5Model {
 		if lo.FromPtrOr(request.MaxCompletionTokens, uint(0)) == 0 && lo.FromPtrOr(request.MaxTokens, uint(0)) != 0 {
 			request.MaxCompletionTokens = request.MaxTokens
 			request.MaxTokens = nil
@@ -328,7 +329,7 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 		}
 
 		// gpt-5系列模型适配 归零不再支持的参数
-		if strings.HasPrefix(upstreamModelName, "gpt-5") {
+		if isGPT5Model {
 			request.Temperature = nil
 			request.TopP = nil
 			request.LogProbs = nil
@@ -345,7 +346,7 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 		info.ReasoningEffort = request.ReasoningEffort
 
 		// o系列模型developer适配（o1-mini除外）
-		if strings.HasPrefix(upstreamModelName, "gpt-5") || !strings.HasPrefix(upstreamModelName, "o1-mini") && !strings.HasPrefix(upstreamModelName, "o1-preview") {
+		if isGPT5Model || (!strings.HasPrefix(upstreamModelName, "o1-mini") && !strings.HasPrefix(upstreamModelName, "o1-preview")) {
 			//修改第一个Message的内容，将system改为developer
 			if len(request.Messages) > 0 && request.Messages[0].Role == "system" {
 				request.Messages[0].Role = "developer"

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -310,18 +310,25 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 		}
 
 	}
-	if strings.HasPrefix(info.UpstreamModelName, "o") || strings.HasPrefix(info.UpstreamModelName, "gpt-5") {
+	upstreamModelName := info.UpstreamModelName
+	openAIProvider := true
+	if idx := strings.Index(upstreamModelName, "/"); idx >= 0 {
+		openAIProvider = strings.HasPrefix(upstreamModelName[:idx], "openai")
+		upstreamModelName = upstreamModelName[idx+1:]
+	}
+	isOModel := openAIProvider && len(upstreamModelName) > 1 && upstreamModelName[0] == 'o' && upstreamModelName[1] >= '0' && upstreamModelName[1] <= '9'
+	if isOModel || strings.HasPrefix(upstreamModelName, "gpt-5") {
 		if lo.FromPtrOr(request.MaxCompletionTokens, uint(0)) == 0 && lo.FromPtrOr(request.MaxTokens, uint(0)) != 0 {
 			request.MaxCompletionTokens = request.MaxTokens
 			request.MaxTokens = nil
 		}
 
-		if strings.HasPrefix(info.UpstreamModelName, "o") {
+		if isOModel {
 			request.Temperature = nil
 		}
 
 		// gpt-5系列模型适配 归零不再支持的参数
-		if strings.HasPrefix(info.UpstreamModelName, "gpt-5") {
+		if strings.HasPrefix(upstreamModelName, "gpt-5") {
 			request.Temperature = nil
 			request.TopP = nil
 			request.LogProbs = nil
@@ -338,7 +345,7 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 		info.ReasoningEffort = request.ReasoningEffort
 
 		// o系列模型developer适配（o1-mini除外）
-		if !strings.HasPrefix(info.UpstreamModelName, "o1-mini") && !strings.HasPrefix(info.UpstreamModelName, "o1-preview") {
+		if strings.HasPrefix(upstreamModelName, "gpt-5") || !strings.HasPrefix(upstreamModelName, "o1-mini") && !strings.HasPrefix(upstreamModelName, "o1-preview") {
 			//修改第一个Message的内容，将system改为developer
 			if len(request.Messages) > 0 && request.Messages[0].Role == "system" {
 				request.Messages[0].Role = "developer"

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -310,14 +310,8 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 		}
 
 	}
-	upstreamModelName := info.UpstreamModelName
-	openAIProvider := true
-	if idx := strings.Index(upstreamModelName, "/"); idx >= 0 {
-		openAIProvider = strings.HasPrefix(upstreamModelName[:idx], "openai")
-		upstreamModelName = upstreamModelName[idx+1:]
-	}
-	isOModel := openAIProvider && len(upstreamModelName) > 1 && upstreamModelName[0] == 'o' && upstreamModelName[1] >= '0' && upstreamModelName[1] <= '9'
-	isGPT5Model := openAIProvider && strings.HasPrefix(upstreamModelName, "gpt-5")
+	isOModel := dto.IsOpenAIReasoningOModel(info.UpstreamModelName)
+	isGPT5Model := dto.IsOpenAIGPT5Model(info.UpstreamModelName)
 	if isOModel || isGPT5Model {
 		if lo.FromPtrOr(request.MaxCompletionTokens, uint(0)) == 0 && lo.FromPtrOr(request.MaxTokens, uint(0)) != 0 {
 			request.MaxCompletionTokens = request.MaxTokens
@@ -346,7 +340,7 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 		info.ReasoningEffort = request.ReasoningEffort
 
 		// o系列模型developer适配（o1-mini除外）
-		if isGPT5Model || (!strings.HasPrefix(upstreamModelName, "o1-mini") && !strings.HasPrefix(upstreamModelName, "o1-preview")) {
+		if !strings.HasPrefix(info.UpstreamModelName, "o1-mini") && !strings.HasPrefix(info.UpstreamModelName, "o1-preview") {
 			//修改第一个Message的内容，将system改为developer
 			if len(request.Messages) > 0 && request.Messages[0].Role == "system" {
 				request.Messages[0].Role = "developer"


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

https://github.com/QuantumNous/new-api/issues/5292

修复 OpenAI adaptor 中 o 系列模型判断过于宽泛的问题

原来 `strings.HasPrefix(info.UpstreamModelName, "o")` 判断是否应用 OpenAI o 系列适配，会误伤 `openrouter/owl-alpha` 这类模型，导致首条 `system` 消息被改写为 `developer`

本修改进行以下修改：
无 provider 前缀，且模型名满足 `o+数字`  或 provider 前缀以 `openai` 开头，且模型名满足 `o+数字`

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5292 


## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
修复后脚本验证：
<img width="867" height="1860" alt="image" src="https://github.com/user-attachments/assets/25fd768e-5b87-4ade-8a4d-619994a66177" />

<img width="2913" height="967" alt="image" src="https://github.com/user-attachments/assets/041aaead-b69a-4a63-a8e8-38c9673ace2d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer OpenAI o-series and gpt-5 models: parameter normalization prevents misapplied token/temperature/top-p/logprob settings.
  * Expanded message-role handling so system→developer rewrites apply correctly to relevant o-series and gpt-5 models, improving prompt behavior.

* **Tests**
  * Added unit tests validating role determination for o-series and gpt-5 model names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->