### PR TITLE
fix: 修复余额显示时只切换了单位未切换数值

### DIFF
--- a/web/classic/src/helpers/render.jsx
+++ b/web/classic/src/helpers/render.jsx
@@ -1068,31 +1068,17 @@ export function getQuotaWithUnit(quota, digits = 6) {
   return (quota / quotaPerUnit).toFixed(digits);
 }
 
+// amount 为系统内部的美元值
 export function renderQuotaWithAmount(amount) {
-  const quotaDisplayType = localStorage.getItem('quota_display_type') || 'USD';
-  if (quotaDisplayType === 'TOKENS') {
+  const { symbol, rate, type } = getCurrencyConfig();
+  if (type === 'TOKENS') {
     return renderNumber(renderUnitWithQuota(amount));
   }
-
   const numericAmount = Number(amount);
-  const formattedAmount = Number.isFinite(numericAmount)
-      ? numericAmount.toFixed(2)
-      : amount;
-
-  if (quotaDisplayType === 'CNY') {
-    return '¥' + formattedAmount;
-  } else if (quotaDisplayType === 'CUSTOM') {
-    const statusStr = localStorage.getItem('status');
-    let symbol = '¤';
-    try {
-      if (statusStr) {
-        const s = JSON.parse(statusStr);
-        symbol = s?.custom_currency_symbol || symbol;
-      }
-    } catch (e) {}
-    return symbol + formattedAmount;
+  if (!Number.isFinite(numericAmount)) {
+    return symbol + amount;
   }
-  return '$' + formattedAmount;
+  return symbol + (numericAmount * rate).toFixed(2);
 }
 
 /**


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
classic的余额显示, 只切换了单位,未切换数值
default的余额显示, 可以正常切换单位和数值

## 📝 变更描述 / Description
同步了default的余额代币转换逻辑

## 📸 运行证明 / Proof of Work
实际余额为 1378.19元
修复前: (显示成了cny单位, $数值)
<img width="608" height="174" alt="image" src="https://github.com/user-attachments/assets/f1138ae7-3e2f-4a4f-b4d5-ef04ccfe9989" />

修复后:显示正确货币单位和数值
<img width="496" height="208" alt="image" src="https://github.com/user-attachments/assets/25856613-8135-4c43-bb17-22f92455d665" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated currency conversion and display logic to dynamically calculate display values based on exchange rates and currency configuration, replacing hardcoded currency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->