### PR TITLE
fix(web): honor currency display in top-up amount

### DIFF
--- a/web/classic/src/components/topup/index.jsx
+++ b/web/classic/src/components/topup/index.jsx
@@ -28,6 +28,7 @@ import {
   renderQuotaWithAmount,
   copy,
   getQuotaPerUnit,
+  getCurrencyConfig,
 } from '../../helpers';
 import { Modal, Toast } from '@douyinfe/semi-ui';
 import { useTranslation } from 'react-i18next';
@@ -800,8 +801,56 @@ const TopUp = () => {
     }
   }, [statusState?.status]);
 
+  const getUsdExchangeRate = () => {
+    const statusStr = localStorage.getItem('status');
+
+    try {
+      if (statusStr) {
+        const status = JSON.parse(statusStr);
+        const rate = Number(status?.usd_exchange_rate);
+        if (Number.isFinite(rate) && rate > 0) {
+          return rate;
+        }
+      }
+    } catch (e) {}
+
+    return 7;
+  };
+
+  const isUsdPaymentMethod = () =>
+    payWay === 'stripe' ||
+    payWay === 'waffo_pancake' ||
+    (typeof payWay === 'string' && payWay.startsWith('waffo:'));
+
+  const formatPaymentAmount = (value) => {
+    const { symbol, rate, type } = getCurrencyConfig();
+    const numericAmount = Number(value);
+    const paymentIsUsd = isUsdPaymentMethod();
+    const displaySymbol =
+      type === 'TOKENS' ? (paymentIsUsd ? '$' : '¥') : symbol;
+
+    if (!Number.isFinite(numericAmount)) {
+      return `${displaySymbol}${value}`;
+    }
+
+    let displayAmount = numericAmount;
+
+    if (!paymentIsUsd) {
+      const usdRate = getUsdExchangeRate();
+      if (type === 'USD') {
+        displayAmount = numericAmount / usdRate;
+      } else if (type === 'CUSTOM') {
+        displayAmount = (numericAmount / usdRate) * rate;
+      }
+    } else if (type !== 'USD' && type !== 'TOKENS') {
+      displayAmount = numericAmount * rate;
+    }
+
+    return `${displaySymbol}${displayAmount.toFixed(2)}`;
+  };
+
   const renderAmount = () => {
-    return amount + ' ' + t('元');
+    return formatPaymentAmount(amount);
   };
 
   const getAmount = async (value) => {
@@ -932,6 +981,7 @@ const TopUp = () => {
         payMethods={confirmPayMethods}
         amountNumber={amount}
         discountRate={topupInfo?.discount?.[topUpCount] || 1.0}
+        formatPaymentAmount={formatPaymentAmount}
       />
 
       {/* 充值账单模态框 */}

--- a/web/classic/src/components/topup/modals/PaymentConfirmModal.jsx
+++ b/web/classic/src/components/topup/modals/PaymentConfirmModal.jsx
@@ -39,6 +39,7 @@ const PaymentConfirmModal = ({
   // 新增：用于显示折扣明细
   amountNumber,
   discountRate,
+  formatPaymentAmount,
 }) => {
   const hasDiscount =
     discountRate && discountRate > 0 && discountRate < 1 && amountNumber > 0;
@@ -97,7 +98,7 @@ const PaymentConfirmModal = ({
                     {t('原价')}：
                   </Text>
                   <Text delete className='text-slate-500 dark:text-slate-400'>
-                    {`${originalAmount.toFixed(2)} ${t('元')}`}
+                    {formatPaymentAmount(originalAmount)}
                   </Text>
                 </div>
                 <div className='flex justify-between items-center'>
@@ -105,7 +106,7 @@ const PaymentConfirmModal = ({
                     {t('优惠')}：
                   </Text>
                   <Text className='text-emerald-600 dark:text-emerald-400'>
-                    {`- ${discountAmount.toFixed(2)} ${t('元')}`}
+                    {`- ${formatPaymentAmount(discountAmount)}`}
                   </Text>
                 </div>
               </>


### PR DESCRIPTION
## 变更描述 / Description
修复充值确认弹窗在站点配置为 USD 或自定义货币展示时，实付金额、原价和优惠明细仍按“元”展示的问题。

这次改动复用现有的货币展示配置，并按支付方式区分金额语义：普通在线充值金额按人民币支付金额换算展示；Stripe/Waffo 等美元支付方式保留美元金额语义，避免二次换算。

## 变更类型 / Type of change
- [x] Bug 修复 (Bug fix)
- [ ] 新功能 (New feature)
- [ ] 性能优化 / 重构 (Refactor)
- [ ] 文档更新 (Documentation)

## 关联任务 / Related Issue
- Closes #3196

## 提交前检查项 / Checklist
- [x] 人工确认：我已整理并撰写此描述，没有直接粘贴未经处理的生成内容。
- [x] 非重复提交：已检查现有 Issues / PRs；相关 PR #4482 处理充值历史列，#4942 处理订阅支付换算，本 PR 仅处理充值确认弹窗展示。
- [x] Bug fix 说明：本 PR 关联现有 bug issue #3196。
- [x] 变更理解：已确认普通在线充值与 Stripe/Waffo 的金额语义不同，并避免对美元支付金额重复换算。
- [x] 范围聚焦：仅修改 classic top-up 确认弹窗相关展示逻辑。
- [x] 本地验证：已运行下方检查。
- [x] 安全合规：无敏感凭据或配置变更。

## 运行证明 / Proof of Work
- `git diff --check` 通过
- `bunx prettier src/components/topup/index.jsx src/components/topup/modals/PaymentConfirmModal.jsx --check` 通过
- `bun run build` 通过
- `bun run lint` 未作为本 PR 阻断项：当前仓库已有多个未触达文件不满足 Prettier 检查；本 PR 触达文件已单独通过 Prettier 检查。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment amount formatting now adapts based on your selected payment method and currency
  * Added USD exchange rate support for payment displays

* **Improvements**
  * Enhanced payment confirmation modal with improved amount formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->