### PR TITLE
Fix USD unit for top-up payment amounts

### DIFF
--- a/web/classic/src/components/topup/index.jsx
+++ b/web/classic/src/components/topup/index.jsx
@@ -39,6 +39,7 @@ import InvitationCard from './InvitationCard';
 import TransferModal from './modals/TransferModal';
 import PaymentConfirmModal from './modals/PaymentConfirmModal';
 import TopupHistoryModal from './modals/TopupHistoryModal';
+import { formatPaymentAmount } from './paymentAmount';
 
 // Reject non-navigable schemes (e.g. javascript:, data:) and relative URLs.
 // Only http / https are allowed for backend-provided redirect targets.
@@ -800,8 +801,8 @@ const TopUp = () => {
     }
   }, [statusState?.status]);
 
-  const renderAmount = () => {
-    return amount + ' ' + t('元');
+  const renderAmount = (value = amount) => {
+    return formatPaymentAmount(value, { t });
   };
 
   const getAmount = async (value) => {

--- a/web/classic/src/components/topup/modals/PaymentConfirmModal.jsx
+++ b/web/classic/src/components/topup/modals/PaymentConfirmModal.jsx
@@ -97,7 +97,7 @@ const PaymentConfirmModal = ({
                     {t('原价')}：
                   </Text>
                   <Text delete className='text-slate-500 dark:text-slate-400'>
-                    {`${originalAmount.toFixed(2)} ${t('元')}`}
+                    {renderAmount(originalAmount)}
                   </Text>
                 </div>
                 <div className='flex justify-between items-center'>
@@ -105,7 +105,7 @@ const PaymentConfirmModal = ({
                     {t('优惠')}：
                   </Text>
                   <Text className='text-emerald-600 dark:text-emerald-400'>
-                    {`- ${discountAmount.toFixed(2)} ${t('元')}`}
+                    {`- ${renderAmount(discountAmount)}`}
                   </Text>
                 </div>
               </>

--- a/web/classic/src/components/topup/paymentAmount.js
+++ b/web/classic/src/components/topup/paymentAmount.js
@@ -1,0 +1,54 @@
+function getLocalStorageValue(key) {
+  if (typeof localStorage === 'undefined') {
+    return null;
+  }
+  return localStorage.getItem(key);
+}
+
+function getStatusFromStorage() {
+  const statusStr = getLocalStorageValue('status');
+  if (!statusStr) {
+    return {};
+  }
+  try {
+    return JSON.parse(statusStr) || {};
+  } catch {
+    return {};
+  }
+}
+
+function getPositiveNumber(value, fallback) {
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) && numberValue > 0
+    ? numberValue
+    : fallback;
+}
+
+export function formatPaymentAmount(amount, options = {}) {
+  const t = options.t || ((key) => key);
+  const numericAmount = Number(amount);
+  const safeAmount = Number.isFinite(numericAmount) ? numericAmount : 0;
+  const quotaDisplayType =
+    options.quotaDisplayType ||
+    getLocalStorageValue('quota_display_type') ||
+    'USD';
+  const status = options.status || getStatusFromStorage();
+  const usdExchangeRate = getPositiveNumber(status?.usd_exchange_rate, 7);
+
+  if (quotaDisplayType === 'USD') {
+    return `${(safeAmount / usdExchangeRate).toFixed(2)} USD`;
+  }
+
+  if (quotaDisplayType === 'CUSTOM') {
+    const symbol = status?.custom_currency_symbol || '¤';
+    const customRate = getPositiveNumber(
+      status?.custom_currency_exchange_rate,
+      1,
+    );
+    return `${symbol}${((safeAmount / usdExchangeRate) * customRate).toFixed(
+      2,
+    )}`;
+  }
+
+  return `${safeAmount.toFixed(2)} ${t('元')}`;
+}

--- a/web/classic/src/components/topup/paymentAmount.test.js
+++ b/web/classic/src/components/topup/paymentAmount.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+
+import { formatPaymentAmount } from './paymentAmount.js';
+
+describe('formatPaymentAmount', () => {
+  test('formats local payment amount as USD when quota display type is USD', () => {
+    const result = formatPaymentAmount(70, {
+      quotaDisplayType: 'USD',
+      status: { usd_exchange_rate: 7 },
+      t: (key) => key,
+    });
+
+    expect(result).toBe('10.00 USD');
+  });
+
+  test('keeps the existing CNY yuan label when quota display type is CNY', () => {
+    const result = formatPaymentAmount(70, {
+      quotaDisplayType: 'CNY',
+      status: { usd_exchange_rate: 7 },
+      t: (key) => key,
+    });
+
+    expect(result).toBe('70.00 元');
+  });
+});


### PR DESCRIPTION
## Summary
- Format classic top-up payment amounts through a shared helper.
- Convert local gateway amounts back to USD when quota display type is USD.
- Reuse the formatter for discount original price and savings rows.

Fixes #3196

## Test Plan
- bun test web/classic/src/components/topup/paymentAmount.test.js
- cd web/classic && bun run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added centralized payment formatting utility supporting multiple currencies (USD, custom currencies, CNY) with exchange rate conversion for the top-up flow

* **Bug Fixes**
  * Standardized payment amount display across top-up components and discount breakdowns with consistent formatting

* **Tests**
  * Added test coverage for payment amount formatting across different currency modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->