### PR TITLE
fix(relay): fix Anthropic-compatible compatibility for GLM (avoid chunked encoding)

### DIFF
--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -155,6 +155,7 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 		if err != nil {
 			return types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
 		}
+		info.UpstreamRequestBodySize = storage.Size()
 		requestBody = common.ReaderOnly(storage)
 	} else {
 		convertedRequest, err := adaptor.ConvertClaudeRequest(c, info, request)


### PR DESCRIPTION
## 📝 变更描述 / Description
修复了 `new-api` 作为 Anthropic 兼容网关时，上游请求因分块传输编码（`Transfer-Encoding: chunked`）导致部分端点（如智谱 GLM-5.1、GLM-5-turbo）报错 400/500 的问题。

**原因与修复：**
在 Claude 的透传（pass-through）路径中，请求体大小在 `BodyStorage` 中虽已知，但未透传给 `RelayInfo.UpstreamRequestBodySize`。这导致后续构建上游请求时无法正确绑定 `req.ContentLength`，引发 Go HTTP 客户端回退为分块传输。本修改将 `storage.Size()` 显式透传，确保正确携带 `Content-Length` 头部。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5304 

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
使用 Anthropic Python SDK 请求修复后的网关，成功返回 `HTTP/1.1 200 OK` ，并可以成功解析响应。

示例：
```json
{
  "id": "msg_...",
  "type": "message",
  "role": "assistant",
  "model": "glm-5.1",
  "content": [
    {
      "type": "text",
      "text": "我就是一个随时准备帮你解答问题、提供建议和陪你聊天的AI助手。"
    }
  ],
  "stop_reason": "end_turn",
  "usage": {
    "input_tokens": 12,
    "output_tokens": 20
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved tracking of upstream request metrics for enhanced monitoring visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->