### PR TITLE
fix(web): avoid applying global web rate limit to static assets 

### DIFF
--- a/router/web-router.go
+++ b/router/web-router.go
@@ -27,9 +27,9 @@ func SetWebRouter(router *gin.Engine, assets ThemeAssets) {
 	themeFS := common.NewThemeAwareFS(defaultFS, classicFS)
 
 	router.Use(gzip.Gzip(gzip.DefaultCompression))
-	router.Use(middleware.GlobalWebRateLimit())
 	router.Use(middleware.Cache())
 	router.Use(static.Serve("/", themeFS))
+	router.Use(middleware.GlobalWebRateLimit())
 	router.NoRoute(func(c *gin.Context) {
 		c.Set(middleware.RouteTagKey, "web")
 		if strings.HasPrefix(c.Request.RequestURI, "/v1") || strings.HasPrefix(c.Request.RequestURI, "/api") || strings.HasPrefix(c.Request.RequestURI, "/assets") {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
1. 调整 Web 路由中间件顺序，避免静态资源请求触发全局 Web 限流。
2. 新版默认主题会加载较多 JS chunk。原先 `/static/*` 和 `/favicon.ico` 也会计入 `GlobalWebRateLimit`，频繁切换页面时可能返回 429，导致 `ChunkLoadError`。
3. 现在静态资源会先被正常返回，只有未命中的页面 fallback 才进入 Web 限流。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Related #5112
- Related #4947 


## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
本地测试通过：

```bash
go test ./router ./middleware
```

结果：

```text
?   	github.com/QuantumNous/new-api/router	[no test files]
ok  	github.com/QuantumNous/new-api/middleware	0.579s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted request handling order so cached and static content are served earlier, improving response efficiency for those assets while preserving global rate-limiting protections to maintain service availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->