### PR TITLE
feat(web): support searching by user id

### DIFF
--- a/web/default/src/features/users/components/users-table.tsx
+++ b/web/default/src/features/users/components/users-table.tsx
@@ -164,6 +164,7 @@ export function UsersTable() {
     globalFilterFn: (row, _columnId, filterValue) => {
       const searchValue = String(filterValue).toLowerCase()
       const fields = [
+        row.original.id,
         row.getValue('username'),
         row.original.display_name,
         row.original.email,
@@ -183,6 +184,7 @@ export function UsersTable() {
     onPaginationChange,
     onGlobalFilterChange,
     onColumnFiltersChange,
+    manualFiltering: true,
     manualPagination: true,
     pageCount: Math.ceil((data?.total || 0) / pagination.pageSize),
   })
@@ -204,7 +206,9 @@ export function UsersTable() {
       )}
       skeletonKeyPrefix='users-skeleton'
       toolbarProps={{
-        searchPlaceholder: t('Filter by username, name or email...'),
+        searchPlaceholder: t(
+          'Filter by user ID, username, name or email...'
+        ),
         filters: [
           {
             columnId: 'status',

--- a/web/default/src/i18n/locales/en.json
+++ b/web/default/src/i18n/locales/en.json
@@ -1733,6 +1733,7 @@
     "Filter by task ID": "Filter by task ID",
     "Filter by token name": "Filter by token name",
     "Filter by username": "Filter by username",
+    "Filter by user ID, username, name or email...": "Filter by user ID, username, name or email...",
     "Filter by username, name or email...": "Filter by username, name or email...",
     "Filter Dashboard Models": "Filter Dashboard Models",
     "Filter models by provider, group, type, endpoint, and tags.": "Filter models by provider, group, type, endpoint, and tags.",

--- a/web/default/src/i18n/locales/fr.json
+++ b/web/default/src/i18n/locales/fr.json
@@ -1733,6 +1733,7 @@
     "Filter by task ID": "Filtrer par ID de tâche",
     "Filter by token name": "Filtrer par nom de jeton",
     "Filter by username": "Filtrer par nom d'utilisateur",
+    "Filter by user ID, username, name or email...": "Filtrer par ID utilisateur, nom d’utilisateur, nom ou e-mail...",
     "Filter by username, name or email...": "Filtrer par nom d'utilisateur, nom ou e-mail...",
     "Filter Dashboard Models": "Filtrer les modèles du tableau de bord",
     "Filter models by provider, group, type, endpoint, and tags.": "Filtrer les modèles par fournisseur, groupe, type, endpoint et tags.",

--- a/web/default/src/i18n/locales/ja.json
+++ b/web/default/src/i18n/locales/ja.json
@@ -1733,6 +1733,7 @@
     "Filter by task ID": "タスクIDでフィルター",
     "Filter by token name": "トークン名でフィルター",
     "Filter by username": "ユーザー名でフィルター",
+    "Filter by user ID, username, name or email...": "ユーザーID、ユーザー名、名前、メールで絞り込み...",
     "Filter by username, name or email...": "ユーザー名、名前またはメールアドレスでフィルター...",
     "Filter Dashboard Models": "ダッシュボードモデルをフィルタリング",
     "Filter models by provider, group, type, endpoint, and tags.": "プロバイダー、グループ、タイプ、エンドポイント、タグでモデルを絞り込みます。",

--- a/web/default/src/i18n/locales/ru.json
+++ b/web/default/src/i18n/locales/ru.json
@@ -1733,6 +1733,7 @@
     "Filter by task ID": "Фильтр по ID задачи",
     "Filter by token name": "Фильтр по имени токена",
     "Filter by username": "Фильтр по имени пользователя",
+    "Filter by user ID, username, name or email...": "Фильтр по ID пользователя, имени пользователя, имени или email...",
     "Filter by username, name or email...": "Фильтр по имени пользователя, имени или email...",
     "Filter Dashboard Models": "Фильтровать модели панели управления",
     "Filter models by provider, group, type, endpoint, and tags.": "Фильтруйте модели по поставщику, группе, типу, endpoint и тегам.",

--- a/web/default/src/i18n/locales/vi.json
+++ b/web/default/src/i18n/locales/vi.json
@@ -1733,6 +1733,7 @@
     "Filter by task ID": "Lọc theo ID nhiệm vụ",
     "Filter by token name": "Lọc theo tên token",
     "Filter by username": "Lọc theo tên người dùng",
+    "Filter by user ID, username, name or email...": "Lọc theo ID người dùng, tên người dùng, tên hoặc email...",
     "Filter by username, name or email...": "Lọc theo tên người dùng, tên hoặc email...",
     "Filter Dashboard Models": "Lọc Mô hình Bảng điều khiển",
     "Filter models by provider, group, type, endpoint, and tags.": "Lọc mô hình theo nhà cung cấp, nhóm, loại, endpoint và thẻ.",

--- a/web/default/src/i18n/locales/zh.json
+++ b/web/default/src/i18n/locales/zh.json
@@ -1733,6 +1733,7 @@
     "Filter by task ID": "按任务 ID 筛选",
     "Filter by token name": "按 Token 名称筛选",
     "Filter by username": "按用户名筛选",
+    "Filter by user ID, username, name or email...": "按用户 ID、用户名、姓名或邮箱筛选...",
     "Filter by username, name or email...": "按用户名、姓名或邮箱筛选...",
     "Filter Dashboard Models": "筛选仪表板模型",
     "Filter models by provider, group, type, endpoint, and tags.": "按供应商、分组、类型、端点和标签筛选模型。",


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

1. 修复新版用户管理表格无法按用户 ID 搜索的问题。
2. 用户列表搜索是服务端分页/搜索模式：搜索框内容会作为 `keyword` 调用 `/api/user/search`。后端 `SearchUsers` 已经支持将纯数字关键字转换为用户 ID，并追加 `id = ?` 查询条件。
3. 问题出在前端表格仍启用了本地过滤模型。服务端按 ID 返回结果后，表格还会用 filter 再过滤一次；原本本地过滤字段只包含用户名、显示名称和邮箱，没有包含用户 ID，导致按 ID 搜索返回的行又被前端过滤掉，看起来像“搜索不到”。

本次改动：

- 将 `row.original.id` 加入用户表格的本地搜索字段；
- 将用户表格设置为 `manualFiltering: true`，让服务端搜索结果直接展示，避免服务端分页/搜索结果被前端二次过滤误删；
- 更新搜索框提示文案，明确支持按用户 ID 搜索；
- 补充 default 前端各语言 locale 中的新文案 key。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #4912

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

本地检查通过：

```bash
git diff --check
```

前端构建通过：

```bash
cd web/default
bun run build
```

使用本地 SQLite 测试数据验证：

```text
1 | root | xxxx2@gmail.com
2 | test | test@qq.com
```

在新版用户管理页面搜索 `1`、`2` 可以按用户 ID 命中对应用户。

<img width="774" height="595" alt="image" src="https://github.com/user-attachments/assets/43cdcca9-f829-4b8f-8e7a-e9b385b82adf" />
