### PR TITLE
feat(web): show user id on profile page

### DIFF
--- a/web/default/src/features/profile/components/profile-header.tsx
+++ b/web/default/src/features/profile/components/profile-header.tsx
@@ -118,6 +118,11 @@ export function ProfileHeader({ profile, loading }: ProfileHeaderProps) {
                 variant='neutral'
                 copyable={false}
               />
+              <StatusBadge
+                label={`${t('User ID')} ${profile.id}`}
+                variant='info'
+                copyText={String(profile.id)}
+              />
             </div>
 
             <div className='text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs sm:gap-x-4 sm:text-sm'>


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

修复新版个人资料页不显示用户 ID 的问题。

1. 当前个人资料接口返回的数据中已经包含 `profile.id`，但新版 profile header 只展示了角色、用户名、邮箱和用户组等信息，用户无法直接在个人资料页查看自己的用户 ID。
2. 本次改动在个人资料页顶部的身份标签区域增加一个可复制的 `User ID` 标签，直接使用现有的 `profile.id` 渲染，不需要改动后端接口，也不会影响用户资料编辑、认证绑定或安全设置逻辑。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5048
- Closes #4594 

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

<img width="783" height="348" alt="image" src="https://github.com/user-attachments/assets/3fe4d8ba-ea67-4d5a-bc8e-eb6a289b3366" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a User ID badge to the profile header, displayed alongside the role badge. The badge shows your unique user identifier and includes copy-to-clipboard functionality for easy reference and sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->