### PR TITLE
fix(distributor): skip token model limit check for task fetch and not…

### DIFF
--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -57,7 +57,7 @@ func Distribute() func(c *gin.Context) {
 			// Select a channel for the user
 			// check token model mapping
 			modelLimitEnable := common.GetContextKeyBool(c, constant.ContextKeyTokenModelLimitEnabled)
-			if modelLimitEnable {
+			if modelLimitEnable && shouldSelectChannel {
 				s, ok := common.GetContextKey(c, constant.ContextKeyTokenModelLimit)
 				if !ok {
 					// token model limit is empty, all models are not allowed


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
> 
> - **提交主题：** `fix(distributor): skip token model limit check for task fetch and notify requests`

## 📝 变更描述 / Description
在 `middleware/distributor.go` 中，将令牌可用模型限制的校验触发条件由 `if modelLimitEnable` 修改为 `if modelLimitEnable && shouldSelectChannel`。

**生效原因与逻辑：**
- 诸如 Midjourney、Suno、Kling 等异步任务的查询（`fetch`）和回调（`notify`）请求在网关中并不涉及上游渠道的路由与分配，因此其 `shouldSelectChannel` 被置为了 `false`。
- 在此前的逻辑中，由于这类非路由请求通常不携带或无法轻易解析出有效的模型名称（`model` 为空 `""`），如果令牌启用了“可用模型限制”，校验流程会因为空模型名匹配失败而误报 `403 Forbidden`（提示没有模型访问权限）。
- 调整后，只有当请求确实需要执行分配渠道操作（`shouldSelectChannel == true`，如新任务提交）时，才会进行可用模型限制校验。所有纯查询、回调和重混（Remix）等请求将直接跳过校验，从而解决上述误拦截 Bug。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *关联对应 Issue/修复查询接口误拦截*
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #4834

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
**手动验证路径：**
1. 创建启用“可用模型限制”（如仅限制使用 `gpt-4o`）的普通令牌。
2. 使用该令牌提交 Midjourney / Suno 异步任务，创建成功（生成请求经过了 `shouldSelectChannel = true` 的模型限制过滤，合法放行）。
3. 任务提交后，通过 `/mj/fetch` 或 `/suno/fetch` 接口查询刚才提交的任务状态。
   - **修改前：** 接口直接返回 `403 Forbidden (This token has no access to model)`。
   - **修改后：** 接口正确绕过模型校验，成功拉取到任务最新状态并返回 `200 OK` 结果。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token model limit validation to apply conditionally based on channel selection, ensuring proper validation behavior in all flow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->