### PR TITLE
feat: add AGIone channel

### DIFF
--- a/common/api_type.go
+++ b/common/api_type.go
@@ -75,6 +75,8 @@ func ChannelType2APIType(channelType int) (int, bool) {
 		apiType = constant.APITypeReplicate
 	case constant.ChannelTypeCodex:
 		apiType = constant.APITypeCodex
+	case constant.ChannelTypeAGIone:
+		apiType = constant.APITypeAGIone
 	}
 	if apiType == -1 {
 		return constant.APITypeOpenAI, false

--- a/constant/api_type.go
+++ b/constant/api_type.go
@@ -36,5 +36,6 @@ const (
 	APITypeMiniMax
 	APITypeReplicate
 	APITypeCodex
+	APITypeAGIone
 	APITypeDummy // this one is only for count, do not add any channel after this
 )

--- a/constant/channel.go
+++ b/constant/channel.go
@@ -55,6 +55,7 @@ const (
 	ChannelTypeSora           = 55
 	ChannelTypeReplicate      = 56
 	ChannelTypeCodex          = 57
+	ChannelTypeAGIone         = 58
 	ChannelTypeDummy          // this one is only for count, do not add any channel after this
 
 )
@@ -118,6 +119,7 @@ var ChannelBaseURLs = []string{
 	"https://api.openai.com",                    //55
 	"https://api.replicate.com",                 //56
 	"https://chatgpt.com",                       //57
+	"https://agione.pro/hyperone/xapi/api/v1", //58
 }
 
 var ChannelTypeNames = map[int]string{
@@ -175,6 +177,7 @@ var ChannelTypeNames = map[int]string{
 	ChannelTypeSora:           "Sora",
 	ChannelTypeReplicate:      "Replicate",
 	ChannelTypeCodex:          "Codex",
+	ChannelTypeAGIone:         "AGIone",
 }
 
 func GetChannelTypeName(channelType int) string {

--- a/controller/channel_upstream_update.go
+++ b/controller/channel_upstream_update.go
@@ -311,6 +311,8 @@ func fetchChannelUpstreamModelIDs(channel *model.Channel) ([]string, error) {
 		} else {
 			url = fmt.Sprintf("%s/v1/models", baseURL)
 		}
+	case constant.ChannelTypeAGIone:
+		url = fmt.Sprintf("%s/models", strings.TrimSuffix(baseURL, "/v1"))
 	default:
 		url = fmt.Sprintf("%s/v1/models", baseURL)
 	}

--- a/relay/channel/agione/adaptor.go
+++ b/relay/channel/agione/adaptor.go
@@ -1,0 +1,43 @@
+package agione
+
+import (
+	"fmt"
+	"strings"
+
+	channelconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/relay/channel/openai"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/types"
+)
+
+type Adaptor struct {
+	openai.Adaptor
+}
+
+func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
+	baseURL := info.ChannelBaseUrl
+	if baseURL == "" {
+		baseURL = channelconstant.ChannelBaseURLs[channelconstant.ChannelTypeAGIone]
+	}
+
+	if (info.RelayFormat == types.RelayFormatClaude || info.RelayFormat == types.RelayFormatGemini) &&
+		info.RelayMode != relayconstant.RelayModeResponses &&
+		info.RelayMode != relayconstant.RelayModeResponsesCompact {
+		return fmt.Sprintf("%s/chat/completions", baseURL), nil
+	}
+
+	requestPath := info.RequestURLPath
+	if requestPath == "" {
+		return baseURL, nil
+	}
+	return fmt.Sprintf("%s%s", baseURL, strings.TrimPrefix(requestPath, "/v1")), nil
+}
+
+func (a *Adaptor) GetModelList() []string {
+	return ModelList
+}
+
+func (a *Adaptor) GetChannelName() string {
+	return ChannelName
+}

--- a/relay/channel/agione/adaptor_test.go
+++ b/relay/channel/agione/adaptor_test.go
@@ -1,0 +1,28 @@
+package agione
+
+import (
+	"testing"
+
+	channelconstant "github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+)
+
+func TestGetRequestURLTrimsOpenAIVersionPrefix(t *testing.T) {
+	adaptor := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelType:    channelconstant.ChannelTypeAGIone,
+			ChannelBaseUrl: channelconstant.ChannelBaseURLs[channelconstant.ChannelTypeAGIone],
+		},
+		RequestURLPath: "/v1/chat/completions",
+	}
+
+	got, err := adaptor.GetRequestURL(info)
+	if err != nil {
+		t.Fatalf("GetRequestURL returned error: %v", err)
+	}
+	want := "https://agione.pro/hyperone/xapi/api/v1/chat/completions"
+	if got != want {
+		t.Fatalf("GetRequestURL() = %q, want %q", got, want)
+	}
+}

--- a/relay/channel/agione/constant.go
+++ b/relay/channel/agione/constant.go
@@ -1,0 +1,9 @@
+package agione
+
+var ModelList = []string{
+	"openai/GPT-5.5/c6fbe",
+	"anthropic/Claude-opus-4.7/a4d5d",
+	"deepseek/deepseek-v3.2/0000n",
+}
+
+var ChannelName = "agione"

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -336,6 +336,7 @@ var streamSupportedChannels = map[int]bool{
 	constant.ChannelTypeMoonshot:    true,
 	constant.ChannelTypeMiniMax:     true,
 	constant.ChannelTypeSiliconFlow: true,
+	constant.ChannelTypeAGIone:      true,
 }
 
 func GenRelayInfoWs(c *gin.Context, ws *websocket.Conn) *RelayInfo {

--- a/relay/relay_adaptor.go
+++ b/relay/relay_adaptor.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/relay/channel"
+	"github.com/QuantumNous/new-api/relay/channel/agione"
 	"github.com/QuantumNous/new-api/relay/channel/ali"
 	"github.com/QuantumNous/new-api/relay/channel/aws"
 	"github.com/QuantumNous/new-api/relay/channel/baidu"
@@ -120,6 +121,8 @@ func GetAdaptor(apiType int) channel.Adaptor {
 		return &replicate.Adaptor{}
 	case constant.APITypeCodex:
 		return &codex.Adaptor{}
+	case constant.APITypeAGIone:
+		return &agione.Adaptor{}
 	}
 	return nil
 }

--- a/web/classic/src/constants/channel.constants.js
+++ b/web/classic/src/constants/channel.constants.js
@@ -189,11 +189,16 @@ export const CHANNEL_OPTIONS = [
     color: 'blue',
     label: 'Codex (OpenAI OAuth)',
   },
+  {
+    value: 58,
+    color: 'green',
+    label: 'AGIone',
+  },
 ];
 
 // Channel types that support upstream model list fetching in UI.
 export const MODEL_FETCHABLE_CHANNEL_TYPES = new Set([
-  1, 4, 14, 34, 17, 26, 27, 24, 47, 25, 20, 23, 31, 40, 42, 48, 43,
+  1, 4, 14, 34, 17, 26, 27, 24, 47, 25, 20, 23, 31, 40, 42, 48, 43, 58,
 ]);
 
 export const MODEL_TABLE_PAGE_SIZE = 10;

--- a/web/default/src/features/channels/constants.ts
+++ b/web/default/src/features/channels/constants.ts
@@ -76,11 +76,12 @@ export const CHANNEL_TYPES = {
   55: 'Sora',
   56: 'Replicate',
   57: 'Codex',
+  58: 'AGIone',
 } as const
 
 const CHANNEL_TYPE_DISPLAY_ORDER: number[] = [
   1, 14, 33, 24, 43, 3, 41, 48, 42, 34, 20, 4, 40, 27, 25, 17, 26, 15, 46, 23,
-  18, 45, 31, 35, 49, 19, 47, 37, 38, 39, 11, 8, 57, 22, 21, 44, 2, 5, 36, 50,
+  18, 45, 31, 35, 49, 19, 47, 37, 38, 39, 11, 58, 8, 57, 22, 21, 44, 2, 5, 36, 50,
   51, 52, 53, 54, 55, 56,
 ]
 
@@ -377,6 +378,7 @@ export const FIELD_DESCRIPTIONS = {
 
 export const MODEL_FETCHABLE_TYPES = new Set([
   1, 4, 14, 17, 20, 23, 24, 25, 26, 27, 31, 34, 35, 40, 42, 43, 47, 48,
+  58,
 ])
 
 export const TYPE_TO_KEY_PROMPT: Record<number, string> = {

--- a/web/default/src/features/channels/lib/channel-type-config.ts
+++ b/web/default/src/features/channels/lib/channel-type-config.ts
@@ -123,6 +123,18 @@ export const CHANNEL_TYPE_CONFIGS: Record<number, ChannelTypeConfig> = {
       models: 'Use model IDs from OpenRouter',
     },
   },
+  58: {
+    id: 58,
+    name: CHANNEL_TYPES[58],
+    icon: 'openai',
+    defaultBaseUrl: 'https://agione.pro/hyperone/xapi/api/v1',
+    hints: {
+      key: 'AGIone Auth Token',
+      models:
+        'openai/GPT-5.5/c6fbe,anthropic/Claude-opus-4.7/a4d5d,deepseek/deepseek-v3.2/0000n',
+      baseUrl: 'Default: https://agione.pro/hyperone/xapi/api/v1',
+    },
+  },
   56: {
     id: 56,
     name: CHANNEL_TYPES[56],


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
本 PR 新增 AGIone 渠道支持，使 New API 可以将请求转发到 AGIone 的 OpenAI-compatible API。

主要改动包括：
- 新增 AGIone channel type 与 API type。
- 新增 AGIone relay adaptor，复用现有 OpenAI-compatible 转发逻辑。
- 默认接口地址设置为 `https://agione.pro/hyperone/xapi/api/v1`。
- 针对 New API 内部已带 `/v1` 的请求路径做了前缀处理，避免最终转发 URL 出现重复的 `/v1/v1/...`。
- 为 AGIone 单独处理模型列表同步路径：聊天接口使用 `/v1` base URL，但模型列表接口使用 `https://agione.pro/hyperone/xapi/api/models`。
- 在 classic 与 default 两套前端 channel 配置中加入 AGIone，方便用户在渠道管理页面选择。
- 
这样实现后，AGIone 可以作为一个标准 OpenAI-compatible 上游接入，同时兼容其模型列表接口与聊天补全接口路径不完全一致的情况。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

本地已运行 AGIone channel 单元测试：

```bash
go test ./relay/channel/agione
```

受影响后端包也做了编译级验证：

```bash
go test ./constant ./common ./relay/... ./controller -run 'TestNonExistent'
```

测试与变更范围截图如下：

**AGIone channel unit test passed**

![AGIone channel unit test passed](https://raw.githubusercontent.com/KaiShaoCheng/new-api/agione-pr-proof-assets/agione-unit-test.svg)

**Affected backend packages compile verification passed**

![Affected backend packages compile verification passed](https://raw.githubusercontent.com/KaiShaoCheng/new-api/agione-pr-proof-assets/compile-verification.svg)

**Focused diff scope and single commit**

![Focused diff scope and single commit](https://raw.githubusercontent.com/KaiShaoCheng/new-api/agione-pr-proof-assets/focused-diff-single-commit.svg)

补充说明：完整测试集中存在若干上游已有测试失败，主要集中在其他 channel/helper/controller 测试，和本次 AGIone 改动无关。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AGIone as a newly supported provider channel with complete platform integration.
  * Users can now select and configure AGIone as a channel option with pre-configured defaults.
  * Supports model fetching and streaming capabilities for AGIone connections.
  * Available in the channel selection interface across platform versions.

* **Tests**
  * Added unit tests for AGIone channel integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->