### PR TITLE
fix(claude): preserve cache_control on OpenAI-to-Claude conversion

### DIFF
--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -571,10 +571,16 @@ func (m *Message) ParseContent() []MediaContent {
 		switch contentType {
 		case ContentTypeText:
 			if text, ok := contentItem["text"].(string); ok {
-				contentList = append(contentList, MediaContent{
+				mc := MediaContent{
 					Type: ContentTypeText,
 					Text: text,
-				})
+				}
+				if cc, ok := contentItem["cache_control"]; ok && cc != nil {
+					if raw, err := common.Marshal(cc); err == nil {
+						mc.CacheControl = raw
+					}
+				}
+				contentList = append(contentList, mc)
 			}
 
 		case ContentTypeImageURL:

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -308,8 +308,9 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 				for _, ctx := range message.ParseContent() {
 					if ctx.Type == "text" && ctx.Text != "" {
 						systemMessages = append(systemMessages, dto.ClaudeMediaMessage{
-							Type: "text",
-							Text: common.GetPointer[string](ctx.Text),
+							Type:         "text",
+							Text:         common.GetPointer[string](ctx.Text),
+							CacheControl: ctx.CacheControl,
 						})
 					}
 					// 未来可以在这里扩展对图片等其他类型的支持
@@ -376,8 +377,9 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 					case "text":
 						if mediaMessage.Text != "" {
 							claudeMediaMessages = append(claudeMediaMessages, dto.ClaudeMediaMessage{
-								Type: "text",
-								Text: common.GetPointer[string](mediaMessage.Text),
+								Type:         "text",
+								Text:         common.GetPointer[string](mediaMessage.Text),
+								CacheControl: mediaMessage.CacheControl,
 							})
 						}
 					default:

--- a/relay/channel/claude/relay_claude_cache_control_test.go
+++ b/relay/channel/claude/relay_claude_cache_control_test.go
@@ -1,0 +1,83 @@
+package claude
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/stretchr/testify/require"
+)
+
+// 模拟客户端发来的标准 JSON：content 为数组分块，文本块带 cache_control。
+// 经标准反序列化后，Content 是 []any of map[string]any，这是真实请求的形态。
+func buildCacheControlRequest() dto.GeneralOpenAIRequest {
+	return dto.GeneralOpenAIRequest{
+		Model: "claude-3-5-sonnet",
+		Messages: []dto.Message{
+			{
+				Role: "system",
+				Content: []any{
+					map[string]any{
+						"type":          "text",
+						"text":          "you are a helpful assistant with a long cached system prompt",
+						"cache_control": map[string]any{"type": "ephemeral"},
+					},
+				},
+			},
+			{
+				Role: "user",
+				Content: []any{
+					map[string]any{
+						"type":          "text",
+						"text":          "hello",
+						"cache_control": map[string]any{"type": "ephemeral"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func cacheControlType(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 {
+		return "", false
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return "", false
+	}
+	t, ok := m["type"].(string)
+	return t, ok
+}
+
+func TestRequestOpenAI2ClaudeMessage_PreservesUserCacheControl(t *testing.T) {
+	req := buildCacheControlRequest()
+
+	claudeReq, err := RequestOpenAI2ClaudeMessage(nil, req)
+	require.NoError(t, err)
+	require.NotEmpty(t, claudeReq.Messages)
+
+	userMsg := claudeReq.Messages[0]
+	blocks, ok := userMsg.Content.([]dto.ClaudeMediaMessage)
+	require.True(t, ok, "user content should be a media-message array")
+	require.NotEmpty(t, blocks)
+
+	ccType, found := cacheControlType(blocks[0].CacheControl)
+	require.True(t, found, "cache_control must be preserved on user text block")
+	require.Equal(t, "ephemeral", ccType)
+}
+
+func TestRequestOpenAI2ClaudeMessage_PreservesSystemCacheControl(t *testing.T) {
+	req := buildCacheControlRequest()
+
+	claudeReq, err := RequestOpenAI2ClaudeMessage(nil, req)
+	require.NoError(t, err)
+
+	sys, ok := claudeReq.System.([]dto.ClaudeMediaMessage)
+	require.True(t, ok, "system should be a media-message array")
+	require.NotEmpty(t, sys)
+
+	ccType, found := cacheControlType(sys[0].CacheControl)
+	require.True(t, found, "cache_control must be preserved on system text block")
+	require.Equal(t, "ephemeral", ccType)
+}

--- a/relay/channel/claude/relay_claude_cache_control_test.go
+++ b/relay/channel/claude/relay_claude_cache_control_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +44,7 @@ func cacheControlType(raw json.RawMessage) (string, bool) {
 		return "", false
 	}
 	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err != nil {
+	if err := common.Unmarshal(raw, &m); err != nil {
 		return "", false
 	}
 	t, ok := m["type"].(string)


### PR DESCRIPTION
## 📝 变更描述 / Description

通过 OpenAI 兼容入口请求 Claude / AWS Bedrock(Claude) 渠道时，content 分块上的 `cache_control`
在 OpenAI→Claude 转换过程中被丢弃，导致上游 Prompt Cache 永不命中（cache tokens 全为 0）；
而原生 `/v1/messages` 路径（原样透传）缓存正常。

丢弃发生在两段，缺一不可：
1. `dto.ParseContent()` 的 text 分支把客户端 JSON 转成 `MediaContent` 时未读取 `cache_control`；
2. `RequestOpenAI2ClaudeMessage()` 构造 `ClaudeMediaMessage`（普通消息文本块、system 文本块）时未透传 `CacheControl`。

本 PR 在这两段补齐：解析层读入 `cache_control`（经 `common.Marshal`，遵循 Rule 1），
转换层把 `CacheControl` 透传到 Claude 文本块。字段缺省时为 `nil` + `omitempty`，对不带缓存标记的请求零影响。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5335

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 已关联对应 Issue #5335，且不会将设计取舍直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地编译并通过单测。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范（JSON 走 common.Marshal）。

## 📸 运行证明 / Proof of Work

新增单测覆盖 user / system 两路 cache_control 透传：

```
$ go test ./relay/channel/claude/ -run TestRequestOpenAI2ClaudeMessage_Preserves -v
=== RUN   TestRequestOpenAI2ClaudeMessage_PreservesUserCacheControl
--- PASS: TestRequestOpenAI2ClaudeMessage_PreservesUserCacheControl (0.00s)
=== RUN   TestRequestOpenAI2ClaudeMessage_PreservesSystemCacheControl
--- PASS: TestRequestOpenAI2ClaudeMessage_PreservesSystemCacheControl (0.00s)
PASS
ok  	github.com/QuantumNous/new-api/relay/channel/claude
```

修复前：两测试均 FAIL（cache_control must be preserved）。修复后：PASS。
`./dto/` 全包测试通过。

> 说明：`relay/channel/claude` 包内 `ConvertsTextFileContentToText` / `SupportsPDFFileContent`
> 两个测试在本 PR 改动前的 `main` 上即为失败（与本 PR 无关），已用 git stash 验证。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cache-control metadata is now preserved when converting OpenAI-compatible requests to Claude format, including for system and user text media entries, ensuring translated messages carry cache behavior.

* **Tests**
  * Added tests validating that cache-control is retained for both system and user message transformations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->