### PR TITLE
[codex] Fix channel test cache billing

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -546,8 +546,16 @@ func settleTestQuota(info *relaycommon.RelayInfo, priceData types.PriceData, usa
 
 	quota := 0
 	if !priceData.UsePrice {
-		quota = usage.PromptTokens + int(math.Round(float64(usage.CompletionTokens)*priceData.CompletionRatio))
-		quota = int(math.Round(float64(quota) * priceData.ModelRatio))
+		isClaudeUsageSemantic := usage.UsageSemantic == "anthropic" ||
+			(info != nil && info.GetFinalRequestRelayFormat() == types.RelayFormatClaude)
+		promptTokens := float64(usage.PromptTokens)
+		cacheTokens := float64(usage.PromptTokensDetails.CachedTokens)
+		completionTokens := float64(usage.CompletionTokens)
+		quotaTokens := promptTokens + cacheTokens*priceData.CacheRatio + completionTokens*priceData.CompletionRatio
+		if !isClaudeUsageSemantic {
+			quotaTokens -= cacheTokens
+		}
+		quota = int(math.Round(quotaTokens * priceData.ModelRatio))
 		if priceData.ModelRatio != 0 && quota <= 0 {
 			quota = 1
 		}

--- a/controller/channel_test_internal_test.go
+++ b/controller/channel_test_internal_test.go
@@ -41,6 +41,41 @@ func TestSettleTestQuotaUsesTieredBilling(t *testing.T) {
 	require.Equal(t, "stream", result.MatchedTier)
 }
 
+func TestSettleTestQuotaAppliesCacheRatio(t *testing.T) {
+	quota, result := settleTestQuota(nil, types.PriceData{
+		ModelRatio:      2.5,
+		CompletionRatio: 6,
+		CacheRatio:      0.1,
+	}, &dto.Usage{
+		PromptTokens:     4440,
+		CompletionTokens: 13,
+		PromptTokensDetails: dto.InputTokenDetails{
+			CachedTokens: 3840,
+		},
+	})
+
+	require.Equal(t, 2655, quota)
+	require.Nil(t, result)
+}
+
+func TestSettleTestQuotaKeepsClaudeSemanticCachedTokensInPromptBase(t *testing.T) {
+	quota, result := settleTestQuota(nil, types.PriceData{
+		ModelRatio:      1,
+		CompletionRatio: 2,
+		CacheRatio:      0.1,
+	}, &dto.Usage{
+		PromptTokens:     1000,
+		CompletionTokens: 200,
+		UsageSemantic:    "anthropic",
+		PromptTokensDetails: dto.InputTokenDetails{
+			CachedTokens: 100,
+		},
+	})
+
+	require.Equal(t, 1410, quota)
+	require.Nil(t, result)
+}
+
 func TestBuildTestLogOtherInjectsTieredInfo(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())


### PR DESCRIPTION
## Summary

- Apply cached prompt token ratios when calculating non-tiered channel test quota.
- Add a regression test covering cached prompt tokens in `settleTestQuota`.

## Root cause

Channel/model tests write their own consume log through `settleTestQuota`. The non-tiered fallback formula counted all prompt tokens at the full model ratio, while the log metadata already included `cache_tokens` and `cache_ratio`. This made the log list quota disagree with the expanded billing details for cached requests.

## Validation

- `go test ./controller -run TestSettleTestQuotaAppliesCacheRatio -count=1` initially failed with actual quota `11295` instead of expected `2655`.
- `go test ./controller -run 'TestSettleTestQuota|TestBuildTestLogOther|TestResolveChannelTestUserID' -count=1`\n\nNote: `go test ./controller -count=1` still fails locally in an unrelated existing test, `TestListModelsTokenLimitIncludesTieredBillingModel`, with the local SQLite test database state.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated quota calculation to apply cache ratio to cached prompt tokens and perform a single model-scaling rounding, improving token usage accuracy.

* **Tests**
  * Added tests verifying correct application of cache ratio and that semantic cached tokens are treated as prompt-base cached tokens in quota computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->