### PR TITLE
feat(web): add page jump input to user table pagination

### DIFF
--- a/web/default/src/components/data-table/pagination.tsx
+++ b/web/default/src/components/data-table/pagination.tsx
@@ -23,9 +23,11 @@ import {
   ChevronsLeft as DoubleArrowLeftIcon,
   ChevronsRight as DoubleArrowRightIcon,
 } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cn, getPageNumbers } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import {
   Select,
   SelectContent,
@@ -46,6 +48,31 @@ export function DataTablePagination<TData>({
   const currentPage = table.getState().pagination.pageIndex + 1
   const totalPages = table.getPageCount()
   const pageNumbers = getPageNumbers(currentPage, totalPages)
+  const [pageInput, setPageInput] = useState(String(currentPage))
+
+  useEffect(() => {
+    setPageInput(String(currentPage))
+  }, [currentPage])
+
+  const handlePageJump = () => {
+    if (totalPages <= 0) {
+      setPageInput(String(currentPage))
+      return
+    }
+
+    const parsedPage = Number(pageInput)
+    if (!Number.isFinite(parsedPage)) {
+      setPageInput(String(currentPage))
+      return
+    }
+
+    const targetPage = Math.min(
+      Math.max(1, Math.trunc(parsedPage)),
+      totalPages
+    )
+    table.setPageIndex(targetPage - 1)
+    setPageInput(String(targetPage))
+  }
 
   return (
     <div
@@ -101,6 +128,40 @@ export function DataTablePagination<TData>({
             total: totalPages,
           })}
         </div>
+        <form
+          className='hidden items-center gap-1.5 md:flex'
+          onSubmit={(event) => {
+            event.preventDefault()
+            handlePageJump()
+          }}
+        >
+          <span className='text-muted-foreground text-sm font-medium whitespace-nowrap'>
+            {t('Page')}
+          </span>
+          <Input
+            aria-label={t('Page')}
+            className='h-8 w-16 text-center'
+            inputMode='numeric'
+            min={1}
+            max={Math.max(1, totalPages)}
+            type='number'
+            value={pageInput}
+            onBlur={handlePageJump}
+            onChange={(event) => setPageInput(event.target.value)}
+          />
+          <span className='text-muted-foreground text-sm font-medium whitespace-nowrap'>
+            / {Math.max(1, totalPages)}
+          </span>
+          <Button
+            type='submit'
+            variant='outline'
+            className='size-8 p-0'
+            disabled={totalPages <= 1}
+          >
+            <span className='sr-only'>{t('Page')}</span>
+            <ChevronRightIcon className='h-4 w-4' />
+          </Button>
+        </form>
         <div className='flex items-center space-x-1.5 sm:space-x-2'>
           <Button
             variant='outline'


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
在新版数据表分页组件中增加页码输入跳转能力，用户列表等使用 `DataTablePagination` 的页面可以直接输入目标页码并跳转。

实现上复用 TanStack Table 的分页状态：输入值会在当前页变化时同步，提交、失焦时会解析页码并限制在 `1 ~ totalPages` 范围内，最后通过 `table.setPageIndex(targetPage - 1)` 触发现有分页流程。因此无需改动后端接口，也不会影响旧版 classic 前端。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- N/A

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
本地验证通过：

```bash
cd web/default
bun run build
```

结果：`Rsbuild v2.0.9` 构建成功。

手动验证：在本地新版用户列表分页区域可以看到页码输入框，例如截图中显示 `页面 8 / 18`，输入页码后可跳转到对应页。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pagination component now supports direct page jumping. Users can enter a specific page number to navigate instantly to that page. The input includes automatic validation and bounds checking, with the feature optimized for larger screens and hidden on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->