### PR TITLE
fix(claude-stream): always emit closing events when upstream sends finish_reason without usage

### DIFF
--- a/relay/channel/openai/helper.go
+++ b/relay/channel/openai/helper.go
@@ -169,6 +169,36 @@ func HandleFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, lastStream
 		for _, resp := range claudeResponses {
 			_ = helper.ClaudeData(c, *resp)
 		}
+
+		// Fallback: ensure closing events are emitted even if upstream never sent
+		// finish_reason / usage. Some OpenAI-compatible upstreams (e.g. LiteLLM)
+		// truncate the stream without proper terminators, and Claude Code hangs
+		// indefinitely without message_stop.
+		if !info.ClaudeConvertInfo.Done {
+			stopReason := service.StopReasonOpenAI2Claude(info.FinishReason)
+			if stopReason == "" {
+				stopReason = "end_turn"
+			}
+			if usage != nil {
+				_ = helper.ClaudeData(c, dto.ClaudeResponse{
+					Type:  "message_delta",
+					Usage: service.BuildClaudeUsageFromOpenAIUsage(usage),
+					Delta: &dto.ClaudeMediaMessage{
+						StopReason: common.GetPointer[string](stopReason),
+					},
+				})
+			} else {
+				_ = helper.ClaudeData(c, dto.ClaudeResponse{
+					Type: "message_delta",
+					Delta: &dto.ClaudeMediaMessage{
+						StopReason: common.GetPointer[string](stopReason),
+					},
+				})
+			}
+			_ = helper.ClaudeData(c, dto.ClaudeResponse{
+				Type: "message_stop",
+			})
+		}
 		info.ClaudeConvertInfo.Done = true
 
 	case types.RelayFormatGemini:

--- a/relay/channel/openai/helper.go
+++ b/relay/channel/openai/helper.go
@@ -175,6 +175,13 @@ func HandleFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, lastStream
 		// truncate the stream without proper terminators, and Claude Code hangs
 		// indefinitely without message_stop.
 		if !info.ClaudeConvertInfo.Done {
+			// Close any open content blocks first so the event sequence stays
+			// valid (content_block_start … content_block_stop pairs).
+			for _, stopBlock := range service.GenerateClaudeStopBlocksForOpenInfo(info) {
+				_ = helper.ClaudeData(c, *stopBlock)
+			}
+			info.ClaudeConvertInfo.LastMessagesType = relaycommon.LastMessageTypeNone
+
 			stopReason := service.StopReasonOpenAI2Claude(info.FinishReason)
 			if stopReason == "" {
 				stopReason = "end_turn"

--- a/service/convert.go
+++ b/service/convert.go
@@ -247,6 +247,13 @@ func buildClaudeUsageFromOpenAIUsage(oaiUsage *dto.Usage) *dto.ClaudeUsage {
 	return usage
 }
 
+// BuildClaudeUsageFromOpenAIUsage is the exported variant of
+// buildClaudeUsageFromOpenAIUsage for cross-package callers (e.g. fallback
+// closing events in relay/channel/openai/helper.go).
+func BuildClaudeUsageFromOpenAIUsage(oaiUsage *dto.Usage) *dto.ClaudeUsage {
+	return buildClaudeUsageFromOpenAIUsage(oaiUsage)
+}
+
 func NormalizeCacheCreationSplit(totalTokens int, tokens5m int, tokens1h int) (int, int) {
 	remainder := lo.Max([]int{totalTokens - tokens5m - tokens1h, 0})
 	return tokens5m + remainder, tokens1h
@@ -468,10 +475,36 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 			oaiUsage := openAIResponse.Usage
 			if oaiUsage == nil {
 				oaiUsage = info.ClaudeConvertInfo.Usage
-				// Some upstreams emit finish_reason first, then send a final usage-only chunk.
-				// Defer closing until usage is available so the final message_delta carries it.
-				return claudeResponses
 			}
+			// Emit closing events immediately. Some OpenAI-compatible upstreams
+			// (e.g. LiteLLM) send finish_reason without usage and never follow up
+			// with a usage-only chunk; deferring would leave Claude Code hanging.
+			stopOpenBlocks()
+			stopReason := stopReasonOpenAI2Claude(info.FinishReason)
+			if stopReason == "" {
+				stopReason = "end_turn"
+			}
+			if oaiUsage != nil {
+				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
+					Type:  "message_delta",
+					Usage: buildClaudeUsageFromOpenAIUsage(oaiUsage),
+					Delta: &dto.ClaudeMediaMessage{
+						StopReason: common.GetPointer[string](stopReason),
+					},
+				})
+			} else {
+				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
+					Type: "message_delta",
+					Delta: &dto.ClaudeMediaMessage{
+						StopReason: common.GetPointer[string](stopReason),
+					},
+				})
+			}
+			claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
+				Type: "message_stop",
+			})
+			info.ClaudeConvertInfo.Done = true
+			return claudeResponses
 		}
 
 		var claudeResponse dto.ClaudeResponse
@@ -645,6 +678,12 @@ func ResponseOpenAI2Claude(openAIResponse *dto.OpenAITextResponse, info *relayco
 
 func stopReasonOpenAI2Claude(reason string) string {
 	return reasonmap.OpenAIFinishReasonToClaudeStopReason(reason)
+}
+
+// StopReasonOpenAI2Claude is the exported variant for cross-package callers
+// (e.g. fallback closing events in relay/channel/openai/helper.go).
+func StopReasonOpenAI2Claude(reason string) string {
+	return stopReasonOpenAI2Claude(reason)
 }
 
 func toJSONString(v interface{}) string {

--- a/service/convert.go
+++ b/service/convert.go
@@ -223,6 +223,29 @@ func generateStopBlock(index int) *dto.ClaudeResponse {
 	}
 }
 
+// GenerateClaudeStopBlocksForOpenInfo returns the content_block_stop events
+// required to close any open Claude content blocks tracked in
+// info.ClaudeConvertInfo. Used by fallback paths that need to emit a valid
+// terminal event sequence without re-implementing the block-tracking logic.
+//
+// Returns an empty slice if no block is currently open.
+func GenerateClaudeStopBlocksForOpenInfo(info *relaycommon.RelayInfo) []*dto.ClaudeResponse {
+	if info == nil {
+		return nil
+	}
+	var responses []*dto.ClaudeResponse
+	switch info.ClaudeConvertInfo.LastMessagesType {
+	case relaycommon.LastMessageTypeText, relaycommon.LastMessageTypeThinking:
+		responses = append(responses, generateStopBlock(info.ClaudeConvertInfo.Index))
+	case relaycommon.LastMessageTypeTools:
+		base := info.ClaudeConvertInfo.ToolCallBaseIndex
+		for offset := 0; offset <= info.ClaudeConvertInfo.ToolCallMaxIndexOffset; offset++ {
+			responses = append(responses, generateStopBlock(base+offset))
+		}
+	}
+	return responses
+}
+
 func buildClaudeUsageFromOpenAIUsage(oaiUsage *dto.Usage) *dto.ClaudeUsage {
 	if oaiUsage == nil {
 		return nil
@@ -425,12 +448,27 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 			if oaiUsage == nil {
 				oaiUsage = info.ClaudeConvertInfo.Usage
 			}
+			// Always emit message_delta + message_stop, even when usage is
+			// missing. Some OpenAI-compatible upstreams (e.g. LiteLLM) send
+			// finish_reason without usage; skipping the terminal events
+			// would leave Claude clients hanging.
+			stopReason := stopReasonOpenAI2Claude(info.FinishReason)
+			if stopReason == "" {
+				stopReason = "end_turn"
+			}
 			if oaiUsage != nil {
 				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
 					Type:  "message_delta",
 					Usage: buildClaudeUsageFromOpenAIUsage(oaiUsage),
 					Delta: &dto.ClaudeMediaMessage{
-						StopReason: common.GetPointer[string](stopReasonOpenAI2Claude(info.FinishReason)),
+						StopReason: common.GetPointer[string](stopReason),
+					},
+				})
+			} else {
+				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
+					Type: "message_delta",
+					Delta: &dto.ClaudeMediaMessage{
+						StopReason: common.GetPointer[string](stopReason),
 					},
 				})
 			}


### PR DESCRIPTION
## Problem

When converting OpenAI streaming responses to Claude format, if the OpenAI-compatible upstream sends a chunk with `finish_reason` but no `usage` field, and never follows up with a separate usage-only chunk, the Claude stream is silently truncated — `message_delta` and `message_stop` events are never emitted.

This violates the [Claude Messages SSE protocol](https://docs.anthropic.com/en/api/messages-streaming), which requires every stream to end with `message_stop`. As a result, Claude clients (e.g. Claude Code) hang indefinitely waiting for the stream to terminate.

## Affected Upstreams

This is the protocol behavior of any OpenAI-compatible upstream that omits `usage` when the client doesn't pass `stream_options.include_usage=true`, which is fully compliant with the OpenAI spec. Confirmed reproducers:

- LiteLLM proxy
- Custom OpenAI-compatible gateways
- Some Azure OpenAI deployments

## Root Cause

In `service/convert.go`, the `doneChunk` branch deferred emitting closing events when `usage` was missing, expecting a follow-up usage-only chunk that never arrives:

```go
if oaiUsage == nil {
    oaiUsage = info.ClaudeConvertInfo.Usage
    // Some upstreams emit finish_reason first, then send a final usage-only chunk.
    // Defer closing until usage is available so the final message_delta carries it.
    return claudeResponses  // ← stream silently truncated when no follow-up chunk
}
```

## Fix

1. **`service/convert.go`**: emit `message_delta` + `message_stop` immediately in the `doneChunk` branch, regardless of whether `usage` is available. The `message_delta` event includes usage when available, omits it otherwise — both forms are valid per Claude protocol spec.

2. **`service/convert.go`**: export `BuildClaudeUsageFromOpenAIUsage` and `StopReasonOpenAI2Claude` (as wrappers) so the fallback path in `relay/channel/openai/helper.go` can reuse the conversion logic without duplication.

3. **`relay/channel/openai/helper.go`**: add fallback closing events in `HandleFinalResponse` for cases where the stream is truncated without `finish_reason` at all (e.g. connection dropped, network timeout). Ensures `message_stop` is always emitted.

## Why new-api Should Fix This

The Anthropic Messages SSE spec requires every stream to terminate with `message_stop`:

> The end of the stream is indicated by a `message_stop` event.

new-api is a protocol converter (OpenAI ↔ Claude), and its contract is to accept any *valid* OpenAI input and produce *valid* Claude output. The OpenAI input here is fully spec-compliant — the fix belongs in new-api.

## Testing

Verified locally with:
- LiteLLM proxy → Claude Code: previously hung, now closes correctly
- Direct OpenAI API → Claude Code: still works (no regression)
- Tool calls / streaming with thinking blocks: still works (no regression)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of Claude API integration by ensuring proper “stop/close” events are emitted during stream finalization, including fallback closing when needed.
  * Enhanced streaming conversion between OpenAI and Claude to immediately terminate messages when finish reasons arrive, with conditional attachment of usage data.
  * Improved stop-reason mapping to ensure a sensible default is used when an unmapped finish reason is encountered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->