### PR TITLE
fix(gemini): infer schema types for tool parameters

### DIFF
--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -819,9 +819,25 @@ func cleanFunctionParametersShallow(params interface{}) interface{} {
 	}
 }
 
+func inferGeminiSchemaType(schema map[string]interface{}) string {
+	if _, ok := schema["properties"]; ok {
+		return "OBJECT"
+	}
+	if _, ok := schema["items"]; ok {
+		return "ARRAY"
+	}
+	if _, ok := schema["enum"]; ok {
+		return "STRING"
+	}
+	return ""
+}
+
 func normalizeGeminiSchemaTypeAndNullable(schema map[string]interface{}) {
 	rawType, ok := schema["type"]
 	if !ok || rawType == nil {
+		if inferred := inferGeminiSchemaType(schema); inferred != "" {
+			schema["type"] = inferred
+		}
 		return
 	}
 

--- a/relay/channel/gemini/schema_test.go
+++ b/relay/channel/gemini/schema_test.go
@@ -1,0 +1,51 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanFunctionParametersInfersMissingGeminiSchemaTypes(t *testing.T) {
+	params := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"edits": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"lines": map[string]interface{}{
+						"items": map[string]interface{}{
+							"properties": map[string]interface{}{
+								"line": map[string]interface{}{"type": "integer"},
+							},
+						},
+					},
+					"mode": map[string]interface{}{
+						"enum": []interface{}{"replace", "insert"},
+					},
+				},
+			},
+		},
+	}
+
+	cleaned, ok := cleanFunctionParameters(params).(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "OBJECT", cleaned["type"])
+
+	properties := cleaned["properties"].(map[string]interface{})
+	edits := properties["edits"].(map[string]interface{})
+	require.Equal(t, "OBJECT", edits["type"])
+
+	editProperties := edits["properties"].(map[string]interface{})
+	lines := editProperties["lines"].(map[string]interface{})
+	require.Equal(t, "ARRAY", lines["type"])
+
+	items := lines["items"].(map[string]interface{})
+	require.Equal(t, "OBJECT", items["type"])
+
+	itemProperties := items["properties"].(map[string]interface{})
+	line := itemProperties["line"].(map[string]interface{})
+	require.Equal(t, "INTEGER", line["type"])
+
+	mode := editProperties["mode"].(map[string]interface{})
+	require.Equal(t, "STRING", mode["type"])
+}


### PR DESCRIPTION
## Description

Gemini function parameter cleaning now infers missing schema `type` values from schema shape before normalizing them for Gemini/Vertex:

- `properties` implies `OBJECT`
- `items` implies `ARRAY`
- `enum` implies `STRING`

This keeps OpenAI-compatible tool schemas that omit nested `type` fields from being forwarded with invalid Gemini schema definitions.

Closes #3022

## Type of change

- [x] Bug fix

## Tests

- [x] `go test ./relay/channel/gemini -run TestCleanFunctionParametersInfersMissingGeminiSchemaTypes -count=1 -v`
- [x] `go test ./relay/channel/gemini -count=1`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Gemini function parameter handling by automatically inferring missing type information from schema structure, enabling proper processing of function calls even when type declarations are incomplete or ambiguous.

* **Tests**
  * Added comprehensive test coverage validating schema type inference for Gemini function parameters at multiple nesting levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->