### PR TITLE
fix(ollama): stream Claude responses in Claude format

### DIFF
--- a/relay/channel/ollama/stream.go
+++ b/relay/channel/ollama/stream.go
@@ -11,6 +11,7 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/logger"
+	"github.com/QuantumNous/new-api/relay/channel/openai"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/service"
@@ -62,6 +63,17 @@ func toUnix(ts string) int64 {
 	return t.Unix()
 }
 
+func sendOllamaStreamResponse(c *gin.Context, info *relaycommon.RelayInfo, response *dto.ChatCompletionsStreamResponse) error {
+	if response == nil {
+		return nil
+	}
+	data, err := common.Marshal(response)
+	if err != nil {
+		return err
+	}
+	return openai.HandleStreamFormat(c, info, string(data), info.ChannelSetting.ForceFormat, info.ChannelSetting.ThinkingToContent)
+}
+
 func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
 	if resp == nil || resp.Body == nil {
 		return nil, types.NewOpenAIError(fmt.Errorf("empty response"), types.ErrorCodeBadResponse, http.StatusBadRequest)
@@ -76,8 +88,9 @@ func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 	var created = time.Now().Unix()
 	var toolCallIndex int
 	start := helper.GenerateStartEmptyResponse(responseId, created, model, nil)
-	if data, err := common.Marshal(start); err == nil {
-		_ = helper.StringData(c, string(data))
+	if err := sendOllamaStreamResponse(c, info, start); err != nil {
+		logger.LogError(c, "ollama stream send start error: "+err.Error())
+		return usage, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
 	}
 
 	for scanner.Scan() {
@@ -143,8 +156,9 @@ func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 					delta.Choices[0].Delta.ToolCalls = append(delta.Choices[0].Delta.ToolCalls, tr)
 				}
 			}
-			if data, err := common.Marshal(delta); err == nil {
-				_ = helper.StringData(c, string(data))
+			if err := sendOllamaStreamResponse(c, info, &delta); err != nil {
+				logger.LogError(c, "ollama stream send delta error: "+err.Error())
+				return usage, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
 			}
 			continue
 		}
@@ -157,20 +171,35 @@ func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 		if finishReason == "" {
 			finishReason = "stop"
 		}
+		if info.RelayFormat == types.RelayFormatClaude {
+			info.FinishReason = finishReason
+			final := helper.GenerateFinalUsageResponse(responseId, created, model, *usage)
+			data, err := common.Marshal(final)
+			if err != nil {
+				logger.LogError(c, "ollama stream marshal Claude final response error: "+err.Error())
+				return usage, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+			}
+			openai.HandleFinalResponse(c, info, string(data), responseId, created, model, "", usage, true)
+			break
+		}
 		// emit stop delta
 		if stop := helper.GenerateStopResponse(responseId, created, model, finishReason); stop != nil {
-			if data, err := common.Marshal(stop); err == nil {
-				_ = helper.StringData(c, string(data))
+			if err := sendOllamaStreamResponse(c, info, stop); err != nil {
+				logger.LogError(c, "ollama stream send stop error: "+err.Error())
+				return usage, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
 			}
 		}
 		// emit usage frame
 		if final := helper.GenerateFinalUsageResponse(responseId, created, model, *usage); final != nil {
-			if data, err := common.Marshal(final); err == nil {
-				_ = helper.StringData(c, string(data))
+			if err := sendOllamaStreamResponse(c, info, final); err != nil {
+				logger.LogError(c, "ollama stream send usage error: "+err.Error())
+				return usage, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
 			}
 		}
 		// send [DONE]
-		helper.Done(c)
+		if info.RelayFormat == types.RelayFormatOpenAI {
+			helper.Done(c)
+		}
 		break
 	}
 	if err := scanner.Err(); err != nil && err != io.EOF {

--- a/relay/channel/ollama/stream_test.go
+++ b/relay/channel/ollama/stream_test.go
@@ -1,0 +1,92 @@
+package ollama
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/types"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func newOllamaStreamTestContext(t *testing.T, format types.RelayFormat) (*gin.Context, *httptest.ResponseRecorder, *relaycommon.RelayInfo) {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	info := &relaycommon.RelayInfo{
+		IsStream:           true,
+		RelayMode:          relayconstant.RelayModeChatCompletions,
+		RelayFormat:        format,
+		ShouldIncludeUsage: false,
+		ClaudeConvertInfo: &relaycommon.ClaudeConvertInfo{
+			LastMessagesType: relaycommon.LastMessageTypeNone,
+		},
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "llama3",
+		},
+	}
+	info.SetEstimatePromptTokens(3)
+
+	return ctx, recorder, info
+}
+
+func newOllamaStreamResponse() *http.Response {
+	body := strings.Join([]string{
+		`{"model":"llama3","created_at":"2026-06-07T00:00:00Z","message":{"role":"assistant","content":"hello"},"done":false}`,
+		`{"model":"llama3","created_at":"2026-06-07T00:00:01Z","done":true,"done_reason":"stop","prompt_eval_count":3,"eval_count":2}`,
+		"",
+	}, "\n")
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestOllamaStreamHandlerConvertsClaudeFormat(t *testing.T) {
+	ctx, recorder, info := newOllamaStreamTestContext(t, types.RelayFormatClaude)
+
+	usage, apiErr := ollamaStreamHandler(ctx, info, newOllamaStreamResponse())
+
+	require.Nil(t, apiErr)
+	require.Equal(t, 3, usage.PromptTokens)
+	require.Equal(t, 2, usage.CompletionTokens)
+	require.Equal(t, 5, usage.TotalTokens)
+
+	body := recorder.Body.String()
+	require.Contains(t, body, "event: message_start")
+	require.Contains(t, body, "event: content_block_start")
+	require.Contains(t, body, "event: content_block_delta")
+	require.Contains(t, body, `"type":"text_delta"`)
+	require.Contains(t, body, `"text":"hello"`)
+	require.Contains(t, body, "event: message_delta")
+	require.Contains(t, body, "event: message_stop")
+	require.NotContains(t, body, `"object":"chat.completion.chunk"`)
+	require.NotContains(t, body, "data: [DONE]")
+}
+
+func TestOllamaStreamHandlerKeepsOpenAIFormat(t *testing.T) {
+	ctx, recorder, info := newOllamaStreamTestContext(t, types.RelayFormatOpenAI)
+
+	usage, apiErr := ollamaStreamHandler(ctx, info, newOllamaStreamResponse())
+
+	require.Nil(t, apiErr)
+	require.Equal(t, 5, usage.TotalTokens)
+
+	body := recorder.Body.String()
+	require.Contains(t, body, `"object":"chat.completion.chunk"`)
+	require.Contains(t, body, `"content":"hello"`)
+	require.Contains(t, body, "data: [DONE]")
+	require.NotContains(t, body, "event: message_start")
+}


### PR DESCRIPTION
## Description

Ollama streaming responses were always written as OpenAI-compatible SSE chunks, even when the client request came through the Claude `/v1/messages` relay format. This reuses the existing OpenAI-to-Claude stream converter for Ollama's internally generated OpenAI chunks, so Claude clients receive Anthropic-style `event:` frames while OpenAI clients keep the existing `data:` / `[DONE]` stream.

Closes #2378

## Type of change

- [x] Bug fix

## Tests

- [x] `go test ./relay/channel/ollama -run TestOllamaStreamHandler -count=1 -v`
- [x] `go test ./relay/channel/ollama -count=1`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for streaming transmission failures with logging and explicit 500 error propagation.

* **Improvements**
  * Enhanced streaming output handling to preserve OpenAI-style chunks and emit Claude-style SSE when configured.
  * Adjusted end-of-stream behavior to emit terminator only for the OpenAI relay format and send a consolidated final response for Claude.

* **Tests**
  * Added tests validating format-specific streaming behavior and token usage aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->