### PR TITLE
fix: show token group key when description is empty

### DIFF
--- a/web/classic/src/components/table/tokens/modals/EditTokenModal.jsx
+++ b/web/classic/src/components/table/tokens/modals/EditTokenModal.jsx
@@ -24,6 +24,7 @@ import {
   showSuccess,
   timestamp2string,
   renderGroupOption,
+  getGroupDisplayLabel,
   getCurrencyConfig,
   getModelCategories,
   selectFilter,
@@ -138,7 +139,7 @@ const EditTokenModal = (props) => {
     const { success, message, data } = res.data;
     if (success) {
       let localGroupOptions = Object.entries(data).map(([group, info]) => ({
-        label: info.desc,
+        label: getGroupDisplayLabel(group, info),
         value: group,
         ratio: info.ratio,
       }));
@@ -552,7 +553,10 @@ const EditTokenModal = (props) => {
                         ? `▾ ${t('收起原生额度输入')}`
                         : `▸ ${t('使用原生额度输入')}`}
                     </div>
-                    <div style={{ display: showQuotaInput ? 'block' : 'none' }} className='mt-2'>
+                    <div
+                      style={{ display: showQuotaInput ? 'block' : 'none' }}
+                      className='mt-2'
+                    >
                       <Form.InputNumber
                         field='remain_quota'
                         label={t('额度')}

--- a/web/classic/src/helpers/api.js
+++ b/web/classic/src/helpers/api.js
@@ -36,7 +36,6 @@ export let API = axios.create({
   },
 });
 
-
 function redirectToOAuthUrl(url, options = {}) {
   const { openInNewTab = false } = options;
   const targetUrl = typeof url === 'string' ? url : url.toString();
@@ -48,7 +47,6 @@ function redirectToOAuthUrl(url, options = {}) {
 
   window.location.assign(targetUrl);
 }
-
 
 function patchAPIInstance(instance) {
   const originalGet = instance.get.bind(instance);
@@ -209,15 +207,22 @@ export const processModelsData = (data, currentModel) => {
   return { modelOptions, selectedModel };
 };
 
+export const getGroupDisplayLabel = (group, info) => {
+  const desc = info?.desc?.trim();
+  return desc || group;
+};
+
 // 处理分组数据
 export const processGroupsData = (data, userGroup) => {
-  let groupOptions = Object.entries(data).map(([group, info]) => ({
-    label:
-      info.desc.length > 20 ? info.desc.substring(0, 20) + '...' : info.desc,
-    value: group,
-    ratio: info.ratio,
-    fullLabel: info.desc,
-  }));
+  let groupOptions = Object.entries(data).map(([group, info]) => {
+    const label = getGroupDisplayLabel(group, info);
+    return {
+      label: label.length > 20 ? label.substring(0, 20) + '...' : label,
+      value: group,
+      ratio: info.ratio,
+      fullLabel: label,
+    };
+  });
 
   if (groupOptions.length === 0) {
     groupOptions = [


### PR DESCRIPTION
## Description
The classic token create/edit drawer builds group options from `/api/user/self/groups` and used `info.desc` directly as the Select label. When a group has no description, the option label is empty, so the token group dropdown can appear blank or confusing even though the submitted group value is valid.

This change falls back to the group key when the description is empty or missing, and reuses the same fallback in the classic group option helper. The submitted `value` is unchanged, so token creation and updates still send the original group key.

## Type of change
- [x] Bug fix

## Related Issue
- Closes #4617

## Checklist
- [x] I manually reviewed and wrote this PR description.
- [x] I searched existing issues and pull requests and did not find an open duplicate for #4617.
- [x] This bug fix is linked to an existing issue.
- [x] The change is focused and does not include unrelated code changes.
- [x] Local validation passed.
- [x] No sensitive credentials are included.

## Proof of Work
- `bunx prettier src/helpers/api.js src/components/table/tokens/modals/EditTokenModal.jsx --check`
- `git diff --check`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group label display consistency in token selection interfaces.
  * Enhanced fallback handling for missing group descriptions to ensure proper display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->