### PR TITLE
feat(dto): expose context_length in /v1/models response

### DIFF
--- a/controller/model.go
+++ b/controller/model.go
@@ -166,6 +166,7 @@ func buildOpenAIModel(modelName string, ownerByModel map[string]string) dto.Open
 		oaiModel.OwnedBy = owner
 	}
 	oaiModel.SupportedEndpointTypes = model.GetModelSupportEndpointTypes(modelName)
+	oaiModel.ContextLength = model.GetModelContextLength(modelName)
 	return oaiModel
 }
 

--- a/dto/pricing.go
+++ b/dto/pricing.go
@@ -9,6 +9,7 @@ type OpenAIModels struct {
 	Created                int                     `json:"created"`
 	OwnedBy                string                  `json:"owned_by"`
 	SupportedEndpointTypes []constant.EndpointType `json:"supported_endpoint_types"`
+	ContextLength          *int64                  `json:"context_length,omitempty"`
 }
 
 type AnthropicModel struct {

--- a/model/model_context_length.go
+++ b/model/model_context_length.go
@@ -1,8 +1,11 @@
 package model
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/QuantumNous/new-api/common"
 )
 
 // GetModelContextLength parses a model's comma-separated Tags field for a
@@ -23,16 +26,29 @@ import (
 // GetPricing() when the cache is already populated, so a call here never
 // triggers a database refresh — making it safe to invoke on every
 // /v1/models request and from tests that do not initialize a database.
-func GetModelContextLength(modelName string) *int64 {
+func GetModelContextLength(modelName string) (result *int64) {
 	if modelName == "" {
 		return nil
 	}
 
-	// Warm the pricing cache only if it already has entries, to avoid
-	// forcing a DB refresh from hot paths and test paths alike.
-	if len(pricingMap) > 0 {
-		GetPricing()
-	}
+	// Ensure the pricing cache is fresh. We always call GetPricing() (which
+	// is internally guarded by a 1-minute TTL and a mutex) so the cold-start
+	// path of /v1/models still surfaces context_length for the first request
+	// after a container restart. This mirrors GetModelEnableGroups and
+	// GetModelQuotaTypes in model_extra.go.
+	//
+	// The recover() guards test paths (and any future degraded DB state)
+	// where the cache refresh might panic. A failed refresh simply means
+	// we cannot resolve context_length for this request, which is the same
+	// outcome as "model not found in the cache" - return nil, do not crash
+	// the /v1/models response.
+	defer func() {
+		if r := recover(); r != nil {
+			common.SysLog(fmt.Sprintf("GetModelContextLength: cache refresh panicked for model %q: %v", modelName, r))
+			result = nil
+		}
+	}()
+	GetPricing()
 
 	for i := range pricingMap {
 		if pricingMap[i].ModelName != modelName {

--- a/model/model_context_length.go
+++ b/model/model_context_length.go
@@ -1,0 +1,107 @@
+package model
+
+import (
+	"strconv"
+	"strings"
+)
+
+// GetModelContextLength parses a model's comma-separated Tags field for a
+// context window token and returns the resolved token count as a *int64.
+// Returns nil if the model is unknown or its tags contain no recognizable
+// context window value.
+//
+// Accepted token formats (case-insensitive, whitespace-tolerant):
+//
+//	"200K"     -> 200_000
+//	"262.1K"   -> 262_100
+//	"1M"       -> 1_000_000
+//	"1.1M"     -> 1_100_000
+//	"200000"   -> 200_000
+//	"128"      -> 128
+//
+// Tags is read from the in-memory pricingMap cache. We only consult
+// GetPricing() when the cache is already populated, so a call here never
+// triggers a database refresh — making it safe to invoke on every
+// /v1/models request and from tests that do not initialize a database.
+func GetModelContextLength(modelName string) *int64 {
+	if modelName == "" {
+		return nil
+	}
+
+	// Warm the pricing cache only if it already has entries, to avoid
+	// forcing a DB refresh from hot paths and test paths alike.
+	if len(pricingMap) > 0 {
+		GetPricing()
+	}
+
+	for i := range pricingMap {
+		if pricingMap[i].ModelName != modelName {
+			continue
+		}
+		tags := pricingMap[i].Tags
+		if strings.TrimSpace(tags) == "" {
+			return nil
+		}
+		for _, token := range strings.Split(tags, ",") {
+			token = strings.TrimSpace(token)
+			if token == "" {
+				continue
+			}
+			if v := parseContextLengthToken(token); v != nil {
+				return v
+			}
+		}
+		return nil
+	}
+	return nil
+}
+
+// parseContextLengthToken tries to interpret a single tag token as a
+// context window size. It accepts:
+//
+//   - "<number>[kKmM]" with an optional decimal component (e.g. "200K",
+//     "262.1K", "1M", "1.1M"). "K" multiplies by 1_000, "M" by 1_000_000.
+//   - A raw non-negative integer (e.g. "128", "200000").
+//
+// Matching is case-insensitive and whitespace around the numeric part is
+// tolerated. Returns nil when the token does not match either pattern.
+func parseContextLengthToken(token string) *int64 {
+	upper := strings.ToUpper(strings.TrimSpace(token))
+	if upper == "" {
+		return nil
+	}
+
+	// Suffix form: <number>[kKmM]
+	if len(upper) > 1 {
+		suffix := upper[len(upper)-1]
+		if suffix == 'K' || suffix == 'M' {
+			numPart := strings.TrimSpace(upper[:len(upper)-1])
+			if numPart == "" {
+				return nil
+			}
+			// Only accept pure decimals here. Using ParseFloat keeps us
+			// safe for "262.1K" style tokens.
+			f, err := strconv.ParseFloat(numPart, 64)
+			if err != nil || f < 0 {
+				return nil
+			}
+			var mult int64
+			if suffix == 'K' {
+				mult = 1_000
+			} else {
+				mult = 1_000_000
+			}
+			return int64Ptr(int64(f * float64(mult)))
+		}
+	}
+
+	// Raw integer form: "128", "200000"
+	if i, err := strconv.ParseInt(upper, 10, 64); err == nil && i >= 0 {
+		return int64Ptr(i)
+	}
+	return nil
+}
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}

--- a/model/model_context_length_test.go
+++ b/model/model_context_length_test.go
@@ -1,0 +1,167 @@
+package model
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseContextLengthToken(t *testing.T) {
+	cases := []struct {
+		name   string
+		token  string
+		want   int64
+		wantOK bool
+	}{
+		{name: "200K", token: "200K", want: 200000, wantOK: true},
+		{name: "1M", token: "1M", want: 1000000, wantOK: true},
+		{name: "262.1K", token: "262.1K", want: 262100, wantOK: true},
+		{name: "1.1M", token: "1.1M", want: 1100000, wantOK: true},
+		{name: "1.5K", token: "1.5K", want: 1500, wantOK: true},
+		{name: "lowercase 200k", token: "200k", want: 200000, wantOK: true},
+		{name: "lowercase 1m", token: "1m", want: 1000000, wantOK: true},
+		{name: "raw integer 128", token: "128", want: 128, wantOK: true},
+		{name: "raw integer 200000", token: "200000", want: 200000, wantOK: true},
+		{name: "whitespace around suffix", token: " 200K ", want: 200000, wantOK: true},
+		{name: "not a number", token: "Tools", want: 0, wantOK: false},
+		{name: "empty", token: "", want: 0, wantOK: false},
+		{name: "just suffix", token: "K", want: 0, wantOK: false},
+		{name: "negative raw", token: "-1", want: 0, wantOK: false},
+		{name: "decimal with no suffix", token: "1.5", want: 0, wantOK: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseContextLengthToken(tc.token)
+			if !tc.wantOK {
+				if got != nil {
+					t.Fatalf("parseContextLengthToken(%q) = %d, want nil", tc.token, *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("parseContextLengthToken(%q) = nil, want %d", tc.token, tc.want)
+			}
+			if *got != tc.want {
+				t.Fatalf("parseContextLengthToken(%q) = %d, want %d", tc.token, *got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetModelContextLength(t *testing.T) {
+	// Snapshot the package-level cache and restore on exit so we don't
+	// leak state into other tests.
+	origPricing := pricingMap
+	origTime := lastGetPricingTime
+	t.Cleanup(func() {
+		pricingMap = origPricing
+		lastGetPricingTime = origTime
+	})
+
+	cases := []struct {
+		name      string
+		modelName string
+		tags      string
+		want      *int64
+	}{
+		{
+			name:      "Reasoning,Tools,200K",
+			modelName: "test-model-200k",
+			tags:      "Reasoning,Tools,200K",
+			want:      int64Ptr(200000),
+		},
+		{
+			name:      "1M only",
+			modelName: "test-model-1m",
+			tags:      "1M",
+			want:      int64Ptr(1000000),
+		},
+		{
+			name:      "262.1K",
+			modelName: "test-model-262-1k",
+			tags:      "262.1K",
+			want:      int64Ptr(262100),
+		},
+		{
+			name:      "1.1M",
+			modelName: "test-model-1-1m",
+			tags:      "1.1M",
+			want:      int64Ptr(1100000),
+		},
+		{
+			name:      "no context token",
+			modelName: "test-model-no-ctx",
+			tags:      "Reasoning,Tools",
+			want:      nil,
+		},
+		{
+			name:      "empty tags",
+			modelName: "test-model-empty",
+			tags:      "",
+			want:      nil,
+		},
+		{
+			name:      "case and whitespace tolerance",
+			modelName: "test-model-lower",
+			tags:      "tools, 200k",
+			want:      int64Ptr(200000),
+		},
+		{
+			name:      "raw integer in middle",
+			modelName: "test-model-raw-int",
+			tags:      "a,128,b",
+			want:      int64Ptr(128),
+		},
+		{
+			name:      "1.5K",
+			modelName: "test-model-1-5k",
+			tags:      "1.5K",
+			want:      int64Ptr(1500),
+		},
+		{
+			name:      "unknown model",
+			modelName: "definitely-not-in-cache",
+			tags:      "",
+			want:      nil,
+		},
+		{
+			name:      "empty model name",
+			modelName: "",
+			tags:      "",
+			want:      nil,
+		},
+	}
+
+	// Build a single pricingMap containing one row per case model name.
+	pricingMap = make([]Pricing, 0, len(cases))
+	for _, tc := range cases {
+		if tc.modelName == "" {
+			continue
+		}
+		pricingMap = append(pricingMap, Pricing{
+			ModelName: tc.modelName,
+			Tags:      tc.tags,
+		})
+	}
+	// Mark the cache fresh so GetPricing() does not try to refresh from
+	// the (non-existent) database during this test.
+	lastGetPricingTime = time.Now()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetModelContextLength(tc.modelName)
+			if tc.want == nil {
+				if got != nil {
+					t.Fatalf("GetModelContextLength(%q) = %d, want nil", tc.modelName, *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("GetModelContextLength(%q) = nil, want %d", tc.modelName, *tc.want)
+			}
+			if *got != *tc.want {
+				t.Fatalf("GetModelContextLength(%q) = %d, want %d", tc.modelName, *got, *tc.want)
+			}
+		})
+	}
+}

--- a/model/model_context_length_test.go
+++ b/model/model_context_length_test.go
@@ -165,3 +165,33 @@ func TestGetModelContextLength(t *testing.T) {
 		})
 	}
 }
+
+// TestGetModelContextLengthColdCache verifies that a call against an
+// empty pricingMap returns nil cleanly (does not panic) even when the
+// underlying GetPricing() refresh would fail because no database is
+// reachable. This is the production cold-start path: every fresh
+// container start hits /v1/models with an empty cache and no DB
+// connection until the first admin request warms it.
+func TestGetModelContextLengthColdCache(t *testing.T) {
+	// Snapshot and restore the global cache state so this test does not
+	// pollute sibling tests.
+	origPricingMap := pricingMap
+	origLastGetPricingTime := lastGetPricingTime
+	t.Cleanup(func() {
+		pricingMap = origPricingMap
+		lastGetPricingTime = origLastGetPricingTime
+	})
+
+	// Simulate a fresh container: empty cache, stale timestamp (so
+	// GetPricing() would attempt a DB refresh if called).
+	pricingMap = nil
+	lastGetPricingTime = time.Time{}
+
+	// In a unit test environment there is no database wired up, so the
+	// refresh path inside GetPricing() may panic. The helper must recover
+	// and return nil rather than crashing the request handler.
+	got := GetModelContextLength("any-model")
+	if got != nil {
+		t.Fatalf("GetModelContextLength with empty cache = %d, want nil", *got)
+	}
+}


### PR DESCRIPTION
## 📝 变更描述 / Description

**English:**

NewAPI's `/v1/models` endpoint returns the OpenAI-compatible model list without any context window information. The context length is only stored in the `model.Model.Tags` field as a comma-separated string (e.g. `Reasoning,Tools,Files,Vision,200K` or `...,1M`).

Because no structured field is exposed, clients like Hermes and other OpenAI SDKs fall back to a 1M default, which causes wrong auto-detection of context windows across every model in the response.

This PR parses the existing `Tags` field for a context window value and surfaces it as a structured `context_length` field on `dto.OpenAIModels`.

The parser is tolerant: it accepts `200K`, `1M`, `262.1K`, `1.1M`, raw integers like `128`, is case-insensitive, and handles whitespace.

The new field is `*int64` with `json:"context_length,omitempty"`. It is omitted from the JSON response when no context window token is found, and present as the parsed token count otherwise. The pointer type avoids the ambiguity between 0 tokens and "unknown".

No database migration is required: the source of truth remains the existing `Tags` column.

**中文:**

NewAPI 的 `/v1/models` 端点返回 OpenAI 兼容的模型列表时，没有暴露任何上下文窗口信息。上下文长度只存储在 `model.Model.Tags` 字段中（以逗号分隔的字符串形式，如 `Reasoning,Tools,Files,Vision,200K` 或 `...,1M`）。

由于没有暴露结构化字段，像 Hermes 和其他 OpenAI SDK 这样的客户端只能回退到默认的 1M，导致响应中每个模型的上下文窗口自动检测都不正确。

本 PR 解析现有的 `Tags` 字段，提取上下文窗口值，并将其作为结构化字段 `context_length` 暴露在 `dto.OpenAIModels` 上。

解析器是宽容的：接受 `200K`、`1M`、`262.1K`、`1.1M`、原始整数如 `128`，不区分大小写，并处理空白。

新字段是 `*int64` 类型，带有 `json:"context_length,omitempty"` 标签。当未找到上下文窗口 token 时，响应 JSON 中会省略该字段；否则以解析出的 token 数显示。使用指针类型避免了 0 token 和 "未知" 之间的歧义。

不需要数据库迁移：数据源仍然是现有的 `Tags` 列。

## 🚀 变更类型 / Type of change

- [x] ✨ 新功能 (New feature)

## 🔗 关联任务 / Related Issue

None.

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** Description written from understanding of the code logic, not pasted from raw AI output.
- [x] **非重复提交:** Searched existing Issues and PRs, no duplicate.
- [x] **Bug fix 说明:** This is a new feature, not a bug fix.
- [x] **变更理解:** Parser reads from the cached `pricingMap` slice (O(n) per call, acceptable for typical model counts), mirrors the existing `GetModelEnableGroups` / `GetModelQuotaTypes` pattern. The init() static list builder is intentionally NOT modified, since those entries are model-name only with no DB record to look up.
- [x] **范围聚焦:** Touches only 4 files: 1 line added to `dto/pricing.go`, 1 line added to `controller/model.go`, 2 new files (`model/model_context_length.go` and its test).
- [x] **本地验证:** Built the docker image, deployed to core.lan, confirmed `/v1/models` now returns `context_length` values matching the admin-configured Tags (e.g. `200000` for Claude Haiku 4.5, `1000000` for DeepSeek V4, `262100` for Kimi K2.6). Tested end-to-end with Hermes. Unit tests pass: 26/26 subtests on `TestParseContextLengthToken` and `TestGetModelContextLength`.
- [x] **安全合规:** No credentials, no DB schema changes, follows existing project conventions (uses in-memory cache, no new dependencies, no QuantumNous branding removed).

## 📸 运行证明 / Proof of Work

### Before the patch

`GET /v1/models` response (excerpt):
```json
{
  "id": "claude-haiku-4.5",
  "object": "model",
  "created": 1626777600,
  "owned_by": "github-copilot"
}
```

No `context_length` field. Clients fall back to 1M default for every model.

### After the patch

`GET /v1/models` response (excerpt):
```json
{
  "id": "claude-haiku-4.5",
  "object": "model",
  "created": 1626777600,
  "owned_by": "github-copilot",
  "context_length": 200000
}
{
  "id": "deepseek-v4-flash",
  "object": "model",
  "created": 1626777600,
  "owned_by": "wafer.ai",
  "context_length": 1000000
}
{
  "id": "kimi-k2.6",
  "object": "model",
  "created": 1626777600,
  "owned_by": "opencode-go",
  "context_length": 262100
}
```

`context_length` is populated from the `Tags` field:
- Tags `...,200K` → `context_length: 200000`
- Tags `...,1M` → `context_length: 1000000`
- Tags `...,262.1K` → `context_length: 262100`
- Models with no context token in Tags → `context_length` field omitted entirely

### Unit tests

```
=== RUN   TestParseContextLengthToken
--- PASS: TestParseContextLengthToken (0.00s)
    --- PASS: TestParseContextLengthToken/200K
    --- PASS: TestParseContextLengthToken/1M
    --- PASS: TestParseContextLengthToken/262.1K
    --- PASS: TestParseContextLengthToken/1.1M
    --- PASS: TestParseContextLengthToken/1.5K
    --- PASS: TestParseContextLengthToken/lowercase_200k
    --- PASS: TestParseContextLengthToken/lowercase_1m
    --- PASS: TestParseContextLengthToken/raw_integer_128
    --- PASS: TestParseContextLengthToken/raw_integer_200000
    --- PASS: TestParseContextLengthToken/whitespace_around_suffix
    --- PASS: TestParseContextLengthToken/not_a_number
    --- PASS: TestParseContextLengthToken/empty
    --- PASS: TestParseContextLengthToken/just_suffix
    --- PASS: TestParseContextLengthToken/negative_raw
    --- PASS: TestParseContextLengthToken/decimal_with_no_suffix
=== RUN   TestGetModelContextLength
--- PASS: TestGetModelContextLength (0.00s)
    --- PASS: TestGetModelContextLength/Reasoning,Tools,200K
    --- PASS: TestGetModelContextLength/1M_only
    --- PASS: TestGetModelContextLength/262.1K
    --- PASS: TestGetModelContextLength/1.1M
    --- PASS: TestGetModelContextLength/no_context_token
    --- PASS: TestGetModelContextLength/empty_tags
    --- PASS: TestGetModelContextLength/case_and_whitespace_tolerance
    --- PASS: TestGetModelContextLength/raw_integer_in_middle
    --- PASS: TestGetModelContextLength/1.5K
    --- PASS: TestGetModelContextLength/unknown_model
    --- PASS: TestGetModelContextLength/empty_model_name
PASS
ok  github.com/QuantumNous/new-api/model
```

### Files changed

```
controller/model.go                |   1 +
dto/pricing.go                     |   1 +
model/model_context_length.go      | 107 ++++++++
model/model_context_length_test.go | 167 ++++++++
4 files changed, 276 insertions(+)
```

### Build verification

```
go test ./dto/... ./model/... -count=1
ok  	github.com/QuantumNous/new-api/dto	0.010s
ok  	github.com/QuantumNous/new-api/model	0.031s

docker buildx build --platform linux/amd64 -t zbejas/newapi:fix-expose-context-length --load .
```

Built image deployed, hermes endpoint test passed with correct context lengths per model.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model API responses now include context length (context_length) in tokens for OpenAI models, so listings and retrievals show each model's context window size.

* **Tests**
  * Added unit tests covering context-length parsing and lookup, including cold-cache scenarios to ensure robust behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->