### PR TITLE
feat(dto): expose context_length in /v1/models response

### DIFF
--- a/controller/model.go
+++ b/controller/model.go
@@ -166,6 +166,7 @@ func buildOpenAIModel(modelName string, ownerByModel map[string]string) dto.Open
 		oaiModel.OwnedBy = owner
 	}
 	oaiModel.SupportedEndpointTypes = model.GetModelSupportEndpointTypes(modelName)
+	oaiModel.ContextLength = model.GetModelContextLength(modelName)
 	return oaiModel
 }
 

--- a/controller/model.go
+++ b/controller/model.go
@@ -150,6 +150,13 @@ func getPreferredModelOwners(modelNames []string, groups []string) map[string]st
 	return owners
 }
 
+// buildOpenAIModel assembles the dto.OpenAIModels payload for a single
+// model name. It looks the model up in the static openAIModelsMap and
+// falls back to a "custom" stub when the model is not statically known.
+// The ownerByModel map (computed once per request by the caller) is
+// applied to override OwnedBy for any models that have a resolved
+// channel-level owner. SupportedEndpointTypes and ContextLength are
+// resolved from the model cache for both static and custom paths.
 func buildOpenAIModel(modelName string, ownerByModel map[string]string) dto.OpenAIModels {
 	var oaiModel dto.OpenAIModels
 	if staticModel, ok := openAIModelsMap[modelName]; ok {

--- a/dto/pricing.go
+++ b/dto/pricing.go
@@ -9,6 +9,7 @@ type OpenAIModels struct {
 	Created                int                     `json:"created"`
 	OwnedBy                string                  `json:"owned_by"`
 	SupportedEndpointTypes []constant.EndpointType `json:"supported_endpoint_types"`
+	ContextLength          *int64                  `json:"context_length,omitempty"`
 }
 
 type AnthropicModel struct {

--- a/model/model_context_length.go
+++ b/model/model_context_length.go
@@ -146,6 +146,9 @@ func parseContextLengthToken(token string) *int64 {
 	return nil
 }
 
+// int64Ptr returns a pointer to the given int64 value. It exists so the
+// parser can return typed pointers directly from branches (regex match,
+// ParseInt) without each call site re-allocating a temp variable.
 func int64Ptr(v int64) *int64 {
 	return &v
 }

--- a/model/model_context_length.go
+++ b/model/model_context_length.go
@@ -1,0 +1,151 @@
+package model
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+// contextLengthPattern matches a single context window token with a
+// K/M/T unit suffix. The number may include a decimal component
+// (e.g. "200K", "262.1K", "2T", "0.5t"). Whitespace around the token
+// is trimmed before matching.
+//
+// The pattern is anchored to digits at the start and a single K/M/T
+// letter at the end, with nothing allowed in between. This explicitly
+// rejects tokens that contain letters anywhere other than the trailing
+// unit, so values like "e4bK", "4bK", "200KB", "1.0X", or "v2K" are
+// all rejected by the pattern without reaching the multiplier math.
+// Bare decimals like "1.5" are also rejected — they fall through to
+// the ParseInt path below, which also rejects them.
+//
+// Bare non-negative integers without a unit (e.g. "128", "200000") are
+// handled by strconv.ParseInt, not by this regex.
+//
+// Examples that match this pattern: "200K", "262.1K", "1M", "2T", "0.5t".
+// Examples that do NOT match: "1.5", "Tools", "K", "-1", "200KB", "1.0X",
+//   "e4bK", "4bK", "v2K", "200k " (trailing space inside the regex).
+var contextLengthPattern = regexp.MustCompile(`^(\d+(?:\.\d+)?)([kKmMtT])$`)
+
+// unitMultipliers maps a suffix character to its power-of-ten multiplier
+// relative to a single token. Keeping the table as a map (rather than
+// scattered branches) makes the supported set obvious at a glance and
+// trivial to extend.
+var unitMultipliers = map[byte]int64{
+	'K': 1_000,
+	'M': 1_000_000,
+	'T': 1_000_000_000,
+}
+
+// GetModelContextLength parses a model's comma-separated Tags field for a
+// context window token and returns the resolved token count as a *int64.
+// Returns nil if the model is unknown or its tags contain no recognizable
+// context window value.
+//
+// Accepted token formats (case-insensitive, whitespace-tolerant):
+//
+//	"200K"     -> 200_000
+//	"262.1K"   -> 262_100
+//	"1M"       -> 1_000_000
+//	"1.1M"     -> 1_100_000
+//	"2T"       -> 2_000_000_000
+//	"0.5T"     -> 500_000_000
+//	"200000"   -> 200_000
+//	"128"      -> 128
+//
+// Tags is read from the in-memory pricingMap cache. We only consult
+// GetPricing() when the cache is already populated, so a call here never
+// triggers a database refresh — making it safe to invoke on every
+// /v1/models request and from tests that do not initialize a database.
+func GetModelContextLength(modelName string) (result *int64) {
+	if modelName == "" {
+		return nil
+	}
+
+	// Ensure the pricing cache is fresh. We always call GetPricing() (which
+	// is internally guarded by a 1-minute TTL and a mutex) so the cold-start
+	// path of /v1/models still surfaces context_length for the first request
+	// after a container restart. This mirrors GetModelEnableGroups and
+	// GetModelQuotaTypes in model_extra.go.
+	//
+	// The recover() guards test paths (and any future degraded DB state)
+	// where the cache refresh might panic. A failed refresh simply means
+	// we cannot resolve context_length for this request, which is the same
+	// outcome as "model not found in the cache" - return nil, do not crash
+	// the /v1/models response.
+	defer func() {
+		if r := recover(); r != nil {
+			common.SysLog(fmt.Sprintf("GetModelContextLength: cache refresh panicked for model %q: %v", modelName, r))
+			result = nil
+		}
+	}()
+	GetPricing()
+
+	for i := range pricingMap {
+		if pricingMap[i].ModelName != modelName {
+			continue
+		}
+		tags := pricingMap[i].Tags
+		if strings.TrimSpace(tags) == "" {
+			return nil
+		}
+		for _, token := range strings.Split(tags, ",") {
+			token = strings.TrimSpace(token)
+			if token == "" {
+				continue
+			}
+			if v := parseContextLengthToken(token); v != nil {
+				return v
+			}
+		}
+		return nil
+	}
+	return nil
+}
+
+// parseContextLengthToken tries to interpret a single tag token as a
+// context window size. It accepts "<number>[KkMmTt]" (optional suffix)
+// where the number may have a decimal component. A raw non-negative
+// integer is also accepted (e.g. "128", "200000").
+//
+// Matching is case-insensitive and whitespace around the token is
+// tolerated. Returns nil when the token does not match the pattern.
+func parseContextLengthToken(token string) *int64 {
+	trimmed := strings.TrimSpace(token)
+	if trimmed == "" {
+		return nil
+	}
+
+	// Suffix form: <number>[KkMmTt]. The number may be a decimal,
+	// and the suffix is required (so "1.5" is rejected outright by
+	// the pattern, never reaching the multiplier math). Lowercase and
+	// uppercase suffix letters are accepted; we normalize to uppercase
+	// before the multiplier lookup so the table stays the single
+	// source of truth.
+	if m := contextLengthPattern.FindStringSubmatch(trimmed); m != nil {
+		f, err := strconv.ParseFloat(m[1], 64)
+		if err != nil || f < 0 {
+			return nil
+		}
+		suffix := m[2][0]
+		if suffix >= 'a' && suffix <= 'z' {
+			suffix -= 'a' - 'A'
+		}
+		return int64Ptr(int64(f * float64(unitMultipliers[suffix])))
+	}
+
+	// Raw integer form: "128", "200000". Strictly integers, no decimal
+	// point and no suffix — anything more exotic falls through.
+	if i, err := strconv.ParseInt(trimmed, 10, 64); err == nil && i >= 0 {
+		return int64Ptr(i)
+	}
+
+	return nil
+}
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}

--- a/model/model_context_length_test.go
+++ b/model/model_context_length_test.go
@@ -1,0 +1,227 @@
+package model
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseContextLengthToken(t *testing.T) {
+	cases := []struct {
+		name   string
+		token  string
+		want   int64
+		wantOK bool
+	}{
+		{name: "200K", token: "200K", want: 200000, wantOK: true},
+		{name: "1M", token: "1M", want: 1000000, wantOK: true},
+		{name: "262.1K", token: "262.1K", want: 262100, wantOK: true},
+		{name: "1.1M", token: "1.1M", want: 1100000, wantOK: true},
+		{name: "1.5K", token: "1.5K", want: 1500, wantOK: true},
+		{name: "2T", token: "2T", want: 2000000000, wantOK: true},
+		{name: "0.5T", token: "0.5T", want: 500000000, wantOK: true},
+		{name: "lowercase 200k", token: "200k", want: 200000, wantOK: true},
+		{name: "lowercase 1m", token: "1m", want: 1000000, wantOK: true},
+		{name: "lowercase 2t", token: "2t", want: 2000000000, wantOK: true},
+		{name: "raw integer 128", token: "128", want: 128, wantOK: true},
+		{name: "raw integer 200000", token: "200000", want: 200000, wantOK: true},
+		{name: "whitespace around suffix", token: " 200K ", want: 200000, wantOK: true},
+		{name: "not a number", token: "Tools", want: 0, wantOK: false},
+		{name: "empty", token: "", want: 0, wantOK: false},
+		{name: "just suffix", token: "K", want: 0, wantOK: false},
+		{name: "negative raw", token: "-1", want: 0, wantOK: false},
+		{name: "decimal with no suffix", token: "1.5", want: 0, wantOK: false},
+		// letters embedded in the middle must NOT match — protect against
+		// tokens like "e4bK", "v2K", "200KB", "1.0X" leaking through.
+		{name: "letters before digits", token: "e4bK", want: 0, wantOK: false},
+		{name: "v-prefixed", token: "v2K", want: 0, wantOK: false},
+		{name: "trailing extra letter", token: "200KB", want: 0, wantOK: false},
+		{name: "unknown unit", token: "1.0X", want: 0, wantOK: false},
+		{name: "letters inside number", token: "2bK", want: 0, wantOK: false},
+		{name: "hex-like suffix", token: "4bK", want: 0, wantOK: false},
+		{name: "internal space", token: "20 0K", want: 0, wantOK: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseContextLengthToken(tc.token)
+			if !tc.wantOK {
+				if got != nil {
+					t.Fatalf("parseContextLengthToken(%q) = %d, want nil", tc.token, *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("parseContextLengthToken(%q) = nil, want %d", tc.token, tc.want)
+			}
+			if *got != tc.want {
+				t.Fatalf("parseContextLengthToken(%q) = %d, want %d", tc.token, *got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetModelContextLength(t *testing.T) {
+	// Snapshot the package-level cache and restore on exit so we don't
+	// leak state into other tests.
+	origPricing := pricingMap
+	origTime := lastGetPricingTime
+	t.Cleanup(func() {
+		pricingMap = origPricing
+		lastGetPricingTime = origTime
+	})
+
+	cases := []struct {
+		name      string
+		modelName string
+		tags      string
+		want      *int64
+	}{
+		{
+			name:      "Reasoning,Tools,200K",
+			modelName: "test-model-200k",
+			tags:      "Reasoning,Tools,200K",
+			want:      int64Ptr(200000),
+		},
+		{
+			name:      "1M only",
+			modelName: "test-model-1m",
+			tags:      "1M",
+			want:      int64Ptr(1000000),
+		},
+		{
+			name:      "262.1K",
+			modelName: "test-model-262-1k",
+			tags:      "262.1K",
+			want:      int64Ptr(262100),
+		},
+		{
+			name:      "1.1M",
+			modelName: "test-model-1-1m",
+			tags:      "1.1M",
+			want:      int64Ptr(1100000),
+		},
+		{
+			name:      "2T",
+			modelName: "test-model-2t",
+			tags:      "2T",
+			want:      int64Ptr(2000000000),
+		},
+		{
+			name:      "0.5T lowercase",
+			modelName: "test-model-half-t",
+			tags:      "tools, 0.5t",
+			want:      int64Ptr(500000000),
+		},
+		{
+			name:      "embedded letter rejected",
+			modelName: "test-model-embedded",
+			tags:      "e4bK,200K",
+			want:      int64Ptr(200000),
+		},
+		{
+			name:      "no context token",
+			modelName: "test-model-no-ctx",
+			tags:      "Reasoning,Tools",
+			want:      nil,
+		},
+		{
+			name:      "empty tags",
+			modelName: "test-model-empty",
+			tags:      "",
+			want:      nil,
+		},
+		{
+			name:      "case and whitespace tolerance",
+			modelName: "test-model-lower",
+			tags:      "tools, 200k",
+			want:      int64Ptr(200000),
+		},
+		{
+			name:      "raw integer in middle",
+			modelName: "test-model-raw-int",
+			tags:      "a,128,b",
+			want:      int64Ptr(128),
+		},
+		{
+			name:      "1.5K",
+			modelName: "test-model-1-5k",
+			tags:      "1.5K",
+			want:      int64Ptr(1500),
+		},
+		{
+			name:      "unknown model",
+			modelName: "definitely-not-in-cache",
+			tags:      "",
+			want:      nil,
+		},
+		{
+			name:      "empty model name",
+			modelName: "",
+			tags:      "",
+			want:      nil,
+		},
+	}
+
+	// Build a single pricingMap containing one row per case model name.
+	pricingMap = make([]Pricing, 0, len(cases))
+	for _, tc := range cases {
+		if tc.modelName == "" {
+			continue
+		}
+		pricingMap = append(pricingMap, Pricing{
+			ModelName: tc.modelName,
+			Tags:      tc.tags,
+		})
+	}
+	// Mark the cache fresh so GetPricing() does not try to refresh from
+	// the (non-existent) database during this test.
+	lastGetPricingTime = time.Now()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetModelContextLength(tc.modelName)
+			if tc.want == nil {
+				if got != nil {
+					t.Fatalf("GetModelContextLength(%q) = %d, want nil", tc.modelName, *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("GetModelContextLength(%q) = nil, want %d", tc.modelName, *tc.want)
+			}
+			if *got != *tc.want {
+				t.Fatalf("GetModelContextLength(%q) = %d, want %d", tc.modelName, *got, *tc.want)
+			}
+		})
+	}
+}
+
+// TestGetModelContextLengthColdCache verifies that a call against an
+// empty pricingMap returns nil cleanly (does not panic) even when the
+// underlying GetPricing() refresh would fail because no database is
+// reachable. This is the production cold-start path: every fresh
+// container start hits /v1/models with an empty cache and no DB
+// connection until the first admin request warms it.
+func TestGetModelContextLengthColdCache(t *testing.T) {
+	// Snapshot and restore the global cache state so this test does not
+	// pollute sibling tests.
+	origPricingMap := pricingMap
+	origLastGetPricingTime := lastGetPricingTime
+	t.Cleanup(func() {
+		pricingMap = origPricingMap
+		lastGetPricingTime = origLastGetPricingTime
+	})
+
+	// Simulate a fresh container: empty cache, stale timestamp (so
+	// GetPricing() would attempt a DB refresh if called).
+	pricingMap = nil
+	lastGetPricingTime = time.Time{}
+
+	// In a unit test environment there is no database wired up, so the
+	// refresh path inside GetPricing() may panic. The helper must recover
+	// and return nil rather than crashing the request handler.
+	got := GetModelContextLength("any-model")
+	if got != nil {
+		t.Fatalf("GetModelContextLength with empty cache = %d, want nil", *got)
+	}
+}

--- a/model/model_context_length_test.go
+++ b/model/model_context_length_test.go
@@ -5,6 +5,10 @@ import (
 	"time"
 )
 
+// TestParseContextLengthToken covers the accepted formats (suffix
+// multipliers with K/M/T, raw integers, case-insensitivity, whitespace)
+// and the rejection cases (embedded letters, unknown units, decimals
+// without a suffix, negatives, empty input).
 func TestParseContextLengthToken(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -60,6 +64,13 @@ func TestParseContextLengthToken(t *testing.T) {
 	}
 }
 
+// TestGetModelContextLength exercises GetModelContextLength against a
+// synthetic pricingMap populated for the duration of the test. It checks
+// resolution for every supported tag shape (suffix, raw integer, mixed
+// tags, embedded-letter rejection) as well as the "no context token",
+// "empty tags", "unknown model" and "empty model name" negative paths.
+// The cache is snapshotted on entry and restored on exit so the test
+// does not leak global state into siblings.
 func TestGetModelContextLength(t *testing.T) {
 	// Snapshot the package-level cache and restore on exit so we don't
 	// leak state into other tests.


### PR DESCRIPTION
## Description

`/v1/models` now exposes a `context_length` field with the correct token count per model, parsed from the existing `Tags` column in the pricing table.

Previously the context window size was hidden inside the comma-separated tags string (e.g. `"Reasoning,Tools,200K"`), forcing clients to hardcode a fallback, which caused wrong context detection across every model in the response.

**How it works:**

- `model.GetModelContextLength(modelName)` scans the in-memory `pricingMap` for a matching model, splits its `Tags` on commas, and runs each token through `parseContextLengthToken`.
- The parser accepts `<number>[KkMmTt]` (with optional decimal, e.g. `"262.1K"` → 262_100) or a bare non-negative integer (e.g. `"128"` → 128).
- An anchored regex (`^\d+(?:\.\d+)?[KkMmTt]$`) rejects false positives: tokens with embedded letters (`e4bK`, `v2K`), trailing extras (`200KB`), unknown units (`1.0X`), or bare decimals (`1.5`) are all discarded.
- The `ContextLength` field on `dto.OpenAIModels` is `*int64` with `omitempty` — nil when no context token is found, present otherwise.
- `GetPricing()` is called on every lookup (internally TTL-guarded) so the cold-start path after a container restart still resolves context_length without waiting for an admin request to warm the cache. The lookup is wrapped in `recover()` so a degraded/absent DB returns nil cleanly rather than crashing `/v1/models`.

**Files changed:**
- `model/model_context_length.go` (new) — parser + lookup
- `model/model_context_length_test.go` (new) — 25 test cases including edge cases, cold-cache recovery
- `controller/model.go` — wires `GetModelContextLength` into the model builder
- `dto/pricing.go` — adds `ContextLength *int64` field

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

## Related Issue

- Closes # (none)

## Checklist

- [x] I have personally written this description (no raw AI output).
- [x] I have checked existing issues/PRs — this is not a duplicate.
- [x] I understand how these changes work and their impact.
- [x] This PR contains only the relevant changes (no unrelated diffs).
- [x] All tests pass locally (`go test ./model/ -run TestParseContextLengthToken -v`, `TestGetModelContextLength -v`, cold-cache test).
- [x] No sensitive credentials in code.

## Proof of Work
```bash
curl -s "http://core.lan:3000/v1/models" \
  -H "Authorization: Bearer sk-abc" | python3 -m json.tool
{
    "data": [
        {
            "id": "glm-5.1",
            "object": "model",
            "created": 1626777600,
            "owned_by": "openai",
            "supported_endpoint_types": [
                "openai"
            ],
            "context_length": 200000
        },
        {
            "id": "deepseek-v4-flash",
            "object": "model",
            "created": 1626777600,
            "owned_by": "openai",
            "supported_endpoint_types": [
                "openai"
            ],
            "context_length": 1000000
        },
        {
            "id": "claude-opus-4.6",
            "object": "model",
            "created": 1626777600,
            "owned_by": "openai",
            "supported_endpoint_types": [
                "openai"
            ],
            "context_length": 200000
        },
        {
            "id": "minimax-m3",
            "object": "model",
            "created": 1626777600,
            "owned_by": "openai",
            "supported_endpoint_types": [
                "openai"
            ],
            "context_length": 500000
        }
    ],
    "object": "list",
    "success": true
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Models now show context length (max tokens) for both standard and custom models.
* **Stability / Bug Fixes**
  * Safely handles missing or stale pricing data without crashing; unknown or unparseable context info yields empty value.
* **Tests**
  * Added thorough tests for context-length parsing and lookup, including cold-cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->