### PR TITLE
fix: stop repeated allow_balance_pay column migration on restart

### DIFF
--- a/model/subscription.go
+++ b/model/subscription.go
@@ -160,7 +160,7 @@ type SubscriptionPlan struct {
 	Enabled   bool `json:"enabled" gorm:"default:true"`
 	SortOrder int  `json:"sort_order" gorm:"type:int;default:0"`
 
-	AllowBalancePay *bool `json:"allow_balance_pay" gorm:"default:true"`
+	AllowBalancePay *bool `json:"allow_balance_pay"`
 
 	StripePriceId         string `json:"stripe_price_id" gorm:"type:varchar(128);default:''"`
 	CreemProductId        string `json:"creem_product_id" gorm:"type:varchar(128);default:''"`


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
当前 bool类型的列, 如果 `default:true`
会造成每次启动时, 如果是mysql数据库 migrate会重复报:
`model/main.go:304 [60.293ms] [rows:0] ALTER TABLE `subscription_plans` MODIFY COLUMN `allow_balance_pay` boolean DEFAULT true`
因为mysql的bool默认值是1, true每次会被识别为不匹配

但如果改成 `default:1`
又会造成如果是postgres数据库 migrate会重复报: 
`model/main.go:304 [60.293ms] [rows:0] ALTER TABLE `subscription_plans` MODIFY COLUMN `allow_balance_pay` boolean DEFAULT 1`

目前无论使用哪种默认值, 都无法兼容mysql和pg数据库

## 🚀 变更类型 / Type of change
最好的方案是去除默认值, 由业务决定默认值,而且这也更符合代码逻辑直觉

## ✅ 提交前检查项 / Checklist
已检查过,当前AllowBalancePay初始化时, 代码已经默认为true, 因此去除gorm默认值不影响原来的业务逻辑
只会减少每次启动时实际的migrate数据库变动日志噪音


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal default value handling for subscription plan configuration to enhance application logic efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->