### PR TITLE
fix(web): persist channels table view options

### DIFF
--- a/web/default/src/features/channels/components/channels-table.tsx
+++ b/web/default/src/features/channels/components/channels-table.tsx
@@ -33,6 +33,7 @@ import { useDebounce, useMediaQuery } from '@/hooks'
 import { useTranslation } from 'react-i18next'
 import { getLobeIcon } from '@/lib/lobe-icon'
 import { useTableUrlState } from '@/hooks/use-table-url-state'
+import { safeJsonParse } from '@/features/system-settings/utils/json-parser'
 import { Input } from '@/components/ui/input'
 import {
   DISABLED_ROW_DESKTOP,
@@ -68,6 +69,15 @@ const CHANNEL_SORTABLE_COLUMNS = new Set<ChannelSortBy>([
   'test_time',
 ])
 
+const CHANNELS_TABLE_COLUMN_VISIBILITY_STORAGE_KEY =
+  'channels-table-column-visibility'
+const CHANNELS_TABLE_LEGACY_COLUMN_VISIBILITY_STORAGE_KEY =
+  'channels-table-columns'
+const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
+  models: false,
+  tag: false,
+}
+
 function isDisabledChannelRow(channel: Channel) {
   return (
     !isTagAggregateRow(channel) && channel.status !== CHANNEL_STATUS.ENABLED
@@ -81,10 +91,25 @@ export function ChannelsTable() {
 
   // Table state
   const [sorting, setSorting] = useState<SortingState>([])
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
-    models: false,
-    tag: false,
-  })
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(
+    () => {
+      const saved =
+        localStorage.getItem(CHANNELS_TABLE_COLUMN_VISIBILITY_STORAGE_KEY) ??
+        localStorage.getItem(
+          CHANNELS_TABLE_LEGACY_COLUMN_VISIBILITY_STORAGE_KEY
+        )
+      if (!saved) {
+        return DEFAULT_COLUMN_VISIBILITY
+      }
+      return {
+        ...DEFAULT_COLUMN_VISIBILITY,
+        ...safeJsonParse<VisibilityState>(saved, {
+          fallback: DEFAULT_COLUMN_VISIBILITY,
+          silent: true,
+        }),
+      }
+    }
+  )
   const [rowSelection, setRowSelection] = useState({})
   const [expanded, setExpanded] = useState<ExpandedState>({})
 
@@ -131,6 +156,13 @@ export function ChannelsTable() {
   useEffect(() => {
     setModelFilterInput(modelFilterFromUrl)
   }, [modelFilterFromUrl])
+
+  useEffect(() => {
+    localStorage.setItem(
+      CHANNELS_TABLE_COLUMN_VISIBILITY_STORAGE_KEY,
+      JSON.stringify(columnVisibility)
+    )
+  }, [columnVisibility])
 
   // Update URL when debounced value changes
   useEffect(() => {


### PR DESCRIPTION
## Summary\n- persist channel table column visibility in the new frontend\n- rehydrate saved view options on load so the \View\ menu behaves like the classic frontend\n- fall back to the legacy \channels-table-columns\ localStorage key for compatibility\n\n## Testing\n- bun run typecheck\n- bun run build\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Column visibility preferences in the channels table are now automatically saved and restored between sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->