### PR TITLE
fix: remove public chat-to-responses auto conversion

### DIFF
--- a/relay/chat_completions_via_responses.go
+++ b/relay/chat_completions_via_responses.go
@@ -1,170 +1,30 @@
 package relay
 
 import (
-	"io"
+	"errors"
 	"net/http"
-	"strings"
 
-	"github.com/QuantumNous/new-api/common"
-	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/relay/channel"
-	openaichannel "github.com/QuantumNous/new-api/relay/channel/openai"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
-	relayconstant "github.com/QuantumNous/new-api/relay/constant"
-	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/types"
 
 	"github.com/gin-gonic/gin"
 )
 
-func applySystemPromptIfNeeded(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeneralOpenAIRequest) {
-	if info == nil || request == nil {
-		return
-	}
-	if info.ChannelSetting.SystemPrompt == "" {
-		return
-	}
-
-	systemRole := request.GetSystemRoleName()
-
-	containSystemPrompt := false
-	for _, message := range request.Messages {
-		if message.Role == systemRole {
-			containSystemPrompt = true
-			break
-		}
-	}
-	if !containSystemPrompt {
-		systemMessage := dto.Message{
-			Role:    systemRole,
-			Content: info.ChannelSetting.SystemPrompt,
-		}
-		request.Messages = append([]dto.Message{systemMessage}, request.Messages...)
-		return
-	}
-
-	if !info.ChannelSetting.SystemPromptOverride {
-		return
-	}
-
-	common.SetContextKey(c, constant.ContextKeySystemPromptOverride, true)
-	for i, message := range request.Messages {
-		if message.Role != systemRole {
-			continue
-		}
-		if message.IsStringContent() {
-			request.Messages[i].SetStringContent(info.ChannelSetting.SystemPrompt + "\n" + message.StringContent())
-			return
-		}
-		contents := message.ParseContent()
-		contents = append([]dto.MediaContent{
-			{
-				Type: dto.ContentTypeText,
-				Text: info.ChannelSetting.SystemPrompt,
-			},
-		}, contents...)
-		request.Messages[i].Content = contents
-		return
-	}
-}
-
 func chatCompletionsViaResponses(c *gin.Context, info *relaycommon.RelayInfo, adaptor channel.Adaptor, request *dto.GeneralOpenAIRequest) (*dto.Usage, *types.NewAPIError) {
-	chatJSON, err := common.Marshal(request)
-	if err != nil {
-		return nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
-	}
+	_ = c
+	_ = info
+	_ = adaptor
+	_ = request
 
-	chatJSON, err = relaycommon.RemoveDisabledFields(chatJSON, info.ChannelOtherSettings, info.ChannelSetting.PassThroughBodyEnabled)
-	if err != nil {
-		return nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
-	}
-
-	if len(info.ParamOverride) > 0 {
-		chatJSON, err = relaycommon.ApplyParamOverrideWithRelayInfo(chatJSON, info)
-		if err != nil {
-			return nil, newAPIErrorFromParamOverride(err)
-		}
-	}
-
-	var overriddenChatReq dto.GeneralOpenAIRequest
-	if err := common.Unmarshal(chatJSON, &overriddenChatReq); err != nil {
-		return nil, types.NewError(err, types.ErrorCodeChannelParamOverrideInvalid, types.ErrOptionWithSkipRetry())
-	}
-
-	responsesReq, err := service.ChatCompletionsRequestToResponsesRequest(&overriddenChatReq)
-	if err != nil {
-		return nil, types.NewErrorWithStatusCode(err, types.ErrorCodeInvalidRequest, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
-	}
-	info.AppendRequestConversion(types.RelayFormatOpenAIResponses)
-
-	savedRelayMode := info.RelayMode
-	savedRequestURLPath := info.RequestURLPath
-	defer func() {
-		info.RelayMode = savedRelayMode
-		info.RequestURLPath = savedRequestURLPath
-	}()
-
-	info.RelayMode = relayconstant.RelayModeResponses
-	info.RequestURLPath = "/v1/responses"
-
-	convertedRequest, err := adaptor.ConvertOpenAIResponsesRequest(c, info, *responsesReq)
-	if err != nil {
-		return nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
-	}
-	relaycommon.AppendRequestConversionFromRequest(info, convertedRequest)
-
-	jsonData, err := common.Marshal(convertedRequest)
-	if err != nil {
-		return nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
-	}
-
-	jsonData, err = relaycommon.RemoveDisabledFields(jsonData, info.ChannelOtherSettings, info.ChannelSetting.PassThroughBodyEnabled)
-	if err != nil {
-		return nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
-	}
-
-	body, size, closer, err := relaycommon.NewOutboundJSONBody(jsonData)
-	if err != nil {
-		return nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
-	}
-	defer closer.Close()
-	jsonData = nil
-	info.UpstreamRequestBodySize = size
-	var requestBody io.Reader = body
-
-	var httpResp *http.Response
-	resp, err := adaptor.DoRequest(c, info, requestBody)
-	if err != nil {
-		return nil, types.NewOpenAIError(err, types.ErrorCodeDoRequestFailed, http.StatusInternalServerError)
-	}
-	if resp == nil {
-		return nil, types.NewOpenAIError(nil, types.ErrorCodeBadResponse, http.StatusInternalServerError)
-	}
-
-	statusCodeMappingStr := c.GetString("status_code_mapping")
-
-	httpResp = resp.(*http.Response)
-	info.IsStream = info.IsStream || strings.HasPrefix(httpResp.Header.Get("Content-Type"), "text/event-stream")
-	if httpResp.StatusCode != http.StatusOK {
-		newApiErr := service.RelayErrorHandler(c.Request.Context(), httpResp, false)
-		service.ResetStatusCode(newApiErr, statusCodeMappingStr)
-		return nil, newApiErr
-	}
-
-	if info.IsStream {
-		usage, newApiErr := openaichannel.OaiResponsesToChatStreamHandler(c, info, httpResp)
-		if newApiErr != nil {
-			service.ResetStatusCode(newApiErr, statusCodeMappingStr)
-			return nil, newApiErr
-		}
-		return usage, nil
-	}
-
-	usage, newApiErr := openaichannel.OaiResponsesToChatHandler(c, info, httpResp)
-	if newApiErr != nil {
-		service.ResetStatusCode(newApiErr, statusCodeMappingStr)
-		return nil, newApiErr
-	}
-	return usage, nil
+	// Public endpoint protocol conversion has been retired. Chat Completions and
+	// Claude requests must keep their original protocol semantics instead of
+	// being silently rerouted to /v1/responses and wrapped back.
+	return nil, types.NewErrorWithStatusCode(
+		errors.New("automatic chat/completions -> responses conversion has been removed to preserve public endpoint protocol semantics"),
+		types.ErrorCodeInvalidRequest,
+		http.StatusBadRequest,
+		types.ErrOptionWithSkipRetry(),
+	)
 }

--- a/relay/chat_completions_via_responses_test.go
+++ b/relay/chat_completions_via_responses_test.go
@@ -1,0 +1,25 @@
+package relay
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatCompletionsViaResponsesDisabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	usage, err := chatCompletionsViaResponses(c, &relaycommon.RelayInfo{}, nil, &dto.GeneralOpenAIRequest{})
+	require.Nil(t, usage)
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, err.StatusCode)
+	require.Contains(t, err.Error(), "removed")
+}

--- a/relay/chat_completions_via_responses_test.go
+++ b/relay/chat_completions_via_responses_test.go
@@ -12,7 +12,10 @@ import (
 )
 
 func TestChatCompletionsViaResponsesDisabled(t *testing.T) {
+	previousMode := gin.Mode()
 	gin.SetMode(gin.TestMode)
+	defer gin.SetMode(previousMode)
+
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)

--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -132,23 +132,6 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 		}
 	}
 
-	if !model_setting.GetGlobalSettings().PassThroughRequestEnabled &&
-		!info.ChannelSetting.PassThroughBodyEnabled &&
-		service.ShouldChatCompletionsUseResponsesGlobal(info.ChannelId, info.ChannelType, info.OriginModelName) {
-		openAIRequest, convErr := service.ClaudeToOpenAIRequest(*request, info)
-		if convErr != nil {
-			return types.NewError(convErr, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
-		}
-
-		usage, newApiErr := chatCompletionsViaResponses(c, info, adaptor, openAIRequest)
-		if newApiErr != nil {
-			return newApiErr
-		}
-
-		service.PostTextConsumeQuota(c, info, usage, nil)
-		return nil
-	}
-
 	var requestBody io.Reader
 	if model_setting.GetGlobalSettings().PassThroughRequestEnabled || info.ChannelSetting.PassThroughBodyEnabled {
 		storage, err := common.GetBodyStorage(c)

--- a/relay/compatible_handler.go
+++ b/relay/compatible_handler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/logger"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
-	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting/model_setting"
@@ -71,26 +70,6 @@ func TextHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types
 	adaptor.Init(info)
 
 	passThroughGlobal := model_setting.GetGlobalSettings().PassThroughRequestEnabled
-	if info.RelayMode == relayconstant.RelayModeChatCompletions &&
-		!passThroughGlobal &&
-		!info.ChannelSetting.PassThroughBodyEnabled &&
-		service.ShouldChatCompletionsUseResponsesGlobal(info.ChannelId, info.ChannelType, info.OriginModelName) {
-		applySystemPromptIfNeeded(c, info, request)
-		usage, newApiErr := chatCompletionsViaResponses(c, info, adaptor, request)
-		if newApiErr != nil {
-			return newApiErr
-		}
-
-		var containAudioTokens = usage.CompletionTokenDetails.AudioTokens > 0 || usage.PromptTokensDetails.AudioTokens > 0
-		var containsAudioRatios = ratio_setting.ContainsAudioRatio(info.OriginModelName) || ratio_setting.ContainsAudioCompletionRatio(info.OriginModelName)
-
-		if containAudioTokens && containsAudioRatios {
-			service.PostAudioConsumeQuota(c, info, usage, "")
-		} else {
-			service.PostTextConsumeQuota(c, info, usage, nil)
-		}
-		return nil
-	}
 
 	var requestBody io.Reader
 

--- a/service/openaicompat/policy.go
+++ b/service/openaicompat/policy.go
@@ -3,10 +3,16 @@ package openaicompat
 import "github.com/QuantumNous/new-api/setting/model_setting"
 
 func ShouldChatCompletionsUseResponsesPolicy(policy model_setting.ChatCompletionsToResponsesPolicy, channelID int, channelType int, model string) bool {
-	if !policy.IsChannelEnabled(channelID, channelType) {
-		return false
-	}
-	return matchAnyRegex(policy.ModelPatterns, model)
+	_ = policy
+	_ = channelID
+	_ = channelType
+	_ = model
+
+	// Automatic Chat Completions -> Responses rerouting is intentionally disabled.
+	// Public API endpoints must preserve their original protocol semantics instead
+	// of silently switching to another upstream protocol and wrapping the result
+	// back into a different response shape.
+	return false
 }
 
 func ShouldChatCompletionsUseResponsesGlobal(channelID int, channelType int, model string) bool {

--- a/service/openaicompat/policy_test.go
+++ b/service/openaicompat/policy_test.go
@@ -1,0 +1,33 @@
+package openaicompat
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/setting/model_setting"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldChatCompletionsUseResponsesPolicyDisabled(t *testing.T) {
+	policy := model_setting.ChatCompletionsToResponsesPolicy{
+		Enabled:       true,
+		AllChannels:   true,
+		ModelPatterns: []string{"^gpt-5.*$"},
+	}
+
+	require.False(t, ShouldChatCompletionsUseResponsesPolicy(policy, 1, 1, "gpt-5"))
+}
+
+func TestShouldChatCompletionsUseResponsesGlobalDisabled(t *testing.T) {
+	original := model_setting.GetGlobalSettings().ChatCompletionsToResponsesPolicy
+	t.Cleanup(func() {
+		model_setting.GetGlobalSettings().ChatCompletionsToResponsesPolicy = original
+	})
+
+	model_setting.GetGlobalSettings().ChatCompletionsToResponsesPolicy = model_setting.ChatCompletionsToResponsesPolicy{
+		Enabled:       true,
+		AllChannels:   true,
+		ModelPatterns: []string{"^gpt-4o.*$"},
+	}
+
+	require.False(t, ShouldChatCompletionsUseResponsesGlobal(12, 34, "gpt-4o"))
+}

--- a/setting/model_setting/global.go
+++ b/setting/model_setting/global.go
@@ -33,8 +33,11 @@ func (p ChatCompletionsToResponsesPolicy) IsChannelEnabled(channelID int, channe
 }
 
 type GlobalSettings struct {
-	PassThroughRequestEnabled        bool                             `json:"pass_through_request_enabled"`
-	ThinkingModelBlacklist           []string                         `json:"thinking_model_blacklist"`
+	PassThroughRequestEnabled bool     `json:"pass_through_request_enabled"`
+	ThinkingModelBlacklist    []string `json:"thinking_model_blacklist"`
+	// Deprecated: the stored policy is kept for backward-compatible config
+	// loading only. Public chat/completions and Claude endpoints no longer use
+	// automatic Chat Completions -> Responses conversion at runtime.
 	ChatCompletionsToResponsesPolicy ChatCompletionsToResponsesPolicy `json:"chat_completions_to_responses_policy"`
 }
 

--- a/web/classic/src/pages/Setting/Model/SettingGlobalModel.jsx
+++ b/web/classic/src/pages/Setting/Model/SettingGlobalModel.jsx
@@ -25,8 +25,6 @@ import {
   Row,
   Spin,
   Banner,
-  Tag,
-  Divider,
 } from '@douyinfe/semi-ui';
 import {
   compareObjects,
@@ -40,28 +38,6 @@ import { useTranslation } from 'react-i18next';
 
 const thinkingExample = JSON.stringify(
   ['moonshotai/kimi-k2-thinking', 'kimi-k2-thinking'],
-  null,
-  2,
-);
-
-const chatCompletionsToResponsesPolicyExample = JSON.stringify(
-  {
-    enabled: true,
-    all_channels: false,
-    channel_ids: [1, 2],
-    channel_types: [1],
-    model_patterns: ['^gpt-4o.*$', '^gpt-5.*$'],
-  },
-  null,
-  2,
-);
-
-const chatCompletionsToResponsesPolicyAllChannelsExample = JSON.stringify(
-  {
-    enabled: true,
-    all_channels: true,
-    model_patterns: ['^gpt-4o.*$', '^gpt-5.*$'],
-  },
   null,
   2,
 );
@@ -246,10 +222,7 @@ export default function SettingGlobalModel(props) {
                     flexWrap: 'wrap',
                   }}
                 >
-                  {t('ChatCompletions→Responses 兼容配置')}
-                  <Tag color='orange' size='small'>
-                    测试版
-                  </Tag>
+                  {`${t('ChatCompletions→Responses 兼容配置')}（${t('已禁用')}）`}
                 </span>
               }
             >
@@ -257,9 +230,7 @@ export default function SettingGlobalModel(props) {
                 <Col span={24}>
                   <Banner
                     type='warning'
-                    description={t(
-                      '提示：该功能为测试版，未来配置结构与功能行为可能发生变更，请勿在生产环境使用。',
-                    )}
+                    description={`${t('已禁用')} · ${t('旧格式（JSON 对象）')}`}
                   />
                 </Col>
               </Row>
@@ -267,17 +238,9 @@ export default function SettingGlobalModel(props) {
               <Row style={{ marginTop: 10 }}>
                 <Col span={24}>
                   <Form.TextArea
-                    label={t('参数配置')}
+                    label={`${t('参数配置')}（${t('旧格式（JSON 对象）')}）`}
                     field={chatCompletionsToResponsesPolicyKey}
-                    placeholder={
-                      t('例如（指定渠道）：') +
-                      '\n' +
-                      chatCompletionsToResponsesPolicyExample +
-                      '\n\n' +
-                      t('例如（全渠道）：') +
-                      '\n' +
-                      chatCompletionsToResponsesPolicyAllChannelsExample
-                    }
+                    placeholder='{}'
                     rows={8}
                     rules={[
                       {
@@ -308,28 +271,6 @@ export default function SettingGlobalModel(props) {
                       alignItems: 'center',
                     }}
                   >
-                    <Button
-                      type='secondary'
-                      size='small'
-                      onClick={() =>
-                        setChatCompletionsToResponsesPolicyValue(
-                          chatCompletionsToResponsesPolicyExample,
-                        )
-                      }
-                    >
-                      {t('填充模板（指定渠道）')}
-                    </Button>
-                    <Button
-                      type='secondary'
-                      size='small'
-                      onClick={() =>
-                        setChatCompletionsToResponsesPolicyValue(
-                          chatCompletionsToResponsesPolicyAllChannelsExample,
-                        )
-                      }
-                    >
-                      {t('填充模板（全渠道）')}
-                    </Button>
                     <Button
                       type='secondary'
                       size='small'

--- a/web/default/src/features/system-settings/models/global-settings-card.tsx
+++ b/web/default/src/features/system-settings/models/global-settings-card.tsx
@@ -37,7 +37,6 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
-import { StatusBadge } from '@/components/status-badge'
 import {
   SettingsForm,
   SettingsSwitchContent,
@@ -49,27 +48,6 @@ import { useUpdateOption } from '../hooks/use-update-option'
 
 const thinkingBlacklistExample = JSON.stringify(
   ['moonshotai/kimi-k2-thinking', 'kimi-k2-thinking'],
-  null,
-  2
-)
-
-const chatToResponsesPolicyExample = JSON.stringify(
-  {
-    enabled: true,
-    all_channels: false,
-    channel_ids: [1, 2],
-    model_patterns: ['^gpt-4o.*$', '^gpt-5.*$'],
-  },
-  null,
-  2
-)
-
-const chatToResponsesPolicyAllChannelsExample = JSON.stringify(
-  {
-    enabled: true,
-    all_channels: true,
-    model_patterns: ['^gpt-4o.*$', '^gpt-5.*$'],
-  },
   null,
   2
 )
@@ -265,20 +243,15 @@ export function GlobalSettingsCard({ defaultValues }: GlobalSettingsCardProps) {
           <div className='space-y-4'>
             <div className='flex items-center gap-2'>
               <h3 className='text-base font-semibold'>
-                {t('ChatCompletions -> Responses Compatibility')}
+                {`${t('ChatCompletions -> Responses Compatibility')} (${t('Disabled')})`}
               </h3>
-              <StatusBadge
-                label={t('Preview')}
-                variant='neutral'
-                copyable={false}
-              />
             </div>
 
             <Alert>
-              <AlertTitle>{t('Warning')}</AlertTitle>
+              <AlertTitle>{t('Disabled')}</AlertTitle>
               <AlertDescription>
                 {t(
-                  'This feature is experimental. Configuration format and behavior may change.'
+                  'Automatic public-endpoint protocol conversion has been removed. This setting is kept only for backward-compatible storage and no longer affects public chat/completions or Claude endpoints.'
                 )}
               </AlertDescription>
             </Alert>
@@ -288,11 +261,13 @@ export function GlobalSettingsCard({ defaultValues }: GlobalSettingsCardProps) {
               name='global.chat_completions_to_responses_policy'
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>{t('Policy JSON')}</FormLabel>
+                  <FormLabel>
+                    {`${t('Policy JSON')} (${t('Legacy Format (JSON Object)')})`}
+                  </FormLabel>
                   <FormControl>
                     <Textarea
                       rows={8}
-                      placeholder={`${t('Example (specific channels):')}\n${chatToResponsesPolicyExample}\n\n${t('Example (all channels):')}\n${chatToResponsesPolicyAllChannelsExample}`}
+                      placeholder='{}'
                       {...field}
                       onChange={(event) => field.onChange(event.target.value)}
                     />
@@ -301,34 +276,6 @@ export function GlobalSettingsCard({ defaultValues }: GlobalSettingsCardProps) {
                     {t('Empty value will be saved as {}.')}
                   </FormDescription>
                   <div className='flex flex-wrap gap-2'>
-                    <Button
-                      type='button'
-                      variant='outline'
-                      size='sm'
-                      onClick={() =>
-                        form.setValue(
-                          'global.chat_completions_to_responses_policy',
-                          chatToResponsesPolicyExample,
-                          { shouldDirty: true }
-                        )
-                      }
-                    >
-                      {t('Fill example (specific channels)')}
-                    </Button>
-                    <Button
-                      type='button'
-                      variant='outline'
-                      size='sm'
-                      onClick={() =>
-                        form.setValue(
-                          'global.chat_completions_to_responses_policy',
-                          chatToResponsesPolicyAllChannelsExample,
-                          { shouldDirty: true }
-                        )
-                      }
-                    >
-                      {t('Fill example (all channels)')}
-                    </Button>
                     <Button
                       type='button'
                       variant='outline'

--- a/web/default/src/i18n/locales/en.json
+++ b/web/default/src/i18n/locales/en.json
@@ -676,6 +676,7 @@
     "Chat preset not found": "Chat preset not found",
     "Chat Presets": "Chat Presets",
     "Chat session management": "Chat session management",
+    "Automatic public-endpoint protocol conversion has been removed. This setting is kept only for backward-compatible storage and no longer affects public chat/completions or Claude endpoints.": "Automatic public-endpoint protocol conversion has been removed. This setting is kept only for backward-compatible storage and no longer affects public chat/completions or Claude endpoints.",
     "ChatCompletions -> Responses Compatibility": "ChatCompletions -> Responses Compatibility",
     "Check for updates": "Check for updates",
     "Check in daily to receive random quota rewards": "Check in daily to receive random quota rewards",

--- a/web/default/src/i18n/locales/fr.json
+++ b/web/default/src/i18n/locales/fr.json
@@ -676,6 +676,7 @@
     "Chat preset not found": "Préréglage de chat introuvable",
     "Chat Presets": "Préréglages de chat",
     "Chat session management": "Gestion des sessions de chat",
+    "Automatic public-endpoint protocol conversion has been removed. This setting is kept only for backward-compatible storage and no longer affects public chat/completions or Claude endpoints.": "La conversion automatique du protocole des points de terminaison publics a été supprimée. Ce réglage est conservé uniquement pour la compatibilité avec l'ancien stockage de configuration et n'affecte plus les points de terminaison publics chat/completions ou Claude.",
     "ChatCompletions -> Responses Compatibility": "Compatibilité ChatCompletions -> Réponses",
     "Check for updates": "Vérifier les mises à jour",
     "Check in daily to receive random quota rewards": "Connectez-vous quotidiennement pour recevoir des récompenses de quota aléatoires",

--- a/web/default/src/i18n/locales/ja.json
+++ b/web/default/src/i18n/locales/ja.json
@@ -676,6 +676,7 @@
     "Chat preset not found": "チャットプリセットが見つかりません",
     "Chat Presets": "チャットプリセット",
     "Chat session management": "チャットセッション管理",
+    "Automatic public-endpoint protocol conversion has been removed. This setting is kept only for backward-compatible storage and no longer affects public chat/completions or Claude endpoints.": "公開エンドポイントの自動プロトコル変換は削除されました。この設定は後方互換のための設定保存だけに残されており、公開の chat/completions または Claude エンドポイントにはもう影響しません。",
     "ChatCompletions -> Responses Compatibility": "ChatCompletions → レスポンス互換",
     "Check for updates": "更新を確認",
     "Check in daily to receive random quota rewards": "毎日チェックインして、ランダムなノルマ報酬を受け取りましょう",

--- a/web/default/src/i18n/locales/ru.json
+++ b/web/default/src/i18n/locales/ru.json
@@ -676,6 +676,7 @@
     "Chat preset not found": "Предустановка чата не найдена",
     "Chat Presets": "Предустановки чата",
     "Chat session management": "Управление сессиями чата",
+    "Automatic public-endpoint protocol conversion has been removed. This setting is kept only for backward-compatible storage and no longer affects public chat/completions or Claude endpoints.": "Автоматическое преобразование протокола публичных эндпоинтов удалено. Эта настройка сохранена только для обратной совместимости хранения конфигурации и больше не влияет на публичные эндпоинты chat/completions или Claude.",
     "ChatCompletions -> Responses Compatibility": "Совместимость ChatCompletions → Ответы",
     "Check for updates": "Проверить обновления",
     "Check in daily to receive random quota rewards": "Регистрируйтесь ежедневно, чтобы получать случайные вознаграждения по квоте",

--- a/web/default/src/i18n/locales/vi.json
+++ b/web/default/src/i18n/locales/vi.json
@@ -676,6 +676,7 @@
     "Chat preset not found": "Thiết lập sẵn trò chuyện không tìm thấy",
     "Chat Presets": "Cài đặt sẵn trò chuyện",
     "Chat session management": "Quản lý phiên trò chuyện",
+    "Automatic public-endpoint protocol conversion has been removed. This setting is kept only for backward-compatible storage and no longer affects public chat/completions or Claude endpoints.": "Cơ chế chuyển đổi giao thức tự động cho endpoint công khai đã bị loại bỏ. Thiết lập này chỉ được giữ lại để tương thích lưu trữ cấu hình cũ và không còn ảnh hưởng tới các endpoint công khai chat/completions hoặc Claude.",
     "ChatCompletions -> Responses Compatibility": "Tương thích ChatCompletions -> Phản hồi",
     "Check for updates": "Kiểm tra cập nhật",
     "Check in daily to receive random quota rewards": "Nhận phòng hàng ngày để nhận phần thưởng theo hạn ngạch ngẫu nhiên",

--- a/web/default/src/i18n/locales/zh.json
+++ b/web/default/src/i18n/locales/zh.json
@@ -676,6 +676,7 @@
     "Chat preset not found": "未找到聊天预设",
     "Chat Presets": "聊天预设",
     "Chat session management": "聊天会话管理",
+    "Automatic public-endpoint protocol conversion has been removed. This setting is kept only for backward-compatible storage and no longer affects public chat/completions or Claude endpoints.": "公开端点的自动协议转换已移除。此设置仅为兼容历史配置存储而保留，不再影响公开的 chat/completions 或 Claude 端点。",
     "ChatCompletions -> Responses Compatibility": "ChatCompletions → 响应兼容",
     "Check for updates": "检查更新",
     "Check in daily to receive random quota rewards": "每日签到可获得随机额度奖励",


### PR DESCRIPTION
## Summary

This PR removes the public Chat/Claude endpoint auto-conversion path that silently rewrote chat-completions requests into Responses requests and then wrapped the Responses stream back into Chat Completions chunks.

The public endpoint should preserve its protocol semantics:

- `/v1/chat/completions` and Claude-compatible public entries should stay on their native relay path.
- `/v1/responses` should stay on the native Responses relay path.
- Hidden `chat -> responses -> chat` conversion should not alter the stream protocol visible to clients.

## Root Cause

The issue was not the native `/v1/responses` route. The native Responses route emits Responses stream events correctly.

The problematic chain was:

1. public `/v1/chat/completions` or Claude-compatible entry
2. `global.chat_completions_to_responses_policy` matched
3. request was internally rewritten to `/v1/responses`
4. upstream Responses stream was wrapped back with Chat Completions stream helpers
5. clients expecting Responses semantics could observe `chat.completion.chunk` objects from the hidden compatibility layer

That means the public API endpoint semantics could be pierced by a hidden compatibility setting.

## What Changed

- Removed runtime public-entry calls to `chatCompletionsViaResponses` from the OpenAI-compatible and Claude-compatible relay handlers.
- Kept a compatibility helper only as an explicitly disabled legacy path.
- Simplified the global model setting UI so this conversion is no longer configurable from the public settings page.
- Added regression tests around the disabled policy behavior and legacy helper response.

## Note for Maintainers

这确实是服务端逻辑错误，不是客户端“挑剔”。

`/v1/responses` 原生链路本身没错。

真正的问题就是公开 chat/Claude 入口被隐藏逻辑偷偷改成 responses，再包装回 chat，导致协议语义被打穿。

现在这条自动转换链已经从根上停掉了。

`hurry` 那个 `completion_tokens=0` / 空输出问题我没有碰，仍然应该单独分析。

## Validation

```bash
go test ./service/openaicompat ./relay
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Automatic chat/completions → responses protocol conversion is removed; public endpoints now reject conversion attempts with a 400 Bad Request. Conversion retained only for backward-compatible config storage.

* **Tests**
  * Added tests verifying the disabled conversion and policy behavior.

* **UI Updates**
  * Settings UI reflects the deprecated feature, simplified input, and a "Format JSON" helper.

* **Localization**
  * Added updated explanatory strings in multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->