### PR TITLE
fix(openai): trim SSE data prefix in stream chunks

### DIFF
--- a/relay/channel/openai/helper.go
+++ b/relay/channel/openai/helper.go
@@ -20,6 +20,7 @@ import (
 // 辅助函数
 func HandleStreamFormat(c *gin.Context, info *relaycommon.RelayInfo, data string, forceFormat bool, thinkToContent bool) error {
 	info.SendResponseCount++
+	data = trimStreamDataPrefix(data)
 
 	switch info.RelayFormat {
 	case types.RelayFormatOpenAI:
@@ -30,6 +31,14 @@ func HandleStreamFormat(c *gin.Context, info *relaycommon.RelayInfo, data string
 		return handleGeminiFormat(c, data, info)
 	}
 	return nil
+}
+
+func trimStreamDataPrefix(data string) string {
+	data = strings.TrimSpace(data)
+	for strings.HasPrefix(data, "data:") {
+		data = strings.TrimSpace(strings.TrimPrefix(data, "data:"))
+	}
+	return data
 }
 
 func handleClaudeFormat(c *gin.Context, data string, info *relaycommon.RelayInfo) error {
@@ -92,6 +101,7 @@ func ProcessStreamResponse(streamResponse dto.ChatCompletionsStreamResponse, res
 }
 
 func processTokenData(relayMode int, data string, responseTextBuilder *strings.Builder, toolCount *int) error {
+	data = trimStreamDataPrefix(data)
 	switch relayMode {
 	case relayconstant.RelayModeChatCompletions:
 		var streamResponse dto.ChatCompletionsStreamResponse
@@ -120,6 +130,7 @@ func handleLastResponse(lastStreamData string, responseId *string, createAt *int
 	containStreamUsage *bool, info *relaycommon.RelayInfo,
 	shouldSendLastResp *bool) error {
 
+	lastStreamData = trimStreamDataPrefix(lastStreamData)
 	var lastStreamResponse dto.ChatCompletionsStreamResponse
 	if err := common.Unmarshal(common.StringToByteSlice(lastStreamData), &lastStreamResponse); err != nil {
 		return err
@@ -147,6 +158,7 @@ func HandleFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, lastStream
 	responseId string, createAt int64, model string, systemFingerprint string,
 	usage *dto.Usage, containStreamUsage bool) {
 
+	lastStreamData = trimStreamDataPrefix(lastStreamData)
 	switch info.RelayFormat {
 	case types.RelayFormatOpenAI:
 		if info.ShouldIncludeUsage && !containStreamUsage {

--- a/relay/channel/openai/helper_test.go
+++ b/relay/channel/openai/helper_test.go
@@ -1,0 +1,60 @@
+package openai
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessTokenDataStripsDataPrefix(t *testing.T) {
+	var responseTextBuilder strings.Builder
+	var toolCount int
+
+	err := processTokenData(
+		relayconstant.RelayModeChatCompletions,
+		`data: {"id":"chatcmpl-test","choices":[{"delta":{"content":"hello"}}]}`,
+		&responseTextBuilder,
+		&toolCount,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "hello", responseTextBuilder.String())
+	require.Equal(t, 0, toolCount)
+}
+
+func TestHandleLastResponseStripsDataPrefix(t *testing.T) {
+	var responseId string
+	var created int64
+	var systemFingerprint string
+	var model string
+	var usage = &dto.Usage{}
+	var containStreamUsage bool
+	var shouldSendLastResp = true
+
+	err := handleLastResponse(
+		`data: {"id":"chatcmpl-test","created":123,"model":"gpt-test","system_fingerprint":"fp-test","choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7}}`,
+		&responseId,
+		&created,
+		&systemFingerprint,
+		&model,
+		&usage,
+		&containStreamUsage,
+		&relaycommon.RelayInfo{ShouldIncludeUsage: true},
+		&shouldSendLastResp,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "chatcmpl-test", responseId)
+	require.Equal(t, int64(123), created)
+	require.Equal(t, "fp-test", systemFingerprint)
+	require.Equal(t, "gpt-test", model)
+	require.True(t, containStreamUsage)
+	require.Equal(t, 3, usage.PromptTokens)
+	require.Equal(t, 4, usage.CompletionTokens)
+	require.Equal(t, 7, usage.TotalTokens)
+	require.True(t, shouldSendLastResp)
+}

--- a/relay/channel/openai/relay-openai.go
+++ b/relay/channel/openai/relay-openai.go
@@ -23,6 +23,7 @@ import (
 )
 
 func sendStreamData(c *gin.Context, info *relaycommon.RelayInfo, data string, forceFormat bool, thinkToContent bool) error {
+	data = trimStreamDataPrefix(data)
 	if data == "" {
 		return nil
 	}
@@ -126,6 +127,7 @@ func OaiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Re
 	isAudioModel := strings.Contains(strings.ToLower(model), "audio")
 
 	helper.StreamScannerHandler(c, resp, info, func(data string, sr *helper.StreamResult) {
+		data = trimStreamDataPrefix(data)
 		if lastStreamData != "" {
 			if err := HandleStreamFormat(c, info, lastStreamData, info.ChannelSetting.ForceFormat, info.ChannelSetting.ThinkingToContent); err != nil {
 				common.SysLog("error handling stream format: " + err.Error())


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - This summary was written and reviewed manually, not pasted as raw AI output.

## 📝 变更描述 / Description
Some upstream streaming chunks can reach the OpenAI relay with a remaining `data:` prefix. The relay then tries to parse that string as JSON, which produces `invalid character 'd' looking for beginning of value` while processing token text or the final usage-bearing chunk.

This trims leading SSE `data:` prefixes in the OpenAI stream path before parsing, forwarding, and final-response handling. The change keeps the existing stream response flow intact and adds focused regression coverage for prefixed token data and prefixed final stream data.

Note: I used Codex while preparing this change, then reviewed the final diff and ran the checks below locally.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Refs #5367

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
Passed:
- `go test ./relay/channel/openai -run 'Test(ProcessTokenData|HandleLastResponse)StripsDataPrefix'`
- `go test ./relay/channel/openai`

Additional check:
- `go test ./relay/channel/...` currently fails in unrelated `relay/channel/claude` file-content tests: `TestRequestOpenAI2ClaudeMessage_IgnoresUnsupportedFileContent`, `TestRequestOpenAI2ClaudeMessage_SupportsPDFFileContent`, and `TestRequestOpenAI2ClaudeMessage_ConvertsTextFileContentToText`. The OpenAI package passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of streaming response processing by enhancing payload normalization.

* **Tests**
  * Added test coverage for streaming payload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->