### PR TITLE
fix: preserve ali video zero-value parameters

### DIFF
--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -48,11 +48,11 @@ type AliVideoInput struct {
 type AliVideoParameters struct {
 	Resolution   string `json:"resolution,omitempty"`    // 分辨率: 480P/720P/1080P（图生视频、首尾帧生视频）
 	Size         string `json:"size,omitempty"`          // 尺寸: 如 "832*480"（文生视频）
-	Duration     int    `json:"duration,omitempty"`      // 时长: 3-10秒
-	PromptExtend bool   `json:"prompt_extend,omitempty"` // 是否开启prompt智能改写
-	Watermark    bool   `json:"watermark,omitempty"`     // 是否添加水印
+	Duration     *int   `json:"duration,omitempty"`      // 时长: 3-10秒
+	PromptExtend *bool  `json:"prompt_extend,omitempty"` // 是否开启prompt智能改写
+	Watermark    *bool  `json:"watermark,omitempty"`     // 是否添加水印
 	Audio        *bool  `json:"audio,omitempty"`         // 是否添加音频（wan2.5）
-	Seed         int    `json:"seed,omitempty"`          // 随机数种子
+	Seed         *int   `json:"seed,omitempty"`          // 随机数种子
 }
 
 // AliVideoResponse 阿里通义万相响应
@@ -264,8 +264,7 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 			ImgURL: req.InputReference,
 		},
 		Parameters: &AliVideoParameters{
-			PromptExtend: true, // 默认开启智能改写
-			Watermark:    false,
+			PromptExtend: lo.ToPtr(true), // 默认开启智能改写
 		},
 	}
 
@@ -312,16 +311,16 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 
 	// 处理时长
 	if req.Duration > 0 {
-		aliReq.Parameters.Duration = req.Duration
+		aliReq.Parameters.Duration = lo.ToPtr(req.Duration)
 	} else if req.Seconds != "" {
 		seconds, err := strconv.Atoi(req.Seconds)
 		if err != nil {
 			return nil, errors.Wrap(err, "convert seconds to int failed")
 		} else {
-			aliReq.Parameters.Duration = seconds
+			aliReq.Parameters.Duration = lo.ToPtr(seconds)
 		}
 	} else {
-		aliReq.Parameters.Duration = 5 // 默认5秒
+		aliReq.Parameters.Duration = lo.ToPtr(5) // 默认5秒
 	}
 
 	// 从 metadata 中提取额外参数
@@ -357,7 +356,7 @@ func (a *TaskAdaptor) EstimateBilling(c *gin.Context, info *relaycommon.RelayInf
 	}
 
 	otherRatios := map[string]float64{
-		"seconds": float64(aliReq.Parameters.Duration),
+		"seconds": float64(lo.FromPtrOr(aliReq.Parameters.Duration, 0)),
 	}
 	ratios, err := ProcessAliOtherRatios(aliReq)
 	if err != nil {

--- a/relay/channel/task/ali/adaptor_test.go
+++ b/relay/channel/task/ali/adaptor_test.go
@@ -1,0 +1,90 @@
+package ali
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertToAliRequestPreservesExplicitZeroValueParameters(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "wan2.5-t2v-preview",
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "wan2.5-t2v-preview",
+			IsModelMapped:     true,
+		},
+	}
+	req := relaycommon.TaskSubmitReq{
+		Prompt: "a quiet mountain lake",
+		Model:  "wan2.5-t2v-preview",
+		Size:   "1920*1080",
+		Metadata: map[string]interface{}{
+			"parameters": map[string]interface{}{
+				"duration":      0,
+				"prompt_extend": false,
+				"watermark":     false,
+				"seed":          0,
+			},
+		},
+	}
+
+	aliReq, err := adaptor.convertToAliRequest(info, req)
+	require.NoError(t, err)
+
+	require.NotNil(t, aliReq.Parameters.Duration)
+	require.Equal(t, 0, *aliReq.Parameters.Duration)
+	require.NotNil(t, aliReq.Parameters.PromptExtend)
+	require.False(t, *aliReq.Parameters.PromptExtend)
+	require.NotNil(t, aliReq.Parameters.Watermark)
+	require.False(t, *aliReq.Parameters.Watermark)
+	require.NotNil(t, aliReq.Parameters.Seed)
+	require.Equal(t, 0, *aliReq.Parameters.Seed)
+
+	encoded, err := common.Marshal(aliReq)
+	require.NoError(t, err)
+
+	require.True(t, gjson.GetBytes(encoded, "parameters.duration").Exists())
+	require.EqualValues(t, 0, gjson.GetBytes(encoded, "parameters.duration").Int())
+	require.True(t, gjson.GetBytes(encoded, "parameters.prompt_extend").Exists())
+	require.False(t, gjson.GetBytes(encoded, "parameters.prompt_extend").Bool())
+	require.True(t, gjson.GetBytes(encoded, "parameters.watermark").Exists())
+	require.False(t, gjson.GetBytes(encoded, "parameters.watermark").Bool())
+	require.True(t, gjson.GetBytes(encoded, "parameters.seed").Exists())
+	require.EqualValues(t, 0, gjson.GetBytes(encoded, "parameters.seed").Int())
+}
+
+func TestConvertToAliRequestKeepsDefaultPromptExtendAndDuration(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "wan2.5-t2v-preview",
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "wan2.5-t2v-preview",
+			IsModelMapped:     true,
+		},
+	}
+	req := relaycommon.TaskSubmitReq{
+		Prompt: "a quiet mountain lake",
+		Model:  "wan2.5-t2v-preview",
+		Size:   "1920*1080",
+	}
+
+	aliReq, err := adaptor.convertToAliRequest(info, req)
+	require.NoError(t, err)
+
+	require.NotNil(t, aliReq.Parameters.Duration)
+	require.Equal(t, 5, *aliReq.Parameters.Duration)
+	require.NotNil(t, aliReq.Parameters.PromptExtend)
+	require.True(t, *aliReq.Parameters.PromptExtend)
+
+	encoded, err := common.Marshal(aliReq)
+	require.NoError(t, err)
+
+	require.EqualValues(t, 5, gjson.GetBytes(encoded, "parameters.duration").Int())
+	require.True(t, gjson.GetBytes(encoded, "parameters.prompt_extend").Bool())
+	require.False(t, gjson.GetBytes(encoded, "parameters.watermark").Exists())
+	require.False(t, gjson.GetBytes(encoded, "parameters.seed").Exists())
+}


### PR DESCRIPTION
## Summary
- Preserve explicit zero/false Ali video task parameters when forwarding requests upstream
- Keep default prompt_extend and duration behavior unchanged
- Add regression coverage for duration=0, prompt_extend=false, watermark=false, and seed=0

## Tests
- go test ./relay/channel/task/ali
- go test ./relay/channel/task/...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of optional parameters for video generation tasks to correctly preserve explicitly set values
  * Fixed default values for duration and related parameters when not explicitly provided
  * Enhanced accuracy in billing calculations for variable parameters

* **Tests**
  * Added test coverage for optional parameter handling behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->