### PR TITLE
fix: stream audio transcription responses

### DIFF
--- a/dto/audio.go
+++ b/dto/audio.go
@@ -17,6 +17,7 @@ type AudioRequest struct {
 	ResponseFormat string          `json:"response_format,omitempty"`
 	Speed          *float64        `json:"speed,omitempty"`
 	StreamFormat   string          `json:"stream_format,omitempty"`
+	Stream         *BoolValue      `json:"stream,omitempty"`
 	Metadata       json.RawMessage `json:"metadata,omitempty"`
 	// vllm-omini
 	TaskType                json.RawMessage `json:"task_type,omitempty"`
@@ -27,7 +28,6 @@ type AudioRequest struct {
 	MaxNewTokens            json.RawMessage `json:"max_new_tokens,omitempty"`
 	InitialCodecChunkFrames json.RawMessage `json:"initial_codec_chunk_frames,omitempty"`
 	// TODO：ensure that the logic remains correct after the stream is started.
-	//Stream                  json.RawMessage `json:"stream,omitempty"`
 }
 
 func (r *AudioRequest) GetTokenCountMeta() *types.TokenCountMeta {
@@ -42,7 +42,17 @@ func (r *AudioRequest) GetTokenCountMeta() *types.TokenCountMeta {
 }
 
 func (r *AudioRequest) IsStream(c *gin.Context) bool {
-	return r.StreamFormat == "sse"
+	if r.StreamFormat == "sse" {
+		return true
+	}
+	if r.Stream == nil || c == nil || c.Request == nil || c.Request.URL == nil {
+		return false
+	}
+	path := c.Request.URL.Path
+	if !strings.HasSuffix(path, "/audio/transcriptions") && !strings.HasSuffix(path, "/audio/translations") {
+		return false
+	}
+	return bool(*r.Stream)
 }
 
 func (r *AudioRequest) SetModelName(modelName string) {

--- a/dto/audio_test.go
+++ b/dto/audio_test.go
@@ -1,0 +1,72 @@
+package dto
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAudioRequestIsStream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name     string
+		path     string
+		raw      string
+		expected bool
+	}{
+		{
+			name:     "transcription parsed multipart stream true",
+			path:     "/v1/audio/transcriptions",
+			raw:      `{"stream":"true"}`,
+			expected: true,
+		},
+		{
+			name:     "translation json stream true",
+			path:     "/v1/audio/translations",
+			raw:      `{"stream":true}`,
+			expected: true,
+		},
+		{
+			name:     "transcription stream false",
+			path:     "/v1/audio/transcriptions",
+			raw:      `{"stream":"false"}`,
+			expected: false,
+		},
+		{
+			name:     "transcription stream missing",
+			path:     "/v1/audio/transcriptions",
+			raw:      `{}`,
+			expected: false,
+		},
+		{
+			name:     "speech stream true does not trigger stt stream",
+			path:     "/v1/audio/speech",
+			raw:      `{"stream":"true"}`,
+			expected: false,
+		},
+		{
+			name:     "stream format sse keeps existing behavior",
+			path:     "/v1/audio/speech",
+			raw:      `{"stream_format":"sse"}`,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &AudioRequest{}
+			require.NoError(t, common.Unmarshal([]byte(tt.raw), req))
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, tt.path, nil)
+
+			require.Equal(t, tt.expected, req.IsStream(c))
+		})
+	}
+}

--- a/relay/channel/openai/audio.go
+++ b/relay/channel/openai/audio.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"strings"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
@@ -115,6 +116,21 @@ func OpenaiTTSHandler(c *gin.Context, resp *http.Response, info *relaycommon.Rel
 }
 
 func OpenaiSTTHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo, responseFormat string) (*types.NewAPIError, *dto.Usage) {
+	if shouldStreamSTTResponse(resp, info) {
+		usage := fallbackSTTUsage(info)
+		helper.StreamScannerHandler(c, resp, info, func(data string, sr *helper.StreamResult) {
+			if service.SundaySearch(data, "usage") {
+				if parsedUsage := parseSTTUsage([]byte(data)); parsedUsage != nil {
+					usage = parsedUsage
+				}
+			}
+			if err := helper.StringData(c, data); err != nil {
+				sr.Error(err)
+			}
+		})
+		return nil, usage
+	}
+
 	defer service.CloseResponseBodyGracefully(resp)
 
 	responseBody, err := io.ReadAll(resp.Body)
@@ -124,6 +140,22 @@ func OpenaiSTTHandler(c *gin.Context, resp *http.Response, info *relaycommon.Rel
 	// 写入新的 response body
 	service.IOCopyBytesGracefully(c, resp, responseBody)
 
+	if usage := parseSTTUsage(responseBody); usage != nil {
+		return nil, usage
+	}
+
+	return nil, fallbackSTTUsage(info)
+}
+
+func shouldStreamSTTResponse(resp *http.Response, info *relaycommon.RelayInfo) bool {
+	if resp == nil || info == nil || !info.IsStream {
+		return false
+	}
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+	return strings.HasPrefix(contentType, "text/event-stream")
+}
+
+func parseSTTUsage(responseBody []byte) *dto.Usage {
 	var responseData struct {
 		Usage *dto.Usage `json:"usage"`
 	}
@@ -136,13 +168,18 @@ func OpenaiSTTHandler(c *gin.Context, resp *http.Response, info *relaycommon.Rel
 			if usage.CompletionTokens == 0 {
 				usage.CompletionTokens = usage.OutputTokens
 			}
-			return nil, usage
+			return usage
 		}
 	}
+	return nil
+}
 
+func fallbackSTTUsage(info *relaycommon.RelayInfo) *dto.Usage {
 	usage := &dto.Usage{}
-	usage.PromptTokens = info.GetEstimatePromptTokens()
+	if info != nil {
+		usage.PromptTokens = info.GetEstimatePromptTokens()
+	}
 	usage.CompletionTokens = 0
 	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
-	return nil, usage
+	return usage
 }

--- a/relay/channel/openai/audio_test.go
+++ b/relay/channel/openai/audio_test.go
@@ -1,0 +1,94 @@
+package openai
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenaiSTTHandlerStreamsEventStreamResponse(t *testing.T) {
+	c, recorder := newAudioTestContext(t)
+	info := &relaycommon.RelayInfo{IsStream: true}
+	info.SetEstimatePromptTokens(7)
+	resp := newAudioTestResponse("text/event-stream", ""+
+		"data: {\"text\":\"hello\"}\n\n"+
+		"data: [DONE]\n\n")
+
+	err, usage := OpenaiSTTHandler(c, resp, info, "json")
+
+	require.Nil(t, err)
+	require.Equal(t, 7, usage.PromptTokens)
+	require.Equal(t, 7, usage.TotalTokens)
+	require.True(t, recorder.Flushed)
+	require.Equal(t, "text/event-stream", recorder.Header().Get("Content-Type"))
+	require.Contains(t, recorder.Body.String(), "data: {\"text\":\"hello\"}\n\n")
+}
+
+func TestOpenaiSTTHandlerKeepsNonStreamJSONBehavior(t *testing.T) {
+	c, recorder := newAudioTestContext(t)
+	info := &relaycommon.RelayInfo{IsStream: true}
+	info.SetEstimatePromptTokens(7)
+	respBody := `{"text":"ok","usage":{"total_tokens":12,"input_tokens":5,"output_tokens":7}}`
+	resp := newAudioTestResponse("application/json", respBody)
+
+	err, usage := OpenaiSTTHandler(c, resp, info, "json")
+
+	require.Nil(t, err)
+	require.Equal(t, respBody, recorder.Body.String())
+	require.Equal(t, strconv.Itoa(len(respBody)), recorder.Header().Get("Content-Length"))
+	require.Equal(t, 5, usage.PromptTokens)
+	require.Equal(t, 7, usage.CompletionTokens)
+	require.Equal(t, 12, usage.TotalTokens)
+}
+
+func TestOpenaiSTTHandlerUsesStreamUsageChunk(t *testing.T) {
+	c, recorder := newAudioTestContext(t)
+	info := &relaycommon.RelayInfo{IsStream: true}
+	info.SetEstimatePromptTokens(7)
+	resp := newAudioTestResponse("text/event-stream; charset=utf-8", ""+
+		"data: {\"text\":\"hello\"}\n\n"+
+		"data: {\"usage\":{\"total_tokens\":9,\"input_tokens\":4,\"output_tokens\":5}}\n\n"+
+		"data: [DONE]\n\n")
+
+	err, usage := OpenaiSTTHandler(c, resp, info, "json")
+
+	require.Nil(t, err)
+	require.Equal(t, 4, usage.PromptTokens)
+	require.Equal(t, 5, usage.CompletionTokens)
+	require.Equal(t, 9, usage.TotalTokens)
+	require.True(t, recorder.Flushed)
+	require.Contains(t, recorder.Body.String(), "data: {\"usage\":{\"total_tokens\":9,\"input_tokens\":4,\"output_tokens\":5}}\n\n")
+}
+
+func newAudioTestContext(t *testing.T) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() {
+		constant.StreamingTimeout = oldTimeout
+	})
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", nil)
+	return c, recorder
+}
+
+func newAudioTestResponse(contentType string, body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{contentType},
+		},
+		Body: io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/relay/helper/valid_request.go
+++ b/relay/helper/valid_request.go
@@ -64,6 +64,7 @@ func GetAndValidAudioRequest(c *gin.Context, relayMode int) (*dto.AudioRequest, 
 		if audioRequest.Model == "" {
 			return nil, errors.New("model is required")
 		}
+		audioRequest.Stream = nil
 	default:
 		if audioRequest.Model == "" {
 			return nil, errors.New("model is required")


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
修复 `/v1/audio/transcriptions` 接口在 `stream=true` 时无法通过网关流式返回的问题。
OPENAI相关接口文档：https://developers.openai.com/api/docs/guides/speech-to-text#streaming-the-transcription-of-a-completed-audio-recording

修复前：客户端通过 multipart 表单传入 `stream=true` 时，网关没有把该请求识别为流式请求；同时 OpenAI 兼容的 STT 响应处理会固定读取完整上游响应体后再返回。因此即使上游 vLLM服务/v1/audio/transcriptions接口 已经按 SSE 流式输出，经过网关后客户端仍只能在请求结束后一次性收到结果。

修复后：音频转写/翻译请求会正确识别 `stream=true`，并在上游响应确认为 `text/event-stream` 时边读边转发给客户端。普通 JSON 响应仍保持原有读取和 usage 解析逻辑。

实现上，新增了音频请求对 `stream` 字段的解析，并将流式响应处理限制在 STT/translation 且上游确认为 SSE 的场景；这样既能恢复转写流式透传，也不会改变非流式接口的行为。


## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5378

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
本地验证通过：

```bash
GOPROXY=https://goproxy.cn,direct go test -timeout=120s ./dto -count=1
ok  	github.com/QuantumNous/new-api/dto	0.272s
GOPROXY=https://goproxy.cn,direct go test -timeout=120s ./relay/channel/openai -count=1
ok  	github.com/QuantumNous/new-api/relay/channel/openai	0.606s
实际基于此分支构建的线上版本验证
curl -N https://myhost/v1/audio/transcriptions \
  -H 'Authorization: Bearer myapi-key' \
  -F model=qwen3-asr-1.7b \
  -F file=@test-asr.wav \
  -F stream=true
