### PR TITLE
fix(keys): open chat preset links inside the click gesture

### DIFF
--- a/web/src/features/keys/components/__tests__/chat-export-popup.test.tsx
+++ b/web/src/features/keys/components/__tests__/chat-export-popup.test.tsx
@@ -1,0 +1,210 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { Row } from '@tanstack/react-table'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Toaster, toast } from 'sonner'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { api } from '@/lib/api'
+
+import type { ApiKey } from '../../types'
+import { ApiKeysProvider } from '../api-keys-provider'
+import { DataTableRowActions } from '../data-table-row-actions'
+
+type KeyResponse = {
+  success: boolean
+  data?: { key: string }
+  message?: string
+}
+
+const originalAdapter = api.defaults.adapter
+let queryClient: QueryClient
+
+beforeEach(() => {
+  localStorage.clear()
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+})
+
+afterEach(() => {
+  api.defaults.adapter = originalAdapter
+  queryClient.clear()
+  localStorage.clear()
+  toast.dismiss()
+  vi.unstubAllGlobals()
+})
+
+function renderActions(url = 'https://chat.example/import?key={key}') {
+  queryClient.setQueryData(['status'], {
+    chats: [{ 'Test chat': url }],
+    server_address: 'https://api.example',
+  })
+
+  let respond: (value: KeyResponse) => void
+  const response = new Promise<KeyResponse>((resolve) => {
+    respond = resolve
+  })
+  api.defaults.adapter = async (config) => {
+    expect(config.url).toBe('/api/token/7/key')
+    return {
+      data: await response,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+    }
+  }
+
+  const row = {
+    original: {
+      id: 7,
+      name: 'Export key',
+      key: 'masked-key',
+      status: 1,
+      remain_quota: 100,
+      used_quota: 0,
+      unlimited_quota: false,
+      expired_time: -1,
+      created_time: 0,
+      accessed_time: 0,
+      model_limits_enabled: false,
+    },
+  } as Row<ApiKey>
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ApiKeysProvider>
+          <DataTableRowActions row={row} />
+          <Toaster />
+        </ApiKeysProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+
+  return { respond: (value: KeyResponse) => respond(value) }
+}
+
+async function openPresetMenu(): Promise<HTMLElement> {
+  const user = userEvent.setup()
+  const exportButton = screen.queryByRole('button', {
+    name: 'Chat (Export to)',
+  })
+  if (exportButton) {
+    await user.click(exportButton)
+  } else {
+    await user.click(screen.getByRole('button', { name: 'Open menu' }))
+    await user.click(screen.getByRole('menuitem', { name: 'Chat' }))
+  }
+  return screen.findByRole('menuitem', { name: 'Test chat' })
+}
+
+describe('API key chat export popup', () => {
+  test('reserves the web tab during the click and navigates after the key resolves', async () => {
+    const request = renderActions()
+    const popup = {
+      opener: window as Window | null,
+      location: { href: '' },
+      close: vi.fn(),
+    }
+    const open = vi
+      .spyOn(window, 'open')
+      .mockReturnValue(popup as unknown as Window)
+    const preset = await openPresetMenu()
+
+    fireEvent.click(preset)
+
+    expect(open).toHaveBeenCalledWith('', '_blank')
+    expect(popup.location.href).toBe('')
+    await act(async () =>
+      request.respond({ success: true, data: { key: 'export-secret' } })
+    )
+    await waitFor(() =>
+      expect(popup.location.href).toBe(
+        'https://chat.example/import?key=sk-export-secret'
+      )
+    )
+    expect(popup.opener).toBeNull()
+    expect(popup.close).not.toHaveBeenCalled()
+  })
+
+  test('closes the reserved tab when the key request fails', async () => {
+    const request = renderActions()
+    const popup = { location: { href: '' }, close: vi.fn() }
+    vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window)
+    const preset = await openPresetMenu()
+
+    fireEvent.click(preset)
+    await act(async () =>
+      request.respond({ success: false, message: 'Key unavailable' })
+    )
+
+    await waitFor(() => expect(popup.close).toHaveBeenCalled())
+    expect(popup.location.href).toBe('')
+  })
+
+  test('reports a blocked popup while keeping the current page unchanged', async () => {
+    const request = renderActions()
+    vi.spyOn(window, 'open').mockReturnValue(null)
+    const currentUrl = window.location.href
+    const preset = await openPresetMenu()
+
+    fireEvent.click(preset)
+    await act(async () =>
+      request.respond({ success: true, data: { key: 'export-secret' } })
+    )
+
+    expect(
+      await screen.findByText(
+        'Popup blocked. Please allow popups for this site.'
+      )
+    ).toBeVisible()
+    expect(window.location.href).toBe(currentUrl)
+  })
+
+  test('launches a desktop protocol from the current page without creating a blank tab', async () => {
+    const request = renderActions('cherry-studio://import?key={key}')
+    const open = vi.spyOn(window, 'open').mockReturnValue(null)
+    const preset = await openPresetMenu()
+    const location = { href: '' }
+    vi.stubGlobal(
+      'window',
+      new Proxy(window, {
+        get: (target, property) =>
+          property === 'location'
+            ? location
+            : Reflect.get(target, property, target),
+      })
+    )
+
+    fireEvent.click(preset)
+    await act(async () =>
+      request.respond({ success: true, data: { key: 'export-secret' } })
+    )
+
+    await waitFor(() =>
+      expect(location.href).toBe('cherry-studio://import?key=sk-export-secret')
+    )
+    expect(open).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/features/keys/components/data-table-row-actions.tsx
+++ b/web/src/features/keys/components/data-table-row-actions.tsx
@@ -116,10 +116,9 @@ export function DataTableRowActions<TData>({
 
   const handleOpenChatPreset = useCallback(
     async (preset: ChatPreset) => {
-      const realKey = await resolveRealKey(apiKey.id)
-      if (!realKey) return
-
       if (preset.type === 'fluent') {
+        const realKey = await resolveRealKey(apiKey.id)
+        if (!realKey) return
         const success = sendToFluent(realKey, serverAddress)
         if (success) {
           toast.success(t('Sent the API key to FluentRead.'))
@@ -133,6 +132,21 @@ export function DataTableRowActions<TData>({
         return
       }
 
+      // Open the web tab synchronously inside the click gesture and redirect it
+      // after the key resolves. Awaiting the key before window.open detached it
+      // from the user gesture, so the popup blocker turned every chat link into
+      // a blank about:blank tab.
+      const pendingWindow =
+        preset.type === 'web' && typeof window !== 'undefined'
+          ? window.open('', '_blank')
+          : null
+
+      const realKey = await resolveRealKey(apiKey.id)
+      if (!realKey) {
+        pendingWindow?.close()
+        return
+      }
+
       const resolvedUrl = resolveChatUrl({
         template: preset.url,
         apiKey: realKey,
@@ -140,15 +154,29 @@ export function DataTableRowActions<TData>({
       })
 
       if (!resolvedUrl) {
+        pendingWindow?.close()
         toast.error(t('Invalid chat link. Please contact your administrator.'))
         return
       }
 
-      if (typeof window === 'undefined') return
+      if (typeof window === 'undefined') {
+        pendingWindow?.close()
+        return
+      }
 
-      try {
-        window.open(resolvedUrl, '_blank', 'noopener')
-      } catch {
+      if (preset.type === 'web') {
+        if (!pendingWindow) {
+          // The synchronous open was still blocked; don't navigate the current
+          // page away to the chat site, just surface it.
+          toast.error(t('Popup blocked. Please allow popups for this site.'))
+          return
+        }
+        // Web link: drop the opener for security, then navigate the tab.
+        pendingWindow.opener = null
+        pendingWindow.location.href = resolvedUrl
+      } else {
+        // Custom-protocol link: launch from the current page so no blank tab is
+        // left behind while the desktop app handler takes over.
         window.location.href = resolvedUrl
       }
     },


### PR DESCRIPTION
标题:fix(keys): 新版UI令牌聊天导出链接点击后跳转空白页

## 📝 变更描述 / Description

令牌列表里"聊天"导出的所有预设链接,点击后都只打开一个空白页(about:blank),无法真正跳到对应客户端。

原因:`DataTableRowActions` 的 `handleOpenChatPreset` 先 `await resolveRealKey()` 解析真实 Key,然后才 `window.open()`。`await` 之后已经脱离了用户点击手势的同步上下文,浏览器弹窗拦截会把这次 `window.open` 拦下,只留一个空白标签页——所以 web / 自定义协议预设一律打不开。

修复:
- web 链接:在点击的同步阶段先 `window.open('', '_blank')` 占住标签页,待 Key 解析完成再重定向到目标地址(解析失败则关闭该标签),绕开弹窗拦截;
- 自定义协议链接(cherrystudio:// 等):改用当前页 `window.location.href` 拉起桌面端,不再额外留下空白标签;
- fluent 预设逻辑不变。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] 人工确认：描述为人工整理撰写。
- [x] 非重复提交：已搜索现有 Issues / PRs。
- [x] Bug fix 说明：无。
- [x] 变更理解：已理解改动原理与影响。
- [x] 范围聚焦：仅改 `handleOpenChatPreset`,无无关改动。
- [x] 本地验证：已随同一份代码整体 Docker 构建并在自有环境运行验证。
- [x] 安全合规：无敏感凭据,符合规范。

## 📸 运行证明 / Proof of Work
- 修复前:直接打开了一个空白网站
- 修复后:web 预设在新标签正常打开目标聊天站;协议预设在当前页拉起本地 App,不再遗留空白标签。
<img width="1002" height="836" alt="image" src="https://github.com/user-attachments/assets/3bf8b1b8-c623-4de3-98f3-219b5a702b1b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Chat preset links now open more reliably in a new browser tab after API-key retrieval.
  - Desktop app links continue opening directly in the current page.
  - Users receive clearer feedback when pop-ups are blocked or link retrieval fails.

- **Bug Fixes**
  - Prevented failed or invalid chat links from leaving blank browser tabs open.
  - Improved navigation behavior for chat exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->