### PR TITLE
feat(keys): surface chat export and CC Switch as dedicated buttons

### DIFF
--- a/web/src/features/keys/components/__tests__/chat-export-actions.test.tsx
+++ b/web/src/features/keys/components/__tests__/chat-export-actions.test.tsx
@@ -1,0 +1,172 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { Row } from '@tanstack/react-table'
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { InternalAxiosRequestConfig } from 'axios'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { api } from '@/lib/api'
+
+import type { ApiKey } from '../../types'
+import { ApiKeysProvider, useApiKeys } from '../api-keys-provider'
+import { DataTableRowActions } from '../data-table-row-actions'
+import { CCSwitchDialog } from '../dialogs/cc-switch-dialog'
+
+const originalAdapter = api.defaults.adapter
+let queryClient: QueryClient
+
+beforeEach(() => {
+  localStorage.clear()
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+})
+
+afterEach(() => {
+  api.defaults.adapter = originalAdapter
+  queryClient.clear()
+  localStorage.clear()
+})
+
+function ExportDialog(): React.ReactNode {
+  const context = useApiKeys()
+  return (
+    <CCSwitchDialog
+      open={context.open === 'cc-switch'}
+      onOpenChange={(open) => !open && context.setOpen(null)}
+      tokenKey={context.resolvedKey}
+    />
+  )
+}
+
+function renderActions(
+  chats: Record<string, string>[] = [
+    { 'First chat': 'https://first.example/?key={key}' },
+    { 'Second chat': 'https://second.example/?key={key}' },
+  ]
+): void {
+  queryClient.setQueryData(['status'], {
+    chats,
+    server_address: 'https://api.example',
+  })
+  queryClient.setQueryData(['user-models-ccswitch'], {
+    success: true,
+    data: ['test-model'],
+  })
+  const row = {
+    original: {
+      id: 7,
+      name: 'Export key',
+      key: 'masked-key',
+      status: 1,
+      remain_quota: 100,
+      used_quota: 0,
+      unlimited_quota: false,
+      expired_time: -1,
+      created_time: 0,
+      accessed_time: 0,
+      model_limits_enabled: false,
+    },
+  } as Row<ApiKey>
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ApiKeysProvider>
+          <DataTableRowActions row={row} />
+          <ExportDialog />
+        </ApiKeysProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('API key export actions', () => {
+  test('shows both export buttons directly and keyboard activation opens choices without exporting to a default chat', async () => {
+    const user = userEvent.setup()
+    const request = vi.fn(async (config: InternalAxiosRequestConfig) => ({
+      data: { success: true, data: { key: 'export-secret' } },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+    }))
+    api.defaults.adapter = request
+    const open = vi.spyOn(window, 'open').mockReturnValue(null)
+    renderActions()
+    const chat = screen.getByRole('button', { name: 'Chat (Export to)' })
+
+    expect(chat).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Export to CCS' })).toBeVisible()
+    expect(chat).toHaveAttribute('aria-expanded', 'false')
+    act(() => chat.focus())
+    await user.keyboard('{Enter}')
+
+    expect(chat).toHaveAttribute('aria-expanded', 'true')
+    expect(
+      await screen.findByRole('menuitem', { name: 'First chat' })
+    ).toBeVisible()
+    expect(screen.getByRole('menuitem', { name: 'Second chat' })).toBeVisible()
+    expect(request).not.toHaveBeenCalled()
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  test('keeps CC Switch available when no chat presets are configured', () => {
+    renderActions([])
+
+    expect(
+      screen.queryByRole('button', { name: 'Chat (Export to)' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Export to CCS' })).toBeVisible()
+  })
+
+  test('opens the CC Switch import dialog after resolving the selected API key', async () => {
+    const user = userEvent.setup()
+    let respond: (value: { success: boolean; data: { key: string } }) => void
+    const response = new Promise<{ success: boolean; data: { key: string } }>(
+      (resolve) => {
+        respond = resolve
+      }
+    )
+    api.defaults.adapter = async (config) => {
+      expect(config.url).toBe('/api/token/7/key')
+      return {
+        data: await response,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+      }
+    }
+    renderActions()
+
+    await user.click(screen.getByRole('button', { name: 'Export to CCS' }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    await act(async () =>
+      respond({ success: true, data: { key: 'export-secret' } })
+    )
+
+    expect(
+      await screen.findByRole('dialog', { name: 'Import to CC Switch' })
+    ).toBeVisible()
+  })
+})

--- a/web/src/features/keys/components/data-table-row-actions.tsx
+++ b/web/src/features/keys/components/data-table-row-actions.tsx
@@ -23,7 +23,6 @@ import {
   Power,
   PowerOff,
   ExternalLink,
-  ArrowRightLeft,
   Copy,
   Link,
   Loader2,
@@ -35,12 +34,12 @@ import { toast } from 'sonner'
 import { DataTableRowActionMenu } from '@/components/data-table/core/row-action-menu'
 import { Button } from '@/components/ui/button'
 import {
+  DropdownMenu,
+  DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuShortcut,
+  DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import {
   Tooltip,
@@ -213,6 +212,46 @@ export function DataTableRowActions<TData>({
         <TooltipContent>{toggleLabel}</TooltipContent>
       </Tooltip>
 
+      {hasChatPresets && (
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger
+            render={<Button variant='outline' size='sm' className='h-8' />}
+          >
+            {t('Chat (Export to)')}
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align='end' className='w-[200px]'>
+            {chatPresets.map((preset) => (
+              <DropdownMenuItem
+                key={preset.id}
+                onClick={() => handleOpenChatPreset(preset)}
+              >
+                {preset.name}
+                {preset.type !== 'web' && (
+                  <DropdownMenuShortcut>
+                    <ExternalLink size={16} />
+                  </DropdownMenuShortcut>
+                )}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+
+      <Button
+        variant='outline'
+        size='sm'
+        className='h-8'
+        onClick={async () => {
+          const realKey = await resolveRealKey(apiKey.id)
+          if (!realKey) return
+          setResolvedKey(realKey)
+          setCurrentRow(apiKey)
+          setOpen('cc-switch')
+        }}
+      >
+        {t('Export to CCS')}
+      </Button>
+
       <Tooltip>
         <TooltipTrigger
           render={
@@ -268,41 +307,6 @@ export function DataTableRowActions<TData>({
             <Link size={16} />
           </DropdownMenuShortcut>
         </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          onClick={async () => {
-            const realKey = await resolveRealKey(apiKey.id)
-            if (!realKey) return
-            setResolvedKey(realKey)
-            setCurrentRow(apiKey)
-            setOpen('cc-switch')
-          }}
-        >
-          {t('CC Switch')}
-          <DropdownMenuShortcut>
-            <ArrowRightLeft size={16} />
-          </DropdownMenuShortcut>
-        </DropdownMenuItem>
-        {hasChatPresets && (
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>{t('Chat')}</DropdownMenuSubTrigger>
-            <DropdownMenuSubContent>
-              {chatPresets.map((preset) => (
-                <DropdownMenuItem
-                  key={preset.id}
-                  onClick={() => handleOpenChatPreset(preset)}
-                >
-                  {preset.name}
-                  {preset.type !== 'web' && (
-                    <DropdownMenuShortcut>
-                      <ExternalLink size={16} />
-                    </DropdownMenuShortcut>
-                  )}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-        )}
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onClick={() => {

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -725,6 +725,8 @@
     "Category name must be less than 50 characters": "分类名称不能超过 50 个字符",
     "Caution": "注意",
     "CC Switch": "CC Switch",
+    "Chat (Export to)": "聊天（导出到）",
+    "Export to CCS": "导出到 CCS",
     "Centered": "居中",
     "Chain": "链路",
     "Change": "更改",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -776,6 +776,8 @@
     "Category name must be less than 50 characters": "分类名称不能超过 50 个字符",
     "Caution": "注意",
     "CC Switch": "CC Switch",
+    "Chat (Export to)": "聊天（导出到）",
+    "Export to CCS": "导出到 CCS",
     "Centered": "居中",
     "Chain": "链路",
     "Change": "更改",


### PR DESCRIPTION

## 📝 变更描述 / Description
缘由：经常有用户询问怎么导出CCS，实际上newapi具备此功能，但实在太不直观，需要优化增强。

做法：把新UI的令牌行里两个常用的"导出/对接客户端"动作从行尾"…"溢出菜单里拿出来,把旧UI的聊天按钮和旁边的下拉框统一，做成更直观的独立按钮,并统一文案:
新旧UI都有的修改：1. "CC Switch" 是客户端产品名, 之前被译成"CC 切换";改为不翻译,保留原名。
2.“聊天”按钮不够准确，改为“聊天（导出到）”。
针对于新UI：
3. 聊天预设:从溢出菜单的子菜单挪出,改为独立的「聊天（导出到）」下拉(default 主题)。
4. CC Switch:从溢出菜单挪出,改为独立的「导出到CCS」按钮(点开同一个 CC Switch 配置弹窗)。
针对于旧UI：
5. classic 主题:原本是 SplitButton——主按钮默认直接触发第一个预设(通常是 Cherry Studio),这种行为不够可控。现合并为单个「聊天（导出到）」下拉,去掉"默认直接打开某客户端"的隐式行为,统一从下拉里选目标。


补齐对应 i18n(default `Chat (Export to)`、`Export to CCS`;classic 英文映射),并清理因移除菜单项而失用的图标 import。

## 🚀 变更类型 / Type of change
- [x] ⚡ 性能优化 / 重构 (Refactor)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] 人工确认：描述为人工整理撰写。
- [x] 非重复提交：已搜索现有 Issues / PRs。
- [x] 变更理解：已理解改动原理与影响。
- [x] 范围聚焦：仅涉及令牌行操作 UI 与对应文案,无无关改动。
- [x] 本地验证：已随同一份代码整体 Docker 构建(前端 Rsbuild 通过)并在自有环境运行验证。
- [x] 安全合规：无敏感凭据,符合规范。

## 📸 运行证明 / Proof of Work
- default:令牌行为 `[聊天（导出到）▾] [导出到CCS] [⋯]`;"…"菜单中不再有 Chat 子项与 CC Switch;CC Switch 显示为原名。
- classic:聊天按钮合并为单个「聊天（导出到）」下拉,点击不再默认打开 Cherry Studio。
<img width="964" height="881" alt="image" src="https://github.com/user-attachments/assets/69375f1e-5250-41d4-83a5-6a52b5f82d68" />
<img width="776" height="718" alt="image" src="https://github.com/user-attachments/assets/6adefdaf-afec-452a-9d21-3a8922a10e72" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dedicated “Chat (Export to)” and “Export to CCS” actions directly to API key rows.
  - “Export to CCS” remains available even when no chat presets are configured.
  - Exporting to CCS now opens the import dialog for the selected API key.
  - Chat export actions can be opened using keyboard controls.

- **Changes**
  - Simplified the row action menu to focus on copying key details and deleting keys.
  - Added Chinese translations for the new export actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->