### PR TITLE
fix: round channel response time to avoid float precision in display

### DIFF
--- a/web/default/src/features/channels/lib/channel-utils.ts
+++ b/web/default/src/features/channels/lib/channel-utils.ts
@@ -335,11 +335,11 @@ type TFunction = (key: string, options?: { value?: number | string }) => string
  */
 export function formatResponseTime(timeMs: number, t?: TFunction): string {
   if (timeMs === 0) return t ? t('Not tested') : 'Not tested'
-  if (timeMs < 1000)
-    return t ? t('{{value}}ms', { value: timeMs }) : `${timeMs}ms`
+  const ms = Math.round(timeMs)
+  if (ms < 1000) return t ? t('{{value}}ms', { value: ms }) : `${ms}ms`
   return t
-    ? t('{{value}}s', { value: (timeMs / 1000).toFixed(2) })
-    : `${(timeMs / 1000).toFixed(2)}s`
+    ? t('{{value}}s', { value: (ms / 1000).toFixed(2) })
+    : `${(ms / 1000).toFixed(2)}s`
 }
 
 /**


### PR DESCRIPTION
修复渠道列表, 响应耗时 显示精度的问题
毫秒和秒统一精度
修复前:
<img width="2084" height="1072" alt="image" src="https://github.com/user-attachments/assets/651eb12a-87e1-4d23-a338-83e09d651072" />

修复后:
<img width="1456" height="666" alt="image" src="https://github.com/user-attachments/assets/58fc30be-291f-4ad5-b486-b03cf0dcee3b" />
