### PR TITLE
feat: 持久化表格每页条数，跨导航/会话记忆 (#5377)

### DIFF
--- a/web/default/src/hooks/use-table-url-state.ts
+++ b/web/default/src/hooks/use-table-url-state.ts
@@ -25,6 +25,27 @@ import type {
 
 type SearchRecord = Record<string, unknown>
 
+// Page size persists globally under the classic theme's key (raw number
+// string), so the choice is remembered and carries over from classic.
+const PAGE_SIZE_STORAGE_KEY = 'page-size'
+
+function getStoredPageSize(): number | undefined {
+  try {
+    const n = parseInt(localStorage.getItem(PAGE_SIZE_STORAGE_KEY) ?? '', 10)
+    return n > 0 ? n : undefined // n > 0 also rejects NaN
+  } catch {
+    return undefined
+  }
+}
+
+function setStoredPageSize(size: number) {
+  try {
+    localStorage.setItem(PAGE_SIZE_STORAGE_KEY, String(size))
+  } catch {
+    /* ignore */
+  }
+}
+
 export type NavigateFn = (opts: {
   search:
     | true
@@ -139,7 +160,9 @@ export function useTableUrlState(
     const rawPageSize = (search as SearchRecord)[pageSizeKey]
     const pageNum = typeof rawPage === 'number' ? rawPage : defaultPage
     const pageSizeNum =
-      typeof rawPageSize === 'number' ? rawPageSize : defaultPageSize
+      typeof rawPageSize === 'number'
+        ? rawPageSize
+        : (getStoredPageSize() ?? defaultPageSize)
     return { pageIndex: Math.max(0, pageNum - 1), pageSize: pageSizeNum }
   }, [search, pageKey, pageSizeKey, defaultPage, defaultPageSize])
 
@@ -147,6 +170,7 @@ export function useTableUrlState(
     const next = typeof updater === 'function' ? updater(pagination) : updater
     const nextPage = next.pageIndex + 1
     const nextPageSize = next.pageSize
+    if (nextPageSize !== pagination.pageSize) setStoredPageSize(nextPageSize)
     navigate({
       search: (prev) => ({
         ...(prev as SearchRecord),


### PR DESCRIPTION
## 📝 变更描述 / Description

新版表格的「每页条数」只保存在 URL 查询参数里。从侧边栏重新进入、或刷新到不带参数的地址时，会回落到默认值（如日志页 100），用户选过的条数记不住（#5377）。

本 PR 在共享 hook `useTableUrlState` 中补上持久化：

- 条数变化时写入 `localStorage`，沿用 classic 主题的 `page-size` 键（纯数字字符串），老用户的偏好能跨主题带过来；
- 当 URL 未带 `pageSize` 时，以存储值作为默认（URL 带参数时仍优先，分享链接 / 深链不受影响）；
- 仅在条数真正变化时写入，普通翻页不触发多余写入。

改动集中在 `useTableUrlState` 一个文件，所有使用该 hook 的表格自动生效。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5377

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述由本人整理撰写。
- [x] **非重复提交:** 已确认无重复的 Issue / PR。
- [x] **变更理解:** 已理解改动原理与影响范围。
- [x] **范围聚焦:** 仅改动 `useTableUrlState`，无无关改动。
- [x] **本地验证:** `bun run typecheck`、`bun run lint` 均通过（仅余与本改动无关的既有告警）。
- [x] **安全合规:** 无敏感凭据，符合代码规范。

## 📸 运行证明 / Proof of Work

日志页将每页条数由 100 改为 10 → 切换菜单后返回 / 刷新页面，仍保持 10；`localStorage['page-size'] === '10'`。其余使用该 hook 的列表（用户、渠道、密钥等）共享同一记忆值。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table page size preferences are now automatically saved and restored. When you adjust the number of rows displayed in a table, your selection is remembered and automatically applied when you return to the page or refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->