### PR TITLE
feat(classic): add rankings page with model and vendor leaderboards

### DIFF
--- a/web/classic/src/App.jsx
+++ b/web/classic/src/App.jsx
@@ -53,6 +53,7 @@ import SetupCheck from './components/layout/SetupCheck';
 const Home = lazy(() => import('./pages/Home'));
 const Dashboard = lazy(() => import('./pages/Dashboard'));
 const About = lazy(() => import('./pages/About'));
+const Rankings = lazy(() => import('./pages/Rankings'));
 const UserAgreement = lazy(() => import('./pages/UserAgreement'));
 const PrivacyPolicy = lazy(() => import('./pages/PrivacyPolicy'));
 
@@ -85,6 +86,20 @@ function App() {
       }
     }
     return false; // 默认不需要登录
+  }, [statusState?.status?.HeaderNavModules]);
+
+  const rankingsRequireAuth = useMemo(() => {
+    const headerNavModulesConfig = statusState?.status?.HeaderNavModules;
+    if (headerNavModulesConfig) {
+      try {
+        const modules = JSON.parse(headerNavModulesConfig);
+        if (typeof modules.rankings === 'boolean') return false;
+        return modules.rankings?.requireAuth === true;
+      } catch {
+        return false;
+      }
+    }
+    return false;
   }, [statusState?.status?.HeaderNavModules]);
 
   return (
@@ -330,6 +345,22 @@ function App() {
             ) : (
               <Suspense fallback={<Loading></Loading>} key={location.pathname}>
                 <Pricing />
+              </Suspense>
+            )
+          }
+        />
+        <Route
+          path='/rankings'
+          element={
+            rankingsRequireAuth ? (
+              <PrivateRoute>
+                <Suspense fallback={<Loading></Loading>} key={location.pathname}>
+                  <Rankings />
+                </Suspense>
+              </PrivateRoute>
+            ) : (
+              <Suspense fallback={<Loading></Loading>} key={location.pathname}>
+                <Rankings />
               </Suspense>
             )
           }

--- a/web/classic/src/components/layout/PageLayout.jsx
+++ b/web/classic/src/components/layout/PageLayout.jsx
@@ -71,7 +71,7 @@ const PageLayout = () => {
 
   const isConsoleRoute = location.pathname.startsWith('/console');
   const showSider = isConsoleRoute && (!isMobile || drawerOpen);
-  const isFixedLayout = isConsoleRoute || location.pathname === '/pricing';
+  const isFixedLayout = isConsoleRoute || location.pathname === '/pricing' || location.pathname === '/rankings';
 
   useEffect(() => {
     if (isMobile && drawerOpen && collapsed) {

--- a/web/classic/src/components/rankings/GrowthText.jsx
+++ b/web/classic/src/components/rankings/GrowthText.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function GrowthText({ value, className = '' }) {
+  if (!Number.isFinite(value) || value === 0) {
+    return <span className={`font-mono text-xs ${className}`} style={{ color: 'var(--semi-color-text-2)' }}>0%</span>;
+  }
+  const isUp = value > 0;
+  const color = isUp ? 'var(--semi-color-success)' : 'var(--semi-color-danger)';
+  return (
+    <span className={`font-mono text-xs ${className}`} style={{ color }}>
+      {isUp ? '↑' : '↓'}
+      {Math.abs(value).toFixed(Math.abs(value) >= 100 ? 0 : 1)}%
+    </span>
+  );
+}

--- a/web/classic/src/components/rankings/MarketShareSection.jsx
+++ b/web/classic/src/components/rankings/MarketShareSection.jsx
@@ -1,0 +1,151 @@
+import React, { useMemo } from 'react';
+import { Card, Typography } from '@douyinfe/semi-ui';
+import { VChart } from '@visactor/react-vchart';
+import { PieChart } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { formatTokens, formatShare } from '../../helpers/rankings';
+
+const { Title, Text } = Typography;
+const CHART_CONFIG = { mode: 'desktop-browser' };
+
+const VENDOR_COLOURS = {
+  OpenAI: '#10a37f', Anthropic: '#d97757', Google: '#4285f4', DeepSeek: '#7c5cff',
+  Alibaba: '#ff9900', xAI: '#1f2937', Meta: '#1877f2', Moonshot: '#ec4899',
+  Zhipu: '#06b6d4', Mistral: '#ff7000', ByteDance: '#3b82f6', Tencent: '#22c55e',
+  MiniMax: '#a855f7', Cohere: '#fb923c', Baidu: '#ef4444', Others: '#94a3b8',
+};
+
+const FALLBACK_PALETTE = ['#0ea5e9','#22c55e','#a855f7','#f97316','#14b8a6','#eab308','#ec4899','#84cc16','#6366f1','#10b981','#f43f5e','#0891b2','#94a3b8'];
+
+function buildColourMap(names) {
+  const result = {};
+  let fi = 0;
+  for (const name of names) {
+    result[name] = VENDOR_COLOURS[name] || FALLBACK_PALETTE[fi++ % FALLBACK_PALETTE.length];
+  }
+  return result;
+}
+
+const PERIOD_DESCRIPTIONS = {
+  today: '过去24小时各厂商的Token占比',
+  week: '过去一周各厂商的Token占比',
+  month: '过去一个月各厂商的Token占比',
+  year: '过去一年各厂商的Token占比',
+  all: '所有时间各厂商的Token占比',
+};
+
+export default function MarketShareSection({ history, rows, period }) {
+  const { t } = useTranslation();
+
+  const colourMap = useMemo(
+    () => buildColourMap((history?.vendors || []).map((v) => v.name)),
+    [history]
+  );
+
+  const orderedPoints = useMemo(() => {
+    if (!history?.points) return [];
+    const order = new Map(history.vendors.map((v, idx) => [v.name, idx]));
+    return [...history.points].sort((a, b) => {
+      const tsCmp = a.ts.localeCompare(b.ts);
+      if (tsCmp !== 0) return tsCmp;
+      return (order.get(a.vendor) ?? 999) - (order.get(b.vendor) ?? 999);
+    });
+  }, [history]);
+
+  const spec = useMemo(() => {
+    if (orderedPoints.length === 0) return null;
+    return {
+      type: 'bar',
+      data: [{ id: 'vendor-share', values: orderedPoints }],
+      xField: 'label',
+      yField: 'share',
+      seriesField: 'vendor',
+      stack: true,
+      legends: { visible: false },
+      color: { specified: colourMap },
+      axes: [
+        { orient: 'bottom', label: { autoHide: true, autoLimit: true }, tick: { visible: false } },
+        {
+          orient: 'left', min: 0, max: 1,
+          label: { formatMethod: (val) => `${Math.round(Number(val) * 100)}%` },
+          grid: { visible: true, style: { lineDash: [3, 3] } },
+        },
+      ],
+      tooltip: {
+        dimension: {
+          title: { value: (datum) => String(datum?.label ?? '') },
+          content: [{ key: (datum) => String(datum?.vendor ?? ''), value: (datum) => Number(datum?.share) || 0 }],
+          updateContent: (array) =>
+            array.filter((item) => Number(item.value) > 0.001)
+              .sort((a, b) => Number(b.value) - Number(a.value))
+              .map((item) => ({ key: item.key, value: `${(Number(item.value) * 100).toFixed(1)}%` })),
+        },
+      },
+      animationAppear: { duration: 500 },
+    };
+  }, [colourMap, orderedPoints]);
+
+  const visible = rows.slice(0, 12);
+  const half = Math.ceil(visible.length / 2);
+  const left = visible.slice(0, half);
+  const right = visible.slice(half);
+
+  return (
+    <Card className='!rounded-2xl'>
+      <div className='mb-4'>
+        <Title heading={5} className='flex items-center gap-2 !mb-1'>
+          <PieChart size={16} className='text-semi-color-primary' />
+          {t('市场份额')}
+        </Title>
+        <Text type='tertiary' size='small'>{t(PERIOD_DESCRIPTIONS[period])}</Text>
+      </div>
+
+      <div className='h-64 md:h-72'>
+        {spec ? (
+          <VChart key={`vendor-${period}`} spec={spec} option={CHART_CONFIG} />
+        ) : (
+          <div className='flex items-center justify-center h-full'>
+            <Text type='tertiary'>{t('暂无历史数据')}</Text>
+          </div>
+        )}
+      </div>
+
+      <div className='border-t border-semi-color-border mt-4 pt-4'>
+        <Title heading={6} className='!mb-1'>{t('按厂商')}</Title>
+        <Text type='tertiary' size='small'>{t('按总Token量排序的厂商')}</Text>
+
+        {visible.length === 0 ? (
+          <div className='text-center py-8'>
+            <Text type='tertiary'>{t('暂无数据')}</Text>
+          </div>
+        ) : (
+          <div className='grid grid-cols-1 md:grid-cols-2 gap-x-8 mt-3'>
+            <VendorList rows={left} colourMap={colourMap} />
+            {right.length > 0 && <VendorList rows={right} colourMap={colourMap} />}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function VendorList({ rows, colourMap }) {
+  return (
+    <ul className='list-none p-0 m-0'>
+      {rows.map((vendor) => (
+        <li key={vendor.vendor} className='flex items-center gap-3 py-2.5 border-b border-semi-color-border last:border-0'>
+          <span className='w-7 h-7 rounded-lg flex items-center justify-center text-xs font-bold shrink-0' style={{
+            backgroundColor: vendor.rank <= 3 ? 'var(--semi-color-primary-light-default)' : 'var(--semi-color-fill-0)',
+            color: vendor.rank <= 3 ? 'var(--semi-color-primary)' : 'var(--semi-color-text-2)',
+          }}>{vendor.rank}</span>
+          <span className='w-3 h-3 rounded-full shrink-0' style={{ backgroundColor: colourMap[vendor.vendor] || '#94a3b8' }} />
+          <span className='flex-1 min-w-0 text-sm font-medium truncate' style={{ color: 'var(--semi-color-text-0)' }}>{vendor.vendor}</span>
+          <div className='text-right'>
+            <div className='text-sm font-semibold font-mono'>{formatTokens(vendor.total_tokens)}</div>
+            <div className='text-xs font-mono' style={{ color: 'var(--semi-color-text-2)' }}>{formatShare(vendor.share)}</div>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/classic/src/components/rankings/ModelsSection.jsx
+++ b/web/classic/src/components/rankings/ModelsSection.jsx
@@ -1,0 +1,154 @@
+import React, { useMemo } from 'react';
+import { Card, Typography } from '@douyinfe/semi-ui';
+import { VChart } from '@visactor/react-vchart';
+import { BarChart3, Trophy } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { formatTokens } from '../../helpers/rankings';
+import { getLobeIcon } from '../../helpers/lobeIcon';
+import GrowthText from './GrowthText';
+
+const { Title, Text } = Typography;
+const CHART_CONFIG = { mode: 'desktop-browser' };
+
+const PERIOD_DESCRIPTIONS = {
+  today: '过去24小时各模型的Token使用量',
+  week: '过去一周各模型的Token使用量',
+  month: '过去一个月各模型的每日Token使用量',
+  year: '过去一年各模型的每周Token使用量',
+  all: '所有时间各模型的Token使用量',
+};
+
+export default function ModelsSection({ history, rows, period }) {
+  const { t } = useTranslation();
+
+  const orderedPoints = useMemo(() => {
+    if (!history?.points) return [];
+    const order = new Map(history.models.map((m, idx) => [m.name, idx]));
+    return [...history.points].sort((a, b) => {
+      const tsCmp = a.ts.localeCompare(b.ts);
+      if (tsCmp !== 0) return tsCmp;
+      return (order.get(a.model) ?? 999) - (order.get(b.model) ?? 999);
+    });
+  }, [history]);
+
+  const totalTokens = useMemo(
+    () => rows.reduce((s, r) => s + r.total_tokens, 0),
+    [rows]
+  );
+
+  const spec = useMemo(() => {
+    if (orderedPoints.length === 0) return null;
+    return {
+      type: 'bar',
+      data: [{ id: 'models-history', values: orderedPoints }],
+      xField: 'label',
+      yField: 'tokens',
+      seriesField: 'model',
+      stack: true,
+      legends: { visible: false },
+      axes: [
+        { orient: 'bottom', label: { autoHide: true, autoLimit: true }, tick: { visible: false } },
+        {
+          orient: 'left',
+          label: { formatMethod: (val) => formatTokens(Number(val)) },
+          grid: { visible: true, style: { lineDash: [3, 3] } },
+        },
+      ],
+      tooltip: {
+        dimension: {
+          title: { value: (datum) => String(datum?.label ?? '') },
+          content: [{ key: (datum) => String(datum?.model ?? ''), value: (datum) => Number(datum?.tokens) || 0 }],
+          updateContent: (array) => {
+            array.sort((a, b) => Number(b.value) - Number(a.value));
+            const sum = array.reduce((s, x) => s + (Number(x.value) || 0), 0);
+            const visible = array.slice(0, 10);
+            const overflow = array.slice(10);
+            const result = visible.map((item) => ({ key: item.key, value: formatTokens(Number(item.value) || 0) }));
+            if (overflow.length > 0) {
+              const otherSum = overflow.reduce((s, item) => s + (Number(item.value) || 0), 0);
+              result.push({ key: `+${overflow.length} more`, value: formatTokens(otherSum) });
+            }
+            result.unshift({ key: t('合计'), value: formatTokens(sum) });
+            return result;
+          },
+        },
+      },
+      animationAppear: { duration: 500 },
+    };
+  }, [orderedPoints, t]);
+
+  const half = Math.ceil(rows.length / 2);
+  const leftRows = rows.slice(0, half);
+  const rightRows = rows.slice(half);
+
+  return (
+    <Card className='!rounded-2xl'>
+      <div className='flex items-start justify-between gap-4 mb-4'>
+        <div>
+          <Title heading={5} className='flex items-center gap-2 !mb-1'>
+            <BarChart3 size={16} className='text-semi-color-primary' />
+            {t('热门模型')}
+          </Title>
+          <Text type='tertiary' size='small'>{t(PERIOD_DESCRIPTIONS[period])}</Text>
+        </div>
+        <div className='text-right'>
+          <Title heading={3} className='!mb-0 font-mono'>{formatTokens(totalTokens)}</Title>
+          <Text type='tertiary' size='small' style={{ textTransform: 'uppercase', letterSpacing: '0.1em' }}>tokens</Text>
+        </div>
+      </div>
+
+      <div className='h-64 md:h-72'>
+        {spec ? (
+          <VChart key={`models-${period}`} spec={spec} option={CHART_CONFIG} />
+        ) : (
+          <div className='flex items-center justify-center h-full'>
+            <Text type='tertiary'>{t('暂无历史数据')}</Text>
+          </div>
+        )}
+      </div>
+
+      <div className='border-t border-semi-color-border mt-4 pt-4'>
+        <Title heading={6} className='flex items-center gap-2 !mb-1'>
+          <Trophy size={14} style={{ color: '#eab308' }} />
+          {t('模型排行')}
+        </Title>
+        <Text type='tertiary' size='small'>{t('平台上最受欢迎的模型')}</Text>
+
+        {rows.length === 0 ? (
+          <div className='text-center py-8'>
+            <Text type='tertiary'>{t('暂无数据')}</Text>
+          </div>
+        ) : (
+          <div className='grid grid-cols-1 md:grid-cols-2 gap-x-8 mt-3'>
+            <ModelList rows={leftRows} />
+            {rightRows.length > 0 && <ModelList rows={rightRows} />}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function ModelList({ rows }) {
+  return (
+    <ul className='list-none p-0 m-0'>
+      {rows.map((row) => (
+        <li key={row.model_name} className='flex items-center gap-3 py-2.5 border-b border-semi-color-border last:border-0'>
+          <span className='w-7 h-7 rounded-lg flex items-center justify-center text-xs font-bold shrink-0' style={{
+            backgroundColor: row.rank <= 3 ? 'var(--semi-color-primary-light-default)' : 'var(--semi-color-fill-0)',
+            color: row.rank <= 3 ? 'var(--semi-color-primary)' : 'var(--semi-color-text-2)',
+          }}>{row.rank}</span>
+          {getLobeIcon(row.vendor_icon, 22)}
+          <div className='flex-1 min-w-0'>
+            <div className='text-sm font-medium font-mono truncate' style={{ color: 'var(--semi-color-text-0)' }}>{row.model_name}</div>
+            <div className='text-xs truncate' style={{ color: 'var(--semi-color-text-2)' }}>{row.vendor.toLowerCase()}</div>
+          </div>
+          <div className='text-right'>
+            <div className='text-sm font-semibold font-mono'>{formatTokens(row.total_tokens)}</div>
+            <GrowthText value={row.growth_pct} />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/classic/src/components/rankings/PulseSection.jsx
+++ b/web/classic/src/components/rankings/PulseSection.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Card, Typography } from '@douyinfe/semi-ui';
+import { TrendingUp, TrendingDown, ArrowUpRight, ArrowDownRight } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+const { Title, Text } = Typography;
+
+export default function PulseSection({ movers, droppers }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className='grid grid-cols-1 lg:grid-cols-2 gap-4'>
+      <Card className='!rounded-2xl'>
+        <Title heading={6} className='flex items-center gap-2 !mb-1'>
+          <TrendingUp size={14} style={{ color: 'var(--semi-color-success)' }} />
+          {t('上升趋势')}
+        </Title>
+        <Text type='tertiary' size='small'>{t('排名上升最快的模型')}</Text>
+        <div className='mt-3'>
+          {movers.length === 0 ? (
+            <div className='text-center py-6'>
+              <Text type='tertiary' size='small'>{t('暂无上升模型')}</Text>
+            </div>
+          ) : (
+            <ul className='list-none p-0 m-0'>
+              {movers.map((row) => (
+                <MoverRow key={row.model_name} row={row} intent='up' />
+              ))}
+            </ul>
+          )}
+        </div>
+      </Card>
+
+      <Card className='!rounded-2xl'>
+        <Title heading={6} className='flex items-center gap-2 !mb-1'>
+          <TrendingDown size={14} style={{ color: 'var(--semi-color-danger)' }} />
+          {t('下降趋势')}
+        </Title>
+        <Text type='tertiary' size='small'>{t('排名下降最多的模型')}</Text>
+        <div className='mt-3'>
+          {droppers.length === 0 ? (
+            <div className='text-center py-6'>
+              <Text type='tertiary' size='small'>{t('暂无下降模型')}</Text>
+            </div>
+          ) : (
+            <ul className='list-none p-0 m-0'>
+              {droppers.map((row) => (
+                <MoverRow key={row.model_name} row={row} intent='down' />
+              ))}
+            </ul>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function MoverRow({ row, intent }) {
+  const color = intent === 'up' ? 'var(--semi-color-success)' : 'var(--semi-color-danger)';
+
+  return (
+    <li className='flex items-center gap-3 py-2.5 border-b border-semi-color-border last:border-0'>
+      <div className='w-7 h-7 rounded-lg flex items-center justify-center shrink-0' style={{ backgroundColor: intent === 'up' ? 'var(--semi-color-success-light-default)' : 'var(--semi-color-danger-light-default)' }}>
+        {intent === 'up' ? <ArrowUpRight size={14} style={{ color }} /> : <ArrowDownRight size={14} style={{ color }} />}
+      </div>
+      <div className='min-w-0 flex-1'>
+        <div className='text-sm font-medium font-mono truncate' style={{ color: 'var(--semi-color-text-0)' }}>{row.model_name}</div>
+        <div className='text-xs truncate' style={{ color: 'var(--semi-color-text-2)' }}>
+          #{row.current_rank} · {row.vendor.toLowerCase()}
+        </div>
+      </div>
+      <span className='inline-flex items-center gap-0.5 font-mono text-sm font-bold shrink-0' style={{ color }}>
+        {intent === 'up' ? '+' : ''}{row.rank_delta}
+      </span>
+    </li>
+  );
+}

--- a/web/classic/src/components/rankings/index.jsx
+++ b/web/classic/src/components/rankings/index.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Spin, Tabs, TabPane, Empty } from '@douyinfe/semi-ui';
+import { useTranslation } from 'react-i18next';
+import { useRankingsData } from '../../hooks/rankings/useRankingsData';
+import ModelsSection from './ModelsSection';
+import MarketShareSection from './MarketShareSection';
+import PulseSection from './PulseSection';
+
+const PERIODS = [
+  { key: 'today', label: '今天' },
+  { key: 'week', label: '本周' },
+  { key: 'month', label: '本月' },
+  { key: 'year', label: '本年' },
+  { key: 'all', label: '全部' },
+];
+
+export default function RankingsPage() {
+  const { t } = useTranslation();
+  const { period, changePeriod, snapshot, loading, error } = useRankingsData('week');
+
+  return (
+    <div style={{ maxWidth: 1280, margin: '0 auto', width: '100%', paddingTop: 80 }} className='p-4 md:p-6 lg:p-8'>
+      <div className='mb-8'>
+        <h1 className='text-2xl font-bold' style={{ color: 'var(--semi-color-text-0)', margin: 0 }}>
+          {t('排行榜')}
+        </h1>
+        <p style={{ color: 'var(--semi-color-text-2)', fontSize: 14, margin: '4px 0 0' }}>
+          {t('发现平台上最受欢迎的模型和厂商，数据来自实时使用统计。')}
+        </p>
+      </div>
+
+      <Tabs type='button' activeKey={period} onChange={changePeriod} className='mb-6'>
+        {PERIODS.map((p) => (
+          <TabPane key={p.key} tab={t(p.label)} itemKey={p.key} />
+        ))}
+      </Tabs>
+
+      {loading ? (
+        <div className='flex justify-center' style={{ padding: '80px 0' }}>
+          <Spin size='large' />
+        </div>
+      ) : error ? (
+        <Empty title={t('加载失败')} description={error} />
+      ) : snapshot ? (
+        <div className='grid gap-6'>
+          <ModelsSection history={snapshot.models_history} rows={snapshot.models} period={period} />
+          <MarketShareSection history={snapshot.vendor_share_history} rows={snapshot.vendors} period={period} />
+          <PulseSection movers={snapshot.top_movers} droppers={snapshot.top_droppers} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/classic/src/helpers/lobeIcon.jsx
+++ b/web/classic/src/helpers/lobeIcon.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import * as LobeIcons from '@lobehub/icons';
+
+function parseValue(raw) {
+  if (raw == null) return true;
+  let v = String(raw).trim();
+  if (v.startsWith('{') && v.endsWith('}')) v = v.slice(1, -1).trim();
+  if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) return v.slice(1, -1);
+  if (v === 'true') return true;
+  if (v === 'false') return false;
+  if (/^-?\d+(?:\.\d+)?$/.test(v)) return Number(v);
+  return v;
+}
+
+export function getLobeIcon(iconName, size = 20) {
+  if (!iconName || typeof iconName !== 'string' || !iconName.trim()) {
+    return (
+      <div className='flex items-center justify-center rounded-full text-xs font-medium'
+        style={{ width: size, height: size, backgroundColor: 'var(--semi-color-fill-0)', color: 'var(--semi-color-text-2)' }}>
+        {iconName ? iconName.charAt(0).toUpperCase() : '?'}
+      </div>
+    );
+  }
+
+  const segments = iconName.trim().split('.');
+  const baseKey = segments[0];
+  const BaseIcon = LobeIcons[baseKey];
+
+  let IconComponent;
+  let propStartIndex;
+
+  if (BaseIcon && segments.length > 1 && BaseIcon[segments[1]]) {
+    IconComponent = BaseIcon[segments[1]];
+    propStartIndex = 2;
+  } else {
+    IconComponent = LobeIcons[baseKey];
+    propStartIndex = segments.length > 1 && /^[A-Z]/.test(segments[1]) ? 2 : 1;
+  }
+
+  if (!IconComponent || (typeof IconComponent !== 'function' && typeof IconComponent !== 'object')) {
+    return (
+      <div className='flex items-center justify-center rounded-full text-xs font-medium'
+        style={{ width: size, height: size, backgroundColor: 'var(--semi-color-fill-0)', color: 'var(--semi-color-text-2)' }}>
+        {baseKey.charAt(0).toUpperCase()}
+      </div>
+    );
+  }
+
+  const props = {};
+  for (let i = propStartIndex; i < segments.length; i++) {
+    const seg = segments[i];
+    if (!seg) continue;
+    const eqIdx = seg.indexOf('=');
+    if (eqIdx === -1) { props[seg.trim()] = true; continue; }
+    props[seg.slice(0, eqIdx).trim()] = parseValue(seg.slice(eqIdx + 1).trim());
+  }
+  if (props.size == null) props.size = size;
+
+  return <IconComponent {...props} />;
+}

--- a/web/classic/src/helpers/rankings.js
+++ b/web/classic/src/helpers/rankings.js
@@ -1,0 +1,13 @@
+export function formatTokens(value) {
+  if (!Number.isFinite(value) || value === 0) return '0';
+  const abs = Math.abs(value);
+  if (abs >= 1e9) return `${(value / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `${(value / 1e6).toFixed(abs >= 1e8 ? 0 : abs >= 1e7 ? 1 : 2)}M`;
+  if (abs >= 1e3) return `${(value / 1e3).toFixed(abs >= 1e5 ? 0 : 1)}K`;
+  return String(Math.round(value));
+}
+
+export function formatShare(share) {
+  if (!Number.isFinite(share)) return '0%';
+  return `${(share * 100).toFixed(1)}%`;
+}

--- a/web/classic/src/hooks/common/useNavigation.js
+++ b/web/classic/src/hooks/common/useNavigation.js
@@ -26,6 +26,7 @@ export const useNavigation = (t, docsLink, headerNavModules) => {
       home: true,
       console: true,
       pricing: true,
+      rankings: true,
       docs: true,
       about: true,
     };
@@ -48,6 +49,11 @@ export const useNavigation = (t, docsLink, headerNavModules) => {
         text: t('模型广场'),
         itemKey: 'pricing',
         to: '/pricing',
+      },
+      {
+        text: t('排行榜'),
+        itemKey: 'rankings',
+        to: '/rankings',
       },
       ...(docsLink
         ? [
@@ -76,6 +82,11 @@ export const useNavigation = (t, docsLink, headerNavModules) => {
         return typeof modules.pricing === 'object'
           ? modules.pricing.enabled
           : modules.pricing;
+      }
+      if (link.itemKey === 'rankings') {
+        return typeof modules.rankings === 'object'
+          ? modules.rankings.enabled
+          : modules.rankings;
       }
       return modules[link.itemKey] === true;
     });

--- a/web/classic/src/hooks/rankings/useRankingsData.js
+++ b/web/classic/src/hooks/rankings/useRankingsData.js
@@ -1,0 +1,45 @@
+import { useState, useEffect, useCallback } from 'react';
+import { API } from '../../helpers/api';
+import { showError } from '../../helpers/utils';
+
+const VALID_PERIODS = ['today', 'week', 'month', 'year', 'all'];
+
+export function useRankingsData(initialPeriod = 'week') {
+  const [period, setPeriod] = useState(
+    VALID_PERIODS.includes(initialPeriod) ? initialPeriod : 'week'
+  );
+  const [snapshot, setSnapshot] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const fetchRankings = useCallback(async (p) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await API.get('/api/rankings', { params: { period: p } });
+      const { success, message, data } = res.data;
+      if (success) {
+        setSnapshot(data);
+      } else {
+        setError(message);
+        showError(message);
+      }
+    } catch (err) {
+      const msg = err?.response?.data?.message || err.message;
+      setError(msg);
+      showError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRankings(period);
+  }, [period, fetchRankings]);
+
+  const changePeriod = useCallback((p) => {
+    if (VALID_PERIODS.includes(p)) setPeriod(p);
+  }, []);
+
+  return { period, changePeriod, snapshot, loading, error };
+}

--- a/web/classic/src/pages/Rankings/index.jsx
+++ b/web/classic/src/pages/Rankings/index.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import RankingsPage from '../../components/rankings';
+
+export default function Rankings() {
+  return <RankingsPage />;
+}

--- a/web/classic/src/pages/Setting/Operation/SettingsHeaderNavModules.jsx
+++ b/web/classic/src/pages/Setting/Operation/SettingsHeaderNavModules.jsx
@@ -46,6 +46,10 @@ export default function SettingsHeaderNavModules(props) {
       enabled: true,
       requireAuth: false, // 默认不需要登录鉴权
     },
+    rankings: {
+      enabled: true,
+      requireAuth: false,
+    },
     docs: true,
     about: true,
   });
@@ -54,7 +58,7 @@ export default function SettingsHeaderNavModules(props) {
   function handleHeaderNavModuleChange(moduleKey) {
     return (checked) => {
       const newModules = { ...headerNavModules };
-      if (moduleKey === 'pricing') {
+      if (moduleKey === 'pricing' || moduleKey === 'rankings') {
         // 对于pricing模块，只更新enabled属性
         newModules[moduleKey] = {
           ...newModules[moduleKey],
@@ -77,12 +81,25 @@ export default function SettingsHeaderNavModules(props) {
     setHeaderNavModules(newModules);
   }
 
+  function handleRankingsAuthChange(checked) {
+    const newModules = { ...headerNavModules };
+    newModules.rankings = {
+      ...newModules.rankings,
+      requireAuth: checked,
+    };
+    setHeaderNavModules(newModules);
+  }
+
   // 重置顶栏模块为默认配置
   function resetHeaderNavModules() {
     const defaultModules = {
       home: true,
       console: true,
       pricing: {
+        enabled: true,
+        requireAuth: false,
+      },
+      rankings: {
         enabled: true,
         requireAuth: false,
       },
@@ -142,6 +159,12 @@ export default function SettingsHeaderNavModules(props) {
           };
         }
 
+        if (typeof modules.rankings === 'boolean') {
+          modules.rankings = { enabled: modules.rankings, requireAuth: false };
+        } else if (modules.rankings === undefined) {
+          modules.rankings = { enabled: true, requireAuth: false };
+        }
+
         setHeaderNavModules(modules);
       } catch (error) {
         // 使用默认配置
@@ -177,6 +200,12 @@ export default function SettingsHeaderNavModules(props) {
       title: t('模型广场'),
       description: t('模型定价，需要登录访问'),
       hasSubConfig: true, // 标识该模块有子配置
+    },
+    {
+      key: 'rankings',
+      title: t('排行榜'),
+      description: t('模型和厂商使用排行'),
+      hasSubConfig: true,
     },
     {
       key: 'docs',
@@ -245,7 +274,7 @@ export default function SettingsHeaderNavModules(props) {
                   <div style={{ marginLeft: '16px' }}>
                     <Switch
                       checked={
-                        module.key === 'pricing'
+                        module.key === 'pricing' || module.key === 'rankings'
                           ? headerNavModules[module.key]?.enabled
                           : headerNavModules[module.key]
                       }
@@ -304,6 +333,60 @@ export default function SettingsHeaderNavModules(props) {
                               headerNavModules.pricing?.requireAuth || false
                             }
                             onChange={handlePricingAuthChange}
+                            size='default'
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  )}
+
+                {/* 为排行榜添加权限控制子开关 */}
+                {module.key === 'rankings' &&
+                  headerNavModules.rankings?.enabled && (
+                    <div
+                      style={{
+                        borderTop: '1px solid var(--semi-color-border)',
+                        marginTop: '12px',
+                        paddingTop: '12px',
+                      }}
+                    >
+                      <div
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                        }}
+                      >
+                        <div style={{ flex: 1, textAlign: 'left' }}>
+                          <div
+                            style={{
+                              fontWeight: '500',
+                              fontSize: '12px',
+                              color: 'var(--semi-color-text-1)',
+                              marginBottom: '2px',
+                            }}
+                          >
+                            {t('需要登录访问')}
+                          </div>
+                          <Text
+                            type='secondary'
+                            size='small'
+                            style={{
+                              fontSize: '11px',
+                              color: 'var(--semi-color-text-2)',
+                              lineHeight: '1.4',
+                              display: 'block',
+                            }}
+                          >
+                            {t('开启后未登录用户无法访问排行榜')}
+                          </Text>
+                        </div>
+                        <div style={{ marginLeft: '16px' }}>
+                          <Switch
+                            checked={
+                              headerNavModules.rankings?.requireAuth || false
+                            }
+                            onChange={handleRankingsAuthChange}
                             size='default'
                           />
                         </div>


### PR DESCRIPTION
Add complete rankings feature to web/classic including:
- Rankings page with period tabs (today/week/month/year/all)
- ModelsSection with VChart history chart and ranked model list
- MarketShareSection with vendor share chart and color-coded list
- PulseSection showing trending up/down models
- Navigation integration and admin settings for rankings module

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ ] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [ ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [ ] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Rankings page with period filtering (today, week, month, year, all-time).
  * Added Models rankings display showing token usage and growth trends.
  * Added Market share section with vendor comparisons and stacked bar charts.
  * Added Pulse section highlighting top market movers and droppers.
  * Added Rankings module to navigation with configurable visibility and optional authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->