### PR TITLE
perf(model): add covering index (type, created_at, quota) for log quo…

### DIFF
--- a/model/log.go
+++ b/model/log.go
@@ -34,13 +34,13 @@ func applyExplicitLogTextFilter(tx *gorm.DB, column string, value string) (*gorm
 type Log struct {
 	Id                int    `json:"id" gorm:"index:idx_created_at_id,priority:2;index:idx_user_id_id,priority:2"`
 	UserId            int    `json:"user_id" gorm:"index;index:idx_user_id_id,priority:1"`
-	CreatedAt         int64  `json:"created_at" gorm:"bigint;index:idx_created_at_id,priority:1;index:idx_created_at_type"`
-	Type              int    `json:"type" gorm:"index:idx_created_at_type"`
+	CreatedAt         int64  `json:"created_at" gorm:"bigint;index:idx_created_at_id,priority:1;index:idx_created_at_type;index:idx_type_created_at_quota,priority:2"`
+	Type              int    `json:"type" gorm:"index:idx_created_at_type;index:idx_type_created_at_quota,priority:1"`
 	Content           string `json:"content"`
 	Username          string `json:"username" gorm:"index;index:index_username_model_name,priority:2;default:''"`
 	TokenName         string `json:"token_name" gorm:"index;default:''"`
 	ModelName         string `json:"model_name" gorm:"index;index:index_username_model_name,priority:1;default:''"`
-	Quota             int    `json:"quota" gorm:"default:0"`
+	Quota             int    `json:"quota" gorm:"default:0;index:idx_type_created_at_quota,priority:3"`
 	PromptTokens      int    `json:"prompt_tokens" gorm:"default:0"`
 	CompletionTokens  int    `json:"completion_tokens" gorm:"default:0"`
 	UseTime           int    `json:"use_time" gorm:"default:0"`


### PR DESCRIPTION
优化使用日志 用量统计
增加用量统计索引: `idx_type_created_at_quota`
测试: 查询6个月3000条日志
优化前[28秒]:
`[28184.462ms] [rows:1] SELECT sum(quota) quota FROM `logs` WHERE created_at >= 1765728000 AND created_at <= 1781107140 AND type = 2`
优化后[0.3秒]:
`[367.696ms] [rows:1] SELECT sum(quota) quota FROM `logs` WHERE created_at >= 1765728000 AND created_at <= 1781107140 AND type = 2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized logging system database schema structure to enhance performance and data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->