### PR TITLE
fix: Moonshot 渠道余额折算应使用汇率 USDExchangeRate 而非充值价格 Price

### DIFF
--- a/controller/channel-billing.go
+++ b/controller/channel-billing.go
@@ -351,7 +351,7 @@ func updateChannelMoonshotBalance(channel *model.Channel) (float64, error) {
 		return 0, fmt.Errorf("failed to update moonshot balance, status: %v, code: %d, scode: %s", response.Status, response.Code, response.Scode)
 	}
 	availableBalanceCny := response.Data.AvailableBalance
-	availableBalanceUsd := decimal.NewFromFloat(availableBalanceCny).Div(decimal.NewFromFloat(operation_setting.Price)).InexactFloat64()
+	availableBalanceUsd := decimal.NewFromFloat(availableBalanceCny).Div(decimal.NewFromFloat(operation_setting.USDExchangeRate)).InexactFloat64()
 	channel.UpdateBalance(availableBalanceUsd)
 	return availableBalanceUsd, nil
 }


### PR DESCRIPTION
## 📝 变更描述 / Description

Moonshot 渠道查询余额时，将上游返回的人民币余额折算成美元，目前除的是充值价格 `Price`，而非汇率 `USDExchangeRate`。

`Price` 的语义是「购买 1 美元额度需支付的本币金额」（含定价加成），`USDExchangeRate` 才是展示折算用的汇率。前端余额展示（`formatCurrencyFromUSD`）是按 `usd_exchange_rate` 把美元余额换算回本币的，两边口径不一致时（例如 Price=7.3、汇率=5），Moonshot 渠道余额显示会被低估约 32%。

本 PR 把折算分母从 `operation_setting.Price` 改为 `operation_setting.USDExchangeRate`，与前端展示口径保持一致。仅一行改动。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the USD balance calculation in channel billing to use the proper exchange rate, ensuring accurate currency conversions and balance reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->