### PR TITLE
feat: support Veo metadata media inputs

### DIFF
--- a/relay/channel/task/gemini/adaptor.go
+++ b/relay/channel/task/gemini/adaptor.go
@@ -85,6 +85,17 @@ func (a *TaskAdaptor) BuildRequestBody(c *gin.Context, info *relaycommon.RelayIn
 			info.Action = constant.TaskActionGenerate
 		}
 	}
+	features, err := ApplyVeoMetadataToInstance(req.Metadata, &instance)
+	if err != nil {
+		return nil, err
+	}
+	if features.HasLastFrame {
+		info.Action = constant.TaskActionFirstTailGenerate
+	} else if features.HasReferenceImages {
+		info.Action = constant.TaskActionReferenceGenerate
+	} else if features.HasImage {
+		info.Action = constant.TaskActionGenerate
+	}
 
 	params := &VeoParameters{}
 	if err := taskcommon.UnmarshalMetadata(req.Metadata, params); err != nil {

--- a/relay/channel/task/gemini/dto.go
+++ b/relay/channel/task/gemini/dto.go
@@ -1,18 +1,29 @@
 package gemini
 
+// VeoInlineData represents inline image bytes in the Gemini Veo request shape.
+type VeoInlineData struct {
+	MimeType string `json:"mimeType"`
+	Data     string `json:"data"`
+}
+
 // VeoImageInput represents an image input for Veo image-to-video.
 // Used by both Gemini and Vertex adaptors.
 type VeoImageInput struct {
-	BytesBase64Encoded string `json:"bytesBase64Encoded"`
-	MimeType           string `json:"mimeType"`
+	InlineData *VeoInlineData `json:"inlineData,omitempty"`
 }
 
 // VeoInstance represents a single instance in the Veo predictLongRunning request.
 type VeoInstance struct {
-	Prompt string         `json:"prompt"`
-	Image  *VeoImageInput `json:"image,omitempty"`
-	// TODO: support referenceImages (style/asset references, up to 3 images)
-	// TODO: support lastFrame (first+last frame interpolation, Veo 3.1)
+	Prompt          string              `json:"prompt"`
+	Image           *VeoImageInput      `json:"image,omitempty"`
+	LastFrame       *VeoImageInput      `json:"lastFrame,omitempty"`
+	ReferenceImages []VeoReferenceImage `json:"referenceImages,omitempty"`
+}
+
+// VeoReferenceImage represents a Veo 3.1 reference image.
+type VeoReferenceImage struct {
+	Image         *VeoImageInput `json:"image,omitempty"`
+	ReferenceType string         `json:"referenceType,omitempty"`
 }
 
 // VeoParameters represents the parameters block for Veo predictLongRunning.

--- a/relay/channel/task/gemini/image.go
+++ b/relay/channel/task/gemini/image.go
@@ -45,10 +45,7 @@ func ExtractMultipartImage(c *gin.Context, info *relaycommon.RelayInfo) *VeoImag
 	}
 
 	info.Action = constant.TaskActionGenerate
-	return &VeoImageInput{
-		BytesBase64Encoded: base64.StdEncoding.EncodeToString(fileBytes),
-		MimeType:           mimeType,
-	}
+	return NewVeoImageInput(base64.StdEncoding.EncodeToString(fileBytes), mimeType)
 }
 
 // ParseImageInput parses an image string (data URI or raw base64) into a
@@ -68,10 +65,7 @@ func ParseImageInput(imageStr string) *VeoImageInput {
 	if err != nil {
 		return nil
 	}
-	return &VeoImageInput{
-		BytesBase64Encoded: imageStr,
-		MimeType:           http.DetectContentType(raw),
-	}
+	return NewVeoImageInput(imageStr, http.DetectContentType(raw))
 }
 
 func parseDataURI(uri string) *VeoImageInput {
@@ -93,8 +87,14 @@ func parseDataURI(uri string) *VeoImageInput {
 		mimeType = parts[0]
 	}
 
+	return NewVeoImageInput(b64, mimeType)
+}
+
+func NewVeoImageInput(data, mimeType string) *VeoImageInput {
 	return &VeoImageInput{
-		BytesBase64Encoded: b64,
-		MimeType:           mimeType,
+		InlineData: &VeoInlineData{
+			Data:     data,
+			MimeType: mimeType,
+		},
 	}
 }

--- a/relay/channel/task/gemini/metadata.go
+++ b/relay/channel/task/gemini/metadata.go
@@ -1,0 +1,223 @@
+package gemini
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+type rawMessage []byte
+
+func (m *rawMessage) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return fmt.Errorf("rawMessage: UnmarshalJSON on nil pointer")
+	}
+	*m = append((*m)[0:0], data...)
+	return nil
+}
+
+type VeoMetadataFeatures struct {
+	HasImage           bool
+	HasLastFrame       bool
+	HasReferenceImages bool
+}
+
+// ApplyVeoMetadataToInstance moves Veo instance-level fields from request
+// metadata into the upstream instance. Supported metadata fields are:
+// image/firstFrame/first_frame, lastFrame/last_frame, and
+// referenceImages/reference_images.
+func ApplyVeoMetadataToInstance(metadata map[string]any, instance *VeoInstance) (VeoMetadataFeatures, error) {
+	var features VeoMetadataFeatures
+	if metadata == nil || instance == nil {
+		return features, nil
+	}
+
+	raw, err := rawMetadata(metadata)
+	if err != nil {
+		return features, err
+	}
+
+	imageRaw := firstRaw(raw["image"], raw["firstFrame"], raw["first_frame"])
+	if hasRaw(imageRaw) {
+		image, err := parseVeoImageMetadata(imageRaw)
+		if err != nil {
+			return features, fmt.Errorf("invalid metadata image: %w", err)
+		}
+		instance.Image = image
+		features.HasImage = true
+	}
+
+	lastFrameRaw := firstRaw(raw["lastFrame"], raw["last_frame"])
+	if hasRaw(lastFrameRaw) {
+		lastFrame, err := parseVeoImageMetadata(lastFrameRaw)
+		if err != nil {
+			return features, fmt.Errorf("invalid metadata lastFrame: %w", err)
+		}
+		instance.LastFrame = lastFrame
+		features.HasLastFrame = true
+	}
+
+	referenceImagesRaw := firstRaw(raw["referenceImages"], raw["reference_images"])
+	if hasRaw(referenceImagesRaw) {
+		referenceImages, err := parseVeoReferenceImagesMetadata(referenceImagesRaw)
+		if err != nil {
+			return features, fmt.Errorf("invalid metadata referenceImages: %w", err)
+		}
+		instance.ReferenceImages = referenceImages
+		features.HasReferenceImages = len(referenceImages) > 0
+	}
+
+	return features, nil
+}
+
+func rawMetadata(metadata map[string]any) (map[string]rawMessage, error) {
+	data, err := common.Marshal(metadata)
+	if err != nil {
+		return nil, fmt.Errorf("marshal metadata failed: %w", err)
+	}
+	var raw map[string]rawMessage
+	if err := common.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("unmarshal metadata failed: %w", err)
+	}
+	return raw, nil
+}
+
+func firstRaw(values ...rawMessage) rawMessage {
+	for _, value := range values {
+		if hasRaw(value) {
+			return value
+		}
+	}
+	return nil
+}
+
+func hasRaw(raw rawMessage) bool {
+	trimmed := bytes.TrimSpace([]byte(raw))
+	return len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null"))
+}
+
+func parseVeoImageMetadata(raw rawMessage) (*VeoImageInput, error) {
+	trimmed := bytes.TrimSpace([]byte(raw))
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("empty image")
+	}
+
+	if trimmed[0] == '"' {
+		var imageStr string
+		if err := common.Unmarshal(trimmed, &imageStr); err != nil {
+			return nil, err
+		}
+		imageStr = strings.TrimSpace(imageStr)
+		if strings.HasPrefix(imageStr, "{") {
+			return parseVeoImageMetadata(rawMessage(imageStr))
+		}
+		if image := ParseImageInput(imageStr); image != nil {
+			return image, nil
+		}
+		return nil, fmt.Errorf("image string must be a data URI or base64 image")
+	}
+
+	var wire struct {
+		InlineData         *VeoInlineData `json:"inlineData"`
+		BytesBase64Encoded string         `json:"bytesBase64Encoded"`
+		MimeType           string         `json:"mimeType"`
+		Data               string         `json:"data"`
+	}
+	if err := common.Unmarshal(trimmed, &wire); err != nil {
+		return nil, err
+	}
+	if wire.InlineData != nil {
+		if wire.InlineData.Data == "" {
+			return nil, fmt.Errorf("inlineData.data is required")
+		}
+		if wire.InlineData.MimeType == "" {
+			wire.InlineData.MimeType = "application/octet-stream"
+		}
+		return &VeoImageInput{InlineData: wire.InlineData}, nil
+	}
+	if wire.BytesBase64Encoded != "" {
+		return NewVeoImageInput(wire.BytesBase64Encoded, defaultMimeType(wire.MimeType)), nil
+	}
+	if wire.Data != "" {
+		return NewVeoImageInput(wire.Data, defaultMimeType(wire.MimeType)), nil
+	}
+	return nil, fmt.Errorf("image.inlineData is required")
+}
+
+func parseVeoReferenceImagesMetadata(raw rawMessage) ([]VeoReferenceImage, error) {
+	trimmed := bytes.TrimSpace([]byte(raw))
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	if trimmed[0] == '"' {
+		var rawStr string
+		if err := common.Unmarshal(trimmed, &rawStr); err != nil {
+			return nil, err
+		}
+		rawStr = strings.TrimSpace(rawStr)
+		if !strings.HasPrefix(rawStr, "[") {
+			return nil, fmt.Errorf("referenceImages string must contain a JSON array")
+		}
+		trimmed = []byte(rawStr)
+	}
+
+	var items []rawMessage
+	if err := common.Unmarshal(trimmed, &items); err != nil {
+		return nil, err
+	}
+
+	out := make([]VeoReferenceImage, 0, len(items))
+	for i, itemRaw := range items {
+		imageRaw, referenceType, err := parseVeoReferenceImageItem(itemRaw)
+		if err != nil {
+			return nil, fmt.Errorf("referenceImages[%d]: %w", i, err)
+		}
+		image, err := parseVeoImageMetadata(imageRaw)
+		if err != nil {
+			return nil, fmt.Errorf("referenceImages[%d].image: %w", i, err)
+		}
+		out = append(out, VeoReferenceImage{
+			Image:         image,
+			ReferenceType: referenceType,
+		})
+	}
+	return out, nil
+}
+
+func parseVeoReferenceImageItem(raw rawMessage) (rawMessage, string, error) {
+	trimmed := bytes.TrimSpace([]byte(raw))
+	if len(trimmed) == 0 {
+		return nil, "", fmt.Errorf("empty reference image")
+	}
+	if trimmed[0] == '"' {
+		return raw, "asset", nil
+	}
+
+	var item struct {
+		Image              rawMessage `json:"image"`
+		ReferenceType      string     `json:"referenceType"`
+		ReferenceTypeSnake string     `json:"reference_type"`
+	}
+	if err := common.Unmarshal(trimmed, &item); err != nil {
+		return nil, "", err
+	}
+	if hasRaw(item.Image) {
+		referenceType := item.ReferenceType
+		if referenceType == "" {
+			referenceType = item.ReferenceTypeSnake
+		}
+		return item.Image, referenceType, nil
+	}
+
+	// Allow a bare image object as a shorthand reference image.
+	return raw, "asset", nil
+}
+
+func defaultMimeType(mimeType string) string {
+	if strings.TrimSpace(mimeType) == "" {
+		return "application/octet-stream"
+	}
+	return mimeType
+}

--- a/relay/channel/task/gemini/metadata_test.go
+++ b/relay/channel/task/gemini/metadata_test.go
@@ -1,0 +1,150 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyVeoMetadataToInstanceSupportsFramesAndReferenceImages(t *testing.T) {
+	instance := VeoInstance{Prompt: "make a video"}
+	features, err := ApplyVeoMetadataToInstance(map[string]any{
+		"image": map[string]any{
+			"inlineData": map[string]any{
+				"mimeType": "image/png",
+				"data":     "first-base64",
+			},
+		},
+		"lastFrame": map[string]any{
+			"inlineData": map[string]any{
+				"mimeType": "image/png",
+				"data":     "last-base64",
+			},
+		},
+		"referenceImages": []any{
+			map[string]any{
+				"image": map[string]any{
+					"inlineData": map[string]any{
+						"mimeType": "image/png",
+						"data":     "asset-base64",
+					},
+				},
+				"referenceType": "asset",
+			},
+		},
+	}, &instance)
+
+	require.NoError(t, err)
+	require.True(t, features.HasImage)
+	require.True(t, features.HasLastFrame)
+	require.True(t, features.HasReferenceImages)
+
+	data, err := common.Marshal(VeoRequestPayload{Instances: []VeoInstance{instance}})
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"instances": [{
+			"prompt": "make a video",
+			"image": {"inlineData": {"mimeType": "image/png", "data": "first-base64"}},
+			"lastFrame": {"inlineData": {"mimeType": "image/png", "data": "last-base64"}},
+			"referenceImages": [{
+				"image": {"inlineData": {"mimeType": "image/png", "data": "asset-base64"}},
+				"referenceType": "asset"
+			}]
+		}]
+	}`, string(data))
+}
+
+func TestApplyVeoMetadataToInstanceSupportsAliasesAndStringifiedJSON(t *testing.T) {
+	instance := VeoInstance{Prompt: "make a video"}
+	features, err := ApplyVeoMetadataToInstance(map[string]any{
+		"first_frame":      "data:image/png;base64,Zmlyc3Q=",
+		"last_frame":       `{"inlineData":{"mimeType":"image/jpeg","data":"last-base64"}}`,
+		"reference_images": `[{"image":{"inlineData":{"mimeType":"image/png","data":"asset-base64"}},"reference_type":"asset"}]`,
+	}, &instance)
+
+	require.NoError(t, err)
+	require.True(t, features.HasImage)
+	require.True(t, features.HasLastFrame)
+	require.True(t, features.HasReferenceImages)
+	require.Equal(t, "image/png", instance.Image.InlineData.MimeType)
+	require.Equal(t, "Zmlyc3Q=", instance.Image.InlineData.Data)
+	require.Equal(t, "image/jpeg", instance.LastFrame.InlineData.MimeType)
+	require.Len(t, instance.ReferenceImages, 1)
+	require.Equal(t, "asset", instance.ReferenceImages[0].ReferenceType)
+}
+
+func TestApplyVeoMetadataToInstanceSupportsBareReferenceImageDataURI(t *testing.T) {
+	instance := VeoInstance{Prompt: "make a video"}
+	features, err := ApplyVeoMetadataToInstance(map[string]any{
+		"referenceImages": []any{
+			"data:image/png;base64,aVZCTw==",
+			map[string]any{
+				"inlineData": map[string]any{
+					"mimeType": "image/jpeg",
+					"data":     "bare-object-base64",
+				},
+			},
+		},
+	}, &instance)
+
+	require.NoError(t, err)
+	require.True(t, features.HasReferenceImages)
+	require.Len(t, instance.ReferenceImages, 2)
+	require.Equal(t, "asset", instance.ReferenceImages[0].ReferenceType)
+	require.Equal(t, "image/png", instance.ReferenceImages[0].Image.InlineData.MimeType)
+	require.Equal(t, "aVZCTw==", instance.ReferenceImages[0].Image.InlineData.Data)
+	require.Equal(t, "asset", instance.ReferenceImages[1].ReferenceType)
+	require.Equal(t, "image/jpeg", instance.ReferenceImages[1].Image.InlineData.MimeType)
+}
+
+func TestApplyVeoMetadataToInstanceReturnsErrorsForInvalidInputs(t *testing.T) {
+	tests := []struct {
+		name        string
+		metadata    map[string]any
+		errContains string
+	}{
+		{
+			name: "image missing inline data",
+			metadata: map[string]any{
+				"image": map[string]any{
+					"inlineData": map[string]any{
+						"mimeType": "image/png",
+					},
+				},
+			},
+			errContains: "inlineData.data is required",
+		},
+		{
+			name: "reference images string is not array",
+			metadata: map[string]any{
+				"referenceImages": "data:image/png;base64,aVZCTw==",
+			},
+			errContains: "referenceImages string must contain a JSON array",
+		},
+		{
+			name: "malformed json image string",
+			metadata: map[string]any{
+				"last_frame": `{"inlineData":{"mimeType":"image/png","data":"broken"`,
+			},
+			errContains: "invalid metadata lastFrame",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := VeoInstance{Prompt: "make a video"}
+			features, err := ApplyVeoMetadataToInstance(tt.metadata, &instance)
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errContains)
+			require.False(t, features.HasImage)
+			require.False(t, features.HasLastFrame)
+			require.False(t, features.HasReferenceImages)
+			require.Nil(t, instance.Image)
+			require.Nil(t, instance.LastFrame)
+			require.Empty(t, instance.ReferenceImages)
+			require.Equal(t, "make a video", instance.Prompt)
+		})
+	}
+}

--- a/relay/channel/task/vertex/adaptor.go
+++ b/relay/channel/task/vertex/adaptor.go
@@ -127,7 +127,10 @@ func (a *TaskAdaptor) EstimateBilling(c *gin.Context, info *relaycommon.RelayInf
 	if !ok {
 		return nil
 	}
-	req := v.(relaycommon.TaskSubmitReq)
+	req, ok := v.(relaycommon.TaskSubmitReq)
+	if !ok {
+		return nil
+	}
 
 	seconds := geminitask.ResolveVeoDuration(req.Metadata, req.Duration, req.Seconds)
 	resolution := geminitask.ResolveVeoResolution(req.Metadata, req.Size)
@@ -145,7 +148,10 @@ func (a *TaskAdaptor) BuildRequestBody(c *gin.Context, info *relaycommon.RelayIn
 	if !ok {
 		return nil, fmt.Errorf("request not found in context")
 	}
-	req := v.(relaycommon.TaskSubmitReq)
+	req, ok := v.(relaycommon.TaskSubmitReq)
+	if !ok {
+		return nil, fmt.Errorf("unexpected task_request type")
+	}
 
 	instance := geminitask.VeoInstance{Prompt: req.Prompt}
 	if img := geminitask.ExtractMultipartImage(c, info); img != nil {
@@ -155,6 +161,17 @@ func (a *TaskAdaptor) BuildRequestBody(c *gin.Context, info *relaycommon.RelayIn
 			instance.Image = parsed
 			info.Action = constant.TaskActionGenerate
 		}
+	}
+	features, err := geminitask.ApplyVeoMetadataToInstance(req.Metadata, &instance)
+	if err != nil {
+		return nil, err
+	}
+	if features.HasLastFrame {
+		info.Action = constant.TaskActionFirstTailGenerate
+	} else if features.HasReferenceImages {
+		info.Action = constant.TaskActionReferenceGenerate
+	} else if features.HasImage {
+		info.Action = constant.TaskActionGenerate
 	}
 
 	params := &geminitask.VeoParameters{}


### PR DESCRIPTION
## 变更描述 / Description
为 Gemini/Vertex Veo 视频任务增加 metadata 媒体输入支持。现在可以通过 metadata 传入首帧、尾帧和 referenceImages，适配 Veo 3.1 的 image、lastFrame、referenceImages 请求结构。

同时保留原有 input_reference/image/images[0] 行为，并兼容 data URI、纯 base64、inlineData 对象以及 reference_images/last_frame 等别名。referenceImages 也支持直接传 data:image/png;base64,... 字符串，默认按 asset 参考图处理。

## 变更类型 / Type of change
- [ ] Bug 修复 (Bug fix)
- [x] 新功能 (New feature)
- [ ] 性能优化 / 重构 (Refactor)
- [ ] 文档更新 (Documentation)

## 关联任务 / Related Issue
- Closes #3315

## 提交前检查项 / Checklist
- [x] 人工确认: 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] 非重复提交: 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] Bug fix 说明: 本 PR 不是 Bug fix，不适用。
- [x] 变更理解: 我已理解这些更改的工作原理及可能影响。
- [x] 范围聚焦: 本 PR 未包含任何与当前任务无关的代码改动。
- [x] 本地验证: 已在本地运行并通过测试。
- [x] 安全合规: 代码中无敏感凭据，且符合项目代码规范。

## 运行证明 / Proof of Work
已运行并通过：

```bash
go test ./relay/channel/task/gemini
go test ./relay/channel/task/...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Requests accept rich metadata to populate image, last-frame, and reference-image inputs; request intent (first-tail / reference / generate) is inferred from provided metadata.

* **Bug Fixes**
  * Metadata parsing errors now surface and block constructing invalid requests.

* **Tests**
  * Added tests covering metadata variants, key aliases, stringified JSON, mixed image formats, and invalid inputs.

* **Refactor**
  * Centralized image-input handling and switched to an inline image payload shape for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->