### PR TITLE
feat(channel): support manually editing channel balance in edit drawer

### DIFF
--- a/web/default/src/features/channels/components/drawers/channel-mutate-drawer.tsx
+++ b/web/default/src/features/channels/components/drawers/channel-mutate-drawer.tsx
@@ -99,6 +99,7 @@ import {
   sideDrawerSectionClassName,
   sideDrawerSwitchItemClassName,
 } from '@/components/drawer-layout'
+import { getCurrencyLabel } from '@/lib/currency'
 import { JsonEditor } from '@/components/json-editor'
 import { MultiSelect } from '@/components/multi-select'
 import {
@@ -278,6 +279,7 @@ export function ChannelMutateDrawer({
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const { setOpen } = useChannels()
+  const currencyLabel = getCurrencyLabel()
   const [fetchModelsDialogOpen, setFetchModelsDialogOpen] = useState(false)
   const [channelKey, setChannelKey] = useState<string | null>(null)
   const [isChannelKeyLoading, setIsChannelKeyLoading] = useState(false)
@@ -287,6 +289,7 @@ export function ChannelMutateDrawer({
   const initialModelsRef = useRef<string[]>([])
   const initialModelMappingRef = useRef<string>('')
   const initialStatusCodeMappingRef = useRef<string>('')
+  const initialBalanceRef = useRef<number | undefined>(undefined)
   const [statusCodeRiskOpen, setStatusCodeRiskOpen] = useState(false)
   const [statusCodeRiskDetailItems, setStatusCodeRiskDetailItems] = useState<
     string[]
@@ -592,12 +595,14 @@ export function ChannelMutateDrawer({
       initialModelMappingRef.current = channelData.data.model_mapping || ''
       initialStatusCodeMappingRef.current =
         channelData.data.status_code_mapping || ''
+      initialBalanceRef.current = defaults.balance
     } else if (!isEditing) {
       form.reset(CHANNEL_FORM_DEFAULT_VALUES)
       setAdvancedSettingsOpen(false)
       initialModelsRef.current = []
       initialModelMappingRef.current = ''
       initialStatusCodeMappingRef.current = ''
+      initialBalanceRef.current = undefined
     }
   }, [isEditing, channelData, form])
 
@@ -994,6 +999,11 @@ export function ChannelMutateDrawer({
             form.setValue('models', data.models)
           }
         }
+      }
+
+      // Skip balance when unchanged so currency conversion rounding never writes back
+      if (isEditing && data.balance === initialBalanceRef.current) {
+        data.balance = undefined
       }
 
       await channelMutation.mutateAsync(data)
@@ -2555,6 +2565,34 @@ export function ChannelMutateDrawer({
                               </FormItem>
                             )}
                           />
+
+                          {isEditing && (
+                            <FormField
+                              control={form.control}
+                              name='balance'
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel>
+                                    {t('Remaining Quota ({{currency}})', {
+                                      currency: currencyLabel,
+                                    })}
+                                  </FormLabel>
+                                  <FormControl>
+                                    <Input
+                                      type='number'
+                                      step='any'
+                                      placeholder='0'
+                                      {...field}
+                                      onChange={(e) =>
+                                        field.onChange(Number(e.target.value))
+                                      }
+                                    />
+                                  </FormControl>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                          )}
                         </div>
 
                         <FormField

--- a/web/default/src/features/channels/lib/channel-form.ts
+++ b/web/default/src/features/channels/lib/channel-form.ts
@@ -23,6 +23,7 @@ import {
   MODEL_FETCHABLE_TYPES,
 } from '../constants'
 import type { Channel } from '../types'
+import { balanceDisplayToUsd, balanceUsdToDisplay } from './channel-utils'
 
 // ============================================================================
 // Form Validation Schema
@@ -138,6 +139,7 @@ export const channelFormSchema = z
       ),
     priority: z.number().optional(),
     weight: z.number().optional(),
+    balance: z.number().optional(),
     test_model: z.string().optional(),
     auto_ban: z.number().optional(),
     status: z.number(),
@@ -278,6 +280,7 @@ export const CHANNEL_FORM_DEFAULT_VALUES: ChannelFormValues = {
   model_mapping: '',
   priority: 0,
   weight: 0,
+  balance: 0,
   test_model: '',
   auto_ban: 1,
   status: CHANNEL_STATUS.ENABLED,
@@ -411,6 +414,7 @@ export function transformChannelToFormDefaults(
     model_mapping: channel.model_mapping || '',
     priority: channel.priority || 0,
     weight: channel.weight || 0,
+    balance: balanceUsdToDisplay(channel.balance || 0),
     test_model: channel.test_model || '',
     auto_ban: channel.auto_ban ?? 1,
     status: channel.status,
@@ -646,6 +650,10 @@ export function transformFormDataToUpdatePayload(
     model_mapping: formData.model_mapping || null,
     priority: formData.priority ?? 0,
     weight: formData.weight ?? 0,
+    balance:
+      formData.balance !== undefined
+        ? balanceDisplayToUsd(formData.balance)
+        : undefined,
     test_model: formData.test_model || null,
     auto_ban: formData.auto_ban ?? 1,
     status: formData.status,

--- a/web/default/src/features/channels/lib/channel-utils.ts
+++ b/web/default/src/features/channels/lib/channel-utils.ts
@@ -16,7 +16,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { formatCurrencyFromUSD, formatQuotaWithCurrency } from '@/lib/currency'
+import {
+  formatCurrencyFromUSD,
+  formatQuotaWithCurrency,
+  getCurrencyDisplay,
+} from '@/lib/currency'
 import dayjs from '@/lib/dayjs'
 import { formatTimestampToDate } from '@/lib/format'
 import {
@@ -308,6 +312,25 @@ export function formatBalance(balance: number | null | undefined): string {
     digitsSmall: 4,
     abbreviate: false,
   })
+}
+
+function balanceDisplayRate(): number {
+  const { config, meta } = getCurrencyDisplay()
+  return meta.kind === 'tokens' ? config.quotaPerUnit : meta.exchangeRate
+}
+
+/**
+ * Convert a stored USD balance to the configured display currency value
+ */
+export function balanceUsdToDisplay(usd: number): number {
+  return Number((usd * balanceDisplayRate()).toFixed(6))
+}
+
+/**
+ * Convert a display currency balance back to USD for storage
+ */
+export function balanceDisplayToUsd(display: number): number {
+  return display / balanceDisplayRate()
 }
 
 /**


### PR DESCRIPTION
## 📝 变更描述 / Description

部分渠道(自定义渠道、各厂商的 Coding/Token Plan 等)无法自动获取余额,但实际存在额度上限。本 PR 在渠道编辑抽屉中新增「剩余额度」输入框(仅编辑已有渠道时显示),允许管理员手动维护渠道余额:

- 输入框按系统配置的显示货币展示(USD / 自定义货币 / Tokens),提交时换算回 USD 存储,与自动查询余额的口径一致;
- 未修改余额时不提交该字段,避免货币换算的舍入误差被写回;
- 纯前端改动:`balance` 经 `PatchChannel` 内嵌的 `model.Channel` 字段绑定,复用现有 `UpdateChannel` → `channel.Update()` 链路写入,后端零改动。因 GORM struct Updates 跳过零值,暂不支持把余额改为 0,影响有限。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #4726

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述,没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs,确认不是重复提交。
- [ ] **Bug fix 说明:** 不适用(非 Bug 修复)。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并手动验证。
- [x] **安全合规:** 代码中无敏感凭据,且符合项目代码规范。

## 📸 运行证明 / Proof of Work
<img width="1578" height="700" alt="image" src="https://github.com/user-attachments/assets/c0694e5d-9cb4-4a91-939d-23fc5122a2a7" />
<img width="460" height="92" alt="image" src="https://github.com/user-attachments/assets/b312fbba-290c-488e-9195-865f78f7a486" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Remaining Quota" (balance) field to channel advanced settings, enabling users to view and edit channel balance with automatic currency conversion and decimal formatting. The system intelligently handles balance updates, omitting unchanged values from submissions to prevent rounding artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->