### PR TITLE
feat(channel): 渠道余额显示实时剩余余额

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -979,6 +979,10 @@ func UpdateChannel(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
+	if channel.Balance != 0 && channel.Balance != originChannel.Balance {
+		// re-stamp balance_snapshot/balance_updated_time alongside the manually edited balance
+		channel.UpdateBalance(channel.Balance)
+	}
 	model.InitChannelCache()
 	service.ResetProxyClientCache()
 	channel.Key = ""
@@ -1215,6 +1219,7 @@ func CopyChannel(c *gin.Context) {
 	if resetBalance {
 		clone.Balance = 0
 		clone.UsedQuota = 0
+		clone.BalanceSnapshot = nil
 	}
 
 	// insert

--- a/model/channel.go
+++ b/model/channel.go
@@ -39,6 +39,7 @@ type Channel struct {
 	Models             string  `json:"models"`
 	Group              string  `json:"group" gorm:"type:varchar(64);default:'default'"`
 	UsedQuota          int64   `json:"used_quota" gorm:"bigint;default:0"`
+	BalanceSnapshot    *int64  `json:"balance_snapshot" gorm:"bigint"` // used_quota at last balance set; NULL = never set
 	ModelMapping       *string `json:"model_mapping" gorm:"type:text"`
 	//MaxInputTokens     *int    `json:"max_input_tokens" gorm:"default:0"`
 	StatusCodeMapping *string `json:"status_code_mapping" gorm:"type:varchar(1024);default:''"`
@@ -583,9 +584,10 @@ func (channel *Channel) UpdateResponseTime(responseTime int64) {
 }
 
 func (channel *Channel) UpdateBalance(balance float64) {
-	err := DB.Model(channel).Select("balance_updated_time", "balance").Updates(Channel{
-		BalanceUpdatedTime: common.GetTimestamp(),
-		Balance:            balance,
+	err := DB.Model(channel).Updates(map[string]interface{}{
+		"balance_updated_time": common.GetTimestamp(),
+		"balance":              balance,
+		"balance_snapshot":     gorm.Expr("used_quota"),
 	}).Error
 	if err != nil {
 		common.SysLog(fmt.Sprintf("failed to update balance: channel_id=%d, error=%v", channel.Id, err))

--- a/web/default/src/features/channels/components/channels-columns.tsx
+++ b/web/default/src/features/channels/components/channels-columns.tsx
@@ -54,6 +54,7 @@ import { TruncatedText } from '@/components/truncated-text'
 import { getCodexUsage } from '../api'
 import { CHANNEL_STATUS_CONFIG, MODEL_FETCHABLE_TYPES } from '../constants'
 import {
+  channelLiveBalanceUsd,
   formatBalance,
   formatRelativeTime,
   formatResponseTime,
@@ -289,7 +290,7 @@ function BalanceCell({ channel }: { channel: Channel }) {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const isTagRow = isTagAggregateRow(channel)
-  const balance = channel.balance || 0
+  const balance = channelLiveBalanceUsd(channel)
   const usedQuota = channel.used_quota || 0
   const [isUpdating, setIsUpdating] = useState(false)
   const [codexUsageOpen, setCodexUsageOpen] = useState(false)

--- a/web/default/src/features/channels/components/drawers/channel-mutate-drawer.tsx
+++ b/web/default/src/features/channels/components/drawers/channel-mutate-drawer.tsx
@@ -99,6 +99,7 @@ import {
   sideDrawerSectionClassName,
   sideDrawerSwitchItemClassName,
 } from '@/components/drawer-layout'
+import { getCurrencyLabel } from '@/lib/currency'
 import { JsonEditor } from '@/components/json-editor'
 import { MultiSelect } from '@/components/multi-select'
 import {
@@ -278,6 +279,7 @@ export function ChannelMutateDrawer({
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const { setOpen } = useChannels()
+  const currencyLabel = getCurrencyLabel()
   const [fetchModelsDialogOpen, setFetchModelsDialogOpen] = useState(false)
   const [channelKey, setChannelKey] = useState<string | null>(null)
   const [isChannelKeyLoading, setIsChannelKeyLoading] = useState(false)
@@ -287,6 +289,7 @@ export function ChannelMutateDrawer({
   const initialModelsRef = useRef<string[]>([])
   const initialModelMappingRef = useRef<string>('')
   const initialStatusCodeMappingRef = useRef<string>('')
+  const initialBalanceRef = useRef<number | undefined>(undefined)
   const [statusCodeRiskOpen, setStatusCodeRiskOpen] = useState(false)
   const [statusCodeRiskDetailItems, setStatusCodeRiskDetailItems] = useState<
     string[]
@@ -592,12 +595,14 @@ export function ChannelMutateDrawer({
       initialModelMappingRef.current = channelData.data.model_mapping || ''
       initialStatusCodeMappingRef.current =
         channelData.data.status_code_mapping || ''
+      initialBalanceRef.current = defaults.balance
     } else if (!isEditing) {
       form.reset(CHANNEL_FORM_DEFAULT_VALUES)
       setAdvancedSettingsOpen(false)
       initialModelsRef.current = []
       initialModelMappingRef.current = ''
       initialStatusCodeMappingRef.current = ''
+      initialBalanceRef.current = undefined
     }
   }, [isEditing, channelData, form])
 
@@ -994,6 +999,11 @@ export function ChannelMutateDrawer({
             form.setValue('models', data.models)
           }
         }
+      }
+
+      // Skip balance when unchanged so currency conversion rounding never writes back
+      if (isEditing && data.balance === initialBalanceRef.current) {
+        data.balance = undefined
       }
 
       await channelMutation.mutateAsync(data)
@@ -2555,6 +2565,34 @@ export function ChannelMutateDrawer({
                               </FormItem>
                             )}
                           />
+
+                          {isEditing && (
+                            <FormField
+                              control={form.control}
+                              name='balance'
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel>
+                                    {t('Remaining Quota ({{currency}})', {
+                                      currency: currencyLabel,
+                                    })}
+                                  </FormLabel>
+                                  <FormControl>
+                                    <Input
+                                      type='number'
+                                      step='any'
+                                      placeholder='0'
+                                      {...field}
+                                      onChange={(e) =>
+                                        field.onChange(Number(e.target.value))
+                                      }
+                                    />
+                                  </FormControl>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                          )}
                         </div>
 
                         <FormField

--- a/web/default/src/features/channels/lib/channel-form.ts
+++ b/web/default/src/features/channels/lib/channel-form.ts
@@ -23,6 +23,7 @@ import {
   MODEL_FETCHABLE_TYPES,
 } from '../constants'
 import type { Channel } from '../types'
+import { balanceDisplayToUsd, balanceUsdToDisplay } from './channel-utils'
 
 // ============================================================================
 // Form Validation Schema
@@ -138,6 +139,7 @@ export const channelFormSchema = z
       ),
     priority: z.number().optional(),
     weight: z.number().optional(),
+    balance: z.number().optional(),
     test_model: z.string().optional(),
     auto_ban: z.number().optional(),
     status: z.number(),
@@ -278,6 +280,7 @@ export const CHANNEL_FORM_DEFAULT_VALUES: ChannelFormValues = {
   model_mapping: '',
   priority: 0,
   weight: 0,
+  balance: 0,
   test_model: '',
   auto_ban: 1,
   status: CHANNEL_STATUS.ENABLED,
@@ -411,6 +414,7 @@ export function transformChannelToFormDefaults(
     model_mapping: channel.model_mapping || '',
     priority: channel.priority || 0,
     weight: channel.weight || 0,
+    balance: balanceUsdToDisplay(channel.balance || 0),
     test_model: channel.test_model || '',
     auto_ban: channel.auto_ban ?? 1,
     status: channel.status,
@@ -646,6 +650,10 @@ export function transformFormDataToUpdatePayload(
     model_mapping: formData.model_mapping || null,
     priority: formData.priority ?? 0,
     weight: formData.weight ?? 0,
+    balance:
+      formData.balance !== undefined
+        ? balanceDisplayToUsd(formData.balance)
+        : undefined,
     test_model: formData.test_model || null,
     auto_ban: formData.auto_ban ?? 1,
     status: formData.status,

--- a/web/default/src/features/channels/lib/channel-form.ts
+++ b/web/default/src/features/channels/lib/channel-form.ts
@@ -23,7 +23,11 @@ import {
   MODEL_FETCHABLE_TYPES,
 } from '../constants'
 import type { Channel } from '../types'
-import { balanceDisplayToUsd, balanceUsdToDisplay } from './channel-utils'
+import {
+  balanceDisplayToUsd,
+  balanceUsdToDisplay,
+  channelLiveBalanceUsd,
+} from './channel-utils'
 
 // ============================================================================
 // Form Validation Schema
@@ -414,7 +418,7 @@ export function transformChannelToFormDefaults(
     model_mapping: channel.model_mapping || '',
     priority: channel.priority || 0,
     weight: channel.weight || 0,
-    balance: balanceUsdToDisplay(channel.balance || 0),
+    balance: balanceUsdToDisplay(channelLiveBalanceUsd(channel)),
     test_model: channel.test_model || '',
     auto_ban: channel.auto_ban ?? 1,
     status: channel.status,

--- a/web/default/src/features/channels/lib/channel-utils.ts
+++ b/web/default/src/features/channels/lib/channel-utils.ts
@@ -334,6 +334,23 @@ export function balanceDisplayToUsd(display: number): number {
 }
 
 /**
+ * Live remaining balance in USD: stored balance minus quota consumed since it
+ * was last set (balance_snapshot). Falls back to the stored balance when the
+ * snapshot was never stamped.
+ */
+export function channelLiveBalanceUsd(channel: {
+  balance?: number | null
+  used_quota?: number | null
+  balance_snapshot?: number | null
+}): number {
+  const balance = channel.balance || 0
+  const snapshot = channel.balance_snapshot
+  if (snapshot == null) return balance
+  const { config } = getCurrencyDisplay()
+  return balance - ((channel.used_quota || 0) - snapshot) / config.quotaPerUnit
+}
+
+/**
  * Get balance status color
  */
 export function getBalanceVariant(

--- a/web/default/src/features/channels/lib/channel-utils.ts
+++ b/web/default/src/features/channels/lib/channel-utils.ts
@@ -16,7 +16,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { formatCurrencyFromUSD, formatQuotaWithCurrency } from '@/lib/currency'
+import {
+  formatCurrencyFromUSD,
+  formatQuotaWithCurrency,
+  getCurrencyDisplay,
+} from '@/lib/currency'
 import dayjs from '@/lib/dayjs'
 import { formatTimestampToDate } from '@/lib/format'
 import {
@@ -308,6 +312,25 @@ export function formatBalance(balance: number | null | undefined): string {
     digitsSmall: 4,
     abbreviate: false,
   })
+}
+
+function balanceDisplayRate(): number {
+  const { config, meta } = getCurrencyDisplay()
+  return meta.kind === 'tokens' ? config.quotaPerUnit : meta.exchangeRate
+}
+
+/**
+ * Convert a stored USD balance to the configured display currency value
+ */
+export function balanceUsdToDisplay(usd: number): number {
+  return Number((usd * balanceDisplayRate()).toFixed(6))
+}
+
+/**
+ * Convert a display currency balance back to USD for storage
+ */
+export function balanceDisplayToUsd(display: number): number {
+  return display / balanceDisplayRate()
 }
 
 /**

--- a/web/default/src/features/channels/types.ts
+++ b/web/default/src/features/channels/types.ts
@@ -53,6 +53,7 @@ export const channelSchema = z.object({
   models: z.string().default(''),
   group: z.string().default('default'),
   used_quota: z.number().default(0),
+  balance_snapshot: z.number().nullish(), // used_quota at last balance set; null = never set
   model_mapping: z.string().nullish(),
   status_code_mapping: z.string().nullish(),
   priority: z.number().nullish(),


### PR DESCRIPTION
基于 #5436（手动编辑渠道余额）

## 变更内容
- 新增 `balance_snapshot` 字段，设置余额时记录当时的 `used_quota`
- 渠道列表余额改为显示实时剩余：余额 − 设置余额后新增的配额消耗（按 quotaPerUnit 折算）；未设置过快照时仍显示原余额
- 手动编辑余额时同步刷新 balance_snapshot / balance_updated_time
- 复制渠道选择重置余额时清空快照