### PR TITLE
feat: allow custom API key on token creation

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -201,11 +201,14 @@ func AddToken(c *gin.Context) {
 		})
 		return
 	}
-	key, err := common.GenerateKey()
-	if err != nil {
-		common.ApiErrorI18n(c, i18n.MsgTokenGenerateFailed)
-		common.SysLog("failed to generate token key: " + err.Error())
-		return
+	key := strings.TrimPrefix(strings.TrimSpace(token.Key), "sk-")
+	if key == "" {
+		key, err = common.GenerateKey()
+		if err != nil {
+			common.ApiErrorI18n(c, i18n.MsgTokenGenerateFailed)
+			common.SysLog("failed to generate token key: " + err.Error())
+			return
+		}
 	}
 	cleanToken := model.Token{
 		UserId:             c.GetInt("id"),

--- a/controller/token_custom_key_test.go
+++ b/controller/token_custom_key_test.go
@@ -1,0 +1,40 @@
+package controller
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/QuantumNous/new-api/model"
+)
+
+func TestAddTokenUsesCustomKey(t *testing.T) {
+	db := setupTokenControllerTestDB(t)
+	customKey := "customApiKey123"
+	body := map[string]any{
+		"name":                 "custom-token",
+		"key":                  "sk-" + customKey,
+		"expired_time":         -1,
+		"remain_quota":         100,
+		"unlimited_quota":      true,
+		"model_limits_enabled": false,
+		"model_limits":         "",
+		"group":                "default",
+		"cross_group_retry":    false,
+	}
+
+	ctx, recorder := newAuthenticatedContext(t, http.MethodPost, "/api/token/", body, 1)
+	AddToken(ctx)
+
+	response := decodeAPIResponse(t, recorder)
+	if !response.Success {
+		t.Fatalf("expected custom key token creation to succeed, got message: %s", response.Message)
+	}
+
+	var inserted model.Token
+	if err := db.First(&inserted, "user_id = ? AND name = ?", 1, "custom-token").Error; err != nil {
+		t.Fatalf("failed to fetch inserted token: %v", err)
+	}
+	if inserted.Key != customKey {
+		t.Fatalf("expected custom key %q, got %q", customKey, inserted.Key)
+	}
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
为管理接口创建 API Key（`POST /api/token/`）增加自定义 key 支持：当请求体中传入非空 `key` 时，创建令牌会使用该值；如果传入值带有 `sk-` 前缀，会按现有鉴权逻辑存储为去除前缀后的 key。

该改动直接复用现有 `Token.Key` 字段和创建流程，仅调整 `AddToken` 中原本固定随机生成 key 的逻辑；未传入 `key` 或传入空值时仍调用 `common.GenerateKey()`，因此原有行为保持不变。

## 🚀 变更类型 / Type of change
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (无)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom token keys are now supported. When creating new tokens, users can provide their own token key, which the system will process and use. If no custom key is provided or the provided key is invalid, the system automatically generates a new token key for the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->