### PR TITLE
fix(subscription): apply Epay price multiplier to subscription payments

### DIFF
--- a/controller/subscription_payment_epay.go
+++ b/controller/subscription_payment_epay.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/Calcium-Ion/go-epay/epay"
@@ -14,6 +13,7 @@ import (
 	"github.com/QuantumNous/new-api/setting/operation_setting"
 	"github.com/gin-gonic/gin"
 	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
 )
 
 type SubscriptionEpayPayRequest struct {
@@ -84,10 +84,15 @@ func SubscriptionRequestEpay(c *gin.Context) {
 		return
 	}
 
+	// plan.PriceAmount is in USD; multiply by Price (CNY per USD) to get the actual charge amount
+	payMoney := decimal.NewFromFloat(plan.PriceAmount).
+		Mul(decimal.NewFromFloat(operation_setting.Price)).
+		Round(2)
+
 	order := &model.SubscriptionOrder{
 		UserId:          userId,
 		PlanId:          plan.Id,
-		Money:           plan.PriceAmount,
+		Money:           payMoney.InexactFloat64(),
 		TradeNo:         tradeNo,
 		PaymentMethod:   req.PaymentMethod,
 		PaymentProvider: model.PaymentProviderEpay,
@@ -102,7 +107,7 @@ func SubscriptionRequestEpay(c *gin.Context) {
 		Type:           req.PaymentMethod,
 		ServiceTradeNo: tradeNo,
 		Name:           fmt.Sprintf("SUB:%s", plan.Title),
-		Money:          strconv.FormatFloat(plan.PriceAmount, 'f', 2, 64),
+		Money:          payMoney.StringFixed(2),
 		Device:         epay.PC,
 		NotifyUrl:      notifyUrl,
 		ReturnUrl:      returnUrl,


### PR DESCRIPTION
> [!IMPORTANT]
> 本 PR 由 AI（Claude Sonnet 4.6）辅助生成，代码逻辑经人工确认。

## 📝 变更描述 / Description

订阅套餐通过 Epay 发起支付时，直接使用 `plan.PriceAmount`（美元金额）作为收费金额，未乘以后台配置的「每美元余额收费金额」(`operation_setting.Price`)。

普通充值流程已通过 `getPayMoney()` 正确应用该乘数，订阅流程遗漏了这一步。

**修复方式：** 在 `SubscriptionRequestEpay` 中，发起支付前计算 `payMoney = plan.PriceAmount × operation_setting.Price`，并同时更新订单记录和 Epay 购买请求的金额字段。

示例：套餐价格 9.9 美元，价格字段配置为 7，修复后实际收费将正确为 69.3 元，而非 9.9 元。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- Closes # (暂无)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 代码逻辑已人工核实，修复方式与 `topup.go` 中 `getPayMoney()` 的实现一致。
- [x] **非重复提交:** 已确认无同类 PR。
- [x] **Bug fix 说明:** 这是明确的计算遗漏，非设计取舍。
- [x] **变更理解:** 修改仅影响 Epay 订阅支付金额计算，不影响其他支付方式或普通充值。
- [x] **范围聚焦:** 仅修改 `controller/subscription_payment_epay.go`，无无关改动。
- [x] **本地验证:** 本地编译通过（`go build ./controller/...`）。
- [x] **安全合规:** 无敏感信息，符合项目规范。

## 📸 运行证明 / Proof of Work

本地 `go build ./controller/...` 编译无报错。

**变更文件：** `controller/subscription_payment_epay.go`

```diff
+	// plan.PriceAmount is in USD; multiply by Price (CNY per USD) to get the actual charge amount
+	payMoney := decimal.NewFromFloat(plan.PriceAmount).
+		Mul(decimal.NewFromFloat(operation_setting.Price)).
+		InexactFloat64()
+
 	order := &model.SubscriptionOrder{
 		...
-		Money:           plan.PriceAmount,
+		Money:           payMoney,
 	}
 	uri, params, err := client.Purchase(&epay.PurchaseArgs{
 		...
-		Money:          strconv.FormatFloat(plan.PriceAmount, 'f', 2, 64),
+		Money:          strconv.FormatFloat(payMoney, 'f', 2, 64),
 	})
```

> ⚠️ 此 PR 由 AI 辅助编写（Claude Sonnet 4.6），提交者 monlor 非项目核心开发者。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription charge calculation corrected so amounts are accurately computed, rounded to two decimals, and recorded/sent with subscription orders, ensuring charges reflect precise currency values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->