### PR TITLE
feat: add TRUSTED_PROXY_CIDRS for Gin trusted proxies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,11 @@ LINUX_DO_USER_ENDPOINT=https://connect.linux.do/api/user
 # 如果是主节点则为master
 # NODE_TYPE=master
 
+# 可信反向代理CIDR（逗号分隔）。部署在K8s/Ingress/Traefik后建议配置Pod/入口网段，
+# 使Gin ClientIP()解析X-Forwarded-For/X-Real-IP（限流、日志、审计等依赖ClientIP的功能）。
+# 示例: TRUSTED_PROXY_CIDRS=10.42.0.0/16,10.43.0.0/16,172.19.0.0/16
+# TRUSTED_PROXY_CIDRS=
+
 # 可信任重定向域名列表（逗号分隔，支持子域名匹配）
 # 用于验证支付成功/取消回调URL的域名安全性
 # 示例: example.com,myapp.io 将允许 example.com, sub.example.com, myapp.io 等

--- a/common/constants.go
+++ b/common/constants.go
@@ -160,6 +160,10 @@ var IsMasterNode bool
 // 用于审计日志中标识节点身份，在容器/K8s 部署时比自动探测到的容器内网 IP 更具可读性。
 var NodeName = ""
 
+// TrustedProxyCIDRs 可信反向代理CIDR列表，来自TRUSTED_PROXY_CIDRS环境变量。
+// 非空时用于Gin SetTrustedProxies，使ClientIP()可解析X-Forwarded-For/X-Real-IP。
+var TrustedProxyCIDRs []string
+
 var requestInterval int
 var RequestInterval time.Duration
 

--- a/common/init.go
+++ b/common/init.go
@@ -180,4 +180,14 @@ func initConstantEnv() {
 		}
 	}
 	constant.TrustedRedirectDomains = trustedDomains
+
+	trustedProxyCIDRsStr := GetEnvOrDefaultString("TRUSTED_PROXY_CIDRS", "")
+	var trustedProxyCIDRs []string
+	for _, cidr := range strings.Split(trustedProxyCIDRsStr, ",") {
+		trimmedCIDR := strings.TrimSpace(cidr)
+		if trimmedCIDR != "" {
+			trustedProxyCIDRs = append(trustedProxyCIDRs, trimmedCIDR)
+		}
+	}
+	TrustedProxyCIDRs = trustedProxyCIDRs
 }

--- a/main.go
+++ b/main.go
@@ -160,6 +160,12 @@ func main() {
 
 	// Initialize HTTP server
 	server := gin.New()
+	if len(common.TrustedProxyCIDRs) > 0 {
+		if err := server.SetTrustedProxies(common.TrustedProxyCIDRs); err != nil {
+			common.FatalLog("failed to set trusted proxies from TRUSTED_PROXY_CIDRS: " + err.Error())
+		}
+		common.SysLog("trusted proxy CIDRs enabled for ClientIP(): " + strings.Join(common.TrustedProxyCIDRs, ", "))
+	}
 	server.Use(gin.CustomRecovery(func(c *gin.Context, err any) {
 		common.SysLog(fmt.Sprintf("panic detected: %v", err))
 		c.JSON(http.StatusInternalServerError, gin.H{


### PR DESCRIPTION
## Summary

- Add optional env `TRUSTED_PROXY_CIDRS` (comma-separated CIDRs).
- Call `gin.Engine.SetTrustedProxies` at startup when set.
- Improves client IP detection behind Kubernetes Ingress/Traefik for rate limiting (`rateLimit:*` Redis keys), logs, and audit entries that use `c.ClientIP()`.

## Motivation

When NEW-API runs behind Traefik/Ingress, Gin had no trusted proxies configured. `c.ClientIP()` often returned the proxy Pod IP (e.g. `10.42.x.x`) instead of the real client from `X-Forwarded-For` / `X-Real-IP`.

## Behavior

- Unset `TRUSTED_PROXY_CIDRS`: unchanged (backward compatible).
- Set e.g. `TRUSTED_PROXY_CIDRS=10.42.0.0/16,10.43.0.0/16`: startup logs trusted CIDRs; `ClientIP()` honors forwarded headers from those proxies.

## Test plan

- [ ] Start without `TRUSTED_PROXY_CIDRS`: no startup trusted-proxy log; behavior unchanged.
- [ ] Start with `TRUSTED_PROXY_CIDRS=10.42.0.0/16` behind Traefik: startup log lists CIDRs; Redis rate-limit keys use real client IP instead of Pod IP.
- [ ] Invalid CIDR in env: process exits with clear fatal log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring trusted reverse proxy CIDR ranges via the `TRUSTED_PROXY_CIDRS` environment variable (comma-separated values). This ensures proper client IP address resolution when deploying behind reverse proxies such as Kubernetes Ingress Controllers or Traefik, which forward client IPs using `X-Forwarded-For` or `X-Real-IP` headers in their requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->