### PR TITLE
feat: add TRUSTED_PROXY_CIDRS for Gin trusted proxies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,11 @@ LINUX_DO_USER_ENDPOINT=https://connect.linux.do/api/user
 # 如果是主节点则为master
 # NODE_TYPE=master
 
+# 可信反向代理CIDR（逗号分隔）。部署在K8s/Ingress/Traefik后建议配置Pod/入口网段，
+# 使Gin ClientIP()解析X-Forwarded-For/X-Real-IP（限流、日志、审计等依赖ClientIP的功能）。
+# 示例: TRUSTED_PROXY_CIDRS=10.42.0.0/16,10.43.0.0/16,172.19.0.0/16
+# TRUSTED_PROXY_CIDRS=
+
 # 可信任重定向域名列表（逗号分隔，支持子域名匹配）
 # 用于验证支付成功/取消回调URL的域名安全性
 # 示例: example.com,myapp.io 将允许 example.com, sub.example.com, myapp.io 等

--- a/common/constants.go
+++ b/common/constants.go
@@ -160,6 +160,10 @@ var IsMasterNode bool
 // 用于审计日志中标识节点身份，在容器/K8s 部署时比自动探测到的容器内网 IP 更具可读性。
 var NodeName = ""
 
+// TrustedProxyCIDRs 可信反向代理CIDR列表，来自TRUSTED_PROXY_CIDRS环境变量。
+// 非空时用于Gin SetTrustedProxies，使ClientIP()可解析X-Forwarded-For/X-Real-IP。
+var TrustedProxyCIDRs []string
+
 var requestInterval int
 var RequestInterval time.Duration
 

--- a/common/init.go
+++ b/common/init.go
@@ -180,4 +180,14 @@ func initConstantEnv() {
 		}
 	}
 	constant.TrustedRedirectDomains = trustedDomains
+
+	trustedProxyCIDRsStr := GetEnvOrDefaultString("TRUSTED_PROXY_CIDRS", "")
+	var trustedProxyCIDRs []string
+	for _, cidr := range strings.Split(trustedProxyCIDRsStr, ",") {
+		trimmedCIDR := strings.TrimSpace(cidr)
+		if trimmedCIDR != "" {
+			trustedProxyCIDRs = append(trustedProxyCIDRs, trimmedCIDR)
+		}
+	}
+	TrustedProxyCIDRs = trustedProxyCIDRs
 }

--- a/main.go
+++ b/main.go
@@ -160,6 +160,12 @@ func main() {
 
 	// Initialize HTTP server
 	server := gin.New()
+	if len(common.TrustedProxyCIDRs) > 0 {
+		if err := server.SetTrustedProxies(common.TrustedProxyCIDRs); err != nil {
+			common.FatalLog("failed to set trusted proxies from TRUSTED_PROXY_CIDRS: " + err.Error())
+		}
+		common.SysLog("trusted proxy CIDRs enabled for ClientIP(): " + strings.Join(common.TrustedProxyCIDRs, ", "))
+	}
 	server.Use(gin.CustomRecovery(func(c *gin.Context, err any) {
 		common.SysLog(fmt.Sprintf("panic detected: %v", err))
 		c.JSON(http.StatusInternalServerError, gin.H{


### PR DESCRIPTION
## Summary

When deployed behind Kubernetes Ingress/Traefik, rate limits and logs use `c.ClientIP()` which may return the proxy Pod IP instead of the real client IP.

This PR adds optional `TRUSTED_PROXY_CIDRS` env var to configure Gin `SetTrustedProxies`, so `ClientIP()` honors `X-Forwarded-For` / `X-Real-IP` when the immediate peer is a trusted proxy.

## Changes

- Parse `TRUSTED_PROXY_CIDRS` (comma-separated CIDRs) in `common/init.go`
- Call `gin.SetTrustedProxies()` in `main.go` when configured
- Document in `.env.example`

---

**Closed by author:** Root cause in our deployment was Traefik Service `externalTrafficPolicy: Local` (SNAT to pod CIDR). After fixing Traefik, client IP / rate-limit keys work with the stock image; this upstream change is no longer needed for our case.