### PR TITLE
fix: convert SiliconFlow and DeepSeek balance from RMB to USD-equivalent

### DIFF
--- a/controller/channel-billing.go
+++ b/controller/channel-billing.go
@@ -258,8 +258,10 @@ func updateChannelSiliconFlowBalance(channel *model.Channel) (float64, error) {
 	if err != nil {
 		return 0, err
 	}
-	channel.UpdateBalance(balance)
-	return balance, nil
+	// SiliconFlow 返回人民币余额，统一转为 USD-equivalent 存储
+	balanceUsd := decimal.NewFromFloat(balance).Div(decimal.NewFromFloat(operation_setting.USDExchangeRate)).InexactFloat64()
+	channel.UpdateBalance(balanceUsd)
+	return balanceUsd, nil
 }
 
 func updateChannelDeepSeekBalance(channel *model.Channel) (float64, error) {
@@ -287,8 +289,10 @@ func updateChannelDeepSeekBalance(channel *model.Channel) (float64, error) {
 	if err != nil {
 		return 0, err
 	}
-	channel.UpdateBalance(balance)
-	return balance, nil
+	// DeepSeek 返回人民币余额，统一转为 USD-equivalent 存储
+	balanceUsd := decimal.NewFromFloat(balance).Div(decimal.NewFromFloat(operation_setting.USDExchangeRate)).InexactFloat64()
+	channel.UpdateBalance(balanceUsd)
+	return balanceUsd, nil
 }
 
 func updateChannelAIGC2DBalance(channel *model.Channel) (float64, error) {

--- a/controller/channel-billing.go
+++ b/controller/channel-billing.go
@@ -361,7 +361,10 @@ func updateChannelMoonshotBalance(channel *model.Channel) (float64, error) {
 		return 0, fmt.Errorf("failed to update moonshot balance, status: %v, code: %d, scode: %s", response.Status, response.Code, response.Scode)
 	}
 	availableBalanceCny := response.Data.AvailableBalance
-	availableBalanceUsd := decimal.NewFromFloat(availableBalanceCny).Div(decimal.NewFromFloat(operation_setting.Price)).InexactFloat64()
+	if operation_setting.USDExchangeRate <= 0 {
+		return 0, errors.New("USDExchangeRate must be greater than 0")
+	}
+	availableBalanceUsd := decimal.NewFromFloat(availableBalanceCny).Div(decimal.NewFromFloat(operation_setting.USDExchangeRate)).InexactFloat64()
 	channel.UpdateBalance(availableBalanceUsd)
 	return availableBalanceUsd, nil
 }

--- a/controller/channel-billing.go
+++ b/controller/channel-billing.go
@@ -258,7 +258,7 @@ func updateChannelSiliconFlowBalance(channel *model.Channel) (float64, error) {
 	if err != nil {
 		return 0, err
 	}
-	// SiliconFlow 返回人民币余额，统一转为 USD-equivalent 存储
+	// SiliconFlow returns CNY balance, convert to USD-equivalent for storage
 	if operation_setting.USDExchangeRate <= 0 {
 		return 0, errors.New("USDExchangeRate must be greater than 0")
 	}
@@ -292,7 +292,7 @@ func updateChannelDeepSeekBalance(channel *model.Channel) (float64, error) {
 	if err != nil {
 		return 0, err
 	}
-	// DeepSeek 返回人民币余额，统一转为 USD-equivalent 存储
+	// DeepSeek returns CNY balance, convert to USD-equivalent for storage
 	if operation_setting.USDExchangeRate <= 0 {
 		return 0, errors.New("USDExchangeRate must be greater than 0")
 	}

--- a/controller/channel-billing.go
+++ b/controller/channel-billing.go
@@ -259,6 +259,9 @@ func updateChannelSiliconFlowBalance(channel *model.Channel) (float64, error) {
 		return 0, err
 	}
 	// SiliconFlow 返回人民币余额，统一转为 USD-equivalent 存储
+	if operation_setting.USDExchangeRate <= 0 {
+		return 0, errors.New("USDExchangeRate must be greater than 0")
+	}
 	balanceUsd := decimal.NewFromFloat(balance).Div(decimal.NewFromFloat(operation_setting.USDExchangeRate)).InexactFloat64()
 	channel.UpdateBalance(balanceUsd)
 	return balanceUsd, nil
@@ -290,6 +293,9 @@ func updateChannelDeepSeekBalance(channel *model.Channel) (float64, error) {
 		return 0, err
 	}
 	// DeepSeek 返回人民币余额，统一转为 USD-equivalent 存储
+	if operation_setting.USDExchangeRate <= 0 {
+		return 0, errors.New("USDExchangeRate must be greater than 0")
+	}
 	balanceUsd := decimal.NewFromFloat(balance).Div(decimal.NewFromFloat(operation_setting.USDExchangeRate)).InexactFloat64()
 	channel.UpdateBalance(balanceUsd)
 	return balanceUsd, nil


### PR DESCRIPTION
Both channels' APIs return balances in RMB, but the system stores balances as USD-equivalent internally. Previously the RMB amounts were stored directly as USD, inflating balances ~7.3x.

## Changes
- `updateChannelSiliconFlowBalance`: divide balance by `USDExchangeRate` before storing
- `updateChannelDeepSeekBalance`: divide balance by `USDExchangeRate` before storing

## Reference
- `operation_setting.USDExchangeRate` is the configured RMB→USD rate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated channel billing balance processing to interpret provider-reported amounts as CNY and convert them to USD using the configured exchange rate before persisting and displaying totals.
  * Added stricter checks to ensure the exchange rate is set to a valid positive value, preventing incorrect USD-equivalent calculations for Moonshot balance updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->