### PR TITLE
fix: refresh channel test dialog status

### DIFF
--- a/web/default/src/features/channels/components/dialogs/channel-test-dialog.tsx
+++ b/web/default/src/features/channels/components/dialogs/channel-test-dialog.tsx
@@ -16,7 +16,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import {
   type ColumnDef,
@@ -212,6 +212,7 @@ export function ChannelTestDialog({
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const { currentRow, setCurrentRow } = useChannels()
+  const currentRowRef = useRef(currentRow)
   const [endpointType, setEndpointType] = useState('auto')
   const [isStreamTest, setIsStreamTest] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
@@ -235,6 +236,10 @@ export function ChannelTestDialog({
       })),
     [t]
   )
+
+  useEffect(() => {
+    currentRowRef.current = currentRow
+  }, [currentRow])
 
   const resetState = useCallback(() => {
     setEndpointType('auto')
@@ -316,7 +321,8 @@ export function ChannelTestDialog({
 
   const testSingleModel = useCallback(
     async (model: string, silent = false): Promise<TestResult | undefined> => {
-      if (!currentRow) return
+      const testChannelRow = currentRow
+      if (!testChannelRow) return
 
       markModelTesting(model, true)
       updateTestResult(model, { status: 'testing' })
@@ -324,7 +330,7 @@ export function ChannelTestDialog({
 
       try {
         await handleTestChannel(
-          currentRow.id,
+          testChannelRow.id,
           {
             testModel: model,
             endpointType: endpointType === 'auto' ? undefined : endpointType,
@@ -340,8 +346,12 @@ export function ChannelTestDialog({
             }
             updateTestResult(model, finalResult)
             if (success && typeof responseTime === 'number') {
+              const activeRow = currentRowRef.current
+              if (activeRow?.id !== testChannelRow.id) {
+                return
+              }
               setCurrentRow({
-                ...currentRow,
+                ...activeRow,
                 response_time: responseTime,
                 test_time: Math.floor(Date.now() / 1000),
               })

--- a/web/default/src/features/channels/components/dialogs/channel-test-dialog.tsx
+++ b/web/default/src/features/channels/components/dialogs/channel-test-dialog.tsx
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   type ColumnDef,
   type RowSelectionState,
@@ -67,7 +68,11 @@ import {
   sideDrawerHeaderClassName,
 } from '@/components/drawer-layout'
 import { StatusBadge } from '@/components/status-badge'
-import { formatResponseTime, handleTestChannel } from '../../lib'
+import {
+  channelsQueryKeys,
+  formatResponseTime,
+  handleTestChannel,
+} from '../../lib'
 import { useChannels } from '../channels-provider'
 
 type ChannelTestDialogProps = {
@@ -77,6 +82,8 @@ type ChannelTestDialogProps = {
 
 type ModelRow = {
   model: string
+  testResult?: TestResult
+  isTesting: boolean
 }
 
 type TestStatus = 'idle' | 'testing' | 'success' | 'error'
@@ -203,7 +210,8 @@ export function ChannelTestDialog({
   onOpenChange,
 }: ChannelTestDialogProps) {
   const { t } = useTranslation()
-  const { currentRow } = useChannels()
+  const queryClient = useQueryClient()
+  const { currentRow, setCurrentRow } = useChannels()
   const [endpointType, setEndpointType] = useState('auto')
   const [isStreamTest, setIsStreamTest] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
@@ -277,8 +285,13 @@ export function ChannelTestDialog({
   }, [searchTerm, modelsValue])
 
   const tableData = useMemo<ModelRow[]>(
-    () => filteredModels.map((model) => ({ model })),
-    [filteredModels]
+    () =>
+      filteredModels.map((model) => ({
+        model,
+        testResult: testResults[model],
+        isTesting: testingModels.has(model),
+      })),
+    [filteredModels, testResults, testingModels]
   )
 
   const markModelTesting = useCallback((key: string, isTesting: boolean) => {
@@ -326,6 +339,16 @@ export function ChannelTestDialog({
               errorCode,
             }
             updateTestResult(model, finalResult)
+            if (success && typeof responseTime === 'number') {
+              setCurrentRow({
+                ...currentRow,
+                response_time: responseTime,
+                test_time: Math.floor(Date.now() / 1000),
+              })
+              queryClient.invalidateQueries({
+                queryKey: channelsQueryKeys.lists(),
+              })
+            }
           }
         )
       } catch (error: unknown) {
@@ -344,6 +367,8 @@ export function ChannelTestDialog({
       endpointType,
       isStreamTest,
       markModelTesting,
+      queryClient,
+      setCurrentRow,
       t,
       updateTestResult,
     ]
@@ -455,7 +480,7 @@ export function ChannelTestDialog({
         header: t('Status'),
         cell: ({ row }) => {
           const model = row.original.model
-          const result = testResults[model]
+          const result = row.original.testResult
           return (
             <TestStatusCell
               result={result}
@@ -472,7 +497,7 @@ export function ChannelTestDialog({
         header: t('Actions'),
         cell: ({ row }) => {
           const model = row.original.model
-          const isTestingModel = testingModels.has(model)
+          const isTestingModel = row.original.isTesting
 
           return (
             <Button
@@ -492,14 +517,7 @@ export function ChannelTestDialog({
         size: 120,
       },
     ],
-    [
-      defaultTestModel,
-      isBatchTesting,
-      t,
-      testResults,
-      testingModels,
-      testSingleModel,
-    ]
+    [defaultTestModel, isBatchTesting, t, testSingleModel]
   )
 
   const { table } = useDataTable({

--- a/web/default/src/features/channels/lib/channel-actions.ts
+++ b/web/default/src/features/channels/lib/channel-actions.ts
@@ -237,11 +237,18 @@ export async function handleTestChannel(
 
   try {
     const response = await testChannel(id, payload)
+    const responseTime =
+      typeof response.data?.response_time === 'number'
+        ? response.data.response_time
+        : typeof response.time === 'number'
+          ? response.time * 1000
+          : undefined
+
     if (response.success) {
       if (!options?.silent) {
         toast.success(i18next.t(SUCCESS_MESSAGES.TESTED))
       }
-      onTestComplete?.(true, response.data?.response_time)
+      onTestComplete?.(true, responseTime)
     } else {
       if (!options?.silent) {
         toast.error(response.message || i18next.t(ERROR_MESSAGES.TEST_FAILED))

--- a/web/default/src/features/channels/lib/channel-actions.ts
+++ b/web/default/src/features/channels/lib/channel-actions.ts
@@ -237,12 +237,12 @@ export async function handleTestChannel(
 
   try {
     const response = await testChannel(id, payload)
-    const responseTime =
-      typeof response.data?.response_time === 'number'
-        ? response.data.response_time
-        : typeof response.time === 'number'
-          ? response.time * 1000
-          : undefined
+    let responseTime: number | undefined
+    if (typeof response.data?.response_time === 'number') {
+      responseTime = response.data.response_time
+    } else if (typeof response.time === 'number') {
+      responseTime = response.time * 1000
+    }
 
     if (response.success) {
       if (!options?.silent) {

--- a/web/default/src/features/channels/types.ts
+++ b/web/default/src/features/channels/types.ts
@@ -143,6 +143,7 @@ export interface ChannelTestResponse {
   success: boolean
   message?: string
   error_code?: string
+  time?: number
   data?: {
     response_time?: number
     error?: string


### PR DESCRIPTION
## 【中文说明】Bug：新版渠道测试弹窗点击模型后仍显示“未测试”

在新版 UI 的「渠道管理 -> 测试连接」弹窗中，点击某个模型进行测试后，后端请求已经完成，但该模型所在行的状态可能仍停留在「未测试」，没有切换到「测试中 / 成功 / 失败」。

根因有两点：
- 后端 `/api/channel/test/:id` 当前返回的是顶层 `time` 字段，例如 `{ "success": true, "message": "", "time": 4.57 }`。新版前端却按 `data.response_time` 读取耗时，导致结果数据没有被正确消费。
- 弹窗表格行只保存 `model`，没有把每个模型对应的 `testResult` / `isTesting` 绑定进 row data，测试状态更新后表格行展示容易继续显示旧状态。

这个 PR 修复后，点击单个模型测试时，行状态会从「未测试」立即变为「测试中」，请求完成后再显示「成功」或「失败」；成功时也会同步刷新渠道响应时间和最后测试时间。

## Summary
- keep channel test dialog row data in sync with each model's testing/result state
- support the existing channel test API response shape where response time is returned as top-level `time`
- update the active channel row and invalidate channel list queries after a successful test

## Test Plan
- `cd web/default && bun run typecheck`

## Notes
The bug is visible in the new UI channel test dialog: clicking a model test can leave the row displayed as `Not tested` even after the backend request completes. The backend currently returns `{ success, message, time }`, while the new UI expected `data.response_time`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel test result tracking and display in the channel list, including accurate “Status” and “Actions” updates per model.
  * Enhanced response time measurement during channel testing by correctly handling multiple response time fields.
* **Refactor**
  * Improved list refresh behavior after channel tests complete to ensure the latest results are shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->