### PR TITLE
fix(home): restore custom iframe/URL homepage height on classic layout

### DIFF
--- a/web/classic/src/pages/Home/index.jsx
+++ b/web/classic/src/pages/Home/index.jsx
@@ -335,11 +335,11 @@ const Home = () => {
           </div>
         </div>
       ) : (
-        <div className='classic-page-fill overflow-x-hidden w-full'>
+        <div className='classic-page-fill min-h-[calc(100vh-64px)] overflow-x-hidden w-full'>
           {homePageContent.startsWith('https://') ? (
             <iframe
               src={homePageContent}
-              className='w-full h-full border-none'
+              className='w-full h-full min-h-[calc(100vh-64px)] border-none'
             />
           ) : (
             <div


### PR DESCRIPTION
## 📝 变更描述 / Description

When `HomePageContent` is set to a URL (or custom `<iframe>` HTML), the classic homepage renders with **zero height** — the page looks empty and the content is pinned to the very top, hidden behind the header.

Root cause is a CSS height-resolution chain on the classic public layout:

- `PageLayout.jsx` renders public routes (including `/`) with `.app-layout`, which is `min-height: 100vh` (not a fixed `height`). The fixed variant `.app-layout-fixed` is only used for console/pricing routes.
- In `Home/index.jsx`, the homepage content wrapper is `.classic-page-fill`, defined as `flex: 1 0 auto; min-height: 100%`.
- A **percentage `min-height` resolves against the parent's `height`**. Since the parent (`.app-layout`) only sets `min-height` and has no resolved `height`, `min-height: 100%` resolves to `auto` — so the wrapper has no definite height.
- The iframe is `className="w-full h-full"`. `height: 100%` then also resolves against a parent with no definite height → collapses to `0`.

This regressed from the previous classic layout, which kept the layout at a fixed `height: 100vh` plus `body { overflow-y: hidden }`, so the iframe always had a definite height to fill.

**Fix:** give the iframe-mode wrapper and the iframe a viewport-based `min-h-[calc(100vh-64px)]` (64px = header height, matching the existing `.app-sider` value) so the height no longer depends on the flexible parent chain. The default banner homepage branch (`homePageContent === ''`) is left untouched, so the intended flexible/scrollable public layout for the default landing page is preserved.

```diff
-        <div className='classic-page-fill overflow-x-hidden w-full'>
+        <div className='classic-page-fill min-h-[calc(100vh-64px)] overflow-x-hidden w-full'>
           {homePageContent.startsWith('https://') ? (
             <iframe
               src={homePageContent}
-              className='w-full h-full border-none'
+              className='w-full h-full min-h-[calc(100vh-64px)] border-none'
             />
```

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- N/A (newly reported; happy to open a tracking issue if maintainers prefer)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述基于对代码逻辑的实际分析撰写。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs。
- [x] **Bug fix 说明:** 这是 URL/iframe 模式首页高度塌陷的回归，非设计取舍。
- [x] **变更理解:** 已理解 CSS 百分比 `min-height` 的解析规则与此布局链的关系。
- [x] **范围聚焦:** 仅改动一个文件的 2 行，无无关改动。
- [x] **本地验证:** `bun run build` 通过；`prettier --check` 通过。
- [x] **安全合规:** 无敏感凭据，符合现有 Tailwind arbitrary value 用法（项目已存在 `h-[calc(100vh-66px)]` 等）。

## 📸 运行证明 / Proof of Work

- `cd web/classic && bun run build` → 构建成功，无报错。
- `bunx prettier --check src/pages/Home/index.jsx` → `All matched files use Prettier code style!`
- Verified the height-resolution chain against the source: `.app-layout` (`min-height:100vh`) → `.classic-page-fill` (`min-height:100%`, unresolved) → iframe (`h-full` → 0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved home page layout consistency by correcting viewport height calculations to ensure proper spacing and alignment of embedded content with application interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->