### PR TITLE
fix(data-table): capture row selection state in memo comparison

### DIFF
--- a/web/default/src/components/data-table/core/data-table-row.tsx
+++ b/web/default/src/components/data-table/core/data-table-row.tsx
@@ -29,15 +29,20 @@ type DataTableRowProps<TData> = {
   getColumnClassName?: DataTableColumnClassName
 } & Omit<React.ComponentProps<typeof TableRow>, 'children'>
 
+type DataTableRowInnerProps<TData> = DataTableRowProps<TData> & {
+  isSelected: boolean
+}
+
 function DataTableRowInner<TData>({
   row,
+  isSelected,
   className,
   getColumnClassName,
   ...rowProps
-}: DataTableRowProps<TData>) {
+}: DataTableRowInnerProps<TData>) {
   return (
     <TableRow
-      data-state={row.getIsSelected() ? 'selected' : undefined}
+      data-state={isSelected ? 'selected' : undefined}
       className={className}
       {...rowProps}
     >
@@ -56,16 +61,24 @@ function DataTableRowInner<TData>({
   )
 }
 
-export const DataTableRow = React.memo(DataTableRowInner, (prev, next) => {
+const MemoizedDataTableRow = React.memo(DataTableRowInner, (prev, next) => {
   // Skip re-render when only the getColumnClassName reference changed but the
-  // row identity and selection state are the same — callers rarely stabilize
-  // this callback, so excluding it from comparison avoids unnecessary renders.
+  // row identity and captured selection state are the same. Callers rarely
+  // stabilize this callback, so excluding it from comparison avoids unnecessary
+  // renders. Do not read row.getIsSelected() here: TanStack row objects may keep
+  // a stable reference while their selection state changes.
   return (
     prev.row === next.row &&
     prev.className === next.className &&
-    prev.row.getIsSelected() === next.row.getIsSelected()
+    prev.isSelected === next.isSelected
   )
 }) as typeof DataTableRowInner
+
+export function DataTableRow<TData>(props: DataTableRowProps<TData>) {
+  return (
+    <MemoizedDataTableRow {...props} isSelected={props.row.getIsSelected()} />
+  )
+}
 
 function renderCellContent<TData>(cell: Cell<TData, unknown>) {
   const content = flexRender(cell.column.columnDef.cell, cell.getContext())

--- a/web/default/src/components/data-table/core/data-table-row.tsx
+++ b/web/default/src/components/data-table/core/data-table-row.tsx
@@ -62,14 +62,12 @@ function DataTableRowInner<TData>({
 }
 
 const MemoizedDataTableRow = React.memo(DataTableRowInner, (prev, next) => {
-  // Skip re-render when only the getColumnClassName reference changed but the
-  // row identity and captured selection state are the same. Callers rarely
-  // stabilize this callback, so excluding it from comparison avoids unnecessary
-  // renders. Do not read row.getIsSelected() here: TanStack row objects may keep
-  // a stable reference while their selection state changes.
+  // Do not read row.getIsSelected() here: TanStack row objects may keep a stable
+  // reference while their selection state changes.
   return (
     prev.row === next.row &&
     prev.className === next.className &&
+    prev.getColumnClassName === next.getColumnClassName &&
     prev.isSelected === next.isSelected
   )
 }) as typeof DataTableRowInner


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

修复使用 DataTable 的页面中，复选框（checkbox）无法正确渲染选中状态的问题。

**问题原因：**
`DataTableRow` 使用 `React.memo` 并自定义了比较函数来减少不必要的重渲染。原比较函数在判断行选中状态是否变化时，直接调用 `row.getIsSelected()`：

```ts
prev.row.getIsSelected() === next.row.getIsSelected()
```

但 TanStack Table 的 row 对象在选中状态切换时可能仍保持**同一个引用**，因此 `prev.row` 与 `next.row` 指向同一对象，`getIsSelected()` 读取到的也是相同的（最新的）值，比较结果恒为相等。memo 据此判定“无需更新”，导致行的 `data-state` 与复选框选中样式不会随选中状态切换而重新渲染。

**修复方式：**
将选中状态在外层组件中提前“快照”为显式的 `isSelected` 布尔属性，传入被 memo 包裹的内层组件，并改为对该属性值进行比较：

- 新增外层包装组件 `DataTableRow`，在每次渲染时计算 `isSelected={props.row.getIsSelected()}` 并下传；
- 内层 `DataTableRowInner` 使用传入的 `isSelected` 渲染 `data-state`，不再实时调用 `row.getIsSelected()`；
- memo 比较函数改为 `prev.isSelected === next.isSelected`，由于该值是每次渲染时按值捕获的快照，选中状态变化时比较结果会发生变化，从而正确触发重渲染。

这样即便 row 对象引用保持稳定，只要选中状态发生变化，行（及其复选框）也能正确重新渲染。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
修复前：
<img width="1042" height="310" alt="image" src="https://github.com/user-attachments/assets/ca5cf558-2450-4e51-9295-c1dc19484582" />

修复后：
<img width="1099" height="342" alt="image" src="https://github.com/user-attachments/assets/cd75133b-6ddd-4b59-b866-e116bd46b342" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized data table row component's selection state handling for improved performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->