### PR TITLE
fix(data-table): prevent component cell clipping

### DIFF
--- a/web/default/src/components/data-table/core/data-table-row.tsx
+++ b/web/default/src/components/data-table/core/data-table-row.tsx
@@ -57,17 +57,22 @@ function DataTableRowInner<TData>({
       className={className}
       {...rowProps}
     >
-      {row.getVisibleCells().map((cell) => (
-        <TableCell
-          key={cell.id}
-          className={cn(
-            'max-w-full min-w-0 overflow-hidden',
-            getColumnClassName?.(cell.column.id, 'cell')
-          )}
-        >
-          {renderCellContent(cell)}
-        </TableCell>
-      ))}
+      {row.getVisibleCells().map((cell) => {
+        const renderedCell = renderCellContent(cell)
+
+        return (
+          <TableCell
+            key={cell.id}
+            className={cn(
+              'max-w-full min-w-0',
+              renderedCell.isPrimitive && 'overflow-hidden',
+              getColumnClassName?.(cell.column.id, 'cell')
+            )}
+          >
+            {renderedCell.content}
+          </TableCell>
+        )
+      })}
     </TableRow>
   )
 }
@@ -100,22 +105,21 @@ function renderCellContent<TData>(cell: Cell<TData, unknown>) {
   const content = flexRender(cell.column.columnDef.cell, cell.getContext())
   const textContent = getPrimitiveTextContent(content)
 
-  if (!textContent) return content
+  if (!textContent) {
+    return { content, isPrimitive: false }
+  }
 
-  return <TruncatedCell tooltipContent={textContent}>{content}</TruncatedCell>
+  return {
+    content: (
+      <TruncatedCell tooltipContent={textContent}>{content}</TruncatedCell>
+    ),
+    isPrimitive: true,
+  }
 }
 
 function getPrimitiveTextContent(content: React.ReactNode): string | null {
   if (typeof content === 'string' || typeof content === 'number') {
     return String(content)
-  }
-
-  if (
-    React.isValidElement<{ children?: React.ReactNode }>(content) &&
-    (typeof content.props.children === 'string' ||
-      typeof content.props.children === 'number')
-  ) {
-    return String(content.props.children)
   }
 
   return null

--- a/web/default/src/components/data-table/core/table-sizing.ts
+++ b/web/default/src/components/data-table/core/table-sizing.ts
@@ -26,5 +26,9 @@ export function getTableSizeStyle<TData>(
     .getVisibleLeafColumns()
     .reduce((total, column) => total + column.getSize(), 0)
 
-  return { minWidth: width, tableLayout: 'fixed', width: '100%' }
+  return {
+    minWidth: `max(100%, ${width}px)`,
+    tableLayout: 'auto',
+    width: 'max-content',
+  }
 }

--- a/web/default/src/features/usage-logs/components/model-badge.tsx
+++ b/web/default/src/features/usage-logs/components/model-badge.tsx
@@ -101,12 +101,12 @@ function ModelBadgeContent(props: ModelBadgeProps) {
       showDot={!provider}
       autoColor={provider ? undefined : props.modelName}
       className={cn(
-        'border-border/60 bg-muted/30 h-6 max-w-full gap-1.5 rounded-md border px-2 [font-family:var(--font-body)]',
+        'border-border/60 bg-muted/30 h-6 max-w-none gap-1.5 rounded-md border px-2 [font-family:var(--font-body)]',
         provider && 'text-foreground',
         props.className
       )}
     >
-      <span className='flex max-w-full min-w-0 items-center gap-1.5'>
+      <span className='flex max-w-none items-center gap-1.5'>
         {provider && (
           <span
             className='flex size-3.5 shrink-0 items-center justify-center'
@@ -116,7 +116,7 @@ function ModelBadgeContent(props: ModelBadgeProps) {
             {getLobeIcon(provider.icon, 14)}
           </span>
         )}
-        <span className='truncate'>{props.modelName}</span>
+        <span className='whitespace-nowrap'>{props.modelName}</span>
       </span>
     </StatusBadge>
   )


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)
修复表格中非纯文本组件内容被外层裁剪或溢出到相邻列的问题。表格层现在只对纯文本单元格应用省略和 tooltip 逻辑；组件型单元格由组件自身决定显示策略。同时调整表格宽度计算，使内容可撑开表格并通过横向滚动承载，避免长模型名称与后续列重叠。模型徽章现在完整单行显示模型名称。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ ] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [ ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [ ] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
<img width="580" height="283" alt="CleanShot 2026-06-16 at 17 25 07" src="https://github.com/user-attachments/assets/d1f0c30e-636c-489c-934d-34516fa65dc1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved data table cell rendering with better overflow handling for text content
  * Enhanced table layout sizing for improved responsiveness and content visibility
  * Refined model badge display to prevent unwanted text truncation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->