### PR TITLE
fix(classic): use configured top-up currency

### DIFF
--- a/web/classic/src/components/topup/index.jsx
+++ b/web/classic/src/components/topup/index.jsx
@@ -26,6 +26,7 @@ import {
   showSuccess,
   renderQuota,
   renderQuotaWithAmount,
+  getCurrencyConfig,
   copy,
   getQuotaPerUnit,
 } from '../../helpers';
@@ -800,8 +801,17 @@ const TopUp = () => {
     }
   }, [statusState?.status]);
 
+  const formatPaymentAmount = (value) => {
+    const { symbol } = getCurrencyConfig();
+    const numericValue = Number(value);
+    const displayValue = Number.isFinite(numericValue)
+      ? numericValue.toFixed(2)
+      : value;
+    return `${symbol}${displayValue}`;
+  };
+
   const renderAmount = () => {
-    return amount + ' ' + t('元');
+    return formatPaymentAmount(amount);
   };
 
   const getAmount = async (value) => {
@@ -928,6 +938,7 @@ const TopUp = () => {
         renderQuotaWithAmount={renderQuotaWithAmount}
         amountLoading={amountLoading}
         renderAmount={renderAmount}
+        formatPaymentAmount={formatPaymentAmount}
         payWay={payWay}
         payMethods={confirmPayMethods}
         amountNumber={amount}

--- a/web/classic/src/components/topup/modals/PaymentConfirmModal.jsx
+++ b/web/classic/src/components/topup/modals/PaymentConfirmModal.jsx
@@ -34,6 +34,7 @@ const PaymentConfirmModal = ({
   renderQuotaWithAmount,
   amountLoading,
   renderAmount,
+  formatPaymentAmount,
   payWay,
   payMethods,
   // 新增：用于显示折扣明细
@@ -97,7 +98,7 @@ const PaymentConfirmModal = ({
                     {t('原价')}：
                   </Text>
                   <Text delete className='text-slate-500 dark:text-slate-400'>
-                    {`${originalAmount.toFixed(2)} ${t('元')}`}
+                    {formatPaymentAmount(originalAmount)}
                   </Text>
                 </div>
                 <div className='flex justify-between items-center'>
@@ -105,7 +106,7 @@ const PaymentConfirmModal = ({
                     {t('优惠')}：
                   </Text>
                   <Text className='text-emerald-600 dark:text-emerald-400'>
-                    {`- ${discountAmount.toFixed(2)} ${t('元')}`}
+                    {`- ${formatPaymentAmount(discountAmount)}`}
                   </Text>
                 </div>
               </>


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
经典前端充值页的实付金额展示原先直接拼接 `元`，导致站点设置为 USD 或自定义货币时仍显示人民币单位。
本次改动复用已有的货币配置读取逻辑，根据当前 `quota_display_type` 对应的符号格式化支付金额，并让确认弹窗中的实付金额、原价和优惠金额保持一致。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5494

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```text
$ bunx prettier "src/components/topup/index.jsx" "src/components/topup/modals/PaymentConfirmModal.jsx" --check
Checking formatting...
All matched files use Prettier code style!

$ bun run build
$ rsbuild build
ready   built in 5.52 s
```