### PR TITLE
fix: 工具调用 arguments 为空时保留 tool_use 块

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -410,9 +410,10 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 				if message.ToolCalls != nil {
 					for _, toolCall := range message.ParseToolCalls() {
 						inputObj := make(map[string]any)
-						if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &inputObj); err != nil {
-							common.SysLog("tool call function arguments is not a map[string]any: " + fmt.Sprintf("%v", toolCall.Function.Arguments))
-							continue
+						if args := toolCall.Function.Arguments; args != "" {
+							if err := json.Unmarshal([]byte(args), &inputObj); err != nil {
+								common.SysLog("tool call function arguments is not a map[string]any: " + fmt.Sprintf("%v", toolCall.Function.Arguments))
+							}
 						}
 						claudeMediaMessages = append(claudeMediaMessages, dto.ClaudeMediaMessage{
 							Type:  "tool_use",


### PR DESCRIPTION
## 📝 变更描述 / Description

OpenAI 格式转 Claude 时,`RequestOpenAI2ClaudeMessage` 会把 `tool_calls` 转成 `tool_use` 块。原逻辑对 `function.arguments` 直接 `json.Unmarshal`,解析失败就 `continue` 跳过整个块。

部分模型在无参数工具调用时 `arguments` 为空字符串 `""`,反序列化必然失败,导致对应的 `tool_use` 块被整个丢弃。而 Claude 要求 `tool_use` 与后续 `tool_result` 一一对应,块丢失后请求结构被破坏,会触发上游报错。

修复:仅在 `arguments` 非空时才反序列化;即使解析失败也不再跳过,照常追加 `tool_use`(input 为空对象),保证块完整。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

修复前:
<img width="1748" height="738" alt="image" src="https://github.com/user-attachments/assets/d6ebb1b8-66a2-4603-acf6-eaf8725713c4" />
修复后:
<img width="1732" height="974" alt="image" src="https://github.com/user-attachments/assets/0fdc388a-26af-4305-9e8d-6b0fbee3f97f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for tool calls in Claude relay. Tool calls with malformed or invalid JSON arguments are now processed with appropriate logging instead of being silently discarded. This improvement provides better error visibility and simplifies troubleshooting of tool integration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->