### PR TITLE
fix(classic): add fallback docs_link in useHeaderBar to match default theme behavior

### DIFF
--- a/web/classic/src/hooks/common/useHeaderBar.js
+++ b/web/classic/src/hooks/common/useHeaderBar.js
@@ -49,7 +49,7 @@ export const useHeaderBar = ({ onMobileMenuToggle, drawerOpen }) => {
   const isNewYear = currentDate.getMonth() === 0 && currentDate.getDate() === 1;
 
   const isSelfUseMode = statusState?.status?.self_use_mode_enabled || false;
-  const docsLink = statusState?.status?.docs_link || '';
+  const docsLink = statusState?.status?.docs_link || 'https://docs.newapi.pro/en/docs';
   const isDemoSiteMode = statusState?.status?.demo_site_enabled || false;
 
   // 获取顶栏模块配置


### PR DESCRIPTION
经典主题在未配置 `docs_link` 时不会显示文档导航项。本 PR 为 `useHeaderBar` 增加官方文档地址回退值，使其行为与默认主题保持一致。

In the classic theme, the Documentation nav item disappears when `docs_link` is not configured. This PR adds an official docs URL fallback in `useHeaderBar` so the behavior matches the default theme.

---

# ⚠️ 提交说明 / PR Notice

> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

**English:** When `docs_link` is not configured in the admin settings (Settings → General), the Documentation nav item in the `web/classic` header is never rendered — not broken, but completely absent. This is because `useHeaderBar.js` falls back to an empty string `''` (falsy), which causes `useNavigation.js` to skip adding the docs item to the nav array entirely.

This 1-line change adds a fallback to the official docs URL (`https://docs.newapi.pro/en/docs`) so the Documentation link appears by default even when unconfigured. This mirrors the identical fallback already present in the `web/default` theme's `hero.tsx` (line 50):

```
// web/default/src/features/home/components/sections/hero.tsx:50
(status?.docs_link as string | undefined) || 'https://docs.newapi.pro'
```

**Data flow of the bug:**
```
DB (docs_link not set / saved as "")
  → GET /api/status → { docs_link: "" }
  → useHeaderBar.js:52 → docsLink = '' || '' = '' (falsy, no fallback)
  → useNavigation.js:52–61 → docs item skipped (conditional spread)
  → useNavigation.js:71–72 → filter returns false
  → Navigation.jsx → Documentation nav item never rendered
```

**中文：** 当管理员未在系统设置中配置 `docs_link` 时，`web/classic` 主题的顶部导航中文档按钮将完全不显示。原因是 `useHeaderBar.js` 中的回退值为空字符串（falsy），导致 `useNavigation.js` 跳过文档导航项。本次修改添加官方文档地址作为默认回退，与 `web/default` 主题中 `hero.tsx` 的现有处理方式保持一致。

##  变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue

- Closes # (no existing issue — bug discovered via external deployment investigation)

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 描述经过整理，非直接粘贴 AI 输出。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，未发现重复。
- [x] **Bug fix 说明:** 此 PR 对应真实行为缺失（文档导航项不渲染），非设计取舍或预期不一致。
- [x] **变更理解:** 已理解数据流路径与修改影响，仅在 `docsLink` 未配置时生效。
- [x] **范围聚焦:** 仅修改 1 行，无任何无关改动。
- [x] **本地验证:** 已在本地代码审查中验证逻辑，管理员配置 `docs_link` 时仍使用管理员值（fallback 不覆盖配置）。
- [x] **安全合规:** 无敏感凭据，符合项目代码规范。

##  运行证明 / Proof of Work

**Diff (1 line changed):**

```diff
// web/classic/src/hooks/common/useHeaderBar.js, line 52
- const docsLink = statusState?.status?.docs_link || '';
+ const docsLink = statusState?.status?.docs_link || 'https://docs.newapi.pro/en/docs';
```

**Behavior change:**

| Scenario | Before | After |
|---|---|---|
| `docs_link` set by admin | ✅ Shows admin URL | ✅ Shows admin URL (unchanged) |
| `docs_link` empty / not configured | ❌ Documentation item not rendered | ✅ Shows `https://docs.newapi.pro/en/docs` |

---

> **AI disclosure (per AGENTS.md Rule 8):** This contribution was AI-assisted (Antigravity / Google DeepMind). The root cause investigation, data flow trace, patch, and PR description were produced with AI assistance and reviewed by the contributor (Ajay Mathuriya). The committer (`Ajay Mathuriya <ajaymathuriya@protonmail.com>`) is not one of the repository's historical core developers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- The documentation link displayed in the application header now shows a default value when a custom documentation link is not configured. Previously, the header would display an empty documentation link field. This change ensures a valid documentation reference is always visible to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->