### PR TITLE
fix(subscription): revert user group on expiry across renewals and stacked plans

### DIFF
--- a/common/redis.go
+++ b/common/redis.go
@@ -303,25 +303,36 @@ func RedisHSetField(key, field string, value interface{}) error {
 	if DebugEnabled {
 		SysLog(fmt.Sprintf("Redis HSET field: key=%s, field=%s, value=%v", key, field, value))
 	}
-	ttlCmd := RDB.TTL(context.Background(), key)
-	ttl, err := ttlCmd.Result()
+	ctx := context.Background()
+
+	// Never create a partial hash: only update the field when the hash already
+	// exists. A missing key is left untouched so GetUserCache lazily rebuilds the
+	// full entry from the DB on the next read.
+	exists, err := RDB.Exists(ctx, key).Result()
+	if err != nil {
+		return fmt.Errorf("failed to check key existence: %w", err)
+	}
+	if exists == 0 {
+		return nil
+	}
+
+	ttl, err := RDB.TTL(ctx, key).Result()
 	if err != nil && !errors.Is(err, redis.Nil) {
 		return fmt.Errorf("failed to get TTL: %w", err)
 	}
 
 	if ttl > 0 {
-		ctx := context.Background()
+		// Update the field while preserving the existing finite TTL.
 		txn := RDB.TxPipeline()
-
-		hsetCmd := txn.HSet(ctx, key, field, value)
-		if err := hsetCmd.Err(); err != nil {
-			return err
-		}
-
+		txn.HSet(ctx, key, field, value)
 		txn.Expire(ctx, key, ttl)
-
 		_, err = txn.Exec(ctx)
 		return err
 	}
-	return nil
+
+	// Key exists without an expiry (persistent cache, e.g. SYNC_FREQUENCY=0).
+	// Previously this returned nil and silently dropped the update, leaving stale
+	// fields — most importantly the user Group after a subscription-expiry revert.
+	// Update the field in place without setting a TTL.
+	return RDB.HSet(ctx, key, field, value).Err()
 }

--- a/model/subscription.go
+++ b/model/subscription.go
@@ -412,6 +412,33 @@ func getUserGroupByIdTx(tx *gorm.DB, userId int) (string, error) {
 	return group, nil
 }
 
+// resolveOriginalUserGroupTx recovers the original (pre-upgrade) group for a user
+// who is currently sitting in upgradedGroup. The baseline MUST be derived from the
+// whole subscription chain, not a single row: a renewal or a stacked plan bought
+// while the user is already in upgradedGroup is created with an empty
+// prev_user_group (see CreateUserSubscriptionFromPlanTx), so trusting one row would
+// lose the baseline. We pick the earliest subscription that recorded a real,
+// different previous group. Returns "" when no baseline is recoverable.
+func resolveOriginalUserGroupTx(tx *gorm.DB, userId int, upgradedGroup string) (string, error) {
+	upgradedGroup = strings.TrimSpace(upgradedGroup)
+	if tx == nil || userId <= 0 || upgradedGroup == "" {
+		return "", nil
+	}
+	var origin UserSubscription
+	q := tx.Where("user_id = ? AND upgrade_group = ? AND prev_user_group <> '' AND prev_user_group <> ?",
+		userId, upgradedGroup, upgradedGroup).
+		Order("start_time asc, id asc").
+		Limit(1).
+		Find(&origin)
+	if q.Error != nil {
+		return "", q.Error
+	}
+	if q.RowsAffected == 0 {
+		return "", nil
+	}
+	return strings.TrimSpace(origin.PrevUserGroup), nil
+}
+
 func downgradeUserGroupForSubscriptionTx(tx *gorm.DB, sub *UserSubscription, now int64) (string, error) {
 	if tx == nil || sub == nil {
 		return "", errors.New("invalid downgrade args")
@@ -437,6 +464,16 @@ func downgradeUserGroupForSubscriptionTx(tx *gorm.DB, sub *UserSubscription, now
 		return "", nil
 	}
 	prevGroup := strings.TrimSpace(sub.PrevUserGroup)
+	if prevGroup == "" {
+		// This row recorded no baseline (it was created while the user was already in
+		// upgradeGroup, e.g. a renewal). Recover the original group from the chain
+		// instead of silently bailing out.
+		resolved, err := resolveOriginalUserGroupTx(tx, sub.UserId, upgradeGroup)
+		if err != nil {
+			return "", err
+		}
+		prevGroup = resolved
+	}
 	if prevGroup == "" || prevGroup == currentGroup {
 		return "", nil
 	}
@@ -493,6 +530,17 @@ func CreateUserSubscriptionFromPlanTx(tx *gorm.DB, userId int, plan *Subscriptio
 				Update("group", upgradeGroup).Error; err != nil {
 				return nil, err
 			}
+		} else {
+			// User is already in upgradeGroup (renewal, or stacking another plan that
+			// grants the same group). currentGroup is NOT the original baseline, so
+			// inherit it from the existing subscription chain; otherwise this later-
+			// ending row would store an empty prev_user_group and the expiry revert
+			// would have no baseline to fall back to.
+			inherited, err := resolveOriginalUserGroupTx(tx, userId, upgradeGroup)
+			if err != nil {
+				return nil, err
+			}
+			prevGroup = inherited
 		}
 	}
 	sub := &UserSubscription{
@@ -982,26 +1030,40 @@ func ExpireDueSubscriptions(limit int) (int, error) {
 				return nil
 			}
 
-			// No active upgraded subscription, downgrade to previous group if needed.
-			var lastExpired UserSubscription
-			expiredQuery := tx.Where("user_id = ? AND status = ? AND upgrade_group <> ''",
-				userId, "expired").
-				Order("end_time desc, id desc").
-				Limit(1).
-				Find(&lastExpired)
-			if expiredQuery.Error != nil || expiredQuery.RowsAffected == 0 {
-				return nil
-			}
-			upgradeGroup := strings.TrimSpace(lastExpired.UpgradeGroup)
-			prevGroup := strings.TrimSpace(lastExpired.PrevUserGroup)
-			if upgradeGroup == "" || prevGroup == "" {
-				return nil
-			}
+			// No active upgraded subscription remains. Revert the user's group back to
+			// the original baseline. The baseline MUST come from the whole chain, not
+			// just the latest-ending expired sub: renewals/stacked subscriptions store
+			// an empty prev_user_group, so trusting a single row would silently skip
+			// the revert and strand the user in the upgraded group.
 			currentGroup, err := getUserGroupByIdTx(tx, userId)
 			if err != nil {
 				return err
 			}
-			if currentGroup != upgradeGroup || currentGroup == prevGroup {
+			currentGroup = strings.TrimSpace(currentGroup)
+			if currentGroup == "" {
+				return nil
+			}
+			// Only revert when the user's current group was actually granted by an
+			// expired subscription, so we never touch a manually-assigned group.
+			var grantedByExpired UserSubscription
+			grantQuery := tx.Where("user_id = ? AND status = ? AND upgrade_group = ?",
+				userId, "expired", currentGroup).
+				Limit(1).
+				Find(&grantedByExpired)
+			if grantQuery.Error != nil {
+				return grantQuery.Error
+			}
+			if grantQuery.RowsAffected == 0 {
+				return nil
+			}
+			prevGroup, err := resolveOriginalUserGroupTx(tx, userId, currentGroup)
+			if err != nil {
+				return err
+			}
+			if prevGroup == "" || prevGroup == currentGroup {
+				// Baseline unrecoverable (every row recorded an empty prev, e.g. the
+				// user was placed into this group manually before subscribing). Leave
+				// the group as-is for admin remediation rather than guessing.
 				return nil
 			}
 			if err := tx.Model(&User{}).Where("id = ?", userId).

--- a/model/subscription_group_revert_test.go
+++ b/model/subscription_group_revert_test.go
@@ -1,0 +1,163 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for the subscription-expiry group-revert defect: a renewal or a
+// stacked plan bought while the user is already in the upgrade group recorded an
+// empty prev_user_group, and ExpireDueSubscriptions trusted only the latest-ending
+// expired row, so it silently skipped the downgrade and left the user stuck in the
+// upgraded group. See model/subscription.go (CreateUserSubscriptionFromPlanTx,
+// ExpireDueSubscriptions, resolveOriginalUserGroupTx).
+
+func insertSubRevertUser(t *testing.T, id int, group string) {
+	t.Helper()
+	user := &User{
+		Id:       id,
+		Username: fmt.Sprintf("subrevert_user_%d", id),
+		Status:   common.UserStatusEnabled,
+		Group:    group,
+	}
+	require.NoError(t, DB.Create(user).Error)
+}
+
+func subRevertUserGroup(t *testing.T, id int) string {
+	t.Helper()
+	var u User
+	require.NoError(t, DB.Where("id = ?", id).First(&u).Error)
+	return u.Group
+}
+
+// Core bug repro: latest-ending expired sub has an empty prev_user_group (renewal),
+// but the baseline must still be recovered from the earlier sub in the chain.
+func TestExpireDueSubscriptions_RevertsWhenLatestExpiredRowHasEmptyPrev(t *testing.T) {
+	truncateTables(t)
+	const uid = 9001
+	insertSubRevertUser(t, uid, "vip")
+
+	now := GetDBTimestamp()
+	// Original upgrade recorded the real baseline "default".
+	require.NoError(t, DB.Create(&UserSubscription{
+		UserId: uid, PlanId: 1, Status: "active",
+		StartTime: now - 100, EndTime: now - 20,
+		UpgradeGroup: "vip", PrevUserGroup: "default",
+	}).Error)
+	// Renewal bought while already "vip" -> empty prev, ends later (the trigger).
+	require.NoError(t, DB.Create(&UserSubscription{
+		UserId: uid, PlanId: 1, Status: "active",
+		StartTime: now - 50, EndTime: now - 10,
+		UpgradeGroup: "vip", PrevUserGroup: "",
+	}).Error)
+
+	n, err := ExpireDueSubscriptions(100)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, "default", subRevertUserGroup(t, uid),
+		"group must revert to the original baseline even though the latest expired row had an empty prev_user_group")
+}
+
+// Fix A: a renewal made while already upgraded must inherit the original baseline
+// instead of storing an empty prev_user_group.
+func TestCreateUserSubscriptionFromPlanTx_RenewalInheritsPrevGroup(t *testing.T) {
+	truncateTables(t)
+	const uid = 9002
+	insertSubRevertUser(t, uid, "default")
+
+	plan := &SubscriptionPlan{
+		Id: 50, Title: "VIP", DurationUnit: SubscriptionDurationMonth, DurationValue: 1,
+		Enabled: true, UpgradeGroup: "vip",
+	}
+	require.NoError(t, DB.Create(plan).Error)
+
+	// CreateUserSubscriptionFromPlanTx accepts the global DB as its session here.
+	// We intentionally do NOT wrap it in DB.Transaction: the function calls
+	// GetDBTimestamp(), which queries the global DB, and the test harness pins
+	// SQLite :memory: to a single connection — an outer transaction would hold that
+	// connection and deadlock. The inheritance logic under test is independent of
+	// transaction atomicity.
+	sub1, err := CreateUserSubscriptionFromPlanTx(DB, uid, plan, "order")
+	require.NoError(t, err)
+	assert.Equal(t, "vip", subRevertUserGroup(t, uid))
+	var reloaded1 UserSubscription
+	require.NoError(t, DB.First(&reloaded1, sub1.Id).Error)
+	assert.Equal(t, "default", reloaded1.PrevUserGroup)
+
+	// Renewal while already "vip" must inherit the baseline, not store empty prev.
+	sub2, err := CreateUserSubscriptionFromPlanTx(DB, uid, plan, "order")
+	require.NoError(t, err)
+	var reloaded2 UserSubscription
+	require.NoError(t, DB.First(&reloaded2, sub2.Id).Error)
+	assert.Equal(t, "default", reloaded2.PrevUserGroup,
+		"renewal must inherit the original baseline, not store an empty prev_user_group")
+}
+
+// Sanity: a single, never-renewed subscription still reverts correctly.
+func TestExpireDueSubscriptions_RevertsSingleSubscription(t *testing.T) {
+	truncateTables(t)
+	const uid = 9004
+	insertSubRevertUser(t, uid, "vip")
+
+	now := GetDBTimestamp()
+	require.NoError(t, DB.Create(&UserSubscription{
+		UserId: uid, PlanId: 1, Status: "active",
+		StartTime: now - 100, EndTime: now - 10,
+		UpgradeGroup: "vip", PrevUserGroup: "default",
+	}).Error)
+
+	n, err := ExpireDueSubscriptions(100)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, "default", subRevertUserGroup(t, uid))
+}
+
+// Safety: while another upgraded subscription is still active, the group is kept.
+func TestExpireDueSubscriptions_KeepsGroupWhenAnotherActiveUpgradeExists(t *testing.T) {
+	truncateTables(t)
+	const uid = 9005
+	insertSubRevertUser(t, uid, "vip")
+
+	now := GetDBTimestamp()
+	require.NoError(t, DB.Create(&UserSubscription{
+		UserId: uid, PlanId: 1, Status: "active",
+		StartTime: now - 100, EndTime: now - 10,
+		UpgradeGroup: "vip", PrevUserGroup: "default",
+	}).Error)
+	require.NoError(t, DB.Create(&UserSubscription{
+		UserId: uid, PlanId: 1, Status: "active",
+		StartTime: now - 50, EndTime: now + 100000,
+		UpgradeGroup: "vip", PrevUserGroup: "",
+	}).Error)
+
+	n, err := ExpireDueSubscriptions(100)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, "vip", subRevertUserGroup(t, uid),
+		"group must stay upgraded while another active upgraded subscription remains")
+}
+
+// Safety: when no baseline is recoverable (user was placed into the group manually,
+// every sub recorded an empty prev), do not guess — leave the group for admin
+// remediation rather than forcing a downgrade.
+func TestExpireDueSubscriptions_LeavesUnrecoverableManualGroupUntouched(t *testing.T) {
+	truncateTables(t)
+	const uid = 9006
+	insertSubRevertUser(t, uid, "vip")
+
+	now := GetDBTimestamp()
+	require.NoError(t, DB.Create(&UserSubscription{
+		UserId: uid, PlanId: 1, Status: "active",
+		StartTime: now - 50, EndTime: now - 10,
+		UpgradeGroup: "vip", PrevUserGroup: "",
+	}).Error)
+
+	n, err := ExpireDueSubscriptions(100)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, "vip", subRevertUserGroup(t, uid))
+}


### PR DESCRIPTION
> 说明 / Note: 本修复由 AI (Claude) 辅助完成根因诊断与代码实现，提交人已人工复核代码与本描述。
> This fix was researched and implemented with AI (Claude) assistance; the author has reviewed the code and curated this description.

## 📝 变更描述 / Description

订阅套餐到期后，用户未自动退回原分组，长期停留在套餐升级分组（`upgrade_group`）。

根因为两处协同缺陷：

1. `CreateUserSubscriptionFromPlanTx` 仅在 `currentGroup != upgradeGroup` 时记录 `prev_user_group`。当用户**已在升级分组内续费**、或叠加另一授予同一分组的套餐时，新订阅的 `prev_user_group` 被记为空字符串。
2. `ExpireDueSubscriptions` 退组时只取 `end_time` 最新的**单条**已过期订阅，其 `prev_user_group` 为空即命中 `prevGroup == ""` 守卫、**静默跳过退组**。由于每次购买都新建订阅、续费行 `end_time` 必然更晚，真正记录了基线（如 `default`）的首单被排序忽略。

单次、从不续费的订阅可以正常退回，因此该缺陷较隐蔽；而续费/叠加是订阅最常见的使用方式，触发面广。管理员注销/删除订阅的 `downgradeUserGroupForSubscriptionTx` 也受同一“单记录”假设影响。

修复（均使用 GORM 抽象，兼容 SQLite / MySQL / PostgreSQL）：

- **`CreateUserSubscriptionFromPlanTx`**：用户已在升级分组时，从其订阅链继承非空 `prev_user_group`，使链路中每条订阅都保留真实基线。
- **`ExpireDueSubscriptions` / `downgradeUserGroupForSubscriptionTx`**：退组目标改为基于整条订阅链（取最早记录的真实基线）推导，而非单条记录；该改动同时能修复历史脏数据。仅回退“**由已过期订阅授予**”的分组，绝不触碰手动分组；无法恢复基线时保守地不改动。
- **`common.RedisHSetField`**：修复对**无 TTL 持久键**静默丢弃写入的问题（此前退组后缓存内分组不更新），改为对已存在的哈希原地更新、键不存在才跳过（避免生成半截哈希）。

> 存量补救（已过期卡住的老用户没有后续过期事件来触发上述逻辑，需一次性修正）。先 SELECT 预览再执行，务必先备份：
> ```sql
> -- PostgreSQL（MySQL / SQLite 请将 "group" 改为反引号 `group`）
> UPDATE users u SET "group" = (
>   SELECT r.prev_user_group FROM user_subscriptions r
>    WHERE r.user_id = u.id AND r.upgrade_group = u."group"
>      AND r.prev_user_group <> '' AND r.prev_user_group <> u."group"
>    ORDER BY r.start_time ASC, r.id ASC LIMIT 1)
>  WHERE EXISTS (SELECT 1 FROM user_subscriptions e
>                 WHERE e.user_id = u.id AND e.status = 'expired' AND e.upgrade_group = u."group")
>    AND NOT EXISTS (SELECT 1 FROM user_subscriptions a
>                     WHERE a.user_id = u.id AND a.status = 'active' AND a.upgrade_group = u."group")
>    AND EXISTS (SELECT 1 FROM user_subscriptions r
>                 WHERE r.user_id = u.id AND r.upgrade_group = u."group"
>                   AND r.prev_user_group <> '' AND r.prev_user_group <> u."group");
> ```

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
Closes #5561

## ✅ 提交前检查项 / Checklist
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，未发现重复或已有修复。
- [x] **Bug fix 说明:** 已附最小复现，非设计取舍/理解偏差。
- [x] **变更理解:** 已理解改动原理与影响范围。
- [x] **范围聚焦:** 本 PR 仅含本次订阅退组修复，无任何无关改动。
- [x] **本地验证:** `go build` 通过，新增 5 个回归测试全部通过。
- [x] **安全合规:** 无敏感凭据，符合三库兼容与项目规范。
- [ ] **AI 协助声明:** 本 PR 由 AI 辅助实现并经人工复核（见顶部说明），描述为人工整理而非原始 AI 输出直接粘贴。

## 📸 运行证明 / Proof of Work

最小复现：用户在 `default`，购买升级到 `vip` 的套餐 → 首单到期前再次购买同类套餐（续费/叠加）→ 第二单 `prev_user_group=''` 且 `end_time` 更晚 → 两单均过期后用户停留 `vip`，预期应退回 `default`。

回归测试（in-memory SQLite）：
```
=== RUN   TestExpireDueSubscriptions_RevertsWhenLatestExpiredRowHasEmptyPrev
--- PASS
=== RUN   TestCreateUserSubscriptionFromPlanTx_RenewalInheritsPrevGroup
--- PASS
=== RUN   TestExpireDueSubscriptions_RevertsSingleSubscription
--- PASS
=== RUN   TestExpireDueSubscriptions_KeepsGroupWhenAnotherActiveUpgradeExists
--- PASS
=== RUN   TestExpireDueSubscriptions_LeavesUnrecoverableManualGroupUntouched
--- PASS
PASS
ok  github.com/QuantumNous/new-api/model
```
