### PR TITLE
fix(subscription): apply gateway price to plan payments

### DIFF
--- a/controller/subscription_payment_epay.go
+++ b/controller/subscription_payment_epay.go
@@ -84,10 +84,20 @@ func SubscriptionRequestEpay(c *gin.Context) {
 		return
 	}
 
+	group, err := model.GetUserGroup(userId, true)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "获取用户分组失败"})
+		return
+	}
+	payMoney := getPayMoney(int64(plan.PriceAmount), group)
+	if payMoney < 0.01 {
+		common.ApiErrorMsg(c, "套餐金额过低")
+		return
+	}
 	order := &model.SubscriptionOrder{
 		UserId:          userId,
 		PlanId:          plan.Id,
-		Money:           plan.PriceAmount,
+		Money:           payMoney,
 		TradeNo:         tradeNo,
 		PaymentMethod:   req.PaymentMethod,
 		PaymentProvider: model.PaymentProviderEpay,
@@ -102,7 +112,7 @@ func SubscriptionRequestEpay(c *gin.Context) {
 		Type:           req.PaymentMethod,
 		ServiceTradeNo: tradeNo,
 		Name:           fmt.Sprintf("SUB:%s", plan.Title),
-		Money:          strconv.FormatFloat(plan.PriceAmount, 'f', 2, 64),
+		Money:          strconv.FormatFloat(payMoney, 'f', 2, 64),
 		Device:         epay.PC,
 		NotifyUrl:      notifyUrl,
 		ReturnUrl:      returnUrl,

--- a/controller/subscription_payment_waffo_pancake.go
+++ b/controller/subscription_payment_waffo_pancake.go
@@ -79,10 +79,15 @@ func SubscriptionRequestWaffoPancakePay(c *gin.Context) {
 	// dispatch in WaffoPancakeWebhook.
 	tradeNo := fmt.Sprintf("WAFFO_PANCAKE_SUB-%d-%d-%s", userId, time.Now().UnixMilli(), randstr.String(6))
 
+	payMoney := getWaffoPancakePayMoney(int64(plan.PriceAmount), user.Group)
+	if payMoney < 0.01 {
+		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "套餐金额过低"})
+		return
+	}
 	order := &model.SubscriptionOrder{
 		UserId:          userId,
 		PlanId:          plan.Id,
-		Money:           plan.PriceAmount,
+		Money:           payMoney,
 		TradeNo:         tradeNo,
 		PaymentMethod:   model.PaymentMethodWaffoPancake,
 		PaymentProvider: model.PaymentProviderWaffoPancake,
@@ -100,7 +105,7 @@ func SubscriptionRequestWaffoPancakePay(c *gin.Context) {
 		ProductID:     plan.WaffoPancakeProductId,
 		BuyerIdentity: service.WaffoPancakeBuyerIdentityFromUserID(user.Id),
 		PriceSnapshot: &service.WaffoPancakePriceSnapshot{
-			Amount:      decimal.NewFromFloat(plan.PriceAmount).StringFixed(2),
+			Amount:      decimal.NewFromFloat(payMoney).StringFixed(2),
 			TaxCategory: "saas",
 		},
 		BuyerEmail:              getWaffoPancakeBuyerEmail(user),
@@ -114,7 +119,7 @@ func SubscriptionRequestWaffoPancakePay(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "拉起支付失败"})
 		return
 	}
-	logger.LogInfo(c.Request.Context(), fmt.Sprintf("Waffo Pancake 订阅订单创建成功 user_id=%d plan_id=%d trade_no=%s session_id=%s money=%.2f", userId, plan.Id, tradeNo, session.SessionID, plan.PriceAmount))
+	logger.LogInfo(c.Request.Context(), fmt.Sprintf("Waffo Pancake 订阅订单创建成功 user_id=%d plan_id=%d trade_no=%s session_id=%s money=%.2f", userId, plan.Id, tradeNo, session.SessionID, payMoney))
 
 	c.JSON(http.StatusOK, gin.H{
 		"message": "success",


### PR DESCRIPTION
## Summary
- Apply the existing Epay top-up payment calculation to Epay subscription checkout
- Apply the existing Waffo Pancake top-up payment calculation to Waffo Pancake subscription checkout
- Store the calculated checkout amount in subscription orders and send it to the gateway

## Why
Subscription plan checkout previously sent `plan.PriceAmount` directly to Epay and Waffo Pancake. This skipped the configured gateway unit price / local-currency ratio used by normal wallet top-ups.

## Notes
- Stripe subscription checkout is unchanged because it uses Stripe Price IDs.
- Creem subscription checkout is unchanged because it is product-price based.
- `plan.PriceAmount` is cast to `int64` to reuse the existing top-up helpers, matching the current integer-oriented recharge amount behavior.

## Testing
- Not run (per request).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription payment amounts now computed based on user group, enabling differentiated pricing.
  * Added validation to ensure subscription payments meet minimum amount threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->