### PR TITLE
fix: extend datetime picker year range

### DIFF
--- a/web/default/src/components/datetime-picker.tsx
+++ b/web/default/src/components/datetime-picker.tsx
@@ -16,12 +16,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import * as React from 'react'
 import { ChevronDownIcon } from 'lucide-react'
+import * as React from 'react'
 import { enUS, fr, ja, ru, vi, zhCN } from 'react-day-picker/locale'
 import { useTranslation } from 'react-i18next'
-import dayjs from '@/lib/dayjs'
-import { cn } from '@/lib/utils'
+
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import { Input } from '@/components/ui/input'
@@ -30,6 +29,8 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import dayjs from '@/lib/dayjs'
+import { cn } from '@/lib/utils'
 
 const calendarLocales = {
   en: enUS,
@@ -45,6 +46,8 @@ interface DateTimePickerProps {
   onChange?: (date: Date | undefined) => void
   placeholder?: string
   className?: string
+  startMonth?: Date
+  endMonth?: Date
 }
 
 export function DateTimePicker({
@@ -52,11 +55,21 @@ export function DateTimePicker({
   onChange,
   placeholder,
   className,
+  startMonth,
+  endMonth,
 }: DateTimePickerProps) {
   const { t, i18n } = useTranslation()
   const placeholderText = placeholder ?? t('Select date')
   const calendarLocale =
     calendarLocales[i18n.language as keyof typeof calendarLocales] ?? enUS
+  const defaultDateRange = React.useMemo(() => {
+    const currentYear = new Date().getFullYear()
+
+    return {
+      startMonth: new Date(currentYear - 100, 0, 1),
+      endMonth: new Date(currentYear + 100, 11, 31),
+    }
+  }, [])
   const [open, setOpen] = React.useState(false)
   const [date, setDate] = React.useState<Date | undefined>(value)
   const [month, setMonth] = React.useState<Date | undefined>(value)
@@ -134,6 +147,8 @@ export function DateTimePicker({
             captionLayout='dropdown'
             onSelect={handleDateSelect}
             locale={calendarLocale}
+            startMonth={startMonth ?? defaultDateRange.startMonth}
+            endMonth={endMonth ?? defaultDateRange.endMonth}
           />
         </PopoverContent>
       </Popover>


### PR DESCRIPTION
## 📝 变更描述 / Description

修复在创建/编辑令牌（API Key）设置过期时间时，年份下拉框可选范围过窄、无法选到目标年份的问题。

`DateTimePicker` 组件基于 react-day-picker，并使用了 `captionLayout='dropdown'` 的下拉式年月选择。在未显式指定 `startMonth` / `endMonth` 的情况下，日历组件默认只渲染较窄的年份区间，导致在令牌过期时间等场景下用户无法选择较远的未来（或过去）年份。

本次改动：

- 为 `DateTimePicker` 新增可选的 `startMonth` / `endMonth` props，允许调用方自定义可选年份区间。
- 通过 `useMemo` 计算一个默认区间：当前年份 `-100` 年 至 当前年份 `+100` 年（`new Date(currentYear - 100, 0, 1)` ~ `new Date(currentYear + 100, 11, 31)`），并将其传递给底层 `Calendar`。
- 当调用方未传入对应 props 时使用默认区间（`startMonth ?? defaultDateRange.startMonth`、`endMonth ?? defaultDateRange.endMonth`），从而让年份下拉框覆盖足够宽的范围，使创建令牌时能正常选择目标年份。

由于该组件被令牌创建、兑换码、日志清理、系统公告等多个场景复用，本次改动统一修复了这些入口的年份选择体验，同时保留了按需覆盖区间的能力，向后兼容。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
![image.png](https://github.com/user-attachments/assets/b89a2cd8-84c2-428d-af20-2e884d17a29a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Datetime picker now supports optional start and end month constraints, enabling customization of selectable date ranges. Defaults to ±100 years from the current date when not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->