### PR TITLE
fix(theme): 切换前端主题后重置到首页，避免路由 404

### DIFF
--- a/web/classic/src/components/settings/OtherSetting.jsx
+++ b/web/classic/src/components/settings/OtherSetting.jsx
@@ -303,7 +303,10 @@ const OtherSetting = () => {
           }
           showSuccess(t('已切换到新版前端，正在刷新页面'));
           setTimeout(() => {
-            window.location.reload();
+            // 新版前端的路由与经典前端不同，原地刷新当前路径会 404，
+            // 因此切换后重置到首页，由后端按新主题返回对应前端。
+            // 使用 replace 避免在历史中留下已失效的路由，防止返回时再次 404。
+            window.location.replace('/');
           }, 600);
         } catch (error) {
           console.error('切换新版前端失败', error);

--- a/web/default/src/features/system-settings/general/system-info-section.tsx
+++ b/web/default/src/features/system-settings/general/system-info-section.tsx
@@ -126,15 +126,33 @@ export function SystemInfoSection({ defaultValues }: SystemInfoSectionProps) {
       >,
       defaultValues: normalizedDefaults,
       onSubmit: async (_data, changedFields) => {
+        let frontendThemeChanged = false
+        let allSucceeded = true
         for (const [key, value] of Object.entries(changedFields)) {
           let v = normalizeValue(value)
           if (key === 'ServerAddress') {
             v = v.replace(/\/+$/, '')
           }
-          await updateOption.mutateAsync({
+          const res = await updateOption.mutateAsync({
             key,
             value: v,
           })
+          if (!res.success) {
+            allSucceeded = false
+          }
+          if (key === 'theme.frontend' && res.success) {
+            frontendThemeChanged = true
+          }
+        }
+        // 切换前端主题会改变后端返回的前端产物，而当前路由在经典前端中并不存在，
+        // 因此切换成功后重置到首页以避免 404。仅在所有更新都成功时才跳转，避免在
+        // 其他设置仍需处理时把用户带离页面（更新失败时会返回 success=false 而非抛错）。
+        // 延时用于让表单脏状态先清除（移除 beforeunload 拦截）并展示成功提示后再刷新；
+        // 使用 replace 让已失效的路由不进入历史，防止返回按钮再次触发 404。
+        if (frontendThemeChanged && allSucceeded) {
+          setTimeout(() => {
+            window.location.replace('/')
+          }, 600)
         }
       },
     })


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

经典前端（web/classic）与新版前端（web/default）的路由路径体系不同。切换主题后，如果停留在当前路径原地刷新，浏览器会请求一个在另一套前端中不存在的路由，导致 404。

本次修复将"刷新当前页"改为"跳转首页"：

- **经典前端侧**（`OtherSetting.jsx`）：用户从经典前端切换到新版前端时，原来执行 `window.location.reload()`，改为 `window.location.href = '/'`，让后端按新主题返回对应前端的入口页。
- **新版前端侧**（`system-info-section.tsx`）：保存系统设置时，若 `theme.frontend` 选项发生变化且保存成功，则在 600ms 后执行 `window.location.href = '/'`。延迟的作用是让表单脏状态清除（移除 `beforeunload` 拦截）并让成功提示先显示，再跳转。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *关联 #4947*

## 🔗 关联任务 / Related Issue
- Closes #4947

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 此 PR 标记为 `Bug fix`，已关联 Issue #4947，问题属于明确的路由 404 行为异常，非设计取舍或预期不一致。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响：仅在主题切换成功后触发跳转，不影响其他设置项的保存行为。
- [x] **范围聚焦:** 本 PR 仅修改了与主题切换相关的两处跳转逻辑，未包含无关改动。
- [x] **本地验证:** 已在本地分别验证经典前端→新版前端、新版前端→经典前端的切换流程，均正确跳转至首页，无 404。
- [x] **安全合规:** 代码中无敏感凭据，符合项目代码规范。

## 📸 运行证明 / Proof of Work

**复现步骤（修复前）：**
1. 进入系统设置 → 通用，当前为某一前端主题
2. 切换 `frontend` 主题选项并保存
3. 页面在原路径刷新，命中另一套前端未定义的路由 → 404

**验证步骤（修复后）：**
1. 同上操作
2. 保存成功后约 600ms，浏览器跳转至 `/`
3. 后端按新主题返回对应前端入口，页面正常加载

<img width="3830" height="1574" alt="image" src="https://github.com/user-attachments/assets/d98bdddb-3434-4026-b463-6948ee9b1b53" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontend switching experience by preventing invalid routes from remaining in browser history that could cause navigation errors.
  * Enhanced frontend theme update process with better state management to ensure all changes apply correctly before navigating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->