### PR TITLE
fix: stop repeated allow_wallet_overflow column migration on restart

### DIFF
--- a/model/subscription.go
+++ b/model/subscription.go
@@ -163,7 +163,7 @@ type SubscriptionPlan struct {
 	AllowBalancePay *bool `json:"allow_balance_pay" gorm:"default:true"`
 
 	// Allow falling back to wallet balance after subscription quota is exhausted (empty = true)
-	AllowWalletOverflow *bool `json:"allow_wallet_overflow" gorm:"default:true"`
+	AllowWalletOverflow *bool `json:"allow_wallet_overflow"`
 
 	StripePriceId         string `json:"stripe_price_id" gorm:"type:varchar(128);default:''"`
 	CreemProductId        string `json:"creem_product_id" gorm:"type:varchar(128);default:''"`
@@ -274,7 +274,7 @@ type UserSubscription struct {
 	DowngradeGroup string `json:"downgrade_group" gorm:"type:varchar(64);default:''"`
 
 	// Whether wallet fallback is allowed after this subscription's quota is exhausted (snapshot from plan)
-	AllowWalletOverflow bool `json:"allow_wallet_overflow" gorm:"default:true"`
+	AllowWalletOverflow bool `json:"allow_wallet_overflow"`
 
 	CreatedAt int64 `json:"created_at" gorm:"bigint"`
 	UpdatedAt int64 `json:"updated_at" gorm:"bigint"`


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
当前 bool 类型的列，如果使用 `default:true`，
在 mysql 数据库下每次启动 migrate 都会重复报：
`model/main.go:269 [rows:0] ALTER TABLE user_subscriptions MODIFY COLUMN allow_wallet_overflow boolean DEFAULT true`
`model/main.go:304 [rows:0] ALTER TABLE subscription_plans MODIFY COLUMN allow_wallet_overflow boolean DEFAULT true`
因为 mysql 的 bool 默认值存储为 `1`，`true` 每次都会被识别为不匹配而重新 ALTER。

但如果改成 `default:1`，
又会造成在 postgres 数据库下每次启动 migrate 重复报：
`model/main.go:304 [rows:0] ALTER TABLE subscription_plans MODIFY COLUMN allow_wallet_overflow boolean DEFAULT 1`

目前无论使用哪种默认值字面量，都无法同时兼容 mysql 和 pg 数据库。
这与 #5361（`allow_balance_pay`）属于同一类问题。

## 📝 变更描述 / Description
去除 `SubscriptionPlan.AllowWalletOverflow` 与 `UserSubscription.AllowWalletOverflow` 两个字段的 `gorm:"default:true"` 列级默认值，改由业务层决定默认值（`SubscriptionPlan.NormalizeDefaults` 已将 nil 默认按 true 处理，`UserSubscription` 创建时也总是从套餐显式快照赋值），从根本上消除 AutoMigrate 每次启动的重复 ALTER，且更符合代码逻辑直觉。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 与 #5361 同类问题（`allow_balance_pay` 的重复 migrate）

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述由人工整理撰写。
- [x] **非重复提交:** 已确认非重复（与 #5361 字段不同，互不重叠）。
- [x] **Bug fix 说明:** 属于真实的启动期重复 DDL 噪音，非设计取舍。
- [x] **变更理解:** 已理解去除列默认值不影响既有业务（空值已在业务层兜底为 true）。
- [x] **范围聚焦:** 本 PR 仅去除上述两处列级默认值。
- [x] **本地验证:** `go build ./model` 通过；重启后不再出现上述重复 ALTER。
- [x] **安全合规:** 无敏感凭据，符合代码规范。

## 📸 运行证明 / Proof of Work
修复前，mysql 每次启动重复执行：
```
[rows:0] ALTER TABLE user_subscriptions MODIFY COLUMN allow_wallet_overflow boolean DEFAULT true
[rows:0] ALTER TABLE subscription_plans MODIFY COLUMN allow_wallet_overflow boolean DEFAULT true
```
去除 `gorm:"default:true"` 后，重启不再触发上述 DDL。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated wallet overflow configuration handling in subscription plans and user subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->