### PR TITLE
fix: preserve StreamOptions for AdvancedCustom channel in streaming

### DIFF
--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -231,7 +231,7 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 	if request == nil {
 		return nil, errors.New("request is nil")
 	}
-	if info.ChannelType != constant.ChannelTypeOpenAI && info.ChannelType != constant.ChannelTypeAzure {
+	if info.ChannelType != constant.ChannelTypeOpenAI && info.ChannelType != constant.ChannelTypeAzure && info.ChannelType != constant.ChannelTypeAdvancedCustom {
 		request.StreamOptions = nil
 	}
 	if info.ChannelType == constant.ChannelTypeOpenRouter {


### PR DESCRIPTION
## Problem

For `ChannelTypeAdvancedCustom` channels, streaming responses always report `prompt_tokens_details.cached_tokens = 0`, while non-streaming responses report it correctly.

## Root cause

`relay_info.go` already lists `ChannelTypeAdvancedCustom: true` in `streamSupportedChannels`, so `SupportStreamOptions` is set to `true` for this channel type. However, `ConvertOpenAIRequest` in `relay/channel/openai/adaptor.go` clears `request.StreamOptions` for any channel that is neither `OpenAI` nor `Azure`:

```go
if info.ChannelType != constant.ChannelTypeOpenAI && info.ChannelType != constant.ChannelTypeAzure {
    request.StreamOptions = nil
}
```

This contradicts the declaration in `streamSupportedChannels`. With `StreamOptions` stripped, the upstream provider does not return streaming usage, New API falls back to local token counting, and `cached_tokens` is lost.

## Fix

Add `ChannelTypeAdvancedCustom` to the exclusion so `StreamOptions` is preserved, consistent with `streamSupportedChannels`:

```go
if info.ChannelType != constant.ChannelTypeOpenAI && info.ChannelType != constant.ChannelTypeAzure && info.ChannelType != constant.ChannelTypeAdvancedCustom {
    request.StreamOptions = nil
}
```

## Verification

- `go build ./relay/channel/openai/` passes.
- End-to-end tested against an Azure OpenAI backend via an AdvancedCustom channel: streaming responses now return `cached_tokens` matching the non-streaming values (e.g. 5120, 5632, 6400, 8704 across successive warm-cache requests), whereas before the fix they were always 0.

## Notes

This bug previously existed for `ChannelTypeCustom` and was fixed locally. After upstream renamed the type to `ChannelTypeAdvancedCustom` and added it to `streamSupportedChannels`, the corresponding exclusion in `ConvertOpenAIRequest` was missed — this PR completes that fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where streaming options were incorrectly cleared for advanced custom channel configurations. Streaming options are now properly preserved for advanced custom channels, consistent with other channel types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->