### PR TITLE
fix(log): 修复新前端日志按登录类型(type=7)筛选失效

### DIFF
--- a/web/default/src/routes/_authenticated/usage-logs/$section.tsx
+++ b/web/default/src/routes/_authenticated/usage-logs/$section.tsx
@@ -24,7 +24,7 @@ import {
   USAGE_LOGS_DEFAULT_SECTION,
 } from '@/features/usage-logs/section-registry'
 
-const logTypeValues = ['0', '1', '2', '3', '4', '5', '6'] as const
+const logTypeValues = ['0', '1', '2', '3', '4', '5', '6', '7'] as const
 const logTypeSearchSchema = z
   .preprocess(
     (value) => {


### PR DESCRIPTION
> 本 PR 由 AI 辅助生成并经人工复核整理。

## 📝 变更描述 / Description

修复新前端「通用日志」按**登录类型**(type=7)筛选无效的问题。

根因:路由 search 校验的枚举 `logTypeValues` 只列了 `'0'`~`'6'`,漏掉了登录类型 `'7'`。下拉框选「登录」后 `type=['7']` 校验失败,被 `.catch([])` 兜底成空数组,导致最终请求丢掉 `type` 参数,后端按全部类型返回。

修复:将 `'7'` 补入 `logTypeValues`,与 `LOG_TYPE_ENUM.LOGIN`、`LOG_TYPES` 保持一致。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## ✅ 提交前检查项 / Checklist
- [x] 非重复提交
- [x] 变更理解
- [x] 范围聚焦
- [x] 本地验证(抓包确认筛选登录类型后请求携带 `type=7`)
- [x] 安全合规

## 📸 运行证明 / Proof of Work

修复前:选「登录」筛选,请求 URL 无 `type` 参数,返回所有类型日志。
修复后:请求携带 `type=7`,仅返回登录日志。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usage logs now support filtering by an additional log type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->