### PR TITLE
fix: surface responses stream errors

### DIFF
--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -392,6 +392,7 @@ const (
 type ResponsesStreamResponse struct {
 	Type     string                   `json:"type"`
 	Response *OpenAIResponsesResponse `json:"response,omitempty"`
+	Error    any                      `json:"error,omitempty"`
 	Delta    string                   `json:"delta,omitempty"`
 	Item     *ResponsesOutput         `json:"item,omitempty"`
 	// - response.function_call_arguments.delta

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -68,6 +68,31 @@ func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 	return &usage, nil
 }
 
+func responsesStreamOpenAIErrorStatusCode(oaiErr *types.OpenAIError) int {
+	if oaiErr == nil {
+		return http.StatusInternalServerError
+	}
+	errType := strings.ToLower(oaiErr.Type)
+	errCode := strings.ToLower(fmt.Sprintf("%v", oaiErr.Code))
+	if errType == "invalid_request_error" || strings.Contains(errCode, "context_length") || strings.Contains(errCode, "invalid_request") {
+		return http.StatusBadRequest
+	}
+	return http.StatusInternalServerError
+}
+
+func responsesStreamErrorFromOpenAIError(oaiErr *types.OpenAIError) *types.NewAPIError {
+	if oaiErr == nil {
+		return nil
+	}
+	if oaiErr.Type == "" {
+		oaiErr.Type = "upstream_error"
+	}
+	if oaiErr.Message == "" {
+		return nil
+	}
+	return types.WithOpenAIError(*oaiErr, responsesStreamOpenAIErrorStatusCode(oaiErr), types.ErrOptionWithSkipRetry())
+}
+
 func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
 	if resp == nil || resp.Body == nil {
 		logger.LogError(c, "invalid response or response body")
@@ -78,8 +103,14 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 
 	var usage = &dto.Usage{}
 	var responseTextBuilder strings.Builder
+	var streamErr *types.NewAPIError
+	var pendingStreamErr *types.NewAPIError
 
 	helper.StreamScannerHandler(c, resp, info, func(data string, sr *helper.StreamResult) {
+		if streamErr != nil {
+			sr.Stop(streamErr)
+			return
+		}
 
 		// 检查当前数据是否包含 completed 状态和 usage 信息
 		var streamResponse dto.ResponsesStreamResponse
@@ -127,8 +158,36 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 					}
 				}
 			}
+		case "error":
+			if pendingErr := responsesStreamErrorFromOpenAIError(dto.GetOpenAIError(streamResponse.Error)); pendingErr != nil {
+				pendingStreamErr = pendingErr
+				sr.Error(pendingErr)
+			}
+		case "response.error", "response.failed":
+			if streamResponse.Response != nil {
+				if extractedErr := responsesStreamErrorFromOpenAIError(streamResponse.Response.GetOpenAIError()); extractedErr != nil {
+					streamErr = extractedErr
+					sr.Stop(streamErr)
+					return
+				}
+			}
+			if pendingStreamErr != nil {
+				streamErr = pendingStreamErr
+				sr.Stop(streamErr)
+				return
+			}
+			streamErr = types.NewOpenAIError(fmt.Errorf("responses stream error: %s", streamResponse.Type), types.ErrorCodeBadResponse, http.StatusInternalServerError, types.ErrOptionWithSkipRetry())
+			sr.Stop(streamErr)
+			return
 		}
 	})
+
+	if streamErr != nil {
+		return nil, streamErr
+	}
+	if pendingStreamErr != nil {
+		return nil, pendingStreamErr
+	}
 
 	if usage.CompletionTokens == 0 {
 		// 计算输出文本的 token 数量

--- a/relay/channel/openai/relay_responses_stream_test.go
+++ b/relay/channel/openai/relay_responses_stream_test.go
@@ -1,0 +1,127 @@
+package openai
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func newResponsesStreamTestContext(t *testing.T, body string) (*gin.Context, *httptest.ResponseRecorder, *http.Response, *relaycommon.RelayInfo) {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "gpt-5.5",
+		},
+		IsStream: true,
+	}
+	return c, recorder, resp, info
+}
+
+func TestOaiResponsesStreamHandlerReturnsErrorForResponseFailed(t *testing.T) {
+	oldMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(oldMode) })
+
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	body := strings.Join([]string{
+		`event: error`,
+		`data: {"type":"error","error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"Your input exceeds the context window of this model. Please adjust your input and try again.","param":"input"},"sequence_number":2}`,
+		``,
+		`event: response.failed`,
+		`data: {"type":"response.failed","response":{"id":"resp_failed","object":"response","created_at":1710000000,"status":"failed","model":"gpt-5.5","error":{"message":"Your input exceeds the context window of this model. Please adjust your input and try again.","code":"context_length_exceeded"}}}`,
+		``,
+	}, "\n")
+
+	c, recorder, resp, info := newResponsesStreamTestContext(t, body)
+
+	usage, err := OaiResponsesStreamHandler(c, info, resp)
+	require.Nil(t, usage)
+	require.NotNil(t, err)
+	require.Equal(t, http.StatusBadRequest, err.StatusCode)
+	require.Contains(t, err.Error(), "context window")
+	require.Equal(t, types.ErrorCode("context_length_exceeded"), err.GetErrorCode())
+	require.True(t, types.IsSkipRetryError(err))
+	require.NotNil(t, info.StreamStatus)
+	require.Contains(t, recorder.Body.String(), `event: error`)
+	require.Contains(t, recorder.Body.String(), `event: response.failed`)
+	require.Contains(t, recorder.Body.String(), `context_length_exceeded`)
+}
+
+func TestOaiResponsesStreamHandlerReturnsPendingTopLevelErrorWithoutFailedEvent(t *testing.T) {
+	oldMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(oldMode) })
+
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	body := strings.Join([]string{
+		`event: error`,
+		`data: {"type":"error","error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"Your input exceeds the context window of this model. Please adjust your input and try again.","param":"input"}}`,
+		``,
+	}, "\n")
+
+	c, recorder, resp, info := newResponsesStreamTestContext(t, body)
+
+	usage, err := OaiResponsesStreamHandler(c, info, resp)
+	require.Nil(t, usage)
+	require.NotNil(t, err)
+	require.Equal(t, http.StatusBadRequest, err.StatusCode)
+	require.Contains(t, err.Error(), "context window")
+	require.Equal(t, types.ErrorCode("context_length_exceeded"), err.GetErrorCode())
+	require.True(t, types.IsSkipRetryError(err))
+	require.Contains(t, recorder.Body.String(), `event: error`)
+	require.Contains(t, recorder.Body.String(), `context_length_exceeded`)
+}
+
+func TestOaiResponsesStreamHandlerExtractsUsageFromCompletedEvent(t *testing.T) {
+	oldMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(oldMode) })
+
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	body := strings.Join([]string{
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"id":"resp_ok","object":"response","created_at":1710000000,"status":"completed","model":"gpt-5.5","usage":{"input_tokens":11,"output_tokens":7,"total_tokens":18,"input_tokens_details":{"cached_tokens":3}}}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	c, recorder, resp, info := newResponsesStreamTestContext(t, body)
+
+	usage, err := OaiResponsesStreamHandler(c, info, resp)
+	require.Nil(t, err)
+	require.NotNil(t, usage)
+	require.Equal(t, 11, usage.PromptTokens)
+	require.Equal(t, 7, usage.CompletionTokens)
+	require.Equal(t, 18, usage.TotalTokens)
+	require.Equal(t, 3, usage.PromptTokensDetails.CachedTokens)
+	require.Contains(t, recorder.Body.String(), `event: response.completed`)
+	require.Contains(t, recorder.Body.String(), `"total_tokens":18`)
+}


### PR DESCRIPTION
## Summary

Fixes `/v1/responses` streaming error handling so upstream SSE error events and `response.failed` events are returned as `NewAPIError` instead of falling through to a zero-usage success result.

## Changes

- Parse top-level Responses stream `error` payloads.
- Return an upstream error for `response.error` / `response.failed` events before usage fallback logic runs.
- Map invalid request / context-length stream errors to HTTP 400 and mark them skip-retry because stream bytes may already be written.
- Add stream handler tests for `response.failed`, top-level error-only streams, and normal `response.completed` usage extraction.

## Testing

- `go test ./relay/channel/openai -run 'TestOaiResponsesStreamHandlerReturns(ErrorForResponseFailed|PendingTopLevelErrorWithoutFailedEvent|ExtractsUsageFromCompletedEvent)' -count=1`
- `go test ./relay/channel/openai ./relay/helper ./relay/common ./dto -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for streaming responses, ensuring errors are properly captured and reported during stream failures.

* **Tests**
  * Added test coverage for streaming error scenarios, including error event handling and token usage extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->