### PR TITLE
fix(wallet): 修复计费历史弹窗分页与列表重叠 (#5624)

### DIFF
--- a/web/default/src/features/wallet/components/dialogs/billing-history-dialog.tsx
+++ b/web/default/src/features/wallet/components/dialogs/billing-history-dialog.tsx
@@ -35,7 +35,6 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import {
   Select,
   SelectContent,
@@ -145,7 +144,7 @@ export function BillingHistoryDialog({
           </div>
 
           {/* Records List */}
-          <ScrollArea className='max-h-[min(54vh,520px)] pr-3 sm:pr-4'>
+          <div className='max-h-[min(54vh,520px)] overflow-y-auto pr-1'>
             {loading ? (
               <div className='space-y-3'>
                 {Array.from({ length: 5 }).map((_, i) => (
@@ -275,7 +274,7 @@ export function BillingHistoryDialog({
                 })}
               </div>
             )}
-          </ScrollArea>
+          </div>
 
           {/* Pagination */}
           {!loading && records.length > 0 && (


### PR DESCRIPTION
> 本 PR 由 AI 辅助生成并经人工整理、本地验证。

## 📝 变更描述 / Description
钱包「订单历史 / 计费历史」弹窗在记录较多时，记录列表会溢出并盖住底部分页，导致「显示第 X-Y 条」统计文字与上一页/下一页控件重叠。

根因：列表用的是 base-ui 的 `ScrollArea`，但只在 Root 上设了 `max-height`。base-ui 的 `Viewport` 用 `height:100%`，而当 Root 只有 `max-height`、没有确定 `height` 时，按 CSS 规则 `height:100%` 会回退为 `auto`，于是 Viewport 撑满全部内容、不产生滚动，并溢出到 Root 之外（Root 不裁剪），盖在下方分页上。

修复：将该列表改用原生 `max-h + overflow-y-auto` 的 `div`。原生 `max-height` 配合 `overflow-y-auto` 能正确约束高度并内部滚动，分页作为同级元素干净地排在列表下方，不再重叠。项目里已有多处采用这种原生滚动写法，且全局 `* { scrollbar-width: thin }` 会自动套用细滚动条样式，视觉保持一致。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5624

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 已整理撰写此描述。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，确认不重复。
- [x] **Bug fix 说明:** 已关联对应 Issue #5624。
- [x] **变更理解:** 已理解更改原理及影响。
- [x] **范围聚焦:** 本 PR 仅含该弹窗的布局修复。
- [x] **本地验证:** 已用还原真实结构的最小页面在浏览器验证布局修复生效。
- [x] **安全合规:** 无敏感凭据，符合代码规范。

## 📸 运行证明 / Proof of Work
用还原弹窗真实 class 结构的最小页面验证：列表在 `max-height` 处截断并内部滚动，分页带 `border-top` 干净地排在列表下方，无重叠。

修复前:
<img width="1762" height="1476" alt="image" src="https://github.com/user-attachments/assets/4609ebcb-fdf0-4114-9b4c-4a9076442e1b" />

修复后:
<img width="1818" height="1486" alt="image" src="https://github.com/user-attachments/assets/fd3dd0e0-8079-405c-bd52-c926e2609f77" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the billing history dialog's scrolling implementation for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->