### PR TITLE
fix(model-pricing): 修复模型定价列表项无法删除 (#5623)

### DIFF
--- a/web/default/src/features/system-settings/models/model-ratio-visual-editor.tsx
+++ b/web/default/src/features/system-settings/models/model-ratio-visual-editor.tsx
@@ -225,6 +225,7 @@ const ModelRatioVisualEditorComponent = forwardRef<
           isDraftNew: Boolean(!saved && draft),
         }
       })
+      .filter((row) => !row.isDraftDeleted)
       .sort((a, b) => a.name.localeCompare(b.name))
   }, [
     savedModelPrice,
@@ -392,6 +393,12 @@ const ModelRatioVisualEditorComponent = forwardRef<
         'billing_setting.billing_expr',
         JSON.stringify(billingExprMap, null, 2)
       )
+
+      if (editData?.name === name) {
+        setEditData(null)
+        setEditorOpen(false)
+        setSheetOpen(false)
+      }
     },
     [
       modelPrice,
@@ -405,6 +412,7 @@ const ModelRatioVisualEditorComponent = forwardRef<
       billingMode,
       billingExpr,
       onChange,
+      editData,
     ]
   )
 


### PR DESCRIPTION
## 📝 变更描述 / Description
新版 UI「系统设置 → 模型定价」可视化编辑器中，点击列表项的删除按钮后该行不会消失，表现为「无法删除」。

根因：删除时 `handleDelete` 已把模型从草稿（draft）map 中移除，但列表数据 `models` 是 `saved ∪ draft` 的并集，且行内容优先取 `displayed = saved ?? draft`。删除后 draft 没了、saved 仍在，行依旧用 saved 数据渲染；代码已算出 `isDraftDeleted` 标记，但渲染处从未使用它，所以列表毫无变化。

修复：
- 在 `models` 中过滤掉已暂存删除（`isDraftDeleted`）的行，删除后该行立即从列表消失，计数 / 空状态同步更新，并随保存持久化。
- 若删除的正是右侧编辑器当前打开的行，则同时关闭编辑器，避免从残留面板再次保存把该模型写回、抵消删除。

> ⚠️ 备注：删除后需要再点击任意一个模型，保存按钮才会出现（保存按钮依赖编辑器/表单的交互态）。这是本次未一并处理的既有交互问题，删除本身在保存后会正确生效。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5623

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 已整理撰写此描述。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，确认不重复。
- [x] **Bug fix 说明:** 已关联对应 Issue #5623。
- [x] **变更理解:** 已理解更改原理及影响。
- [x] **范围聚焦:** 本 PR 仅修复该列表删除问题。
- [x] **本地验证:** 已分析并核对 saved/draft 数据流与保存链路，确认删除经保存可正确持久化。
- [x] **安全合规:** 无敏感凭据，符合代码规范。

## 📸 运行证明 / Proof of Work
代码逻辑核对：删除将模型从草稿 map 移除并触发 `onChange` 更新表单字段；过滤 `isDraftDeleted` 后该行从列表移除；保存时整段 JSON 草稿被持久化，删除生效。

修复后:
<img width="3006" height="1622" alt="image" src="https://github.com/user-attachments/assets/267835d3-7878-49b6-b624-e05b8eb454b6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Draft-deleted models no longer appear in the model list display.
  * The model editor now properly closes and clears all related panels when you delete the model currently being edited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->