### PR TITLE
fix(usage-logs): show provider icons for CN models (align with classic frontend)

### DIFF
--- a/web/default/src/features/usage-logs/components/model-badge.tsx
+++ b/web/default/src/features/usage-logs/components/model-badge.tsx
@@ -79,6 +79,36 @@ function resolveModelProvider(modelName: string): ModelProvider | null {
   if (hasAny(['moonshot-', 'kimi-'])) {
     return { icon: 'Moonshot.Color', label: 'Moonshot' }
   }
+  if (hasAny(['minimax', 'abab'])) {
+    return { icon: 'Minimax.Color', label: 'MiniMax' }
+  }
+  if (hasAny(['glm-', 'chatglm', 'cogview', 'cogvideo'])) {
+    return { icon: 'Zhipu.Color', label: 'Zhipu' }
+  }
+  if (hasAny(['mimo-'])) {
+    return { icon: 'XiaomiMiMo', label: 'MiMo' }
+  }
+  if (hasAny(['ernie'])) {
+    return { icon: 'Wenxin.Color', label: 'Baidu' }
+  }
+  if (hasAny(['spark'])) {
+    return { icon: 'Spark.Color', label: 'iFlyTek' }
+  }
+  if (hasAny(['hunyuan'])) {
+    return { icon: 'Hunyuan.Color', label: 'Tencent' }
+  }
+  if (hasAny(['baichuan'])) {
+    return { icon: 'Baichuan.Color', label: 'Baichuan' }
+  }
+  if (hasAny(['internlm'])) {
+    return { icon: 'InternLM.Color', label: 'InternLM' }
+  }
+  if (hasAny(['step-'])) {
+    return { icon: 'StepFun.Color', label: 'StepFun' }
+  }
+  if (hasAny(['yi-'])) {
+    return { icon: 'Yi.Color', label: 'Yi' }
+  }
   if (hasAny(['mistral-', 'mixtral-'])) {
     return { icon: 'Mistral.Color', label: 'Mistral' }
   }


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

Fixes the usage-logs model badge so models from Zhipu (`glm-`), MiniMax, Xiaomi MiMo, Baidu (`ernie`), iFlyTek (`spark`), Tencent (`hunyuan`), Baichuan, InternLM, StepFun, and Yi render their brand icon instead of a grey dot.

**Why it works:** `resolveModelProvider()` in `web/default/src/features/usage-logs/components/model-badge.tsx` maps a model name to a provider via keyword matching, then renders the `@lobehub/icons` glyph. It previously only covered the mainstream providers and returned `null` for the ones above, which triggered the grey-dot fallback. This PR adds the missing keyword→icon mappings, aligned with what the **classic frontend** already does in `getModelCategories()` (`web/classic/src/helpers/render.jsx`) — so the two frontends now agree. No new dependency; all icons already exist in `@lobehub/icons`.

Only `web/default` is changed (the file where the bug lives). `web/classic` already covers these providers, so it is left untouched to keep the diff focused.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*

## 🔗 关联任务 / Related Issue
- Closes #5630

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 已关联 Issue #5630。
- [x] **变更理解:** 改动是纯前端的关键字→图标映射扩展，沿用现有 `resolveModelProvider` 模式，无副作用。
- [x] **范围聚焦:** 仅改动 `web/default/src/features/usage-logs/components/model-badge.tsx` 一个文件（+30 行）。
- [x] **本地验证:** `tsc --noEmit` 通过；已在生产部署验证（usage-logs 现正确显示 Zhipu/MiniMax/XiaomiMiMo 等图标）。
- [x] **安全合规:** 无敏感凭据，符合代码规范。

## 📸 运行证明 / Proof of Work

Before: usage-logs `Model` column showed a grey dot for `glm-5.2` / `minimax-m3` / `mimo-v2.5-pro`.

After (verified on a live deployment): the same column renders the Zhipu / MiniMax / XiaomiMiMo SVG brand icons, matching the pricing page. Icons confirmed present in the production JS bundle via `<svg><title>` (Zhipu, Minimax, XiaomiMiMo, …).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing additional AI model providers including Minimax, Zhipu, MiMo, Baidu, iFlyTek, Tencent, Baichuan, InternLM, StepFun, and Yi. The application now properly identifies and displays these models in usage logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->