### PR TITLE
fix(web): avoid rerendering custom homepage content

### DIFF
--- a/web/classic/src/pages/Home/index.jsx
+++ b/web/classic/src/pages/Home/index.jsx
@@ -80,6 +80,7 @@ const Home = () => {
   const endpointItems = API_ENDPOINTS.map((e) => ({ value: e }));
   const [endpointIndex, setEndpointIndex] = useState(0);
   const isChinese = i18n.language.startsWith('zh');
+  const showDefaultHomePage = homePageContentLoaded && homePageContent === '';
 
   const displayHomePageContent = async () => {
     setHomePageContent(localStorage.getItem('home_page_content') || '');
@@ -142,11 +143,14 @@ const Home = () => {
   }, []);
 
   useEffect(() => {
+    if (!showDefaultHomePage) {
+      return undefined;
+    }
     const timer = setInterval(() => {
       setEndpointIndex((prev) => (prev + 1) % endpointItems.length);
     }, 3000);
     return () => clearInterval(timer);
-  }, [endpointItems.length]);
+  }, [endpointItems.length, showDefaultHomePage]);
 
   return (
     <div className='classic-page-fill classic-home-page w-full overflow-x-hidden'>
@@ -155,7 +159,7 @@ const Home = () => {
         onClose={() => setNoticeVisible(false)}
         isMobile={isMobile}
       />
-      {homePageContentLoaded && homePageContent === '' ? (
+      {showDefaultHomePage ? (
         <div className='classic-home-default w-full overflow-x-hidden'>
           {/* Banner 部分 */}
           <div className='classic-home-hero w-full border-b border-semi-color-border relative overflow-x-hidden'>


### PR DESCRIPTION
## Summary
- stop the classic homepage endpoint auto-rotation timer when custom homepage content is configured
- derive a shared showDefaultHomePage flag for the default homepage branch
- avoid rerendering injected custom homepage HTML every 3 seconds

## Testing
- verified the classic homepage code path and confirmed the timer now only runs for the default homepage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved home page display logic to correctly show the default home page when no custom content is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->