### PR TITLE
fix(subscription): preserve wallet overflow snapshots

### DIFF
--- a/model/subscription.go
+++ b/model/subscription.go
@@ -273,7 +273,8 @@ type UserSubscription struct {
 	// Downgrade target group on expiry (snapshot from plan; empty = revert to PrevUserGroup)
 	DowngradeGroup string `json:"downgrade_group" gorm:"type:varchar(64);default:''"`
 
-	// Whether wallet fallback is allowed after this subscription's quota is exhausted (snapshot from plan)
+	// Whether wallet fallback is allowed after this subscription's quota is exhausted (snapshot from plan).
+	// Keep field stable across usage/reset updates; write only touched columns.
 	AllowWalletOverflow bool `json:"allow_wallet_overflow"`
 
 	CreatedAt int64 `json:"created_at" gorm:"bigint"`
@@ -1128,16 +1129,29 @@ func maybeResetUserSubscriptionWithPlanTx(tx *gorm.DB, sub *UserSubscription, pl
 	}
 	if !advanced {
 		if sub.NextResetTime == 0 && next > 0 {
-			sub.NextResetTime = next
 			sub.LastResetTime = base.Unix()
-			return tx.Save(sub).Error
+			sub.NextResetTime = next
+			return tx.Model(&UserSubscription{}).
+				Where("id = ?", sub.Id).
+				Updates(map[string]interface{}{
+					"last_reset_time": sub.LastResetTime,
+					"next_reset_time": sub.NextResetTime,
+					"updated_at":      common.GetTimestamp(),
+				}).Error
 		}
 		return nil
 	}
 	sub.AmountUsed = 0
 	sub.LastResetTime = base.Unix()
 	sub.NextResetTime = next
-	return tx.Save(sub).Error
+	return tx.Model(&UserSubscription{}).
+		Where("id = ?", sub.Id).
+		Updates(map[string]interface{}{
+			"amount_used":      sub.AmountUsed,
+			"last_reset_time":  sub.LastResetTime,
+			"next_reset_time":  sub.NextResetTime,
+			"updated_at":       common.GetTimestamp(),
+		}).Error
 }
 
 // PreConsumeUserSubscription pre-consumes from any active subscription total quota.
@@ -1226,7 +1240,12 @@ func PreConsumeUserSubscription(requestId string, userId int, modelName string, 
 				return err
 			}
 			sub.AmountUsed += amount
-			if err := tx.Save(&sub).Error; err != nil {
+			if err := tx.Model(&UserSubscription{}).
+				Where("id = ?", sub.Id).
+				Updates(map[string]interface{}{
+					"amount_used": sub.AmountUsed,
+					"updated_at":  common.GetTimestamp(),
+				}).Error; err != nil {
 				return err
 			}
 			returnValue.UserSubscriptionId = sub.Id
@@ -1374,7 +1393,11 @@ func PostConsumeUserSubscriptionDelta(userSubscriptionId int, delta int64) error
 		if sub.AmountTotal > 0 && newUsed > sub.AmountTotal {
 			return fmt.Errorf("subscription used exceeds total, used=%d total=%d", newUsed, sub.AmountTotal)
 		}
-		sub.AmountUsed = newUsed
-		return tx.Save(&sub).Error
+		return tx.Model(&UserSubscription{}).
+			Where("id = ?", sub.Id).
+			Updates(map[string]interface{}{
+				"amount_used": newUsed,
+				"updated_at":  common.GetTimestamp(),
+			}).Error
 	})
 }

--- a/model/subscription_test.go
+++ b/model/subscription_test.go
@@ -1,0 +1,117 @@
+package model
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupSubscriptionTestDB(t *testing.T) func() {
+	t.Helper()
+
+	oldDB := DB
+	oldLogDB := LOG_DB
+	oldUsingSQLite := common.UsingSQLite
+	oldUsingPostgreSQL := common.UsingPostgreSQL
+	oldUsingMySQL := common.UsingMySQL
+	oldRedisEnabled := common.RedisEnabled
+
+	testDB, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "subscription-test.db")), &gorm.Config{})
+	require.NoError(t, err)
+
+	DB = testDB
+	LOG_DB = testDB
+	common.UsingSQLite = true
+	common.UsingPostgreSQL = false
+	common.UsingMySQL = false
+	common.RedisEnabled = false
+	initCol()
+
+	return func() {
+		DB = oldDB
+		LOG_DB = oldLogDB
+		common.UsingSQLite = oldUsingSQLite
+		common.UsingPostgreSQL = oldUsingPostgreSQL
+		common.UsingMySQL = oldUsingMySQL
+		common.RedisEnabled = oldRedisEnabled
+		initCol()
+	}
+}
+
+func TestSubscriptionUsageUpdatesDoNotOverwriteWalletOverflowSnapshot(t *testing.T) {
+	cleanup := setupSubscriptionTestDB(t)
+	defer cleanup()
+
+	require.NoError(t, DB.AutoMigrate(&SubscriptionPlan{}, &UserSubscription{}, &SubscriptionPreConsumeRecord{}))
+
+	plan := &SubscriptionPlan{
+		Title:            "Reset Snapshot",
+		PriceAmount:      9.9,
+		Currency:         "USD",
+		DurationUnit:     SubscriptionDurationMonth,
+		DurationValue:    1,
+		Enabled:          true,
+		TotalAmount:      100,
+		QuotaResetPeriod: SubscriptionResetDaily,
+	}
+	require.NoError(t, DB.Create(plan).Error)
+
+	now := GetDBTimestamp()
+	sub := &UserSubscription{
+		UserId:        1,
+		PlanId:        plan.Id,
+		AmountTotal:   100,
+		AmountUsed:    60,
+		StartTime:     now - 86400,
+		EndTime:       now + 86400,
+		Status:        "active",
+		LastResetTime: now - 86400,
+		NextResetTime: now - 1,
+		CreatedAt:    common.GetTimestamp(),
+		UpdatedAt:    common.GetTimestamp(),
+	}
+	require.NoError(t, DB.Create(sub).Error)
+	require.NoError(t, DB.Model(&UserSubscription{}).
+		Where("id = ?", sub.Id).
+		Update("allow_wallet_overflow", gorm.Expr("NULL")).Error)
+
+	require.NoError(t, DB.Transaction(func(tx *gorm.DB) error {
+		var locked UserSubscription
+		if err := tx.Set("gorm:query_option", "FOR UPDATE").
+			First(&locked, sub.Id).Error; err != nil {
+			return err
+		}
+		return maybeResetUserSubscriptionWithPlanTx(tx, &locked, plan, GetDBTimestamp())
+	}))
+
+	var updated UserSubscription
+	require.NoError(t, DB.First(&updated, sub.Id).Error)
+	require.EqualValues(t, 0, updated.AmountUsed)
+	requireWalletOverflowSnapshotNull(t, sub.Id)
+
+	_, err := PreConsumeUserSubscription(fmt.Sprintf("req-reset-%s", t.Name()), 1, "gpt-4o", 0, 10)
+	require.NoError(t, err)
+	require.NoError(t, DB.First(&updated, sub.Id).Error)
+	require.EqualValues(t, 10, updated.AmountUsed)
+	requireWalletOverflowSnapshotNull(t, sub.Id)
+
+	require.NoError(t, PostConsumeUserSubscriptionDelta(sub.Id, -5))
+	require.NoError(t, DB.First(&updated, sub.Id).Error)
+	require.EqualValues(t, 5, updated.AmountUsed)
+	requireWalletOverflowSnapshotNull(t, sub.Id)
+}
+
+func requireWalletOverflowSnapshotNull(t *testing.T, userSubscriptionId int) {
+	t.Helper()
+
+	var overflowSnapshot sql.NullBool
+	require.NoError(t, DB.Raw("SELECT allow_wallet_overflow FROM user_subscriptions WHERE id = ?", userSubscriptionId).
+		Scan(&overflowSnapshot).Error)
+	require.False(t, overflowSnapshot.Valid)
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本描述已人工整理后提交。
> - 本次代码由 Codex 辅助生成，并已人工复核和本地验证。

## 📝 变更描述 / Description

本 PR 修复订阅用量更新时误覆盖 `user_subscriptions` 快照字段的问题。

`allow_wallet_overflow` 是从订阅计划复制到用户订阅上的快照字段。当前订阅重置额度、预扣额度、退款回滚额度时使用了 `Save`，会把整个 `UserSubscription` 结构写回数据库。对于历史数据中 `allow_wallet_overflow` 为 SQL `NULL` 的记录，Go 会按 `bool` 零值读成 `false`，后续只想更新用量字段的操作就可能把该快照列误写成显式 `false`。

修复方式：把相关路径从整行 `Save` 改为只更新自身负责的列：

- `amount_used`
- `last_reset_time`
- `next_reset_time`
- `updated_at`

这样订阅重置、预扣、退款回滚不会再改动 `allow_wallet_overflow` 等订阅快照字段。

同时新增回归测试：构造 `allow_wallet_overflow = NULL` 的用户订阅，依次执行 reset、pre-consume、refund delta，确认该列仍保持 `NULL`，不会被用量更新改写。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

暂无关联 Issue。

提交前已搜索现有 Issues 和 PRs，关键词包括：

- `allow_wallet_overflow`
- `wallet overflow`
- `no matched subscription for group`

未发现重复提交。已有相关 PR #5616 只处理重复迁移列的问题，不覆盖本次整行 `Save` 覆盖快照字段的问题。

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

本地验证已通过：

```bash
go test ./model ./service
# ok github.com/QuantumNous/new-api/model
# ok github.com/QuantumNous/new-api/service

go test ./...
# all packages passed

git diff --check upstream/main..HEAD
# no output
```

同类修复已先在 fork 部署验证：

- 运行镜像：`ghcr.io/mxyhi/new-api:main-e26d7dca5f57`
- 公网响应头：`x-new-api-version: main-e26d7dca5f57`
- 修复后 active 订阅中 `allow_wallet_overflow=false` 的异常行数：`0`
- 部署后日志未再出现新的 `no matched subscription for group: cc-max`、`panic` 或 `fatal`
