### PR TITLE
[codex] log image relay upstream channel

### DIFF
--- a/relay/image_handler.go
+++ b/relay/image_handler.go
@@ -104,6 +104,7 @@ func ImageHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *type
 				httpResp.StatusCode = http.StatusOK
 			} else {
 				newAPIError = service.RelayErrorHandler(c.Request.Context(), httpResp, false)
+				logger.LogError(c, fmt.Sprintf("image relay upstream error: status code %d, channel_name: %s, info: %s, err: %s", httpResp.StatusCode, c.GetString("channel_name"), info.ToString(), common.LocalLogPreview(newAPIError.Error())))
 				// reset status code 重置状态码
 				service.ResetStatusCode(newAPIError, statusCodeMappingStr)
 				return newAPIError


### PR DESCRIPTION
## What changed

Add a targeted error log in the image relay path when upstream returns a non-200 response.

## Why

The existing error chain only surfaced the upstream body and hid which channel/image path failed. This log now includes:
- `channel_name`
- full `RelayInfo`
- upstream status code
- truncated error text

## Impact

This does not change request/response behavior. It only makes production failures traceable.

## Validation

- `git diff --check`
- `go test ./relay/... ./service/... ./controller/...` could not run here because the local Go toolchain is `go1.18.1`, while `go.mod` requires `1.25.1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error logging for relay failures to improve system diagnostics and troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->