### PR TITLE
feat(doubao): 接入 Seedance 2.0 素材资产管理 9 个接口

### DIFF
--- a/controller/asset.go
+++ b/controller/asset.go
@@ -1,0 +1,42 @@
+package controller
+
+import (
+	"github.com/QuantumNous/new-api/relay/channel/task/doubao"
+	"github.com/gin-gonic/gin"
+)
+
+func RelayListAssets(c *gin.Context) {
+	doubao.HandleListAssets(c)
+}
+
+func RelayGetAsset(c *gin.Context) {
+	doubao.HandleGetAsset(c)
+}
+
+func RelayCreateAsset(c *gin.Context) {
+	doubao.HandleCreateAsset(c)
+}
+
+func RelayUpdateAsset(c *gin.Context) {
+	doubao.HandleUpdateAsset(c)
+}
+
+func RelayDeleteAsset(c *gin.Context) {
+	doubao.HandleDeleteAsset(c)
+}
+
+func RelayCreateAssetGroup(c *gin.Context) {
+	doubao.HandleCreateAssetGroup(c)
+}
+
+func RelayListAssetGroups(c *gin.Context) {
+	doubao.HandleListAssetGroups(c)
+}
+
+func RelayGetAssetGroup(c *gin.Context) {
+	doubao.HandleGetAssetGroup(c)
+}
+
+func RelayUpdateAssetGroup(c *gin.Context) {
+	doubao.HandleUpdateAssetGroup(c)
+}

--- a/model/option.go
+++ b/model/option.go
@@ -74,6 +74,7 @@ func InitOptionMap() {
 	common.OptionMap["WorkerUrl"] = system_setting.WorkerUrl
 	common.OptionMap["WorkerValidKey"] = system_setting.WorkerValidKey
 	common.OptionMap["WorkerAllowHttpImageRequestEnabled"] = strconv.FormatBool(system_setting.WorkerAllowHttpImageRequestEnabled)
+	common.OptionMap["VolcAssetConfig"] = volcAssetConfig2JSONString()
 	common.OptionMap["PayAddress"] = ""
 	common.OptionMap["CustomCallbackAddress"] = ""
 	common.OptionMap["EpayId"] = ""
@@ -486,6 +487,8 @@ func updateOptionMap(key string, value string) (err error) {
 		common.WeChatServerToken = value
 	case "WeChatAccountQRCodeImageURL":
 		common.WeChatAccountQRCodeImageURL = value
+	case "VolcAssetConfig":
+		err = updateVolcAssetConfigByJSONString(value)
 	case "TelegramBotToken":
 		common.TelegramBotToken = value
 	case "TelegramBotName":
@@ -605,4 +608,18 @@ func handleConfigUpdate(key, value string) bool {
 	}
 
 	return true // 已处理
+}
+
+func volcAssetConfig2JSONString() string {
+	data, _ := common.Marshal(system_setting.VolcAssetConfig)
+	return string(data)
+}
+
+func updateVolcAssetConfigByJSONString(value string) error {
+	var cfg system_setting.VolcAssetSettings
+	if err := common.UnmarshalJsonStr(value, &cfg); err != nil {
+		return err
+	}
+	system_setting.VolcAssetConfig = cfg
+	return nil
 }

--- a/relay/channel/task/doubao/asset.go
+++ b/relay/channel/task/doubao/asset.go
@@ -1,0 +1,554 @@
+package doubao
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/setting/system_setting"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	assetServiceName = "ark"
+	assetAPIVersion  = "2024-01-01"
+)
+
+// ============================
+// Asset API Request / Response
+// ============================
+
+type AssetFilter struct {
+	GroupIds  []string `json:"GroupIds,omitempty"`
+	GroupType string   `json:"GroupType" example:"AIGC"` // 可选，留空使用默认值(AIGC)
+	Statuses  []string `json:"Statuses,omitempty"`
+	Name      string   `json:"Name,omitempty"`
+}
+
+type ListAssetsRequest struct {
+	Filter      *AssetFilter `json:"Filter,omitempty"`
+	PageNumber  int64        `json:"PageNumber"`
+	PageSize    int64        `json:"PageSize"`
+	SortBy      string       `json:"SortBy,omitempty"`
+	SortOrder   string       `json:"SortOrder,omitempty"`
+	ProjectName string       `json:"ProjectName,omitempty"` // 可选，留空使用默认值
+}
+
+type AssetError struct {
+	Code    string `json:"Code,omitempty"`
+	Message string `json:"Message,omitempty"`
+}
+
+type AssetItem struct {
+	Id          string     `json:"Id"`
+	Name        string     `json:"Name"`
+	URL         string     `json:"URL"`
+	GroupId     string     `json:"GroupId"`
+	AssetType   string     `json:"AssetType" example:"Image" enums:"Image,Video,Audio"` // 素材类型：Image=图像, Video=视频, Audio=音频
+	Status      string     `json:"Status"`
+	Error       AssetError `json:"Error,omitempty"`
+	ProjectName string     `json:"ProjectName"`
+	CreateTime  string     `json:"CreateTime"`
+	UpdateTime  string     `json:"UpdateTime"`
+}
+
+type ListAssetsResponse struct {
+	Items      []AssetItem `json:"Items"`
+	TotalCount int64       `json:"TotalCount"`
+	PageNumber int64       `json:"PageNumber"`
+	PageSize   int64       `json:"PageSize"`
+}
+
+// ============================
+// Credential helpers
+// ============================
+
+// getVolcAKSK reads Volcengine AK/SK from system settings (options table).
+func getVolcAKSK() (accessKey, secretKey string, err error) {
+	cfg := &system_setting.VolcAssetConfig
+	if cfg.AccessKey == "" || cfg.SecretKey == "" {
+		return "", "", fmt.Errorf("VolcAssetConfig access_key or secret_key is not configured in system settings")
+	}
+	return cfg.AccessKey, cfg.SecretKey, nil
+}
+
+// applyDefaults fills empty ProjectName / GroupId / GroupType with system defaults.
+func applyDefaults(projectName, groupId, groupType *string) {
+	cfg := &system_setting.VolcAssetConfig
+	if projectName != nil && *projectName == "" {
+		*projectName = cfg.ProjectName
+	}
+	if groupId != nil && *groupId == "" {
+		*groupId = cfg.GroupId
+	}
+	if groupType != nil && *groupType == "" {
+		*groupType = cfg.GetGroupType()
+	}
+}
+
+// ============================
+// Volcengine HMAC-SHA256 signing
+// ============================
+
+func signVolcengineRequest(req *http.Request, bodyBytes []byte, accessKey, secretKey string) {
+	hexPayloadHash := hex.EncodeToString(common.Sha256Raw(bodyBytes))
+
+	t := time.Now().UTC()
+	xDate := t.Format("20060102T150405Z")
+	shortDate := t.Format("20060102")
+
+	req.Header.Set("Host", req.URL.Host)
+	req.Header.Set("X-Date", xDate)
+	req.Header.Set("X-Content-Sha256", hexPayloadHash)
+
+	// Canonical query string
+	queryParams := req.URL.Query()
+	sortedKeys := make([]string, 0, len(queryParams))
+	for k := range queryParams {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+	var queryParts []string
+	for _, k := range sortedKeys {
+		values := queryParams[k]
+		sort.Strings(values)
+		for _, v := range values {
+			queryParts = append(queryParts, fmt.Sprintf("%s=%s", url.QueryEscape(k), url.QueryEscape(v)))
+		}
+	}
+	canonicalQueryString := strings.Join(queryParts, "&")
+
+	// Canonical headers
+	headersToSign := map[string]string{
+		"host":             req.URL.Host,
+		"x-date":           xDate,
+		"x-content-sha256": hexPayloadHash,
+	}
+	if req.Header.Get("Content-Type") != "" {
+		headersToSign["content-type"] = req.Header.Get("Content-Type")
+	}
+
+	var signedHeaderKeys []string
+	for k := range headersToSign {
+		signedHeaderKeys = append(signedHeaderKeys, k)
+	}
+	sort.Strings(signedHeaderKeys)
+
+	var canonicalHeaders strings.Builder
+	for _, k := range signedHeaderKeys {
+		canonicalHeaders.WriteString(k)
+		canonicalHeaders.WriteString(":")
+		canonicalHeaders.WriteString(strings.TrimSpace(headersToSign[k]))
+		canonicalHeaders.WriteString("\n")
+	}
+	signedHeaders := strings.Join(signedHeaderKeys, ";")
+
+	canonicalRequest := fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s",
+		req.Method,
+		req.URL.Path,
+		canonicalQueryString,
+		canonicalHeaders.String(),
+		signedHeaders,
+		hexPayloadHash,
+	)
+
+	hexHashedCanonicalRequest := hex.EncodeToString(common.Sha256Raw([]byte(canonicalRequest)))
+
+	region := system_setting.VolcAssetConfig.GetRegion()
+	credentialScope := fmt.Sprintf("%s/%s/%s/request", shortDate, region, assetServiceName)
+	stringToSign := fmt.Sprintf("HMAC-SHA256\n%s\n%s\n%s",
+		xDate,
+		credentialScope,
+		hexHashedCanonicalRequest,
+	)
+
+	kDate := common.HmacSha256Raw([]byte(shortDate), []byte(secretKey))
+	kRegion := common.HmacSha256Raw([]byte(region), kDate)
+	kService := common.HmacSha256Raw([]byte(assetServiceName), kRegion)
+	kSigning := common.HmacSha256Raw([]byte("request"), kService)
+	signature := hex.EncodeToString(common.HmacSha256Raw([]byte(stringToSign), kSigning))
+
+	authorization := fmt.Sprintf("HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		accessKey,
+		credentialScope,
+		signedHeaders,
+		signature,
+	)
+	req.Header.Set("Authorization", authorization)
+}
+
+func filterEmptyStrings(s []string) []string {
+	var result []string
+	for _, v := range s {
+		if v != "" {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// ============================
+// Proxy handlers
+// ============================
+
+// doAssetAPICall is the common upstream call logic for all Asset API actions.
+func doAssetAPICall(c *gin.Context, action string, body []byte) {
+	accessKey, secretKey, err := getVolcAKSK()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	upstreamURL := fmt.Sprintf("%s/?Action=%s&Version=%s", system_setting.VolcAssetConfig.GetBaseURL(), action, assetAPIVersion)
+
+	req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodPost, upstreamURL, bytes.NewBuffer(body))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to create upstream request: %v", err)})
+		return
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Accept", "application/json")
+
+	signVolcengineRequest(req, body, accessKey, secretKey)
+
+	client, err := service.GetHttpClientWithProxy("")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to create http client: %v", err)})
+		return
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": fmt.Sprintf("upstream request failed: %v", err)})
+		return
+	}
+	defer resp.Body.Close()
+
+	const maxRespSize = 10 << 20 // 10MB
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxRespSize))
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to read upstream response"})
+		return
+	}
+
+	var envelope struct {
+		ResponseMetadata struct {
+			Error struct {
+				Code    string `json:"Code"`
+				Message string `json:"Message"`
+			} `json:"Error"`
+		} `json:"ResponseMetadata"`
+		Result json.RawMessage `json:"Result"`
+	}
+	if err := common.Unmarshal(respBody, &envelope); err != nil {
+		c.Data(resp.StatusCode, "application/json", respBody)
+		return
+	}
+
+	if envelope.ResponseMetadata.Error.Code != "" {
+		c.JSON(resp.StatusCode, gin.H{
+			"error": gin.H{
+				"code":    envelope.ResponseMetadata.Error.Code,
+				"message": envelope.ResponseMetadata.Error.Message,
+			},
+		})
+		return
+	}
+
+	if len(envelope.Result) > 0 {
+		c.Data(http.StatusOK, "application/json", envelope.Result)
+		return
+	}
+
+	c.Data(resp.StatusCode, "application/json", respBody)
+}
+
+// HandleListAssets proxies a ListAssets request to the Doubao Asset API.
+func HandleListAssets(c *gin.Context) {
+	var listReq ListAssetsRequest
+	if err := common.UnmarshalBodyReusable(c, &listReq); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request body: %v", err)})
+		return
+	}
+
+	if listReq.Filter == nil {
+		listReq.Filter = &AssetFilter{}
+	}
+	listReq.Filter.GroupIds = filterEmptyStrings(listReq.Filter.GroupIds)
+	listReq.Filter.Statuses = filterEmptyStrings(listReq.Filter.Statuses)
+	applyDefaults(&listReq.ProjectName, nil, &listReq.Filter.GroupType)
+
+	body, err := common.Marshal(listReq)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to marshal request"})
+		return
+	}
+
+	doAssetAPICall(c, "ListAssets", body)
+}
+
+// GetAssetRequest is the request for GetAsset API.
+type GetAssetRequest struct {
+	Id          string `json:"Id"`
+	ProjectName string `json:"ProjectName,omitempty"` // 可选，留空使用默认值
+}
+
+// HandleGetAsset proxies a GetAsset request to the Doubao Asset API.
+func HandleGetAsset(c *gin.Context) {
+	var req GetAssetRequest
+	if err := common.UnmarshalBodyReusable(c, &req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request body: %v", err)})
+		return
+	}
+	if req.Id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Id is required"})
+		return
+	}
+	applyDefaults(&req.ProjectName, nil, nil)
+
+	body, err := common.Marshal(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to marshal request"})
+		return
+	}
+	doAssetAPICall(c, "GetAsset", body)
+}
+
+// ============================
+// CreateAsset
+// ============================
+
+type CreateAssetRequest struct {
+	GroupId     string `json:"GroupId"` // 可选，留空使用默认值
+	URL         string `json:"URL"`
+	Name        string `json:"Name,omitempty"`
+	AssetType   string `json:"AssetType" example:"Image" enums:"Image,Video,Audio"` // 素材类型：Image=图像, Video=视频, Audio=音频
+	ProjectName string `json:"ProjectName,omitempty"`                               // 可选，留空使用默认值
+}
+
+func HandleCreateAsset(c *gin.Context) {
+	var req CreateAssetRequest
+	if err := common.UnmarshalBodyReusable(c, &req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request body: %v", err)})
+		return
+	}
+
+	applyDefaults(&req.ProjectName, &req.GroupId, nil)
+	body, err := common.Marshal(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to marshal request"})
+		return
+	}
+	doAssetAPICall(c, "CreateAsset", body)
+}
+
+// ============================
+// UpdateAsset
+// ============================
+
+type UpdateAssetRequest struct {
+	Id          string `json:"Id"`
+	Name        string `json:"Name,omitempty"`
+	ProjectName string `json:"ProjectName,omitempty"` // 可选，留空使用默认值
+}
+
+func HandleUpdateAsset(c *gin.Context) {
+	var req UpdateAssetRequest
+	if err := common.UnmarshalBodyReusable(c, &req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request body: %v", err)})
+		return
+	}
+
+	applyDefaults(&req.ProjectName, nil, nil)
+	if req.Id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Id is required"})
+		return
+	}
+	body, err := common.Marshal(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to marshal request"})
+		return
+	}
+	doAssetAPICall(c, "UpdateAsset", body)
+}
+
+// ============================
+// DeleteAsset
+// ============================
+
+type DeleteAssetRequest struct {
+	Id          string `json:"Id"`
+	ProjectName string `json:"ProjectName,omitempty"` // 可选，留空使用默认值
+}
+
+func HandleDeleteAsset(c *gin.Context) {
+	var req DeleteAssetRequest
+	if err := common.UnmarshalBodyReusable(c, &req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request body: %v", err)})
+		return
+	}
+
+	applyDefaults(&req.ProjectName, nil, nil)
+	if req.Id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Id is required"})
+		return
+	}
+	body, err := common.Marshal(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to marshal request"})
+		return
+	}
+	doAssetAPICall(c, "DeleteAsset", body)
+}
+
+// ============================
+// CreateAssetGroup
+// ============================
+
+type CreateAssetGroupRequest struct {
+	Name        string `json:"Name"`
+	Description string `json:"Description,omitempty"`
+	GroupType   string `json:"GroupType,omitempty" example:"AIGC"` // 可选，留空使用默认值(AIGC)
+	ProjectName string `json:"ProjectName,omitempty"`              // 可选，留空使用默认值
+}
+
+func HandleCreateAssetGroup(c *gin.Context) {
+	var req CreateAssetGroupRequest
+	if err := common.UnmarshalBodyReusable(c, &req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request body: %v", err)})
+		return
+	}
+
+	applyDefaults(&req.ProjectName, nil, &req.GroupType)
+	body, err := common.Marshal(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to marshal request"})
+		return
+	}
+	doAssetAPICall(c, "CreateAssetGroup", body)
+}
+
+// ============================
+// ListAssetGroups
+// ============================
+
+type AssetGroupFilter struct {
+	Name      string   `json:"Name,omitempty"`
+	GroupIds  []string `json:"GroupIds,omitempty"`
+	GroupType string   `json:"GroupType" example:"AIGC"` // 可选，留空使用默认值(AIGC)
+}
+
+type ListAssetGroupsRequest struct {
+	Filter      *AssetGroupFilter `json:"Filter,omitempty"`
+	PageNumber  int64             `json:"PageNumber"`
+	PageSize    int64             `json:"PageSize"`
+	SortBy      string            `json:"SortBy,omitempty"`
+	SortOrder   string            `json:"SortOrder,omitempty"`
+	ProjectName string            `json:"ProjectName,omitempty"` // 可选，留空使用默认值
+}
+
+type AssetGroupItem struct {
+	Id          string `json:"Id"`
+	Name        string `json:"Name"`
+	Description string `json:"Description"`
+	GroupType   string `json:"GroupType" example:"AIGC"`
+	ProjectName string `json:"ProjectName"`
+	CreateTime  string `json:"CreateTime"`
+	UpdateTime  string `json:"UpdateTime"`
+}
+
+type ListAssetGroupsResponse struct {
+	Items      []AssetGroupItem `json:"Items"`
+	TotalCount int64            `json:"TotalCount"`
+	PageNumber int64            `json:"PageNumber"`
+	PageSize   int64            `json:"PageSize"`
+}
+
+func HandleListAssetGroups(c *gin.Context) {
+	var req ListAssetGroupsRequest
+	if err := common.UnmarshalBodyReusable(c, &req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request body: %v", err)})
+		return
+	}
+
+	if req.Filter == nil {
+		req.Filter = &AssetGroupFilter{}
+	}
+	req.Filter.GroupIds = filterEmptyStrings(req.Filter.GroupIds)
+	applyDefaults(&req.ProjectName, nil, &req.Filter.GroupType)
+	body, err := common.Marshal(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to marshal request"})
+		return
+	}
+	doAssetAPICall(c, "ListAssetGroups", body)
+}
+
+// ============================
+// GetAssetGroup
+// ============================
+
+type GetAssetGroupRequest struct {
+	Id          string `json:"Id"`
+	ProjectName string `json:"ProjectName,omitempty"` // 可选，留空使用默认值
+}
+
+func HandleGetAssetGroup(c *gin.Context) {
+	var req GetAssetGroupRequest
+	if err := common.UnmarshalBodyReusable(c, &req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request body: %v", err)})
+		return
+	}
+
+	applyDefaults(&req.ProjectName, nil, nil)
+	if req.Id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Id is required"})
+		return
+	}
+	body, err := common.Marshal(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to marshal request"})
+		return
+	}
+	doAssetAPICall(c, "GetAssetGroup", body)
+}
+
+// ============================
+// UpdateAssetGroup
+// ============================
+
+type UpdateAssetGroupRequest struct {
+	Id          string `json:"Id"`
+	Name        string `json:"Name,omitempty"`
+	Description string `json:"Description,omitempty"`
+	ProjectName string `json:"ProjectName,omitempty"` // 可选，留空使用默认值
+}
+
+func HandleUpdateAssetGroup(c *gin.Context) {
+	var req UpdateAssetGroupRequest
+	if err := common.UnmarshalBodyReusable(c, &req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request body: %v", err)})
+		return
+	}
+
+	applyDefaults(&req.ProjectName, nil, nil)
+	if req.Id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Id is required"})
+		return
+	}
+	body, err := common.Marshal(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to marshal request"})
+		return
+	}
+	doAssetAPICall(c, "UpdateAssetGroup", body)
+}

--- a/router/video-router.go
+++ b/router/video-router.go
@@ -49,4 +49,20 @@ func SetVideoRouter(router *gin.Engine) {
 		// Maps to: /?Action=CVSync2AsyncSubmitTask&Version=2022-08-31 and /?Action=CVSync2AsyncGetResult&Version=2022-08-31
 		jimengOfficialGroup.POST("/", controller.RelayTask)
 	}
+
+	// Doubao Asset API routes - proxy to volcengine Asset API with AK/SK auth
+	doubaoGroup := router.Group("/doubao")
+	doubaoGroup.Use(middleware.RouteTag("relay"))
+	doubaoGroup.Use(middleware.TokenAuth())
+	{
+		doubaoGroup.POST("/open/ListAssets", controller.RelayListAssets)
+		doubaoGroup.POST("/open/GetAsset", controller.RelayGetAsset)
+		doubaoGroup.POST("/open/CreateAsset", controller.RelayCreateAsset)
+		doubaoGroup.POST("/open/UpdateAsset", controller.RelayUpdateAsset)
+		doubaoGroup.POST("/open/DeleteAsset", controller.RelayDeleteAsset)
+		doubaoGroup.POST("/open/CreateAssetGroup", controller.RelayCreateAssetGroup)
+		doubaoGroup.POST("/open/ListAssetGroups", controller.RelayListAssetGroups)
+		doubaoGroup.POST("/open/GetAssetGroup", controller.RelayGetAssetGroup)
+		doubaoGroup.POST("/open/UpdateAssetGroup", controller.RelayUpdateAssetGroup)
+	}
 }

--- a/setting/system_setting/volc_asset.go
+++ b/setting/system_setting/volc_asset.go
@@ -1,0 +1,32 @@
+package system_setting
+
+import "fmt"
+
+var VolcAssetConfig = VolcAssetSettings{}
+
+type VolcAssetSettings struct {
+	AccessKey   string `json:"access_key"`
+	SecretKey   string `json:"secret_key"`
+	Region      string `json:"region"`
+	ProjectName string `json:"project_name"`
+	GroupId     string `json:"group_id"`
+	GroupType   string `json:"group_type"`
+}
+
+func (v *VolcAssetSettings) GetRegion() string {
+	if v.Region == "" {
+		return "cn-beijing"
+	}
+	return v.Region
+}
+
+func (v *VolcAssetSettings) GetGroupType() string {
+	if v.GroupType == "" {
+		return "AIGC"
+	}
+	return v.GroupType
+}
+
+func (v *VolcAssetSettings) GetBaseURL() string {
+	return fmt.Sprintf("https://ark.%s.volcengineapi.com", v.GetRegion())
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
接入火山引擎 Seedance 2.0 官方格式的 9 个素材(Asset)管理接口,以代理转发方式统一收口到网关:请求侧用平台 Token 鉴权,网关内部用火山 AK/SK 对上游签名。
官方文档: https://www.volcengine.com/docs/82379/2333589?lang=zh

| 接口 | Method | 网关路由 |
|---|---|---|
| 创建素材资产 | POST | `/doubao/open/CreateAsset` |
| 创建素材组 | POST | `/doubao/open/CreateAssetGroup` |
| 删除素材资产 | POST | `/doubao/open/DeleteAsset` |
| 查询素材资产信息 | POST | `/doubao/open/GetAsset` |
| 查询素材组信息 | POST | `/doubao/open/GetAssetGroup` |
| 查询素材组列表 | POST | `/doubao/open/ListAssetGroups` |
| 查询素材资产列表 | POST | `/doubao/open/ListAssets` |
| 更新素材资产 | POST | `/doubao/open/UpdateAsset` |
| 更新素材组 | POST | `/doubao/open/UpdateAssetGroup` |

## 📝 变更描述 / Description
为豆包(火山引擎)新增一套素材资产管理的代理接口,客户端无需自行持有火山 AK/SK,即可通过网关完成素材与素材组的增删改查。实现分三层:

- **配置层**:新增 `setting/system_setting/volc_asset.go`,定义 `VolcAssetSettings`(AK/SK、region、project、默认 group 等);通过 `model/option.go` 把 `VolcAssetConfig` 接入 options 配置体系,支持热更新。Region 缺省 `cn-beijing`,GroupType 缺省 `AIGC`。
- **relay 实现层**:新增 `relay/channel/task/doubao/asset.go`,实现对火山 Asset API(service=`ark`,version=`2024-01-01`)的请求构造与 **AK/SK 签名**,覆盖 list/get/create/update/delete asset 与 create/list/get/update asset group。
- **暴露层**:`controller/asset.go` 提供 9 个 handler,`router/video-router.go` 注册 `/doubao/open/*` 路由组,统一走 `TokenAuth` 鉴权。

生效原理:网关接收客户端的平台 Token 请求 → 取出已配置的火山 AK/SK 对上游做签名 → 透传转发到火山 Asset API 并回传结果,从而屏蔽上游鉴权细节、统一入口与权限控制。

**配置说明:** 启用前需在 options 表写入一条 `key = VolcAssetConfig` 的配置(代码已在 `InitOptionMap` 自动注册并支持热更新,无需改表结构),`value` 为如下 JSON:

```json
{
  "access_key": "AKLT****your-volc-ak****",
  "secret_key": "****your-volc-sk****",
  "region": "cn-beijing",
  "project_name": "default",
  "group_id": "",
  "group_type": "AIGC"
}
```

其中 `access_key`/`secret_key` 必填,其余可选(`region` 缺省 `cn-beijing`,`group_type` 缺省 `AIGC`)。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (无)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述,没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs,确认不是重复提交。
- [ ] **Bug fix 说明:** 不适用(本 PR 为新功能)。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 仅含素材接口相关改动,不含无关代码。
- [x] **本地验证:** 已在本地 `go build ./...` 通过,并验证路由与接口可用。
- [x] **安全合规:** 代码中无敏感凭据,AK/SK 由部署方在 options 配置,符合项目规范。

## 📸 运行证明 / Proof of Work
(在此粘贴 9 个接口的调用截图 / 关键日志 / 测试报告)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asset management API endpoints for listing, retrieving, creating, updating, and deleting assets.
  * Added asset group management API endpoints for listing, retrieving, creating, and updating asset groups.
  * Added configuration support for asset API credentials and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->