### PR TITLE
feat: default node name to hostname when NODE_NAME unset

### DIFF
--- a/common/init.go
+++ b/common/init.go
@@ -82,7 +82,9 @@ func InitEnv() {
 	DebugEnabled = os.Getenv("DEBUG") == "true"
 	MemoryCacheEnabled = os.Getenv("MEMORY_CACHE_ENABLED") == "true"
 	IsMasterNode = os.Getenv("NODE_TYPE") != "slave"
-	NodeName = os.Getenv("NODE_NAME")
+	// NodeName 优先用 NODE_NAME，未配置时回退主机名（容器下=容器 ID/Pod 名，自动扩容天然唯一）。
+	hostname, _ := os.Hostname()
+	NodeName = GetEnvOrDefaultString("NODE_NAME", hostname)
 	TLSInsecureSkipVerify = GetEnvOrDefaultBool("TLS_INSECURE_SKIP_VERIFY", false)
 	if TLSInsecureSkipVerify {
 		if tr, ok := http.DefaultTransport.(*http.Transport); ok && tr != nil {


### PR DESCRIPTION
## 📝 变更描述 / Description

`NodeName`(写入审计/用量日志,用于标识执行节点)此前仅从 `NODE_NAME` 环境变量读取,未配置时为空字符串。

本 PR 在未配置 `NODE_NAME` 时回退到操作系统主机名:

```go
hostname, _ := os.Hostname()
NodeName = GetEnvOrDefaultString("NODE_NAME", hostname)
```

优先级为 `NODE_NAME` → hostname → 空。显式配置始终优先,只在缺省时兜底,不改变已配置场景的行为。

**为什么这样改能生效:** 在容器 / Kubernetes 部署中,容器主机名默认等于容器 ID 或 Pod 名,在自动扩容场景下每个实例天然唯一,因此日志能自动标识出是哪个实例执行,无需对每个动态实例手动配置 `NODE_NAME`。`os.Hostname()` 出错时返回空串,退回原有行为,不会 panic。

## 📸 运行证明 / Proof of Work

优化前:
<img width="4086" height="1994" alt="image" src="https://github.com/user-attachments/assets/14f1f6c2-d3bf-4dc8-b468-a2755bb76a65" />
优化后:
<img width="4080" height="1964" alt="image" src="https://github.com/user-attachments/assets/cca93159-9af1-4464-8e23-6bfae05d1bad" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced node name initialization with automatic fallback to system hostname when environment configuration is unavailable, improving system resilience in containerized deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->