### PR TITLE
fix(task): attribute async task usage log to the initiating node

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -583,6 +583,7 @@ func RelayTask(c *gin.Context) {
 		task.PrivateData.BillingSource = relayInfo.BillingSource
 		task.PrivateData.SubscriptionId = relayInfo.SubscriptionId
 		task.PrivateData.TokenId = relayInfo.TokenId
+		task.PrivateData.NodeName = common.NodeName
 		task.PrivateData.BillingContext = &model.TaskBillingContext{
 			ModelPrice:      relayInfo.PriceData.ModelPrice,
 			GroupRatio:      relayInfo.PriceData.GroupRatioInfo.GroupRatio,

--- a/model/log.go
+++ b/model/log.go
@@ -390,6 +390,7 @@ type RecordTaskBillingLogParams struct {
 	TokenId   int
 	Group     string
 	Other     map[string]interface{}
+	NodeName  string // 任务发起节点；为空时回退当前节点
 }
 
 func RecordTaskBillingLog(params RecordTaskBillingLogParams) {
@@ -423,6 +424,10 @@ func RecordTaskBillingLog(params RecordTaskBillingLogParams) {
 		common.SysLog("failed to record task billing log: " + err.Error())
 	}
 	if params.LogType == LogTypeConsume && common.DataExportEnabled {
+		nodeName := params.NodeName
+		if nodeName == "" {
+			nodeName = common.NodeName
+		}
 		gopool.Go(func() {
 			LogQuotaData(QuotaDataLogParams{
 				UserID:    params.UserId,
@@ -433,7 +438,7 @@ func RecordTaskBillingLog(params RecordTaskBillingLogParams) {
 				UseGroup:  params.Group,
 				TokenID:   params.TokenId,
 				ChannelID: params.ChannelId,
-				NodeName:  common.NodeName,
+				NodeName:  nodeName,
 			})
 		})
 	}

--- a/model/task.go
+++ b/model/task.go
@@ -104,6 +104,7 @@ type TaskPrivateData struct {
 	BillingSource  string              `json:"billing_source,omitempty"`  // "wallet" 或 "subscription"
 	SubscriptionId int                 `json:"subscription_id,omitempty"` // 订阅 ID，用于订阅退款
 	TokenId        int                 `json:"token_id,omitempty"`        // 令牌 ID，用于令牌额度退款
+	NodeName       string              `json:"node_name,omitempty"`       // 发起任务的节点名，轮询结算阶段据此归属日志而非最后查询节点
 	BillingContext *TaskBillingContext `json:"billing_context,omitempty"` // 计费参数快照（用于轮询阶段重新计算）
 }
 

--- a/service/task_billing.go
+++ b/service/task_billing.go
@@ -241,6 +241,7 @@ func RecalculateTaskQuota(ctx context.Context, task *model.Task, actualQuota int
 		TokenId:   task.PrivateData.TokenId,
 		Group:     task.Group,
 		Other:     other,
+		NodeName:  task.PrivateData.NodeName,
 	})
 }
 


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
修复多实例下分流图节点飘移问题

## 📝 变更描述 / Description
异步任务的用量日志在多实例执行查询任务时, 会记录成查询的实例NodeName,导致整笔额度在结算时全部落到最后一次查询任务的节点上,使分流图上的节点归属发生飘移。

修复方式:在提交任务(`RelayTask`)时把 `common.NodeName` 快照进 `TaskPrivateData.NodeName`;轮询结算写消费日志(`RecalculateTaskQuota` -> `RecordTaskBillingLog`)时改用这个快照值。当快照为空时回退到当前节点,保证存量任务兼容。这样分流图就能正确显示"用户发起任务时的节点"。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

按正确的用户在哪个实例发起任务, 则分流图指向哪个节点
<img width="5060" height="2042" alt="282a8816c1c48a2a46f96c3d1276cce1" src="https://github.com/user-attachments/assets/7b0a5158-a51e-4a47-add9-9800c4229428" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced task tracking by adding node identification to billing and quota records, improving multi-node environment support and billing accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->