### PR TITLE
fix(web): hide wallet entry in profile dropdown when wallet module disabled

### DIFF
--- a/web/default/src/components/profile-dropdown.tsx
+++ b/web/default/src/components/profile-dropdown.tsx
@@ -24,6 +24,7 @@ import { useAuthStore } from '@/stores/auth-store'
 import { getUserAvatarFallback, getUserAvatarStyle } from '@/lib/avatar'
 import { ROLE } from '@/lib/roles'
 import useDialogState from '@/hooks/use-dialog'
+import { useIsSidebarModuleVisible } from '@/hooks/use-sidebar-config'
 import { useUserDisplay } from '@/hooks/use-user-display'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
@@ -45,6 +46,7 @@ export function ProfileDropdown() {
   const user = useAuthStore((state) => state.auth.user)
   const { displayName, roleLabel } = useUserDisplay(user)
   const isSuperAdmin = user?.role === ROLE.SUPER_ADMIN
+  const isWalletVisible = useIsSidebarModuleVisible('/wallet')
   const avatarName = user?.username || displayName
   const avatarFallback = getUserAvatarFallback(avatarName)
   const avatarFallbackStyle = useMemo(
@@ -104,10 +106,12 @@ export function ProfileDropdown() {
             {t('Profile')}
           </DropdownMenuItem>
 
-          <DropdownMenuItem onClick={() => navigate({ to: '/wallet' })}>
-            <Wallet className='size-4' />
-            {t('Wallet')}
-          </DropdownMenuItem>
+          {isWalletVisible && (
+            <DropdownMenuItem onClick={() => navigate({ to: '/wallet' })}>
+              <Wallet className='size-4' />
+              {t('Wallet')}
+            </DropdownMenuItem>
+          )}
 
           {isSuperAdmin && (
             <DropdownMenuItem

--- a/web/default/src/hooks/use-sidebar-config.ts
+++ b/web/default/src/hooks/use-sidebar-config.ts
@@ -308,3 +308,23 @@ export function useSidebarConfig(navGroups: NavGroup[]): NavGroup[] {
 
   return filteredNavGroups
 }
+
+/**
+ * Check whether a single route is visible under the current sidebar_modules
+ * config. Used by entries living outside the sidebar (e.g. the profile
+ * dropdown's wallet link) so they honour the same "wallet display" toggle.
+ */
+export function useIsSidebarModuleVisible(url: string): boolean {
+  const { status } = useStatus()
+  const { auth } = useAuthStore()
+
+  const adminConfig = parseSidebarConfig(
+    status?.SidebarModulesAdmin as string | null | undefined
+  )
+  const userConfig =
+    auth?.user?.permissions?.sidebar_settings === false
+      ? null
+      : parseUserSidebarConfig(auth?.user?.sidebar_modules)
+
+  return isModuleEnabled(url, adminConfig, userConfig)
+}


### PR DESCRIPTION
## 📝 变更描述 / Description
右上角用户下拉菜单里的「钱包」入口是无条件渲染的，没有读取侧边栏模块配置。所以当管理员在系统设置里关闭 `personal/topup`(钱包)模块后,侧边栏的钱包入口已隐藏,下拉菜单里却仍然显示。

本 PR 让下拉菜单复用侧边栏已有的模块可见性判定:新增 `useIsSidebarModuleVisible(url)`(复用现有的 `parseSidebarConfig` / `parseUserSidebarConfig` / `isModuleEnabled`),钱包菜单项仅在 `/wallet` 模块可见时才渲染。这样下拉菜单与侧边栏走完全相同的 admin × user 两层规则,关闭钱包显示后两处一致隐藏。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- Closes #5696

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs,确认不是重复提交。
- [x] **Bug fix 说明:** 已关联对应 Issue #5696。
- [x] **变更理解:** 已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 仅包含此项修复,无无关改动。
- [x] **本地验证:** 已本地复现该 bug,并验证修复后下拉菜单随模块开关一致隐藏;`tsc --noEmit` 通过。
- [x] **安全合规:** 无敏感凭据,符合项目代码规范。

## 📸 运行证明 / Proof of Work
关闭「钱包」模块前:下拉菜单显示 个人资料 / 钱包 / 系统设置 / 登出。
关闭后:下拉菜单显示 个人资料 / 系统设置 / 登出,与侧边栏一致(钱包入口隐藏)。
修复前:
<img width="576" height="504" alt="image" src="https://github.com/user-attachments/assets/4435d885-08d1-47a1-b669-52833ada3215" />
修复后:
<img width="518" height="406" alt="image" src="https://github.com/user-attachments/assets/f299e3b4-bb3b-4ef6-880c-055d38cab458" />

