### PR TITLE
fix(web): render custom OAuth provider icons

### DIFF
--- a/web/default/src/features/auth/components/oauth-providers.tsx
+++ b/web/default/src/features/auth/components/oauth-providers.tsx
@@ -18,14 +18,16 @@ For commercial licensing, please contact support@quantumnous.com
 */
 import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
+
 import {
   IconDiscord,
   IconGithub,
   IconLinuxDo,
   IconWeChat,
 } from '@/assets/brand-icons'
-import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
 import { useOAuthLogin } from '../hooks/use-oauth-login'
 import type { SystemStatus } from '../types'
 
@@ -43,6 +45,23 @@ type ProviderButton = {
   onClick: () => void
   icon?: ReactNode
   disabled?: boolean
+}
+
+function CustomProviderIcon(props: { icon?: string; name: string }) {
+  if (!props.icon) return null
+
+  return (
+    <img
+      src={props.icon}
+      alt={props.name}
+      className='h-4 w-4 rounded-sm object-contain'
+      loading='lazy'
+      referrerPolicy='no-referrer'
+      onError={(event) => {
+        event.currentTarget.style.display = 'none'
+      }}
+    />
+  )
 }
 
 export function OAuthProviders({
@@ -129,6 +148,7 @@ export function OAuthProviders({
         key: `custom-${provider.slug}`,
         label: t('Continue with {{name}}', { name: provider.name }),
         onClick: () => handleCustomOAuthLogin(provider),
+        icon: <CustomProviderIcon icon={provider.icon} name={provider.name} />,
       })
     }
   }


### PR DESCRIPTION
## Summary
Render configured custom OAuth provider icons in the new auth UI.

## Motivation
Custom OAuth provider metadata already includes an `icon` field, but the new UI did not pass it into the provider button, so custom providers were rendered without their configured icons.

Refs #5639

## Changes
- Add a small `CustomProviderIcon` component for custom OAuth provider buttons.
- Render `provider.icon` as a safe `<img>` React node when present.
- Preserve the existing no-icon fallback behavior.
- Avoid raw HTML injection; broken images hide themselves via `onError`.

## Testing
- `corepack pnpm --dir web/default exec tsc --noEmit --project tsconfig.app.json --pretty false`
- `corepack pnpm --dir web/default exec oxlint -c .oxlintrc.json src/features/auth/components/oauth-providers.tsx`
- `corepack pnpm --dir web/default exec oxfmt --check src/features/auth/components/oauth-providers.tsx`
- `corepack pnpm --dir web/default run typecheck`
- `corepack pnpm --dir web/default run build`
- `git diff --check`
- Secret scan on diff: clean

Note: the full project lint has pre-existing unrelated warnings/errors; the modified file passes targeted lint cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom OAuth providers can now display their own icons in the sign-in flow.
  * Added a fallback so provider icons are hidden if they fail to load, helping keep the login screen clean and polished.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->