### PR TITLE
fix(i18n): honor Accept-Language q values

### DIFF
--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -2,6 +2,7 @@ package i18n
 
 import (
 	"embed"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -182,19 +183,72 @@ func ParseAcceptLanguage(header string) string {
 		return DefaultLang
 	}
 
-	// Simple parsing: take the first language tag
-	parts := strings.Split(header, ",")
-	if len(parts) == 0 {
-		return DefaultLang
+	bestLang := DefaultLang
+	bestQ := -1.0
+
+	for _, part := range strings.Split(header, ",") {
+		lang, q := parseLanguageRange(part)
+		if lang == "" || q <= 0 {
+			continue
+		}
+		normalized, ok := matchSupportedLang(lang)
+		if !ok {
+			continue
+		}
+		if q > bestQ {
+			bestLang = normalized
+			bestQ = q
+		}
 	}
 
-	// Get the first language and remove quality value
-	firstLang := strings.TrimSpace(parts[0])
-	if idx := strings.Index(firstLang, ";"); idx > 0 {
-		firstLang = firstLang[:idx]
+	return bestLang
+}
+
+func parseLanguageRange(part string) (string, float64) {
+	part = strings.TrimSpace(part)
+	if part == "" {
+		return "", 0
 	}
 
-	return normalizeLang(firstLang)
+	segments := strings.Split(part, ";")
+	lang := strings.TrimSpace(segments[0])
+	q := 1.0
+
+	for _, segment := range segments[1:] {
+		param := strings.TrimSpace(segment)
+		if len(param) < 2 || !strings.EqualFold(param[:2], "q=") {
+			continue
+		}
+		parsedQ, err := strconv.ParseFloat(strings.TrimSpace(param[2:]), 64)
+		if err != nil {
+			continue
+		}
+		switch {
+		case parsedQ < 0:
+			q = 0
+		case parsedQ > 1:
+			q = 1
+		default:
+			q = parsedQ
+		}
+	}
+
+	return lang, q
+}
+
+func matchSupportedLang(lang string) (string, bool) {
+	lang = strings.ToLower(strings.TrimSpace(lang))
+
+	switch {
+	case strings.HasPrefix(lang, "zh-tw"):
+		return LangZhTW, true
+	case strings.HasPrefix(lang, "zh"):
+		return LangZhCN, true
+	case strings.HasPrefix(lang, "en"):
+		return LangEn, true
+	default:
+		return "", false
+	}
 }
 
 // normalizeLang normalizes language code to supported format

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -1,0 +1,45 @@
+package i18n
+
+import "testing"
+
+func TestParseAcceptLanguageHonorsQualityValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{
+			name:   "higher q wins over first language",
+			header: "zh-CN;q=0.4,en;q=0.9",
+			want:   LangEn,
+		},
+		{
+			name:   "traditional chinese can win by q",
+			header: "en;q=0.1, zh-TW;q=0.9",
+			want:   LangZhTW,
+		},
+		{
+			name:   "unsupported language does not mask lower q supported language",
+			header: "fr;q=1.0, zh-CN;q=0.5",
+			want:   LangZhCN,
+		},
+		{
+			name:   "zero q is not accepted",
+			header: "en;q=0, zh-CN;q=0.8",
+			want:   LangZhCN,
+		},
+		{
+			name:   "unsupported languages fall back to default",
+			header: "fr;q=1.0, de;q=0.8",
+			want:   DefaultLang,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseAcceptLanguage(tt.header); got != tt.want {
+				t.Fatalf("ParseAcceptLanguage(%q) = %q, want %q", tt.header, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Parse `Accept-Language` quality values instead of always taking the first tag.
- Ignore unsupported higher-priority languages when a lower-priority supported language is present.

## Why
Browsers commonly send weighted language lists such as `zh-CN;q=0.4,en;q=0.9`. The previous parser selected the first tag and could return a lower-priority language.

## Testing
- `go test ./i18n`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved language detection from browser preferences by honoring `Accept-Language` quality values.
  * Better selection between supported languages, including simplified and traditional Chinese and English.

* **Bug Fixes**
  * Fixed cases where the first listed language could be chosen even when a lower-priority supported language was a better match.
  * Ignored invalid or zero-priority language entries more reliably, falling back to the default language when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->