### PR TITLE
fix(common): trim numeric env values before parsing

### DIFF
--- a/common/env.go
+++ b/common/env.go
@@ -4,13 +4,15 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 )
 
 func GetEnvOrDefault(env string, defaultValue int) int {
-	if env == "" || os.Getenv(env) == "" {
+	value := strings.TrimSpace(os.Getenv(env))
+	if env == "" || value == "" {
 		return defaultValue
 	}
-	num, err := strconv.Atoi(os.Getenv(env))
+	num, err := strconv.Atoi(value)
 	if err != nil {
 		SysError(fmt.Sprintf("failed to parse %s: %s, using default value: %d", env, err.Error(), defaultValue))
 		return defaultValue
@@ -26,10 +28,11 @@ func GetEnvOrDefaultString(env string, defaultValue string) string {
 }
 
 func GetEnvOrDefaultBool(env string, defaultValue bool) bool {
-	if env == "" || os.Getenv(env) == "" {
+	value := strings.TrimSpace(os.Getenv(env))
+	if env == "" || value == "" {
 		return defaultValue
 	}
-	b, err := strconv.ParseBool(os.Getenv(env))
+	b, err := strconv.ParseBool(value)
 	if err != nil {
 		SysError(fmt.Sprintf("failed to parse %s: %s, using default value: %t", env, err.Error(), defaultValue))
 		return defaultValue

--- a/common/env_test.go
+++ b/common/env_test.go
@@ -1,0 +1,27 @@
+package common
+
+import "testing"
+
+func TestGetEnvOrDefaultTrimsWhitespace(t *testing.T) {
+	t.Setenv("NEW_API_TEST_INT", " 42 \n")
+
+	if got := GetEnvOrDefault("NEW_API_TEST_INT", 7); got != 42 {
+		t.Fatalf("GetEnvOrDefault() = %d, want 42", got)
+	}
+}
+
+func TestGetEnvOrDefaultWhitespaceUsesDefault(t *testing.T) {
+	t.Setenv("NEW_API_TEST_INT_EMPTY", " \t\n")
+
+	if got := GetEnvOrDefault("NEW_API_TEST_INT_EMPTY", 7); got != 7 {
+		t.Fatalf("GetEnvOrDefault() = %d, want default 7", got)
+	}
+}
+
+func TestGetEnvOrDefaultBoolTrimsWhitespace(t *testing.T) {
+	t.Setenv("NEW_API_TEST_BOOL", " true \n")
+
+	if got := GetEnvOrDefaultBool("NEW_API_TEST_BOOL", false); !got {
+		t.Fatalf("GetEnvOrDefaultBool() = false, want true")
+	}
+}


### PR DESCRIPTION
## Summary
- Trim whitespace before parsing integer and boolean environment variables.
- Treat whitespace-only numeric/bool env values as unset and use the default.
- Leave string env behavior unchanged.

## Why
Deployment platforms and copied `.env` values can include trailing whitespace/newlines. `strconv.Atoi` and `strconv.ParseBool` reject those values even when the intended value is valid.

## Testing
- `go test ./common`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment variable values now ignore leading and trailing whitespace before being checked or parsed.
  * Integer and boolean settings are more reliable when values include extra spaces or line breaks.
  * Whitespace-only values now fall back to the expected default for numeric settings.

* **Tests**
  * Added coverage for trimmed environment values and default handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->