### PR TITLE
fix(service): only strip base64 data URL prefixes

### DIFF
--- a/service/audio.go
+++ b/service/audio.go
@@ -35,7 +35,10 @@ func DecodeBase64AudioData(audioBase64 string) (string, error) {
 	// 检查并移除 data:audio/xxx;base64, 前缀
 	idx := strings.Index(audioBase64, ",")
 	if idx != -1 {
-		audioBase64 = audioBase64[idx+1:]
+		prefix := strings.ToLower(strings.TrimSpace(audioBase64[:idx]))
+		if strings.HasPrefix(prefix, "data:") && strings.Contains(prefix, ";base64") {
+			audioBase64 = audioBase64[idx+1:]
+		}
 	}
 
 	// 解码 Base64 数据

--- a/service/audio_test.go
+++ b/service/audio_test.go
@@ -1,0 +1,21 @@
+package service
+
+import "testing"
+
+func TestDecodeBase64AudioDataStripsDataURLPrefix(t *testing.T) {
+	const encoded = "AQIDBA=="
+
+	got, err := DecodeBase64AudioData("data:audio/wav;base64," + encoded)
+	if err != nil {
+		t.Fatalf("DecodeBase64AudioData() unexpected error: %v", err)
+	}
+	if got != encoded {
+		t.Fatalf("DecodeBase64AudioData() = %q, want %q", got, encoded)
+	}
+}
+
+func TestDecodeBase64AudioDataRejectsArbitraryCommaPrefix(t *testing.T) {
+	if _, err := DecodeBase64AudioData("filename.wav,AQIDBA=="); err == nil {
+		t.Fatalf("DecodeBase64AudioData() expected error for non-data URL comma prefix")
+	}
+}


### PR DESCRIPTION
## Summary
- Strip the prefix only for real `data:*;base64,` inputs.
- Reject arbitrary comma-prefixed strings instead of silently accepting the part after the comma.

## Why
`DecodeBase64AudioData` previously removed everything before any comma. Malformed values like `filename.wav,<base64>` could be accepted as valid audio payloads.

## Testing
- `go test ./service -run TestDecodeBase64AudioData`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio data decoding so only valid `data:*;base64,` prefixes are removed.
  * Inputs with unrelated comma-delimited text are now rejected instead of being parsed incorrectly.

* **Tests**
  * Added coverage for valid Data URL audio input.
  * Added coverage for invalid comma-prefixed input to ensure it returns an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->