### PR TITLE
fix(common): normalize redirect URL root dots

### DIFF
--- a/common/url_validator.go
+++ b/common/url_validator.go
@@ -27,13 +27,18 @@ func ValidateRedirectURL(rawURL string) error {
 		return fmt.Errorf("invalid URL scheme: only http and https are allowed")
 	}
 
-	domain := strings.ToLower(parsedURL.Hostname())
+	domain := normalizeRedirectDomain(parsedURL.Hostname())
 
 	for _, trustedDomain := range constant.TrustedRedirectDomains {
+		trustedDomain = normalizeRedirectDomain(trustedDomain)
 		if domain == trustedDomain || strings.HasSuffix(domain, "."+trustedDomain) {
 			return nil
 		}
 	}
 
 	return fmt.Errorf("domain %s is not in the trusted domains list", domain)
+}
+
+func normalizeRedirectDomain(domain string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(domain)), ".")
 }

--- a/common/url_validator_test.go
+++ b/common/url_validator_test.go
@@ -46,6 +46,18 @@ func TestValidateRedirectURL(t *testing.T) {
 			trustedDomains: []string{"example.com"},
 			wantErr:        false,
 		},
+		{
+			name:           "root dot URL domain",
+			url:            "https://example.com./success",
+			trustedDomains: []string{"example.com"},
+			wantErr:        false,
+		},
+		{
+			name:           "root dot trusted domain",
+			url:            "https://sub.example.com/success",
+			trustedDomains: []string{"example.com."},
+			wantErr:        false,
+		},
 
 		// Invalid cases - untrusted domain
 		{


### PR DESCRIPTION
## Summary
- Normalize a trailing DNS root dot when checking redirect URL hostnames.
- Apply the same normalization to configured trusted redirect domains.

## Why
`example.com.` and `example.com` refer to the same DNS host. The previous strict string comparison rejected otherwise trusted redirect URLs or trusted-domain settings with a root dot.

## Testing
- `go test ./common -run TestValidateRedirectURL`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect URL validation to handle hostnames with extra whitespace, mixed casing, or a trailing dot.
  * Redirects now match trusted domains more consistently, including valid subdomain checks.
  * Added coverage for URLs and trusted-domain entries that include a trailing dot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->