### PR TITLE
feat: add ETOS LLM Studio quick import support

### DIFF
--- a/setting/chat.go
+++ b/setting/chat.go
@@ -1,10 +1,6 @@
 package setting
 
-import (
-	"encoding/json"
-
-	"github.com/QuantumNous/new-api/common"
-)
+import "github.com/QuantumNous/new-api/common"
 
 var Chats = []map[string]string{
 	//{
@@ -26,6 +22,9 @@ var Chats = []map[string]string{
 		"DeepChat": "deepchat://provider/install?v=1&data={deepchatConfig}",
 	},
 	{
+		"ETOS LLM Studio": "etosllmstudio://provider/install?v=1&data={etosConfig}",
+	},
+	{
 		"Lobe Chat 官方示例": "https://chat-preview.lobehub.com/?settings={\"keyVaults\":{\"openai\":{\"apiKey\":\"{key}\",\"baseURL\":\"{address}/v1\"}}}",
 	},
 	{
@@ -41,11 +40,11 @@ var Chats = []map[string]string{
 
 func UpdateChatsByJsonString(jsonString string) error {
 	Chats = make([]map[string]string, 0)
-	return json.Unmarshal([]byte(jsonString), &Chats)
+	return common.Unmarshal([]byte(jsonString), &Chats)
 }
 
 func Chats2JsonString() string {
-	jsonBytes, err := json.Marshal(Chats)
+	jsonBytes, err := common.Marshal(Chats)
 	if err != nil {
 		common.SysLog("error marshalling chats: " + err.Error())
 		return "[]"

--- a/web/classic/src/components/layout/SiderBar.jsx
+++ b/web/classic/src/components/layout/SiderBar.jsx
@@ -254,7 +254,8 @@ const SiderBar = ({ onNavigate = () => {} }) => {
               if (
                 link.startsWith('fluent') ||
                 link.startsWith('ccswitch') ||
-                link.startsWith('deepchat')
+                link.startsWith('deepchat') ||
+                link.startsWith('etosllmstudio')
               ) {
                 shouldSkip = true;
                 break;

--- a/web/classic/src/hooks/tokens/useTokensData.jsx
+++ b/web/classic/src/hooks/tokens/useTokensData.jsx
@@ -261,6 +261,16 @@ export const useTokensData = (openFluentNotification, openCCSwitchModal) => {
         encodeToBase64(JSON.stringify(deepchatConfig)),
       );
       url = url.replaceAll('{deepchatConfig}', encodedConfig);
+    } else if (url.includes('{etosConfig}') === true) {
+      let etosConfig = {
+        id: 'new-api',
+        baseUrl: serverAddress,
+        apiKey: `sk-${fullKey}`,
+      };
+      let encodedConfig = encodeURIComponent(
+        encodeToBase64(JSON.stringify(etosConfig)),
+      );
+      url = url.replaceAll('{etosConfig}', encodedConfig);
     } else {
       let encodedServerAddress = encodeURIComponent(serverAddress);
       url = url.replaceAll('{address}', encodedServerAddress);

--- a/web/classic/src/pages/Setting/Chat/SettingsChats.jsx
+++ b/web/classic/src/pages/Setting/Chat/SettingsChats.jsx
@@ -72,6 +72,7 @@ export default function SettingsChats(props) {
     { name: '流畅阅读', url: 'fluentread' },
     { name: 'CC Switch', url: 'ccswitch' },
     { name: 'DeepChat', url: 'deepchat://provider/install?v=1&data={deepchatConfig}' },
+    { name: 'ETOS LLM Studio', url: 'etosllmstudio://provider/install?v=1&data={etosConfig}' },
     { name: 'Lobe Chat', url: 'https://chat-preview.lobehub.com/?settings={"keyVaults":{"openai":{"apiKey":"{key}","baseURL":"{address}/v1"}}}' },
     { name: 'AI as Workspace', url: 'https://aiaw.app/set-provider?provider={"type":"openai","settings":{"apiKey":"{key}","baseURL":"{address}/v1","compatibility":"strict"}}' },
     { name: 'AMA 问天', url: 'ama://set-api-key?server={address}&key={key}' },

--- a/web/default/src/features/chat/lib/chat-links.ts
+++ b/web/default/src/features/chat/lib/chat-links.ts
@@ -89,7 +89,8 @@ export function chatLinkRequiresApiKey(url: string): boolean {
     url.includes('{key}') ||
     url.includes('{cherryConfig}') ||
     url.includes('{aionuiConfig}') ||
-    url.includes('{deepchatConfig}')
+    url.includes('{deepchatConfig}') ||
+    url.includes('{etosConfig}')
   )
 }
 
@@ -187,6 +188,16 @@ export function resolveChatUrl({
     }
     const encoded = encodeURIComponent(toBase64(JSON.stringify(payload)))
     return replaceToken(url, '{deepchatConfig}', encoded)
+  }
+
+  if (url.includes('{etosConfig}')) {
+    const payload = {
+      id: 'new-api',
+      baseUrl: safeServerAddress,
+      apiKey: safeApiKey,
+    }
+    const encoded = encodeURIComponent(toBase64(JSON.stringify(payload)))
+    return replaceToken(url, '{etosConfig}', encoded)
   }
 
   if (safeServerAddress) {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本 PR 描述已整理为简洁摘要，没有直接粘贴未经整理的 AI 输出。
> - AI-assisted: this change was prepared with AI assistance under the Eric-Terminal account.

## 📝 变更描述 / Description
新增 ETOS LLM Studio 的聊天快捷导入入口，让管理员在 `/console/setting?tab=chats` 可以使用内置模板添加：

`etosllmstudio://provider/install?v=1&data={etosConfig}`

前端打开该模板时会把 `{etosConfig}` 替换为 Base64 JSON，内容与 Cherry Studio / DeepChat 的导入格式保持一致，包含 `id: new-api`、`baseUrl` 和 `apiKey`。classic 前端同步加入模板，并在侧边栏过滤 `etosllmstudio` 外部 scheme，避免它被当成内嵌聊天页面展示。

同时将 `setting/chat.go` 中的 JSON 编解码切换到项目统一的 `common.Marshal` / `common.Unmarshal` 包装函数。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
重复提交搜索：

```text
gh pr list --repo QuantumNous/new-api --search "ETOS OR etosllmstudio" --state all --limit 20
gh issue list --repo QuantumNous/new-api --search "ETOS OR etosllmstudio" --state all --limit 20
# 均无结果
```

本地检查：

```text
git diff --check origin/main..HEAD
# passed
```

```text
go test ./common ./controller ./middleware ./model ./relay/channel ./relay/channel/advancedcustom ./relay/channel/aws ./relay/channel/claude ./relay/channel/gemini ./relay/channel/minimax ./relay/channel/moonshot ./relay/channel/openai ./relay/common ./relay/helper ./service ./setting/config ./setting/model_setting ./setting/operation_setting
# passed
```

说明：当前本地环境没有 `bun`，且前端依赖未安装，因此未运行 frontend build。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the new **ETOS LLM Studio** chat provider/template.
  * Chat links can now generate the required configuration automatically for this provider.

* **Bug Fixes**
  * The sidebar now correctly hides ETOS LLM Studio links from the chat list where applicable.
  * Improved handling of chat link setup so ETOS LLM Studio connections work consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->