### PR TITLE
fix(web): render custom homepage HTML safely

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -90,7 +90,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^4.3.0",
         "dayjs": "catalog:",
-        "dompurify": "3.4.5",
+        "dompurify": "3.4.11",
         "i18next": "^26.2.0",
         "i18next-browser-languagedetector": "^8.2.1",
         "input-otp": "^1.4.2",
@@ -1643,7 +1643,7 @@
 
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
-    "dompurify": ["dompurify@3.4.5", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA=="],
+    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
 
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 

--- a/web/default/src/components/ui/markdown.tsx
+++ b/web/default/src/components/ui/markdown.tsx
@@ -123,7 +123,7 @@ const allowedTags = [
   'tspan',
 ]
 
-const sanitizeOptions = {
+export const markdownSanitizeOptions = {
   ADD_ATTR: allowedAttributes,
   ADD_TAGS: allowedTags,
 } as const
@@ -696,9 +696,23 @@ function addExternalLinkAttributes(html: string): string {
 
 function renderMarkdown(markdown: string): string {
   const parsedHtml = markdownParser.parse(markdown, markdownOptions)
-  const html = DOMPurify.sanitize(parsedHtml, sanitizeOptions)
+  const html = DOMPurify.sanitize(parsedHtml, markdownSanitizeOptions)
 
   return addExternalLinkAttributes(html)
+}
+
+export function HtmlContent(props: MarkdownProps) {
+  const html = useMemo(
+    () => DOMPurify.sanitize(props.children, markdownSanitizeOptions),
+    [props.children]
+  )
+
+  return (
+    <div
+      className={props.className}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
 }
 
 export function Markdown(props: MarkdownProps) {

--- a/web/default/src/features/home/index.tsx
+++ b/web/default/src/features/home/index.tsx
@@ -18,7 +18,7 @@ For commercial licensing, please contact support@quantumnous.com
 */
 import { useTranslation } from 'react-i18next'
 import { useAuthStore } from '@/stores/auth-store'
-import { Markdown } from '@/components/ui/markdown'
+import { HtmlContent } from '@/components/ui/markdown'
 import { PublicLayout } from '@/components/layout'
 import { Footer } from '@/components/layout/components/footer'
 import { CTA, Features, Hero, HowItWorks, Stats } from './components'
@@ -52,7 +52,7 @@ export function Home() {
             />
           ) : (
             <div className='container mx-auto py-8'>
-              <Markdown className='custom-home-content'>{content}</Markdown>
+              <HtmlContent className='custom-home-content'>{content}</HtmlContent>
             </div>
           )}
         </main>


### PR DESCRIPTION
## Summary

- preserve the new Markdown renderer for normal Markdown content
- add a sanitized HTML rendering path for custom homepage content only
- reuse the existing DOMPurify allowlist by exporting `markdownSanitizeOptions`
- sync `web/bun.lock` for the current `dompurify@3.4.11` dependency so `bun install --frozen-lockfile` can build cleanly

Fixes #5732.

## Why

After #5689, `HomePageContent` is rendered through the new Markdown renderer. Deployments that use raw HTML for their custom homepage now see the HTML/code escaped as plain text instead of rendered as homepage content.

`HomePageContent` historically works as custom HTML, so this PR keeps normal Markdown behavior unchanged and only switches the homepage custom content path to sanitized HTML.

## Verification

Verified on a production build from `b191f473`:

```text
docker build -t local/new-api:b191f473-homehtmlfix .
new-api healthy
/api/status -> success true
```

Also verified that the homepage serves the SPA shell and no longer includes the reported raw code snippet in server-returned HTML.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The home page now supports displaying custom HTML content directly.
  * Content rendering is now sanitized consistently before being shown to users, helping keep embedded content safer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->