### PR TITLE
fix(web): add New chat button to default theme playground

### DIFF
--- a/web/default/src/features/playground/components/playground-input.tsx
+++ b/web/default/src/features/playground/components/playground-input.tsx
@@ -31,6 +31,7 @@ import {
   NotepadTextIcon,
   CodeSquareIcon,
   GraduationCapIcon,
+  SquarePenIcon,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -64,6 +65,8 @@ interface PlaygroundInputProps {
   groups: GroupOption[]
   groupValue: string
   onGroupChange: (value: string) => void
+  onNewChat?: () => void
+  hasMessages?: boolean
 }
 
 const suggestions = [
@@ -87,6 +90,8 @@ export function PlaygroundInput({
   groups,
   groupValue,
   onGroupChange,
+  onNewChat,
+  hasMessages = false,
 }: PlaygroundInputProps) {
   const { t } = useTranslation()
   const [text, setText] = useState('')
@@ -128,6 +133,19 @@ export function PlaygroundInput({
 
         <PromptInputFooter className='p-2.5'>
           <PromptInputTools>
+            {onNewChat && (
+              <PromptInputButton
+                className='border font-medium'
+                disabled={!hasMessages}
+                onClick={onNewChat}
+                variant='outline'
+              >
+                <SquarePenIcon size={16} />
+                <span className='hidden sm:inline'>{t('New chat')}</span>
+                <span className='sr-only sm:hidden'>{t('New chat')}</span>
+              </PromptInputButton>
+            )}
+
             <DropdownMenu>
               <DropdownMenuTrigger
                 render={

--- a/web/default/src/features/playground/index.tsx
+++ b/web/default/src/features/playground/index.tsx
@@ -36,6 +36,7 @@ export function Playground() {
     models,
     groups,
     updateMessages,
+    clearMessages,
     setModels,
     setGroups,
     updateConfig,
@@ -46,6 +47,11 @@ export function Playground() {
     parameterEnabled,
     onMessageUpdate: updateMessages,
   })
+
+  const handleNewChat = useCallback(() => {
+    stopGeneration()
+    clearMessages()
+  }, [stopGeneration, clearMessages])
 
   // Edit dialog state
   const [editingMessageKey, setEditingMessageKey] = useState<string | null>(
@@ -216,8 +222,10 @@ export function Playground() {
           isModelLoading={isLoadingModels}
           modelValue={config.model}
           models={models}
+          hasMessages={messages.length > 0}
           onGroupChange={(value) => updateConfig('group', value)}
           onModelChange={(value) => updateConfig('model', value)}
+          onNewChat={handleNewChat}
           onStop={stopGeneration}
           onSubmit={handleSendMessage}
         />

--- a/web/default/src/i18n/locales/en.json
+++ b/web/default/src/i18n/locales/en.json
@@ -3873,6 +3873,7 @@
     "Selected nodes": "Selected nodes",
     "Selected when creating a token and used as the default billing group for API calls.": "Selected when creating a token and used as the default billing group for API calls.",
     "Self-Use Mode": "Self-Use Mode",
+    "New chat": "New chat",
     "Send": "Send",
     "Send a request": "Send a request",
     "Send code": "Send code",

--- a/web/default/src/i18n/locales/fr.json
+++ b/web/default/src/i18n/locales/fr.json
@@ -3873,6 +3873,7 @@
     "Selected nodes": "Nœuds sélectionnés",
     "Selected when creating a token and used as the default billing group for API calls.": "Sélectionné lors de la création d’un jeton et utilisé comme groupe de facturation par défaut pour les appels API.",
     "Self-Use Mode": "Mode d'utilisation personnelle",
+    "New chat": "Nouvelle conversation",
     "Send": "Envoyer",
     "Send a request": "Envoyer une requête",
     "Send code": "Envoyer le code",

--- a/web/default/src/i18n/locales/ja.json
+++ b/web/default/src/i18n/locales/ja.json
@@ -3873,6 +3873,7 @@
     "Selected nodes": "選択したノード",
     "Selected when creating a token and used as the default billing group for API calls.": "トークン作成時に選択され、API 呼び出しのデフォルト課金グループとして使われます。",
     "Self-Use Mode": "セルフユースモード",
+    "New chat": "新しいチャット",
     "Send": "送信",
     "Send a request": "リクエストを送信",
     "Send code": "コードを送信",

--- a/web/default/src/i18n/locales/ru.json
+++ b/web/default/src/i18n/locales/ru.json
@@ -3873,6 +3873,7 @@
     "Selected nodes": "Выбранные узлы",
     "Selected when creating a token and used as the default billing group for API calls.": "Выбирается при создании токена и используется как группа тарификации по умолчанию для вызовов API.",
     "Self-Use Mode": "Режим самоиспользования",
+    "New chat": "Новый чат",
     "Send": "Отправить",
     "Send a request": "Отправить запрос",
     "Send code": "Отправить код",

--- a/web/default/src/i18n/locales/vi.json
+++ b/web/default/src/i18n/locales/vi.json
@@ -3873,6 +3873,7 @@
     "Selected nodes": "Nút đã chọn",
     "Selected when creating a token and used as the default billing group for API calls.": "Được chọn khi tạo token và dùng làm nhóm tính phí mặc định cho các lệnh gọi API.",
     "Self-Use Mode": "Chế độ tự sử dụng",
+    "New chat": "Trò chuyện mới",
     "Send": "Gửi",
     "Send a request": "Gửi yêu cầu",
     "Send code": "Gửi mã",

--- a/web/default/src/i18n/locales/zh.json
+++ b/web/default/src/i18n/locales/zh.json
@@ -3873,6 +3873,7 @@
     "Selected nodes": "已选节点",
     "Selected when creating a token and used as the default billing group for API calls.": "创建令牌时选择，用作 API 调用的默认计费分组。",
     "Self-Use Mode": "自用模式",
+    "New chat": "新会话",
     "Send": "发送",
     "Send a request": "发送请求",
     "Send code": "发送验证码",


### PR DESCRIPTION
## 📝 变更描述 / Description

默认主题(`web/default`)的游乐场没有「新建会话」入口:一旦开始对话,就只能在同一段上下文里继续,无法清空重开。经典主题(`web/classic`)是靠 Semi 的 `<Chat showClearContext />` 自带了这个能力,默认主题这边一直漏了。

状态层里其实早就有 `clearMessages`,只是没接到任何 UI 上。这次把它接到输入框工具栏新增的「新建会话」按钮:点击会先停掉正在进行的生成,再清空消息开启新会话;没有消息时按钮置灰。顺带补上 `New chat` 的多语言文案(en/zh/fr/ja/ru/vi)。

改动只落在默认主题的游乐场,范围很小。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5728

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述为人工整理撰写。
- [x] **非重复提交:** 已搜索现有 Issue / PR,确认不重复。
- [x] **Bug fix 说明:** 已关联 #5728。
- [x] **变更理解:** 清楚改动原理与影响范围(仅默认主题游乐场 + 多语言新增一个 key)。
- [x] **范围聚焦:** 仅新增按钮与对应文案,无其它无关改动。
- [x] **本地验证:** `tsc --noEmit` 通过;6 个 locale 文件 `JSON.parse` 校验通过。逻辑按代码走查确认,未附 UI 截图。
- [x] **安全合规:** 无敏感凭据。

## 📸 运行证明 / Proof of Work

- `npx tsc --noEmit` 通过,无新增类型错误。
- en/zh/fr/ja/ru/vi 六个 locale 文件均通过 `JSON.parse` 校验,各新增一行 `New chat` key。
- 预期行为:有消息时「新建会话」按钮可点 → 停止生成并清空对话开启新会话;无消息时按钮置灰。

<img width="919" height="152" alt="image" src="https://github.com/user-attachments/assets/e816eb10-a1cd-4ba4-aa14-5a5e8da7290a" />
