### PR TITLE
fix: sync bun.lock with dompurify 3.4.11 to restore frozen-lockfile build

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -90,7 +90,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^4.3.0",
         "dayjs": "catalog:",
-        "dompurify": "3.4.5",
+        "dompurify": "3.4.11",
         "i18next": "^26.2.0",
         "i18next-browser-languagedetector": "^8.2.1",
         "input-otp": "^1.4.2",
@@ -1643,7 +1643,7 @@
 
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
-    "dompurify": ["dompurify@3.4.5", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA=="],
+    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
 
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 


### PR DESCRIPTION
## 📝 变更描述 / Description

PR #5718 将 `web/default` 的 `dompurify` 从 `3.4.5` 升级到 `3.4.11`，但只修改了 `web/default/package.json`，漏掉了 workspace 共享的 `web/bun.lock`（其中 `dompurify` 仍锁定在 `3.4.5`）。

由于 `package.json` 与 lockfile 不一致，`bun install --frozen-lockfile`（CI 发布构建及 `make build-frontend` 使用）会直接报错退出：

```
Building default frontend...
bun install v1.3.14 (0d9b296a)
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
make: *** [makefile:19：build-frontend] 错误
```

本 PR 仅把 `web/bun.lock` 中的 `dompurify` 同步到 `3.4.11`（依赖声明与解析条目两处），使锁文件与 `package.json` 一致，恢复 frozen-lockfile 构建。除此之外没有任何依赖变动。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5741
- Follow-up to #5718（该 dependabot 升级遗漏了 lockfile 同步）

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 这是 #5718 遗漏 lockfile 同步导致的 frozen-lockfile 构建中断，非设计取舍或理解偏差。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 仅改动 `web/bun.lock` 一个文件，无任何无关改动。
- [x] **本地验证:** `cd web && bun install --frozen-lockfile` 已通过。
- [x] **安全合规:** 代码中无敏感凭据，符合项目代码规范。

## 📸 运行证明 / Proof of Work

修复后：
```
make build-all-frontends 
Building default frontend...
bun install v1.3.14 (0d9b296a)

Checked 1526 installs across 1580 packages (no changes) [25.00ms]
$ rsbuild build
Rsbuild v2.0.9

info    build started...
ready   built in 2.73 s

File (web)                                                             Size         Gzip   
dist/static/js/async/8018.634f81a845.js                                0.15 kB      0.14 kB
...
dist/static/js/async/9777.eebb153087.js                                6827.3 kB    2750.5 kB

                                                              Total:   60305.2 kB   16796.1 kB

Building classic frontend...
bun install v1.3.14 (0d9b296a)

Checked 1526 installs across 1580 packages (no changes) [22.00ms]
$ rsbuild build
Rsbuild v2.0.9

info    build started...
ready   built in 1.81 s

File (web)                                                    Size         Gzip   
dist/static/js/async/6681.74c9aa1623.js                       0.17 kB      0.15 kB
...
dist/static/js/130.7fec1f2e02.js                              8664.8 kB    1903.9 kB

                                                     Total:   18899.3 kB   5397.3 kB
```
