### PR TITLE
fix: preserve Responses streaming tool call arguments

### DIFF
--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -334,7 +334,7 @@ func (o *OpenAIResponsesResponse) GetSize() string {
 }
 
 type IncompleteDetails struct {
-	Reasoning string `json:"reasoning"`
+	Reason string `json:"reason"`
 }
 
 type ResponsesOutput struct {

--- a/relay/channel/openai/chat_via_responses.go
+++ b/relay/channel/openai/chat_via_responses.go
@@ -355,6 +355,9 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 		if !sendStartIfNeeded() {
 			return false
 		}
+		if usage.TotalTokens == 0 {
+			usage = service.ResponseText2Usage(c, usageText.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
+		}
 		if info.RelayFormat == types.RelayFormatClaude && info.ClaudeConvertInfo != nil {
 			info.ClaudeConvertInfo.Usage = usage
 		}
@@ -532,10 +535,6 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 
 	if streamErr != nil {
 		return nil, streamErr
-	}
-
-	if usage.TotalTokens == 0 {
-		usage = service.ResponseText2Usage(c, usageText.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
 	}
 
 	if !sendFinalChunk(nil) {

--- a/relay/channel/openai/chat_via_responses.go
+++ b/relay/channel/openai/chat_via_responses.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -17,26 +18,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 )
-
-func responsesStreamIndexKey(itemID string, idx *int) string {
-	if itemID == "" {
-		return ""
-	}
-	if idx == nil {
-		return itemID
-	}
-	return fmt.Sprintf("%s:%d", itemID, *idx)
-}
-
-func stringDeltaFromPrefix(prev string, next string) string {
-	if next == "" {
-		return ""
-	}
-	if prev != "" && strings.HasPrefix(next, prev) {
-		return next[len(prev):]
-	}
-	return next
-}
 
 func OaiResponsesToChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
 	if resp == nil || resp.Body == nil {
@@ -103,7 +84,6 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 
 	var (
 		usage       = &dto.Usage{}
-		outputText  strings.Builder
 		usageText   strings.Builder
 		sentStart   bool
 		sentStop    bool
@@ -118,7 +98,6 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 	toolCallCanonicalIDByItemID := make(map[string]string)
 	hasSentReasoningSummary := false
 	needsReasoningSummarySeparator := false
-	//reasoningSummaryTextByKey := make(map[string]string)
 
 	if info.RelayFormat == types.RelayFormatClaude && info.ClaudeConvertInfo == nil {
 		info.ClaudeConvertInfo = &relaycommon.ClaudeConvertInfo{LastMessagesType: relaycommon.LastMessageTypeNone}
@@ -158,36 +137,6 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 		sentStart = true
 		return true
 	}
-
-	//sendReasoningDelta := func(delta string) bool {
-	//	if delta == "" {
-	//		return true
-	//	}
-	//	if !sendStartIfNeeded() {
-	//		return false
-	//	}
-	//
-	//	usageText.WriteString(delta)
-	//	chunk := &dto.ChatCompletionsStreamResponse{
-	//		Id:      responseId,
-	//		Object:  "chat.completion.chunk",
-	//		Created: createAt,
-	//		Model:   model,
-	//		Choices: []dto.ChatCompletionsStreamResponseChoice{
-	//			{
-	//				Index: 0,
-	//				Delta: dto.ChatCompletionsStreamResponseChoiceDelta{
-	//					ReasoningContent: &delta,
-	//				},
-	//			},
-	//		},
-	//	}
-	//	if err := helper.ObjectData(c, chunk); err != nil {
-	//		streamErr = types.NewOpenAIError(err, types.ErrorCodeBadResponse, http.StatusInternalServerError)
-	//		return false
-	//	}
-	//	return true
-	//}
 
 	sendReasoningSummaryDelta := func(delta string) bool {
 		if delta == "" {
@@ -232,10 +181,6 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 
 	sendToolCallDelta := func(callID string, name string, argsDelta string) bool {
 		if callID == "" {
-			return true
-		}
-		if outputText.Len() > 0 {
-			// Prefer streaming assistant text over tool calls to match non-stream behavior.
 			return true
 		}
 		if !sendStartIfNeeded() {
@@ -296,6 +241,137 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 		return true
 	}
 
+	migrateToolCallState := func(itemID string, callID string) {
+		if itemID == "" || callID == "" {
+			return
+		}
+		toolCallCanonicalIDByItemID[itemID] = callID
+		if itemID == callID {
+			return
+		}
+
+		if idx, ok := toolCallIndexByID[itemID]; ok {
+			if _, exists := toolCallIndexByID[callID]; !exists {
+				toolCallIndexByID[callID] = idx
+			}
+			delete(toolCallIndexByID, itemID)
+		}
+		if args, ok := toolCallArgsByID[itemID]; ok {
+			if _, exists := toolCallArgsByID[callID]; !exists {
+				toolCallArgsByID[callID] = args
+			}
+			delete(toolCallArgsByID, itemID)
+		}
+		if name, ok := toolCallNameByID[itemID]; ok {
+			if _, exists := toolCallNameByID[callID]; !exists {
+				toolCallNameByID[callID] = name
+			}
+			delete(toolCallNameByID, itemID)
+		}
+		if sent, ok := toolCallNameSent[itemID]; ok {
+			if _, exists := toolCallNameSent[callID]; !exists {
+				toolCallNameSent[callID] = sent
+			}
+			delete(toolCallNameSent, itemID)
+		}
+	}
+
+	flushPendingToolCall := func(itemID string) bool {
+		itemID = strings.TrimSpace(itemID)
+		if itemID == "" {
+			return true
+		}
+		if toolCallCanonicalIDByItemID[itemID] != "" {
+			return true
+		}
+		if _, ok := toolCallIndexByID[itemID]; ok {
+			return true
+		}
+		args := toolCallArgsByID[itemID]
+		if args == "" {
+			return true
+		}
+		return sendToolCallDelta(itemID, "", args)
+	}
+
+	flushPendingToolCalls := func() bool {
+		itemIDs := make([]string, 0, len(toolCallArgsByID))
+		for itemID := range toolCallArgsByID {
+			itemIDs = append(itemIDs, itemID)
+		}
+		// Keep fallback tool indexes deterministic despite randomized map iteration.
+		sort.Strings(itemIDs)
+		for _, itemID := range itemIDs {
+			if !flushPendingToolCall(itemID) {
+				return false
+			}
+		}
+		return true
+	}
+
+	applyResponseMetadata := func(response *dto.OpenAIResponsesResponse) {
+		if response == nil {
+			return
+		}
+		if response.Model != "" {
+			model = response.Model
+		}
+		if response.CreatedAt != 0 {
+			createAt = int64(response.CreatedAt)
+		}
+		if response.Usage == nil {
+			return
+		}
+		if response.Usage.InputTokens != 0 {
+			usage.PromptTokens = response.Usage.InputTokens
+			usage.InputTokens = response.Usage.InputTokens
+		}
+		if response.Usage.OutputTokens != 0 {
+			usage.CompletionTokens = response.Usage.OutputTokens
+			usage.OutputTokens = response.Usage.OutputTokens
+		}
+		if response.Usage.TotalTokens != 0 {
+			usage.TotalTokens = response.Usage.TotalTokens
+		} else {
+			usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+		}
+		if response.Usage.InputTokensDetails != nil {
+			usage.PromptTokensDetails.CachedTokens = response.Usage.InputTokensDetails.CachedTokens
+			usage.PromptTokensDetails.ImageTokens = response.Usage.InputTokensDetails.ImageTokens
+			usage.PromptTokensDetails.AudioTokens = response.Usage.InputTokensDetails.AudioTokens
+		}
+		if response.Usage.CompletionTokenDetails.ReasoningTokens != 0 {
+			usage.CompletionTokenDetails.ReasoningTokens = response.Usage.CompletionTokenDetails.ReasoningTokens
+		}
+	}
+
+	sendFinalChunk := func(response *dto.OpenAIResponsesResponse) bool {
+		if sentStop {
+			return true
+		}
+		if !flushPendingToolCalls() {
+			return false
+		}
+		if !sendStartIfNeeded() {
+			return false
+		}
+		if info.RelayFormat == types.RelayFormatClaude && info.ClaudeConvertInfo != nil {
+			info.ClaudeConvertInfo.Usage = usage
+		}
+		finishReason := "stop"
+		if mappedReason, ok := service.ResponsesFinishReasonFromStatus(response); ok {
+			finishReason = mappedReason
+		} else if sawToolCall {
+			finishReason = "tool_calls"
+		}
+		stop := helper.GenerateStopResponse(responseId, createAt, model, finishReason)
+		if !sendChatChunk(stop) {
+			return false
+		}
+		sentStop = true
+		return true
+	}
+
 	helper.StreamScannerHandler(c, resp, info, func(data string, sr *helper.StreamResult) {
 		if streamErr != nil {
 			sr.Stop(streamErr)
@@ -311,22 +387,7 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 
 		switch streamResp.Type {
 		case "response.created":
-			if streamResp.Response != nil {
-				if streamResp.Response.Model != "" {
-					model = streamResp.Response.Model
-				}
-				if streamResp.Response.CreatedAt != 0 {
-					createAt = int64(streamResp.Response.CreatedAt)
-				}
-			}
-
-		//case "response.reasoning_text.delta":
-		//if !sendReasoningDelta(streamResp.Delta) {
-		//	sr.Stop(streamErr)
-		//	return
-		//}
-
-		//case "response.reasoning_text.done":
+			applyResponseMetadata(streamResp.Response)
 
 		case "response.reasoning_summary_text.delta":
 			if !sendReasoningSummaryDelta(streamResp.Delta) {
@@ -339,24 +400,6 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 				needsReasoningSummarySeparator = true
 			}
 
-		//case "response.reasoning_summary_part.added", "response.reasoning_summary_part.done":
-		//	key := responsesStreamIndexKey(strings.TrimSpace(streamResp.ItemID), streamResp.SummaryIndex)
-		//	if key == "" || streamResp.Part == nil {
-		//		break
-		//	}
-		//	// Only handle summary text parts, ignore other part types.
-		//	if streamResp.Part.Type != "" && streamResp.Part.Type != "summary_text" {
-		//		break
-		//	}
-		//	prev := reasoningSummaryTextByKey[key]
-		//	next := streamResp.Part.Text
-		//	delta := stringDeltaFromPrefix(prev, next)
-		//	reasoningSummaryTextByKey[key] = next
-		//	if !sendReasoningSummaryDelta(delta) {
-		//		sr.Stop(streamErr)
-		//		return
-		//	}
-
 		case "response.output_text.delta":
 			if !sendStartIfNeeded() {
 				sr.Stop(streamErr)
@@ -364,7 +407,6 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 			}
 
 			if streamResp.Delta != "" {
-				outputText.WriteString(streamResp.Delta)
 				usageText.WriteString(streamResp.Delta)
 				delta := streamResp.Delta
 				chunk := &dto.ChatCompletionsStreamResponse{
@@ -401,7 +443,7 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 				callID = itemID
 			}
 			if itemID != "" && callID != "" {
-				toolCallCanonicalIDByItemID[itemID] = callID
+				migrateToolCallState(itemID, callID)
 			}
 			name := strings.TrimSpace(streamResp.Item.Name)
 			if name != "" {
@@ -409,15 +451,20 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 			}
 
 			newArgs := streamResp.Item.ArgumentsString()
+			_, hasSentToolCall := toolCallIndexByID[callID]
 			prevArgs := toolCallArgsByID[callID]
 			argsDelta := ""
 			if newArgs != "" {
-				if strings.HasPrefix(newArgs, prevArgs) {
+				if !hasSentToolCall {
+					argsDelta = newArgs
+				} else if strings.HasPrefix(newArgs, prevArgs) {
 					argsDelta = newArgs[len(prevArgs):]
 				} else {
 					argsDelta = newArgs
 				}
 				toolCallArgsByID[callID] = newArgs
+			} else if !hasSentToolCall && prevArgs != "" {
+				argsDelta = prevArgs
 			}
 
 			if !sendToolCallDelta(callID, name, argsDelta) {
@@ -429,9 +476,9 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 			itemID := strings.TrimSpace(streamResp.ItemID)
 			callID := toolCallCanonicalIDByItemID[itemID]
 			if callID == "" {
-				callID = itemID
-			}
-			if callID == "" {
+				if itemID != "" {
+					toolCallArgsByID[itemID] += streamResp.Delta
+				}
 				break
 			}
 			toolCallArgsByID[callID] += streamResp.Delta
@@ -441,58 +488,30 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 			}
 
 		case "response.function_call_arguments.done":
-
-		case "response.completed":
-			if streamResp.Response != nil {
-				if streamResp.Response.Model != "" {
-					model = streamResp.Response.Model
-				}
-				if streamResp.Response.CreatedAt != 0 {
-					createAt = int64(streamResp.Response.CreatedAt)
-				}
-				if streamResp.Response.Usage != nil {
-					if streamResp.Response.Usage.InputTokens != 0 {
-						usage.PromptTokens = streamResp.Response.Usage.InputTokens
-						usage.InputTokens = streamResp.Response.Usage.InputTokens
-					}
-					if streamResp.Response.Usage.OutputTokens != 0 {
-						usage.CompletionTokens = streamResp.Response.Usage.OutputTokens
-						usage.OutputTokens = streamResp.Response.Usage.OutputTokens
-					}
-					if streamResp.Response.Usage.TotalTokens != 0 {
-						usage.TotalTokens = streamResp.Response.Usage.TotalTokens
-					} else {
-						usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
-					}
-					if streamResp.Response.Usage.InputTokensDetails != nil {
-						usage.PromptTokensDetails.CachedTokens = streamResp.Response.Usage.InputTokensDetails.CachedTokens
-						usage.PromptTokensDetails.ImageTokens = streamResp.Response.Usage.InputTokensDetails.ImageTokens
-						usage.PromptTokensDetails.AudioTokens = streamResp.Response.Usage.InputTokensDetails.AudioTokens
-					}
-					if streamResp.Response.Usage.CompletionTokenDetails.ReasoningTokens != 0 {
-						usage.CompletionTokenDetails.ReasoningTokens = streamResp.Response.Usage.CompletionTokenDetails.ReasoningTokens
-					}
-				}
-			}
-
-			if !sendStartIfNeeded() {
+			if !flushPendingToolCall(streamResp.ItemID) {
 				sr.Stop(streamErr)
 				return
 			}
-			if !sentStop {
-				if info.RelayFormat == types.RelayFormatClaude && info.ClaudeConvertInfo != nil {
-					info.ClaudeConvertInfo.Usage = usage
-				}
-				finishReason := "stop"
-				if sawToolCall && outputText.Len() == 0 {
-					finishReason = "tool_calls"
-				}
-				stop := helper.GenerateStopResponse(responseId, createAt, model, finishReason)
-				if !sendChatChunk(stop) {
-					sr.Stop(streamErr)
-					return
-				}
-				sentStop = true
+
+		case "response.completed":
+			applyResponseMetadata(streamResp.Response)
+			if !sendFinalChunk(streamResp.Response) {
+				sr.Stop(streamErr)
+				return
+			}
+
+		case "response.incomplete":
+			response := streamResp.Response
+			if response == nil {
+				response = &dto.OpenAIResponsesResponse{}
+			}
+			if len(response.Status) == 0 {
+				response.Status = []byte(`"incomplete"`)
+			}
+			applyResponseMetadata(response)
+			if !sendFinalChunk(response) {
+				sr.Stop(streamErr)
+				return
 			}
 
 		case "response.error", "response.failed":
@@ -519,23 +538,8 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 		usage = service.ResponseText2Usage(c, usageText.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
 	}
 
-	if !sentStart {
-		if !sendChatChunk(helper.GenerateStartEmptyResponse(responseId, createAt, model, nil)) {
-			return nil, streamErr
-		}
-	}
-	if !sentStop {
-		if info.RelayFormat == types.RelayFormatClaude && info.ClaudeConvertInfo != nil {
-			info.ClaudeConvertInfo.Usage = usage
-		}
-		finishReason := "stop"
-		if sawToolCall && outputText.Len() == 0 {
-			finishReason = "tool_calls"
-		}
-		stop := helper.GenerateStopResponse(responseId, createAt, model, finishReason)
-		if !sendChatChunk(stop) {
-			return nil, streamErr
-		}
+	if !sendFinalChunk(nil) {
+		return nil, streamErr
 	}
 	if info.RelayFormat == types.RelayFormatOpenAI && info.ShouldIncludeUsage && usage != nil {
 		if err := helper.ObjectData(c, helper.GenerateFinalUsageResponse(responseId, createAt, model, *usage)); err != nil {

--- a/service/convert.go
+++ b/service/convert.go
@@ -615,24 +615,25 @@ func ResponseOpenAI2Claude(openAIResponse *dto.OpenAITextResponse, info *relayco
 	}
 	for _, choice := range openAIResponse.Choices {
 		stopReason = stopReasonOpenAI2Claude(choice.FinishReason)
-		if choice.FinishReason == "tool_calls" {
-			for _, toolUse := range choice.Message.ParseToolCalls() {
-				claudeContent := dto.ClaudeMediaMessage{}
-				claudeContent.Type = "tool_use"
-				claudeContent.Id = toolUse.ID
-				claudeContent.Name = toolUse.Function.Name
-				var mapParams map[string]interface{}
-				if err := common.Unmarshal([]byte(toolUse.Function.Arguments), &mapParams); err == nil {
-					claudeContent.Input = mapParams
-				} else {
-					claudeContent.Input = toolUse.Function.Arguments
-				}
-				contents = append(contents, claudeContent)
-			}
-		} else {
+		textContent := choice.Message.StringContent()
+		toolCalls := choice.Message.ParseToolCalls()
+		if textContent != "" || len(toolCalls) == 0 {
 			claudeContent := dto.ClaudeMediaMessage{}
 			claudeContent.Type = "text"
-			claudeContent.SetText(choice.Message.StringContent())
+			claudeContent.SetText(textContent)
+			contents = append(contents, claudeContent)
+		}
+		for _, toolUse := range toolCalls {
+			claudeContent := dto.ClaudeMediaMessage{}
+			claudeContent.Type = "tool_use"
+			claudeContent.Id = toolUse.ID
+			claudeContent.Name = toolUse.Function.Name
+			var mapParams map[string]interface{}
+			if err := common.Unmarshal([]byte(toolUse.Function.Arguments), &mapParams); err == nil {
+				claudeContent.Input = mapParams
+			} else {
+				claudeContent.Input = toolUse.Function.Arguments
+			}
 			contents = append(contents, claudeContent)
 		}
 	}
@@ -863,37 +864,32 @@ func ResponseOpenAI2Gemini(openAIResponse *dto.OpenAITextResponse, info *relayco
 			Parts: make([]dto.GeminiPart, 0),
 		}
 
-		// 处理工具调用
-		toolCalls := choice.Message.ParseToolCalls()
-		if len(toolCalls) > 0 {
-			for _, toolCall := range toolCalls {
-				// 解析参数
-				var args map[string]interface{}
-				if toolCall.Function.Arguments != "" {
-					if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
-						args = map[string]interface{}{"arguments": toolCall.Function.Arguments}
-					}
-				} else {
-					args = make(map[string]interface{})
-				}
+		textContent := choice.Message.StringContent()
+		if textContent != "" {
+			part := dto.GeminiPart{
+				Text: textContent,
+			}
+			content.Parts = append(content.Parts, part)
+		}
 
-				part := dto.GeminiPart{
-					FunctionCall: &dto.FunctionCall{
-						FunctionName: toolCall.Function.Name,
-						Arguments:    args,
-					},
+		toolCalls := choice.Message.ParseToolCalls()
+		for _, toolCall := range toolCalls {
+			var args map[string]interface{}
+			if toolCall.Function.Arguments != "" {
+				if err := common.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
+					args = map[string]interface{}{"arguments": toolCall.Function.Arguments}
 				}
-				content.Parts = append(content.Parts, part)
+			} else {
+				args = make(map[string]interface{})
 			}
-		} else {
-			// 处理文本内容
-			textContent := choice.Message.StringContent()
-			if textContent != "" {
-				part := dto.GeminiPart{
-					Text: textContent,
-				}
-				content.Parts = append(content.Parts, part)
+
+			part := dto.GeminiPart{
+				FunctionCall: &dto.FunctionCall{
+					FunctionName: toolCall.Function.Name,
+					Arguments:    args,
+				},
 			}
+			content.Parts = append(content.Parts, part)
 		}
 
 		candidate.Content = content

--- a/service/openai_chat_responses_compat.go
+++ b/service/openai_chat_responses_compat.go
@@ -13,6 +13,10 @@ func ResponsesResponseToChatCompletionsResponse(resp *dto.OpenAIResponsesRespons
 	return openaicompat.ResponsesResponseToChatCompletionsResponse(resp, id)
 }
 
+func ResponsesFinishReasonFromStatus(resp *dto.OpenAIResponsesResponse) (string, bool) {
+	return openaicompat.ResponsesFinishReasonFromStatus(resp)
+}
+
 func ExtractOutputTextFromResponses(resp *dto.OpenAIResponsesResponse) string {
 	return openaicompat.ExtractOutputTextFromResponses(resp)
 }

--- a/service/openaicompat/responses_to_chat.go
+++ b/service/openaicompat/responses_to_chat.go
@@ -4,8 +4,34 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
 )
+
+func ResponsesFinishReasonFromStatus(resp *dto.OpenAIResponsesResponse) (string, bool) {
+	if resp == nil {
+		return "", false
+	}
+
+	status := ""
+	if len(resp.Status) > 0 {
+		_ = common.Unmarshal(resp.Status, &status)
+		status = strings.TrimSpace(status)
+	}
+
+	if status != "incomplete" {
+		return "", false
+	}
+
+	reason := ""
+	if resp.IncompleteDetails != nil {
+		reason = strings.TrimSpace(resp.IncompleteDetails.Reason)
+	}
+	if reason == "content_filter" {
+		return "content_filter", true
+	}
+	return "length", true
+}
 
 func ResponsesResponseToChatCompletionsResponse(resp *dto.OpenAIResponsesResponse, id string) (*dto.OpenAITextResponse, *dto.Usage, error) {
 	if resp == nil {
@@ -42,7 +68,7 @@ func ResponsesResponseToChatCompletionsResponse(resp *dto.OpenAIResponsesRespons
 	created := resp.CreatedAt
 
 	var toolCalls []dto.ToolCallResponse
-	if text == "" && len(resp.Output) > 0 {
+	if len(resp.Output) > 0 {
 		for _, out := range resp.Output {
 			if out.Type != "function_call" {
 				continue
@@ -67,7 +93,9 @@ func ResponsesResponseToChatCompletionsResponse(resp *dto.OpenAIResponsesRespons
 	}
 
 	finishReason := "stop"
-	if len(toolCalls) > 0 {
+	if mappedReason, ok := ResponsesFinishReasonFromStatus(resp); ok {
+		finishReason = mappedReason
+	} else if len(toolCalls) > 0 {
 		finishReason = "tool_calls"
 	}
 
@@ -77,7 +105,6 @@ func ResponsesResponseToChatCompletionsResponse(resp *dto.OpenAIResponsesRespons
 	}
 	if len(toolCalls) > 0 {
 		msg.SetToolCalls(toolCalls)
-		msg.Content = ""
 	}
 
 	out := &dto.OpenAITextResponse{


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)
修复 `ChatCompletions -> Responses` 中转时的工具调用中断问题。
之前 Responses 流式结果在转换回 Chat Completions 时，部分场景会把正文、工具调用和结束原因处理成互斥关系：有正文时可能丢掉 tool call；`response.incomplete` 或 `status:"incomplete"` 可能被包装成 `stop`；部分非标准上游缺少 `call_id` 或只发送 tool argument delta 时，工具参数会被缓冲但没有正确下发。这样 agent 会误以为本轮已经正常结束，导致后续工具调用链路中断。
本次修复让 Chat 输出允许同时保留 `content` 和 `tool_calls`，并统一 Responses 流式收尾逻辑：工具调用参数会在完成、incomplete 或 EOF fallback 前 flush；`incomplete_details.reason` 会正确映射为 `length` / `content_filter`，且优先级高于 `tool_calls`，避免执行被截断的工具参数。同时补充了流式/非流式回归测试，覆盖正文与工具调用共存、缺 `call_id`、delta-only、incomplete 优先级。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed tool-call handling so content and tool-use blocks can appear together more consistently, with more reliable finalization.
  * Fixed chat finish reasons for incomplete responses, including better mapping for content filtering and length limits.
  * Made response conversion more consistent, allowing text and tool-use parts to be included together when applicable.
  * Preserved token usage/completion details more accurately and updated incomplete-details to use the `reason` JSON key for compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->