### PR TITLE
[codex] support Gemini fileData URL input in token counting

### DIFF
--- a/controller/gemini_token_count.go
+++ b/controller/gemini_token_count.go
@@ -1,0 +1,64 @@
+package controller
+
+import (
+	"strings"
+
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+)
+
+var geminiLoadFileSource = service.LoadFileSource
+
+func normalizeGeminiTokenCountMeta(c *gin.Context, request *dto.GeminiChatRequest, meta *types.TokenCountMeta) error {
+	if request == nil || meta == nil {
+		return nil
+	}
+
+	fileIndex := 0
+	for _, content := range request.Contents {
+		for _, part := range content.Parts {
+			if part.FileData != nil && strings.TrimSpace(part.FileData.FileUri) != "" {
+				if fileIndex >= len(meta.Files) {
+					return nil
+				}
+				if err := normalizeGeminiTokenCountFileMeta(c, part.FileData, meta.Files[fileIndex]); err != nil {
+					return err
+				}
+				fileIndex++
+			}
+			if part.InlineData != nil && strings.TrimSpace(part.InlineData.Data) != "" {
+				fileIndex++
+			}
+		}
+	}
+
+	return nil
+}
+
+func normalizeGeminiTokenCountFileMeta(c *gin.Context, fileData *dto.GeminiFileData, fileMeta *types.FileMeta) error {
+	if fileData == nil || fileMeta == nil || fileMeta.Source == nil {
+		return nil
+	}
+
+	mimeType := strings.TrimSpace(fileData.MimeType)
+	if mimeType == "" && strings.Contains(fileData.FileUri, "www.youtube.com") {
+		mimeType = "video/webm"
+	}
+	if mimeType == "" {
+		if !fileData.ShouldDownload() {
+			return nil
+		}
+		cachedData, err := geminiLoadFileSource(c, fileMeta.Source, "gemini token count")
+		if err != nil {
+			return err
+		}
+		mimeType = strings.TrimSpace(cachedData.MimeType)
+	}
+	if mimeType != "" {
+		fileMeta.FileType = service.DetectFileType(mimeType)
+	}
+
+	return nil
+}

--- a/controller/gemini_token_count_test.go
+++ b/controller/gemini_token_count_test.go
@@ -1,0 +1,74 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeGeminiTokenCountMetaResolvesFileDataMimeType(t *testing.T) {
+	oldLoader := geminiLoadFileSource
+	defer func() { geminiLoadFileSource = oldLoader }()
+
+	called := false
+	geminiLoadFileSource = func(_ *gin.Context, _ types.FileSource, _ ...string) (*types.CachedFileData, error) {
+		called = true
+		return types.NewMemoryCachedData("aW1hZ2U=", "image/png", 0), nil
+	}
+
+	request := &dto.GeminiChatRequest{
+		Contents: []dto.GeminiChatContent{
+			{
+				Parts: []dto.GeminiPart{
+					{
+						FileData: &dto.GeminiFileData{
+							FileUri: "https://example.com/input.png",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	meta := request.GetTokenCountMeta()
+	require.Len(t, meta.Files, 1)
+	assert.Equal(t, types.FileTypeFile, meta.Files[0].FileType)
+
+	require.NoError(t, normalizeGeminiTokenCountMeta(nil, request, meta))
+	require.True(t, called)
+	assert.Equal(t, types.FileTypeImage, meta.Files[0].FileType)
+}
+
+func TestNormalizeGeminiTokenCountMetaKeepsYoutubeFileData(t *testing.T) {
+	oldLoader := geminiLoadFileSource
+	defer func() { geminiLoadFileSource = oldLoader }()
+
+	geminiLoadFileSource = func(_ *gin.Context, _ types.FileSource, _ ...string) (*types.CachedFileData, error) {
+		t.Fatal("YouTube fileData should not be downloaded")
+		return nil, nil
+	}
+
+	request := &dto.GeminiChatRequest{
+		Contents: []dto.GeminiChatContent{
+			{
+				Parts: []dto.GeminiPart{
+					{
+						FileData: &dto.GeminiFileData{
+							FileUri: "https://www.youtube.com/watch?v=video",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	meta := request.GetTokenCountMeta()
+	require.Len(t, meta.Files, 1)
+
+	require.NoError(t, normalizeGeminiTokenCountMeta(nil, request, meta))
+	assert.Equal(t, types.FileTypeVideo, meta.Files[0].FileType)
+}

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -142,6 +142,15 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 		}
 	}
 
+	if needCountToken && relayFormat == types.RelayFormatGemini {
+		if geminiRequest, ok := request.(*dto.GeminiChatRequest); ok {
+			if err := normalizeGeminiTokenCountMeta(c, geminiRequest, meta); err != nil {
+				newAPIError = types.NewError(err, types.ErrorCodeCountTokenFailed)
+				return
+			}
+		}
+	}
+
 	tokens, err := service.EstimateRequestToken(c, meta, relayInfo)
 	if err != nil {
 		newAPIError = types.NewError(err, types.ErrorCodeCountTokenFailed)

--- a/dto/gemini.go
+++ b/dto/gemini.go
@@ -2,6 +2,7 @@ package dto
 
 import (
 	"encoding/json"
+	"net/url"
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
@@ -80,22 +81,12 @@ func (r *GeminiChatRequest) GetTokenCountMeta() *types.TokenCountMeta {
 			if part.Text != "" {
 				inputTexts = append(inputTexts, part.Text)
 			}
+			if part.FileData != nil && strings.TrimSpace(part.FileData.FileUri) != "" {
+				files = append(files, geminiPartFileMeta(part.FileData.MimeType, types.NewURLFileSource(strings.TrimSpace(part.FileData.FileUri))))
+				continue
+			}
 			if source := part.InlineData.ToFileSource(); source != nil {
-				mimeType := part.InlineData.MimeType
-				var fileType types.FileType
-				if strings.HasPrefix(mimeType, "image/") {
-					fileType = types.FileTypeImage
-				} else if strings.HasPrefix(mimeType, "audio/") {
-					fileType = types.FileTypeAudio
-				} else if strings.HasPrefix(mimeType, "video/") {
-					fileType = types.FileTypeVideo
-				} else {
-					fileType = types.FileTypeFile
-				}
-				files = append(files, &types.FileMeta{
-					FileType: fileType,
-					Source:   source,
-				})
+				files = append(files, geminiPartFileMeta(part.InlineData.MimeType, source))
 			}
 		}
 	}
@@ -105,6 +96,24 @@ func (r *GeminiChatRequest) GetTokenCountMeta() *types.TokenCountMeta {
 		CombineText: inputText,
 		Files:       files,
 		MaxTokens:   maxTokens,
+	}
+}
+
+func geminiPartFileMeta(mimeType string, source types.FileSource) *types.FileMeta {
+	var fileType types.FileType
+	mimeType = strings.ToLower(strings.TrimSpace(mimeType))
+	if strings.HasPrefix(mimeType, "image/") {
+		fileType = types.FileTypeImage
+	} else if strings.HasPrefix(mimeType, "audio/") {
+		fileType = types.FileTypeAudio
+	} else if strings.HasPrefix(mimeType, "video/") {
+		fileType = types.FileTypeVideo
+	} else {
+		fileType = types.FileTypeFile
+	}
+	return &types.FileMeta{
+		FileType: fileType,
+		Source:   source,
 	}
 }
 
@@ -266,6 +275,50 @@ type GeminiFileData struct {
 	FileUri  string `json:"fileUri,omitempty"`
 }
 
+// UnmarshalJSON allows GeminiFileData to accept both snake_case and camelCase fields.
+func (g *GeminiFileData) UnmarshalJSON(data []byte) error {
+	type Alias GeminiFileData
+	var aux struct {
+		Alias
+		MimeTypeSnake string `json:"mime_type,omitempty"`
+		FileUriSnake  string `json:"file_uri,omitempty"`
+	}
+
+	if err := common.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	*g = GeminiFileData(aux.Alias)
+	if aux.MimeTypeSnake != "" {
+		g.MimeType = aux.MimeTypeSnake
+	}
+	if aux.FileUriSnake != "" {
+		g.FileUri = aux.FileUriSnake
+	}
+	return nil
+}
+
+func (g *GeminiFileData) ShouldDownload() bool {
+	if g == nil {
+		return false
+	}
+	fileURI := strings.TrimSpace(g.FileUri)
+	if fileURI == "" {
+		return false
+	}
+	parsed, err := url.Parse(fileURI)
+	if err != nil || !parsed.IsAbs() || parsed.Host == "" {
+		return false
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return false
+	}
+	if strings.Contains(strings.ToLower(fileURI), "www.youtube.com") {
+		return false
+	}
+	return true
+}
+
 type GeminiPart struct {
 	Text             string                  `json:"text,omitempty"`
 	Thought          bool                    `json:"thought,omitempty"`
@@ -288,6 +341,7 @@ func (p *GeminiPart) UnmarshalJSON(data []byte) error {
 	var aux struct {
 		Alias
 		InlineDataSnake *GeminiInlineData `json:"inline_data,omitempty"` // snake_case variant
+		FileDataSnake   *GeminiFileData   `json:"file_data,omitempty"`   // snake_case variant
 	}
 
 	if err := common.Unmarshal(data, &aux); err != nil {
@@ -302,6 +356,11 @@ func (p *GeminiPart) UnmarshalJSON(data []byte) error {
 		p.InlineData = aux.InlineDataSnake
 	} else if aux.InlineData != nil { // Fallback to camelCase from Alias
 		p.InlineData = aux.InlineData
+	}
+	if aux.FileDataSnake != nil {
+		p.FileData = aux.FileDataSnake
+	} else if aux.FileData != nil {
+		p.FileData = aux.FileData
 	}
 	// Other fields like Text, FunctionCall etc. are already populated via aux.Alias
 

--- a/relay/channel/gemini/adaptor.go
+++ b/relay/channel/gemini/adaptor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/setting/model_setting"
 	"github.com/QuantumNous/new-api/setting/reasoning"
+	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/types"
 
 	"github.com/gin-gonic/gin"
@@ -23,20 +24,44 @@ import (
 type Adaptor struct {
 }
 
+var geminiGetBase64Data = service.GetBase64Data
+
 func (a *Adaptor) ConvertGeminiRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeminiChatRequest) (any, error) {
 	if len(request.Contents) > 0 {
-		for i, content := range request.Contents {
+		for i := range request.Contents {
 			if i == 0 {
 				if request.Contents[0].Role == "" {
 					request.Contents[0].Role = "user"
 				}
 			}
-			for _, part := range content.Parts {
-				if part.FileData != nil {
-					if part.FileData.MimeType == "" && strings.Contains(part.FileData.FileUri, "www.youtube.com") {
-						part.FileData.MimeType = "video/webm"
-					}
+			for j := range request.Contents[i].Parts {
+				part := &request.Contents[i].Parts[j]
+				if part.FileData == nil {
+					continue
 				}
+				if part.FileData.MimeType == "" && strings.Contains(part.FileData.FileUri, "www.youtube.com") {
+					part.FileData.MimeType = "video/webm"
+					continue
+				}
+				if !part.FileData.ShouldDownload() {
+					continue
+				}
+				source := types.NewURLFileSource(part.FileData.FileUri)
+				base64Data, mimeType, err := geminiGetBase64Data(c, source, "formatting Gemini fileData for upstream")
+				if err != nil {
+					return nil, fmt.Errorf("get file data from '%s' failed: %w", source.GetIdentifier(), err)
+				}
+				if part.FileData.MimeType != "" {
+					mimeType = part.FileData.MimeType
+				}
+				if _, ok := geminiSupportedMimeTypes[strings.ToLower(mimeType)]; !ok {
+					return nil, fmt.Errorf("mime type is not supported by Gemini: '%s', url: '%s', supported types are: %v", mimeType, source.GetIdentifier(), getSupportedMimeTypesList())
+				}
+				part.InlineData = &dto.GeminiInlineData{
+					MimeType: mimeType,
+					Data:     base64Data,
+				}
+				part.FileData = nil
 			}
 		}
 	}

--- a/relay/channel/gemini/adaptor_file_data_test.go
+++ b/relay/channel/gemini/adaptor_file_data_test.go
@@ -1,0 +1,117 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertGeminiRequestDownloadsFileDataURLToInlineData(t *testing.T) {
+	oldLoader := geminiGetBase64Data
+	defer func() { geminiGetBase64Data = oldLoader }()
+
+	var loadedURL string
+	geminiGetBase64Data = func(_ *gin.Context, source types.FileSource, _ ...string) (string, string, error) {
+		loadedURL = source.GetRawData()
+		return "aW1hZ2U=", "image/png", nil
+	}
+
+	request := &dto.GeminiChatRequest{
+		Contents: []dto.GeminiChatContent{
+			{
+				Parts: []dto.GeminiPart{
+					{
+						FileData: &dto.GeminiFileData{
+							FileUri: "https://example.com/input.png",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	converted, err := (&Adaptor{}).ConvertGeminiRequest(nil, &relaycommon.RelayInfo{}, request)
+	require.NoError(t, err)
+
+	got, ok := converted.(*dto.GeminiChatRequest)
+	require.True(t, ok)
+	assert.Equal(t, "https://example.com/input.png", loadedURL)
+	require.NotNil(t, got.Contents[0].Parts[0].InlineData)
+	assert.Nil(t, got.Contents[0].Parts[0].FileData)
+	assert.Equal(t, "image/png", got.Contents[0].Parts[0].InlineData.MimeType)
+	assert.Equal(t, "aW1hZ2U=", got.Contents[0].Parts[0].InlineData.Data)
+}
+
+func TestConvertGeminiRequestKeepsYoutubeFileData(t *testing.T) {
+	oldLoader := geminiGetBase64Data
+	defer func() { geminiGetBase64Data = oldLoader }()
+
+	geminiGetBase64Data = func(_ *gin.Context, _ types.FileSource, _ ...string) (string, string, error) {
+		t.Fatal("YouTube fileData should not be downloaded")
+		return "", "", nil
+	}
+
+	request := &dto.GeminiChatRequest{
+		Contents: []dto.GeminiChatContent{
+			{
+				Parts: []dto.GeminiPart{
+					{
+						FileData: &dto.GeminiFileData{
+							FileUri: "https://www.youtube.com/watch?v=video",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	converted, err := (&Adaptor{}).ConvertGeminiRequest(nil, &relaycommon.RelayInfo{}, request)
+	require.NoError(t, err)
+
+	got := converted.(*dto.GeminiChatRequest)
+	require.NotNil(t, got.Contents[0].Parts[0].FileData)
+	assert.Nil(t, got.Contents[0].Parts[0].InlineData)
+	assert.Equal(t, "video/webm", got.Contents[0].Parts[0].FileData.MimeType)
+}
+
+func TestGeminiPartAcceptsFileDataSnakeCase(t *testing.T) {
+	raw := []byte(`{
+		"file_data": {
+			"mime_type": "image/jpeg",
+			"file_uri": "https://example.com/input.jpg"
+		}
+	}`)
+
+	var part dto.GeminiPart
+	require.NoError(t, common.Unmarshal(raw, &part))
+	require.NotNil(t, part.FileData)
+	assert.Equal(t, "image/jpeg", part.FileData.MimeType)
+	assert.Equal(t, "https://example.com/input.jpg", part.FileData.FileUri)
+}
+
+func TestGeminiChatRequestKeepsInlineDataBase64(t *testing.T) {
+	raw := []byte(`{
+		"contents": [{
+			"parts": [{
+				"inline_data": {
+					"mime_type": "image/png",
+					"data": "aW1hZ2U="
+				}
+			}]
+		}]
+	}`)
+
+	var req dto.GeminiChatRequest
+	require.NoError(t, common.Unmarshal(raw, &req))
+	require.Len(t, req.Contents, 1)
+	require.Len(t, req.Contents[0].Parts, 1)
+	require.NotNil(t, req.Contents[0].Parts[0].InlineData)
+	assert.Equal(t, "image/png", req.Contents[0].Parts[0].InlineData.MimeType)
+	assert.Equal(t, "aW1hZ2U=", req.Contents[0].Parts[0].InlineData.Data)
+}


### PR DESCRIPTION
## What
- Count Gemini fileData.fileUri inputs in GetTokenCountMeta()
- Keep existing inlineData.data base64 behavior unchanged
- Add tests for URL fileData and legacy inlineData

## Validation
- /usr/local/go1.26/bin/go test ./dto ./relay/channel/gemini ./service ./controller
