### PR TITLE
fix(model-pricing): refresh tiered expression editor when switching models

### DIFF
--- a/web/default/src/features/system-settings/models/model-pricing-sheet.tsx
+++ b/web/default/src/features/system-settings/models/model-pricing-sheet.tsx
@@ -153,6 +153,7 @@ export const ModelPricingEditorPanel = forwardRef<
   })
   const [billingExpr, setBillingExpr] = useState('')
   const [requestRuleExpr, setRequestRuleExpr] = useState('')
+  const [editorReloadToken, setEditorReloadToken] = useState(0)
   const isEditMode = !!editData
 
   const form = useForm<ModelPricingFormValues>({
@@ -214,6 +215,7 @@ export const ModelPricingEditorPanel = forwardRef<
     setPromptPrice(nextLaneState.promptPrice)
     setLanePrices(nextLaneState.prices)
     setLaneEnabled(nextLaneState.enabled)
+    setEditorReloadToken((token) => token + 1)
   }, [editData, form])
 
   const setFormValue = (field: keyof ModelPricingFormValues, value: string) => {
@@ -638,6 +640,7 @@ export const ModelPricingEditorPanel = forwardRef<
                   <TabsContent value='tiered_expr' className='pt-0'>
                     <FieldGroup className='gap-5'>
                       <TieredPricingEditor
+                        key={editorReloadToken}
                         modelName={watchedValues.name}
                         billingExpr={billingExpr}
                         requestRuleExpr={requestRuleExpr}


### PR DESCRIPTION
## 📝 变更描述 / Description

表达式定价模式下,在模型列表里切换模型时,右侧内容区不刷新——只有名称变了,阶梯条件和价格还是上一个模型的,很容易改错价。(per-token、按次模式正常)

原因是表达式编辑器 `TieredPricingEditor` 的内部状态只在挂载时初始化一次,切模型时没去重新读取新数据。

改法:加载新模型时给编辑器换 `key` 触发重挂载,让它按新模型的表达式重新渲染一遍。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- Closes #5750

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述为人工撰写整理。
- [x] **非重复提交:** 已检索现有 Issue / PR。
- [x] **Bug fix 说明:** 已关联 #5750。
- [x] **变更理解:** 已理解原理及影响。
- [x] **范围聚焦:** 仅改动 `model-pricing-sheet.tsx`(3 行)。
- [x] **本地验证:** `bun run typecheck` 通过,无新增 lint。
- [x] **安全合规:** 无敏感凭据。

## 📸 运行证明 / Proof of Work

复现步骤(同 #5750):表达式模式下先选模型qwen3.6-plus,再选模型 qwen3.6-max-preview。
- 修复前:内容区仅名称变为 qwen3.6-max-preview,阶梯条件与价格仍是 qwen3.6-plus 的。
- 修复后:切到 qwen3.6-max-preview 时阶梯与价格随名称一起刷新。
<img width="2020" height="934" alt="image" src="https://github.com/user-attachments/assets/410ed24f-9a4a-4550-9287-070b87a80c54" />
