### PR TITLE
feat: 新增阿里云百炼 Token Plan 渠道类型，修复 responses API 路径问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ data/
 token_estimator_test.go
 skills-lock.json
 .playwright-mcp
+.qoder/

--- a/common/api_type.go
+++ b/common/api_type.go
@@ -77,6 +77,8 @@ func ChannelType2APIType(channelType int) (int, bool) {
 		apiType = constant.APITypeCodex
 	case constant.ChannelTypeAdvancedCustom:
 		apiType = constant.APITypeAdvancedCustom
+	case constant.ChannelTypeAliTokenPlan:
+		apiType = constant.APITypeAliTokenPlan
 	}
 	if apiType == -1 {
 		return constant.APITypeOpenAI, false

--- a/constant/api_type.go
+++ b/constant/api_type.go
@@ -37,5 +37,6 @@ const (
 	APITypeReplicate
 	APITypeCodex
 	APITypeAdvancedCustom
+	APITypeAliTokenPlan
 	APITypeDummy // this one is only for count, do not add any channel after this
 )

--- a/constant/channel.go
+++ b/constant/channel.go
@@ -56,6 +56,7 @@ const (
 	ChannelTypeReplicate      = 56
 	ChannelTypeCodex          = 57
 	ChannelTypeAdvancedCustom = 58
+	ChannelTypeAliTokenPlan   = 59
 	ChannelTypeDummy          // this one is only for count, do not add any channel after this
 
 )
@@ -120,6 +121,7 @@ var ChannelBaseURLs = []string{
 	"https://api.replicate.com",                 //56
 	"https://chatgpt.com",                       //57
 	"",                                          //58
+	"https://token-plan.cn-beijing.maas.aliyuncs.com", //59
 }
 
 var ChannelTypeNames = map[int]string{
@@ -178,6 +180,7 @@ var ChannelTypeNames = map[int]string{
 	ChannelTypeReplicate:      "Replicate",
 	ChannelTypeCodex:          "ChatGPT Subscription (Codex)",
 	ChannelTypeAdvancedCustom: "Advanced Custom",
+	ChannelTypeAliTokenPlan:   "阿里云百炼Token Plan",
 }
 
 func GetChannelTypeName(channelType int) string {

--- a/relay/channel/ali_token_plan/adaptor.go
+++ b/relay/channel/ali_token_plan/adaptor.go
@@ -1,0 +1,45 @@
+package ali_token_plan
+
+import (
+	"fmt"
+
+	"github.com/QuantumNous/new-api/relay/channel/ali"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/types"
+)
+
+type Adaptor struct {
+	ali.Adaptor
+}
+
+func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
+	if info.RelayFormat == types.RelayFormatClaude {
+		return fmt.Sprintf("%s/compatible-mode/v1/chat/completions", info.ChannelBaseUrl), nil
+	}
+
+	switch info.RelayMode {
+	case constant.RelayModeResponses:
+		return fmt.Sprintf("%s/compatible-mode/v1/responses", info.ChannelBaseUrl), nil
+	case constant.RelayModeEmbeddings:
+		return fmt.Sprintf("%s/compatible-mode/v1/embeddings", info.ChannelBaseUrl), nil
+	case constant.RelayModeCompletions:
+		return fmt.Sprintf("%s/compatible-mode/v1/completions", info.ChannelBaseUrl), nil
+	case constant.RelayModeImagesGenerations:
+		return a.Adaptor.GetRequestURL(info)
+	case constant.RelayModeImagesEdits:
+		return a.Adaptor.GetRequestURL(info)
+	case constant.RelayModeRerank:
+		return fmt.Sprintf("%s/compatible-mode/v1/rerank", info.ChannelBaseUrl), nil
+	default:
+		return fmt.Sprintf("%s/compatible-mode/v1/chat/completions", info.ChannelBaseUrl), nil
+	}
+}
+
+func (a *Adaptor) GetModelList() []string {
+	return ali.ModelList
+}
+
+func (a *Adaptor) GetChannelName() string {
+	return "ali_token_plan"
+}

--- a/relay/channel/ali_token_plan/adaptor.go
+++ b/relay/channel/ali_token_plan/adaptor.go
@@ -32,7 +32,7 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	case constant.RelayModeRerank:
 		return fmt.Sprintf("%s/compatible-mode/v1/rerank", info.ChannelBaseUrl), nil
 	default:
-		return fmt.Sprintf("%s/compatible-mode/v1/chat/completions", info.ChannelBaseUrl), nil
+		return a.Adaptor.GetRequestURL(info)
 	}
 }
 

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -337,6 +337,7 @@ var streamSupportedChannels = map[int]bool{
 	constant.ChannelTypeMiniMax:        true,
 	constant.ChannelTypeSiliconFlow:    true,
 	constant.ChannelTypeAdvancedCustom: true,
+	constant.ChannelTypeAliTokenPlan:    true,
 }
 
 func GenRelayInfoWs(c *gin.Context, ws *websocket.Conn) *RelayInfo {

--- a/relay/relay_adaptor.go
+++ b/relay/relay_adaptor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/QuantumNous/new-api/relay/channel"
 	"github.com/QuantumNous/new-api/relay/channel/advancedcustom"
 	"github.com/QuantumNous/new-api/relay/channel/ali"
+	"github.com/QuantumNous/new-api/relay/channel/ali_token_plan"
 	"github.com/QuantumNous/new-api/relay/channel/aws"
 	"github.com/QuantumNous/new-api/relay/channel/baidu"
 	"github.com/QuantumNous/new-api/relay/channel/baidu_v2"
@@ -123,6 +124,8 @@ func GetAdaptor(apiType int) channel.Adaptor {
 		return &codex.Adaptor{}
 	case constant.APITypeAdvancedCustom:
 		return &advancedcustom.Adaptor{}
+	case constant.APITypeAliTokenPlan:
+		return &ali_token_plan.Adaptor{}
 	}
 	return nil
 }

--- a/web/classic/src/constants/channel.constants.js
+++ b/web/classic/src/constants/channel.constants.js
@@ -189,11 +189,16 @@ export const CHANNEL_OPTIONS = [
     color: 'blue',
     label: 'ChatGPT Subscription (Codex)',
   },
+  {
+    value: 59,
+    color: 'orange',
+    label: '阿里云百炼Token Plan',
+  },
 ];
 
 // Channel types that support upstream model list fetching in UI.
 export const MODEL_FETCHABLE_CHANNEL_TYPES = new Set([
-  1, 4, 14, 34, 17, 26, 27, 24, 47, 25, 20, 23, 31, 40, 42, 48, 43,
+  1, 4, 14, 34, 17, 26, 27, 24, 47, 25, 20, 23, 31, 40, 42, 48, 43, 59,
 ]);
 
 export const MODEL_TABLE_PAGE_SIZE = 10;


### PR DESCRIPTION
## 问题

使用阿里通义千问渠道类型（ChannelTypeAli）配置 Token Plan API 地址 `https://token-plan.cn-beijing.maas.aliyuncs.com` 时，调用 responses 接口返回 `bad_response_status_code` 错误。

## 根因分析

Ali 适配器在 `RelayModeResponses` 下构造的请求路径为：
```
/api/v2/apps/protocols/compatible-mode/v1/responses
```
该前缀 `/api/v2/apps/protocols/` 是 DashScope（dashscope.aliyuncs.com）平台专属路径，Token Plan 平台不支持。

Token Plan 的正确 responses 端点应为：
```
/compatible-mode/v1/responses
```

## 修复方案

1. 新增 `ChannelTypeAliTokenPlan = 59` 渠道类型（阿里百炼 Token Plan 与通义千问是不同产品线）
2. 2. 新增 `APITypeAliTokenPlan` API 类型
3. 3. 创建 `relay/channel/ali_token_plan/adaptor.go`，通过 Go 结构体嵌入继承 `ali.Adaptor`，仅覆写 `GetRequestURL()` 方法修复路径
4. 4. 注册流式支持和前端 UI 选项
## 变更文件

- `constant/channel.go` - 新增渠道类型常量和 base URL
- - `constant/api_type.go` - 新增 API 类型
- - `common/api_type.go` - 添加类型映射
- - `relay/relay_adaptor.go` - 注册适配器工厂
- - `relay/channel/ali_token_plan/adaptor.go` - 新建适配器（继承 Ali）
- - `relay/common/relay_info.go` - 注册流式支持
- - `web/classic/src/constants/channel.constants.js` - 前端 UI 选项
Closes #5763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Ali Token Plan** channel across the API and UI, including display name, base URL mapping, and selector option.
  * Added a dedicated routing adaptor for this channel, supporting Claude chat-completions as well as responses, embeddings, completions, rerank, and image-related flows.
  * Enabled upstream model list fetching and **streaming** support for the new channel.
* **Chores**
  * Updated ignore rules to exclude the `.qoder/` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->