### PR TITLE
fix(task): sync Data JSON status when sweepTimedOutTasks marks task as failed (#5715)

### DIFF
--- a/service/task_polling.go
+++ b/service/task_polling.go
@@ -627,20 +627,26 @@ func truncateBase64(s string) string {
 	return s[:maxKeep] + "..."
 }
 
-// patchDataStatus overwrites the "status" field inside a task's Data JSON.
+// patchDataStatus overwrites the top-level "status" field inside a task's Data JSON.
 // If Data is nil/empty or not a JSON object, it returns Data unchanged.
+// Uses map[string]json.RawMessage to preserve all other fields as raw bytes
+// without numeric precision loss from float64 round-tripping.
 func patchDataStatus(data json.RawMessage, status string) json.RawMessage {
 	if len(data) == 0 {
 		return data
 	}
-	var m map[string]any
+	var m map[string]json.RawMessage
 	if err := common.Unmarshal(data, &m); err != nil {
 		return data
 	}
 	if _, exists := m["status"]; !exists {
 		return data
 	}
-	m["status"] = status
+	statusBytes, err := common.Marshal(status)
+	if err != nil {
+		return data
+	}
+	m["status"] = json.RawMessage(statusBytes)
 	b, err := common.Marshal(m)
 	if err != nil {
 		return data

--- a/service/task_polling.go
+++ b/service/task_polling.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -68,6 +69,7 @@ func sweepTimedOutTasks(ctx context.Context) {
 		} else {
 			task.FailReason = reason
 		}
+		task.Data = patchDataStatus(task.Data, string(model.TaskStatusFailure))
 
 		won, err := task.UpdateWithStatus(oldStatus)
 		if err != nil {
@@ -623,6 +625,27 @@ func truncateBase64(s string) string {
 		return s
 	}
 	return s[:maxKeep] + "..."
+}
+
+// patchDataStatus overwrites the "status" field inside a task's Data JSON.
+// If Data is nil/empty or not a JSON object, it returns Data unchanged.
+func patchDataStatus(data json.RawMessage, status string) json.RawMessage {
+	if len(data) == 0 {
+		return data
+	}
+	var m map[string]any
+	if err := common.Unmarshal(data, &m); err != nil {
+		return data
+	}
+	if _, exists := m["status"]; !exists {
+		return data
+	}
+	m["status"] = status
+	b, err := common.Marshal(m)
+	if err != nil {
+		return data
+	}
+	return b
 }
 
 // settleTaskBillingOnComplete 任务完成时的统一计费调整。


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

任务超时被 `sweepTimedOutTasks` 强制标记为失败时，仅更新了外层 `task.Status = FAILURE`，但 `task.Data`（存储上游原始 JSON 响应）中的 `status` 字段未同步修改，导致下游通过 `TaskModel2Dto` 查询任务时，外层状态为 FAILURE，而 `data.status` 仍为 IN_PROGRESS 或 QUEUED，产生矛盾。

修复方式：新增 `patchDataStatus` 辅助函数，在标记超时失败、写入数据库前，解析 `task.Data` JSON 并将其中顶层 `status` 字段覆写为 `FAILURE`。使用 `map[string]json.RawMessage` 保证其他字段保持原始字节不变，避免 float64 精度丢失。若 Data 为空、非 JSON 对象或不含 status 字段，则原样返回，不破坏现有数据。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5715

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地编译通过（`go build ./...`），无新增编译错误。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

编译验证：
```
$ go build ./service/
# 无错误输出，编译通过
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When timed-out tasks are marked as failed, their stored details now also reflect the failed status.
  * Task history and status displays should now stay consistent after timeout handling, reducing mismatches between summary and underlying task data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->