### PR TITLE
fix(relay): remove extra blank line from Claude SSE stream

### DIFF
--- a/relay/helper/common.go
+++ b/relay/helper/common.go
@@ -68,7 +68,7 @@ func ClaudeData(c *gin.Context, resp dto.ClaudeResponse) error {
 
 func ClaudeChunkData(c *gin.Context, resp dto.ClaudeResponse, data string) {
 	c.Render(-1, common.CustomEvent{Data: fmt.Sprintf("event: %s\n", resp.Type)})
-	c.Render(-1, common.CustomEvent{Data: fmt.Sprintf("data: %s\n", data)})
+	c.Render(-1, common.CustomEvent{Data: fmt.Sprintf("data: %s", data)})
 	_ = FlushWriter(c)
 }
 

--- a/relay/helper/common_test.go
+++ b/relay/helper/common_test.go
@@ -1,0 +1,36 @@
+package helper
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaudeChunkDataDoesNotEmitExtraBlankLine(t *testing.T) {
+	oldMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(oldMode) })
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	ClaudeChunkData(c, dto.ClaudeResponse{Type: "message_start"}, `{"type":"message_start"}`)
+	ClaudeChunkData(c, dto.ClaudeResponse{Type: "content_block_start"}, `{"type":"content_block_start"}`)
+
+	require.Equal(t, strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start"}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start"}`,
+		``,
+		``,
+	}, "\n"), recorder.Body.String())
+	require.NotContains(t, recorder.Body.String(), "\n\n\n")
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

修复 Claude 原生 `/v1/messages` 流式转发时，SSE event 之间多输出一个空行的问题。

问题原因是 `ClaudeChunkData` 在 `data:` 行尾主动追加了 `\n`，而 `common.CustomEvent` 在写出 `data:` 字段时还会自动补上标准 SSE event 终止符 `\n\n`，最终导致输出变成 `data: ...\n\n\n`。本次改动移除了 `ClaudeChunkData` 中的多余换行，让 Claude stream event 恢复为标准的单个空行分隔。

同时新增回归测试，连续写出两个 Claude SSE chunk，断言输出不包含三连换行，避免后续再次引入同类格式回归。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #5402

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```text
go test ./relay/helper
go test ./relay/channel/claude
go test ./relay/...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming event formatting so SSE payloads no longer include an extra blank line.
  * Improved response formatting consistency for message streaming, preventing malformed line breaks in event output.
* **Tests**
  * Added coverage to verify streamed events are formatted correctly and do not contain unintended extra newlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->