### PR TITLE
feat: 新增阿里云百炼 Token Plan 渠道类型

### DIFF
--- a/common/api_type.go
+++ b/common/api_type.go
@@ -77,6 +77,8 @@ func ChannelType2APIType(channelType int) (int, bool) {
 		apiType = constant.APITypeCodex
 	case constant.ChannelTypeAdvancedCustom:
 		apiType = constant.APITypeAdvancedCustom
+	case constant.ChannelTypeAliTokenPlan:
+		apiType = constant.APITypeAliTokenPlan
 	}
 	if apiType == -1 {
 		return constant.APITypeOpenAI, false

--- a/constant/api_type.go
+++ b/constant/api_type.go
@@ -37,5 +37,6 @@ const (
 	APITypeReplicate
 	APITypeCodex
 	APITypeAdvancedCustom
+	APITypeAliTokenPlan
 	APITypeDummy // this one is only for count, do not add any channel after this
 )

--- a/constant/channel.go
+++ b/constant/channel.go
@@ -56,6 +56,7 @@ const (
 	ChannelTypeReplicate      = 56
 	ChannelTypeCodex          = 57
 	ChannelTypeAdvancedCustom = 58
+	ChannelTypeAliTokenPlan   = 59
 	ChannelTypeDummy          // this one is only for count, do not add any channel after this
 
 )
@@ -120,6 +121,7 @@ var ChannelBaseURLs = []string{
 	"https://api.replicate.com",                 //56
 	"https://chatgpt.com",                       //57
 	"",                                          //58
+	"https://token-plan.cn-beijing.maas.aliyuncs.com", //59
 }
 
 var ChannelTypeNames = map[int]string{
@@ -178,6 +180,7 @@ var ChannelTypeNames = map[int]string{
 	ChannelTypeReplicate:      "Replicate",
 	ChannelTypeCodex:          "ChatGPT Subscription (Codex)",
 	ChannelTypeAdvancedCustom: "Advanced Custom",
+	ChannelTypeAliTokenPlan:   "阿里云百炼Token Plan",
 }
 
 func GetChannelTypeName(channelType int) string {

--- a/relay/channel/ali_token_plan/adaptor.go
+++ b/relay/channel/ali_token_plan/adaptor.go
@@ -1,0 +1,64 @@
+package ali_token_plan
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/QuantumNous/new-api/relay/channel"
+	"github.com/QuantumNous/new-api/relay/channel/ali"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/types"
+
+	"github.com/gin-gonic/gin"
+)
+
+type Adaptor struct {
+	ali.Adaptor
+}
+
+func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
+	if info.RelayFormat == types.RelayFormatClaude {
+		return fmt.Sprintf("%s/compatible-mode/v1/chat/completions", info.ChannelBaseUrl), nil
+	}
+
+	switch info.RelayMode {
+	case constant.RelayModeResponses:
+		return fmt.Sprintf("%s/compatible-mode/v1/responses", info.ChannelBaseUrl), nil
+	case constant.RelayModeEmbeddings:
+		return fmt.Sprintf("%s/compatible-mode/v1/embeddings", info.ChannelBaseUrl), nil
+	case constant.RelayModeCompletions:
+		return fmt.Sprintf("%s/compatible-mode/v1/completions", info.ChannelBaseUrl), nil
+	case constant.RelayModeImagesGenerations:
+		return a.Adaptor.GetRequestURL(info)
+	case constant.RelayModeImagesEdits:
+		return a.Adaptor.GetRequestURL(info)
+	case constant.RelayModeRerank:
+		return fmt.Sprintf("%s/compatible-mode/v1/rerank", info.ChannelBaseUrl), nil
+	default:
+		return a.Adaptor.GetRequestURL(info)
+	}
+}
+
+// SetupRequestHeader 覆写父类方法，去掉 DashScope 专属头部（X-DashScope-SSE 等）
+// Token Plan 的 compatible-mode API 使用标准 OpenAI 协议，不需要 DashScope 头
+func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *relaycommon.RelayInfo) error {
+	channel.SetupApiRequestHeader(info, c, req)
+	req.Set("Authorization", "Bearer "+info.ApiKey)
+	return nil
+}
+
+// DoRequest 覆写父类方法，确保 DoApiRequest 接收的是 *ali_token_plan.Adaptor
+// 而非内层的 *ali.Adaptor，这样 GetRequestURL 和 SetupRequestHeader 的覆写才能生效
+func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBody io.Reader) (any, error) {
+	return channel.DoApiRequest(a, c, info, requestBody)
+}
+
+func (a *Adaptor) GetModelList() []string {
+	return ali.ModelList
+}
+
+func (a *Adaptor) GetChannelName() string {
+	return "ali_token_plan"
+}

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -337,6 +337,7 @@ var streamSupportedChannels = map[int]bool{
 	constant.ChannelTypeMiniMax:        true,
 	constant.ChannelTypeSiliconFlow:    true,
 	constant.ChannelTypeAdvancedCustom: true,
+	constant.ChannelTypeAliTokenPlan:    true,
 }
 
 func GenRelayInfoWs(c *gin.Context, ws *websocket.Conn) *RelayInfo {

--- a/relay/relay_adaptor.go
+++ b/relay/relay_adaptor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/QuantumNous/new-api/relay/channel"
 	"github.com/QuantumNous/new-api/relay/channel/advancedcustom"
 	"github.com/QuantumNous/new-api/relay/channel/ali"
+	"github.com/QuantumNous/new-api/relay/channel/ali_token_plan"
 	"github.com/QuantumNous/new-api/relay/channel/aws"
 	"github.com/QuantumNous/new-api/relay/channel/baidu"
 	"github.com/QuantumNous/new-api/relay/channel/baidu_v2"
@@ -123,6 +124,8 @@ func GetAdaptor(apiType int) channel.Adaptor {
 		return &codex.Adaptor{}
 	case constant.APITypeAdvancedCustom:
 		return &advancedcustom.Adaptor{}
+	case constant.APITypeAliTokenPlan:
+		return &ali_token_plan.Adaptor{}
 	}
 	return nil
 }

--- a/web/classic/src/constants/channel.constants.js
+++ b/web/classic/src/constants/channel.constants.js
@@ -189,11 +189,16 @@ export const CHANNEL_OPTIONS = [
     color: 'blue',
     label: 'ChatGPT Subscription (Codex)',
   },
+  {
+    value: 59,
+    color: 'orange',
+    label: '阿里云百炼Token Plan',
+  },
 ];
 
 // Channel types that support upstream model list fetching in UI.
 export const MODEL_FETCHABLE_CHANNEL_TYPES = new Set([
-  1, 4, 14, 34, 17, 26, 27, 24, 47, 25, 20, 23, 31, 40, 42, 48, 43,
+  1, 4, 14, 34, 17, 26, 27, 24, 47, 25, 20, 23, 31, 40, 42, 48, 43, 59,
 ]);
 
 export const MODEL_TABLE_PAGE_SIZE = 10;


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

新增阿里云百炼 Token Plan 专用渠道类型（type=59），解决使用"阿里千问"渠道类型时 `/v1/responses` 返回 500 的问题。

Token Plan 服务使用标准 OpenAI 兼容协议（`/compatible-mode/v1/...`），但现有 Ali 适配器会将 responses 请求路由到 DashScope 专有路径并注入不兼容的头部。本 PR 新建 `ali_token_plan` 适配器包，嵌入 `ali.Adaptor` 并覆写路由和头部逻辑，使 Token Plan 的 `/v1/responses` 端点正常工作。

## 🚀 变更类型 / Type of change
- [x] ✨ 新功能 (New feature)

## 🔗 关联任务 / Related Issue
- Closes #5763

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

已部署至生产环境验证，responses 和 chat/completions 均正常：

<img width="812" alt="测试结果" src="https://github.com/user-attachments/assets/69530e72-8c96-4644-919f-ff65a63341b5" />

渠道配置界面：

<img width="1164" alt="渠道配置" src="https://github.com/user-attachments/assets/029058c1-339b-4f90-8f22-287379891c6d" />

curl 验证 responses 可用：

<img width="1840" alt="curl验证" src="https://github.com/user-attachments/assets/d3e32222-dd5a-4722-b92e-dc484688584b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new channel option, “阿里云百炼 Token Plan,” across the app.
  * The new channel can now use compatible-mode requests and supports streaming.
  * The UI can display and fetch models for this channel.

* **Bug Fixes**
  * Requests to the new channel now use the correct authorization and routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->