### PR TITLE
fix(openai): use second-to-last SSE as fallback when last frame lacks valid usage

### DIFF
--- a/relay/channel/openai/relay-openai.go
+++ b/relay/channel/openai/relay-openai.go
@@ -117,10 +117,7 @@ func OaiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Re
 	var toolCount int
 	var usage = &dto.Usage{}
 	var lastStreamData string
-	var secondLastStreamData string // 存储倒数第二个stream data，用于音频模型
-
-	// 检查是否为音频模型
-	isAudioModel := strings.Contains(strings.ToLower(model), "audio")
+	var secondLastStreamData string // 存储倒数第二个stream data，用于最后一帧畸形时兜底
 
 	helper.StreamScannerHandler(c, resp, info, func(data string, sr *helper.StreamResult) {
 		if lastStreamData != "" {
@@ -130,8 +127,8 @@ func OaiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Re
 			}
 		}
 		if len(data) > 0 {
-			// 对音频模型，保存倒数第二个stream data
-			if isAudioModel && lastStreamData != "" {
+			// 始终保存倒数第二个 stream data，用于最后一帧畸形时兜底
+			if lastStreamData != "" {
 				secondLastStreamData = lastStreamData
 			}
 
@@ -143,8 +140,18 @@ func OaiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Re
 		}
 	})
 
-	// 对音频模型，从倒数第二个stream data中提取usage信息
-	if isAudioModel && secondLastStreamData != "" {
+	// 处理最后的响应
+	shouldSendLastResp := true
+	if err := handleLastResponse(lastStreamData, &responseId, &createAt, &systemFingerprint, &model, &usage,
+		&containStreamUsage, info, &shouldSendLastResp); err != nil {
+		logger.LogError(c, fmt.Sprintf("error handling last response: %s, lastStreamData: [%s]", err.Error(), lastStreamData))
+	}
+
+	// 兼容兜底：仅当最后一帧没有有效 usage 时（畸形 SSE，例如末尾为 {"choices":[],"cost":"0"} + TCP EOF），
+	// 才尝试从倒数第二帧提取 usage，避免 fallback 到 ResponseText2Usage 本地计费导致 cache_tokens 丢失。
+	// 同时要求客户端显式请求 usage（与 handleLastResponse 对齐），避免在没有 stream_options.include_usage
+	// 的请求上"解锁"额外的 usage 元数据。
+	if !containStreamUsage && info.ShouldIncludeUsage && secondLastStreamData != "" {
 		var streamResp struct {
 			Usage *dto.Usage `json:"usage"`
 		}
@@ -154,18 +161,11 @@ func OaiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Re
 			containStreamUsage = true
 
 			if common.DebugEnabled {
-				logger.LogDebug(c, "Audio model usage extracted from second last SSE: PromptTokens=%d, CompletionTokens=%d, TotalTokens=%d, InputTokens=%d, OutputTokens=%d",
+				logger.LogDebug(c, "Usage extracted from second last SSE (last frame had no valid usage): PromptTokens=%d, CompletionTokens=%d, TotalTokens=%d, InputTokens=%d, OutputTokens=%d",
 					usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens,
 					usage.InputTokens, usage.OutputTokens)
 			}
 		}
-	}
-
-	// 处理最后的响应
-	shouldSendLastResp := true
-	if err := handleLastResponse(lastStreamData, &responseId, &createAt, &systemFingerprint, &model, &usage,
-		&containStreamUsage, info, &shouldSendLastResp); err != nil {
-		logger.LogError(c, fmt.Sprintf("error handling last response: %s, lastStreamData: [%s]", err.Error(), lastStreamData))
 	}
 
 	if info.RelayFormat == types.RelayFormatOpenAI {


### PR DESCRIPTION
## Summary

Some upstreams (e.g. opencode-zen for `minimax-m3`) emit a malformed trailing SSE
frame such as `{"choices":[],"cost":"0"}` followed by TCP EOF without a `data: [DONE]`
sentinel. The actual `usage` (including `cached_tokens`) is carried in the
**second-to-last** frame.

`relay/channel/openai/relay-openai.go` already has a second-to-last fallback, but
it is gated on `isAudioModel`, so it is skipped for non-audio models. In that
case `handleLastResponse` cannot extract a valid `usage` from the last frame,
`containStreamUsage` stays `false`, and the code falls back to
`service.ResponseText2Usage(...)` which performs local token counting and never
fills `PromptTokensDetails.CachedTokens`. Result: `cache_tokens=0`,
`local_count_tokens=true`, `end_reason="eof"` in the log — a silent billing
inaccuracy for any user of such an upstream.

## Reproduction

```
$ curl -N -X POST http://localhost:3002/v1/chat/completions \
    -H "Authorization: Bearer $TOKEN" \
    -d '{"model":"minimax-m3","stream":true,"messages":[{"role":"user","content":"hi"}]}'
```

Upstream emits (3 content chunks + 1 usage chunk + 1 malformed `{"choices":[],"cost":"0"}`
+ TCP EOF, no `[DONE]`). Before this fix the log line shows:

```
prompt_tokens=14 completion_tokens=94 cache_tokens=0 local_count_tokens=true
stream_status.end_reason="eof"
```

After this fix the same upstream response yields:

```
prompt_tokens=183 completion_tokens=193 cache_tokens=114
```

(Large prompts also work, e.g. `prompt_tokens=160553 cache_tokens=159730`.)

## Change

`relay/channel/openai/relay-openai.go` (`OaiStreamHandler`):

1. Always save `secondLastStreamData` (previously only when `isAudioModel`).
2. Move the second-to-last `usage` extraction to **after** `handleLastResponse`.
3. Gate it on `!containStreamUsage` instead of `isAudioModel`.

The fallback is a pure pass-through: it only fires when the last frame
`ValidUsage` check failed, so behavior for normal streams (where the last frame
carries a valid `usage` and `containStreamUsage` is already `true`) is
**unchanged**.

## Compatibility

- Normal models whose last frame is valid: `containStreamUsage=true` after
  `handleLastResponse` → fallback is skipped → identical to `main`.
- Audio models (the original use case): same effective behavior — the original
  code already preferred second-to-last; with this change, the *last* frame is
  preferred when it has valid usage, otherwise the second-to-last is used. The
  resulting `usage` is the same valid one; the only difference is which frame
  is preferred when both are valid, which is benign.
- Malformed streams (this fix's target): cache tokens are now extracted
  correctly instead of being lost to local counting.

## Test

Local smoke test on the patched binary (default token, channel 102,
`opencode.ai/zen/go` for `minimax-m3`):

| model | stream | local | prompt | completion | cache | eof |
|---|---|---|---|---|---|---|
| minimax-m3 | yes | upstream | 183 | 193 | 114 | yes |
| minimax-m3 | yes | upstream | 159832 | 168 | 157464 | yes |
| minimax-m3 | yes | upstream | 160553 | 384 | 159730 | yes |
| minimax-m3 | no  | upstream | 186 | 134 | 114 | no  |
| deepseek-v4-flash | yes | upstream | 93 | 989 | 0 | no (unchanged) |

No errors in `service-3002-stderr.log` during the run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming response handling so usage data can be recovered when the final SSE frame is malformed or lacks valid usage information.
  * Updated logging to clearly reflect when and why fallback usage extraction occurs.
  * Made stream finalization more reliable by handling the last response earlier when required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->