### PR TITLE
fix: isolate classic frontend install in Makefile to match Docker

### DIFF
--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ build-frontend:
 
 build-frontend-classic:
 	@echo "Building classic frontend..."
-	@cd ./web && bun install --frozen-lockfile
+	@cd ./web && rm -rf node_modules classic/node_modules && bun install --filter ./classic --frozen-lockfile
 	@cd $(FRONTEND_CLASSIC_DIR) && VITE_REACT_APP_VERSION=$(cat ../../VERSION) bun run build
 
 build-all-frontends: build-frontend build-frontend-classic


### PR DESCRIPTION
## 📝 变更描述 / Description

本地用 `make build-all-frontends` 构建后,classic(旧版)主题的数据看板会白屏崩溃:`Cannot read properties of undefined (reading 'createCanvas')`。

根因:`web/` 是 bun workspace,classic 走全量 `bun install` 时,default 主题的 `vrender-core@1.0.45`(VChart 2.0)占住了顶层 hoist 位,把 classic 用的 `vrender-core@0.17.17`(VChart 1.8)挤成了多份嵌套副本。vrender-core 的 `container`/`application` 是模块级单例,多份副本会让 DI 容器分裂——浏览器环境注册到其中一份,渲染时却读到另一份的空 `envContribution`,于是 `createCanvas` 取到 undefined 报错。

`Dockerfile` 的 `builder-classic` 阶段本来就用 `bun install --filter ./classic`(独立容器、只装 classic),所以官方 Docker 镜像不受影响。这个 PR 把 `make build-frontend-classic` 对齐成同样的隔离安装(构建前清掉 node_modules,再 `--filter ./classic`),让本地构建产物和 Docker 一致。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- 无单独 Issue:这是本地 `make` 构建与 Docker 不一致导致的工具链问题,官方镜像无此现象。

## ✅ 提交前检查项 / Checklist
- [x] 人工确认
- [x] 非重复提交
- [x] Bug fix 说明:仅影响本地 `make` 构建,官方 Docker 镜像不受影响
- [x] 变更理解
- [x] 范围聚焦:仅改 `makefile` 一行
- [x] 本地验证

## 📸 运行证明 / Proof of Work

以 classic 构建产物里 vrender-core 的副本数衡量(看 chunk 内 `getCommonCanvas` 出现次数,单份=正常):

- 修复前 `make build-all-frontends`:classic chunk `getCommonCanvas` = 10(多份分裂)→ 看板崩溃
- 修复后:classic chunk `getCommonCanvas` = 2(单份,与 default 新版主题一致)→ 看板正常
<img width="2550" height="1268" alt="image" src="https://github.com/user-attachments/assets/8983b3ec-f57a-4169-9ed8-b9ceaa764eb5" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the classic frontend build process to start from a clean dependency state, helping avoid issues caused by leftover packages from previous installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->