### PR TITLE
fix(makefile): run only default web dev server from dev-web

### DIFF
--- a/makefile
+++ b/makefile
@@ -39,34 +39,14 @@ dev-api-rebuild:
 	@docker compose -f $(DEV_COMPOSE_FILE) up -d --build $(DEV_BACKEND_SERVICE)
 
 dev-web:
-	@echo "Starting both frontend dev servers..."
+	@echo "Starting default frontend dev server..."
 	@echo "Default frontend: http://localhost:$(DEV_FRONTEND_DEFAULT_PORT)"
-	@echo "Classic frontend: http://localhost:$(DEV_FRONTEND_CLASSIC_PORT)"
-	@cd ./web && bun install
-	@(cd $(FRONTEND_DIR) && bun run dev -- --host 0.0.0.0 --port $(DEV_FRONTEND_DEFAULT_PORT)) & \
-		default_pid=$$!; \
-		(cd $(FRONTEND_CLASSIC_DIR) && bun run dev -- --host 0.0.0.0 --port $(DEV_FRONTEND_CLASSIC_PORT)) & \
-		classic_pid=$$!; \
-		trap 'kill $$default_pid $$classic_pid 2>/dev/null; wait $$default_pid $$classic_pid 2>/dev/null; exit 130' INT TERM; \
-		while kill -0 $$default_pid 2>/dev/null && kill -0 $$classic_pid 2>/dev/null; do \
-			sleep 1; \
-		done; \
-		if ! kill -0 $$default_pid 2>/dev/null; then \
-			wait $$default_pid; \
-			status=$$?; \
-			kill $$classic_pid 2>/dev/null; \
-			wait $$classic_pid 2>/dev/null; \
-			exit $$status; \
-		fi; \
-		wait $$classic_pid; \
-		status=$$?; \
-		kill $$default_pid 2>/dev/null; \
-		wait $$default_pid 2>/dev/null; \
-		exit $$status
+	@cd ./web && bun install --filter ./default
+	@cd $(FRONTEND_DIR) && bun run dev -- --host 0.0.0.0 --port $(DEV_FRONTEND_DEFAULT_PORT)
 
 dev-web-classic:
 	@echo "Starting classic frontend dev server..."
-	@cd ./web && bun install
+	@cd ./web && bun install --filter ./classic
 	@cd $(FRONTEND_CLASSIC_DIR) && bun run dev -- --host 0.0.0.0 --port $(DEV_FRONTEND_CLASSIC_PORT)
 
 dev: dev-api dev-web

--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
-FRONTEND_DIR = ./web/default
-FRONTEND_CLASSIC_DIR = ./web/classic
+WEB_DIR = ./web/default
+WEB_CLASSIC_DIR = ./web/classic
 BACKEND_DIR = .
-DEV_FRONTEND_DEFAULT_PORT ?= 5173
-DEV_FRONTEND_CLASSIC_PORT ?= 5174
+DEV_WEB_DEFAULT_PORT ?= 5173
+DEV_WEB_CLASSIC_PORT ?= 5174
 DEV_COMPOSE_FILE = docker-compose.dev.yml
 DEV_POSTGRES_SERVICE = postgres
 DEV_BACKEND_SERVICE = new-api
@@ -10,21 +10,21 @@ DEV_POSTGRES_DB = new-api
 DEV_POSTGRES_USER = root
 DEV_SQLITE_PATH ?= one-api.db
 
-.PHONY: all build-frontend build-frontend-classic build-all-frontends start-backend dev dev-api dev-api-rebuild dev-web dev-web-classic reset-setup
+.PHONY: all build-web build-web-classic build-all-web start-backend dev dev-api dev-api-rebuild dev-web dev-web-classic reset-setup
 
-all: build-all-frontends start-backend
+all: build-all-web start-backend
 
-build-frontend:
-	@echo "Building default frontend..."
+build-web:
+	@echo "Building default web..."
 	@cd ./web && bun install --frozen-lockfile
-	@cd $(FRONTEND_DIR) && DISABLE_ESLINT_PLUGIN='true' VITE_REACT_APP_VERSION=$(cat ../../VERSION) bun run build
+	@cd $(WEB_DIR) && DISABLE_ESLINT_PLUGIN='true' VITE_REACT_APP_VERSION=$(cat ../../VERSION) bun run build
 
-build-frontend-classic:
-	@echo "Building classic frontend..."
+build-web-classic:
+	@echo "Building classic web..."
 	@cd ./web && bun install --frozen-lockfile
-	@cd $(FRONTEND_CLASSIC_DIR) && VITE_REACT_APP_VERSION=$(cat ../../VERSION) bun run build
+	@cd $(WEB_CLASSIC_DIR) && VITE_REACT_APP_VERSION=$(cat ../../VERSION) bun run build
 
-build-all-frontends: build-frontend build-frontend-classic
+build-all-web: build-web build-web-classic
 
 start-backend:
 	@echo "Starting backend dev server..."
@@ -39,15 +39,15 @@ dev-api-rebuild:
 	@docker compose -f $(DEV_COMPOSE_FILE) up -d --build $(DEV_BACKEND_SERVICE)
 
 dev-web:
-	@echo "Starting default frontend dev server..."
-	@echo "Default frontend: http://localhost:$(DEV_FRONTEND_DEFAULT_PORT)"
+	@echo "Starting default web dev server..."
+	@echo "Default web: http://localhost:$(DEV_WEB_DEFAULT_PORT)"
 	@cd ./web && bun install --filter ./default
-	@cd $(FRONTEND_DIR) && bun run dev -- --host 0.0.0.0 --port $(DEV_FRONTEND_DEFAULT_PORT)
+	@cd $(WEB_DIR) && bun run dev -- --host 0.0.0.0 --port $(DEV_WEB_DEFAULT_PORT)
 
 dev-web-classic:
-	@echo "Starting classic frontend dev server..."
+	@echo "Starting classic web dev server..."
 	@cd ./web && bun install --filter ./classic
-	@cd $(FRONTEND_CLASSIC_DIR) && bun run dev -- --host 0.0.0.0 --port $(DEV_FRONTEND_CLASSIC_PORT)
+	@cd $(WEB_CLASSIC_DIR) && bun run dev -- --host 0.0.0.0 --port $(DEV_WEB_CLASSIC_PORT)
 
 dev: dev-api dev-web
 


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)
### 问题描述
- `make dev-web` 原本会同时启动 default 和 classic 两个前端开发服务，不适合部分依赖的加载。

### 修复方式
- 将 `dev-web` 改为只安装并启动 `web/default`。
- 保留 `dev-web-classic` 作为 classic Web 的独立开发入口。
- 将 build/dev 相关 make 目标和变量从 frontend 命名统一调整为 web 命名。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ ] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [ ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [ ] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Renamed web-related build and development targets for clearer naming.
  * Updated the default build flow to use the new web build target names.
  * Simplified the web development commands so each target now starts a single server.
  * Improved the classic web workflow to install only the needed package before starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->