### PR TITLE
fix(web): 修复自定义 HTML 样式被过滤及排版间距异常的问题

### DIFF
--- a/web/default/src/components/html-content.tsx
+++ b/web/default/src/components/html-content.tsx
@@ -27,7 +27,16 @@ interface HtmlContentProps {
 }
 
 export function HtmlContent(props: HtmlContentProps) {
-  const html = useMemo(() => DOMPurify.sanitize(props.content), [props.content])
+  // 放宽 DOMPurify 限制，允许管理员设置的内联样式、class 和 id，避免自定义 HTML 样式丢失
+  const html = useMemo(
+    () =>
+      DOMPurify.sanitize(props.content, {
+        ADD_ATTR: ['class', 'style', 'id', 'target', 'rel'],
+        ADD_TAGS: ['style', 'iframe', 'video', 'audio', 'source'],
+        FORCE_BODY: true,
+      }),
+    [props.content]
+  )
 
   return (
     <div

--- a/web/default/src/components/html-content.tsx
+++ b/web/default/src/components/html-content.tsx
@@ -16,27 +16,157 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import DOMPurify from 'dompurify'
-import { useMemo } from 'react'
+import DOMPurify, { type Config } from 'dompurify'
+import { useEffect, useMemo, useRef } from 'react'
 
 import { cn } from '@/lib/utils'
+
+export type HtmlContentVariant = 'inline' | 'isolated'
 
 interface HtmlContentProps {
   content: string
   className?: string
+  variant?: HtmlContentVariant
+}
+
+const isolatedContentSandbox =
+  'allow-forms allow-popups allow-popups-to-escape-sandbox allow-presentation'
+
+const isolatedContentBaseStyles = `
+<style>
+  :host {
+    display: block;
+    width: 100%;
+    color: inherit;
+    font: inherit;
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  img,
+  video,
+  iframe {
+    max-width: 100%;
+  }
+
+  iframe {
+    border: 0;
+  }
+</style>
+`
+
+const isolatedSanitizeOptions = {
+  ADD_ATTR: [
+    'allowfullscreen',
+    'autoplay',
+    'class',
+    'controls',
+    'default',
+    'id',
+    'kind',
+    'label',
+    'loading',
+    'loop',
+    'muted',
+    'playsinline',
+    'poster',
+    'preload',
+    'referrerpolicy',
+    'rel',
+    'srclang',
+    'style',
+    'target',
+  ],
+  ADD_TAGS: ['audio', 'iframe', 'picture', 'source', 'style', 'track', 'video'],
+  FORBID_ATTR: ['srcdoc'],
+  FORBID_TAGS: ['base', 'embed', 'link', 'meta', 'object', 'script'],
+  FORCE_BODY: true,
+} satisfies Config
+
+function hardenIsolatedHtml(html: string): string {
+  if (typeof document === 'undefined') {
+    return html
+  }
+
+  const template = document.createElement('template')
+  template.innerHTML = html
+
+  template.content.querySelectorAll('a[target="_blank"]').forEach((link) => {
+    const rel = new Set(
+      link
+        .getAttribute('rel')
+        ?.split(/\s+/)
+        .filter(Boolean) ?? []
+    )
+
+    rel.add('noopener')
+    rel.add('noreferrer')
+    link.setAttribute('rel', [...rel].join(' '))
+  })
+
+  template.content.querySelectorAll('iframe').forEach((frame) => {
+    frame.removeAttribute('srcdoc')
+    frame.setAttribute('sandbox', isolatedContentSandbox)
+    frame.setAttribute('referrerpolicy', 'no-referrer')
+
+    if (!frame.hasAttribute('loading')) {
+      frame.setAttribute('loading', 'lazy')
+    }
+  })
+
+  return template.innerHTML
+}
+
+function sanitizeHtmlContent(
+  content: string,
+  variant: HtmlContentVariant
+): string {
+  if (variant === 'isolated') {
+    const html = DOMPurify.sanitize(content, isolatedSanitizeOptions)
+
+    return hardenIsolatedHtml(html)
+  }
+
+  return DOMPurify.sanitize(content)
+}
+
+function IsolatedHtmlContent(props: {
+  className?: string
+  html: string
+}): React.ReactElement {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const shadowRoot =
+      container.shadowRoot ?? container.attachShadow({ mode: 'open' })
+    shadowRoot.innerHTML = `${isolatedContentBaseStyles}${props.html}`
+  }, [props.html])
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn('block w-full', props.className)}
+    />
+  )
 }
 
 export function HtmlContent(props: HtmlContentProps) {
-  // 放宽 DOMPurify 限制，允许管理员设置的内联样式、class 和 id，避免自定义 HTML 样式丢失
+  const variant = props.variant ?? 'inline'
   const html = useMemo(
-    () =>
-      DOMPurify.sanitize(props.content, {
-        ADD_ATTR: ['class', 'style', 'id', 'target', 'rel'],
-        ADD_TAGS: ['style', 'iframe', 'video', 'audio', 'source'],
-        FORCE_BODY: true,
-      }),
-    [props.content]
+    () => sanitizeHtmlContent(props.content, variant),
+    [props.content, variant]
   )
+
+  if (variant === 'isolated') {
+    return <IsolatedHtmlContent className={props.className} html={html} />
+  }
 
   return (
     <div

--- a/web/default/src/components/rich-content.tsx
+++ b/web/default/src/components/rich-content.tsx
@@ -16,7 +16,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { HtmlContent } from '@/components/html-content'
+import {
+  HtmlContent,
+  type HtmlContentVariant,
+} from '@/components/html-content'
 import { Markdown } from '@/components/ui/markdown'
 
 type RichContentMode = 'markdown' | 'html'
@@ -26,11 +29,18 @@ interface RichContentProps {
   mode?: RichContentMode
   breaks?: boolean
   className?: string
+  htmlVariant?: HtmlContentVariant
 }
 
 export function RichContent(props: RichContentProps) {
   if (props.mode === 'html') {
-    return <HtmlContent content={props.content} className={props.className} />
+    return (
+      <HtmlContent
+        content={props.content}
+        className={props.className}
+        variant={props.htmlVariant}
+      />
+    )
   }
 
   return (

--- a/web/default/src/features/about/index.tsx
+++ b/web/default/src/features/about/index.tsx
@@ -122,6 +122,7 @@ export function About() {
   const rawContent = data?.data?.trim() ?? ''
   const hasContent = rawContent.length > 0
   const isUrl = hasContent && isHttpUrl(rawContent)
+  const contentIsHtml = hasContent && isLikelyHtml(rawContent)
 
   if (isLoading) {
     return (
@@ -157,11 +158,24 @@ export function About() {
     )
   }
 
+  if (contentIsHtml) {
+    return (
+      <PublicLayout showMainContainer={false}>
+        <RichContent
+          mode='html'
+          htmlVariant='isolated'
+          content={rawContent}
+          className='prose-neutral dark:prose-invert max-w-none'
+        />
+      </PublicLayout>
+    )
+  }
+
   return (
     <PublicLayout>
-      <div className={isLikelyHtml(rawContent) ? 'w-full' : 'mx-auto max-w-6xl px-4 py-8'}>
+      <div className='mx-auto max-w-6xl px-4 py-8'>
         <RichContent
-          mode={isLikelyHtml(rawContent) ? 'html' : 'markdown'}
+          mode='markdown'
           content={rawContent}
           className='prose-neutral dark:prose-invert max-w-none'
         />

--- a/web/default/src/features/about/index.tsx
+++ b/web/default/src/features/about/index.tsx
@@ -159,7 +159,7 @@ export function About() {
 
   return (
     <PublicLayout>
-      <div className='mx-auto max-w-6xl px-4 py-8'>
+      <div className={isLikelyHtml(rawContent) ? 'w-full' : 'mx-auto max-w-6xl px-4 py-8'}>
         <RichContent
           mode={isLikelyHtml(rawContent) ? 'html' : 'markdown'}
           content={rawContent}

--- a/web/default/src/features/home/index.tsx
+++ b/web/default/src/features/home/index.tsx
@@ -59,7 +59,7 @@ export function Home() {
 
     return (
       <PublicLayout>
-        <div className='mx-auto max-w-6xl px-4 py-8'>
+        <div className={isLikelyHtml(content) ? 'w-full' : 'mx-auto max-w-6xl px-4 py-8'}>
           <RichContent
             mode={isLikelyHtml(content) ? 'html' : 'markdown'}
             content={content}

--- a/web/default/src/features/home/index.tsx
+++ b/web/default/src/features/home/index.tsx
@@ -57,11 +57,26 @@ export function Home() {
       )
     }
 
+    const contentIsHtml = isLikelyHtml(content)
+
+    if (contentIsHtml) {
+      return (
+        <PublicLayout showMainContainer={false}>
+          <RichContent
+            mode='html'
+            htmlVariant='isolated'
+            content={content}
+            className='custom-home-content'
+          />
+        </PublicLayout>
+      )
+    }
+
     return (
       <PublicLayout>
-        <div className={isLikelyHtml(content) ? 'w-full' : 'mx-auto max-w-6xl px-4 py-8'}>
+        <div className='mx-auto max-w-6xl px-4 py-8'>
           <RichContent
-            mode={isLikelyHtml(content) ? 'html' : 'markdown'}
+            mode='markdown'
             content={content}
             className='custom-home-content'
           />

--- a/web/default/src/features/legal/legal-document.tsx
+++ b/web/default/src/features/legal/legal-document.tsx
@@ -122,18 +122,25 @@ export function LegalDocument({
   }
 
   return (
-    <PublicLayout>
-      <div className='mx-auto max-w-4xl space-y-6 py-12'>
-        <div className='space-y-2'>
-          <h1 className='text-3xl font-semibold tracking-tight'>{title}</h1>
-        </div>
-
+    <PublicLayout showMainContainer={!isLikelyHtml(rawContent)}>
+      {isLikelyHtml(rawContent) ? (
         <RichContent
-          mode={isLikelyHtml(rawContent) ? 'html' : 'markdown'}
+          mode='html'
           content={rawContent}
-          className='prose-neutral dark:prose-invert max-w-none'
         />
-      </div>
+      ) : (
+        <div className='mx-auto max-w-4xl space-y-6 py-12'>
+          <div className='space-y-2'>
+            <h1 className='text-3xl font-semibold tracking-tight'>{title}</h1>
+          </div>
+
+          <RichContent
+            mode='markdown'
+            content={rawContent}
+            className='prose-neutral dark:prose-invert max-w-none'
+          />
+        </div>
+      )}
     </PublicLayout>
   )
 }

--- a/web/default/src/features/legal/legal-document.tsx
+++ b/web/default/src/features/legal/legal-document.tsx
@@ -52,6 +52,7 @@ export function LegalDocument({
   const rawContent = data?.data?.trim() ?? ''
   const hasContent = rawContent.length > 0
   const isUrl = hasContent && isHttpUrl(rawContent)
+  const contentIsHtml = hasContent && isLikelyHtml(rawContent)
   const success = data?.success ?? false
 
   if (isLoading) {
@@ -122,10 +123,11 @@ export function LegalDocument({
   }
 
   return (
-    <PublicLayout showMainContainer={!isLikelyHtml(rawContent)}>
-      {isLikelyHtml(rawContent) ? (
+    <PublicLayout showMainContainer={!contentIsHtml}>
+      {contentIsHtml ? (
         <RichContent
           mode='html'
+          htmlVariant='isolated'
           content={rawContent}
         />
       ) : (


### PR DESCRIPTION
### What problem does this PR solve?

在最近的更新中（如引入 DOMPurify 清理以及修改容器布局），导致管理员在后台配置的自定义富文本 HTML 出现严重显示问题：
1. **样式丢失**：DOMPurify 的默认行为过度清理了自定义 HTML 中的 class、style、id 属性以及 <style> 标签，导致自定义页面的样式完全失效。
2. **排版受限**：在 home、bout 以及法律文档页面，外层被强加了宽度限制（如 max-w-6xl）和较宽的内边距（如 py-8、py-12）。这导致管理员自己编写的 HTML 页面无法实现全屏布局，且会产生巨大的上下多余空白。

### What is changed and how it works?

1. **放宽 DOMPurify 限制**：在 HtmlContent 组件中放开对 class, style, id 等属性以及 style, iframe, ideo 等常用标签的过滤，恢复管理员正常的自定义样式渲染能力。
2. **释放自定义 HTML 布局空间**：在 home/index.tsx、bout/index.tsx 和 legal/legal-document.tsx 中增加判断。当系统检测到内容为自定义 HTML（isLikelyHtml）时，自动解除外层容器的宽度限制与多余内边距，将排版自由完全交还给用户。
