### PR TITLE
fix(playground): don't enable top_p by default (avoid sending temperature + top_p together)

### DIFF
--- a/web/default/src/features/playground/constants.ts
+++ b/web/default/src/features/playground/constants.ts
@@ -58,7 +58,7 @@ export const DEFAULT_CONFIG: PlaygroundConfig = {
 
 export const DEFAULT_PARAMETER_ENABLED: ParameterEnabled = {
   temperature: true,
-  top_p: true,
+  top_p: false,
   max_tokens: false,
   frequency_penalty: true,
   presence_penalty: true,


### PR DESCRIPTION
## Problem

In the default frontend playground, every chat request includes **both** `temperature` and `top_p`, because `DEFAULT_PARAMETER_ENABLED` enables both:

```ts
export const DEFAULT_PARAMETER_ENABLED: ParameterEnabled = {
  temperature: true,
  top_p: true,
  ...
}
```

`lib/streaming/payload-builder.ts` adds a parameter to the payload whenever its flag is `true`, so out of the box the playground always sends `temperature` + `top_p` together. Some upstream providers reject requests that specify both, so the playground can fail by default.

The default frontend currently has no parameter settings panel, so users cannot toggle this off from the UI to work around it.

## Fix

Disable `top_p` by default (send only `temperature`), following the common guidance to adjust one of `temperature` / `top_p` but not both. Behavior is unchanged for the other parameters.

## Note

The classic frontend's parameter settings panel (`SettingsPanel` / `ParameterControl`) does not appear to be ported to the default frontend `features/playground`, so there is currently no UI to re-enable/toggle these flags. Restoring that panel seems worth tracking separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default parameter visibility in the playground so `top_p` is no longer enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->