### PR TITLE
fix(model-pricing): 修复可视化定价删除模型后无法保存

### DIFF
--- a/web/default/src/features/system-settings/models/model-ratio-form.tsx
+++ b/web/default/src/features/system-settings/models/model-ratio-form.tsx
@@ -203,17 +203,15 @@ export const ModelRatioForm = memo(function ModelRatioForm({
           <RotateCcw data-icon='inline-start' />
           {t('Reset prices')}
         </Button>
-        {editMode === 'json' && (
-          <Button
-            type='button'
-            size='sm'
-            onClick={handleSave}
-            disabled={isSaving}
-          >
-            <Save data-icon='inline-start' />
-            {isSaving ? t('Saving...') : t('Save model prices')}
-          </Button>
-        )}
+        <Button
+          type='button'
+          size='sm'
+          onClick={handleSave}
+          disabled={isSaving}
+        >
+          <Save data-icon='inline-start' />
+          {isSaving ? t('Saving...') : t('Save model prices')}
+        </Button>
         <Button variant='outline' size='sm' onClick={toggleEditMode}>
           {editMode === 'visual' ? (
             <>


### PR DESCRIPTION
## 📝 变更描述 / Description

可视化模型定价中，"保存模型价格"按钮原本只在 JSON 模式的顶部工具栏显示；可视化模式下唯一的保存入口位于右侧编辑面板内，而该面板仅在打开某个模型进行编辑时才渲染。

因此删除模型后（若删除的正是正在编辑的那一行，编辑面板还会被关闭）就没有任何保存按钮，必须再点开另一个模型重新唤出编辑面板才能拿到保存按钮完成保存。

**修复逻辑**：让顶部工具栏的"保存模型价格"按钮在可视化与 JSON 两种模式下都常驻显示。该按钮绑定的 handleSave 在可视化模式下会先提交已打开编辑器的草稿、再提交表单，因此删除等改动可被正确保存。


## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- Closes #5809

## ✅ 提交前检查项 / Checklist
- [x] **非重复提交**
- [x] **变更理解**
- [x] **范围聚焦**：本 PR 仅含该按钮显隐改动
- [x] **安全合规**

## 📸 运行证明 / Proof of Work
<img width="1336" height="782" alt="image" src="https://github.com/user-attachments/assets/1ee5210a-f358-4dd5-a7c6-01659049dc0d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent **Save model prices** button in system settings, making saving available in both visual and JSON editing modes.
* **Bug Fixes**
  * Improved save behavior so changes are properly committed before submission, and the button is disabled while saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->