### PR TITLE
docs: fix typos in comments and messages

### DIFF
--- a/common/go-channel.go
+++ b/common/go-channel.go
@@ -6,7 +6,7 @@ import (
 
 func SafeSendBool(ch chan bool, value bool) (closed bool) {
 	defer func() {
-		// Recover from panic if one occured. A panic would mean the channel was closed.
+		// Recover from panic if one occurred. A panic would mean the channel was closed.
 		if recover() != nil {
 			closed = true
 		}
@@ -21,7 +21,7 @@ func SafeSendBool(ch chan bool, value bool) (closed bool) {
 
 func SafeSendString(ch chan string, value string) (closed bool) {
 	defer func() {
-		// Recover from panic if one occured. A panic would mean the channel was closed.
+		// Recover from panic if one occurred. A panic would mean the channel was closed.
 		if recover() != nil {
 			closed = true
 		}
@@ -37,7 +37,7 @@ func SafeSendString(ch chan string, value string) (closed bool) {
 // SafeSendStringTimeout send, return true, else return false
 func SafeSendStringTimeout(ch chan string, value string, timeout int) (closed bool) {
 	defer func() {
-		// Recover from panic if one occured. A panic would mean the channel was closed.
+		// Recover from panic if one occurred. A panic would mean the channel was closed.
 		if recover() != nil {
 			closed = false
 		}

--- a/common/utils.go
+++ b/common/utils.go
@@ -317,7 +317,7 @@ func Any2Type[T any](data any) (T, error) {
 	return res, nil
 }
 
-// SaveTmpFile saves data to a temporary file. The filename would be apppended with a random string.
+// SaveTmpFile saves data to a temporary file. The filename is appended with a random string.
 func SaveTmpFile(filename string, data io.Reader) (string, error) {
 	f, err := os.CreateTemp(os.TempDir(), filename)
 	if err != nil {

--- a/controller/swag_video.go
+++ b/controller/swag_video.go
@@ -13,7 +13,7 @@ import (
 // @Tags Video
 // @Accept json
 // @Produce json
-// @Param Authorization header string true "用户认证令牌 (Aeess-Token: sk-xxxx)"
+// @Param Authorization header string true "用户认证令牌 (Access-Token: sk-xxxx)"
 // @Param request body dto.VideoRequest true "视频生成请求参数"
 // @Failure 400 {object} dto.OpenAIError "请求参数错误"
 // @Failure 401 {object} dto.OpenAIError "未授权"
@@ -46,7 +46,7 @@ func VideoGenerationsTaskId(c *gin.Context) {
 // @Tags Video
 // @Accept json
 // @Produce json
-// @Param Authorization header string true "用户认证令牌 (Aeess-Token: sk-xxxx)"
+// @Param Authorization header string true "用户认证令牌 (Access-Token: sk-xxxx)"
 // @Param request body KlingText2VideoRequest true "视频生成请求参数"
 // @Success 200 {object} dto.VideoTaskResponse "任务状态和结果"
 // @Failure 400 {object} dto.OpenAIError "请求参数错误"
@@ -90,7 +90,7 @@ type KlingCameraConfig struct {
 // @Tags Video
 // @Accept json
 // @Produce json
-// @Param Authorization header string true "用户认证令牌 (Aeess-Token: sk-xxxx)"
+// @Param Authorization header string true "用户认证令牌 (Access-Token: sk-xxxx)"
 // @Param request body KlingImage2VideoRequest true "图生视频请求参数"
 // @Success 200 {object} dto.VideoTaskResponse "任务状态和结果"
 // @Failure 400 {object} dto.OpenAIError "请求参数错误"

--- a/relay/helper/valid_request.go
+++ b/relay/helper/valid_request.go
@@ -198,7 +198,7 @@ func GetAndValidOpenAIImageRequest(c *gin.Context, relayMode int) (*dto.ImageReq
 		}
 
 		if strings.Contains(imageRequest.Size, "×") {
-			return nil, errors.New("size an unexpected error occurred in the parameter, please use 'x' instead of the multiplication sign '×'")
+			return nil, errors.New("size parameter must use 'x' instead of the multiplication sign '×'")
 		}
 
 		// Not "256x256", "512x512", or "1024x1024"


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
Fix several small typos in comments, Swagger documentation, and an image size validation error message. These changes do not alter API behavior; they improve generated documentation and make an existing validation message clearer.

AI-assisted: this PR was prepared with Codex assistance because the current git author is not one of the repository's recurring core developers.

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [x] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- N/A

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```text
GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache go test ./common ./relay/helper ./controller
ok  github.com/QuantumNous/new-api/common        11.204s
ok  github.com/QuantumNous/new-api/relay/helper 3.862s
ok  github.com/QuantumNous/new-api/controller   0.454s
```

Also verified the original typo patterns no longer appear in the touched files:

```text
rg -n 'Aeess-Token|occured|apppended|size an unexpected error occurred' common/go-channel.go common/utils.go controller/swag_video.go relay/helper/valid_request.go
# no matches
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected several comments and API descriptions for clearer wording.
  * Updated Swagger documentation to show the correct token header name.
* **Bug Fixes**
  * Improved an image request validation message so invalid size values now return a clearer, more accurate error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->