### PR TITLE
fix: avoid counting failed requests toward success rate limit

### DIFF
--- a/common/rate-limit.go
+++ b/common/rate-limit.go
@@ -68,3 +68,21 @@ func (l *InMemoryRateLimiter) Request(key string, maxRequestNum int, duration in
 	}
 	return true
 }
+
+// Allow 检查当前请求是否会被允许，但不写入计数。
+// duration 参数单位为秒。
+func (l *InMemoryRateLimiter) Allow(key string, maxRequestNum int, duration int64) bool {
+	if maxRequestNum <= 0 {
+		return true
+	}
+
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	queue, ok := l.store[key]
+	if !ok || len(*queue) < maxRequestNum {
+		return true
+	}
+
+	return time.Now().Unix()-(*queue)[0] >= duration
+}

--- a/middleware/model-rate-limit.go
+++ b/middleware/model-rate-limit.go
@@ -145,9 +145,7 @@ func memoryRateLimitHandler(duration int64, totalMaxCount, successMaxCount int) 
 		}
 
 		// 2. 检查成功请求数限制
-		// 使用一个临时key来检查限制，这样可以避免实际记录
-		checkKey := successKey + "_check"
-		if !inMemoryRateLimiter.Request(checkKey, successMaxCount, duration) {
+		if successMaxCount > 0 && !inMemoryRateLimiter.Allow(successKey, successMaxCount, duration) {
 			c.Status(http.StatusTooManyRequests)
 			c.Abort()
 			return
@@ -157,7 +155,7 @@ func memoryRateLimitHandler(duration int64, totalMaxCount, successMaxCount int) 
 		c.Next()
 
 		// 4. 如果请求成功，记录到实际的成功请求计数中
-		if c.Writer.Status() < 400 {
+		if successMaxCount > 0 && c.Writer.Status() < 400 {
 			inMemoryRateLimiter.Request(successKey, successMaxCount, duration)
 		}
 	}

--- a/middleware/model-rate-limit_test.go
+++ b/middleware/model-rate-limit_test.go
@@ -1,0 +1,66 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/setting"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetModelRateLimitTestState(t *testing.T) {
+	t.Helper()
+	originalMode := gin.Mode()
+	originalDurationMinutes := setting.ModelRequestRateLimitDurationMinutes
+	gin.SetMode(gin.TestMode)
+	inMemoryRateLimiter = common.InMemoryRateLimiter{}
+	t.Cleanup(func() {
+		gin.SetMode(originalMode)
+		setting.ModelRequestRateLimitDurationMinutes = originalDurationMinutes
+		inMemoryRateLimiter = common.InMemoryRateLimiter{}
+	})
+}
+
+func performModelRateLimitRequest(handler gin.HandlerFunc, status int) *httptest.ResponseRecorder {
+	router := gin.New()
+	router.GET("/", func(c *gin.Context) {
+		c.Set("id", 123)
+		handler(c)
+	}, func(c *gin.Context) {
+		c.Status(status)
+	})
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+	return recorder
+}
+
+func TestMemoryModelRateLimitFailedRequestsDoNotConsumeSuccessLimit(t *testing.T) {
+	resetModelRateLimitTestState(t)
+	setting.ModelRequestRateLimitDurationMinutes = 1
+	handler := memoryRateLimitHandler(60, 0, 1)
+
+	failed := performModelRateLimitRequest(handler, http.StatusInternalServerError)
+	require.Equal(t, http.StatusInternalServerError, failed.Code)
+
+	firstSuccess := performModelRateLimitRequest(handler, http.StatusOK)
+	require.Equal(t, http.StatusOK, firstSuccess.Code)
+
+	secondSuccess := performModelRateLimitRequest(handler, http.StatusOK)
+	assert.Equal(t, http.StatusTooManyRequests, secondSuccess.Code)
+}
+
+func TestMemoryModelRateLimitZeroSuccessLimitIsUnlimited(t *testing.T) {
+	resetModelRateLimitTestState(t)
+	setting.ModelRequestRateLimitDurationMinutes = 1
+	handler := memoryRateLimitHandler(60, 0, 0)
+
+	firstSuccess := performModelRateLimitRequest(handler, http.StatusOK)
+	require.Equal(t, http.StatusOK, firstSuccess.Code)
+
+	secondSuccess := performModelRateLimitRequest(handler, http.StatusOK)
+	assert.Equal(t, http.StatusOK, secondSuccess.Code)
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本 PR 为 AI 辅助完成；以下描述已按实际代码逻辑整理。

## 📝 变更描述 / Description
内存模式下，模型“成功请求数”限流在请求执行前会先检查是否超限。原实现用临时 key 调用 `Request` 做检查，但 `Request` 本身会写入计数，所以失败请求也会消耗这次预检查额度，导致后续成功请求可能被提前拒绝。

本 PR 为内存限流器补充只检查、不写入的 `Allow` 方法，并在成功请求限流预检查中使用它。请求处理完成后，只有响应状态码小于 400 时才写入成功请求计数。

同时补齐 `successMaxCount == 0` 的语义：内存模式会跳过成功请求限流检查和记录，保持与 Redis 分支一致，表示不限制成功请求数。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5815

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```text
GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache go test ./common ./middleware
ok  	github.com/QuantumNous/new-api/common	(cached)
ok  	github.com/QuantumNous/new-api/middleware	(cached)
```