### PR TITLE
fix: close response bodies on non-OK responses

### DIFF
--- a/controller/channel-billing.go
+++ b/controller/channel-billing.go
@@ -136,7 +136,7 @@ func GetClaudeAuthHeader(token string) http.Header {
 	return h
 }
 
-func GetResponseBody(method, url string, channel *model.Channel, headers http.Header) ([]byte, error) {
+func GetResponseBody(method, url string, channel *model.Channel, headers http.Header) (body []byte, err error) {
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, err
@@ -152,14 +152,15 @@ func GetResponseBody(method, url string, channel *model.Channel, headers http.He
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if closeErr := res.Body.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}()
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("status code: %d", res.StatusCode)
 	}
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-	err = res.Body.Close()
+	body, err = io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/channel.go
+++ b/controller/channel.go
@@ -1241,6 +1241,7 @@ func FetchModels(c *gin.Context) {
 		})
 		return
 	}
+	defer response.Body.Close()
 	//check status code
 	if response.StatusCode != http.StatusOK {
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -1249,7 +1250,6 @@ func FetchModels(c *gin.Context) {
 		})
 		return
 	}
-	defer response.Body.Close()
 
 	var result struct {
 		Data []struct {

--- a/service/task_polling.go
+++ b/service/task_polling.go
@@ -243,11 +243,11 @@ func updateSunoTasks(ctx context.Context, channelId int, taskIds []string, taskM
 		common.SysLog(fmt.Sprintf("Get Task Do req error: %v", err))
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		logger.LogError(ctx, fmt.Sprintf("Get Task status code: %d", resp.StatusCode))
 		return fmt.Errorf("Get Task status code: %d", resp.StatusCode)
 	}
-	defer resp.Body.Close()
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		common.SysLog(fmt.Sprintf("Get Suno Task parse body error: %v", err))

--- a/service/task_polling_test.go
+++ b/service/task_polling_test.go
@@ -27,6 +27,8 @@ type taskPollingFetchAdaptor struct {
 	blockStarted chan struct{}
 	releaseBlock chan struct{}
 	blockOnce    sync.Once
+	statusCode   int
+	body         io.ReadCloser
 }
 
 func (a *taskPollingFetchAdaptor) Init(_ *relaycommon.RelayInfo) {}
@@ -51,6 +53,16 @@ func (a *taskPollingFetchAdaptor) FetchTask(_ string, _ string, body map[string]
 		default:
 		}
 	}
+	statusCode := a.statusCode
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	if a.body != nil {
+		return &http.Response{
+			StatusCode: statusCode,
+			Body:       a.body,
+		}, nil
+	}
 
 	response := dto.TaskResponse[model.Task]{
 		Code: dto.TaskSuccessCode,
@@ -65,7 +77,7 @@ func (a *taskPollingFetchAdaptor) FetchTask(_ string, _ string, body map[string]
 		return nil, err
 	}
 	return &http.Response{
-		StatusCode: http.StatusOK,
+		StatusCode: statusCode,
 		Body:       io.NopCloser(bytes.NewReader(responseBody)),
 	}, nil
 }
@@ -90,14 +102,29 @@ func (a *taskPollingFetchAdaptor) fetchedTaskIDs() []string {
 	return append([]string(nil), a.taskIDs...)
 }
 
+type closeTrackingReadCloser struct {
+	closed bool
+}
+
+func (b *closeTrackingReadCloser) Read(_ []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (b *closeTrackingReadCloser) Close() error {
+	b.closed = true
+	return nil
+}
+
 func seedTaskPollingChannel(t *testing.T, id int, disableSleep bool) {
 	t.Helper()
+	baseURL := "http://example.test"
 	ch := &model.Channel{
-		Id:     id,
-		Type:   constant.ChannelTypeKling,
-		Name:   "polling_channel",
-		Key:    "sk-test",
-		Status: common.ChannelStatusEnabled,
+		Id:      id,
+		Type:    constant.ChannelTypeKling,
+		Name:    "polling_channel",
+		Key:     "sk-test",
+		Status:  common.ChannelStatusEnabled,
+		BaseURL: &baseURL,
 	}
 	if disableSleep {
 		ch.SetOtherSettings(dto.ChannelOtherSettings{DisableTaskPollingSleep: true})
@@ -123,6 +150,29 @@ func seedPollingTask(t *testing.T, channelID int, publicID string, upstreamID st
 	}
 	require.NoError(t, model.DB.Create(task).Error)
 	return task
+}
+
+func TestUpdateSunoTasksClosesNonOKResponseBody(t *testing.T) {
+	truncate(t)
+
+	const channelID = 1001
+	seedTaskPollingChannel(t, channelID, true)
+	task := seedPollingTask(t, channelID, "suno_public_non_ok", "suno_upstream_non_ok")
+	body := &closeTrackingReadCloser{}
+	adaptor := &taskPollingFetchAdaptor{
+		statusCode: http.StatusInternalServerError,
+		body:       body,
+	}
+	previousFactory := GetTaskAdaptorFunc
+	GetTaskAdaptorFunc = func(constant.TaskPlatform) TaskPollingAdaptor { return adaptor }
+	t.Cleanup(func() { GetTaskAdaptorFunc = previousFactory })
+
+	err := updateSunoTasks(context.Background(), channelID, []string{task.GetUpstreamTaskID()}, map[string]*model.Task{
+		task.GetUpstreamTaskID(): task,
+	})
+
+	require.Error(t, err)
+	assert.True(t, body.closed)
 }
 
 func TestUpdateVideoTasksDefaultSleepWaitsBetweenTasks(t *testing.T) {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本 PR 为 AI 辅助完成；以下描述已按实际代码逻辑整理。

## 📝 变更描述 / Description
部分 HTTP 请求路径在 `client.Do(req)` 成功后，会先判断上游响应状态码是否为 200，再延后执行 `defer resp.Body.Close()`。如果上游可达但返回 401、429、500 等非 200 响应，函数会直接返回错误，导致该响应体没有及时关闭。

本 PR 将这些路径的 `defer resp.Body.Close()` 移到确认 `client.Do` 成功之后，保证后续所有错误返回分支都会关闭 response body。

覆盖的路径包括：

- 渠道余额查询辅助函数的非 200 响应分支。
- Suno 任务轮询的非 200 响应分支。
- 拉取渠道模型列表的非 200 响应分支。

同时补充了 Suno 轮询的回归测试：构造一个返回 500 的 fake response body，断言函数返回错误时仍会调用 `Close()`。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5816

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```text
GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache go test ./service -run TestUpdateSunoTasksClosesNonOKResponseBody
ok  	github.com/QuantumNous/new-api/service	0.104s

GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache go test ./service ./controller
ok  	github.com/QuantumNous/new-api/service	0.744s
ok  	github.com/QuantumNous/new-api/controller	(cached)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when fetching models and polling tasks by handling HTTP responses more consistently.
  * Fixed response handling so failed requests are cleaned up properly, reducing the risk of hangs or resource issues.
  * Added coverage for error-response handling to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->