### PR TITLE
fix(relay/codex): force stream=true on /v1/responses

### DIFF
--- a/relay/channel/codex/adaptor.go
+++ b/relay/channel/codex/adaptor.go
@@ -14,6 +14,7 @@ import (
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/types"
+	"github.com/samber/lo"
 
 	"github.com/gin-gonic/gin"
 )
@@ -98,6 +99,14 @@ func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommo
 
 	if isCompact {
 		return request, nil
+	}
+	// Codex upstream (chatgpt.com/backend-api/codex/responses) only accepts
+	// streaming requests and rejects with 400 "Stream must be set to true"
+	// otherwise. Force it here so every call path (manual test, batch test,
+	// playground, third-party clients) honors the upstream contract.
+	request.Stream = lo.ToPtr(true)
+	if info != nil {
+		info.IsStream = true
 	}
 	// codex: store must be false
 	request.Store = json.RawMessage("false")


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 摘要由人工整理；改动在 Claude 协助下完成（详见下方"AI 协助说明"）。

## 📝 变更描述 / Description

Codex 渠道（`ChannelTypeCodex=57`）走 `chatgpt.com/backend-api/codex/responses`，上游只接受流式请求，缺少 `"stream": true` 会返回 HTTP 400 `Stream must be set to true`。

`#4325` 已经让"批量自动测试"路径强制使用 stream，但**手动测试按钮**路径漏了：前端测试弹窗默认 `Stream Mode` 开关关闭时，`stream` query 参数未发送，后端 `strconv.ParseBool` 解析为空→`false`，`buildTestRequest` 拼出 `Stream: lo.ToPtr(false)`，导致手动测试必然 400。

把强制 `stream=true` 的逻辑下沉到 codex 适配器（`relay/channel/codex/adaptor.go:103-110`），让所有调用路径（手动测试、批量测试、playground、第三方客户端）都符合上游契约。同时把 `info.IsStream` 同步置 `true`，避免 `DoResponse` 把 SSE 响应按非流式 JSON 解析。

`/v1/responses/compact` 端点不在此约束范围内，因此保留原有行为。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - 关联 PR #4325

## 🔗 关联任务 / Related Issue
- Follow-up to #4325 (`fix: use stream for codex auto test`)
- 现象：手动测试 Codex 渠道时收到 `400 Stream must be set to true`

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已搜索现有 Issues/PRs，确认是 #4325 的延续修复，非重复提交。
- [x] **Bug fix 说明:** 配套 #4325，明确指向同一上游契约的另一切面，不归类为设计取舍或理解偏差。
- [x] **变更理解:** 在 Codex 渠道适配器层强制 stream=true，覆盖所有调用路径；同步 `info.IsStream` 避免响应解析错误。
- [x] **范围聚焦:** 仅修改 `relay/channel/codex/adaptor.go` 一个文件、9 行新增。
- [x] **本地验证:** 因本地无 Go toolchain，未运行 `go test`；改动面小且正交，参考 #4325 同一文件同类改动可由维护者快速复核。
- [x] **安全合规:** 代码中无敏感凭据；`codex_key.json` 等本地调试文件未入库。

## 📸 运行证明 / Proof of Work

调用路径推导（`controller/channel-test.go:75-152` → `controller/channel-test.go:695-756` → `relay/responses_handler.go:81-86` → `relay/channel/codex/adaptor.go:56-117`）：

- **修复前**：手动测试 `Stream Mode=off` → `isStream=false` → `request.Stream=*bool{false}` → 上游 400
- **修复后**：`request.Stream=lo.ToPtr(true)` 由 codex 适配器无条件覆盖 → 上游接受

## 🤖 AI 协助说明 / AI Assistance Disclosure

本次改动由 Claude（Anthropic）协助完成：
- 定位根因（手动测试路径漏了 stream 强制）
- 设计修复方案（适配器层强制而非调用方补丁）
- 实现 9 行改动
- 起草 PR 描述

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex “responses (non-compact)” handling by automatically enabling streaming mode for these requests.
  * When stream-related metadata is provided, the system now marks it as streaming to stay consistent with upstream expectations, reducing request rejections while preserving existing response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->