### PR TITLE
fix(playground): filter model list by selected group (#5818)

### DIFF
--- a/web/default/src/components/model-group-selector.tsx
+++ b/web/default/src/components/model-group-selector.tsx
@@ -545,6 +545,7 @@ export interface ModelGroupSelectorProps {
   // Common props
   className?: string
   disabled?: boolean
+  isModelLoading?: boolean
 }
 
 /**
@@ -560,6 +561,7 @@ export const ModelGroupSelector: React.FC<ModelGroupSelectorProps> = ({
   onGroupChange,
   className,
   disabled = false,
+  isModelLoading = false,
 }) => {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
@@ -673,6 +675,67 @@ export const ModelGroupSelector: React.FC<ModelGroupSelectorProps> = ({
     </div>
   )
 
+  const renderLoadingContent = () => (
+    <div className='text-muted-foreground flex items-center justify-center px-3 py-8 text-[12px] leading-5'>
+      <svg
+        aria-hidden='true'
+        className='mr-2 size-4 animate-spin'
+        fill='none'
+        viewBox='0 0 24 24'
+      >
+        <circle
+          className='opacity-25'
+          cx='12'
+          cy='12'
+          r='10'
+          stroke='currentColor'
+          strokeWidth='4'
+        />
+        <path
+          className='opacity-75'
+          d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z'
+          fill='currentColor'
+        />
+      </svg>
+      {t('Loading models...')}
+    </div>
+  )
+
+  const renderEmptyContent = () => (
+    <div className='text-muted-foreground px-3 py-8 text-center text-[12px] leading-5'>
+      {t('No model found.')}
+    </div>
+  )
+
+  const renderModelItemsContent = () => (
+    <CommandGroup className='p-1'>
+      {filteredModels.map((model) => (
+        <CommandItem
+          className='mb-0.5 flex items-center justify-between rounded-md px-2 py-1.5 text-[12px] leading-4 transition-colors'
+          key={model.value}
+          onSelect={handleModelChange}
+          value={model.value}
+        >
+          <span className='min-w-0 truncate font-medium'>
+            {model.label}
+          </span>
+          <Check
+            className={cn(
+              'size-3.5 shrink-0',
+              selectedModel === model.value ? 'opacity-100' : 'opacity-0'
+            )}
+          />
+        </CommandItem>
+      ))}
+    </CommandGroup>
+  )
+
+  const renderModelListContent = () => {
+    if (isModelLoading) return renderLoadingContent()
+    if (filteredModels.length === 0) return renderEmptyContent()
+    return renderModelItemsContent()
+  }
+
   const renderModelList = () => (
     <Command
       className='min-w-0 rounded-lg border-0 bg-transparent p-1'
@@ -681,37 +744,13 @@ export const ModelGroupSelector: React.FC<ModelGroupSelectorProps> = ({
     >
       <CommandInput
         className='h-8 text-[13px]'
+        disabled={isModelLoading}
         onValueChange={setSearchQuery}
         placeholder={t('Search models...')}
         value={searchQuery}
       />
       <CommandList className={isMobile ? 'max-h-[45vh]' : 'max-h-[20rem]'}>
-        {filteredModels.length === 0 ? (
-          <div className='text-muted-foreground px-3 py-8 text-center text-[12px] leading-5'>
-            {t('No model found.')}
-          </div>
-        ) : (
-          <CommandGroup className='p-1'>
-            {filteredModels.map((model) => (
-              <CommandItem
-                className='mb-0.5 flex items-center justify-between rounded-md px-2 py-1.5 text-[12px] leading-4 transition-colors'
-                key={model.value}
-                onSelect={handleModelChange}
-                value={model.value}
-              >
-                <span className='min-w-0 truncate font-medium'>
-                  {model.label}
-                </span>
-                <Check
-                  className={cn(
-                    'size-3.5 shrink-0',
-                    selectedModel === model.value ? 'opacity-100' : 'opacity-0'
-                  )}
-                />
-              </CommandItem>
-            ))}
-          </CommandGroup>
-        )}
+        {renderModelListContent()}
       </CommandList>
     </Command>
   )

--- a/web/default/src/features/playground/components/input/playground-input-controls.tsx
+++ b/web/default/src/features/playground/components/input/playground-input-controls.tsx
@@ -76,6 +76,7 @@ export function PlaygroundInputControls({
       groups={groups}
       onGroupChange={onGroupChange}
       disabled={isSelectorDisabled}
+      isModelLoading={isModelLoading}
     />
   )
 

--- a/web/default/src/features/playground/hooks/use-playground-options.ts
+++ b/web/default/src/features/playground/hooks/use-playground-options.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 /*
 Copyright (C) 2023-2026 QuantumNous
 
@@ -54,10 +54,12 @@ export function usePlaygroundOptions({
     data: modelsData,
     error: modelsError,
     isError: isModelsError,
-    isLoading: isLoadingModels,
+    isFetching: isModelsFetching,
+    isPlaceholderData: isModelsPlaceholder,
   } = useQuery({
     queryKey: ['playground-models', currentGroup],
     queryFn: () => getUserModels(currentGroup),
+    placeholderData: keepPreviousData,
     enabled: currentGroup !== '',
   })
 
@@ -118,6 +120,8 @@ export function usePlaygroundOptions({
       updateConfig('group', fallback)
     }
   }, [groupsData, currentGroup, setGroups, updateConfig])
+
+  const isLoadingModels = !modelsData || (isModelsFetching && isModelsPlaceholder)
 
   return {
     isLoadingModels,

--- a/web/default/src/i18n/locales/en.json
+++ b/web/default/src/i18n/locales/en.json
@@ -2404,6 +2404,7 @@
     "Loading current models...": "Loading current models...",
     "Loading failed": "Loading failed",
     "Loading maintenance settings...": "Loading maintenance settings...",
+    "Loading models...": "Loading models...",
     "Loading settings...": "Loading settings...",
     "Loading setup status…": "Loading setup status…",
     "Loading...": "Loading...",

--- a/web/default/src/i18n/locales/fr.json
+++ b/web/default/src/i18n/locales/fr.json
@@ -2404,6 +2404,7 @@
     "Loading current models...": "Chargement des modèles actuels...",
     "Loading failed": "Échec du chargement",
     "Loading maintenance settings...": "Chargement des paramètres de maintenance...",
+    "Loading models...": "Chargement des modèles...",
     "Loading settings...": "Chargement des paramètres...",
     "Loading setup status…": "Chargement du statut de configuration…",
     "Loading...": "Chargement...",

--- a/web/default/src/i18n/locales/ja.json
+++ b/web/default/src/i18n/locales/ja.json
@@ -2404,6 +2404,7 @@
     "Loading current models...": "現在のモデルをロード中...",
     "Loading failed": "読み込みに失敗しました",
     "Loading maintenance settings...": "メンテナンス設定をロード中...",
+    "Loading models...": "モデルを読み込み中...",
     "Loading settings...": "設定をロード中...",
     "Loading setup status…": "セットアップステータスをロード中…",
     "Loading...": "読み込み中...",

--- a/web/default/src/i18n/locales/ru.json
+++ b/web/default/src/i18n/locales/ru.json
@@ -2404,6 +2404,7 @@
     "Loading current models...": "Загрузка текущих моделей...",
     "Loading failed": "Ошибка загрузки",
     "Loading maintenance settings...": "Загрузка настроек обслуживания...",
+    "Loading models...": "Загрузка моделей...",
     "Loading settings...": "Загрузка настроек...",
     "Loading setup status…": "Загрузка статуса установки...",
     "Loading...": "Загрузка...",

--- a/web/default/src/i18n/locales/vi.json
+++ b/web/default/src/i18n/locales/vi.json
@@ -2404,6 +2404,7 @@
     "Loading current models...": "Đang tải các mô hình hiện tại...",
     "Loading failed": "Tải thất bại",
     "Loading maintenance settings...": "Đang tải cài đặt bảo trì...",
+    "Loading models...": "Đang tải mô hình...",
     "Loading settings...": "Đang tải cài đặt...",
     "Loading setup status…": "Đang tải trạng thái cài đặt…",
     "Loading...": "Đang tải...",

--- a/web/default/src/i18n/locales/zh.json
+++ b/web/default/src/i18n/locales/zh.json
@@ -2404,6 +2404,7 @@
     "Loading current models...": "正在加载当前模型...",
     "Loading failed": "加载失败",
     "Loading maintenance settings...": "正在加载维护设置...",
+    "Loading models...": "加载模型中...",
     "Loading settings...": "正在加载设置...",
     "Loading setup status…": "正在加载设置状态…",
     "Loading...": "加载中...",


### PR DESCRIPTION
## Summary

This PR fixes issue #5818 — the playground model list was not filtering by the selected group, always showing all models.

## Root Cause

When switching groups, React Query fired a new fetch and `modelsData` became `undefined` during loading. The `useEffect` guarding with `if (!modelsData) return` skipped, leaving stale models in state. The `ModelGroupSelector` continued showing the previous (or all) models.

## Changes

1. **`use-playground-options.ts`** — Added `placeholderData: keepPreviousData` so `modelsData` stays defined during group transitions, ensuring the effect always runs and `setModels()` is called with correct data.

2. **`playground-input-controls.tsx`** — Passes `isModelLoading` to `ModelGroupSelector`.

3. **`model-group-selector.tsx`** — Shows a loading spinner while models are being fetched for the new group.

4. **i18n** — Added `"Loading models..."` key to all 6 locale files.

## Verification

- Backend `GetUserModels` (controller/user.go:581) correctly filters by `?group=` query param — verified by existing test `TestGetUserModelsFiltersByRequestedGroup`.
- Frontend typecheck passes cleanly (`bun run typecheck`).
- No new lint errors introduced.

> **Note**: This code was AI-assisted. The analysis, implementation plan, and review were guided by AI, with manual verification and editing by the PR author.

Closes #5818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model selection now displays a centered loading state (“Loading models…”) while models are being fetched.
  * The model search field is disabled during loading to avoid premature input.
  * Added localized “Loading models…” messaging across multiple languages.

* **Improvements**
  * When switching model groups, previously loaded models remain visible briefly to reduce flicker and improve perceived responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->