### PR TITLE
feat: support doubao seedance 2.0 safety_identifier/priority and 4k billing

### DIFF
--- a/relay/channel/task/doubao/adaptor.go
+++ b/relay/channel/task/doubao/adaptor.go
@@ -52,13 +52,15 @@ type requestPayload struct {
 	Tools                 []struct {
 		Type string `json:"type,omitempty"`
 	} `json:"tools,omitempty"`
-	Resolution  string         `json:"resolution,omitempty"`
-	Ratio       string         `json:"ratio,omitempty"`
-	Duration    *dto.IntValue  `json:"duration,omitempty"`
-	Frames      *dto.IntValue  `json:"frames,omitempty"`
-	Seed        *dto.IntValue  `json:"seed,omitempty"`
-	CameraFixed *dto.BoolValue `json:"camera_fixed,omitempty"`
-	Watermark   *dto.BoolValue `json:"watermark,omitempty"`
+	SafetyIdentifier string         `json:"safety_identifier,omitempty"`
+	Priority         *dto.IntValue  `json:"priority,omitempty"`
+	Resolution       string         `json:"resolution,omitempty"`
+	Ratio            string         `json:"ratio,omitempty"`
+	Duration         *dto.IntValue  `json:"duration,omitempty"`
+	Frames           *dto.IntValue  `json:"frames,omitempty"`
+	Seed             *dto.IntValue  `json:"seed,omitempty"`
+	CameraFixed      *dto.BoolValue `json:"camera_fixed,omitempty"`
+	Watermark        *dto.BoolValue `json:"watermark,omitempty"`
 }
 
 type responsePayload struct {

--- a/relay/channel/task/doubao/constants.go
+++ b/relay/channel/task/doubao/constants.go
@@ -13,25 +13,28 @@ var ModelList = []string{
 
 var ChannelName = "doubao-video"
 
-// videoPriceKey 价格表的二维键：输出分辨率是否为 1080p、输入是否含视频。
+// videoPriceKey 价格表的键：输出分辨率档（is1080p/is4k 均为 false 即 480p/720p 基准档）、输入是否含视频。
 type videoPriceKey struct {
 	is1080p  bool
+	is4k     bool
 	hasVideo bool
 }
 
 // videoPriceTable 各模型在不同 (输出分辨率档, 是否含视频输入) 下的单价（元/百万 token）。
-// 其中 {480p/720p, 不含视频}（零值键）为基准价，等于管理员应配置的 ModelRatio；
-// 计费时取 实际单价/基准价 作为 OtherRatio，缺省分辨率按 480p/720p 档处理。
+// 其中零值键 {480p/720p, 不含视频} 为基准价，等于管理员应配置的 ModelRatio；
+// 计费时取 实际单价/基准价 作为 OtherRatio。
 var videoPriceTable = map[string]map[videoPriceKey]float64{
 	"doubao-seedance-2-0-260128": {
-		{is1080p: false, hasVideo: false}: 46.0,
-		{is1080p: false, hasVideo: true}:  28.0,
-		{is1080p: true, hasVideo: false}:  51.0,
-		{is1080p: true, hasVideo: true}:   31.0,
+		{hasVideo: false}:                46.0,
+		{hasVideo: true}:                 28.0,
+		{is1080p: true, hasVideo: false}: 51.0,
+		{is1080p: true, hasVideo: true}:  31.0,
+		{is4k: true, hasVideo: false}:    26.0,
+		{is4k: true, hasVideo: true}:     16.0,
 	},
 	"doubao-seedance-2-0-fast-260128": {
-		{is1080p: false, hasVideo: false}: 37.0,
-		{is1080p: false, hasVideo: true}:  22.0,
+		{hasVideo: false}: 37.0,
+		{hasVideo: true}:  22.0,
 	},
 }
 
@@ -43,9 +46,10 @@ func GetVideoInputRatio(modelName, resolution string, hasVideo bool) (float64, b
 	if !ok || base <= 0 {
 		return 0, false
 	}
-	price, ok := prices[videoPriceKey{is1080p: strings.EqualFold(resolution, "1080p"), hasVideo: hasVideo}]
+	res := strings.ToLower(strings.TrimSpace(resolution))
+	price, ok := prices[videoPriceKey{is1080p: res == "1080p", is4k: res == "4k", hasVideo: hasVideo}]
 	if !ok {
-		// 未配置的组合（如 fast 无 1080p，上游会自行报错）按基准价计费即可。
+		// 未配置的组合（如 fast 无 1080p/4k，上游会自行报错）按基准价计费即可。
 		return 1.0, true
 	}
 	return price / base, true


### PR DESCRIPTION
## 📝 变更描述 / Description
官方文档: `https://www.volcengine.com/docs/82379/1520757`

为 Doubao Seedance 2.0 系列视频模型补齐两处与官方接口对齐的改动：

1. **请求参数补齐**：`requestPayload` 新增 `safety_identifier`（终端用户唯一标识）与 `priority`（队列优先级，仅 Seedance 2.0 支持）两个字段，经 metadata 透传至上游。`priority` 采用指针类型，以区分「未传」与「显式传 0」，避免零值被 `omitempty` 丢弃。
<img width="1762" height="614" alt="image" src="https://github.com/user-attachments/assets/d146a943-60ff-4ad8-bb5d-03206f797e01" />

2. **4K 分辨率计费**：
<img width="2088" height="840" alt="image" src="https://github.com/user-attachments/assets/4ab19df6-b3ae-4814-a673-5456a1d6a1c0" />




## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述由人工整理撰写。
- [x] **非重复提交:** 已确认无重复 PR。
- [x] **变更理解:** 已理解改动原理与影响范围。
- [x] **范围聚焦:** 仅改动 doubao 视频适配器,无无关改动。
- [x] **本地验证:** `go build ./relay/channel/task/doubao/` 通过。
- [x] **安全合规:** 无敏感凭据,符合代码规范。

## 📸 运行证明 / Proof of Work
修复前,按720计费, 9元/秒 
<img width="1046" height="1080" alt="image" src="https://github.com/user-attachments/assets/dd320790-c76c-4c62-99c6-378bd2f40d67" />
修复后: 按4k正确计费 5元/秒
<img width="1026" height="1082" alt="image" src="https://github.com/user-attachments/assets/537ce5ee-b3e5-4793-98bb-d8e497e78599" />

