### PR TITLE
feat: expose video task billing usage (token via header, seconds in body)

### DIFF
--- a/model/task.go
+++ b/model/task.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql/driver"
 	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
@@ -531,5 +532,11 @@ func (t *Task) ToOpenAIVideo() *dto.OpenAIVideo {
 	openAIVideo.CreatedAt = t.CreatedAt
 	openAIVideo.CompletedAt = t.UpdatedAt
 	openAIVideo.SetMetadata("url", t.GetResultURL())
+	// 按秒计费的时长（OtherRatios["seconds"]）统一带出，供下游按秒计费
+	if bc := t.PrivateData.BillingContext; bc != nil {
+		if s, ok := bc.OtherRatios["seconds"]; ok && s > 0 {
+			openAIVideo.Seconds = strconv.Itoa(int(s))
+		}
+	}
 	return openAIVideo
 }

--- a/relay/relay_task.go
+++ b/relay/relay_task.go
@@ -397,6 +397,15 @@ func videoFetchByIDRespBodyBuilder(c *gin.Context) (respBody []byte, taskResp *d
 				taskResp = service.TaskErrorWrapper(err, "convert_to_openai_video_failed", http.StatusInternalServerError)
 				return
 			}
+			// 计量经 header 透传给下游（中转套娃），保持 body 为纯 OpenAI 标准结构
+			if ti, perr := adaptor.ParseTaskResult(originTask.Data); perr == nil && ti != nil && ti.TotalTokens > 0 {
+				if usageJSON, merr := common.Marshal(map[string]int{
+					"completion_tokens": ti.CompletionTokens,
+					"total_tokens":      ti.TotalTokens,
+				}); merr == nil {
+					c.Header("X-New-Api-Usage", string(usageJSON))
+				}
+			}
 			respBody = openAIVideoData
 			return
 		}


### PR DESCRIPTION
## 📝 变更描述 / Description

向视频任务查询接口的输出补充**计费计量信息**，方便下游（含中转/网关场景）据此计费。分两类：

**1. 按量（token）计费 → 响应头 `X-New-Api-Usage`**

在 `GET /v1/videos/{task_id}` 响应上新增响应头，携带任务 token 用量：

```
X-New-Api-Usage: {"completion_tokens": 1234, "total_tokens": 1234}
```

- 仅在适配器 `ParseTaskResult` 能解析出 `total_tokens > 0` 时设置。
- 走响应头而非响应体，body 保持纯 OpenAI 视频对象标准结构。

**2. 按秒计费 → 响应体标准字段 `seconds`**

`ToOpenAIVideo` 统一将计费所用时长（`BillingContext.OtherRatios["seconds"]`，即实际计费依据）写入标准的 `seconds` 字段：

```json
{ "model": "...", "status": "completed", "seconds": "5", ... }
```

- `seconds` 是 OpenAI 视频对象的标准字段，不污染结构。
- 单点实现，所有按秒计费渠道（Ali/Veo 等）自动生效；非按秒渠道（无 `seconds` 倍率）不受影响。
- 返回值等于实际计费依据，显示与扣费一致。

两处均为纯增量，不改变任何现有计费/响应逻辑；普通客户端忽略即可。

## 🚀 变更类型 / Type of change
- [x] ✨ 新功能 (New feature)

## 🔗 关联任务 / Related Issue
- N/A

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述由人工整理撰写。
- [x] **非重复提交:** 已确认无重复 PR。
- [x] **变更理解:** 已理解改动原理与影响范围。
- [x] **范围聚焦:** 仅向 video 响应补充计量信息（header + seconds 字段），无其它改动。
- [x] **本地验证:** `go build ./...` 通过。
- [x] **安全合规:** 无敏感凭据，仅暴露计量信息，符合代码规范。

## 📸 运行证明 / Proof of Work

- 按量模型完成态查询：响应头 `X-New-Api-Usage: {"completion_tokens":1234,"total_tokens":1234}`。
- 按秒模型（如 happyhorse / veo）完成态查询：响应体 `"seconds": "5"`，与实际计费时长一致。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exporting token usage metadata on video fetch responses when available.
  * Video fetch responses now include a usage header alongside the standard OpenAI-compatible video payload.
  * Extended OpenAI video output to optionally include per-second billing duration when provided by billing context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->