### PR TITLE
fix(task): record token usage in async billing logs

### DIFF
--- a/model/log.go
+++ b/model/log.go
@@ -407,16 +407,18 @@ func RecordConsumeLog(c *gin.Context, userId int, params RecordConsumeLogParams)
 }
 
 type RecordTaskBillingLogParams struct {
-	UserId    int
-	LogType   int
-	Content   string
-	ChannelId int
-	ModelName string
-	Quota     int
-	TokenId   int
-	Group     string
-	Other     map[string]interface{}
-	NodeName  string // 任务发起节点；为空时回退当前节点
+	UserId           int
+	LogType          int
+	Content          string
+	ChannelId        int
+	ModelName        string
+	Quota            int
+	TokenId          int
+	Group            string
+	PromptTokens     int
+	CompletionTokens int
+	Other            map[string]interface{}
+	NodeName         string // 任务发起节点；为空时回退当前节点
 }
 
 func RecordTaskBillingLog(params RecordTaskBillingLogParams) {
@@ -437,13 +439,15 @@ func RecordTaskBillingLog(params RecordTaskBillingLogParams) {
 		CreatedAt: createdAt,
 		Type:      params.LogType,
 		Content:   params.Content,
-		TokenName: tokenName,
-		ModelName: params.ModelName,
-		Quota:     params.Quota,
-		ChannelId: params.ChannelId,
-		TokenId:   params.TokenId,
-		Group:     params.Group,
-		Other:     common.MapToJsonStr(params.Other),
+		TokenName:        tokenName,
+		ModelName:        params.ModelName,
+		Quota:            params.Quota,
+		PromptTokens:     params.PromptTokens,
+		CompletionTokens: params.CompletionTokens,
+		ChannelId:        params.ChannelId,
+		TokenId:          params.TokenId,
+		Group:            params.Group,
+		Other:            common.MapToJsonStr(params.Other),
 	}
 	err := createLog(log)
 	if err != nil {
@@ -461,6 +465,7 @@ func RecordTaskBillingLog(params RecordTaskBillingLogParams) {
 				ModelName: params.ModelName,
 				Quota:     params.Quota,
 				CreatedAt: createdAt,
+				TokenUsed: params.PromptTokens + params.CompletionTokens,
 				UseGroup:  params.Group,
 				TokenID:   params.TokenId,
 				ChannelID: params.ChannelId,

--- a/service/task_billing.go
+++ b/service/task_billing.go
@@ -185,6 +185,11 @@ func RefundTaskQuota(ctx context.Context, task *model.Task, reason string) {
 // actualQuota 是任务完成后的实际应扣额度，与预扣额度 (task.Quota) 做差额结算。
 // reason 用于日志记录（例如 "token重算" 或 "adaptor调整"）。
 func RecalculateTaskQuota(ctx context.Context, task *model.Task, actualQuota int, reason string) {
+	RecalculateTaskQuotaWithUsage(ctx, task, actualQuota, reason, 0, 0)
+}
+
+// RecalculateTaskQuotaWithUsage records optional token usage when settling an async task.
+func RecalculateTaskQuotaWithUsage(ctx context.Context, task *model.Task, actualQuota int, reason string, promptTokens int, completionTokens int) {
 	if actualQuota <= 0 {
 		return
 	}
@@ -240,6 +245,8 @@ func RecalculateTaskQuota(ctx context.Context, task *model.Task, actualQuota int
 		Quota:     logQuota,
 		TokenId:   task.PrivateData.TokenId,
 		Group:     task.Group,
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
 		Other:     other,
 		NodeName:  task.PrivateData.NodeName,
 	})
@@ -298,5 +305,5 @@ func RecalculateTaskQuotaByTokens(ctx context.Context, task *model.Task, totalTo
 	actualQuota := int(float64(totalTokens) * modelRatio * finalGroupRatio * otherMultiplier)
 
 	reason := fmt.Sprintf("token重算：tokens=%d, modelRatio=%.2f, groupRatio=%.2f, otherMultiplier=%.4f", totalTokens, modelRatio, finalGroupRatio, otherMultiplier)
-	RecalculateTaskQuota(ctx, task, actualQuota, reason)
+	RecalculateTaskQuotaWithUsage(ctx, task, actualQuota, reason, 0, totalTokens)
 }


### PR DESCRIPTION
## Summary
- add prompt/completion token fields to async task billing log params
- persist async task billing token usage into logs.prompt_tokens and logs.completion_tokens
- include token usage in quota export for async task billing logs

## Why
Async task settlement can recalculate quota from upstream `total_tokens`, but the follow-up consume/refund log only stored the token count in the human-readable content string. As a result, the admin log token column and token-based exports showed zero tokens for these settlement logs even though billing used the token count correctly.

## Test
- Not run: local environment does not have the Go toolchain installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Billing and quota records now include separate prompt and completion token counts for improved usage tracking.
  * Token-based quota recalculation now uses the recorded token breakdown for more accurate accounting.

* **Bug Fixes**
  * Fixed quota settlement so token usage is captured consistently when billing logs are created.
  * Improved how usage data is stored for downstream reporting and export flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->