### PR TITLE
feat: SSE raw passthrough for Claude-format relay

### DIFF
--- a/common/init.go
+++ b/common/init.go
@@ -132,7 +132,7 @@ func InitEnv() {
 }
 
 func initConstantEnv() {
-	constant.StreamingTimeout = GetEnvOrDefault("STREAMING_TIMEOUT", 300)
+	constant.StreamingTimeout = GetEnvOrDefault("STREAMING_TIMEOUT", 0)
 	constant.DifyDebug = GetEnvOrDefaultBool("DIFY_DEBUG", true)
 	constant.MaxFileDownloadMB = GetEnvOrDefault("MAX_FILE_DOWNLOAD_MB", 64)
 	constant.StreamScannerMaxBufferMB = GetEnvOrDefault("STREAM_SCANNER_MAX_BUFFER_MB", 128)

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -785,6 +785,49 @@ func FormatClaudeResponseInfo(claudeResponse *dto.ClaudeResponse, oaiResponse *d
 	return true
 }
 
+func HandleRawLineStreamData(c *gin.Context, info *relaycommon.RelayInfo, claudeInfo *ClaudeResponseInfo, line string) *types.NewAPIError {
+	if info.ClientDisconnected {
+		if strings.HasPrefix(line, "data: ") {
+			payload := strings.TrimPrefix(line, "data: ")
+			payload = strings.TrimSpace(payload)
+			if payload != "" && payload != "[DONE]" {
+				var claudeResponse dto.ClaudeResponse
+				if err := common.UnmarshalJsonStr(payload, &claudeResponse); err == nil {
+					FormatClaudeResponseInfo(&claudeResponse, nil, claudeInfo)
+				}
+			}
+		}
+		return nil
+	}
+
+	if _, err := fmt.Fprintf(c.Writer, "%s\n", line); err != nil {
+		info.ClientDisconnected = true
+		return nil
+	}
+
+	if line == "" {
+		helper.FlushWriter(c)
+	}
+
+	if strings.HasPrefix(line, "data: ") {
+		payload := strings.TrimPrefix(line, "data: ")
+		payload = strings.TrimSpace(payload)
+		if payload != "" && payload != "[DONE]" {
+			info.SetFirstResponseTime()
+			info.ReceivedResponseCount++
+			var claudeResponse dto.ClaudeResponse
+			if err := common.UnmarshalJsonStr(payload, &claudeResponse); err == nil {
+				FormatClaudeResponseInfo(&claudeResponse, nil, claudeInfo)
+				if claudeResponse.Message != nil && claudeResponse.Message.Model != "" {
+					info.UpstreamModelName = claudeResponse.Message.Model
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 func HandleStreamResponseData(c *gin.Context, info *relaycommon.RelayInfo, claudeInfo *ClaudeResponseInfo, data string) *types.NewAPIError {
 	var claudeResponse dto.ClaudeResponse
 	err := common.UnmarshalJsonStr(data, &claudeResponse)
@@ -878,9 +921,18 @@ func ClaudeStreamHandler(c *gin.Context, resp *http.Response, info *relaycommon.
 		ResponseText: strings.Builder{},
 		Usage:        &dto.Usage{},
 	}
+
+	if info.RelayFormat == types.RelayFormatClaude {
+		info.RawLineMode = true
+	}
+
 	var err *types.NewAPIError
 	helper.StreamScannerHandler(c, resp, info, func(data string, sr *helper.StreamResult) {
-		err = HandleStreamResponseData(c, info, claudeInfo, data)
+		if info.RawLineMode {
+			err = HandleRawLineStreamData(c, info, claudeInfo, data)
+		} else {
+			err = HandleStreamResponseData(c, info, claudeInfo, data)
+		}
 		if err != nil {
 			sr.Stop(err)
 		}

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -107,6 +107,8 @@ type RelayInfo struct {
 	RequestHeaders         map[string]string
 	ShouldIncludeUsage     bool
 	DisablePing            bool // 是否禁止向下游发送自定义 Ping
+	RawLineMode            bool // SSE 原样透传模式，不过滤 event: 行
+	ClientDisconnected     bool // 客户端已断开，继续读上游获取 usage
 	ClientWs               *websocket.Conn
 	TargetWs               *websocket.Conn
 	InputAudioFormat       string

--- a/relay/helper/common.go
+++ b/relay/helper/common.go
@@ -106,6 +106,19 @@ func PingData(c *gin.Context) error {
 	return FlushWriter(c)
 }
 
+func ClaudePingData(c *gin.Context) error {
+	if c == nil || c.Writer == nil {
+		return errors.New("context or writer is nil")
+	}
+	if c.Request != nil && c.Request.Context().Err() != nil {
+		return fmt.Errorf("request context done: %w", c.Request.Context().Err())
+	}
+	if _, err := c.Writer.Write([]byte("event: ping\ndata: {\"type\": \"ping\"}\n\n")); err != nil {
+		return fmt.Errorf("write claude ping data failed: %w", err)
+	}
+	return FlushWriter(c)
+}
+
 func ObjectData(c *gin.Context, object interface{}) error {
 	if object == nil {
 		return errors.New("object is nil")

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -59,13 +59,19 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	streamingTimeout := time.Duration(constant.StreamingTimeout) * time.Second
 
 	var (
-		stopChan   = make(chan bool, 3) // 增加缓冲区避免阻塞
+		stopChan   = make(chan bool, 3)
 		scanner    = NewStreamScanner(resp.Body)
-		ticker     = time.NewTicker(streamingTimeout)
+		ticker     *time.Ticker
 		pingTicker *time.Ticker
-		writeMutex sync.Mutex     // Mutex to protect concurrent writes
-		wg         sync.WaitGroup // 用于等待所有 goroutine 退出
+		writeMutex sync.Mutex
+		wg         sync.WaitGroup
 	)
+
+	if streamingTimeout > 0 {
+		ticker = time.NewTicker(streamingTimeout)
+	} else {
+		ticker = time.NewTicker(24 * time.Hour) // 不超时，用极大值占位
+	}
 
 	generalSettings := operation_setting.GetGeneralSetting()
 	pingEnabled := generalSettings.PingIntervalEnabled && !info.DisablePing
@@ -145,7 +151,11 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 					gopool.Go(func() {
 						writeMutex.Lock()
 						defer writeMutex.Unlock()
-						done <- PingData(c)
+						if info.RawLineMode {
+							done <- ClaudePingData(c)
+						} else {
+							done <- PingData(c)
+						}
 					})
 
 					select {
@@ -219,21 +229,38 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 		}()
 
 		for scanner.Scan() {
-			// 检查是否需要停止
 			select {
 			case <-stopChan:
 				return
 			case <-ctx.Done():
 				return
 			case <-c.Request.Context().Done():
-				info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, c.Request.Context().Err())
-				return
+				if !info.RawLineMode {
+					info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, c.Request.Context().Err())
+					return
+				}
+				info.ClientDisconnected = true
 			default:
 			}
 
-			ticker.Reset(streamingTimeout)
+			if streamingTimeout > 0 {
+				ticker.Reset(streamingTimeout)
+			}
 			data := scanner.Text()
 			logger.LogDebug(c, "stream scanner data: %s", data)
+
+			if info.RawLineMode {
+				select {
+				case dataChan <- data:
+				case <-ctx.Done():
+					if !info.ClientDisconnected {
+						return
+					}
+				case <-stopChan:
+					return
+				}
+				continue
+			}
 
 			if len(data) < 6 {
 				continue
@@ -273,14 +300,22 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonEOF, nil)
 	})
 
-	// 主循环等待完成或超时
-	select {
-	case <-ticker.C:
-		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonTimeout, nil)
-	case <-stopChan:
-		// EndReason already set by the goroutine that triggered stopChan
-	case <-c.Request.Context().Done():
-		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, c.Request.Context().Err())
+	if info.RawLineMode {
+		select {
+		case <-ticker.C:
+			if streamingTimeout > 0 {
+				info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonTimeout, nil)
+			}
+		case <-stopChan:
+		}
+	} else {
+		select {
+		case <-ticker.C:
+			info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonTimeout, nil)
+		case <-stopChan:
+		case <-c.Request.Context().Done():
+			info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, c.Request.Context().Err())
+		}
 	}
 
 	if info.StreamStatus.IsNormalEnd() && !info.StreamStatus.HasErrors() {


### PR DESCRIPTION
- Add RawLineMode to transparently forward all SSE lines (event:, data:, empty) instead of filtering out event: lines, matching sub2api's passthrough design
- Parse usage data as a side-effect without modifying the stream
- Continue reading upstream after client disconnect to collect billing usage
- Add Anthropic-native ping format (event: ping) for Claude relay
- Change STREAMING_TIMEOUT default from 300s to 0 (disabled), matching sub2api
- Fixes Agent tool-call disconnections and missing token statistics

AI-assisted: code generated with Claude Code

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ ] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [ ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [ ] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude streaming reliability, including support for raw line streaming and cleaner handling of streamed events.
  * Fixed client-disconnect handling so responses can continue long enough to capture final usage details.
  * Updated streaming timeout behavior so no-timeout cases behave more predictably.
  * Added a lightweight ping response for streaming connections to help keep streams active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->