### PR TITLE
fix: subtract cached_tokens from input_tokens in OpenAI→Claude usage conversion

### DIFF
--- a/service/relayconvert/internal/oai_chat/to_claude_messages_resp.go
+++ b/service/relayconvert/internal/oai_chat/to_claude_messages_resp.go
@@ -41,11 +41,15 @@ func buildClaudeUsageFromOpenAIUsage(oaiUsage *dto.Usage) *dto.ClaudeUsage {
 	)
 	cacheCreationTokens := oaiUsage.PromptTokensDetails.CacheCreationTokensTotal()
 	inputTokens := oaiUsage.PromptTokens
-	if oaiUsage.PromptTokensDetails.CacheWriteTokens > 0 {
-		// OpenAI native cache-write usage counts cached and cache-write tokens
-		// inside prompt_tokens, while Claude semantics reports input_tokens
-		// excluding both. Both counts are unadjusted prefixes and may overlap,
-		// so clamp a negative remainder at zero.
+	// OpenAI native cache-write / cache-read usage counts both cached and
+	// cache-creation tokens inside prompt_tokens, while Claude semantics
+	// reports input_tokens excluding both.  Deduplicate so that the sum
+	// `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`
+	// equals the true total context size rather than double-counting cached
+	// tokens (§ref HsMirage, issue #4395).
+	//   - CacheWriteTokens > 0: openai cache-write route (original guard)
+	//   - CachedTokens    > 0: pure cache-read (bypassed the old guard)
+	if oaiUsage.PromptTokensDetails.CacheWriteTokens > 0 || oaiUsage.PromptTokensDetails.CachedTokens > 0 {
 		inputTokens = oaiUsage.PromptTokens - oaiUsage.PromptTokensDetails.CachedTokens - cacheCreationTokens
 		if inputTokens < 0 {
 			inputTokens = 0

--- a/service/relayconvert/internal/oai_chat/to_claude_messages_resp_test.go
+++ b/service/relayconvert/internal/oai_chat/to_claude_messages_resp_test.go
@@ -103,6 +103,31 @@ func TestBuildClaudeUsageFromOpenAICacheWriteUsage(t *testing.T) {
 	assert.Equal(t, 3616, usage.BillingUsage.OpenAIUsage.PromptTokensDetails.CacheWriteTokens)
 }
 
+func TestBuildClaudeUsageFromOpenAIPureCacheRead(t *testing.T) {
+	// HsMirage's pure cache-read reproduction (issue #4395):
+	// second identical request hits cache; CacheWriteTokens==0, CachedTokens>0.
+	usage := buildClaudeUsageFromOpenAIUsage(&dto.Usage{
+		PromptTokens:     15305,
+		CompletionTokens: 5,
+		TotalTokens:      15310,
+		PromptTokensDetails: dto.InputTokenDetails{
+			CachedTokens:     15104,
+			CacheWriteTokens: 0,
+		},
+	})
+
+	require.NotNil(t, usage)
+	// input_tokens must exclude cached: 15305 - 15104 = 201
+	assert.Equal(t, 201, usage.InputTokens)
+	assert.Equal(t, 15104, usage.CacheReadInputTokens)
+	assert.Equal(t, 0, usage.CacheCreationInputTokens)
+	assert.Equal(t, 5, usage.OutputTokens)
+	// Total context = 201 + 15104 = 15305 (not double-counted)
+	require.NotNil(t, usage.BillingUsage)
+	require.NotNil(t, usage.BillingUsage.OpenAIUsage)
+	assert.Equal(t, 15305, usage.BillingUsage.OpenAIUsage.PromptTokens)
+}
+
 func TestStreamResponseOpenAI2ClaudeClosesTextThinkingAndToolBlocks(t *testing.T) {
 	info := &relaycommon.RelayInfo{
 		ClaudeConvertInfo: &relaycommon.ClaudeConvertInfo{


### PR DESCRIPTION
## 变更描述 / Description

### 功能概述

修复 OpenAI 兼容上游通过 `/v1/messages` Anthropic 格式请求时，`input_tokens` 未扣除缓存部分导致数值虚高的问题。修复覆盖两种场景：

1. **Cache-Write**（首次请求，缓存写入）：原有分支已处理，保留
2. **Cache-Read**（重复请求，纯缓存读取，`CacheWriteTokens==0` 且 `CachedTokens>0`）：原代码漏掉，本次修复补齐

### 背景

OpenAI 兼容上游返回的 `prompt_tokens` 是全量 token 数（包含已缓存的 token），`prompt_tokens_details.cached_tokens` 标明缓存命中数。Anthropic 协议中 `input_tokens` 语义是不含缓存的纯输入，缓存单独放在 `cache_read_input_tokens`。

旧代码只在 `CacheWriteTokens > 0` 时做减法，纯 cache-read 场景（第二次相同请求命中缓存）绕过了条件，导致 `input_tokens` 包含全量 + `cache_read_input_tokens` 再次加上缓存 = 双倍统计，可能触发客户端提前自动压缩上下文。

参考：HsMirage 在 #4395 的详细分析。

### 具体变更

**文件**：`service/relayconvert/internal/oai_chat/to_claude_messages_resp.go`

**`buildClaudeUsageFromOpenAIUsage()` 函数**：条件从仅 `CacheWriteTokens > 0` 扩展为 `CacheWriteTokens > 0 || CachedTokens > 0`

```go
// 旧
if oaiUsage.PromptTokensDetails.CacheWriteTokens > 0 {

// 新
if oaiUsage.PromptTokensDetails.CacheWriteTokens > 0 || oaiUsage.PromptTokensDetails.CachedTokens > 0 {
```

### 测试

新增 `TestBuildClaudeUsageFromOpenAIPureCacheRead` 回归用例：

| 输入 | 期望 |
|---|---|
| PromptTokens=15305, CachedTokens=15104, CacheWriteTokens=0 | InputTokens=201 |
| CompletionTokens=5 | CacheReadInputTokens=15104 |
| | OutputTokens=5 |

总上下文 = 201 + 15104 = 15305（不双倍统计）

### 关联

Fixes #4395
