### PR TITLE
feat: add Responses replay and identity sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ ENV GO111MODULE=on CGO_ENABLED=0
 
 ARG TARGETOS
 ARG TARGETARCH
-ENV GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64}
 ENV GOEXPERIMENT=greenteagc
 
 WORKDIR /build
@@ -36,7 +35,8 @@ RUN go mod download
 COPY . .
 COPY --from=builder /build/web/default/dist ./web/default/dist
 COPY --from=builder-classic /build/web/classic/dist ./web/classic/dist
-RUN go build -ldflags "-s -w -X 'github.com/QuantumNous/new-api/common.Version=$(cat VERSION)'" -o new-api
+RUN GOOS="${TARGETOS:-$(go env GOOS)}" GOARCH="${TARGETARCH:-$(go env GOARCH)}" \
+    go build -ldflags "-s -w -X 'github.com/QuantumNous/new-api/common.Version=$(cat VERSION)'" -o new-api
 
 FROM debian:bookworm-slim@sha256:f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a
 

--- a/README.en.md
+++ b/README.en.md
@@ -309,7 +309,7 @@ docker run --name new-api -d --restart always \
 | `CRYPTO_SECRET` | Encryption secret (required for Redis) | - |
 | `SQL_DSN` | Database connection string | - |
 | `REDIS_CONN_STRING` | Redis connection string | - |
-| `STREAMING_TIMEOUT` | Streaming timeout (seconds) | `300` |
+| `STREAMING_TIMEOUT` | Streaming idle/first-data timeout (seconds) | `60` |
 | `STREAM_SCANNER_MAX_BUFFER_MB` | Max per-line buffer (MB) for the stream scanner; increase when upstream sends huge image/base64 payloads | `64` |
 | `MAX_REQUEST_BODY_MB` | Max request body size (MB, counted **after decompression**; prevents huge requests/zip bombs from exhausting memory). Exceeding it returns `413` | `32` |
 | `AZURE_DEFAULT_API_VERSION` | Azure API version | `2025-04-01-preview` |

--- a/README.fr.md
+++ b/README.fr.md
@@ -316,7 +316,7 @@ docker run --name new-api -d --restart always \
 | `CRYPTO_SECRET` | Secret de chiffrement (requis pour Redis) | - |
 | `SQL_DSN` | Chaine de connexion à la base de données | - |
 | `REDIS_CONN_STRING` | Chaine de connexion Redis | - |
-| `STREAMING_TIMEOUT` | Délai d'expiration du streaming (secondes) | `300` |
+| `STREAMING_TIMEOUT` | Délai d'inactivité/première donnée du streaming (secondes) | `60` |
 | `STREAM_SCANNER_MAX_BUFFER_MB` | Taille max du buffer par ligne (Mo) pour le scanner SSE ; à augmenter quand les sorties image/base64 sont très volumineuses (ex. images 4K) | `64` |
 | `MAX_REQUEST_BODY_MB` | Taille maximale du corps de requête (Mo, comptée **après décompression** ; évite les requêtes énormes/zip bombs qui saturent la mémoire). Dépassement ⇒ `413` | `32` |
 | `AZURE_DEFAULT_API_VERSION` | Version de l'API Azure | `2025-04-01-preview` |

--- a/README.ja.md
+++ b/README.ja.md
@@ -318,7 +318,7 @@ docker run --name new-api -d --restart always \
 | `CRYPTO_SECRET` | 暗号化シークレット（Redisに必須） | - |
 | `SQL_DSN** | データベース接続文字列 | - |
 | `REDIS_CONN_STRING` | Redis接続文字列 | - |
-| `STREAMING_TIMEOUT` | ストリーミング応答のタイムアウト時間（秒） | `300` |
+| `STREAMING_TIMEOUT` | ストリーミングのアイドル/初回データタイムアウト（秒） | `60` |
 | `STREAM_SCANNER_MAX_BUFFER_MB` | ストリームスキャナの1行あたりバッファ上限（MB）。4K画像など巨大なbase64 `data:` ペイロードを扱う場合は値を増加させてください | `64` |
 | `MAX_REQUEST_BODY_MB` | リクエストボディ最大サイズ（MB、**解凍後**に計測。巨大リクエスト/zip bomb によるメモリ枯渇を防止）。超過時は `413` | `32` |
 | `AZURE_DEFAULT_API_VERSION` | Azure APIバージョン | `2025-04-01-preview` |

--- a/README.md
+++ b/README.md
@@ -316,6 +316,13 @@ docker run --name new-api -d --restart always \
 | `CRYPTO_SECRET` | Encryption secret (required for Redis) | - |
 | `SQL_DSN` | Database connection string | - |
 | `REDIS_CONN_STRING` | Redis connection string | - |
+| `IDENTITY_SYNC_ENABLED` | Enable one-way identity/auth table sync from a remote database | `false` |
+| `IDENTITY_SYNC_REMOTE_DSN` | Remote database DSN for identity sync; store it in runtime Secret/config only | - |
+| `IDENTITY_SYNC_TABLES` | Comma-separated allowlisted tables to sync | `users,setups,custom_oauth_providers,tokens,two_fas,two_fa_backup_codes,passkey_credentials,user_oauth_bindings` |
+| `IDENTITY_SYNC_INTERVAL_SECONDS` | Periodic identity sync interval; set `0` for startup-only sync | `300` |
+| `IDENTITY_SYNC_ON_STARTUP` | Run one identity sync pass during startup | `true` |
+| `IDENTITY_SYNC_DELETE_MISSING` | Delete local rows from synced tables when they no longer exist remotely | `true` |
+| `IDENTITY_SYNC_MAX_ROWS_PER_TABLE` | Safety cap for each synced remote table | `10000` |
 | `RELAY_IDLE_CONN_TIMEOUT` | Idle keep-alive timeout for relay HTTP clients, seconds. Defaults to Go standard library behavior; set `0` to disable | `90` |
 | `STREAMING_TIMEOUT` | Streaming idle/first-data timeout (seconds) | `60` |
 | `STREAM_SCANNER_MAX_BUFFER_MB` | Max per-line buffer (MB) for the stream scanner; increase when upstream sends huge image/base64 payloads | `64` |

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ docker run --name new-api -d --restart always \
 | `SQL_DSN` | Database connection string | - |
 | `REDIS_CONN_STRING` | Redis connection string | - |
 | `RELAY_IDLE_CONN_TIMEOUT` | Idle keep-alive timeout for relay HTTP clients, seconds. Defaults to Go standard library behavior; set `0` to disable | `90` |
-| `STREAMING_TIMEOUT` | Streaming timeout (seconds) | `300` |
+| `STREAMING_TIMEOUT` | Streaming idle/first-data timeout (seconds) | `60` |
 | `STREAM_SCANNER_MAX_BUFFER_MB` | Max per-line buffer (MB) for the stream scanner; increase when upstream sends huge image/base64 payloads | `64` |
 | `MAX_REQUEST_BODY_MB` | Max request body size (MB, counted **after decompression**; prevents huge requests/zip bombs from exhausting memory). Exceeding it returns `413` | `32` |
 | `AZURE_DEFAULT_API_VERSION` | Azure API version | `2025-04-01-preview` |

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -316,7 +316,7 @@ docker run --name new-api -d --restart always \
 | `CRYPTO_SECRET` | 加密密钥（Redis 必须）                                               | - |
 | `SQL_DSN` | 数据库连接字符串                                                     | - |
 | `REDIS_CONN_STRING` | Redis 连接字符串                                                  | - |
-| `STREAMING_TIMEOUT` | 流式超时时间（秒）                                                    | `300` |
+| `STREAMING_TIMEOUT` | 流式无响应/首包超时时间（秒）                                        | `60` |
 | `STREAM_SCANNER_MAX_BUFFER_MB` | 流式扫描器单行最大缓冲（MB），图像生成等超大 `data:` 片段（如 4K 图片 base64）需适当调大 | `64` |
 | `MAX_REQUEST_BODY_MB` | 请求体最大大小（MB，**解压后**计；防止超大请求/zip bomb 导致内存暴涨），超过将返回 `413` | `32` |
 | `AZURE_DEFAULT_API_VERSION` | Azure API 版本                                                 | `2025-04-01-preview` |

--- a/README.zh_TW.md
+++ b/README.zh_TW.md
@@ -316,7 +316,7 @@ docker run --name new-api -d --restart always \
 | `CRYPTO_SECRET` | 加密密鑰（Redis 必須）                                               | - |
 | `SQL_DSN` | 資料庫連接字符串                                                     | - |
 | `REDIS_CONN_STRING` | Redis 連接字符串                                                  | - |
-| `STREAMING_TIMEOUT` | 流式超時時間（秒）                                                    | `300` |
+| `STREAMING_TIMEOUT` | 流式無回應/首包超時時間（秒）                                        | `60` |
 | `STREAM_SCANNER_MAX_BUFFER_MB` | 流式掃描器單行最大緩衝（MB），圖像生成等超大 `data:` 片段（如 4K 圖片 base64）需適當調大 | `64` |
 | `MAX_REQUEST_BODY_MB` | 請求體最大大小（MB，**解壓縮後**計；防止超大請求/zip bomb 導致記憶體暴漲），超過將返回 `413` | `32` |
 | `AZURE_DEFAULT_API_VERSION` | Azure API 版本                                                 | `2025-04-01-preview` |

--- a/common/init.go
+++ b/common/init.go
@@ -132,7 +132,7 @@ func InitEnv() {
 }
 
 func initConstantEnv() {
-	constant.StreamingTimeout = GetEnvOrDefault("STREAMING_TIMEOUT", 300)
+	constant.StreamingTimeout = GetEnvOrDefault("STREAMING_TIMEOUT", 60)
 	constant.DifyDebug = GetEnvOrDefaultBool("DIFY_DEBUG", true)
 	constant.MaxFileDownloadMB = GetEnvOrDefault("MAX_FILE_DOWNLOAD_MB", 64)
 	constant.StreamScannerMaxBufferMB = GetEnvOrDefault("STREAM_SCANNER_MAX_BUFFER_MB", 128)

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -89,10 +89,21 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 	defer func() {
 		if newAPIError != nil {
 			logger.LogError(c, fmt.Sprintf("relay error: %s", common.LocalLogPreview(newAPIError.Error())))
+			if relayFormat == types.RelayFormatOpenAIRealtime {
+				newAPIError.SetMessage(common.MessageWithRequestId(newAPIError.Error(), requestId))
+				helper.WssError(c, ws, newAPIError.ToOpenAIError())
+				return
+			}
+			if c.Writer != nil && c.Writer.Written() {
+				logger.LogError(c, "relay error occurred after downstream response was written; skipping error body")
+				return
+			}
+			if c.Request != nil && c.Request.Context().Err() != nil {
+				logger.LogError(c, fmt.Sprintf("relay error occurred after downstream disconnected; skipping error body: %s", c.Request.Context().Err()))
+				return
+			}
 			newAPIError.SetMessage(common.MessageWithRequestId(newAPIError.Error(), requestId))
 			switch relayFormat {
-			case types.RelayFormatOpenAIRealtime:
-				helper.WssError(c, ws, newAPIError.ToOpenAIError())
 			case types.RelayFormatClaude:
 				c.JSON(newAPIError.StatusCode, gin.H{
 					"type":  "error",
@@ -325,6 +336,14 @@ func getChannel(c *gin.Context, info *relaycommon.RelayInfo, retryParam *service
 func shouldRetry(c *gin.Context, openaiErr *types.NewAPIError, retryTimes int) bool {
 	if openaiErr == nil {
 		return false
+	}
+	if c != nil {
+		if c.Writer != nil && c.Writer.Written() {
+			return false
+		}
+		if c.Request != nil && c.Request.Context().Err() != nil {
+			return false
+		}
 	}
 	if service.ShouldSkipRetryAfterChannelAffinityFailure(c) {
 		return false

--- a/controller/relay_retry_test.go
+++ b/controller/relay_retry_test.go
@@ -1,0 +1,23 @@
+package controller
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldRetrySkipsAfterResponseWritten(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+
+	c.String(http.StatusOK, "partial stream")
+	err := types.NewOpenAIError(errors.New("upstream stream failed"), types.ErrorCodeBadResponse, http.StatusBadGateway)
+
+	require.False(t, shouldRetry(c, err, 1))
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - ERROR_LOG_ENABLED=true # 是否启用错误日志记录 (Whether to enable error log recording)
       - BATCH_UPDATE_ENABLED=true  # 是否启用批量更新 (Whether to enable batch update)
       - NODE_NAME=new-api-node-1  # 节点名称，用于审计日志中标识节点身份；多节点/容器部署时建议设置 (Node name used in audit logs; recommended when running multiple instances or in containers)
-#      - STREAMING_TIMEOUT=300  # 流模式无响应超时时间，单位秒，默认120秒，如果出现空补全可以尝试改为更大值 （Streaming timeout in seconds, default is 120s. Increase if experiencing empty completions）
+#      - STREAMING_TIMEOUT=60  # 流模式无响应/首包超时时间，单位秒，默认60秒，如果出现空补全可以尝试改为更大值 （Streaming idle/first-data timeout in seconds, default is 60s. Increase if experiencing empty completions）
 #      - RELAY_IDLE_CONN_TIMEOUT=90  # Relay HTTP 客户端空闲连接超时时间，单位秒，默认跟随 Go 标准库，设置为0表示不限制 (Relay HTTP client idle keep-alive timeout in seconds, defaults to Go standard library; set 0 to disable)
 #      - SESSION_SECRET=random_string  # 多机部署时设置，必须修改这个随机字符串！！ （multi-node deployment, set this to a random string!!!!!!!）
 #      - SYNC_FREQUENCY=60  # Uncomment if regular database syncing is needed

--- a/dto/channel_settings.go
+++ b/dto/channel_settings.go
@@ -33,13 +33,13 @@ type ChannelOtherSettings struct {
 	AzureResponsesVersion                 string                `json:"azure_responses_version,omitempty"`
 	VertexKeyType                         VertexKeyType         `json:"vertex_key_type,omitempty"` // "json" or "api_key"
 	OpenRouterEnterprise                  *bool                 `json:"openrouter_enterprise,omitempty"`
-	ClaudeBetaQuery                       bool                  `json:"claude_beta_query,omitempty"`          // Claude 渠道是否强制追加 ?beta=true
-	AllowServiceTier                      bool                  `json:"allow_service_tier,omitempty"`         // 是否允许 service_tier 透传（默认过滤以避免额外计费）
-	AllowInferenceGeo                     bool                  `json:"allow_inference_geo,omitempty"`        // 是否允许 inference_geo 透传（仅 Claude，默认过滤以满足数据驻留合规
-	AllowSpeed                            bool                  `json:"allow_speed,omitempty"`                // 是否允许 speed 透传（仅 Claude，默认过滤以避免意外切换推理速度模式）
-	AllowSafetyIdentifier                 bool                  `json:"allow_safety_identifier,omitempty"`    // 是否允许 safety_identifier 透传（默认过滤以保护用户隐私）
-	DisableStore                          bool                  `json:"disable_store,omitempty"`              // 是否禁用 store 透传（默认允许透传，禁用后可能导致 Codex 无法使用）
-	AllowIncludeObfuscation               bool                  `json:"allow_include_obfuscation,omitempty"`  // 是否允许 stream_options.include_obfuscation 透传（默认过滤以避免关闭流混淆保护）
+	ClaudeBetaQuery                       bool                  `json:"claude_beta_query,omitempty"`         // Claude 渠道是否强制追加 ?beta=true
+	AllowServiceTier                      bool                  `json:"allow_service_tier,omitempty"`        // 是否允许 service_tier 透传（默认过滤以避免额外计费）
+	AllowInferenceGeo                     bool                  `json:"allow_inference_geo,omitempty"`       // 是否允许 inference_geo 透传（仅 Claude，默认过滤以满足数据驻留合规
+	AllowSpeed                            bool                  `json:"allow_speed,omitempty"`               // 是否允许 speed 透传（仅 Claude，默认过滤以避免意外切换推理速度模式）
+	AllowSafetyIdentifier                 bool                  `json:"allow_safety_identifier,omitempty"`   // 是否允许 safety_identifier 透传（默认过滤以保护用户隐私）
+	DisableStore                          bool                  `json:"disable_store,omitempty"`             // 是否禁用 store 透传（默认允许透传，禁用后可能导致 Codex 无法使用）
+	AllowIncludeObfuscation               bool                  `json:"allow_include_obfuscation,omitempty"` // 是否允许 stream_options.include_obfuscation 透传（默认过滤以避免关闭流混淆保护）
 	ResponsesTranscriptReplayEnabled      bool                  `json:"responses_transcript_replay_enabled,omitempty"`
 	DisableTaskPollingSleep               bool                  `json:"disable_task_polling_sleep,omitempty"` // 是否跳过异步任务轮询间隔
 	AwsKeyType                            AwsKeyType            `json:"aws_key_type,omitempty"`

--- a/dto/channel_settings.go
+++ b/dto/channel_settings.go
@@ -40,6 +40,7 @@ type ChannelOtherSettings struct {
 	AllowSafetyIdentifier                 bool                  `json:"allow_safety_identifier,omitempty"`    // 是否允许 safety_identifier 透传（默认过滤以保护用户隐私）
 	DisableStore                          bool                  `json:"disable_store,omitempty"`              // 是否禁用 store 透传（默认允许透传，禁用后可能导致 Codex 无法使用）
 	AllowIncludeObfuscation               bool                  `json:"allow_include_obfuscation,omitempty"`  // 是否允许 stream_options.include_obfuscation 透传（默认过滤以避免关闭流混淆保护）
+	ResponsesTranscriptReplayEnabled      bool                  `json:"responses_transcript_replay_enabled,omitempty"`
 	DisableTaskPollingSleep               bool                  `json:"disable_task_polling_sleep,omitempty"` // 是否跳过异步任务轮询间隔
 	AwsKeyType                            AwsKeyType            `json:"aws_key_type,omitempty"`
 	UpstreamModelUpdateCheckEnabled       bool                  `json:"upstream_model_update_check_enabled,omitempty"`        // 是否检测上游模型更新

--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -392,6 +392,7 @@ const (
 type ResponsesStreamResponse struct {
 	Type     string                   `json:"type"`
 	Response *OpenAIResponsesResponse `json:"response,omitempty"`
+	Error    any                      `json:"error,omitempty"`
 	Delta    string                   `json:"delta,omitempty"`
 	Item     *ResponsesOutput         `json:"item,omitempty"`
 	// - response.function_call_arguments.delta

--- a/main.go
+++ b/main.go
@@ -316,6 +316,13 @@ func InitResources() error {
 		return err
 	}
 
+	model.StartIdentitySync(func() {
+		model.InitOptionMap()
+		if err := oauth.LoadCustomProviders(); err != nil {
+			common.SysError("failed to reload custom OAuth providers after identity sync: " + err.Error())
+		}
+	})
+
 	perfmetrics.Init()
 
 	// 启动系统监控

--- a/model/identity_sync.go
+++ b/model/identity_sync.go
@@ -1,0 +1,624 @@
+package model
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const identitySyncRemoteDSNEnv = "IDENTITY_SYNC_REMOTE_DSN"
+
+var identitySyncIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+type identitySyncTableSpec struct {
+	Table       string
+	PrimaryKeys []string
+	Required    bool
+	CacheCols   []string
+}
+
+var defaultIdentitySyncTableOrder = []string{
+	"users",
+	"setups",
+	"custom_oauth_providers",
+	"tokens",
+	"two_fas",
+	"two_fa_backup_codes",
+	"passkey_credentials",
+	"user_oauth_bindings",
+}
+
+var identitySyncAllowedTables = map[string]identitySyncTableSpec{
+	"users":                  {Table: "users", PrimaryKeys: []string{"id"}, Required: true},
+	"setups":                 {Table: "setups", PrimaryKeys: []string{"id"}, Required: true},
+	"tokens":                 {Table: "tokens", PrimaryKeys: []string{"id"}, Required: true, CacheCols: []string{"key"}},
+	"two_fas":                {Table: "two_fas", PrimaryKeys: []string{"id"}},
+	"two_fa_backup_codes":    {Table: "two_fa_backup_codes", PrimaryKeys: []string{"id"}},
+	"passkey_credentials":    {Table: "passkey_credentials", PrimaryKeys: []string{"id"}},
+	"custom_oauth_providers": {Table: "custom_oauth_providers", PrimaryKeys: []string{"id"}},
+	"user_oauth_bindings":    {Table: "user_oauth_bindings", PrimaryKeys: []string{"id"}},
+}
+
+type identitySyncConfig struct {
+	Enabled            bool
+	RemoteDSN          string
+	Tables             []identitySyncTableSpec
+	Interval           time.Duration
+	Timeout            time.Duration
+	BatchSize          int
+	MaxRowsPerTable    int64
+	DeleteMissing      bool
+	RefreshOnSync      bool
+	RunOnStartup       bool
+	FailStartupOnError bool
+}
+
+type identitySyncer struct {
+	config   identitySyncConfig
+	remoteDB *gorm.DB
+	localDB  *gorm.DB
+}
+
+type identitySyncResult struct {
+	Tables []identitySyncTableResult
+}
+
+type identitySyncTableResult struct {
+	Table     string
+	Rows      int64
+	Upserted  int64
+	Deleted   int64
+	Skipped   bool
+	SkipCause string
+}
+
+func (r identitySyncResult) DidWrite() bool {
+	for _, table := range r.Tables {
+		if table.Upserted > 0 || table.Deleted > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func loadIdentitySyncConfigFromEnv() (identitySyncConfig, error) {
+	cfg := identitySyncConfig{
+		Enabled:            common.GetEnvOrDefaultBool("IDENTITY_SYNC_ENABLED", false),
+		RemoteDSN:          strings.TrimSpace(os.Getenv(identitySyncRemoteDSNEnv)),
+		Interval:           time.Duration(common.GetEnvOrDefault("IDENTITY_SYNC_INTERVAL_SECONDS", 300)) * time.Second,
+		Timeout:            time.Duration(common.GetEnvOrDefault("IDENTITY_SYNC_TIMEOUT_SECONDS", 30)) * time.Second,
+		BatchSize:          common.GetEnvOrDefault("IDENTITY_SYNC_BATCH_SIZE", 100),
+		MaxRowsPerTable:    int64(common.GetEnvOrDefault("IDENTITY_SYNC_MAX_ROWS_PER_TABLE", 10000)),
+		DeleteMissing:      common.GetEnvOrDefaultBool("IDENTITY_SYNC_DELETE_MISSING", true),
+		RefreshOnSync:      common.GetEnvOrDefaultBool("IDENTITY_SYNC_REFRESH_ON_SYNC", true),
+		RunOnStartup:       common.GetEnvOrDefaultBool("IDENTITY_SYNC_ON_STARTUP", true),
+		FailStartupOnError: common.GetEnvOrDefaultBool("IDENTITY_SYNC_FAIL_STARTUP_ON_ERROR", false),
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = 100
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 30 * time.Second
+	}
+	tables, err := parseIdentitySyncTables(os.Getenv("IDENTITY_SYNC_TABLES"))
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Tables = tables
+	return cfg, nil
+}
+
+func parseIdentitySyncTables(raw string) ([]identitySyncTableSpec, error) {
+	if strings.TrimSpace(raw) == "" {
+		specs := make([]identitySyncTableSpec, 0, len(defaultIdentitySyncTableOrder))
+		for _, table := range defaultIdentitySyncTableOrder {
+			specs = append(specs, identitySyncAllowedTables[table])
+		}
+		return specs, nil
+	}
+
+	seen := make(map[string]struct{})
+	var specs []identitySyncTableSpec
+	for _, part := range strings.Split(raw, ",") {
+		table := strings.TrimSpace(part)
+		if table == "" {
+			continue
+		}
+		if !identitySyncIdentifierPattern.MatchString(table) {
+			return nil, fmt.Errorf("identity sync table %q is not a safe identifier", table)
+		}
+		spec, ok := identitySyncAllowedTables[table]
+		if !ok {
+			return nil, fmt.Errorf("identity sync table %q is not in the allowed table list", table)
+		}
+		if _, ok := seen[table]; ok {
+			continue
+		}
+		seen[table] = struct{}{}
+		specs = append(specs, spec)
+	}
+	if len(specs) == 0 {
+		return nil, fmt.Errorf("IDENTITY_SYNC_TABLES did not contain any allowed table")
+	}
+	return specs, nil
+}
+
+func newIdentitySyncerFromEnv(cfg identitySyncConfig) (*identitySyncer, error) {
+	if cfg.RemoteDSN == "" {
+		return nil, fmt.Errorf("%s is required when IDENTITY_SYNC_ENABLED=true", identitySyncRemoteDSNEnv)
+	}
+	remoteDB, _, err := chooseDB(identitySyncRemoteDSNEnv, false)
+	if err != nil {
+		return nil, fmt.Errorf("connect identity sync remote database: %w", err)
+	}
+	configureIdentitySyncRemotePool(remoteDB)
+	return &identitySyncer{
+		config:   cfg,
+		remoteDB: remoteDB,
+		localDB:  DB,
+	}, nil
+}
+
+func configureIdentitySyncRemotePool(db *gorm.DB) {
+	sqlDB, err := db.DB()
+	if err != nil {
+		common.SysError("identity sync remote database pool unavailable: " + err.Error())
+		return
+	}
+	sqlDB.SetMaxIdleConns(common.GetEnvOrDefault("IDENTITY_SYNC_REMOTE_MAX_IDLE_CONNS", 1))
+	sqlDB.SetMaxOpenConns(common.GetEnvOrDefault("IDENTITY_SYNC_REMOTE_MAX_OPEN_CONNS", 2))
+	sqlDB.SetConnMaxLifetime(time.Second * time.Duration(common.GetEnvOrDefault("IDENTITY_SYNC_REMOTE_CONN_MAX_LIFETIME_SECONDS", 300)))
+}
+
+// StartIdentitySync starts the optional one-way identity table sync loop.
+// The optional afterSync callback should refresh in-memory state that depends on
+// synchronized identity tables.
+func StartIdentitySync(afterSync func()) {
+	cfg, err := loadIdentitySyncConfigFromEnv()
+	if err != nil {
+		common.SysError("identity sync config error: " + err.Error())
+		return
+	}
+	if !cfg.Enabled {
+		return
+	}
+
+	syncer, err := newIdentitySyncerFromEnv(cfg)
+	if err != nil {
+		common.SysError("identity sync disabled: " + err.Error())
+		if cfg.FailStartupOnError {
+			common.FatalLog(err.Error())
+		}
+		return
+	}
+
+	runOnce := func(reason string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)
+		defer cancel()
+		result, err := syncer.Sync(ctx)
+		if err != nil {
+			common.SysError("identity sync " + reason + " failed: " + err.Error())
+			return err
+		}
+		logIdentitySyncResult(reason, result)
+		if cfg.RefreshOnSync && result.DidWrite() {
+			syncer.refreshCaches(result)
+			if afterSync != nil {
+				afterSync()
+			}
+		}
+		return nil
+	}
+
+	if cfg.RunOnStartup {
+		if err := runOnce("startup"); err != nil && cfg.FailStartupOnError {
+			common.FatalLog(err.Error())
+		}
+	}
+
+	if cfg.Interval <= 0 {
+		common.SysLog("identity sync interval disabled; startup sync only")
+		return
+	}
+
+	go func() {
+		ticker := time.NewTicker(cfg.Interval)
+		defer ticker.Stop()
+		for range ticker.C {
+			_ = runOnce("periodic")
+		}
+	}()
+	common.SysLog(fmt.Sprintf("identity sync enabled for %d tables every %s", len(cfg.Tables), cfg.Interval))
+}
+
+func (s *identitySyncer) Sync(ctx context.Context) (identitySyncResult, error) {
+	var result identitySyncResult
+	for _, spec := range s.config.Tables {
+		tableResult, err := s.syncTable(ctx, spec)
+		result.Tables = append(result.Tables, tableResult)
+		if err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+func (s *identitySyncer) syncTable(ctx context.Context, spec identitySyncTableSpec) (identitySyncTableResult, error) {
+	result := identitySyncTableResult{Table: spec.Table}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	if !s.remoteDB.Migrator().HasTable(spec.Table) {
+		if spec.Required {
+			return result, fmt.Errorf("remote identity table %s does not exist", spec.Table)
+		}
+		result.Skipped = true
+		result.SkipCause = "remote table missing"
+		return result, nil
+	}
+	if !s.localDB.Migrator().HasTable(spec.Table) {
+		return result, fmt.Errorf("local identity table %s does not exist", spec.Table)
+	}
+
+	columns, err := identitySyncSharedColumns(s.remoteDB, s.localDB, spec.Table)
+	if err != nil {
+		return result, err
+	}
+	if err := identitySyncValidatePrimaryKeys(spec, columns); err != nil {
+		return result, err
+	}
+
+	var total int64
+	if err := s.remoteDB.WithContext(ctx).Table(spec.Table).Count(&total).Error; err != nil {
+		return result, fmt.Errorf("count remote table %s: %w", spec.Table, err)
+	}
+	result.Rows = total
+	if s.config.MaxRowsPerTable > 0 && total > s.config.MaxRowsPerTable {
+		return result, fmt.Errorf("remote identity table %s has %d rows, above max %d", spec.Table, total, s.config.MaxRowsPerTable)
+	}
+
+	remoteRows, remoteKeySet, err := s.loadRemoteRows(ctx, spec, columns)
+	if err != nil {
+		return result, err
+	}
+
+	result.Upserted, err = s.upsertRows(ctx, spec, columns, remoteRows)
+	if err != nil {
+		return result, err
+	}
+
+	if s.config.DeleteMissing {
+		result.Deleted, err = s.deleteMissingRows(ctx, spec, columns, remoteKeySet)
+		if err != nil {
+			return result, err
+		}
+	}
+
+	return result, nil
+}
+
+func identitySyncSharedColumns(remoteDB, localDB *gorm.DB, table string) ([]string, error) {
+	remoteCols, err := identitySyncColumnSet(remoteDB, table)
+	if err != nil {
+		return nil, fmt.Errorf("read remote columns for %s: %w", table, err)
+	}
+	localCols, err := identitySyncColumnSet(localDB, table)
+	if err != nil {
+		return nil, fmt.Errorf("read local columns for %s: %w", table, err)
+	}
+	var columns []string
+	for col := range remoteCols {
+		if _, ok := localCols[col]; ok {
+			columns = append(columns, col)
+		}
+	}
+	sort.Strings(columns)
+	if len(columns) == 0 {
+		return nil, fmt.Errorf("identity table %s has no shared columns", table)
+	}
+	return columns, nil
+}
+
+func identitySyncColumnSet(db *gorm.DB, table string) (map[string]struct{}, error) {
+	columnTypes, err := db.Migrator().ColumnTypes(table)
+	if err != nil {
+		return nil, err
+	}
+	columns := make(map[string]struct{}, len(columnTypes))
+	for _, col := range columnTypes {
+		name := strings.ToLower(strings.TrimSpace(col.Name()))
+		if name != "" {
+			columns[name] = struct{}{}
+		}
+	}
+	return columns, nil
+}
+
+func identitySyncValidatePrimaryKeys(spec identitySyncTableSpec, columns []string) error {
+	columnSet := make(map[string]struct{}, len(columns))
+	for _, col := range columns {
+		columnSet[col] = struct{}{}
+	}
+	for _, pk := range spec.PrimaryKeys {
+		if _, ok := columnSet[pk]; !ok {
+			return fmt.Errorf("identity table %s shared columns do not include primary key %s", spec.Table, pk)
+		}
+	}
+	return nil
+}
+
+func (s *identitySyncer) loadRemoteRows(ctx context.Context, spec identitySyncTableSpec, columns []string) ([]map[string]interface{}, map[string]struct{}, error) {
+	order := identitySyncQuotedColumnList(s.remoteDB, spec.PrimaryKeys)
+	selectColumns := identitySyncQuotedColumnList(s.remoteDB, columns)
+	remoteKeys := make(map[string]struct{})
+	remoteRows := make([]map[string]interface{}, 0)
+	for offset := 0; ; offset += s.config.BatchSize {
+		var rows []map[string]interface{}
+		err := s.remoteDB.WithContext(ctx).
+			Table(spec.Table).
+			Select(selectColumns).
+			Order(order).
+			Limit(s.config.BatchSize).
+			Offset(offset).
+			Find(&rows).Error
+		if err != nil {
+			return nil, nil, fmt.Errorf("read remote table %s: %w", spec.Table, err)
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, row := range rows {
+			normalizeIdentitySyncRow(row)
+			remoteKeys[identitySyncPrimaryKeyString(row, spec.PrimaryKeys)] = struct{}{}
+			remoteRows = append(remoteRows, row)
+		}
+		if len(rows) < s.config.BatchSize {
+			break
+		}
+	}
+	return remoteRows, remoteKeys, nil
+}
+
+func (s *identitySyncer) upsertRows(ctx context.Context, spec identitySyncTableSpec, columns []string, rows []map[string]interface{}) (int64, error) {
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	updateColumns := identitySyncUpdateColumns(columns, spec.PrimaryKeys)
+	onConflict := clause.OnConflict{
+		Columns: identitySyncClauseColumns(spec.PrimaryKeys),
+	}
+	if len(updateColumns) == 0 {
+		onConflict.DoNothing = true
+	} else {
+		onConflict.DoUpdates = clause.AssignmentColumns(updateColumns)
+	}
+
+	var affected int64
+	for start := 0; start < len(rows); start += s.config.BatchSize {
+		end := start + s.config.BatchSize
+		if end > len(rows) {
+			end = len(rows)
+		}
+		tx := s.localDB.WithContext(ctx).
+			Table(spec.Table).
+			Clauses(onConflict).
+			Create(rows[start:end])
+		if tx.Error != nil {
+			return affected, fmt.Errorf("upsert local table %s: %w", spec.Table, tx.Error)
+		}
+		affected += tx.RowsAffected
+	}
+	return affected, nil
+}
+
+func identitySyncUpdateColumns(columns, primaryKeys []string) []string {
+	pkSet := make(map[string]struct{}, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		pkSet[pk] = struct{}{}
+	}
+	updateColumns := make([]string, 0, len(columns))
+	for _, column := range columns {
+		if _, ok := pkSet[column]; ok {
+			continue
+		}
+		updateColumns = append(updateColumns, column)
+	}
+	return updateColumns
+}
+
+func identitySyncClauseColumns(columns []string) []clause.Column {
+	result := make([]clause.Column, 0, len(columns))
+	for _, column := range columns {
+		result = append(result, clause.Column{Name: column})
+	}
+	return result
+}
+
+func (s *identitySyncer) deleteMissingRows(ctx context.Context, spec identitySyncTableSpec, columns []string, remoteKeys map[string]struct{}) (int64, error) {
+	selectColumns := identitySyncSelectColumns(spec.PrimaryKeys, spec.CacheCols, columns)
+	selectExpr := identitySyncQuotedColumnList(s.localDB, selectColumns)
+	var localRows []map[string]interface{}
+	if err := s.localDB.WithContext(ctx).Table(spec.Table).Select(selectExpr).Find(&localRows).Error; err != nil {
+		return 0, fmt.Errorf("read local table %s keys: %w", spec.Table, err)
+	}
+
+	var deleted int64
+	for _, row := range localRows {
+		normalizeIdentitySyncRow(row)
+		if _, ok := remoteKeys[identitySyncPrimaryKeyString(row, spec.PrimaryKeys)]; ok {
+			continue
+		}
+		where, args := identitySyncPKWhere(s.localDB, row, spec.PrimaryKeys)
+		tx := s.localDB.WithContext(ctx).Exec("DELETE FROM "+identitySyncQuoteIdentifier(s.localDB, spec.Table)+" WHERE "+where, args...)
+		if tx.Error != nil {
+			return deleted, fmt.Errorf("delete local table %s: %w", spec.Table, tx.Error)
+		}
+		deleted += tx.RowsAffected
+		s.invalidateRowCache(spec, row)
+	}
+	return deleted, nil
+}
+
+func identitySyncSelectColumns(primaryKeys, cacheCols, available []string) []string {
+	availableSet := make(map[string]struct{}, len(available))
+	for _, col := range available {
+		availableSet[col] = struct{}{}
+	}
+	seen := make(map[string]struct{})
+	var columns []string
+	for _, col := range append(primaryKeys, cacheCols...) {
+		if _, ok := availableSet[col]; !ok {
+			continue
+		}
+		if _, ok := seen[col]; ok {
+			continue
+		}
+		seen[col] = struct{}{}
+		columns = append(columns, col)
+	}
+	return columns
+}
+
+func identitySyncPKWhere(db *gorm.DB, row map[string]interface{}, primaryKeys []string) (string, []interface{}) {
+	parts := make([]string, 0, len(primaryKeys))
+	args := make([]interface{}, 0, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		parts = append(parts, identitySyncQuoteIdentifier(db, pk)+" = ?")
+		args = append(args, row[pk])
+	}
+	return strings.Join(parts, " AND "), args
+}
+
+func identitySyncQuotedColumnList(db *gorm.DB, columns []string) string {
+	quoted := make([]string, 0, len(columns))
+	for _, column := range columns {
+		quoted = append(quoted, identitySyncQuoteIdentifier(db, column))
+	}
+	return strings.Join(quoted, ", ")
+}
+
+func identitySyncQuoteIdentifier(db *gorm.DB, identifier string) string {
+	var builder strings.Builder
+	db.Dialector.QuoteTo(&builder, identifier)
+	return builder.String()
+}
+
+func identitySyncPrimaryKeyString(row map[string]interface{}, primaryKeys []string) string {
+	parts := make([]string, 0, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		parts = append(parts, fmt.Sprint(row[pk]))
+	}
+	return strings.Join(parts, "\x00")
+}
+
+func normalizeIdentitySyncRow(row map[string]interface{}) {
+	for key, value := range row {
+		lowerKey := strings.ToLower(key)
+		if lowerKey != key {
+			delete(row, key)
+			row[lowerKey] = value
+		}
+		switch v := row[lowerKey].(type) {
+		case []byte:
+			row[lowerKey] = string(v)
+		case sql.RawBytes:
+			row[lowerKey] = string(v)
+		}
+	}
+}
+
+func (s *identitySyncer) refreshCaches(result identitySyncResult) {
+	if !common.RedisEnabled {
+		return
+	}
+	for _, spec := range s.config.Tables {
+		switch spec.Table {
+		case "users":
+			var users []User
+			if err := s.localDB.Select("id").Find(&users).Error; err != nil {
+				common.SysError("identity sync failed to refresh user cache: " + err.Error())
+				continue
+			}
+			for _, user := range users {
+				if err := invalidateUserCache(user.Id); err != nil {
+					common.SysError(fmt.Sprintf("identity sync failed to invalidate user cache %d: %s", user.Id, err.Error()))
+				}
+			}
+		case "tokens":
+			var tokens []Token
+			if err := s.localDB.Select("key").Find(&tokens).Error; err != nil {
+				common.SysError("identity sync failed to refresh token cache: " + err.Error())
+				continue
+			}
+			for _, token := range tokens {
+				if token.Key == "" {
+					continue
+				}
+				if err := cacheDeleteToken(token.Key); err != nil {
+					common.SysError("identity sync failed to invalidate token cache: " + err.Error())
+				}
+			}
+		}
+	}
+	_ = result
+}
+
+func (s *identitySyncer) invalidateRowCache(spec identitySyncTableSpec, row map[string]interface{}) {
+	if !common.RedisEnabled {
+		return
+	}
+	switch spec.Table {
+	case "users":
+		if id, ok := identitySyncInt(row["id"]); ok {
+			if err := invalidateUserCache(id); err != nil {
+				common.SysError(fmt.Sprintf("identity sync failed to invalidate deleted user cache %d: %s", id, err.Error()))
+			}
+		}
+	case "tokens":
+		if key, ok := row["key"].(string); ok && key != "" {
+			if err := cacheDeleteToken(key); err != nil {
+				common.SysError("identity sync failed to invalidate deleted token cache: " + err.Error())
+			}
+		}
+	}
+}
+
+func identitySyncInt(value interface{}) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	case int32:
+		return int(v), true
+	case uint:
+		return int(v), true
+	case uint64:
+		return int(v), true
+	case uint32:
+		return int(v), true
+	default:
+		return 0, false
+	}
+}
+
+func logIdentitySyncResult(reason string, result identitySyncResult) {
+	parts := make([]string, 0, len(result.Tables))
+	for _, table := range result.Tables {
+		if table.Skipped {
+			parts = append(parts, fmt.Sprintf("%s:skipped(%s)", table.Table, table.SkipCause))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s:rows=%d,upserted=%d,deleted=%d", table.Table, table.Rows, table.Upserted, table.Deleted))
+	}
+	common.SysLog(fmt.Sprintf("identity sync %s complete: %s", reason, strings.Join(parts, "; ")))
+}

--- a/model/identity_sync.go
+++ b/model/identity_sync.go
@@ -540,8 +540,11 @@ func (s *identitySyncer) refreshCaches(result identitySyncResult) {
 	if !common.RedisEnabled {
 		return
 	}
-	for _, spec := range s.config.Tables {
-		switch spec.Table {
+	for _, tableResult := range result.Tables {
+		if tableResult.Upserted == 0 && tableResult.Deleted == 0 {
+			continue
+		}
+		switch tableResult.Table {
 		case "users":
 			var users []User
 			if err := s.localDB.Select("id").Find(&users).Error; err != nil {
@@ -569,7 +572,6 @@ func (s *identitySyncer) refreshCaches(result identitySyncResult) {
 			}
 		}
 	}
-	_ = result
 }
 
 func (s *identitySyncer) invalidateRowCache(spec identitySyncTableSpec, row map[string]interface{}) {

--- a/model/identity_sync_test.go
+++ b/model/identity_sync_test.go
@@ -1,0 +1,135 @@
+package model
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestParseIdentitySyncTablesRejectsUnknown(t *testing.T) {
+	_, err := parseIdentitySyncTables("users,channels")
+	require.Error(t, err)
+}
+
+func TestIdentitySyncerSyncsAndDeletesWhitelistedTables(t *testing.T) {
+	remoteDB := newIdentitySyncTestDB(t)
+	localDB := newIdentitySyncTestDB(t)
+
+	require.NoError(t, remoteDB.Create(&User{
+		Id:          1,
+		Username:    "alice",
+		Password:    "password",
+		DisplayName: "Alice",
+		Status:      1,
+		Group:       "default",
+		Quota:       100,
+	}).Error)
+	require.NoError(t, remoteDB.Create(&Token{
+		Id:             10,
+		UserId:         1,
+		Key:            "remote-token",
+		Status:         1,
+		Name:           "remote",
+		CreatedTime:    1000,
+		ExpiredTime:    -1,
+		UnlimitedQuota: true,
+	}).Error)
+	require.NoError(t, remoteDB.Create(&Setup{
+		ID:            1,
+		Version:       "test",
+		InitializedAt: 100,
+	}).Error)
+
+	require.NoError(t, localDB.Create(&Token{
+		Id:          20,
+		UserId:      1,
+		Key:         "stale-token",
+		Status:      1,
+		Name:        "stale",
+		CreatedTime: 900,
+		ExpiredTime: -1,
+	}).Error)
+
+	syncer := &identitySyncer{
+		config: identitySyncConfig{
+			Tables: []identitySyncTableSpec{
+				identitySyncAllowedTables["users"],
+				identitySyncAllowedTables["setups"],
+				identitySyncAllowedTables["tokens"],
+			},
+			BatchSize:       2,
+			MaxRowsPerTable: 100,
+			DeleteMissing:   true,
+		},
+		remoteDB: remoteDB,
+		localDB:  localDB,
+	}
+
+	result, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+	require.True(t, result.DidWrite())
+
+	var user User
+	require.NoError(t, localDB.First(&user, 1).Error)
+	require.Equal(t, "alice", user.Username)
+	require.Equal(t, 100, user.Quota)
+
+	var token Token
+	require.NoError(t, localDB.First(&token, 10).Error)
+	require.Equal(t, "remote-token", token.Key)
+	require.True(t, token.UnlimitedQuota)
+
+	var staleCount int64
+	require.NoError(t, localDB.Model(&Token{}).Where("id = ?", 20).Count(&staleCount).Error)
+	require.EqualValues(t, 0, staleCount)
+
+	var setup Setup
+	require.NoError(t, localDB.First(&setup, 1).Error)
+	require.Equal(t, "test", setup.Version)
+}
+
+func TestIdentitySyncerSkipsOptionalMissingRemoteTable(t *testing.T) {
+	remoteDB := newIdentitySyncTestDB(t)
+	localDB := newIdentitySyncTestDB(t)
+	require.NoError(t, remoteDB.Migrator().DropTable(&PasskeyCredential{}))
+
+	syncer := &identitySyncer{
+		config: identitySyncConfig{
+			Tables:          []identitySyncTableSpec{identitySyncAllowedTables["passkey_credentials"]},
+			BatchSize:       10,
+			MaxRowsPerTable: 100,
+			DeleteMissing:   true,
+		},
+		remoteDB: remoteDB,
+		localDB:  localDB,
+	}
+
+	result, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result.Tables, 1)
+	require.True(t, result.Tables[0].Skipped)
+}
+
+func newIdentitySyncTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&User{},
+		&Token{},
+		&Setup{},
+		&TwoFA{},
+		&TwoFABackupCode{},
+		&PasskeyCredential{},
+		&CustomOAuthProvider{},
+		&UserOAuthBinding{},
+	))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetConnMaxLifetime(time.Minute)
+	return db
+}

--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -42,13 +42,6 @@ func applyUpstreamContentLength(req *http.Request, info *common.RelayInfo) {
 	}
 }
 
-func applyUpstreamBodyEncoding(req *http.Request, info *common.RelayInfo) {
-	if req == nil || info == nil || strings.TrimSpace(info.UpstreamRequestBodyEncoding) == "" {
-		return
-	}
-	req.Header.Set("Content-Encoding", strings.TrimSpace(info.UpstreamRequestBodyEncoding))
-}
-
 func SetupApiRequestHeader(info *common.RelayInfo, c *gin.Context, req *http.Header) {
 	if info.RelayMode == constant.RelayModeAudioTranscription || info.RelayMode == constant.RelayModeAudioTranslation {
 		// multipart/form-data
@@ -334,7 +327,6 @@ func DoApiRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody
 		return nil, err
 	}
 	applyHeaderOverrideToRequest(req, headerOverride)
-	applyUpstreamBodyEncoding(req, info)
 	resp, err := doRequest(c, req, info)
 	if err != nil {
 		return nil, fmt.Errorf("do request failed: %w", err)
@@ -367,7 +359,6 @@ func DoFormRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBod
 		return nil, err
 	}
 	applyHeaderOverrideToRequest(req, headerOverride)
-	applyUpstreamBodyEncoding(req, info)
 	resp, err := doRequest(c, req, info)
 	if err != nil {
 		return nil, fmt.Errorf("do request failed: %w", err)

--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -487,13 +487,13 @@ func DoRequest(c *gin.Context, req *http.Request, info *common.RelayInfo) (*http
 func doRequest(c *gin.Context, req *http.Request, info *common.RelayInfo) (*http.Response, error) {
 	var client *http.Client
 	var err error
-	if info.ChannelSetting.Proxy != "" {
-		client, err = service.NewProxyHttpClient(info.ChannelSetting.Proxy)
-		if err != nil {
-			return nil, fmt.Errorf("new proxy http client failed: %w", err)
-		}
+	if info.IsStream {
+		client, err = service.GetStreamHttpClientWithProxy(info.ChannelSetting.Proxy)
 	} else {
-		client = service.GetHttpClient()
+		client, err = service.GetHttpClientWithProxy(info.ChannelSetting.Proxy)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("new proxy http client failed: %w", err)
 	}
 
 	var stopPinger context.CancelFunc

--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -42,6 +42,13 @@ func applyUpstreamContentLength(req *http.Request, info *common.RelayInfo) {
 	}
 }
 
+func applyUpstreamBodyEncoding(req *http.Request, info *common.RelayInfo) {
+	if req == nil || info == nil || strings.TrimSpace(info.UpstreamRequestBodyEncoding) == "" {
+		return
+	}
+	req.Header.Set("Content-Encoding", strings.TrimSpace(info.UpstreamRequestBodyEncoding))
+}
+
 func SetupApiRequestHeader(info *common.RelayInfo, c *gin.Context, req *http.Header) {
 	if info.RelayMode == constant.RelayModeAudioTranscription || info.RelayMode == constant.RelayModeAudioTranslation {
 		// multipart/form-data
@@ -327,6 +334,7 @@ func DoApiRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody
 		return nil, err
 	}
 	applyHeaderOverrideToRequest(req, headerOverride)
+	applyUpstreamBodyEncoding(req, info)
 	resp, err := doRequest(c, req, info)
 	if err != nil {
 		return nil, fmt.Errorf("do request failed: %w", err)
@@ -359,6 +367,7 @@ func DoFormRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBod
 		return nil, err
 	}
 	applyHeaderOverrideToRequest(req, headerOverride)
+	applyUpstreamBodyEncoding(req, info)
 	resp, err := doRequest(c, req, info)
 	if err != nil {
 		return nil, fmt.Errorf("do request failed: %w", err)

--- a/relay/channel/api_request_test.go
+++ b/relay/channel/api_request_test.go
@@ -191,25 +191,3 @@ func TestProcessHeaderOverride_PassHeadersTemplateSetsRuntimeHeaders(t *testing.
 	require.Equal(t, "sess-123", upstreamReq.Header.Get("Session_id"))
 	require.Empty(t, upstreamReq.Header.Get("X-Codex-Beta-Features"))
 }
-
-func TestApplyUpstreamBodyEncodingSetsContentEncoding(t *testing.T) {
-	t.Parallel()
-
-	req := httptest.NewRequest(http.MethodPost, "https://example.com/v1/responses", nil)
-	info := &relaycommon.RelayInfo{UpstreamRequestBodyEncoding: " gzip "}
-
-	applyUpstreamBodyEncoding(req, info)
-
-	require.Equal(t, "gzip", req.Header.Get("Content-Encoding"))
-}
-
-func TestApplyUpstreamBodyEncodingIgnoresEmptyEncoding(t *testing.T) {
-	t.Parallel()
-
-	req := httptest.NewRequest(http.MethodPost, "https://example.com/v1/responses", nil)
-	req.Header.Set("Content-Encoding", "identity")
-
-	applyUpstreamBodyEncoding(req, &relaycommon.RelayInfo{})
-
-	require.Equal(t, "identity", req.Header.Get("Content-Encoding"))
-}

--- a/relay/channel/api_request_test.go
+++ b/relay/channel/api_request_test.go
@@ -191,3 +191,25 @@ func TestProcessHeaderOverride_PassHeadersTemplateSetsRuntimeHeaders(t *testing.
 	require.Equal(t, "sess-123", upstreamReq.Header.Get("Session_id"))
 	require.Empty(t, upstreamReq.Header.Get("X-Codex-Beta-Features"))
 }
+
+func TestApplyUpstreamBodyEncodingSetsContentEncoding(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "https://example.com/v1/responses", nil)
+	info := &relaycommon.RelayInfo{UpstreamRequestBodyEncoding: " gzip "}
+
+	applyUpstreamBodyEncoding(req, info)
+
+	require.Equal(t, "gzip", req.Header.Get("Content-Encoding"))
+}
+
+func TestApplyUpstreamBodyEncodingIgnoresEmptyEncoding(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "https://example.com/v1/responses", nil)
+	req.Header.Set("Content-Encoding", "identity")
+
+	applyUpstreamBodyEncoding(req, &relaycommon.RelayInfo{})
+
+	require.Equal(t, "identity", req.Header.Get("Content-Encoding"))
+}

--- a/relay/channel/codex/adaptor.go
+++ b/relay/channel/codex/adaptor.go
@@ -101,10 +101,39 @@ func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommo
 	}
 	// codex: store must be false
 	request.Store = json.RawMessage("false")
+	request.Include = ensureCodexResponsesInclude(request.Include, "reasoning.encrypted_content")
 	// rm max_output_tokens
 	request.MaxOutputTokens = nil
 	request.Temperature = nil
 	return request, nil
+}
+
+func ensureCodexResponsesInclude(include json.RawMessage, value string) json.RawMessage {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return include
+	}
+	trimmed := strings.TrimSpace(string(include))
+	if trimmed == "" || trimmed == "null" {
+		raw, _ := json.Marshal([]string{value})
+		return raw
+	}
+
+	var items []string
+	if err := json.Unmarshal(include, &items); err != nil {
+		return include
+	}
+	for _, item := range items {
+		if item == value {
+			return include
+		}
+	}
+	items = append(items, value)
+	raw, err := json.Marshal(items)
+	if err != nil {
+		return include
+	}
+	return raw
 }
 
 func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBody io.Reader) (any, error) {

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -152,7 +152,7 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 		if isResponsesStreamTerminalError(streamResponse.Type) {
 			openAIError := responsesStreamOpenAIError(streamResponse)
 			streamErr = types.WithOpenAIError(openAIError, http.StatusInternalServerError)
-			logResponsesStreamTerminalError(c, info, streamResponse.Type, openAIError)
+			logResponsesStreamTerminalError(c, info, streamResponse.Type, openAIError, data)
 			if !shouldDeferResponsesStreamErrorToHandler(c, sentDownstream) {
 				flushPendingPrelude()
 				sendResponsesStreamData(c, streamResponse, data)
@@ -267,8 +267,23 @@ func responsesStreamOpenAIError(streamResponse dto.ResponsesStreamResponse) type
 			}
 		}
 	}
+	return responsesStreamFallbackOpenAIError(streamResponse)
+}
+
+func responsesStreamFallbackOpenAIError(streamResponse dto.ResponsesStreamResponse) types.OpenAIError {
+	message := fmt.Sprintf("responses stream terminal event: %s", streamResponse.Type)
+	if streamResponse.Response != nil {
+		if status := common.JsonRawMessageToString(streamResponse.Response.Status); status != "" {
+			message += fmt.Sprintf(" status=%s", status)
+		}
+		if streamResponse.Response.IncompleteDetails != nil {
+			if details, err := common.Marshal(streamResponse.Response.IncompleteDetails); err == nil {
+				message += fmt.Sprintf(" incomplete_details=%s", details)
+			}
+		}
+	}
 	return types.OpenAIError{
-		Message: fmt.Sprintf("responses stream terminal event: %s", streamResponse.Type),
+		Message: message,
 		Type:    string(types.ErrorCodeBadResponse),
 		Code:    string(types.ErrorCodeBadResponse),
 	}
@@ -353,7 +368,7 @@ func responsesStreamFailureEvent(newAPIError *types.NewAPIError) (dto.ResponsesS
 	return streamResponse, string(data)
 }
 
-func logResponsesStreamTerminalError(c *gin.Context, info *relaycommon.RelayInfo, eventType string, openAIError types.OpenAIError) {
+func logResponsesStreamTerminalError(c *gin.Context, info *relaycommon.RelayInfo, eventType string, openAIError types.OpenAIError, data string) {
 	channelID := 0
 	if info != nil {
 		channelID = info.ChannelId
@@ -366,6 +381,14 @@ func logResponsesStreamTerminalError(c *gin.Context, info *relaycommon.RelayInfo
 		openAIError.Code,
 		truncateResponsesStreamErrorMessage(openAIError.Message),
 	))
+	if openAIError.Code == string(types.ErrorCodeBadResponse) && strings.HasPrefix(openAIError.Message, "responses stream terminal event:") {
+		logger.LogError(c, fmt.Sprintf(
+			"responses stream terminal event raw payload on channel #%d: event=%s payload=%s",
+			channelID,
+			eventType,
+			truncateResponsesStreamErrorMessage(data),
+		))
+	}
 }
 
 func logResponsesStreamIncomplete(c *gin.Context, info *relaycommon.RelayInfo, sentDownstream bool, newAPIError *types.NewAPIError) {

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -31,10 +31,6 @@ type responsesStreamDataEvent struct {
 	Data     string
 }
 
-type responsesStreamErrorPayload struct {
-	Error types.OpenAIError `json:"error"`
-}
-
 func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
 	defer service.CloseResponseBodyGracefully(resp)
 
@@ -136,13 +132,10 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 			openAIError := responsesStreamOpenAIError(streamResponse)
 			streamErr = types.WithOpenAIError(openAIError, http.StatusInternalServerError)
 			logResponsesStreamTerminalError(c, info, streamResponse.Type, openAIError)
-			if !shouldDeferResponsesStreamErrorForReplay(info, openAIError, sentDownstream) {
+			if !shouldDeferResponsesStreamErrorToHandler(c, sentDownstream) {
 				flushPendingPrelude()
-				if sendErr := sendResponsesStreamErrorData(c, openAIError); sendErr != nil {
-					streamErr = types.NewOpenAIError(sendErr, types.ErrorCodeBadResponse, http.StatusInternalServerError)
-				} else {
-					sentDownstream = true
-				}
+				sendResponsesStreamData(c, streamResponse, data)
+				sentDownstream = true
 			}
 			sr.Stop(streamErr)
 			return
@@ -230,6 +223,11 @@ func shouldBufferResponsesStreamPrelude(info *relaycommon.RelayInfo, eventType s
 }
 
 func responsesStreamOpenAIError(streamResponse dto.ResponsesStreamResponse) types.OpenAIError {
+	if openAIError := dto.GetOpenAIError(streamResponse.Error); openAIError != nil {
+		if openAIError.Message != "" || openAIError.Type != "" || openAIError.Code != nil {
+			return *openAIError
+		}
+	}
 	if streamResponse.Response != nil {
 		if openAIError := streamResponse.Response.GetOpenAIError(); openAIError != nil {
 			if openAIError.Message != "" || openAIError.Type != "" || openAIError.Code != nil {
@@ -244,25 +242,11 @@ func responsesStreamOpenAIError(streamResponse dto.ResponsesStreamResponse) type
 	}
 }
 
-func shouldDeferResponsesStreamErrorForReplay(info *relaycommon.RelayInfo, openAIError types.OpenAIError, sentDownstream bool) bool {
-	if sentDownstream || info == nil || info.ResponsesTranscriptReplay == nil || info.ResponsesTranscriptReplay.Replayed {
+func shouldDeferResponsesStreamErrorToHandler(c *gin.Context, sentDownstream bool) bool {
+	if sentDownstream || c == nil || c.Writer == nil {
 		return false
 	}
-	body, err := common.Marshal(responsesStreamErrorPayload{Error: openAIError})
-	if err != nil {
-		return false
-	}
-	return relaycommon.IsResponsesTranscriptReplayError(http.StatusBadRequest, body)
-}
-
-func sendResponsesStreamErrorData(c *gin.Context, openAIError types.OpenAIError) error {
-	payload, err := common.Marshal(responsesStreamErrorPayload{Error: openAIError})
-	if err != nil {
-		return err
-	}
-	c.Render(-1, common.CustomEvent{Data: "event: error\n"})
-	c.Render(-1, common.CustomEvent{Data: "data: " + string(payload)})
-	return helper.FlushWriter(c)
+	return !c.Writer.Written()
 }
 
 func logResponsesStreamTerminalError(c *gin.Context, info *relaycommon.RelayInfo, eventType string, openAIError types.OpenAIError) {

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -17,6 +17,24 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const (
+	responsesStreamEventCompleted  = "response.completed"
+	responsesStreamEventCreated    = "response.created"
+	responsesStreamEventError      = "response.error"
+	responsesStreamEventFailed     = "response.failed"
+	responsesStreamEventInProgress = "response.in_progress"
+	responsesStreamEventTextDelta  = "response.output_text.delta"
+)
+
+type responsesStreamDataEvent struct {
+	Response dto.ResponsesStreamResponse
+	Data     string
+}
+
+type responsesStreamErrorPayload struct {
+	Error types.OpenAIError `json:"error"`
+}
+
 func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
 	defer service.CloseResponseBodyGracefully(resp)
 
@@ -79,6 +97,30 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 
 	var usage = &dto.Usage{}
 	var responseTextBuilder strings.Builder
+	var streamErr *types.NewAPIError
+	var sentDownstream bool
+	var pendingPrelude []responsesStreamDataEvent
+
+	flushPendingPrelude := func() {
+		for _, event := range pendingPrelude {
+			sendResponsesStreamData(c, event.Response, event.Data)
+			sentDownstream = true
+		}
+		pendingPrelude = nil
+	}
+
+	sendStreamData := func(streamResponse dto.ResponsesStreamResponse, data string) {
+		if shouldBufferResponsesStreamPrelude(info, streamResponse.Type, sentDownstream) {
+			pendingPrelude = append(pendingPrelude, responsesStreamDataEvent{
+				Response: streamResponse,
+				Data:     data,
+			})
+			return
+		}
+		flushPendingPrelude()
+		sendResponsesStreamData(c, streamResponse, data)
+		sentDownstream = true
+	}
 
 	helper.StreamScannerHandler(c, resp, info, func(data string, sr *helper.StreamResult) {
 
@@ -90,9 +132,25 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 			return
 		}
 		relaycommon.ObserveResponsesTranscriptReplayStreamEvent(info, data)
-		sendResponsesStreamData(c, streamResponse, data)
+		if isResponsesStreamTerminalError(streamResponse.Type) {
+			openAIError := responsesStreamOpenAIError(streamResponse)
+			streamErr = types.WithOpenAIError(openAIError, http.StatusInternalServerError)
+			logResponsesStreamTerminalError(c, info, streamResponse.Type, openAIError)
+			if !shouldDeferResponsesStreamErrorForReplay(info, openAIError, sentDownstream) {
+				flushPendingPrelude()
+				if sendErr := sendResponsesStreamErrorData(c, openAIError); sendErr != nil {
+					streamErr = types.NewOpenAIError(sendErr, types.ErrorCodeBadResponse, http.StatusInternalServerError)
+				} else {
+					sentDownstream = true
+				}
+			}
+			sr.Stop(streamErr)
+			return
+		}
+
+		sendStreamData(streamResponse, data)
 		switch streamResponse.Type {
-		case "response.completed":
+		case responsesStreamEventCompleted:
 			if streamResponse.Response != nil {
 				if streamResponse.Response.Usage != nil {
 					if streamResponse.Response.Usage.InputTokens != 0 {
@@ -114,7 +172,7 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 					c.Set("image_generation_call_size", streamResponse.Response.GetSize())
 				}
 			}
-		case "response.output_text.delta":
+		case responsesStreamEventTextDelta:
 			// 处理输出文本
 			responseTextBuilder.WriteString(streamResponse.Delta)
 		case dto.ResponsesOutputTypeItemDone:
@@ -131,6 +189,11 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 			}
 		}
 	})
+
+	if streamErr != nil {
+		return nil, streamErr
+	}
+	flushPendingPrelude()
 
 	if usage.CompletionTokens == 0 {
 		// 计算输出文本的 token 数量
@@ -149,4 +212,78 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
 
 	return usage, nil
+}
+
+func isResponsesStreamTerminalError(eventType string) bool {
+	return eventType == responsesStreamEventError || eventType == responsesStreamEventFailed
+}
+
+func isResponsesStreamPrelude(eventType string) bool {
+	return eventType == responsesStreamEventCreated || eventType == responsesStreamEventInProgress
+}
+
+func shouldBufferResponsesStreamPrelude(info *relaycommon.RelayInfo, eventType string, sentDownstream bool) bool {
+	if sentDownstream || !isResponsesStreamPrelude(eventType) {
+		return false
+	}
+	return info != nil && info.ResponsesTranscriptReplay != nil && !info.ResponsesTranscriptReplay.Replayed
+}
+
+func responsesStreamOpenAIError(streamResponse dto.ResponsesStreamResponse) types.OpenAIError {
+	if streamResponse.Response != nil {
+		if openAIError := streamResponse.Response.GetOpenAIError(); openAIError != nil {
+			if openAIError.Message != "" || openAIError.Type != "" || openAIError.Code != nil {
+				return *openAIError
+			}
+		}
+	}
+	return types.OpenAIError{
+		Message: fmt.Sprintf("responses stream terminal event: %s", streamResponse.Type),
+		Type:    string(types.ErrorCodeBadResponse),
+		Code:    string(types.ErrorCodeBadResponse),
+	}
+}
+
+func shouldDeferResponsesStreamErrorForReplay(info *relaycommon.RelayInfo, openAIError types.OpenAIError, sentDownstream bool) bool {
+	if sentDownstream || info == nil || info.ResponsesTranscriptReplay == nil || info.ResponsesTranscriptReplay.Replayed {
+		return false
+	}
+	body, err := common.Marshal(responsesStreamErrorPayload{Error: openAIError})
+	if err != nil {
+		return false
+	}
+	return relaycommon.IsResponsesTranscriptReplayError(http.StatusBadRequest, body)
+}
+
+func sendResponsesStreamErrorData(c *gin.Context, openAIError types.OpenAIError) error {
+	payload, err := common.Marshal(responsesStreamErrorPayload{Error: openAIError})
+	if err != nil {
+		return err
+	}
+	c.Render(-1, common.CustomEvent{Data: "event: error\n"})
+	c.Render(-1, common.CustomEvent{Data: "data: " + string(payload)})
+	return helper.FlushWriter(c)
+}
+
+func logResponsesStreamTerminalError(c *gin.Context, info *relaycommon.RelayInfo, eventType string, openAIError types.OpenAIError) {
+	channelID := 0
+	if info != nil {
+		channelID = info.ChannelId
+	}
+	logger.LogError(c, fmt.Sprintf(
+		"responses stream terminal event on channel #%d: event=%s error_type=%s code=%v message=%s",
+		channelID,
+		eventType,
+		openAIError.Type,
+		openAIError.Code,
+		truncateResponsesStreamErrorMessage(openAIError.Message),
+	))
+}
+
+func truncateResponsesStreamErrorMessage(message string) string {
+	const maxMessageBytes = 512
+	if len(message) <= maxMessageBytes {
+		return message
+	}
+	return message[:maxMessageBytes] + "...(truncated)"
 }

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -31,6 +31,16 @@ type responsesStreamDataEvent struct {
 	Data     string
 }
 
+type responsesStreamFailurePayload struct {
+	Type     string                         `json:"type"`
+	Response responsesStreamFailureResponse `json:"response"`
+}
+
+type responsesStreamFailureResponse struct {
+	Status string            `json:"status"`
+	Error  types.OpenAIError `json:"error"`
+}
+
 func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
 	defer service.CloseResponseBodyGracefully(resp)
 
@@ -95,6 +105,7 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 	var responseTextBuilder strings.Builder
 	var streamErr *types.NewAPIError
 	var sentDownstream bool
+	var sawCompleted bool
 	var pendingPrelude []responsesStreamDataEvent
 
 	flushPendingPrelude := func() {
@@ -114,6 +125,16 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 			return
 		}
 		flushPendingPrelude()
+		sendResponsesStreamData(c, streamResponse, data)
+		sentDownstream = true
+	}
+
+	sendStreamFailure := func(newAPIError *types.NewAPIError) {
+		if newAPIError == nil {
+			return
+		}
+		flushPendingPrelude()
+		streamResponse, data := responsesStreamFailureEvent(newAPIError)
 		sendResponsesStreamData(c, streamResponse, data)
 		sentDownstream = true
 	}
@@ -144,6 +165,7 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 		sendStreamData(streamResponse, data)
 		switch streamResponse.Type {
 		case responsesStreamEventCompleted:
+			sawCompleted = true
 			if streamResponse.Response != nil {
 				if streamResponse.Response.Usage != nil {
 					if streamResponse.Response.Usage.InputTokens != 0 {
@@ -165,6 +187,7 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 					c.Set("image_generation_call_size", streamResponse.Response.GetSize())
 				}
 			}
+			sr.Done()
 		case responsesStreamEventTextDelta:
 			// 处理输出文本
 			responseTextBuilder.WriteString(streamResponse.Delta)
@@ -183,6 +206,15 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 		}
 	})
 
+	if streamErr == nil {
+		streamErr = responsesStreamCompletionError(info, sawCompleted)
+		if streamErr != nil {
+			logResponsesStreamIncomplete(c, info, sentDownstream, streamErr)
+			if !shouldDeferResponsesStreamErrorToHandler(c, sentDownstream) {
+				sendStreamFailure(streamErr)
+			}
+		}
+	}
 	if streamErr != nil {
 		return nil, streamErr
 	}
@@ -249,6 +281,78 @@ func shouldDeferResponsesStreamErrorToHandler(c *gin.Context, sentDownstream boo
 	return !c.Writer.Written()
 }
 
+func responsesStreamCompletionError(info *relaycommon.RelayInfo, sawCompleted bool) *types.NewAPIError {
+	if sawCompleted {
+		return nil
+	}
+	if info == nil || info.StreamStatus == nil {
+		return nil
+	}
+
+	status := info.StreamStatus
+	switch status.EndReason {
+	case relaycommon.StreamEndReasonEOF, relaycommon.StreamEndReasonDone:
+		return types.NewOpenAIError(
+			fmt.Errorf("responses stream closed before completion event: %s", status.Summary()),
+			types.ErrorCodeBadResponse,
+			http.StatusBadGateway,
+		)
+	case relaycommon.StreamEndReasonTimeout, relaycommon.StreamEndReasonScannerErr, relaycommon.StreamEndReasonPanic, relaycommon.StreamEndReasonPingFail:
+		return types.NewOpenAIError(
+			fmt.Errorf("responses stream interrupted before completion event: %s", status.Summary()),
+			types.ErrorCodeBadResponse,
+			http.StatusBadGateway,
+		)
+	case relaycommon.StreamEndReasonClientGone:
+		return types.NewOpenAIError(
+			fmt.Errorf("responses stream client disconnected before completion event: %s", status.Summary()),
+			types.ErrorCodeBadResponse,
+			499,
+			types.ErrOptionWithSkipRetry(),
+		)
+	case relaycommon.StreamEndReasonHandlerStop:
+		if status.HasErrors() {
+			return types.NewOpenAIError(
+				fmt.Errorf("responses stream handler stopped before completion event: %s", status.Summary()),
+				types.ErrorCodeBadResponse,
+				http.StatusBadGateway,
+			)
+		}
+	}
+	return nil
+}
+
+func responsesStreamFailureEvent(newAPIError *types.NewAPIError) (dto.ResponsesStreamResponse, string) {
+	openAIError := types.OpenAIError{
+		Message: string(types.ErrorCodeBadResponse),
+		Type:    string(types.ErrorCodeBadResponse),
+		Code:    string(types.ErrorCodeBadResponse),
+	}
+	if newAPIError != nil {
+		openAIError = newAPIError.ToOpenAIError()
+	}
+	streamResponse := dto.ResponsesStreamResponse{
+		Type: responsesStreamEventFailed,
+	}
+	payload := responsesStreamFailurePayload{
+		Type: responsesStreamEventFailed,
+		Response: responsesStreamFailureResponse{
+			Status: "failed",
+			Error:  openAIError,
+		},
+	}
+	data, err := common.Marshal(payload)
+	if err != nil {
+		return streamResponse, fmt.Sprintf(`{"type":"%s","response":{"status":"failed","error":{"message":"%s","type":"%s","code":"%s"}}}`,
+			responsesStreamEventFailed,
+			string(types.ErrorCodeBadResponse),
+			string(types.ErrorCodeBadResponse),
+			string(types.ErrorCodeBadResponse),
+		)
+	}
+	return streamResponse, string(data)
+}
+
 func logResponsesStreamTerminalError(c *gin.Context, info *relaycommon.RelayInfo, eventType string, openAIError types.OpenAIError) {
 	channelID := 0
 	if info != nil {
@@ -261,6 +365,28 @@ func logResponsesStreamTerminalError(c *gin.Context, info *relaycommon.RelayInfo
 		openAIError.Type,
 		openAIError.Code,
 		truncateResponsesStreamErrorMessage(openAIError.Message),
+	))
+}
+
+func logResponsesStreamIncomplete(c *gin.Context, info *relaycommon.RelayInfo, sentDownstream bool, newAPIError *types.NewAPIError) {
+	channelID := 0
+	streamSummary := "StreamStatus<nil>"
+	if info != nil {
+		channelID = info.ChannelId
+		if info.StreamStatus != nil {
+			streamSummary = info.StreamStatus.Summary()
+		}
+	}
+	message := ""
+	if newAPIError != nil {
+		message = newAPIError.Error()
+	}
+	logger.LogError(c, fmt.Sprintf(
+		"responses stream ended before completion event on channel #%d: sent_downstream=%t stream=%s error=%s",
+		channelID,
+		sentDownstream,
+		streamSummary,
+		truncateResponsesStreamErrorMessage(message),
 	))
 }
 

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -33,6 +33,7 @@ func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 	if oaiError := responsesResponse.GetOpenAIError(); oaiError != nil && oaiError.Type != "" {
 		return nil, types.WithOpenAIError(*oaiError, resp.StatusCode)
 	}
+	relaycommon.ObserveResponsesTranscriptReplayResponseBody(info, responseBody)
 
 	if responsesResponse.HasImageGenerationCall() {
 		c.Set("image_generation_call", true)
@@ -88,6 +89,7 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 			sr.Error(err)
 			return
 		}
+		relaycommon.ObserveResponsesTranscriptReplayStreamEvent(info, data)
 		sendResponsesStreamData(c, streamResponse, data)
 		switch streamResponse.Type {
 		case "response.completed":

--- a/relay/channel/openai/relay_responses_test.go
+++ b/relay/channel/openai/relay_responses_test.go
@@ -1,0 +1,115 @@
+package openai
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func setupResponsesStreamHandlerTest(t *testing.T, body string) (*gin.Context, *httptest.ResponseRecorder, *http.Response, *relaycommon.RelayInfo) {
+	t.Helper()
+
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() {
+		constant.StreamingTimeout = oldTimeout
+	})
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	resp := &http.Response{
+		Body: io.NopCloser(strings.NewReader(body)),
+	}
+	info := &relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeResponses,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelId:         12,
+			UpstreamModelName: "gpt-5",
+		},
+	}
+
+	return c, recorder, resp, info
+}
+
+func TestOaiResponsesStreamHandlerConvertsTerminalFailureToErrorEvent(t *testing.T) {
+	c, recorder, resp, info := setupResponsesStreamHandlerTest(t, strings.Join([]string{
+		`event: response.failed`,
+		`data: {"type":"response.failed","response":{"error":{"message":"The encrypted content gAAA...as53 could not be verified. Reason: Encrypted content could not be decrypted or parsed.","type":"invalid_request_error","param":"","code":"thinking_signature_invalid"}}}`,
+		``,
+	}, "\n"))
+
+	usage, newAPIError := OaiResponsesStreamHandler(c, info, resp)
+
+	require.Nil(t, usage)
+	require.NotNil(t, newAPIError)
+	require.Equal(t, "thinking_signature_invalid", string(newAPIError.GetErrorCode()))
+
+	body := recorder.Body.String()
+	require.Contains(t, body, "event: error")
+	require.Contains(t, body, `"code":"thinking_signature_invalid"`)
+	require.NotContains(t, body, "event: response.failed")
+}
+
+func TestOaiResponsesStreamHandlerDefersReplayableFailureBeforeWriting(t *testing.T) {
+	c, recorder, resp, info := setupResponsesStreamHandlerTest(t, strings.Join([]string{
+		`data: {"type":"response.created","response":{"id":"resp_1"}}`,
+		`data: {"type":"response.failed","response":{"error":{"message":"code: invalid_encrypted_content; message: The encrypted content gAAA...V2ln could not be verified. Reason: Encrypted content could not be decrypted or parsed.","type":"invalid_request_error","param":"","code":"-4003"}}}`,
+		``,
+	}, "\n"))
+	info.ResponsesTranscriptReplay = &relaycommon.ResponsesTranscriptReplayState{
+		RequestBody: []byte(`{"input":[{"type":"reasoning","encrypted_content":"bad-ciphertext","summary":[]}]}`),
+	}
+
+	usage, newAPIError := OaiResponsesStreamHandler(c, info, resp)
+
+	require.Nil(t, usage)
+	require.NotNil(t, newAPIError)
+	require.Equal(t, "-4003", string(newAPIError.GetErrorCode()))
+	require.Empty(t, recorder.Body.String())
+	require.False(t, c.Writer.Written())
+}
+
+func TestOaiResponsesStreamHandlerFlushesBufferedPreludeOnNormalStream(t *testing.T) {
+	c, recorder, resp, info := setupResponsesStreamHandlerTest(t, strings.Join([]string{
+		`data: {"type":"response.created","response":{"id":"resp_1"}}`,
+		`data: {"type":"response.output_text.delta","delta":"hi"}`,
+		`data: {"type":"response.completed","response":{"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}`,
+		`data: [DONE]`,
+		``,
+	}, "\n"))
+	info.ResponsesTranscriptReplay = &relaycommon.ResponsesTranscriptReplayState{}
+
+	usage, newAPIError := OaiResponsesStreamHandler(c, info, resp)
+
+	require.Nil(t, newAPIError)
+	require.NotNil(t, usage)
+	require.Equal(t, 2, usage.PromptTokens)
+	require.Equal(t, 1, usage.CompletionTokens)
+	require.Equal(t, 3, usage.TotalTokens)
+
+	body := recorder.Body.String()
+	require.Contains(t, body, "event: response.created")
+	require.Contains(t, body, "event: response.output_text.delta")
+}
+
+func TestResponsesStreamOpenAIErrorFallsBackForEmptyPayload(t *testing.T) {
+	openAIError := responsesStreamOpenAIError(dto.ResponsesStreamResponse{Type: responsesStreamEventError})
+
+	require.Equal(t, "bad_response", openAIError.Code)
+	require.Contains(t, openAIError.Message, "response.error")
+}

--- a/relay/channel/openai/relay_responses_test.go
+++ b/relay/channel/openai/relay_responses_test.go
@@ -192,7 +192,7 @@ func TestResponsesStreamOpenAIErrorFallbackIncludesResponseStatus(t *testing.T) 
 		Response: &dto.OpenAIResponsesResponse{
 			Status: json.RawMessage(`"failed"`),
 			IncompleteDetails: &dto.IncompleteDetails{
-				Reasoning: "upstream stopped",
+				Reason: "upstream stopped",
 			},
 		},
 	})

--- a/relay/channel/openai/relay_responses_test.go
+++ b/relay/channel/openai/relay_responses_test.go
@@ -46,7 +46,7 @@ func setupResponsesStreamHandlerTest(t *testing.T, body string) (*gin.Context, *
 	return c, recorder, resp, info
 }
 
-func TestOaiResponsesStreamHandlerConvertsTerminalFailureToErrorEvent(t *testing.T) {
+func TestOaiResponsesStreamHandlerDefersTerminalFailureBeforeWriting(t *testing.T) {
 	c, recorder, resp, info := setupResponsesStreamHandlerTest(t, strings.Join([]string{
 		`event: response.failed`,
 		`data: {"type":"response.failed","response":{"error":{"message":"The encrypted content gAAA...as53 could not be verified. Reason: Encrypted content could not be decrypted or parsed.","type":"invalid_request_error","param":"","code":"thinking_signature_invalid"}}}`,
@@ -58,11 +58,26 @@ func TestOaiResponsesStreamHandlerConvertsTerminalFailureToErrorEvent(t *testing
 	require.Nil(t, usage)
 	require.NotNil(t, newAPIError)
 	require.Equal(t, "thinking_signature_invalid", string(newAPIError.GetErrorCode()))
+	require.Empty(t, recorder.Body.String())
+	require.False(t, c.Writer.Written())
+}
 
+func TestOaiResponsesStreamHandlerPassesTerminalFailureAfterWriting(t *testing.T) {
+	c, recorder, resp, info := setupResponsesStreamHandlerTest(t, strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"partial"}`,
+		`data: {"type":"response.failed","response":{"error":{"message":"upstream failed","type":"server_error","param":"","code":"server_error"}}}`,
+		``,
+	}, "\n"))
+
+	usage, newAPIError := OaiResponsesStreamHandler(c, info, resp)
+
+	require.Nil(t, usage)
+	require.NotNil(t, newAPIError)
+	require.Equal(t, "server_error", string(newAPIError.GetErrorCode()))
 	body := recorder.Body.String()
-	require.Contains(t, body, "event: error")
-	require.Contains(t, body, `"code":"thinking_signature_invalid"`)
-	require.NotContains(t, body, "event: response.failed")
+	require.Contains(t, body, "event: response.output_text.delta")
+	require.Contains(t, body, "event: response.failed")
+	require.Contains(t, body, `"code":"server_error"`)
 }
 
 func TestOaiResponsesStreamHandlerDefersReplayableFailureBeforeWriting(t *testing.T) {
@@ -112,4 +127,19 @@ func TestResponsesStreamOpenAIErrorFallsBackForEmptyPayload(t *testing.T) {
 
 	require.Equal(t, "bad_response", openAIError.Code)
 	require.Contains(t, openAIError.Message, "response.error")
+}
+
+func TestResponsesStreamOpenAIErrorUsesTopLevelError(t *testing.T) {
+	openAIError := responsesStreamOpenAIError(dto.ResponsesStreamResponse{
+		Type: responsesStreamEventFailed,
+		Error: map[string]interface{}{
+			"message": "code: invalid_encrypted_content; message: could not verify",
+			"type":    "invalid_request_error",
+			"code":    "-4003",
+		},
+	})
+
+	require.Equal(t, "-4003", openAIError.Code)
+	require.Equal(t, "invalid_request_error", openAIError.Type)
+	require.Contains(t, openAIError.Message, "invalid_encrypted_content")
 }

--- a/relay/channel/openai/relay_responses_test.go
+++ b/relay/channel/openai/relay_responses_test.go
@@ -116,10 +116,66 @@ func TestOaiResponsesStreamHandlerFlushesBufferedPreludeOnNormalStream(t *testin
 	require.Equal(t, 2, usage.PromptTokens)
 	require.Equal(t, 1, usage.CompletionTokens)
 	require.Equal(t, 3, usage.TotalTokens)
+	require.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
 
 	body := recorder.Body.String()
 	require.Contains(t, body, "event: response.created")
 	require.Contains(t, body, "event: response.output_text.delta")
+}
+
+func TestOaiResponsesStreamHandlerDefersEOFBeforeCompletedBeforeWriting(t *testing.T) {
+	c, recorder, resp, info := setupResponsesStreamHandlerTest(t, strings.Join([]string{
+		`data: {"type":"response.created","response":{"id":"resp_1"}}`,
+		`data: {"type":"response.in_progress","response":{"id":"resp_1"}}`,
+		``,
+	}, "\n"))
+	info.ResponsesTranscriptReplay = &relaycommon.ResponsesTranscriptReplayState{}
+
+	usage, newAPIError := OaiResponsesStreamHandler(c, info, resp)
+
+	require.Nil(t, usage)
+	require.NotNil(t, newAPIError)
+	require.Equal(t, "bad_response", string(newAPIError.GetErrorCode()))
+	require.Contains(t, newAPIError.Error(), "completion event")
+	require.Empty(t, recorder.Body.String())
+	require.False(t, c.Writer.Written())
+}
+
+func TestOaiResponsesStreamHandlerEmitsFailureWhenEOFBeforeCompletedAfterWriting(t *testing.T) {
+	c, recorder, resp, info := setupResponsesStreamHandlerTest(t, strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"partial"}`,
+		``,
+	}, "\n"))
+
+	usage, newAPIError := OaiResponsesStreamHandler(c, info, resp)
+
+	require.Nil(t, usage)
+	require.NotNil(t, newAPIError)
+	require.Equal(t, "bad_response", string(newAPIError.GetErrorCode()))
+	require.Contains(t, newAPIError.Error(), "completion event")
+	body := recorder.Body.String()
+	require.Contains(t, body, "event: response.output_text.delta")
+	require.Contains(t, body, "event: response.failed")
+	require.Contains(t, body, "responses stream closed before completion event")
+	require.NotContains(t, body, `"object":""`)
+}
+
+func TestOaiResponsesStreamHandlerAllowsCompletedStreamWithoutDone(t *testing.T) {
+	c, recorder, resp, info := setupResponsesStreamHandlerTest(t, strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"hi"}`,
+		`data: {"type":"response.completed","response":{"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}`,
+		``,
+	}, "\n"))
+
+	usage, newAPIError := OaiResponsesStreamHandler(c, info, resp)
+
+	require.Nil(t, newAPIError)
+	require.NotNil(t, usage)
+	require.Equal(t, 2, usage.PromptTokens)
+	require.Equal(t, 1, usage.CompletionTokens)
+	require.Equal(t, 3, usage.TotalTokens)
+	require.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
+	require.NotContains(t, recorder.Body.String(), "event: response.failed")
 }
 
 func TestResponsesStreamOpenAIErrorFallsBackForEmptyPayload(t *testing.T) {

--- a/relay/channel/openai/relay_responses_test.go
+++ b/relay/channel/openai/relay_responses_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -183,6 +184,22 @@ func TestResponsesStreamOpenAIErrorFallsBackForEmptyPayload(t *testing.T) {
 
 	require.Equal(t, "bad_response", openAIError.Code)
 	require.Contains(t, openAIError.Message, "response.error")
+}
+
+func TestResponsesStreamOpenAIErrorFallbackIncludesResponseStatus(t *testing.T) {
+	openAIError := responsesStreamOpenAIError(dto.ResponsesStreamResponse{
+		Type: responsesStreamEventFailed,
+		Response: &dto.OpenAIResponsesResponse{
+			Status: json.RawMessage(`"failed"`),
+			IncompleteDetails: &dto.IncompleteDetails{
+				Reasoning: "upstream stopped",
+			},
+		},
+	})
+
+	require.Equal(t, "bad_response", openAIError.Code)
+	require.Contains(t, openAIError.Message, "status=failed")
+	require.Contains(t, openAIError.Message, "upstream stopped")
 }
 
 func TestResponsesStreamOpenAIErrorUsesTopLevelError(t *testing.T) {

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -153,6 +153,7 @@ type RelayInfo struct {
 	RuntimeHeadersOverride                map[string]interface{}
 	UseRuntimeHeadersOverride             bool
 	ParamOverrideAudit                    []string
+	ResponsesTranscriptReplay             *ResponsesTranscriptReplayState
 
 	// UpstreamRequestBodySize is the byte size of the marshaled upstream request
 	// body. It is set when the body is wrapped in a BodyStorage (see

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -161,9 +161,6 @@ type RelayInfo struct {
 	// http.Request.ContentLength manually (net/http only auto-detects it for
 	// *bytes.Reader/Buffer/strings.Reader). 0 means "let net/http decide".
 	UpstreamRequestBodySize int64
-	// UpstreamRequestBodyEncoding is set when the outbound body is encoded
-	// before it is sent upstream, for example "gzip".
-	UpstreamRequestBodyEncoding string
 
 	PriceData types.PriceData
 

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -161,6 +161,9 @@ type RelayInfo struct {
 	// http.Request.ContentLength manually (net/http only auto-detects it for
 	// *bytes.Reader/Buffer/strings.Reader). 0 means "let net/http decide".
 	UpstreamRequestBodySize int64
+	// UpstreamRequestBodyEncoding is set when the outbound body is encoded
+	// before it is sent upstream, for example "gzip".
+	UpstreamRequestBodyEncoding string
 
 	PriceData types.PriceData
 

--- a/relay/common/responses_transcript_replay.go
+++ b/relay/common/responses_transcript_replay.go
@@ -1,0 +1,391 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const responsesTranscriptReplayTTL = time.Hour
+
+type ResponsesTranscriptReplayState struct {
+	CacheKey     string
+	RequestBody  []byte
+	BaseInputRaw string
+	OutputRaw    string
+	OutputItems  []string
+	Replayed     bool
+}
+
+type responsesTranscriptReplayCacheEntry struct {
+	InputRaw string
+	Expire   time.Time
+}
+
+var (
+	responsesTranscriptReplayMu    sync.RWMutex
+	responsesTranscriptReplayCache = map[string]responsesTranscriptReplayCacheEntry{}
+)
+
+func PrepareResponsesTranscriptReplay(info *RelayInfo, requestBody []byte) {
+	if info == nil || len(requestBody) == 0 {
+		return
+	}
+	cacheKey := responsesTranscriptReplayCacheKey(info, requestBody)
+	if cacheKey == "" {
+		info.ResponsesTranscriptReplay = nil
+		return
+	}
+	baseInputRaw := ""
+	if input := gjson.GetBytes(requestBody, "input"); input.Exists() && input.IsArray() &&
+		gjson.GetBytes(requestBody, "previous_response_id").Exists() &&
+		!responsesInputLooksFullTranscript(input) {
+		if cachedInput, ok := getResponsesTranscriptReplayCachedInput(cacheKey); ok {
+			baseInputRaw = cachedInput
+		}
+	}
+	info.ResponsesTranscriptReplay = &ResponsesTranscriptReplayState{
+		CacheKey:     cacheKey,
+		RequestBody:  append([]byte(nil), requestBody...),
+		BaseInputRaw: baseInputRaw,
+	}
+}
+
+func UpdateResponsesTranscriptReplayRequest(info *RelayInfo, requestBody []byte, replayed bool) {
+	if info == nil || len(requestBody) == 0 {
+		return
+	}
+	if info.ResponsesTranscriptReplay == nil {
+		PrepareResponsesTranscriptReplay(info, requestBody)
+		if info.ResponsesTranscriptReplay == nil {
+			return
+		}
+	}
+	info.ResponsesTranscriptReplay.RequestBody = append([]byte(nil), requestBody...)
+	info.ResponsesTranscriptReplay.BaseInputRaw = ""
+	info.ResponsesTranscriptReplay.OutputRaw = ""
+	info.ResponsesTranscriptReplay.OutputItems = nil
+	info.ResponsesTranscriptReplay.Replayed = replayed
+}
+
+func BuildResponsesTranscriptReplayRequest(info *RelayInfo, requestBody []byte) ([]byte, bool, string) {
+	if info == nil || len(requestBody) == 0 {
+		return nil, false, "missing request body"
+	}
+	hasPreviousResponseID := gjson.GetBytes(requestBody, "previous_response_id").Exists()
+	input := gjson.GetBytes(requestBody, "input")
+	if !input.Exists() || !input.IsArray() {
+		return nil, false, "request input is not an array"
+	}
+
+	mergedInput := input.Raw
+	reason := "using full input transcript"
+	if !responsesInputLooksFullTranscript(input) {
+		state := info.ResponsesTranscriptReplay
+		if state == nil || state.CacheKey == "" {
+			return nil, false, "missing transcript replay cache key"
+		}
+		cachedInput, ok := getResponsesTranscriptReplayCachedInput(state.CacheKey)
+		if !ok {
+			return nil, false, "missing cached transcript"
+		}
+		var err error
+		mergedInput, err = mergeResponsesJSONArrayRaw(cachedInput, input.Raw)
+		if err != nil {
+			return nil, false, fmt.Sprintf("merge transcript failed: %v", err)
+		}
+		reason = "using cached transcript"
+	}
+
+	strippedInput, strippedEncryptedContent, err := stripResponsesEncryptedContentFromJSONArrayRaw(mergedInput)
+	if err != nil {
+		return nil, false, fmt.Sprintf("strip encrypted_content failed: %v", err)
+	}
+	if strippedEncryptedContent {
+		mergedInput = strippedInput
+		reason += "; stripped encrypted_content"
+	}
+	if !hasPreviousResponseID && !strippedEncryptedContent {
+		return nil, false, "request has no previous_response_id and no encrypted_content to strip"
+	}
+
+	out, err := sjson.DeleteBytes(append([]byte(nil), requestBody...), "previous_response_id")
+	if err != nil {
+		out = append([]byte(nil), requestBody...)
+	}
+	out, err = sjson.SetRawBytes(out, "input", []byte(mergedInput))
+	if err != nil {
+		return nil, false, fmt.Sprintf("set replay input failed: %v", err)
+	}
+	return out, true, reason
+}
+
+func IsResponsesTranscriptReplayError(statusCode int, body []byte) bool {
+	if statusCode < 400 || len(body) == 0 {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(string(body)))
+	code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.code").String()))
+	message := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.message").String()))
+	if message == "" {
+		message = strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "message").String()))
+	}
+	return strings.Contains(lower, "invalid_encrypted_content") ||
+		strings.Contains(lower, "invalid signature in thinking block") ||
+		strings.Contains(lower, "encrypted_content") && (strings.Contains(lower, "invalid") || strings.Contains(lower, "decrypt") || strings.Contains(lower, "signature")) ||
+		code == "invalid_encrypted_content" ||
+		strings.Contains(message, "encrypted_content") && (strings.Contains(message, "invalid") || strings.Contains(message, "decrypt") || strings.Contains(message, "signature"))
+}
+
+func ResponsesTranscriptReplayRequestHasEncryptedContent(requestBody []byte) bool {
+	if len(requestBody) == 0 {
+		return false
+	}
+	input := gjson.GetBytes(requestBody, "input")
+	if !input.Exists() || !input.IsArray() {
+		return false
+	}
+	_, stripped, err := stripResponsesEncryptedContentFromJSONArrayRaw(input.Raw)
+	return err == nil && stripped
+}
+
+func ObserveResponsesTranscriptReplayResponseBody(info *RelayInfo, responseBody []byte) {
+	state := responsesTranscriptReplayState(info)
+	if state == nil || len(responseBody) == 0 {
+		return
+	}
+	if output := gjson.GetBytes(responseBody, "output"); output.Exists() && output.IsArray() {
+		state.OutputRaw = normalizeResponsesJSONArrayRaw(output.Raw)
+		return
+	}
+	if output := gjson.GetBytes(responseBody, "response.output"); output.Exists() && output.IsArray() {
+		state.OutputRaw = normalizeResponsesJSONArrayRaw(output.Raw)
+	}
+}
+
+func ObserveResponsesTranscriptReplayStreamEvent(info *RelayInfo, data string) {
+	state := responsesTranscriptReplayState(info)
+	if state == nil || strings.TrimSpace(data) == "" {
+		return
+	}
+	event := gjson.Parse(data)
+	if output := event.Get("response.output"); output.Exists() && output.IsArray() {
+		state.OutputRaw = normalizeResponsesJSONArrayRaw(output.Raw)
+		return
+	}
+	if event.Get("type").String() != "response.output_item.done" {
+		return
+	}
+	item := event.Get("item")
+	if item.Exists() && item.IsObject() {
+		state.OutputItems = append(state.OutputItems, item.Raw)
+	}
+}
+
+func CommitResponsesTranscriptReplay(info *RelayInfo) bool {
+	state := responsesTranscriptReplayState(info)
+	if state == nil || state.CacheKey == "" || len(state.RequestBody) == 0 {
+		return false
+	}
+	input := gjson.GetBytes(state.RequestBody, "input")
+	if !input.Exists() || !input.IsArray() {
+		return false
+	}
+	inputRaw := input.Raw
+	if !state.Replayed &&
+		gjson.GetBytes(state.RequestBody, "previous_response_id").Exists() &&
+		!responsesInputLooksFullTranscript(input) {
+		baseInputRaw := state.BaseInputRaw
+		if baseInputRaw == "" {
+			if cachedInput, ok := getResponsesTranscriptReplayCachedInput(state.CacheKey); ok {
+				baseInputRaw = cachedInput
+			}
+		}
+		if baseInputRaw != "" {
+			mergedInput, err := mergeResponsesJSONArrayRaw(baseInputRaw, input.Raw)
+			if err == nil {
+				inputRaw = mergedInput
+			}
+		}
+	}
+	outputRaw := state.OutputRaw
+	if outputRaw == "" && len(state.OutputItems) > 0 {
+		outputRaw = "[" + strings.Join(state.OutputItems, ",") + "]"
+	}
+	if outputRaw == "" {
+		outputRaw = "[]"
+	}
+	merged, err := mergeResponsesJSONArrayRaw(inputRaw, outputRaw)
+	if err != nil {
+		return false
+	}
+	setResponsesTranscriptReplayCachedInput(state.CacheKey, merged)
+	return true
+}
+
+func responsesTranscriptReplayState(info *RelayInfo) *ResponsesTranscriptReplayState {
+	if info == nil {
+		return nil
+	}
+	return info.ResponsesTranscriptReplay
+}
+
+func responsesTranscriptReplayCacheKey(info *RelayInfo, requestBody []byte) string {
+	sessionID := strings.TrimSpace(gjson.GetBytes(requestBody, "prompt_cache_key").String())
+	if sessionID == "" {
+		for _, name := range []string{"Session_id", "session_id", "X-Session-ID", "x-session-id", "Conversation_id", "conversation_id"} {
+			if v := requestHeaderValueCaseInsensitive(info.RequestHeaders, name); v != "" {
+				sessionID = v
+				break
+			}
+		}
+	}
+	if sessionID == "" {
+		return ""
+	}
+	model := strings.TrimSpace(gjson.GetBytes(requestBody, "model").String())
+	if model == "" {
+		model = strings.TrimSpace(info.UpstreamModelName)
+	}
+	return fmt.Sprintf("channel:%d:model:%s:session:%s", info.ChannelId, model, sessionID)
+}
+
+func requestHeaderValueCaseInsensitive(headers map[string]string, name string) string {
+	if len(headers) == 0 || strings.TrimSpace(name) == "" {
+		return ""
+	}
+	if v := strings.TrimSpace(headers[name]); v != "" {
+		return v
+	}
+	for key, value := range headers {
+		if strings.EqualFold(key, name) {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func responsesInputLooksFullTranscript(input gjson.Result) bool {
+	if !input.IsArray() {
+		return false
+	}
+	for _, item := range input.Array() {
+		switch strings.TrimSpace(item.Get("type").String()) {
+		case "compaction", "compaction_summary", "function_call", "custom_tool_call", "reasoning":
+			return true
+		case "message":
+			if strings.TrimSpace(item.Get("role").String()) == "assistant" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func getResponsesTranscriptReplayCachedInput(cacheKey string) (string, bool) {
+	now := time.Now()
+	responsesTranscriptReplayMu.RLock()
+	entry, ok := responsesTranscriptReplayCache[cacheKey]
+	responsesTranscriptReplayMu.RUnlock()
+	if !ok || entry.Expire.Before(now) {
+		if ok {
+			responsesTranscriptReplayMu.Lock()
+			delete(responsesTranscriptReplayCache, cacheKey)
+			responsesTranscriptReplayMu.Unlock()
+		}
+		return "", false
+	}
+	return entry.InputRaw, true
+}
+
+func setResponsesTranscriptReplayCachedInput(cacheKey string, inputRaw string) {
+	if strings.TrimSpace(cacheKey) == "" || strings.TrimSpace(inputRaw) == "" {
+		return
+	}
+	responsesTranscriptReplayMu.Lock()
+	responsesTranscriptReplayCache[cacheKey] = responsesTranscriptReplayCacheEntry{
+		InputRaw: normalizeResponsesJSONArrayRaw(inputRaw),
+		Expire:   time.Now().Add(responsesTranscriptReplayTTL),
+	}
+	responsesTranscriptReplayMu.Unlock()
+}
+
+func mergeResponsesJSONArrayRaw(existingRaw string, appendRaw string) (string, error) {
+	existingRaw = normalizeResponsesJSONArrayRaw(existingRaw)
+	appendRaw = normalizeResponsesJSONArrayRaw(appendRaw)
+
+	var existing []json.RawMessage
+	if err := json.Unmarshal([]byte(existingRaw), &existing); err != nil {
+		return "", err
+	}
+	var appendItems []json.RawMessage
+	if err := json.Unmarshal([]byte(appendRaw), &appendItems); err != nil {
+		return "", err
+	}
+	merged := append(existing, appendItems...)
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func normalizeResponsesJSONArrayRaw(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "[]"
+	}
+	if strings.HasPrefix(trimmed, "[") {
+		return trimmed
+	}
+	return "[]"
+}
+
+func stripResponsesEncryptedContentFromJSONArrayRaw(raw string) (string, bool, error) {
+	raw = normalizeResponsesJSONArrayRaw(raw)
+	var items []any
+	if err := json.Unmarshal([]byte(raw), &items); err != nil {
+		return "", false, err
+	}
+	stripped := stripResponsesEncryptedContentValue(items)
+	if !stripped {
+		return raw, false, nil
+	}
+	out, err := json.Marshal(items)
+	if err != nil {
+		return "", false, err
+	}
+	return string(out), true, nil
+}
+
+func stripResponsesEncryptedContentValue(value any) bool {
+	switch typed := value.(type) {
+	case []any:
+		stripped := false
+		for _, item := range typed {
+			if stripResponsesEncryptedContentValue(item) {
+				stripped = true
+			}
+		}
+		return stripped
+	case map[string]any:
+		stripped := false
+		if _, ok := typed["encrypted_content"]; ok {
+			delete(typed, "encrypted_content")
+			stripped = true
+		}
+		for _, item := range typed {
+			if stripResponsesEncryptedContentValue(item) {
+				stripped = true
+			}
+		}
+		return stripped
+	default:
+		return false
+	}
+}

--- a/relay/common/responses_transcript_replay.go
+++ b/relay/common/responses_transcript_replay.go
@@ -260,17 +260,11 @@ func IsResponsesTranscriptReplayError(statusCode int, body []byte) bool {
 	if statusCode < 400 || len(body) == 0 {
 		return false
 	}
-	lower := strings.ToLower(strings.TrimSpace(string(body)))
 	code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.code").String()))
-	message := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.message").String()))
-	if message == "" {
-		message = strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "message").String()))
+	if code == "" {
+		code = strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "code").String()))
 	}
-	return strings.Contains(lower, "invalid_encrypted_content") ||
-		strings.Contains(lower, "invalid signature in thinking block") ||
-		strings.Contains(lower, "encrypted_content") && (strings.Contains(lower, "invalid") || strings.Contains(lower, "decrypt") || strings.Contains(lower, "signature")) ||
-		code == "invalid_encrypted_content" ||
-		strings.Contains(message, "encrypted_content") && (strings.Contains(message, "invalid") || strings.Contains(message, "decrypt") || strings.Contains(message, "signature"))
+	return code == "invalid_encrypted_content" || code == "thinking_signature_invalid"
 }
 
 func ResponsesTranscriptReplayRequestHasEncryptedContent(requestBody []byte) bool {

--- a/relay/common/responses_transcript_replay.go
+++ b/relay/common/responses_transcript_replay.go
@@ -145,7 +145,8 @@ type openAIErrorCodeResponse struct {
 }
 
 type openAIErrorCodeObject struct {
-	Code any `json:"code,omitempty"`
+	Code    any    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 type responsesTranscriptReplayCacheEntry struct {
@@ -367,8 +368,12 @@ func IsResponsesTranscriptReplayError(statusCode int, body []byte) bool {
 	if statusCode < 400 || len(body) == 0 {
 		return false
 	}
-	code := parseOpenAIErrorCode(body)
-	return code == openAIInvalidEncryptedContentCode || code == openAIThinkingSignatureInvalidCode
+	for _, code := range parseOpenAIErrorCodes(body) {
+		if isResponsesTranscriptReplayErrorCode(code) {
+			return true
+		}
+	}
+	return false
 }
 
 func ResponsesTranscriptReplayRequestHasEncryptedContent(requestBody []byte) bool {
@@ -1017,20 +1022,44 @@ func responsesTranscriptItemHasCallCounterpart(itemType string) bool {
 	}
 }
 
-func parseOpenAIErrorCode(body []byte) string {
+func parseOpenAIErrorCodes(body []byte) []string {
 	var response openAIErrorCodeResponse
 	if err := json.Unmarshal(body, &response); err != nil {
-		return ""
+		return nil
 	}
+	codes := make([]string, 0, 3)
 	if rawJSONHasValue(response.Error) && isJSONObjectRaw(response.Error) {
 		var nested openAIErrorCodeObject
 		if err := json.Unmarshal(response.Error, &nested); err == nil {
-			if code := errorCodeString(nested.Code); code != "" {
-				return code
-			}
+			codes = appendErrorCode(codes, errorCodeString(nested.Code))
+			codes = appendErrorCode(codes, parseWrappedOpenAIErrorCode(nested.Message))
 		}
 	}
-	return errorCodeString(response.Code)
+	codes = appendErrorCode(codes, errorCodeString(response.Code))
+	return codes
+}
+
+func appendErrorCode(codes []string, code string) []string {
+	if code == "" {
+		return codes
+	}
+	return append(codes, code)
+}
+
+func isResponsesTranscriptReplayErrorCode(code string) bool {
+	return code == openAIInvalidEncryptedContentCode || code == openAIThinkingSignatureInvalidCode
+}
+
+func parseWrappedOpenAIErrorCode(message string) string {
+	message = strings.TrimSpace(message)
+	if message == "" || !strings.HasPrefix(strings.ToLower(message), "code:") {
+		return ""
+	}
+	codeText := strings.TrimSpace(message[len("code:"):])
+	if code, _, ok := strings.Cut(codeText, ";"); ok {
+		codeText = code
+	}
+	return strings.ToLower(strings.TrimSpace(codeText))
 }
 
 func errorCodeString(value any) string {

--- a/relay/common/responses_transcript_replay.go
+++ b/relay/common/responses_transcript_replay.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
@@ -15,6 +14,11 @@ const responsesTranscriptReplayTTL = time.Hour
 const responsesTranscriptPreflightSanitizeMinBytes = 900 * 1024
 const responsesTranscriptPreflightSanitizeTargetBytes = responsesTranscriptPreflightSanitizeMinBytes - 64*1024
 const responsesTranscriptOmittedImageText = "[image omitted from oversized transcript replay]"
+
+const (
+	openAIInvalidEncryptedContentCode  = "invalid_encrypted_content"
+	openAIThinkingSignatureInvalidCode = "thinking_signature_invalid"
+)
 
 type ResponsesTranscriptReplayState struct {
 	CacheKey     string
@@ -43,6 +47,107 @@ type ResponsesTranscriptRequestShape struct {
 	InlineImageItems      int
 }
 
+type responsesTranscriptRequestEnvelope struct {
+	Model              string          `json:"model,omitempty"`
+	PromptCacheKey     json.RawMessage `json:"prompt_cache_key,omitempty"`
+	PreviousResponseID json.RawMessage `json:"previous_response_id,omitempty"`
+	Input              json.RawMessage `json:"input,omitempty"`
+}
+
+type responsesTranscriptInput struct {
+	Raw   string
+	Items []responsesTranscriptItem
+}
+
+type responsesTranscriptItem struct {
+	Type     string `json:"type,omitempty"`
+	Role     string `json:"role,omitempty"`
+	CallID   string `json:"call_id,omitempty"`
+	ImageURL string `json:"image_url,omitempty"`
+
+	object map[string]any
+	value  any
+}
+
+func (item *responsesTranscriptItem) UnmarshalJSON(data []byte) error {
+	var object map[string]any
+	if err := json.Unmarshal(data, &object); err == nil && object != nil {
+		item.object = object
+		item.value = object
+		item.Type = stringFromAny(object["type"])
+		item.Role = stringFromAny(object["role"])
+		item.CallID = stringFromAny(object["call_id"])
+		item.ImageURL = stringFromAny(object["image_url"])
+		return nil
+	}
+
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	item.value = value
+	return nil
+}
+
+func (item responsesTranscriptItem) MarshalJSON() ([]byte, error) {
+	if item.object != nil {
+		return json.Marshal(item.object)
+	}
+	return json.Marshal(item.value)
+}
+
+func (item responsesTranscriptItem) mutableValue() any {
+	if item.object != nil {
+		return item.object
+	}
+	return item.value
+}
+
+func (item responsesTranscriptItem) typeValue() string {
+	if item.object != nil {
+		return stringFromAny(item.object["type"])
+	}
+	return strings.TrimSpace(item.Type)
+}
+
+func (item responsesTranscriptItem) roleValue() string {
+	if item.object != nil {
+		return stringFromAny(item.object["role"])
+	}
+	return strings.TrimSpace(item.Role)
+}
+
+func (item responsesTranscriptItem) callIDValue() string {
+	if item.object != nil {
+		return stringFromAny(item.object["call_id"])
+	}
+	return strings.TrimSpace(item.CallID)
+}
+
+type responsesTranscriptResponseEnvelope struct {
+	Output   json.RawMessage                    `json:"output,omitempty"`
+	Response responsesTranscriptResponsePayload `json:"response,omitempty"`
+}
+
+type responsesTranscriptResponsePayload struct {
+	Output json.RawMessage `json:"output,omitempty"`
+}
+
+type responsesTranscriptStreamEvent struct {
+	Type     string                             `json:"type,omitempty"`
+	Item     json.RawMessage                    `json:"item,omitempty"`
+	Response responsesTranscriptResponsePayload `json:"response,omitempty"`
+}
+
+type openAIErrorCodeResponse struct {
+	Code  any             `json:"code,omitempty"`
+	Error json.RawMessage `json:"error,omitempty"`
+}
+
+type openAIErrorCodeObject struct {
+	Code any `json:"code,omitempty"`
+}
+
 type responsesTranscriptReplayCacheEntry struct {
 	InputRaw string
 	Expire   time.Time
@@ -57,15 +162,18 @@ func PrepareResponsesTranscriptReplay(info *RelayInfo, requestBody []byte) {
 	if info == nil || len(requestBody) == 0 {
 		return
 	}
+	envelope, ok := parseResponsesTranscriptRequestEnvelope(requestBody)
+	if !ok {
+		info.ResponsesTranscriptReplay = nil
+		return
+	}
 	cacheKey := responsesTranscriptReplayCacheKey(info, requestBody)
 	if cacheKey == "" {
 		info.ResponsesTranscriptReplay = nil
 		return
 	}
 	baseInputRaw := ""
-	if input := gjson.GetBytes(requestBody, "input"); input.Exists() && input.IsArray() &&
-		gjson.GetBytes(requestBody, "previous_response_id").Exists() &&
-		!responsesInputLooksFullTranscript(input) {
+	if envelope.hasPreviousResponseID() && !responsesInputLooksFullTranscript(envelope.Input) {
 		if cachedInput, ok := getResponsesTranscriptReplayCachedInput(cacheKey); ok {
 			baseInputRaw = cachedInput
 		}
@@ -98,17 +206,16 @@ func BuildResponsesTranscriptReplayRequest(info *RelayInfo, requestBody []byte) 
 	if info == nil || len(requestBody) == 0 {
 		return nil, false, "missing request body"
 	}
-	hasPreviousResponseID := gjson.GetBytes(requestBody, "previous_response_id").Exists()
-	input := gjson.GetBytes(requestBody, "input")
-	if !input.Exists() || !input.IsArray() {
+	envelope, ok := parseResponsesTranscriptRequestEnvelope(requestBody)
+	if !ok {
 		return nil, false, "request input is not an array"
 	}
 
-	if hasPreviousResponseID {
-		return buildResponsesIncrementalTranscriptRetryRequest(requestBody, input)
+	if envelope.hasPreviousResponseID() {
+		return buildResponsesIncrementalTranscriptRetryRequest(requestBody, envelope.Input)
 	}
 
-	mergedInput := input.Raw
+	mergedInput := string(envelope.Input)
 	reason := "using full input transcript"
 
 	sanitizedInput, err := sanitizeResponsesTranscriptReplayInputRaw(mergedInput)
@@ -143,16 +250,16 @@ func SanitizeResponsesTranscriptInitialRequest(requestBody []byte) ([]byte, bool
 	if len(requestBody) < responsesTranscriptPreflightSanitizeMinBytes {
 		return nil, false, "request body below transcript preflight sanitize threshold"
 	}
-	hasPreviousResponseID := gjson.GetBytes(requestBody, "previous_response_id").Exists()
-	input := gjson.GetBytes(requestBody, "input")
-	if hasPreviousResponseID && !responsesInputLooksFullTranscript(input) && !responsesInputLooksTranscriptReplacement(input) {
-		return nil, false, "incremental request keeps previous_response_id"
-	}
-	if !input.Exists() || !input.IsArray() {
+	envelope, ok := parseResponsesTranscriptRequestEnvelope(requestBody)
+	if !ok {
 		return nil, false, "request input is not an array"
 	}
+	hasPreviousResponseID := envelope.hasPreviousResponseID()
+	if hasPreviousResponseID && !responsesInputLooksFullTranscript(envelope.Input) && !responsesInputLooksTranscriptReplacement(envelope.Input) {
+		return nil, false, "incremental request keeps previous_response_id"
+	}
 
-	sanitizedInput, err := sanitizeResponsesTranscriptReplayInputRaw(input.Raw)
+	sanitizedInput, err := sanitizeResponsesTranscriptReplayInputRaw(string(envelope.Input))
 	if err != nil {
 		return nil, false, fmt.Sprintf("strip encrypted_content failed: %v", err)
 	}
@@ -167,8 +274,8 @@ func SanitizeResponsesTranscriptInitialRequest(requestBody []byte) ([]byte, bool
 	strippedLatestImages := 0
 	trimmedItems := 0
 	if len(out) > responsesTranscriptPreflightSanitizeTargetBytes {
-		var items []any
-		if err := json.Unmarshal([]byte(inputRaw), &items); err != nil {
+		items, err := parseResponsesTranscriptInputItems(inputRaw)
+		if err != nil {
 			return nil, false, fmt.Sprintf("parse sanitized input failed: %v", err)
 		}
 
@@ -232,8 +339,8 @@ func SanitizeResponsesTranscriptInitialRequest(requestBody []byte) ([]byte, bool
 	return out, true, reason
 }
 
-func buildResponsesIncrementalTranscriptRetryRequest(requestBody []byte, input gjson.Result) ([]byte, bool, string) {
-	sanitizedInput, err := sanitizeResponsesTranscriptReplayInputRaw(input.Raw)
+func buildResponsesIncrementalTranscriptRetryRequest(requestBody []byte, input json.RawMessage) ([]byte, bool, string) {
+	sanitizedInput, err := sanitizeResponsesTranscriptReplayInputRaw(string(input))
 	if err != nil {
 		return nil, false, fmt.Sprintf("strip encrypted_content failed: %v", err)
 	}
@@ -260,44 +367,46 @@ func IsResponsesTranscriptReplayError(statusCode int, body []byte) bool {
 	if statusCode < 400 || len(body) == 0 {
 		return false
 	}
-	code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.code").String()))
-	if code == "" {
-		code = strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "code").String()))
-	}
-	return code == "invalid_encrypted_content" || code == "thinking_signature_invalid"
+	code := parseOpenAIErrorCode(body)
+	return code == openAIInvalidEncryptedContentCode || code == openAIThinkingSignatureInvalidCode
 }
 
 func ResponsesTranscriptReplayRequestHasEncryptedContent(requestBody []byte) bool {
 	if len(requestBody) == 0 {
 		return false
 	}
-	input := gjson.GetBytes(requestBody, "input")
-	if !input.Exists() || !input.IsArray() {
+	envelope, ok := parseResponsesTranscriptRequestEnvelope(requestBody)
+	if !ok {
 		return false
 	}
-	_, stripped, err := stripResponsesEncryptedContentFromJSONArrayRaw(input.Raw)
+	_, stripped, err := stripResponsesEncryptedContentFromJSONArrayRaw(string(envelope.Input))
 	return err == nil && stripped
 }
 
 func InspectResponsesTranscriptRequestShape(requestBody []byte) ResponsesTranscriptRequestShape {
 	shape := ResponsesTranscriptRequestShape{
-		BodyBytes:             len(requestBody),
-		HasPreviousResponseID: gjson.GetBytes(requestBody, "previous_response_id").Exists(),
-		HasPromptCacheKey:     strings.TrimSpace(gjson.GetBytes(requestBody, "prompt_cache_key").String()) != "",
+		BodyBytes: len(requestBody),
 	}
-	input := gjson.GetBytes(requestBody, "input")
-	shape.InputExists = input.Exists()
-	shape.InputIsArray = input.IsArray()
-	if !input.IsArray() {
+	envelope, ok := parseResponsesTranscriptRequestEnvelope(requestBody)
+	if !ok {
+		shape.InputExists = envelope.inputExists()
 		return shape
 	}
+	shape.HasPreviousResponseID = envelope.hasPreviousResponseID()
+	shape.HasPromptCacheKey = envelope.promptCacheKey() != ""
+	shape.InputExists = true
+	shape.InputIsArray = true
 
-	items := input.Array()
-	shape.InputItems = len(items)
-	shape.LooksFullTranscript = responsesInputLooksFullTranscript(input)
-	shape.LooksReplacementInput = responsesInputLooksTranscriptReplacement(input)
-	for _, item := range items {
-		switch strings.TrimSpace(item.Get("type").String()) {
+	input, err := parseResponsesTranscriptInput(envelope.Input)
+	if err != nil {
+		return shape
+	}
+	shape.InputItems = len(input.Items)
+	shape.LooksFullTranscript = responsesInputLooksFullTranscript(envelope.Input)
+	shape.LooksReplacementInput = responsesInputLooksTranscriptReplacement(envelope.Input)
+	for _, item := range input.Items {
+		itemType := item.typeValue()
+		switch itemType {
 		case "compaction", "compaction_summary":
 			shape.CompactionItems++
 		case "function_call":
@@ -307,14 +416,14 @@ func InspectResponsesTranscriptRequestShape(requestBody []byte) ResponsesTranscr
 		case "reasoning":
 			shape.ReasoningItems++
 		case "message":
-			if strings.TrimSpace(item.Get("role").String()) == "assistant" {
+			if item.roleValue() == "assistant" {
 				shape.AssistantMessageItems++
 			}
 		}
-		if responsesItemHasEncryptedContent(item) {
+		if responsesValueHasEncryptedContent(item.mutableValue()) {
 			shape.EncryptedContentItems++
 		}
-		shape.InlineImageItems += countResponsesInlineImageItems(item)
+		shape.InlineImageItems += countResponsesInlineImageItems(item.mutableValue())
 	}
 	return shape
 }
@@ -324,12 +433,16 @@ func ObserveResponsesTranscriptReplayResponseBody(info *RelayInfo, responseBody 
 	if state == nil || len(responseBody) == 0 {
 		return
 	}
-	if output := gjson.GetBytes(responseBody, "output"); output.Exists() && output.IsArray() {
-		state.OutputRaw = normalizeResponsesJSONArrayRaw(output.Raw)
+	var envelope responsesTranscriptResponseEnvelope
+	if err := json.Unmarshal(responseBody, &envelope); err != nil {
 		return
 	}
-	if output := gjson.GetBytes(responseBody, "response.output"); output.Exists() && output.IsArray() {
-		state.OutputRaw = normalizeResponsesJSONArrayRaw(output.Raw)
+	if isJSONArrayRaw(envelope.Output) {
+		state.OutputRaw = normalizeResponsesJSONArrayRaw(string(envelope.Output))
+		return
+	}
+	if isJSONArrayRaw(envelope.Response.Output) {
+		state.OutputRaw = normalizeResponsesJSONArrayRaw(string(envelope.Response.Output))
 	}
 }
 
@@ -338,17 +451,19 @@ func ObserveResponsesTranscriptReplayStreamEvent(info *RelayInfo, data string) {
 	if state == nil || strings.TrimSpace(data) == "" {
 		return
 	}
-	event := gjson.Parse(data)
-	if output := event.Get("response.output"); output.Exists() && output.IsArray() {
-		state.OutputRaw = normalizeResponsesJSONArrayRaw(output.Raw)
+	var event responsesTranscriptStreamEvent
+	if err := json.Unmarshal([]byte(data), &event); err != nil {
 		return
 	}
-	if event.Get("type").String() != "response.output_item.done" {
+	if isJSONArrayRaw(event.Response.Output) {
+		state.OutputRaw = normalizeResponsesJSONArrayRaw(string(event.Response.Output))
 		return
 	}
-	item := event.Get("item")
-	if item.Exists() && item.IsObject() {
-		state.OutputItems = append(state.OutputItems, item.Raw)
+	if event.Type != "response.output_item.done" {
+		return
+	}
+	if isJSONObjectRaw(event.Item) {
+		state.OutputItems = append(state.OutputItems, string(event.Item))
 	}
 }
 
@@ -357,14 +472,14 @@ func CommitResponsesTranscriptReplay(info *RelayInfo) bool {
 	if state == nil || state.CacheKey == "" || len(state.RequestBody) == 0 {
 		return false
 	}
-	input := gjson.GetBytes(state.RequestBody, "input")
-	if !input.Exists() || !input.IsArray() {
+	envelope, ok := parseResponsesTranscriptRequestEnvelope(state.RequestBody)
+	if !ok {
 		return false
 	}
-	inputRaw := input.Raw
+	inputRaw := string(envelope.Input)
 	if !state.Replayed &&
-		gjson.GetBytes(state.RequestBody, "previous_response_id").Exists() &&
-		!responsesInputLooksFullTranscript(input) {
+		envelope.hasPreviousResponseID() &&
+		!responsesInputLooksFullTranscript(envelope.Input) {
 		baseInputRaw := state.BaseInputRaw
 		if baseInputRaw == "" {
 			if cachedInput, ok := getResponsesTranscriptReplayCachedInput(state.CacheKey); ok {
@@ -372,7 +487,7 @@ func CommitResponsesTranscriptReplay(info *RelayInfo) bool {
 			}
 		}
 		if baseInputRaw != "" {
-			mergedInput, err := mergeResponsesJSONArrayRaw(baseInputRaw, input.Raw)
+			mergedInput, err := mergeResponsesJSONArrayRaw(baseInputRaw, inputRaw)
 			if err == nil {
 				inputRaw = mergedInput
 			}
@@ -404,7 +519,8 @@ func responsesTranscriptReplayState(info *RelayInfo) *ResponsesTranscriptReplayS
 }
 
 func responsesTranscriptReplayCacheKey(info *RelayInfo, requestBody []byte) string {
-	sessionID := strings.TrimSpace(gjson.GetBytes(requestBody, "prompt_cache_key").String())
+	envelope, _ := parseResponsesTranscriptRequestEnvelope(requestBody)
+	sessionID := envelope.promptCacheKey()
 	if sessionID == "" {
 		for _, name := range []string{"Session_id", "session_id", "X-Session-ID", "x-session-id", "Conversation_id", "conversation_id"} {
 			if v := requestHeaderValueCaseInsensitive(info.RequestHeaders, name); v != "" {
@@ -416,7 +532,7 @@ func responsesTranscriptReplayCacheKey(info *RelayInfo, requestBody []byte) stri
 	if sessionID == "" {
 		return ""
 	}
-	model := strings.TrimSpace(gjson.GetBytes(requestBody, "model").String())
+	model := strings.TrimSpace(envelope.Model)
 	if model == "" {
 		model = strings.TrimSpace(info.UpstreamModelName)
 	}
@@ -438,12 +554,53 @@ func requestHeaderValueCaseInsensitive(headers map[string]string, name string) s
 	return ""
 }
 
-func responsesInputLooksFullTranscript(input gjson.Result) bool {
-	if !input.IsArray() {
+func parseResponsesTranscriptRequestEnvelope(body []byte) (responsesTranscriptRequestEnvelope, bool) {
+	var envelope responsesTranscriptRequestEnvelope
+	if len(body) == 0 {
+		return envelope, false
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return envelope, false
+	}
+	return envelope, isJSONArrayRaw(envelope.Input)
+}
+
+func (envelope responsesTranscriptRequestEnvelope) inputExists() bool {
+	return len(envelope.Input) > 0
+}
+
+func (envelope responsesTranscriptRequestEnvelope) hasPreviousResponseID() bool {
+	return rawJSONHasValue(envelope.PreviousResponseID)
+}
+
+func (envelope responsesTranscriptRequestEnvelope) promptCacheKey() string {
+	return stringFromRawJSON(envelope.PromptCacheKey)
+}
+
+func parseResponsesTranscriptInput(raw json.RawMessage) (responsesTranscriptInput, error) {
+	normalized := normalizeResponsesJSONArrayRaw(string(raw))
+	var items []responsesTranscriptItem
+	if err := json.Unmarshal([]byte(normalized), &items); err != nil {
+		return responsesTranscriptInput{}, err
+	}
+	return responsesTranscriptInput{Raw: normalized, Items: items}, nil
+}
+
+func parseResponsesTranscriptInputItems(raw string) ([]responsesTranscriptItem, error) {
+	input, err := parseResponsesTranscriptInput(json.RawMessage(raw))
+	if err != nil {
+		return nil, err
+	}
+	return input.Items, nil
+}
+
+func responsesInputLooksFullTranscript(inputRaw json.RawMessage) bool {
+	input, err := parseResponsesTranscriptInput(inputRaw)
+	if err != nil {
 		return false
 	}
-	for _, item := range input.Array() {
-		switch strings.TrimSpace(item.Get("type").String()) {
+	for _, item := range input.Items {
+		switch item.typeValue() {
 		case "compaction", "compaction_summary":
 			return true
 		}
@@ -451,16 +608,17 @@ func responsesInputLooksFullTranscript(input gjson.Result) bool {
 	return false
 }
 
-func responsesInputLooksTranscriptReplacement(input gjson.Result) bool {
-	if !input.IsArray() {
+func responsesInputLooksTranscriptReplacement(inputRaw json.RawMessage) bool {
+	input, err := parseResponsesTranscriptInput(inputRaw)
+	if err != nil {
 		return false
 	}
-	for _, item := range input.Array() {
-		switch strings.TrimSpace(item.Get("type").String()) {
+	for _, item := range input.Items {
+		switch item.typeValue() {
 		case "function_call", "custom_tool_call":
 			return true
 		case "message":
-			if strings.TrimSpace(item.Get("role").String()) == "assistant" {
+			if item.roleValue() == "assistant" {
 				return true
 			}
 		}
@@ -468,31 +626,23 @@ func responsesInputLooksTranscriptReplacement(input gjson.Result) bool {
 	return false
 }
 
-func responsesItemHasEncryptedContent(item gjson.Result) bool {
-	if !item.Exists() {
-		return false
-	}
-	if item.IsArray() {
-		for _, child := range item.Array() {
-			if responsesItemHasEncryptedContent(child) {
+func responsesValueHasEncryptedContent(value any) bool {
+	switch typed := value.(type) {
+	case []any:
+		for _, child := range typed {
+			if responsesValueHasEncryptedContent(child) {
 				return true
 			}
 		}
-		return false
-	}
-	if item.IsObject() {
-		if item.Get("encrypted_content").Exists() {
+	case map[string]any:
+		if _, ok := typed["encrypted_content"]; ok {
 			return true
 		}
-		found := false
-		item.ForEach(func(_, child gjson.Result) bool {
-			if responsesItemHasEncryptedContent(child) {
-				found = true
-				return false
+		for _, child := range typed {
+			if responsesValueHasEncryptedContent(child) {
+				return true
 			}
-			return true
-		})
-		return found
+		}
 	}
 	return false
 }
@@ -573,8 +723,8 @@ type responsesTranscriptReplaySanitizedInput struct {
 
 func sanitizeResponsesTranscriptReplayInputRaw(raw string) (responsesTranscriptReplaySanitizedInput, error) {
 	raw = normalizeResponsesJSONArrayRaw(raw)
-	var items []any
-	if err := json.Unmarshal([]byte(raw), &items); err != nil {
+	items, err := parseResponsesTranscriptInputItems(raw)
+	if err != nil {
 		return responsesTranscriptReplaySanitizedInput{}, err
 	}
 	stripped := stripResponsesEncryptedContentValue(items)
@@ -595,15 +745,14 @@ func sanitizeResponsesTranscriptReplayInputRaw(raw string) (responsesTranscriptR
 	}, nil
 }
 
-func removeTopLevelResponsesReasoningItems(items []any) ([]any, int) {
+func removeTopLevelResponsesReasoningItems(items []responsesTranscriptItem) ([]responsesTranscriptItem, int) {
 	if len(items) == 0 {
 		return items, 0
 	}
 	removed := 0
 	out := items[:0]
 	for _, item := range items {
-		typed, ok := item.(map[string]any)
-		if ok && strings.TrimSpace(fmt.Sprint(typed["type"])) == "reasoning" {
+		if item.typeValue() == "reasoning" {
 			removed++
 			continue
 		}
@@ -618,6 +767,14 @@ func stripResponsesEncryptedContentValue(value any) bool {
 		stripped := false
 		for _, item := range typed {
 			if stripResponsesEncryptedContentValue(item) {
+				stripped = true
+			}
+		}
+		return stripped
+	case []responsesTranscriptItem:
+		stripped := false
+		for _, item := range typed {
+			if stripResponsesEncryptedContentValue(item.mutableValue()) {
 				stripped = true
 			}
 		}
@@ -639,7 +796,7 @@ func stripResponsesEncryptedContentValue(value any) bool {
 	}
 }
 
-func marshalResponsesTranscriptInputIntoRequest(requestBody []byte, items []any) ([]byte, string, error) {
+func marshalResponsesTranscriptInputIntoRequest(requestBody []byte, items []responsesTranscriptItem) ([]byte, string, error) {
 	inputJSON, err := json.Marshal(items)
 	if err != nil {
 		return nil, "", err
@@ -651,7 +808,7 @@ func marshalResponsesTranscriptInputIntoRequest(requestBody []byte, items []any)
 	return out, string(inputJSON), nil
 }
 
-func stripResponsesInlineImageItems(items []any, preserveLatestUserMessageImages bool) int {
+func stripResponsesInlineImageItems(items []responsesTranscriptItem, preserveLatestUserMessageImages bool) int {
 	latestUserIndex := -1
 	if preserveLatestUserMessageImages {
 		for i, item := range items {
@@ -666,7 +823,7 @@ func stripResponsesInlineImageItems(items []any, preserveLatestUserMessageImages
 		if preserveLatestUserMessageImages && i == latestUserIndex {
 			continue
 		}
-		stripped += stripResponsesInlineImageValue(item)
+		stripped += stripResponsesInlineImageValue(item.mutableValue())
 	}
 	return stripped
 }
@@ -699,30 +856,27 @@ func stripResponsesInlineImageValue(value any) int {
 	}
 }
 
-func countResponsesInlineImageItems(item gjson.Result) int {
-	if !item.Exists() {
-		return 0
-	}
-	if item.IsArray() {
+func countResponsesInlineImageItems(value any) int {
+	switch typed := value.(type) {
+	case []any:
 		count := 0
-		for _, child := range item.Array() {
+		for _, child := range typed {
 			count += countResponsesInlineImageItems(child)
 		}
 		return count
-	}
-	if item.IsObject() {
-		if strings.TrimSpace(item.Get("type").String()) == "input_image" &&
-			isResponsesInlineImageDataURL(item.Get("image_url").String()) {
+	case map[string]any:
+		if stringFromAny(typed["type"]) == "input_image" &&
+			isResponsesInlineImageDataURL(stringFromAny(typed["image_url"])) {
 			return 1
 		}
 		count := 0
-		item.ForEach(func(_, child gjson.Result) bool {
+		for _, child := range typed {
 			count += countResponsesInlineImageItems(child)
-			return true
-		})
+		}
 		return count
+	default:
+		return 0
 	}
-	return 0
 }
 
 func isResponsesInlineImageDataURL(value string) bool {
@@ -741,7 +895,7 @@ func isResponsesInlineImageDataURL(value string) bool {
 	return strings.Contains(lower[:comma], ";base64")
 }
 
-func trimResponsesTranscriptHistoryToRequestBudget(requestBody []byte, items []any, targetBytes int) ([]any, int, bool) {
+func trimResponsesTranscriptHistoryToRequestBudget(requestBody []byte, items []responsesTranscriptItem, targetBytes int) ([]responsesTranscriptItem, int, bool) {
 	if len(items) == 0 {
 		return items, 0, false
 	}
@@ -770,7 +924,7 @@ func trimResponsesTranscriptHistoryToRequestBudget(requestBody []byte, items []a
 	return items, trimmed, trimmed > 0
 }
 
-func oldestResponsesTranscriptTrimCandidate(items []any) int {
+func oldestResponsesTranscriptTrimCandidate(items []responsesTranscriptItem) int {
 	latestUserIndex := -1
 	for i, item := range items {
 		if responsesTranscriptItemIsUserMessage(item) {
@@ -789,28 +943,19 @@ func oldestResponsesTranscriptTrimCandidate(items []any) int {
 	return -1
 }
 
-func responsesTranscriptItemIsUserMessage(item any) bool {
-	typed, ok := item.(map[string]any)
-	if !ok {
-		return false
-	}
-	return strings.TrimSpace(fmt.Sprint(typed["type"])) == "message" &&
-		strings.TrimSpace(fmt.Sprint(typed["role"])) == "user"
+func responsesTranscriptItemIsUserMessage(item responsesTranscriptItem) bool {
+	return item.typeValue() == "message" && item.roleValue() == "user"
 }
 
-func responsesTranscriptItemIsTrimProtected(item any) bool {
-	typed, ok := item.(map[string]any)
-	if !ok {
-		return false
-	}
-	itemType := strings.TrimSpace(fmt.Sprint(typed["type"]))
+func responsesTranscriptItemIsTrimProtected(item responsesTranscriptItem) bool {
+	itemType := item.typeValue()
 	if itemType == "compaction" || itemType == "compaction_summary" {
 		return true
 	}
-	return itemType == "message" && strings.TrimSpace(fmt.Sprint(typed["role"])) == "developer"
+	return itemType == "message" && item.roleValue() == "developer"
 }
 
-func removeResponsesTranscriptItemWithCounterpart(items []any, index int) []any {
+func removeResponsesTranscriptItemWithCounterpart(items []responsesTranscriptItem, index int) []responsesTranscriptItem {
 	if index < 0 || index >= len(items) {
 		return items
 	}
@@ -855,20 +1000,12 @@ func removeResponsesTranscriptItemWithCounterpart(items []any, index int) []any 
 	return out
 }
 
-func responsesTranscriptItemType(item any) string {
-	typed, ok := item.(map[string]any)
-	if !ok {
-		return ""
-	}
-	return strings.TrimSpace(fmt.Sprint(typed["type"]))
+func responsesTranscriptItemType(item responsesTranscriptItem) string {
+	return item.typeValue()
 }
 
-func responsesTranscriptItemCallID(item any) string {
-	typed, ok := item.(map[string]any)
-	if !ok {
-		return ""
-	}
-	return strings.TrimSpace(fmt.Sprint(typed["call_id"]))
+func responsesTranscriptItemCallID(item responsesTranscriptItem) string {
+	return item.callIDValue()
 }
 
 func responsesTranscriptItemHasCallCounterpart(itemType string) bool {
@@ -878,4 +1015,72 @@ func responsesTranscriptItemHasCallCounterpart(itemType string) bool {
 	default:
 		return false
 	}
+}
+
+func parseOpenAIErrorCode(body []byte) string {
+	var response openAIErrorCodeResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return ""
+	}
+	if rawJSONHasValue(response.Error) && isJSONObjectRaw(response.Error) {
+		var nested openAIErrorCodeObject
+		if err := json.Unmarshal(response.Error, &nested); err == nil {
+			if code := errorCodeString(nested.Code); code != "" {
+				return code
+			}
+		}
+	}
+	return errorCodeString(response.Code)
+}
+
+func errorCodeString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.ToLower(strings.TrimSpace(typed))
+	case json.RawMessage:
+		return strings.ToLower(strings.TrimSpace(stringFromRawJSON(typed)))
+	case nil:
+		return ""
+	default:
+		return strings.ToLower(strings.TrimSpace(fmt.Sprint(value)))
+	}
+}
+
+func rawJSONHasValue(raw json.RawMessage) bool {
+	trimmed := strings.TrimSpace(string(raw))
+	return trimmed != "" && trimmed != "null"
+}
+
+func stringFromRawJSON(raw json.RawMessage) string {
+	if !rawJSONHasValue(raw) {
+		return ""
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err == nil {
+		return strings.TrimSpace(value)
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+func stringFromAny(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case json.RawMessage:
+		return stringFromRawJSON(typed)
+	case nil:
+		return ""
+	default:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	}
+}
+
+func isJSONArrayRaw(raw json.RawMessage) bool {
+	trimmed := strings.TrimSpace(string(raw))
+	return strings.HasPrefix(trimmed, "[")
+}
+
+func isJSONObjectRaw(raw json.RawMessage) bool {
+	trimmed := strings.TrimSpace(string(raw))
+	return strings.HasPrefix(trimmed, "{")
 }

--- a/relay/common/responses_transcript_replay.go
+++ b/relay/common/responses_transcript_replay.go
@@ -12,6 +12,7 @@ import (
 )
 
 const responsesTranscriptReplayTTL = time.Hour
+const responsesTranscriptPreflightSanitizeMinBytes = 900 * 1024
 
 type ResponsesTranscriptReplayState struct {
 	CacheKey     string
@@ -30,6 +31,7 @@ type ResponsesTranscriptRequestShape struct {
 	InputIsArray          bool
 	InputItems            int
 	LooksFullTranscript   bool
+	LooksReplacementInput bool
 	CompactionItems       int
 	AssistantMessageItems int
 	FunctionCallItems     int
@@ -134,6 +136,41 @@ func BuildResponsesTranscriptReplayRequest(info *RelayInfo, requestBody []byte) 
 	return out, true, reason
 }
 
+func SanitizeResponsesTranscriptInitialRequest(requestBody []byte) ([]byte, bool, string) {
+	if len(requestBody) < responsesTranscriptPreflightSanitizeMinBytes {
+		return nil, false, "request body below transcript preflight sanitize threshold"
+	}
+	if gjson.GetBytes(requestBody, "previous_response_id").Exists() {
+		return nil, false, "incremental request keeps previous_response_id"
+	}
+	input := gjson.GetBytes(requestBody, "input")
+	if !input.Exists() || !input.IsArray() {
+		return nil, false, "request input is not an array"
+	}
+
+	sanitizedInput, err := sanitizeResponsesTranscriptReplayInputRaw(input.Raw)
+	if err != nil {
+		return nil, false, fmt.Sprintf("strip encrypted_content failed: %v", err)
+	}
+	if !sanitizedInput.StrippedEncryptedContent && !sanitizedInput.RemovedReasoningItems {
+		return nil, false, "request has no encrypted_content or reasoning items to strip"
+	}
+
+	out, err := sjson.SetRawBytes(append([]byte(nil), requestBody...), "input", []byte(sanitizedInput.InputRaw))
+	if err != nil {
+		return nil, false, fmt.Sprintf("set sanitized input failed: %v", err)
+	}
+
+	reason := "sanitized oversized full input transcript"
+	if sanitizedInput.StrippedEncryptedContent {
+		reason += "; stripped encrypted_content"
+	}
+	if sanitizedInput.RemovedReasoningItems {
+		reason += "; removed reasoning items"
+	}
+	return out, true, reason
+}
+
 func buildResponsesIncrementalTranscriptRetryRequest(requestBody []byte, input gjson.Result) ([]byte, bool, string) {
 	sanitizedInput, err := sanitizeResponsesTranscriptReplayInputRaw(input.Raw)
 	if err != nil {
@@ -203,6 +240,7 @@ func InspectResponsesTranscriptRequestShape(requestBody []byte) ResponsesTranscr
 	items := input.Array()
 	shape.InputItems = len(items)
 	shape.LooksFullTranscript = responsesInputLooksFullTranscript(input)
+	shape.LooksReplacementInput = responsesInputLooksTranscriptReplacement(input)
 	for _, item := range items {
 		switch strings.TrimSpace(item.Get("type").String()) {
 		case "compaction", "compaction_summary":
@@ -352,6 +390,23 @@ func responsesInputLooksFullTranscript(input gjson.Result) bool {
 		switch strings.TrimSpace(item.Get("type").String()) {
 		case "compaction", "compaction_summary":
 			return true
+		}
+	}
+	return false
+}
+
+func responsesInputLooksTranscriptReplacement(input gjson.Result) bool {
+	if !input.IsArray() {
+		return false
+	}
+	for _, item := range input.Array() {
+		switch strings.TrimSpace(item.Get("type").String()) {
+		case "function_call", "custom_tool_call":
+			return true
+		case "message":
+			if strings.TrimSpace(item.Get("role").String()) == "assistant" {
+				return true
+			}
 		}
 	}
 	return false

--- a/relay/common/responses_transcript_replay.go
+++ b/relay/common/responses_transcript_replay.go
@@ -102,15 +102,20 @@ func BuildResponsesTranscriptReplayRequest(info *RelayInfo, requestBody []byte) 
 		reason = "using cached transcript"
 	}
 
-	strippedInput, strippedEncryptedContent, err := stripResponsesEncryptedContentFromJSONArrayRaw(mergedInput)
+	sanitizedInput, err := sanitizeResponsesTranscriptReplayInputRaw(mergedInput)
 	if err != nil {
 		return nil, false, fmt.Sprintf("strip encrypted_content failed: %v", err)
 	}
-	if strippedEncryptedContent {
-		mergedInput = strippedInput
+	if sanitizedInput.StrippedEncryptedContent || sanitizedInput.RemovedReasoningItems {
+		mergedInput = sanitizedInput.InputRaw
+	}
+	if sanitizedInput.StrippedEncryptedContent {
 		reason += "; stripped encrypted_content"
 	}
-	if !hasPreviousResponseID && !strippedEncryptedContent {
+	if sanitizedInput.RemovedReasoningItems {
+		reason += "; removed reasoning items"
+	}
+	if !hasPreviousResponseID && !sanitizedInput.StrippedEncryptedContent {
 		return nil, false, "request has no previous_response_id and no encrypted_content to strip"
 	}
 
@@ -223,6 +228,9 @@ func CommitResponsesTranscriptReplay(info *RelayInfo) bool {
 	merged, err := mergeResponsesJSONArrayRaw(inputRaw, outputRaw)
 	if err != nil {
 		return false
+	}
+	if sanitized, err := sanitizeResponsesTranscriptReplayInputRaw(merged); err == nil {
+		merged = sanitized.InputRaw
 	}
 	setResponsesTranscriptReplayCachedInput(state.CacheKey, merged)
 	return true
@@ -347,20 +355,56 @@ func normalizeResponsesJSONArrayRaw(raw string) string {
 }
 
 func stripResponsesEncryptedContentFromJSONArrayRaw(raw string) (string, bool, error) {
-	raw = normalizeResponsesJSONArrayRaw(raw)
-	var items []any
-	if err := json.Unmarshal([]byte(raw), &items); err != nil {
-		return "", false, err
-	}
-	stripped := stripResponsesEncryptedContentValue(items)
-	if !stripped {
-		return raw, false, nil
-	}
-	out, err := json.Marshal(items)
+	sanitized, err := sanitizeResponsesTranscriptReplayInputRaw(raw)
 	if err != nil {
 		return "", false, err
 	}
-	return string(out), true, nil
+	return sanitized.InputRaw, sanitized.StrippedEncryptedContent, nil
+}
+
+type responsesTranscriptReplaySanitizedInput struct {
+	InputRaw                 string
+	StrippedEncryptedContent bool
+	RemovedReasoningItems    bool
+}
+
+func sanitizeResponsesTranscriptReplayInputRaw(raw string) (responsesTranscriptReplaySanitizedInput, error) {
+	raw = normalizeResponsesJSONArrayRaw(raw)
+	var items []any
+	if err := json.Unmarshal([]byte(raw), &items); err != nil {
+		return responsesTranscriptReplaySanitizedInput{}, err
+	}
+	stripped := stripResponsesEncryptedContentValue(items)
+	items, removedReasoningItems := removeTopLevelResponsesReasoningItems(items)
+	if !stripped && !removedReasoningItems {
+		return responsesTranscriptReplaySanitizedInput{InputRaw: raw}, nil
+	}
+	out, err := json.Marshal(items)
+	if err != nil {
+		return responsesTranscriptReplaySanitizedInput{}, err
+	}
+	return responsesTranscriptReplaySanitizedInput{
+		InputRaw:                 string(out),
+		StrippedEncryptedContent: stripped,
+		RemovedReasoningItems:    removedReasoningItems,
+	}, nil
+}
+
+func removeTopLevelResponsesReasoningItems(items []any) ([]any, bool) {
+	if len(items) == 0 {
+		return items, false
+	}
+	removed := false
+	out := items[:0]
+	for _, item := range items {
+		typed, ok := item.(map[string]any)
+		if ok && strings.TrimSpace(fmt.Sprint(typed["type"])) == "reasoning" {
+			removed = true
+			continue
+		}
+		out = append(out, item)
+	}
+	return out, removed
 }
 
 func stripResponsesEncryptedContentValue(value any) bool {

--- a/relay/common/responses_transcript_replay.go
+++ b/relay/common/responses_transcript_replay.go
@@ -22,6 +22,22 @@ type ResponsesTranscriptReplayState struct {
 	Replayed     bool
 }
 
+type ResponsesTranscriptRequestShape struct {
+	BodyBytes             int
+	HasPreviousResponseID bool
+	HasPromptCacheKey     bool
+	InputExists           bool
+	InputIsArray          bool
+	InputItems            int
+	LooksFullTranscript   bool
+	CompactionItems       int
+	AssistantMessageItems int
+	FunctionCallItems     int
+	CustomToolCallItems   int
+	ReasoningItems        int
+	EncryptedContentItems int
+}
+
 type responsesTranscriptReplayCacheEntry struct {
 	InputRaw string
 	Expire   time.Time
@@ -83,24 +99,12 @@ func BuildResponsesTranscriptReplayRequest(info *RelayInfo, requestBody []byte) 
 		return nil, false, "request input is not an array"
 	}
 
+	if hasPreviousResponseID {
+		return buildResponsesIncrementalTranscriptRetryRequest(requestBody, input)
+	}
+
 	mergedInput := input.Raw
 	reason := "using full input transcript"
-	if !responsesInputLooksFullTranscript(input) {
-		state := info.ResponsesTranscriptReplay
-		if state == nil || state.CacheKey == "" {
-			return nil, false, "missing transcript replay cache key"
-		}
-		cachedInput, ok := getResponsesTranscriptReplayCachedInput(state.CacheKey)
-		if !ok {
-			return nil, false, "missing cached transcript"
-		}
-		var err error
-		mergedInput, err = mergeResponsesJSONArrayRaw(cachedInput, input.Raw)
-		if err != nil {
-			return nil, false, fmt.Sprintf("merge transcript failed: %v", err)
-		}
-		reason = "using cached transcript"
-	}
 
 	sanitizedInput, err := sanitizeResponsesTranscriptReplayInputRaw(mergedInput)
 	if err != nil {
@@ -115,8 +119,8 @@ func BuildResponsesTranscriptReplayRequest(info *RelayInfo, requestBody []byte) 
 	if sanitizedInput.RemovedReasoningItems {
 		reason += "; removed reasoning items"
 	}
-	if !hasPreviousResponseID && !sanitizedInput.StrippedEncryptedContent {
-		return nil, false, "request has no previous_response_id and no encrypted_content to strip"
+	if !sanitizedInput.StrippedEncryptedContent && !sanitizedInput.RemovedReasoningItems {
+		return nil, false, "request has no encrypted_content or reasoning items to strip"
 	}
 
 	out, err := sjson.DeleteBytes(append([]byte(nil), requestBody...), "previous_response_id")
@@ -126,6 +130,30 @@ func BuildResponsesTranscriptReplayRequest(info *RelayInfo, requestBody []byte) 
 	out, err = sjson.SetRawBytes(out, "input", []byte(mergedInput))
 	if err != nil {
 		return nil, false, fmt.Sprintf("set replay input failed: %v", err)
+	}
+	return out, true, reason
+}
+
+func buildResponsesIncrementalTranscriptRetryRequest(requestBody []byte, input gjson.Result) ([]byte, bool, string) {
+	sanitizedInput, err := sanitizeResponsesTranscriptReplayInputRaw(input.Raw)
+	if err != nil {
+		return nil, false, fmt.Sprintf("strip encrypted_content failed: %v", err)
+	}
+	if !sanitizedInput.StrippedEncryptedContent && !sanitizedInput.RemovedReasoningItems {
+		return nil, false, "incremental request has no encrypted_content or reasoning items to strip"
+	}
+
+	out, err := sjson.SetRawBytes(append([]byte(nil), requestBody...), "input", []byte(sanitizedInput.InputRaw))
+	if err != nil {
+		return nil, false, fmt.Sprintf("set retry input failed: %v", err)
+	}
+
+	reason := "using incremental previous_response_id"
+	if sanitizedInput.StrippedEncryptedContent {
+		reason += "; stripped encrypted_content"
+	}
+	if sanitizedInput.RemovedReasoningItems {
+		reason += "; removed reasoning items"
 	}
 	return out, true, reason
 }
@@ -157,6 +185,44 @@ func ResponsesTranscriptReplayRequestHasEncryptedContent(requestBody []byte) boo
 	}
 	_, stripped, err := stripResponsesEncryptedContentFromJSONArrayRaw(input.Raw)
 	return err == nil && stripped
+}
+
+func InspectResponsesTranscriptRequestShape(requestBody []byte) ResponsesTranscriptRequestShape {
+	shape := ResponsesTranscriptRequestShape{
+		BodyBytes:             len(requestBody),
+		HasPreviousResponseID: gjson.GetBytes(requestBody, "previous_response_id").Exists(),
+		HasPromptCacheKey:     strings.TrimSpace(gjson.GetBytes(requestBody, "prompt_cache_key").String()) != "",
+	}
+	input := gjson.GetBytes(requestBody, "input")
+	shape.InputExists = input.Exists()
+	shape.InputIsArray = input.IsArray()
+	if !input.IsArray() {
+		return shape
+	}
+
+	items := input.Array()
+	shape.InputItems = len(items)
+	shape.LooksFullTranscript = responsesInputLooksFullTranscript(input)
+	for _, item := range items {
+		switch strings.TrimSpace(item.Get("type").String()) {
+		case "compaction", "compaction_summary":
+			shape.CompactionItems++
+		case "function_call":
+			shape.FunctionCallItems++
+		case "custom_tool_call":
+			shape.CustomToolCallItems++
+		case "reasoning":
+			shape.ReasoningItems++
+		case "message":
+			if strings.TrimSpace(item.Get("role").String()) == "assistant" {
+				shape.AssistantMessageItems++
+			}
+		}
+		if responsesItemHasEncryptedContent(item) {
+			shape.EncryptedContentItems++
+		}
+	}
+	return shape
 }
 
 func ObserveResponsesTranscriptReplayResponseBody(info *RelayInfo, responseBody []byte) {
@@ -284,13 +350,38 @@ func responsesInputLooksFullTranscript(input gjson.Result) bool {
 	}
 	for _, item := range input.Array() {
 		switch strings.TrimSpace(item.Get("type").String()) {
-		case "compaction", "compaction_summary", "function_call", "custom_tool_call", "reasoning":
+		case "compaction", "compaction_summary":
 			return true
-		case "message":
-			if strings.TrimSpace(item.Get("role").String()) == "assistant" {
+		}
+	}
+	return false
+}
+
+func responsesItemHasEncryptedContent(item gjson.Result) bool {
+	if !item.Exists() {
+		return false
+	}
+	if item.IsArray() {
+		for _, child := range item.Array() {
+			if responsesItemHasEncryptedContent(child) {
 				return true
 			}
 		}
+		return false
+	}
+	if item.IsObject() {
+		if item.Get("encrypted_content").Exists() {
+			return true
+		}
+		found := false
+		item.ForEach(func(_, child gjson.Result) bool {
+			if responsesItemHasEncryptedContent(child) {
+				found = true
+				return false
+			}
+			return true
+		})
+		return found
 	}
 	return false
 }

--- a/relay/common/responses_transcript_replay.go
+++ b/relay/common/responses_transcript_replay.go
@@ -13,6 +13,8 @@ import (
 
 const responsesTranscriptReplayTTL = time.Hour
 const responsesTranscriptPreflightSanitizeMinBytes = 900 * 1024
+const responsesTranscriptPreflightSanitizeTargetBytes = responsesTranscriptPreflightSanitizeMinBytes - 64*1024
+const responsesTranscriptOmittedImageText = "[image omitted from oversized transcript replay]"
 
 type ResponsesTranscriptReplayState struct {
 	CacheKey     string
@@ -38,6 +40,7 @@ type ResponsesTranscriptRequestShape struct {
 	CustomToolCallItems   int
 	ReasoningItems        int
 	EncryptedContentItems int
+	InlineImageItems      int
 }
 
 type responsesTranscriptReplayCacheEntry struct {
@@ -140,10 +143,11 @@ func SanitizeResponsesTranscriptInitialRequest(requestBody []byte) ([]byte, bool
 	if len(requestBody) < responsesTranscriptPreflightSanitizeMinBytes {
 		return nil, false, "request body below transcript preflight sanitize threshold"
 	}
-	if gjson.GetBytes(requestBody, "previous_response_id").Exists() {
+	hasPreviousResponseID := gjson.GetBytes(requestBody, "previous_response_id").Exists()
+	input := gjson.GetBytes(requestBody, "input")
+	if hasPreviousResponseID && !responsesInputLooksFullTranscript(input) && !responsesInputLooksTranscriptReplacement(input) {
 		return nil, false, "incremental request keeps previous_response_id"
 	}
-	input := gjson.GetBytes(requestBody, "input")
 	if !input.Exists() || !input.IsArray() {
 		return nil, false, "request input is not an array"
 	}
@@ -152,21 +156,78 @@ func SanitizeResponsesTranscriptInitialRequest(requestBody []byte) ([]byte, bool
 	if err != nil {
 		return nil, false, fmt.Sprintf("strip encrypted_content failed: %v", err)
 	}
-	if !sanitizedInput.StrippedEncryptedContent && !sanitizedInput.RemovedReasoningItems {
-		return nil, false, "request has no encrypted_content or reasoning items to strip"
-	}
 
 	out, err := sjson.SetRawBytes(append([]byte(nil), requestBody...), "input", []byte(sanitizedInput.InputRaw))
 	if err != nil {
 		return nil, false, fmt.Sprintf("set sanitized input failed: %v", err)
 	}
 
+	inputRaw := sanitizedInput.InputRaw
+	strippedHistoricalImages := 0
+	strippedLatestImages := 0
+	trimmedItems := 0
+	if len(out) > responsesTranscriptPreflightSanitizeTargetBytes {
+		var items []any
+		if err := json.Unmarshal([]byte(inputRaw), &items); err != nil {
+			return nil, false, fmt.Sprintf("parse sanitized input failed: %v", err)
+		}
+
+		strippedHistoricalImages = stripResponsesInlineImageItems(items, true)
+		if strippedHistoricalImages > 0 {
+			out, _, err = marshalResponsesTranscriptInputIntoRequest(requestBody, items)
+			if err != nil {
+				return nil, false, fmt.Sprintf("set image-stripped input failed: %v", err)
+			}
+		}
+
+		if len(out) > responsesTranscriptPreflightSanitizeTargetBytes {
+			strippedLatestImages = stripResponsesInlineImageItems(items, false)
+			if strippedLatestImages > 0 {
+				out, _, err = marshalResponsesTranscriptInputIntoRequest(requestBody, items)
+				if err != nil {
+					return nil, false, fmt.Sprintf("set fully image-stripped input failed: %v", err)
+				}
+			}
+		}
+
+		if len(out) > responsesTranscriptPreflightSanitizeTargetBytes {
+			var trimmed bool
+			items, trimmedItems, trimmed = trimResponsesTranscriptHistoryToRequestBudget(requestBody, items, responsesTranscriptPreflightSanitizeTargetBytes)
+			if trimmed {
+				out, _, err = marshalResponsesTranscriptInputIntoRequest(requestBody, items)
+				if err != nil {
+					return nil, false, fmt.Sprintf("set trimmed input failed: %v", err)
+				}
+			}
+		}
+	}
+
+	if !sanitizedInput.StrippedEncryptedContent &&
+		!sanitizedInput.RemovedReasoningItems &&
+		strippedHistoricalImages == 0 &&
+		strippedLatestImages == 0 &&
+		trimmedItems == 0 {
+		return nil, false, "request has no oversized transcript fields to strip"
+	}
+
 	reason := "sanitized oversized full input transcript"
+	if hasPreviousResponseID {
+		reason = "sanitized oversized previous_response_id transcript fallback"
+	}
 	if sanitizedInput.StrippedEncryptedContent {
 		reason += "; stripped encrypted_content"
 	}
 	if sanitizedInput.RemovedReasoningItems {
 		reason += "; removed reasoning items"
+	}
+	if strippedHistoricalImages > 0 {
+		reason += fmt.Sprintf("; stripped historical inline_images=%d", strippedHistoricalImages)
+	}
+	if strippedLatestImages > 0 {
+		reason += fmt.Sprintf("; stripped latest inline_images=%d", strippedLatestImages)
+	}
+	if trimmedItems > 0 {
+		reason += fmt.Sprintf("; trimmed history_items=%d", trimmedItems)
 	}
 	return out, true, reason
 }
@@ -259,6 +320,7 @@ func InspectResponsesTranscriptRequestShape(requestBody []byte) ResponsesTranscr
 		if responsesItemHasEncryptedContent(item) {
 			shape.EncryptedContentItems++
 		}
+		shape.InlineImageItems += countResponsesInlineImageItems(item)
 	}
 	return shape
 }
@@ -512,6 +574,7 @@ type responsesTranscriptReplaySanitizedInput struct {
 	InputRaw                 string
 	StrippedEncryptedContent bool
 	RemovedReasoningItems    bool
+	RemovedReasoningCount    int
 }
 
 func sanitizeResponsesTranscriptReplayInputRaw(raw string) (responsesTranscriptReplaySanitizedInput, error) {
@@ -521,7 +584,8 @@ func sanitizeResponsesTranscriptReplayInputRaw(raw string) (responsesTranscriptR
 		return responsesTranscriptReplaySanitizedInput{}, err
 	}
 	stripped := stripResponsesEncryptedContentValue(items)
-	items, removedReasoningItems := removeTopLevelResponsesReasoningItems(items)
+	items, removedReasoningCount := removeTopLevelResponsesReasoningItems(items)
+	removedReasoningItems := removedReasoningCount > 0
 	if !stripped && !removedReasoningItems {
 		return responsesTranscriptReplaySanitizedInput{InputRaw: raw}, nil
 	}
@@ -533,19 +597,20 @@ func sanitizeResponsesTranscriptReplayInputRaw(raw string) (responsesTranscriptR
 		InputRaw:                 string(out),
 		StrippedEncryptedContent: stripped,
 		RemovedReasoningItems:    removedReasoningItems,
+		RemovedReasoningCount:    removedReasoningCount,
 	}, nil
 }
 
-func removeTopLevelResponsesReasoningItems(items []any) ([]any, bool) {
+func removeTopLevelResponsesReasoningItems(items []any) ([]any, int) {
 	if len(items) == 0 {
-		return items, false
+		return items, 0
 	}
-	removed := false
+	removed := 0
 	out := items[:0]
 	for _, item := range items {
 		typed, ok := item.(map[string]any)
 		if ok && strings.TrimSpace(fmt.Sprint(typed["type"])) == "reasoning" {
-			removed = true
+			removed++
 			continue
 		}
 		out = append(out, item)
@@ -575,6 +640,247 @@ func stripResponsesEncryptedContentValue(value any) bool {
 			}
 		}
 		return stripped
+	default:
+		return false
+	}
+}
+
+func marshalResponsesTranscriptInputIntoRequest(requestBody []byte, items []any) ([]byte, string, error) {
+	inputJSON, err := json.Marshal(items)
+	if err != nil {
+		return nil, "", err
+	}
+	out, err := sjson.SetRawBytes(append([]byte(nil), requestBody...), "input", inputJSON)
+	if err != nil {
+		return nil, "", err
+	}
+	return out, string(inputJSON), nil
+}
+
+func stripResponsesInlineImageItems(items []any, preserveLatestUserMessageImages bool) int {
+	latestUserIndex := -1
+	if preserveLatestUserMessageImages {
+		for i, item := range items {
+			if responsesTranscriptItemIsUserMessage(item) {
+				latestUserIndex = i
+			}
+		}
+	}
+
+	stripped := 0
+	for i, item := range items {
+		if preserveLatestUserMessageImages && i == latestUserIndex {
+			continue
+		}
+		stripped += stripResponsesInlineImageValue(item)
+	}
+	return stripped
+}
+
+func stripResponsesInlineImageValue(value any) int {
+	switch typed := value.(type) {
+	case []any:
+		stripped := 0
+		for _, item := range typed {
+			stripped += stripResponsesInlineImageValue(item)
+		}
+		return stripped
+	case map[string]any:
+		if strings.TrimSpace(fmt.Sprint(typed["type"])) == "input_image" &&
+			isResponsesInlineImageDataURL(fmt.Sprint(typed["image_url"])) {
+			for key := range typed {
+				delete(typed, key)
+			}
+			typed["type"] = "input_text"
+			typed["text"] = responsesTranscriptOmittedImageText
+			return 1
+		}
+		stripped := 0
+		for _, item := range typed {
+			stripped += stripResponsesInlineImageValue(item)
+		}
+		return stripped
+	default:
+		return 0
+	}
+}
+
+func countResponsesInlineImageItems(item gjson.Result) int {
+	if !item.Exists() {
+		return 0
+	}
+	if item.IsArray() {
+		count := 0
+		for _, child := range item.Array() {
+			count += countResponsesInlineImageItems(child)
+		}
+		return count
+	}
+	if item.IsObject() {
+		if strings.TrimSpace(item.Get("type").String()) == "input_image" &&
+			isResponsesInlineImageDataURL(item.Get("image_url").String()) {
+			return 1
+		}
+		count := 0
+		item.ForEach(func(_, child gjson.Result) bool {
+			count += countResponsesInlineImageItems(child)
+			return true
+		})
+		return count
+	}
+	return 0
+}
+
+func isResponsesInlineImageDataURL(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	lower := strings.ToLower(value)
+	if !strings.HasPrefix(lower, "data:image/") {
+		return false
+	}
+	comma := strings.IndexByte(lower, ',')
+	if comma < 0 {
+		return false
+	}
+	return strings.Contains(lower[:comma], ";base64")
+}
+
+func trimResponsesTranscriptHistoryToRequestBudget(requestBody []byte, items []any, targetBytes int) ([]any, int, bool) {
+	if len(items) == 0 {
+		return items, 0, false
+	}
+	if body, _, err := marshalResponsesTranscriptInputIntoRequest(requestBody, items); err != nil || len(body) <= targetBytes {
+		return items, 0, false
+	}
+
+	trimmed := 0
+	for len(items) > 1 {
+		removeIndex := oldestResponsesTranscriptTrimCandidate(items)
+		if removeIndex < 0 {
+			break
+		}
+		before := len(items)
+		items = removeResponsesTranscriptItemWithCounterpart(items, removeIndex)
+		trimmed += before - len(items)
+
+		body, _, err := marshalResponsesTranscriptInputIntoRequest(requestBody, items)
+		if err != nil {
+			break
+		}
+		if len(body) <= targetBytes {
+			return items, trimmed, true
+		}
+	}
+	return items, trimmed, trimmed > 0
+}
+
+func oldestResponsesTranscriptTrimCandidate(items []any) int {
+	latestUserIndex := -1
+	for i, item := range items {
+		if responsesTranscriptItemIsUserMessage(item) {
+			latestUserIndex = i
+		}
+	}
+	if latestUserIndex < 0 {
+		latestUserIndex = len(items) - 1
+	}
+	for i := 0; i < latestUserIndex; i++ {
+		if responsesTranscriptItemIsTrimProtected(items[i]) {
+			continue
+		}
+		return i
+	}
+	return -1
+}
+
+func responsesTranscriptItemIsUserMessage(item any) bool {
+	typed, ok := item.(map[string]any)
+	if !ok {
+		return false
+	}
+	return strings.TrimSpace(fmt.Sprint(typed["type"])) == "message" &&
+		strings.TrimSpace(fmt.Sprint(typed["role"])) == "user"
+}
+
+func responsesTranscriptItemIsTrimProtected(item any) bool {
+	typed, ok := item.(map[string]any)
+	if !ok {
+		return false
+	}
+	itemType := strings.TrimSpace(fmt.Sprint(typed["type"]))
+	if itemType == "compaction" || itemType == "compaction_summary" {
+		return true
+	}
+	return itemType == "message" && strings.TrimSpace(fmt.Sprint(typed["role"])) == "developer"
+}
+
+func removeResponsesTranscriptItemWithCounterpart(items []any, index int) []any {
+	if index < 0 || index >= len(items) {
+		return items
+	}
+	if responsesTranscriptItemIsUserMessage(items[index]) {
+		remove := map[int]struct{}{}
+		for i := index; i < len(items); i++ {
+			if i > index && responsesTranscriptItemIsUserMessage(items[i]) {
+				break
+			}
+			remove[i] = struct{}{}
+		}
+		out := items[:0]
+		for i, item := range items {
+			if _, ok := remove[i]; ok {
+				continue
+			}
+			out = append(out, item)
+		}
+		return out
+	}
+	callID := responsesTranscriptItemCallID(items[index])
+	itemType := responsesTranscriptItemType(items[index])
+	remove := map[int]struct{}{index: {}}
+	if callID != "" && responsesTranscriptItemHasCallCounterpart(itemType) {
+		for i, item := range items {
+			if i == index {
+				continue
+			}
+			if responsesTranscriptItemCallID(item) == callID && responsesTranscriptItemHasCallCounterpart(responsesTranscriptItemType(item)) {
+				remove[i] = struct{}{}
+			}
+		}
+	}
+
+	out := items[:0]
+	for i, item := range items {
+		if _, ok := remove[i]; ok {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func responsesTranscriptItemType(item any) string {
+	typed, ok := item.(map[string]any)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(typed["type"]))
+}
+
+func responsesTranscriptItemCallID(item any) string {
+	typed, ok := item.(map[string]any)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(typed["call_id"]))
+}
+
+func responsesTranscriptItemHasCallCounterpart(itemType string) bool {
+	switch itemType {
+	case "function_call", "function_call_output", "custom_tool_call", "custom_tool_call_output":
+		return true
 	default:
 		return false
 	}

--- a/relay/common/responses_transcript_replay_test.go
+++ b/relay/common/responses_transcript_replay_test.go
@@ -1,0 +1,139 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func resetResponsesTranscriptReplayCacheForTest(t *testing.T) {
+	t.Helper()
+	responsesTranscriptReplayMu.Lock()
+	responsesTranscriptReplayCache = map[string]responsesTranscriptReplayCacheEntry{}
+	responsesTranscriptReplayMu.Unlock()
+}
+
+func TestResponsesTranscriptReplayBuildUsesCachedTranscript(t *testing.T) {
+	resetResponsesTranscriptReplayCacheForTest(t)
+
+	info := &RelayInfo{ChannelMeta: &ChannelMeta{ChannelId: 12, UpstreamModelName: "gpt-5"}}
+	firstRequest := []byte(`{
+		"model":"gpt-5",
+		"prompt_cache_key":"sess-1",
+		"input":[{"type":"message","role":"user","content":"first"}]
+	}`)
+	PrepareResponsesTranscriptReplay(info, firstRequest)
+	ObserveResponsesTranscriptReplayResponseBody(info, []byte(`{
+		"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first answer"}]}]
+	}`))
+	require.True(t, CommitResponsesTranscriptReplay(info))
+
+	secondRequest := []byte(`{
+		"model":"gpt-5",
+		"prompt_cache_key":"sess-1",
+		"previous_response_id":"resp_1",
+		"input":[{"type":"message","role":"user","content":"second"}]
+	}`)
+	PrepareResponsesTranscriptReplay(info, secondRequest)
+	replayBody, ok, reason := BuildResponsesTranscriptReplayRequest(info, secondRequest)
+	require.True(t, ok, reason)
+	require.False(t, gjson.GetBytes(replayBody, "previous_response_id").Exists())
+	require.Len(t, gjson.GetBytes(replayBody, "input").Array(), 3)
+	require.Equal(t, "first", gjson.GetBytes(replayBody, "input.0.content").String())
+	require.Equal(t, "first answer", gjson.GetBytes(replayBody, "input.1.content.0.text").String())
+	require.Equal(t, "second", gjson.GetBytes(replayBody, "input.2.content").String())
+}
+
+func TestResponsesTranscriptReplayCommitExtendsCachedTranscript(t *testing.T) {
+	resetResponsesTranscriptReplayCacheForTest(t)
+
+	info := &RelayInfo{ChannelMeta: &ChannelMeta{ChannelId: 12, UpstreamModelName: "gpt-5"}}
+	firstRequest := []byte(`{
+		"model":"gpt-5",
+		"prompt_cache_key":"sess-2",
+		"input":[{"type":"message","role":"user","content":"first"}]
+	}`)
+	PrepareResponsesTranscriptReplay(info, firstRequest)
+	ObserveResponsesTranscriptReplayResponseBody(info, []byte(`{
+		"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first answer"}]}]
+	}`))
+	require.True(t, CommitResponsesTranscriptReplay(info))
+
+	secondRequest := []byte(`{
+		"model":"gpt-5",
+		"prompt_cache_key":"sess-2",
+		"previous_response_id":"resp_1",
+		"input":[{"type":"message","role":"user","content":"second"}]
+	}`)
+	PrepareResponsesTranscriptReplay(info, secondRequest)
+	ObserveResponsesTranscriptReplayResponseBody(info, []byte(`{
+		"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"second answer"}]}]
+	}`))
+	require.True(t, CommitResponsesTranscriptReplay(info))
+
+	thirdRequest := []byte(`{
+		"model":"gpt-5",
+		"prompt_cache_key":"sess-2",
+		"previous_response_id":"resp_2",
+		"input":[{"type":"message","role":"user","content":"third"}]
+	}`)
+	PrepareResponsesTranscriptReplay(info, thirdRequest)
+	replayBody, ok, reason := BuildResponsesTranscriptReplayRequest(info, thirdRequest)
+	require.True(t, ok, reason)
+	require.Len(t, gjson.GetBytes(replayBody, "input").Array(), 5)
+	require.Equal(t, "first", gjson.GetBytes(replayBody, "input.0.content").String())
+	require.Equal(t, "first answer", gjson.GetBytes(replayBody, "input.1.content.0.text").String())
+	require.Equal(t, "second", gjson.GetBytes(replayBody, "input.2.content").String())
+	require.Equal(t, "second answer", gjson.GetBytes(replayBody, "input.3.content.0.text").String())
+	require.Equal(t, "third", gjson.GetBytes(replayBody, "input.4.content").String())
+}
+
+func TestResponsesTranscriptReplayFullTranscriptDeletesPreviousResponseID(t *testing.T) {
+	replayBody, ok, reason := BuildResponsesTranscriptReplayRequest(&RelayInfo{}, []byte(`{
+		"model":"gpt-5",
+		"previous_response_id":"resp_1",
+		"input":[
+			{"type":"message","role":"user","content":"first"},
+			{"type":"reasoning","encrypted_content":"bad-ciphertext","summary":[]},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first answer"}]},
+			{"type":"message","role":"user","content":"second"}
+		]
+	}`))
+	require.True(t, ok, reason)
+	require.False(t, gjson.GetBytes(replayBody, "previous_response_id").Exists())
+	require.False(t, gjson.GetBytes(replayBody, "input.1.encrypted_content").Exists())
+	require.Len(t, gjson.GetBytes(replayBody, "input").Array(), 4)
+}
+
+func TestResponsesTranscriptReplayWithoutPreviousResponseIDStripsEncryptedContent(t *testing.T) {
+	replayBody, ok, reason := BuildResponsesTranscriptReplayRequest(&RelayInfo{}, []byte(`{
+		"model":"gpt-5",
+		"input":[
+			{"type":"message","role":"user","content":"first"},
+			{"type":"reasoning","encrypted_content":"bad-ciphertext","summary":[]},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first answer"}]},
+			{"type":"message","role":"user","content":"second"}
+		]
+	}`))
+	require.True(t, ok, reason)
+	require.False(t, gjson.GetBytes(replayBody, "previous_response_id").Exists())
+	require.False(t, gjson.GetBytes(replayBody, "input.1.encrypted_content").Exists())
+	require.Contains(t, reason, "stripped encrypted_content")
+}
+
+func TestResponsesTranscriptReplayRequestHasEncryptedContent(t *testing.T) {
+	require.True(t, ResponsesTranscriptReplayRequestHasEncryptedContent([]byte(`{
+		"input":[{"type":"reasoning","encrypted_content":"bad-ciphertext","summary":[]}]
+	}`)))
+	require.False(t, ResponsesTranscriptReplayRequestHasEncryptedContent([]byte(`{
+		"input":[{"type":"reasoning","summary":[]}]
+	}`)))
+}
+
+func TestIsResponsesTranscriptReplayError(t *testing.T) {
+	require.True(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"code":"invalid_encrypted_content","message":"bad encrypted_content"}}`)))
+	require.True(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"message":"Invalid signature in thinking block"}}`)))
+	require.False(t, IsResponsesTranscriptReplayError(404, []byte(`{"error":{"code":"previous_response_not_found","message":"missing"}}`)))
+	require.False(t, IsResponsesTranscriptReplayError(429, []byte(`{"error":{"code":"rate_limit_exceeded","message":"slow down"}}`)))
+}

--- a/relay/common/responses_transcript_replay_test.go
+++ b/relay/common/responses_transcript_replay_test.go
@@ -270,84 +270,25 @@ func TestInspectResponsesTranscriptRequestShape(t *testing.T) {
 	require.Equal(t, 0, shape.InlineImageItems)
 }
 
-func TestIsResponsesTranscriptReplayError(t *testing.T) {
-	tests := []struct {
-		name       string
-		statusCode int
-		body       string
-		want       bool
-	}{
-		{
-			name:       "nested invalid encrypted content code",
-			statusCode: 400,
-			body:       `{"error":{"code":"invalid_encrypted_content"}}`,
-			want:       true,
-		},
-		{
-			name:       "nested thinking signature code",
-			statusCode: 400,
-			body:       `{"error":{"code":"thinking_signature_invalid"}}`,
-			want:       true,
-		},
-		{
-			name:       "top level invalid encrypted content code",
-			statusCode: 400,
-			body:       `{"code":"invalid_encrypted_content"}`,
-			want:       true,
-		},
-		{
-			name:       "message only is ignored",
-			statusCode: 400,
-			body:       `{"error":{"message":"invalid_encrypted_content"}}`,
-			want:       false,
-		},
-		{
-			name:       "wrapped invalid encrypted content code in message",
-			statusCode: 400,
-			body:       `{"error":{"message":"code: invalid_encrypted_content; message: The encrypted content gAAA...V2ln could not be verified. Reason: Encrypted content could not be decrypted or parsed.","type":"invalid_request_error","param":"","code":"-4003"}}`,
-			want:       true,
-		},
-		{
-			name:       "wrapped thinking signature code in message",
-			statusCode: 400,
-			body:       `{"error":{"message":"code: thinking_signature_invalid; message: encrypted content rejected","type":"invalid_request_error","code":"-4003"}}`,
-			want:       true,
-		},
-		{
-			name:       "plain message text with target code is ignored",
-			statusCode: 400,
-			body:       `{"error":{"message":"upstream returned invalid_encrypted_content","code":"-4003"}}`,
-			want:       false,
-		},
-		{
-			name:       "empty nested code falls back to top level code",
-			statusCode: 400,
-			body:       `{"error":{},"code":"thinking_signature_invalid"}`,
-			want:       true,
-		},
-		{
-			name:       "string error falls back to top level code",
-			statusCode: 400,
-			body:       `{"error":"bad request","code":"invalid_encrypted_content"}`,
-			want:       true,
-		},
-		{
-			name:       "previous response error is unrelated",
-			statusCode: 404,
-			body:       `{"error":{"code":"previous_response_not_found"}}`,
-			want:       false,
-		},
-		{
-			name:       "rate limit error is unrelated",
-			statusCode: 429,
-			body:       `{"error":{"code":"rate_limit_exceeded"}}`,
-			want:       false,
-		},
-	}
+func TestIsResponsesTranscriptReplayErrorMatchesStructuredCodes(t *testing.T) {
+	require.True(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"code":"invalid_encrypted_content"}}`)))
+	require.True(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"code":"thinking_signature_invalid"}}`)))
+	require.True(t, IsResponsesTranscriptReplayError(400, []byte(`{"code":"invalid_encrypted_content"}`)))
+	require.True(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{},"code":"thinking_signature_invalid"}`)))
+	require.True(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":"bad request","code":"invalid_encrypted_content"}`)))
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, IsResponsesTranscriptReplayError(tt.statusCode, []byte(tt.body)))
-		})
-	}
+func TestIsResponsesTranscriptReplayErrorMatchesWrappedCodes(t *testing.T) {
+	require.True(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"message":"code: invalid_encrypted_content; message: The encrypted content gAAA...V2ln could not be verified. Reason: Encrypted content could not be decrypted or parsed.","type":"invalid_request_error","param":"","code":"-4003"}}`)))
+	require.True(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"message":"code: thinking_signature_invalid; message: encrypted content rejected","type":"invalid_request_error","code":"-4003"}}`)))
+}
+
+func TestIsResponsesTranscriptReplayErrorIgnoresMessageOnlyCodes(t *testing.T) {
+	require.False(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"message":"invalid_encrypted_content"}}`)))
+	require.False(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"message":"upstream returned invalid_encrypted_content","code":"-4003"}}`)))
+}
+
+func TestIsResponsesTranscriptReplayErrorIgnoresUnrelatedErrors(t *testing.T) {
+	require.False(t, IsResponsesTranscriptReplayError(404, []byte(`{"error":{"code":"previous_response_not_found"}}`)))
+	require.False(t, IsResponsesTranscriptReplayError(429, []byte(`{"error":{"code":"rate_limit_exceeded"}}`)))
 }

--- a/relay/common/responses_transcript_replay_test.go
+++ b/relay/common/responses_transcript_replay_test.go
@@ -102,8 +102,9 @@ func TestResponsesTranscriptReplayFullTranscriptDeletesPreviousResponseID(t *tes
 	}`))
 	require.True(t, ok, reason)
 	require.False(t, gjson.GetBytes(replayBody, "previous_response_id").Exists())
-	require.False(t, gjson.GetBytes(replayBody, "input.1.encrypted_content").Exists())
-	require.Len(t, gjson.GetBytes(replayBody, "input").Array(), 4)
+	require.Len(t, gjson.GetBytes(replayBody, "input").Array(), 3)
+	require.Equal(t, "message", gjson.GetBytes(replayBody, "input.1.type").String())
+	require.Contains(t, reason, "removed reasoning items")
 }
 
 func TestResponsesTranscriptReplayWithoutPreviousResponseIDStripsEncryptedContent(t *testing.T) {
@@ -118,8 +119,47 @@ func TestResponsesTranscriptReplayWithoutPreviousResponseIDStripsEncryptedConten
 	}`))
 	require.True(t, ok, reason)
 	require.False(t, gjson.GetBytes(replayBody, "previous_response_id").Exists())
-	require.False(t, gjson.GetBytes(replayBody, "input.1.encrypted_content").Exists())
+	require.Len(t, gjson.GetBytes(replayBody, "input").Array(), 3)
+	require.Equal(t, "message", gjson.GetBytes(replayBody, "input.1.type").String())
 	require.Contains(t, reason, "stripped encrypted_content")
+	require.Contains(t, reason, "removed reasoning items")
+}
+
+func TestResponsesTranscriptReplayCacheDropsReasoningItems(t *testing.T) {
+	resetResponsesTranscriptReplayCacheForTest(t)
+
+	info := &RelayInfo{ChannelMeta: &ChannelMeta{ChannelId: 12, UpstreamModelName: "gpt-5"}}
+	firstRequest := []byte(`{
+		"model":"gpt-5",
+		"prompt_cache_key":"sess-reasoning",
+		"input":[{"type":"message","role":"user","content":"first"}]
+	}`)
+	PrepareResponsesTranscriptReplay(info, firstRequest)
+	ObserveResponsesTranscriptReplayResponseBody(info, []byte(`{
+		"output":[
+			{"type":"reasoning","encrypted_content":"large-ciphertext","summary":[]},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first answer"}]}
+		]
+	}`))
+	require.True(t, CommitResponsesTranscriptReplay(info))
+
+	secondRequest := []byte(`{
+		"model":"gpt-5",
+		"prompt_cache_key":"sess-reasoning",
+		"previous_response_id":"resp_1",
+		"input":[{"type":"message","role":"user","content":"second"}]
+	}`)
+	PrepareResponsesTranscriptReplay(info, secondRequest)
+	replayBody, ok, reason := BuildResponsesTranscriptReplayRequest(info, secondRequest)
+	require.True(t, ok, reason)
+	require.Len(t, gjson.GetBytes(replayBody, "input").Array(), 3)
+	require.Equal(t, "first", gjson.GetBytes(replayBody, "input.0.content").String())
+	require.Equal(t, "first answer", gjson.GetBytes(replayBody, "input.1.content.0.text").String())
+	require.Equal(t, "second", gjson.GetBytes(replayBody, "input.2.content").String())
+	for _, item := range gjson.GetBytes(replayBody, "input").Array() {
+		require.NotEqual(t, "reasoning", item.Get("type").String())
+		require.False(t, item.Get("encrypted_content").Exists())
+	}
 }
 
 func TestResponsesTranscriptReplayRequestHasEncryptedContent(t *testing.T) {

--- a/relay/common/responses_transcript_replay_test.go
+++ b/relay/common/responses_transcript_replay_test.go
@@ -302,6 +302,24 @@ func TestIsResponsesTranscriptReplayError(t *testing.T) {
 			want:       false,
 		},
 		{
+			name:       "wrapped invalid encrypted content code in message",
+			statusCode: 400,
+			body:       `{"error":{"message":"code: invalid_encrypted_content; message: The encrypted content gAAA...V2ln could not be verified. Reason: Encrypted content could not be decrypted or parsed.","type":"invalid_request_error","param":"","code":"-4003"}}`,
+			want:       true,
+		},
+		{
+			name:       "wrapped thinking signature code in message",
+			statusCode: 400,
+			body:       `{"error":{"message":"code: thinking_signature_invalid; message: encrypted content rejected","type":"invalid_request_error","code":"-4003"}}`,
+			want:       true,
+		},
+		{
+			name:       "plain message text with target code is ignored",
+			statusCode: 400,
+			body:       `{"error":{"message":"upstream returned invalid_encrypted_content","code":"-4003"}}`,
+			want:       false,
+		},
+		{
 			name:       "empty nested code falls back to top level code",
 			statusCode: 400,
 			body:       `{"error":{},"code":"thinking_signature_invalid"}`,

--- a/relay/common/responses_transcript_replay_test.go
+++ b/relay/common/responses_transcript_replay_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -228,13 +229,13 @@ func TestSanitizeResponsesTranscriptInitialRequestKeepsIncrementalRequest(t *tes
 }
 
 func TestResponsesInputLooksFullTranscriptMatchesCompactionMarkers(t *testing.T) {
-	require.False(t, responsesInputLooksFullTranscript(gjson.Parse(`[
+	require.False(t, responsesInputLooksFullTranscript(json.RawMessage(`[
 		{"type":"message","role":"user","content":"hello"},
 		{"type":"message","role":"assistant","content":"hi there"},
 		{"type":"function_call","call_id":"call-1"},
 		{"type":"reasoning","encrypted_content":"summary"}
 	]`)))
-	require.True(t, responsesInputLooksFullTranscript(gjson.Parse(`[
+	require.True(t, responsesInputLooksFullTranscript(json.RawMessage(`[
 		{"type":"message","role":"user","content":"hello"},
 		{"type":"compaction","encrypted_content":"summary"}
 	]`)))
@@ -270,9 +271,65 @@ func TestInspectResponsesTranscriptRequestShape(t *testing.T) {
 }
 
 func TestIsResponsesTranscriptReplayError(t *testing.T) {
-	require.True(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"code":"invalid_encrypted_content","message":"bad encrypted_content"}}`)))
-	require.True(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"code":"thinking_signature_invalid","message":"The encrypted content gAAA...as53 could not be verified. Reason: Encrypted content could not be decrypted or parsed."}}`)))
-	require.False(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"message":"Invalid signature in thinking block"}}`)))
-	require.False(t, IsResponsesTranscriptReplayError(404, []byte(`{"error":{"code":"previous_response_not_found","message":"missing"}}`)))
-	require.False(t, IsResponsesTranscriptReplayError(429, []byte(`{"error":{"code":"rate_limit_exceeded","message":"slow down"}}`)))
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		want       bool
+	}{
+		{
+			name:       "nested invalid encrypted content code",
+			statusCode: 400,
+			body:       `{"error":{"code":"invalid_encrypted_content"}}`,
+			want:       true,
+		},
+		{
+			name:       "nested thinking signature code",
+			statusCode: 400,
+			body:       `{"error":{"code":"thinking_signature_invalid"}}`,
+			want:       true,
+		},
+		{
+			name:       "top level invalid encrypted content code",
+			statusCode: 400,
+			body:       `{"code":"invalid_encrypted_content"}`,
+			want:       true,
+		},
+		{
+			name:       "message only is ignored",
+			statusCode: 400,
+			body:       `{"error":{"message":"invalid_encrypted_content"}}`,
+			want:       false,
+		},
+		{
+			name:       "empty nested code falls back to top level code",
+			statusCode: 400,
+			body:       `{"error":{},"code":"thinking_signature_invalid"}`,
+			want:       true,
+		},
+		{
+			name:       "string error falls back to top level code",
+			statusCode: 400,
+			body:       `{"error":"bad request","code":"invalid_encrypted_content"}`,
+			want:       true,
+		},
+		{
+			name:       "previous response error is unrelated",
+			statusCode: 404,
+			body:       `{"error":{"code":"previous_response_not_found"}}`,
+			want:       false,
+		},
+		{
+			name:       "rate limit error is unrelated",
+			statusCode: 429,
+			body:       `{"error":{"code":"rate_limit_exceeded"}}`,
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsResponsesTranscriptReplayError(tt.statusCode, []byte(tt.body)))
+		})
+	}
 }

--- a/relay/common/responses_transcript_replay_test.go
+++ b/relay/common/responses_transcript_replay_test.go
@@ -271,7 +271,8 @@ func TestInspectResponsesTranscriptRequestShape(t *testing.T) {
 
 func TestIsResponsesTranscriptReplayError(t *testing.T) {
 	require.True(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"code":"invalid_encrypted_content","message":"bad encrypted_content"}}`)))
-	require.True(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"message":"Invalid signature in thinking block"}}`)))
+	require.True(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"code":"thinking_signature_invalid","message":"The encrypted content gAAA...as53 could not be verified. Reason: Encrypted content could not be decrypted or parsed."}}`)))
+	require.False(t, IsResponsesTranscriptReplayError(400, []byte(`{"error":{"message":"Invalid signature in thinking block"}}`)))
 	require.False(t, IsResponsesTranscriptReplayError(404, []byte(`{"error":{"code":"previous_response_not_found","message":"missing"}}`)))
 	require.False(t, IsResponsesTranscriptReplayError(429, []byte(`{"error":{"code":"rate_limit_exceeded","message":"slow down"}}`)))
 }

--- a/relay/common/responses_transcript_replay_test.go
+++ b/relay/common/responses_transcript_replay_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -147,6 +148,43 @@ func TestResponsesTranscriptReplayRequestHasEncryptedContent(t *testing.T) {
 	}`)))
 }
 
+func TestSanitizeResponsesTranscriptInitialRequestStripsOversizedFullInput(t *testing.T) {
+	largeEncryptedContent := strings.Repeat("x", responsesTranscriptPreflightSanitizeMinBytes)
+	body := []byte(`{
+		"model":"gpt-5",
+		"prompt_cache_key":"sess-large",
+		"input":[
+			{"type":"message","role":"user","content":"first"},
+			{"type":"reasoning","encrypted_content":"` + largeEncryptedContent + `","summary":[]},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"answer"}]},
+			{"type":"function_call","call_id":"call-1","name":"tool","arguments":"{}"},
+			{"type":"message","role":"user","content":"second"}
+		]
+	}`)
+
+	sanitized, ok, reason := SanitizeResponsesTranscriptInitialRequest(body)
+	require.True(t, ok, reason)
+	require.False(t, gjson.GetBytes(sanitized, "previous_response_id").Exists())
+	require.Len(t, gjson.GetBytes(sanitized, "input").Array(), 4)
+	require.False(t, ResponsesTranscriptReplayRequestHasEncryptedContent(sanitized))
+	require.Contains(t, reason, "sanitized oversized full input transcript")
+	require.Contains(t, reason, "removed reasoning items")
+	require.Less(t, len(sanitized), len(body)/10)
+}
+
+func TestSanitizeResponsesTranscriptInitialRequestKeepsIncrementalRequest(t *testing.T) {
+	largeEncryptedContent := strings.Repeat("x", responsesTranscriptPreflightSanitizeMinBytes)
+	body := []byte(`{
+		"model":"gpt-5",
+		"previous_response_id":"resp_1",
+		"input":[{"type":"reasoning","encrypted_content":"` + largeEncryptedContent + `","summary":[]}]
+	}`)
+
+	sanitized, ok, reason := SanitizeResponsesTranscriptInitialRequest(body)
+	require.False(t, ok, reason)
+	require.Nil(t, sanitized)
+}
+
 func TestResponsesInputLooksFullTranscriptMatchesCompactionMarkers(t *testing.T) {
 	require.False(t, responsesInputLooksFullTranscript(gjson.Parse(`[
 		{"type":"message","role":"user","content":"hello"},
@@ -179,6 +217,7 @@ func TestInspectResponsesTranscriptRequestShape(t *testing.T) {
 	require.True(t, shape.InputIsArray)
 	require.Equal(t, 6, shape.InputItems)
 	require.True(t, shape.LooksFullTranscript)
+	require.True(t, shape.LooksReplacementInput)
 	require.Equal(t, 1, shape.CompactionItems)
 	require.Equal(t, 1, shape.AssistantMessageItems)
 	require.Equal(t, 1, shape.FunctionCallItems)

--- a/relay/common/responses_transcript_replay_test.go
+++ b/relay/common/responses_transcript_replay_test.go
@@ -14,35 +14,27 @@ func resetResponsesTranscriptReplayCacheForTest(t *testing.T) {
 	responsesTranscriptReplayMu.Unlock()
 }
 
-func TestResponsesTranscriptReplayBuildUsesCachedTranscript(t *testing.T) {
+func TestResponsesTranscriptReplayBuildPreservesPreviousResponseIDForIncrementalRetry(t *testing.T) {
 	resetResponsesTranscriptReplayCacheForTest(t)
 
 	info := &RelayInfo{ChannelMeta: &ChannelMeta{ChannelId: 12, UpstreamModelName: "gpt-5"}}
-	firstRequest := []byte(`{
-		"model":"gpt-5",
-		"prompt_cache_key":"sess-1",
-		"input":[{"type":"message","role":"user","content":"first"}]
-	}`)
-	PrepareResponsesTranscriptReplay(info, firstRequest)
-	ObserveResponsesTranscriptReplayResponseBody(info, []byte(`{
-		"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first answer"}]}]
-	}`))
-	require.True(t, CommitResponsesTranscriptReplay(info))
-
-	secondRequest := []byte(`{
+	request := []byte(`{
 		"model":"gpt-5",
 		"prompt_cache_key":"sess-1",
 		"previous_response_id":"resp_1",
-		"input":[{"type":"message","role":"user","content":"second"}]
+		"input":[
+			{"type":"reasoning","encrypted_content":"bad-ciphertext","summary":[]},
+			{"type":"message","role":"user","content":"second"}
+		]
 	}`)
-	PrepareResponsesTranscriptReplay(info, secondRequest)
-	replayBody, ok, reason := BuildResponsesTranscriptReplayRequest(info, secondRequest)
+	PrepareResponsesTranscriptReplay(info, request)
+	replayBody, ok, reason := BuildResponsesTranscriptReplayRequest(info, request)
 	require.True(t, ok, reason)
-	require.False(t, gjson.GetBytes(replayBody, "previous_response_id").Exists())
-	require.Len(t, gjson.GetBytes(replayBody, "input").Array(), 3)
-	require.Equal(t, "first", gjson.GetBytes(replayBody, "input.0.content").String())
-	require.Equal(t, "first answer", gjson.GetBytes(replayBody, "input.1.content.0.text").String())
-	require.Equal(t, "second", gjson.GetBytes(replayBody, "input.2.content").String())
+	require.Equal(t, "resp_1", gjson.GetBytes(replayBody, "previous_response_id").String())
+	require.Len(t, gjson.GetBytes(replayBody, "input").Array(), 1)
+	require.Equal(t, "second", gjson.GetBytes(replayBody, "input.0.content").String())
+	require.Contains(t, reason, "using incremental previous_response_id")
+	require.Contains(t, reason, "removed reasoning items")
 }
 
 func TestResponsesTranscriptReplayCommitExtendsCachedTranscript(t *testing.T) {
@@ -72,24 +64,16 @@ func TestResponsesTranscriptReplayCommitExtendsCachedTranscript(t *testing.T) {
 	}`))
 	require.True(t, CommitResponsesTranscriptReplay(info))
 
-	thirdRequest := []byte(`{
-		"model":"gpt-5",
-		"prompt_cache_key":"sess-2",
-		"previous_response_id":"resp_2",
-		"input":[{"type":"message","role":"user","content":"third"}]
-	}`)
-	PrepareResponsesTranscriptReplay(info, thirdRequest)
-	replayBody, ok, reason := BuildResponsesTranscriptReplayRequest(info, thirdRequest)
-	require.True(t, ok, reason)
-	require.Len(t, gjson.GetBytes(replayBody, "input").Array(), 5)
-	require.Equal(t, "first", gjson.GetBytes(replayBody, "input.0.content").String())
-	require.Equal(t, "first answer", gjson.GetBytes(replayBody, "input.1.content.0.text").String())
-	require.Equal(t, "second", gjson.GetBytes(replayBody, "input.2.content").String())
-	require.Equal(t, "second answer", gjson.GetBytes(replayBody, "input.3.content.0.text").String())
-	require.Equal(t, "third", gjson.GetBytes(replayBody, "input.4.content").String())
+	cachedInput, ok := getResponsesTranscriptReplayCachedInput(info.ResponsesTranscriptReplay.CacheKey)
+	require.True(t, ok)
+	require.Len(t, gjson.Parse(cachedInput).Array(), 4)
+	require.Equal(t, "first", gjson.Get(cachedInput, "0.content").String())
+	require.Equal(t, "first answer", gjson.Get(cachedInput, "1.content.0.text").String())
+	require.Equal(t, "second", gjson.Get(cachedInput, "2.content").String())
+	require.Equal(t, "second answer", gjson.Get(cachedInput, "3.content.0.text").String())
 }
 
-func TestResponsesTranscriptReplayFullTranscriptDeletesPreviousResponseID(t *testing.T) {
+func TestResponsesTranscriptReplayIncrementalKeepsPreviousResponseID(t *testing.T) {
 	replayBody, ok, reason := BuildResponsesTranscriptReplayRequest(&RelayInfo{}, []byte(`{
 		"model":"gpt-5",
 		"previous_response_id":"resp_1",
@@ -101,7 +85,7 @@ func TestResponsesTranscriptReplayFullTranscriptDeletesPreviousResponseID(t *tes
 		]
 	}`))
 	require.True(t, ok, reason)
-	require.False(t, gjson.GetBytes(replayBody, "previous_response_id").Exists())
+	require.Equal(t, "resp_1", gjson.GetBytes(replayBody, "previous_response_id").String())
 	require.Len(t, gjson.GetBytes(replayBody, "input").Array(), 3)
 	require.Equal(t, "message", gjson.GetBytes(replayBody, "input.1.type").String())
 	require.Contains(t, reason, "removed reasoning items")
@@ -143,20 +127,12 @@ func TestResponsesTranscriptReplayCacheDropsReasoningItems(t *testing.T) {
 	}`))
 	require.True(t, CommitResponsesTranscriptReplay(info))
 
-	secondRequest := []byte(`{
-		"model":"gpt-5",
-		"prompt_cache_key":"sess-reasoning",
-		"previous_response_id":"resp_1",
-		"input":[{"type":"message","role":"user","content":"second"}]
-	}`)
-	PrepareResponsesTranscriptReplay(info, secondRequest)
-	replayBody, ok, reason := BuildResponsesTranscriptReplayRequest(info, secondRequest)
-	require.True(t, ok, reason)
-	require.Len(t, gjson.GetBytes(replayBody, "input").Array(), 3)
-	require.Equal(t, "first", gjson.GetBytes(replayBody, "input.0.content").String())
-	require.Equal(t, "first answer", gjson.GetBytes(replayBody, "input.1.content.0.text").String())
-	require.Equal(t, "second", gjson.GetBytes(replayBody, "input.2.content").String())
-	for _, item := range gjson.GetBytes(replayBody, "input").Array() {
+	cachedInput, ok := getResponsesTranscriptReplayCachedInput(info.ResponsesTranscriptReplay.CacheKey)
+	require.True(t, ok)
+	require.Len(t, gjson.Parse(cachedInput).Array(), 2)
+	require.Equal(t, "first", gjson.Get(cachedInput, "0.content").String())
+	require.Equal(t, "first answer", gjson.Get(cachedInput, "1.content.0.text").String())
+	for _, item := range gjson.Parse(cachedInput).Array() {
 		require.NotEqual(t, "reasoning", item.Get("type").String())
 		require.False(t, item.Get("encrypted_content").Exists())
 	}
@@ -169,6 +145,46 @@ func TestResponsesTranscriptReplayRequestHasEncryptedContent(t *testing.T) {
 	require.False(t, ResponsesTranscriptReplayRequestHasEncryptedContent([]byte(`{
 		"input":[{"type":"reasoning","summary":[]}]
 	}`)))
+}
+
+func TestResponsesInputLooksFullTranscriptMatchesCompactionMarkers(t *testing.T) {
+	require.False(t, responsesInputLooksFullTranscript(gjson.Parse(`[
+		{"type":"message","role":"user","content":"hello"},
+		{"type":"message","role":"assistant","content":"hi there"},
+		{"type":"function_call","call_id":"call-1"},
+		{"type":"reasoning","encrypted_content":"summary"}
+	]`)))
+	require.True(t, responsesInputLooksFullTranscript(gjson.Parse(`[
+		{"type":"message","role":"user","content":"hello"},
+		{"type":"compaction","encrypted_content":"summary"}
+	]`)))
+}
+
+func TestInspectResponsesTranscriptRequestShape(t *testing.T) {
+	shape := InspectResponsesTranscriptRequestShape([]byte(`{
+		"prompt_cache_key":"sess-shape",
+		"previous_response_id":"resp_1",
+		"input":[
+			{"type":"message","role":"assistant","content":"hi"},
+			{"type":"function_call","call_id":"call-1"},
+			{"type":"custom_tool_call","call_id":"call-2"},
+			{"type":"reasoning","encrypted_content":"secret"},
+			{"type":"message","role":"user","content":[{"type":"input_text","encrypted_content":"nested"}]},
+			{"type":"compaction_summary","encrypted_content":"summary"}
+		]
+	}`))
+	require.True(t, shape.HasPreviousResponseID)
+	require.True(t, shape.HasPromptCacheKey)
+	require.True(t, shape.InputExists)
+	require.True(t, shape.InputIsArray)
+	require.Equal(t, 6, shape.InputItems)
+	require.True(t, shape.LooksFullTranscript)
+	require.Equal(t, 1, shape.CompactionItems)
+	require.Equal(t, 1, shape.AssistantMessageItems)
+	require.Equal(t, 1, shape.FunctionCallItems)
+	require.Equal(t, 1, shape.CustomToolCallItems)
+	require.Equal(t, 1, shape.ReasoningItems)
+	require.Equal(t, 3, shape.EncryptedContentItems)
 }
 
 func TestIsResponsesTranscriptReplayError(t *testing.T) {

--- a/relay/common/responses_transcript_replay_test.go
+++ b/relay/common/responses_transcript_replay_test.go
@@ -172,6 +172,48 @@ func TestSanitizeResponsesTranscriptInitialRequestStripsOversizedFullInput(t *te
 	require.Less(t, len(sanitized), len(body)/10)
 }
 
+func TestSanitizeResponsesTranscriptInitialRequestStripsHistoricalImagesBeforeLatestUserImage(t *testing.T) {
+	historicalImage := "data:image/png;base64," + strings.Repeat("a", responsesTranscriptPreflightSanitizeMinBytes)
+	latestImage := "data:image/png;base64," + strings.Repeat("b", 1024)
+	body := []byte(`{
+		"model":"gpt-5",
+		"prompt_cache_key":"sess-large-images",
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"first"},{"type":"input_image","image_url":"` + historicalImage + `"}]},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"answer"}]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"second"},{"type":"input_image","image_url":"` + latestImage + `"}]}
+		]
+	}`)
+
+	sanitized, ok, reason := SanitizeResponsesTranscriptInitialRequest(body)
+	require.True(t, ok, reason)
+	require.Contains(t, reason, "stripped historical inline_images=1")
+	require.Less(t, len(sanitized), responsesTranscriptPreflightSanitizeMinBytes)
+	require.Equal(t, "input_text", gjson.GetBytes(sanitized, "input.0.content.1.type").String())
+	require.Equal(t, responsesTranscriptOmittedImageText, gjson.GetBytes(sanitized, "input.0.content.1.text").String())
+	require.Equal(t, "input_image", gjson.GetBytes(sanitized, "input.2.content.1.type").String())
+	require.Equal(t, latestImage, gjson.GetBytes(sanitized, "input.2.content.1.image_url").String())
+}
+
+func TestSanitizeResponsesTranscriptInitialRequestTrimsOldHistoryWhenImagesAreNotEnough(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-5",
+		"prompt_cache_key":"sess-large-text",
+		"input":[
+			{"type":"message","role":"user","content":"` + strings.Repeat("old", responsesTranscriptPreflightSanitizeMinBytes/3) + `"},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"answer"}]},
+			{"type":"message","role":"user","content":"latest"}
+		]
+	}`)
+
+	sanitized, ok, reason := SanitizeResponsesTranscriptInitialRequest(body)
+	require.True(t, ok, reason)
+	require.Contains(t, reason, "trimmed history_items=")
+	require.Less(t, len(sanitized), responsesTranscriptPreflightSanitizeMinBytes)
+	require.Len(t, gjson.GetBytes(sanitized, "input").Array(), 1)
+	require.Equal(t, "latest", gjson.GetBytes(sanitized, "input.0.content").String())
+}
+
 func TestSanitizeResponsesTranscriptInitialRequestKeepsIncrementalRequest(t *testing.T) {
 	largeEncryptedContent := strings.Repeat("x", responsesTranscriptPreflightSanitizeMinBytes)
 	body := []byte(`{
@@ -224,6 +266,7 @@ func TestInspectResponsesTranscriptRequestShape(t *testing.T) {
 	require.Equal(t, 1, shape.CustomToolCallItems)
 	require.Equal(t, 1, shape.ReasoningItems)
 	require.Equal(t, 3, shape.EncryptedContentItems)
+	require.Equal(t, 0, shape.InlineImageItems)
 }
 
 func TestIsResponsesTranscriptReplayError(t *testing.T) {

--- a/relay/common/stream_status.go
+++ b/relay/common/stream_status.go
@@ -29,9 +29,8 @@ type StreamErrorEntry struct {
 }
 
 type StreamStatus struct {
-	EndReason  StreamEndReason
-	EndError   error
-	endOnce    sync.Once
+	EndReason StreamEndReason
+	EndError  error
 
 	mu         sync.Mutex
 	Errors     []StreamErrorEntry
@@ -46,10 +45,26 @@ func (s *StreamStatus) SetEndReason(reason StreamEndReason, err error) {
 	if s == nil {
 		return
 	}
-	s.endOnce.Do(func() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.EndReason != StreamEndReasonNone {
+		return
+	}
+	s.EndReason = reason
+	s.EndError = err
+}
+
+func (s *StreamStatus) SetHandlerEndReason(reason StreamEndReason, err error) {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.EndReason == StreamEndReasonNone || s.EndReason == StreamEndReasonEOF {
 		s.EndReason = reason
 		s.EndError = err
-	})
+	}
 }
 
 func (s *StreamStatus) RecordError(msg string) {
@@ -89,6 +104,8 @@ func (s *StreamStatus) IsNormalEnd() bool {
 	if s == nil {
 		return true
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.EndReason == StreamEndReasonDone ||
 		s.EndReason == StreamEndReasonEOF ||
 		s.EndReason == StreamEndReasonHandlerStop
@@ -99,14 +116,14 @@ func (s *StreamStatus) Summary() string {
 		return "StreamStatus<nil>"
 	}
 	b := &strings.Builder{}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	fmt.Fprintf(b, "reason=%s", s.EndReason)
 	if s.EndError != nil {
 		fmt.Fprintf(b, " end_error=%q", s.EndError.Error())
 	}
-	s.mu.Lock()
 	if s.ErrorCount > 0 {
 		fmt.Fprintf(b, " soft_errors=%d", s.ErrorCount)
 	}
-	s.mu.Unlock()
 	return b.String()
 }

--- a/relay/common/stream_status_test.go
+++ b/relay/common/stream_status_test.go
@@ -31,6 +31,29 @@ func TestStreamStatus_SetEndReason_WithError(t *testing.T) {
 	assert.Equal(t, expectedErr, s.EndError)
 }
 
+func TestStreamStatus_SetHandlerEndReason_OverridesEOF(t *testing.T) {
+	t.Parallel()
+	s := NewStreamStatus()
+
+	s.SetEndReason(StreamEndReasonEOF, nil)
+	s.SetHandlerEndReason(StreamEndReasonDone, nil)
+
+	assert.Equal(t, StreamEndReasonDone, s.EndReason)
+	assert.Nil(t, s.EndError)
+}
+
+func TestStreamStatus_SetHandlerEndReason_DoesNotOverrideScannerError(t *testing.T) {
+	t.Parallel()
+	s := NewStreamStatus()
+
+	expectedErr := fmt.Errorf("read failed")
+	s.SetEndReason(StreamEndReasonScannerErr, expectedErr)
+	s.SetHandlerEndReason(StreamEndReasonDone, nil)
+
+	assert.Equal(t, StreamEndReasonScannerErr, s.EndReason)
+	assert.Equal(t, expectedErr, s.EndError)
+}
+
 func TestStreamStatus_SetEndReason_NilSafe(t *testing.T) {
 	t.Parallel()
 	var s *StreamStatus

--- a/relay/helper/stream_result.go
+++ b/relay/helper/stream_result.go
@@ -30,14 +30,14 @@ func (r *StreamResult) Stop(err error) {
 	if err != nil {
 		r.status.RecordError(err.Error())
 	}
-	r.status.SetEndReason(relaycommon.StreamEndReasonHandlerStop, err)
+	r.status.SetHandlerEndReason(relaycommon.StreamEndReasonHandlerStop, err)
 	r.stopped = true
 }
 
 // Done signals that the handler has finished processing normally
 // (e.g., Dify "message_end"). The stream stops after this chunk.
 func (r *StreamResult) Done() {
-	r.status.SetEndReason(relaycommon.StreamEndReasonDone, nil)
+	r.status.SetHandlerEndReason(relaycommon.StreamEndReasonDone, nil)
 	r.stopped = true
 }
 

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -25,6 +25,7 @@ const (
 	InitialScannerBufferSize    = 64 << 10  // 64KB (64*1024)
 	DefaultMaxScannerBufferSize = 128 << 20 // 64MB (64*1024*1024) default SSE buffer size
 	DefaultPingInterval         = 10 * time.Second
+	DefaultStreamingTimeout     = 300 * time.Second
 )
 
 func getScannerBufferSize() int {
@@ -42,12 +43,13 @@ func NewStreamScanner(reader io.Reader) *bufio.Scanner {
 
 func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo, dataHandler func(data string, sr *StreamResult)) {
 
-	if resp == nil || dataHandler == nil {
+	if resp == nil || dataHandler == nil || info == nil {
 		return
 	}
 
-	// 无条件新建 StreamStatus
-	info.StreamStatus = relaycommon.NewStreamStatus()
+	if info.StreamStatus == nil {
+		info.StreamStatus = relaycommon.NewStreamStatus()
+	}
 
 	// 确保响应体总是被关闭
 	defer func() {
@@ -57,6 +59,9 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	}()
 
 	streamingTimeout := time.Duration(constant.StreamingTimeout) * time.Second
+	if streamingTimeout <= 0 {
+		streamingTimeout = DefaultStreamingTimeout
+	}
 
 	var (
 		stopChan   = make(chan bool, 3) // 增加缓冲区避免阻塞

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -25,7 +25,7 @@ const (
 	InitialScannerBufferSize    = 64 << 10  // 64KB (64*1024)
 	DefaultMaxScannerBufferSize = 128 << 20 // 64MB (64*1024*1024) default SSE buffer size
 	DefaultPingInterval         = 10 * time.Second
-	DefaultStreamingTimeout     = 300 * time.Second
+	DefaultStreamingTimeout     = 60 * time.Second
 )
 
 func getScannerBufferSize() int {
@@ -39,6 +39,19 @@ func NewStreamScanner(reader io.Reader) *bufio.Scanner {
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(make([]byte, InitialScannerBufferSize), getScannerBufferSize())
 	return scanner
+}
+
+func parseStreamDataLine(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	switch {
+	case strings.HasPrefix(line, "data:"):
+		data := strings.TrimSpace(line[5:])
+		return data, data != ""
+	case strings.HasPrefix(line, "[DONE]"):
+		return "[DONE]", true
+	default:
+		return "", false
+	}
 }
 
 func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo, dataHandler func(data string, sr *StreamResult)) {
@@ -240,21 +253,17 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 			default:
 			}
 
-			ticker.Reset(streamingTimeout)
-			data := scanner.Text()
-			logger.LogDebug(c, "stream scanner data: %s", data)
+			rawLine := scanner.Text()
+			logger.LogDebug(c, "stream scanner data: %s", rawLine)
 
-			if len(data) < 6 {
+			data, ok := parseStreamDataLine(rawLine)
+			if !ok {
+				if info.HasSendResponse() {
+					ticker.Reset(streamingTimeout)
+				}
 				continue
 			}
-			if data[:5] != "data:" && data[:6] != "[DONE]" {
-				continue
-			}
-			data = data[5:]
-			data = strings.TrimSpace(data)
-			if data == "" {
-				continue
-			}
+			ticker.Reset(streamingTimeout)
 			if !strings.HasPrefix(data, "[DONE]") {
 				info.SetFirstResponseTime()
 				info.ReceivedResponseCount++

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -71,6 +71,7 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 		writeMutex sync.Mutex     // Mutex to protect concurrent writes
 		wg         sync.WaitGroup // 用于等待所有 goroutine 退出
 	)
+	var cleanupOnce sync.Once
 
 	generalSettings := operation_setting.GetGeneralSetting()
 	pingEnabled := generalSettings.PingIntervalEnabled && !info.DisablePing
@@ -90,30 +91,33 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	logger.LogDebug(c, "ping interval seconds: %d", int64(pingInterval.Seconds()))
 
 	// 改进资源清理，确保所有 goroutine 正确退出
-	defer func() {
+	cleanup := func() {
 		// 通知所有 goroutine 停止
-		common.SafeSendBool(stopChan, true)
+		cleanupOnce.Do(func() {
+			common.SafeSendBool(stopChan, true)
 
-		ticker.Stop()
-		if pingTicker != nil {
-			pingTicker.Stop()
-		}
+			ticker.Stop()
+			if pingTicker != nil {
+				pingTicker.Stop()
+			}
 
-		// 等待所有 goroutine 退出，最多等待5秒
-		done := make(chan struct{})
-		gopool.Go(func() {
-			wg.Wait()
-			close(done)
+			// 等待所有 goroutine 退出，最多等待5秒
+			done := make(chan struct{})
+			gopool.Go(func() {
+				wg.Wait()
+				close(done)
+			})
+
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				logger.LogError(c, "timeout waiting for goroutines to exit")
+			}
+
+			close(stopChan)
 		})
-
-		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			logger.LogError(c, "timeout waiting for goroutines to exit")
-		}
-
-		close(stopChan)
-	}()
+	}
+	defer cleanup()
 
 	scanner.Split(bufio.ScanLines)
 	SetEventStreamHeaders(c)
@@ -287,6 +291,8 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	case <-c.Request.Context().Done():
 		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, c.Request.Context().Err())
 	}
+
+	cleanup()
 
 	if info.StreamStatus.IsNormalEnd() && !info.StreamStatus.HasErrors() {
 		logger.LogInfo(c, fmt.Sprintf("stream ended: %s", info.StreamStatus.Summary()))

--- a/relay/helper/stream_scanner_test.go
+++ b/relay/helper/stream_scanner_test.go
@@ -559,5 +559,5 @@ func TestStreamScannerHandler_StreamStatus_PreInitialized(t *testing.T) {
 	StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {})
 
 	assert.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
-	assert.Equal(t, 0, info.StreamStatus.TotalErrorCount())
+	assert.Equal(t, 1, info.StreamStatus.TotalErrorCount())
 }

--- a/relay/helper/stream_scanner_test.go
+++ b/relay/helper/stream_scanner_test.go
@@ -484,7 +484,22 @@ func TestStreamScannerHandler_StreamStatus_InitializedIfNil(t *testing.T) {
 	assert.NotNil(t, info.StreamStatus)
 }
 
-func TestStreamScannerHandler_StreamStatus_ReplacesPreInitialized(t *testing.T) {
+func TestStreamScannerHandler_DefaultsNonPositiveStreamingTimeout(t *testing.T) {
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 0
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	body := buildSSEBody(1)
+	c, resp, info := setupStreamTest(t, strings.NewReader(body))
+
+	require.NotPanics(t, func() {
+		StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {})
+	})
+	require.NotNil(t, info.StreamStatus)
+	assert.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
+}
+
+func TestStreamScannerHandler_StreamStatus_PreInitialized(t *testing.T) {
 	t.Parallel()
 
 	body := buildSSEBody(5)

--- a/relay/helper/stream_scanner_test.go
+++ b/relay/helper/stream_scanner_test.go
@@ -415,6 +415,54 @@ func TestStreamScannerHandler_StreamStatus_Timeout(t *testing.T) {
 	assert.False(t, info.StreamStatus.IsNormalEnd())
 }
 
+func TestStreamScannerHandler_StreamStatus_FirstDataTimeout(t *testing.T) {
+	// Not parallel: modifies global constant.StreamingTimeout
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 1
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	pr, pw := io.Pipe()
+	go func() {
+		defer pw.Close()
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		deadline := time.After(2 * time.Second)
+		for {
+			select {
+			case <-ticker.C:
+				if _, err := fmt.Fprint(pw, "event: keepalive\n\n"); err != nil {
+					return
+				}
+			case <-deadline:
+				return
+			}
+		}
+	}()
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	resp := &http.Response{Body: pr}
+	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{}}
+
+	done := make(chan struct{})
+	go func() {
+		StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first data timeout")
+	}
+
+	require.NotNil(t, info.StreamStatus)
+	assert.Equal(t, relaycommon.StreamEndReasonTimeout, info.StreamStatus.EndReason)
+	assert.Equal(t, 0, info.ReceivedResponseCount)
+}
+
 func TestStreamScannerHandler_StreamStatus_SoftErrors(t *testing.T) {
 	t.Parallel()
 

--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -233,6 +233,9 @@ func retryCodexResponsesTranscriptReplay(
 	}
 
 	if !shouldRetryResponsesTranscriptReplay(httpResp.StatusCode, responseBody, requestBodyBytes) {
+		if httpResp.StatusCode == http.StatusRequestEntityTooLarge {
+			logResponsesTranscriptRequestShape(c, info, "upstream_413_before_retry", requestBodyBytes, httpResp.StatusCode)
+		}
 		return nil, newAPIErrorFromCapturedHTTPError(c, httpResp, responseBody, statusCodeMappingStr, false)
 	}
 
@@ -249,7 +252,7 @@ func retryCodexResponsesTranscriptReplay(
 	}
 	defer replayCloser.Close()
 
-	logger.LogInfo(c, fmt.Sprintf("codex responses transcript replay on channel #%d: %s", info.ChannelId, reason))
+	logger.LogInfo(c, fmt.Sprintf("codex responses transcript replay on channel #%d: %s; original_body_bytes=%d retry_body_bytes=%d", info.ChannelId, reason, len(requestBodyBytes), len(replayBody)))
 	resp, err := adaptor.DoRequest(c, info, replayRequestBody)
 	if err != nil {
 		return nil, types.NewOpenAIError(err, types.ErrorCodeDoRequestFailed, http.StatusInternalServerError, types.ErrOptionWithSkipRetry())
@@ -257,6 +260,9 @@ func retryCodexResponsesTranscriptReplay(
 	replayResp := resp.(*http.Response)
 	if replayResp.StatusCode == http.StatusOK {
 		return replayResp, nil
+	}
+	if replayResp.StatusCode == http.StatusRequestEntityTooLarge {
+		logResponsesTranscriptRequestShape(c, info, "upstream_413_after_retry", replayBody, replayResp.StatusCode)
 	}
 
 	replayResponseBody, readErr := captureHTTPErrorBody(replayResp)
@@ -270,6 +276,33 @@ func retryCodexResponsesTranscriptReplay(
 
 func shouldRetryResponsesTranscriptReplay(statusCode int, responseBody []byte, requestBody []byte) bool {
 	return relaycommon.IsResponsesTranscriptReplayError(statusCode, responseBody)
+}
+
+func logResponsesTranscriptRequestShape(c *gin.Context, info *relaycommon.RelayInfo, phase string, requestBody []byte, statusCode int) {
+	shape := relaycommon.InspectResponsesTranscriptRequestShape(requestBody)
+	channelID := 0
+	if info != nil {
+		channelID = info.ChannelId
+	}
+	logger.LogWarn(c, fmt.Sprintf(
+		"codex responses request diagnostics on channel #%d: phase=%s status=%d body_bytes=%d input_exists=%t input_array=%t input_items=%d previous_response_id=%t prompt_cache_key=%t full_transcript=%t compaction_items=%d assistant_messages=%d function_calls=%d custom_tool_calls=%d reasoning_items=%d encrypted_content_items=%d",
+		channelID,
+		phase,
+		statusCode,
+		shape.BodyBytes,
+		shape.InputExists,
+		shape.InputIsArray,
+		shape.InputItems,
+		shape.HasPreviousResponseID,
+		shape.HasPromptCacheKey,
+		shape.LooksFullTranscript,
+		shape.CompactionItems,
+		shape.AssistantMessageItems,
+		shape.FunctionCallItems,
+		shape.CustomToolCallItems,
+		shape.ReasoningItems,
+		shape.EncryptedContentItems,
+	))
 }
 
 func captureHTTPErrorBody(resp *http.Response) ([]byte, error) {

--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"bytes"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,6 +22,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 )
+
+const responsesOutboundGzipMinBytes = 900 * 1024
 
 func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
 	info.InitChannelMeta(c)
@@ -91,6 +94,19 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 			if bodyBytes, err := storage.Bytes(); err == nil {
 				requestBodyBytes = append([]byte(nil), bodyBytes...)
 				relaycommon.PrepareResponsesTranscriptReplay(info, requestBodyBytes)
+				shouldRewriteBody := false
+				if sanitizedBody, ok := sanitizeResponsesTranscriptInitialRequest(c, info, requestBodyBytes); ok {
+					requestBodyBytes = sanitizedBody
+					shouldRewriteBody = true
+				}
+				if shouldRewriteBody || shouldGzipResponsesOutboundBody(info, requestBodyBytes) {
+					body, closer, newAPIError := newResponsesOutboundJSONBody(c, info, requestBodyBytes)
+					if newAPIError != nil {
+						return newAPIError
+					}
+					requestBodyCloser = closer
+					requestBody = body
+				}
 			} else {
 				logger.LogWarn(c, fmt.Sprintf("codex responses transcript replay disabled: read pass-through body failed: %s", err.Error()))
 			}
@@ -124,8 +140,11 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 		requestBodyBytes = append([]byte(nil), jsonData...)
 		if shouldUseResponsesTranscriptReplay(info) {
 			relaycommon.PrepareResponsesTranscriptReplay(info, requestBodyBytes)
+			if sanitizedBody, ok := sanitizeResponsesTranscriptInitialRequest(c, info, requestBodyBytes); ok {
+				requestBodyBytes = sanitizedBody
+			}
 		}
-		body, closer, newAPIError := newResponsesOutboundJSONBody(info, requestBodyBytes)
+		body, closer, newAPIError := newResponsesOutboundJSONBody(c, info, requestBodyBytes)
 		if newAPIError != nil {
 			return newAPIError
 		}
@@ -206,8 +225,23 @@ func shouldUseResponsesTranscriptReplay(info *relaycommon.RelayInfo) bool {
 	return info.ChannelOtherSettings.ResponsesTranscriptReplayEnabled
 }
 
-func newResponsesOutboundJSONBody(info *relaycommon.RelayInfo, requestBody []byte) (io.Reader, io.Closer, *types.NewAPIError) {
-	body, size, closer, err := relaycommon.NewOutboundJSONBody(requestBody)
+func newResponsesOutboundJSONBody(c *gin.Context, info *relaycommon.RelayInfo, requestBody []byte) (io.Reader, io.Closer, *types.NewAPIError) {
+	bodyData := requestBody
+	if info != nil {
+		info.UpstreamRequestBodyEncoding = ""
+	}
+	if shouldGzipResponsesOutboundBody(info, requestBody) {
+		gzipData, err := gzipResponsesOutboundBody(requestBody)
+		if err != nil {
+			return nil, nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
+		}
+		if len(gzipData) < len(requestBody) {
+			bodyData = gzipData
+			info.UpstreamRequestBodyEncoding = "gzip"
+			logResponsesInfo(c, fmt.Sprintf("codex responses outbound body gzip on channel #%d: original_body_bytes=%d gzip_body_bytes=%d", info.ChannelId, len(requestBody), len(gzipData)))
+		}
+	}
+	body, size, closer, err := relaycommon.NewOutboundJSONBody(bodyData)
 	if err != nil {
 		return nil, nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
 	}
@@ -215,6 +249,44 @@ func newResponsesOutboundJSONBody(info *relaycommon.RelayInfo, requestBody []byt
 		info.UpstreamRequestBodySize = size
 	}
 	return body, closer, nil
+}
+
+func shouldGzipResponsesOutboundBody(info *relaycommon.RelayInfo, requestBody []byte) bool {
+	return shouldUseResponsesTranscriptReplay(info) && len(requestBody) >= responsesOutboundGzipMinBytes
+}
+
+func gzipResponsesOutboundBody(requestBody []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	if _, err := writer.Write(requestBody); err != nil {
+		_ = writer.Close()
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func sanitizeResponsesTranscriptInitialRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBodyBytes []byte) ([]byte, bool) {
+	if !shouldUseResponsesTranscriptReplay(info) || len(requestBodyBytes) == 0 {
+		return nil, false
+	}
+	sanitizedBody, ok, reason := relaycommon.SanitizeResponsesTranscriptInitialRequest(requestBodyBytes)
+	if !ok {
+		return nil, false
+	}
+	relaycommon.UpdateResponsesTranscriptReplayRequest(info, sanitizedBody, false)
+	logResponsesInfo(c, fmt.Sprintf("codex responses transcript preflight sanitized on channel #%d: %s; original_body_bytes=%d sanitized_body_bytes=%d", info.ChannelId, reason, len(requestBodyBytes), len(sanitizedBody)))
+	return sanitizedBody, true
+}
+
+func logResponsesInfo(c *gin.Context, msg string) {
+	if c == nil {
+		logger.LogInfo(nil, msg)
+		return
+	}
+	logger.LogInfo(c, msg)
 }
 
 func retryCodexResponsesTranscriptReplay(
@@ -246,7 +318,7 @@ func retryCodexResponsesTranscriptReplay(
 	}
 
 	relaycommon.UpdateResponsesTranscriptReplayRequest(info, replayBody, true)
-	replayRequestBody, replayCloser, newAPIError := newResponsesOutboundJSONBody(info, replayBody)
+	replayRequestBody, replayCloser, newAPIError := newResponsesOutboundJSONBody(c, info, replayBody)
 	if newAPIError != nil {
 		return nil, markResponsesTranscriptReplaySkipRetry(newAPIError)
 	}
@@ -285,7 +357,7 @@ func logResponsesTranscriptRequestShape(c *gin.Context, info *relaycommon.RelayI
 		channelID = info.ChannelId
 	}
 	logger.LogWarn(c, fmt.Sprintf(
-		"codex responses request diagnostics on channel #%d: phase=%s status=%d body_bytes=%d input_exists=%t input_array=%t input_items=%d previous_response_id=%t prompt_cache_key=%t full_transcript=%t compaction_items=%d assistant_messages=%d function_calls=%d custom_tool_calls=%d reasoning_items=%d encrypted_content_items=%d",
+		"codex responses request diagnostics on channel #%d: phase=%s status=%d body_bytes=%d input_exists=%t input_array=%t input_items=%d previous_response_id=%t prompt_cache_key=%t full_transcript=%t replacement_input=%t compaction_items=%d assistant_messages=%d function_calls=%d custom_tool_calls=%d reasoning_items=%d encrypted_content_items=%d",
 		channelID,
 		phase,
 		statusCode,
@@ -296,6 +368,7 @@ func logResponsesTranscriptRequestShape(c *gin.Context, info *relaycommon.RelayI
 		shape.HasPreviousResponseID,
 		shape.HasPromptCacheKey,
 		shape.LooksFullTranscript,
+		shape.LooksReplacementInput,
 		shape.CompactionItems,
 		shape.AssistantMessageItems,
 		shape.FunctionCallItems,

--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -178,6 +178,15 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 
 	usage, newAPIError := adaptor.DoResponse(c, httpResp, info)
 	if newAPIError != nil {
+		replayResp, replayError := retryCodexResponsesTranscriptReplayAfterStreamError(c, info, adaptor, newAPIError, requestBodyBytes, statusCodeMappingStr)
+		if replayError != nil {
+			return replayError
+		}
+		if replayResp != nil {
+			usage, newAPIError = adaptor.DoResponse(c, replayResp, info)
+		}
+	}
+	if newAPIError != nil {
 		// reset status code 重置状态码
 		service.ResetStatusCode(newAPIError, statusCodeMappingStr)
 		return newAPIError
@@ -251,6 +260,10 @@ func logResponsesInfo(c *gin.Context, msg string) {
 	logger.LogInfo(c, msg)
 }
 
+type responsesTranscriptReplayErrorPayload struct {
+	Error types.OpenAIError `json:"error"`
+}
+
 func retryCodexResponsesTranscriptReplay(
 	c *gin.Context,
 	info *relaycommon.RelayInfo,
@@ -306,6 +319,77 @@ func retryCodexResponsesTranscriptReplay(
 		return nil, newAPIError
 	}
 	return nil, newAPIErrorFromCapturedHTTPError(c, replayResp, replayResponseBody, statusCodeMappingStr, true)
+}
+
+func retryCodexResponsesTranscriptReplayAfterStreamError(
+	c *gin.Context,
+	info *relaycommon.RelayInfo,
+	adaptor relaychannel.Adaptor,
+	streamErr *types.NewAPIError,
+	requestBodyBytes []byte,
+	statusCodeMappingStr string,
+) (*http.Response, *types.NewAPIError) {
+	if c == nil || c.Writer.Written() || !shouldUseResponsesTranscriptReplay(info) || streamErr == nil || len(requestBodyBytes) == 0 {
+		return nil, nil
+	}
+	if info.ResponsesTranscriptReplay != nil && info.ResponsesTranscriptReplay.Replayed {
+		return nil, nil
+	}
+	responseBody, err := responsesTranscriptReplayErrorBody(streamErr)
+	if err != nil {
+		logger.LogWarn(c, fmt.Sprintf("codex responses transcript replay skipped on channel #%d: marshal stream error failed: %s", info.ChannelId, err.Error()))
+		return nil, nil
+	}
+	statusCode := streamErr.StatusCode
+	if statusCode < http.StatusBadRequest {
+		statusCode = http.StatusInternalServerError
+	}
+	if !shouldRetryResponsesTranscriptReplay(statusCode, responseBody, requestBodyBytes) {
+		return nil, nil
+	}
+
+	replayBody, ok, reason := relaycommon.BuildResponsesTranscriptReplayRequest(info, requestBodyBytes)
+	if !ok {
+		logger.LogWarn(c, fmt.Sprintf("codex responses transcript replay skipped on channel #%d after stream error: %s", info.ChannelId, reason))
+		return nil, markResponsesTranscriptReplaySkipRetry(streamErr)
+	}
+
+	relaycommon.UpdateResponsesTranscriptReplayRequest(info, replayBody, true)
+	replayRequestBody, replayCloser, newAPIError := newResponsesOutboundJSONBody(info, replayBody)
+	if newAPIError != nil {
+		return nil, markResponsesTranscriptReplaySkipRetry(newAPIError)
+	}
+	defer replayCloser.Close()
+
+	logger.LogInfo(c, fmt.Sprintf("codex responses transcript replay after stream error on channel #%d: %s; original_body_bytes=%d retry_body_bytes=%d", info.ChannelId, reason, len(requestBodyBytes), len(replayBody)))
+	resp, err := adaptor.DoRequest(c, info, replayRequestBody)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeDoRequestFailed, http.StatusInternalServerError, types.ErrOptionWithSkipRetry())
+	}
+	replayResp := resp.(*http.Response)
+	if replayResp.StatusCode == http.StatusOK {
+		return replayResp, nil
+	}
+	if replayResp.StatusCode == http.StatusRequestEntityTooLarge {
+		logResponsesTranscriptRequestShape(c, info, "upstream_413_after_stream_retry", replayBody, replayResp.StatusCode)
+	}
+
+	replayResponseBody, readErr := captureHTTPErrorBody(replayResp)
+	if readErr != nil {
+		newAPIError := types.NewOpenAIError(readErr, types.ErrorCodeReadResponseBodyFailed, http.StatusInternalServerError, types.ErrOptionWithSkipRetry())
+		service.ResetStatusCode(newAPIError, statusCodeMappingStr)
+		return nil, newAPIError
+	}
+	return nil, newAPIErrorFromCapturedHTTPError(c, replayResp, replayResponseBody, statusCodeMappingStr, true)
+}
+
+func responsesTranscriptReplayErrorBody(newAPIError *types.NewAPIError) ([]byte, error) {
+	if newAPIError == nil {
+		return nil, fmt.Errorf("missing stream error")
+	}
+	return common.Marshal(responsesTranscriptReplayErrorPayload{
+		Error: newAPIError.ToOpenAIError(),
+	})
 }
 
 func shouldRetryResponsesTranscriptReplay(statusCode int, responseBody []byte, requestBody []byte) bool {

--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -216,9 +216,6 @@ func shouldUseResponsesTranscriptReplay(info *relaycommon.RelayInfo) bool {
 	if info == nil || info.RelayMode != relayconstant.RelayModeResponses {
 		return false
 	}
-	if info.ApiType == appconstant.APITypeCodex {
-		return true
-	}
 	return info.ChannelOtherSettings.ResponsesTranscriptReplayEnabled
 }
 

--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	appconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/logger"
+	relaychannel "github.com/QuantumNous/new-api/relay/channel"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/relay/helper"
@@ -71,12 +73,28 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 	}
 	adaptor.Init(info)
 	var requestBody io.Reader
+	var requestBodyBytes []byte
+	var requestBodyCloser io.Closer
+	defer func() {
+		if requestBodyCloser != nil {
+			_ = requestBodyCloser.Close()
+		}
+	}()
 	if model_setting.GetGlobalSettings().PassThroughRequestEnabled || info.ChannelSetting.PassThroughBodyEnabled {
 		storage, err := common.GetBodyStorage(c)
 		if err != nil {
 			return types.NewError(err, types.ErrorCodeReadRequestBodyFailed, types.ErrOptionWithSkipRetry())
 		}
 		requestBody = common.ReaderOnly(storage)
+		info.UpstreamRequestBodySize = storage.Size()
+		if shouldUseResponsesTranscriptReplay(info) {
+			if bodyBytes, err := storage.Bytes(); err == nil {
+				requestBodyBytes = append([]byte(nil), bodyBytes...)
+				relaycommon.PrepareResponsesTranscriptReplay(info, requestBodyBytes)
+			} else {
+				logger.LogWarn(c, fmt.Sprintf("codex responses transcript replay disabled: read pass-through body failed: %s", err.Error()))
+			}
+		}
 	} else {
 		convertedRequest, err := adaptor.ConvertOpenAIResponsesRequest(c, info, *request)
 		if err != nil {
@@ -103,13 +121,16 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 		}
 
 		logger.LogDebug(c, "requestBody: %s", jsonData)
-		body, size, closer, err := relaycommon.NewOutboundJSONBody(jsonData)
-		if err != nil {
-			return types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
+		requestBodyBytes = append([]byte(nil), jsonData...)
+		if shouldUseResponsesTranscriptReplay(info) {
+			relaycommon.PrepareResponsesTranscriptReplay(info, requestBodyBytes)
 		}
-		defer closer.Close()
+		body, closer, newAPIError := newResponsesOutboundJSONBody(info, requestBodyBytes)
+		if newAPIError != nil {
+			return newAPIError
+		}
+		requestBodyCloser = closer
 		jsonData = nil
-		info.UpstreamRequestBodySize = size
 		requestBody = body
 	}
 
@@ -125,10 +146,17 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 		httpResp = resp.(*http.Response)
 
 		if httpResp.StatusCode != http.StatusOK {
-			newAPIError = service.RelayErrorHandler(c.Request.Context(), httpResp, false)
-			// reset status code 重置状态码
-			service.ResetStatusCode(newAPIError, statusCodeMappingStr)
-			return newAPIError
+			if shouldUseResponsesTranscriptReplay(info) {
+				httpResp, newAPIError = retryCodexResponsesTranscriptReplay(c, info, adaptor, httpResp, requestBodyBytes, statusCodeMappingStr)
+				if newAPIError != nil {
+					return newAPIError
+				}
+			} else {
+				newAPIError = service.RelayErrorHandler(c.Request.Context(), httpResp, false)
+				// reset status code 重置状态码
+				service.ResetStatusCode(newAPIError, statusCodeMappingStr)
+				return newAPIError
+			}
 		}
 	}
 
@@ -137,6 +165,9 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 		// reset status code 重置状态码
 		service.ResetStatusCode(newAPIError, statusCodeMappingStr)
 		return newAPIError
+	}
+	if shouldUseResponsesTranscriptReplay(info) {
+		relaycommon.CommitResponsesTranscriptReplay(info)
 	}
 
 	usageDto := usage.(*dto.Usage)
@@ -163,4 +194,114 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 		service.PostTextConsumeQuota(c, info, usageDto, nil)
 	}
 	return nil
+}
+
+func shouldUseResponsesTranscriptReplay(info *relaycommon.RelayInfo) bool {
+	if info == nil || info.RelayMode != relayconstant.RelayModeResponses {
+		return false
+	}
+	if info.ApiType == appconstant.APITypeCodex {
+		return true
+	}
+	return info.ChannelOtherSettings.ResponsesTranscriptReplayEnabled
+}
+
+func newResponsesOutboundJSONBody(info *relaycommon.RelayInfo, requestBody []byte) (io.Reader, io.Closer, *types.NewAPIError) {
+	body, size, closer, err := relaycommon.NewOutboundJSONBody(requestBody)
+	if err != nil {
+		return nil, nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
+	}
+	if info != nil {
+		info.UpstreamRequestBodySize = size
+	}
+	return body, closer, nil
+}
+
+func retryCodexResponsesTranscriptReplay(
+	c *gin.Context,
+	info *relaycommon.RelayInfo,
+	adaptor relaychannel.Adaptor,
+	httpResp *http.Response,
+	requestBodyBytes []byte,
+	statusCodeMappingStr string,
+) (*http.Response, *types.NewAPIError) {
+	responseBody, readErr := captureHTTPErrorBody(httpResp)
+	if readErr != nil {
+		newAPIError := types.NewOpenAIError(readErr, types.ErrorCodeReadResponseBodyFailed, http.StatusInternalServerError, types.ErrOptionWithSkipRetry())
+		service.ResetStatusCode(newAPIError, statusCodeMappingStr)
+		return nil, newAPIError
+	}
+
+	if !shouldRetryResponsesTranscriptReplay(httpResp.StatusCode, responseBody, requestBodyBytes) {
+		return nil, newAPIErrorFromCapturedHTTPError(c, httpResp, responseBody, statusCodeMappingStr, false)
+	}
+
+	replayBody, ok, reason := relaycommon.BuildResponsesTranscriptReplayRequest(info, requestBodyBytes)
+	if !ok {
+		logger.LogWarn(c, fmt.Sprintf("codex responses transcript replay skipped on channel #%d: %s", info.ChannelId, reason))
+		return nil, newAPIErrorFromCapturedHTTPError(c, httpResp, responseBody, statusCodeMappingStr, true)
+	}
+
+	relaycommon.UpdateResponsesTranscriptReplayRequest(info, replayBody, true)
+	replayRequestBody, replayCloser, newAPIError := newResponsesOutboundJSONBody(info, replayBody)
+	if newAPIError != nil {
+		return nil, markResponsesTranscriptReplaySkipRetry(newAPIError)
+	}
+	defer replayCloser.Close()
+
+	logger.LogInfo(c, fmt.Sprintf("codex responses transcript replay on channel #%d: %s", info.ChannelId, reason))
+	resp, err := adaptor.DoRequest(c, info, replayRequestBody)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeDoRequestFailed, http.StatusInternalServerError, types.ErrOptionWithSkipRetry())
+	}
+	replayResp := resp.(*http.Response)
+	if replayResp.StatusCode == http.StatusOK {
+		return replayResp, nil
+	}
+
+	replayResponseBody, readErr := captureHTTPErrorBody(replayResp)
+	if readErr != nil {
+		newAPIError := types.NewOpenAIError(readErr, types.ErrorCodeReadResponseBodyFailed, http.StatusInternalServerError, types.ErrOptionWithSkipRetry())
+		service.ResetStatusCode(newAPIError, statusCodeMappingStr)
+		return nil, newAPIError
+	}
+	return nil, newAPIErrorFromCapturedHTTPError(c, replayResp, replayResponseBody, statusCodeMappingStr, true)
+}
+
+func shouldRetryResponsesTranscriptReplay(statusCode int, responseBody []byte, requestBody []byte) bool {
+	if relaycommon.IsResponsesTranscriptReplayError(statusCode, responseBody) {
+		return true
+	}
+	return statusCode == http.StatusRequestEntityTooLarge &&
+		relaycommon.ResponsesTranscriptReplayRequestHasEncryptedContent(requestBody)
+}
+
+func captureHTTPErrorBody(resp *http.Response) ([]byte, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, fmt.Errorf("empty upstream error response")
+	}
+	responseBody, err := io.ReadAll(resp.Body)
+	service.CloseResponseBodyGracefully(resp)
+	if err != nil {
+		return nil, err
+	}
+	return responseBody, nil
+}
+
+func newAPIErrorFromCapturedHTTPError(c *gin.Context, resp *http.Response, responseBody []byte, statusCodeMappingStr string, skipRetry bool) *types.NewAPIError {
+	respCopy := *resp
+	respCopy.Body = io.NopCloser(bytes.NewReader(responseBody))
+	newAPIError := service.RelayErrorHandler(c.Request.Context(), &respCopy, false)
+	if skipRetry {
+		newAPIError = markResponsesTranscriptReplaySkipRetry(newAPIError)
+	}
+	service.ResetStatusCode(newAPIError, statusCodeMappingStr)
+	return newAPIError
+}
+
+func markResponsesTranscriptReplaySkipRetry(newAPIError *types.NewAPIError) *types.NewAPIError {
+	if newAPIError == nil {
+		return nil
+	}
+	return types.NewError(newAPIError, newAPIError.GetErrorCode(), types.ErrOptionWithSkipRetry())
 }

--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -269,11 +269,7 @@ func retryCodexResponsesTranscriptReplay(
 }
 
 func shouldRetryResponsesTranscriptReplay(statusCode int, responseBody []byte, requestBody []byte) bool {
-	if relaycommon.IsResponsesTranscriptReplayError(statusCode, responseBody) {
-		return true
-	}
-	return statusCode == http.StatusRequestEntityTooLarge &&
-		relaycommon.ResponsesTranscriptReplayRequestHasEncryptedContent(requestBody)
+	return relaycommon.IsResponsesTranscriptReplayError(statusCode, responseBody)
 }
 
 func captureHTTPErrorBody(resp *http.Response) ([]byte, error) {

--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -2,7 +2,6 @@ package relay
 
 import (
 	"bytes"
-	"compress/gzip"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,8 +21,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 )
-
-const responsesOutboundGzipMinBytes = 900 * 1024
 
 func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
 	info.InitChannelMeta(c)
@@ -99,8 +96,8 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 					requestBodyBytes = sanitizedBody
 					shouldRewriteBody = true
 				}
-				if shouldRewriteBody || shouldGzipResponsesOutboundBody(info, requestBodyBytes) {
-					body, closer, newAPIError := newResponsesOutboundJSONBody(c, info, requestBodyBytes)
+				if shouldRewriteBody {
+					body, closer, newAPIError := newResponsesOutboundJSONBody(info, requestBodyBytes)
 					if newAPIError != nil {
 						return newAPIError
 					}
@@ -144,7 +141,7 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 				requestBodyBytes = sanitizedBody
 			}
 		}
-		body, closer, newAPIError := newResponsesOutboundJSONBody(c, info, requestBodyBytes)
+		body, closer, newAPIError := newResponsesOutboundJSONBody(info, requestBodyBytes)
 		if newAPIError != nil {
 			return newAPIError
 		}
@@ -225,23 +222,8 @@ func shouldUseResponsesTranscriptReplay(info *relaycommon.RelayInfo) bool {
 	return info.ChannelOtherSettings.ResponsesTranscriptReplayEnabled
 }
 
-func newResponsesOutboundJSONBody(c *gin.Context, info *relaycommon.RelayInfo, requestBody []byte) (io.Reader, io.Closer, *types.NewAPIError) {
-	bodyData := requestBody
-	if info != nil {
-		info.UpstreamRequestBodyEncoding = ""
-	}
-	if shouldGzipResponsesOutboundBody(info, requestBody) {
-		gzipData, err := gzipResponsesOutboundBody(requestBody)
-		if err != nil {
-			return nil, nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
-		}
-		if len(gzipData) < len(requestBody) {
-			bodyData = gzipData
-			info.UpstreamRequestBodyEncoding = "gzip"
-			logResponsesInfo(c, fmt.Sprintf("codex responses outbound body gzip on channel #%d: original_body_bytes=%d gzip_body_bytes=%d", info.ChannelId, len(requestBody), len(gzipData)))
-		}
-	}
-	body, size, closer, err := relaycommon.NewOutboundJSONBody(bodyData)
+func newResponsesOutboundJSONBody(info *relaycommon.RelayInfo, requestBody []byte) (io.Reader, io.Closer, *types.NewAPIError) {
+	body, size, closer, err := relaycommon.NewOutboundJSONBody(requestBody)
 	if err != nil {
 		return nil, nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
 	}
@@ -249,23 +231,6 @@ func newResponsesOutboundJSONBody(c *gin.Context, info *relaycommon.RelayInfo, r
 		info.UpstreamRequestBodySize = size
 	}
 	return body, closer, nil
-}
-
-func shouldGzipResponsesOutboundBody(info *relaycommon.RelayInfo, requestBody []byte) bool {
-	return shouldUseResponsesTranscriptReplay(info) && len(requestBody) >= responsesOutboundGzipMinBytes
-}
-
-func gzipResponsesOutboundBody(requestBody []byte) ([]byte, error) {
-	var buf bytes.Buffer
-	writer := gzip.NewWriter(&buf)
-	if _, err := writer.Write(requestBody); err != nil {
-		_ = writer.Close()
-		return nil, err
-	}
-	if err := writer.Close(); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
 }
 
 func sanitizeResponsesTranscriptInitialRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBodyBytes []byte) ([]byte, bool) {
@@ -318,7 +283,7 @@ func retryCodexResponsesTranscriptReplay(
 	}
 
 	relaycommon.UpdateResponsesTranscriptReplayRequest(info, replayBody, true)
-	replayRequestBody, replayCloser, newAPIError := newResponsesOutboundJSONBody(c, info, replayBody)
+	replayRequestBody, replayCloser, newAPIError := newResponsesOutboundJSONBody(info, replayBody)
 	if newAPIError != nil {
 		return nil, markResponsesTranscriptReplaySkipRetry(newAPIError)
 	}
@@ -357,7 +322,7 @@ func logResponsesTranscriptRequestShape(c *gin.Context, info *relaycommon.RelayI
 		channelID = info.ChannelId
 	}
 	logger.LogWarn(c, fmt.Sprintf(
-		"codex responses request diagnostics on channel #%d: phase=%s status=%d body_bytes=%d input_exists=%t input_array=%t input_items=%d previous_response_id=%t prompt_cache_key=%t full_transcript=%t replacement_input=%t compaction_items=%d assistant_messages=%d function_calls=%d custom_tool_calls=%d reasoning_items=%d encrypted_content_items=%d",
+		"codex responses request diagnostics on channel #%d: phase=%s status=%d body_bytes=%d input_exists=%t input_array=%t input_items=%d previous_response_id=%t prompt_cache_key=%t full_transcript=%t replacement_input=%t compaction_items=%d assistant_messages=%d function_calls=%d custom_tool_calls=%d reasoning_items=%d encrypted_content_items=%d inline_image_items=%d",
 		channelID,
 		phase,
 		statusCode,
@@ -375,6 +340,7 @@ func logResponsesTranscriptRequestShape(c *gin.Context, info *relaycommon.RelayI
 		shape.CustomToolCallItems,
 		shape.ReasoningItems,
 		shape.EncryptedContentItems,
+		shape.InlineImageItems,
 	))
 }
 

--- a/relay/responses_handler_test.go
+++ b/relay/responses_handler_test.go
@@ -1,6 +1,10 @@
 package relay
 
 import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/QuantumNous/new-api/constant"
@@ -52,4 +56,72 @@ func TestShouldRetryResponsesTranscriptReplayIgnoresPayloadTooLarge(t *testing.T
 	require.False(t, shouldRetryResponsesTranscriptReplay(413, []byte(`<html>too large</html>`), []byte(`{
 		"input":[{"type":"reasoning","encrypted_content":"bad-ciphertext","summary":[]}]
 	}`)))
+}
+
+func TestGzipResponsesOutboundBodyRoundTrip(t *testing.T) {
+	original := []byte(strings.Repeat(`{"type":"message","role":"user","content":"hello"}`, 20000))
+
+	gzipBody, err := gzipResponsesOutboundBody(original)
+	require.NoError(t, err)
+	require.Less(t, len(gzipBody), len(original))
+
+	reader, err := gzip.NewReader(bytes.NewReader(gzipBody))
+	require.NoError(t, err)
+	defer reader.Close()
+
+	decompressed, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, original, decompressed)
+}
+
+func TestNewResponsesOutboundJSONBodyGzipsLargeReplayEnabledBody(t *testing.T) {
+	original := []byte(`{"input":"` + strings.Repeat("x", responsesOutboundGzipMinBytes) + `"}`)
+	info := &relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeResponses,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelId: 5,
+			ApiType:   constant.APITypeCodex,
+		},
+	}
+
+	body, closer, newAPIError := newResponsesOutboundJSONBody(nil, info, original)
+	require.Nil(t, newAPIError)
+	defer closer.Close()
+
+	require.Equal(t, "gzip", info.UpstreamRequestBodyEncoding)
+	require.Less(t, info.UpstreamRequestBodySize, int64(len(original)))
+
+	gzipBody, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, info.UpstreamRequestBodySize, int64(len(gzipBody)))
+
+	reader, err := gzip.NewReader(bytes.NewReader(gzipBody))
+	require.NoError(t, err)
+	defer reader.Close()
+
+	decompressed, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, original, decompressed)
+}
+
+func TestNewResponsesOutboundJSONBodyDoesNotGzipNormalOpenAIResponses(t *testing.T) {
+	original := []byte(`{"input":"` + strings.Repeat("x", responsesOutboundGzipMinBytes) + `"}`)
+	info := &relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeResponses,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelId: 5,
+			ApiType:   constant.APITypeOpenAI,
+		},
+	}
+
+	body, closer, newAPIError := newResponsesOutboundJSONBody(nil, info, original)
+	require.Nil(t, newAPIError)
+	defer closer.Close()
+
+	require.Empty(t, info.UpstreamRequestBodyEncoding)
+	require.Equal(t, int64(len(original)), info.UpstreamRequestBodySize)
+
+	outboundBody, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, original, outboundBody)
 }

--- a/relay/responses_handler_test.go
+++ b/relay/responses_handler_test.go
@@ -1,8 +1,6 @@
 package relay
 
 import (
-	"bytes"
-	"compress/gzip"
 	"io"
 	"strings"
 	"testing"
@@ -58,24 +56,8 @@ func TestShouldRetryResponsesTranscriptReplayIgnoresPayloadTooLarge(t *testing.T
 	}`)))
 }
 
-func TestGzipResponsesOutboundBodyRoundTrip(t *testing.T) {
-	original := []byte(strings.Repeat(`{"type":"message","role":"user","content":"hello"}`, 20000))
-
-	gzipBody, err := gzipResponsesOutboundBody(original)
-	require.NoError(t, err)
-	require.Less(t, len(gzipBody), len(original))
-
-	reader, err := gzip.NewReader(bytes.NewReader(gzipBody))
-	require.NoError(t, err)
-	defer reader.Close()
-
-	decompressed, err := io.ReadAll(reader)
-	require.NoError(t, err)
-	require.Equal(t, original, decompressed)
-}
-
-func TestNewResponsesOutboundJSONBodyGzipsLargeReplayEnabledBody(t *testing.T) {
-	original := []byte(`{"input":"` + strings.Repeat("x", responsesOutboundGzipMinBytes) + `"}`)
+func TestNewResponsesOutboundJSONBodyKeepsLargeReplayBodyAsJSON(t *testing.T) {
+	original := []byte(`{"input":"` + strings.Repeat("x", 900*1024) + `"}`)
 	info := &relaycommon.RelayInfo{
 		RelayMode: relayconstant.RelayModeResponses,
 		ChannelMeta: &relaycommon.ChannelMeta{
@@ -84,28 +66,18 @@ func TestNewResponsesOutboundJSONBodyGzipsLargeReplayEnabledBody(t *testing.T) {
 		},
 	}
 
-	body, closer, newAPIError := newResponsesOutboundJSONBody(nil, info, original)
+	body, closer, newAPIError := newResponsesOutboundJSONBody(info, original)
 	require.Nil(t, newAPIError)
 	defer closer.Close()
 
-	require.Equal(t, "gzip", info.UpstreamRequestBodyEncoding)
-	require.Less(t, info.UpstreamRequestBodySize, int64(len(original)))
-
-	gzipBody, err := io.ReadAll(body)
+	outboundBody, err := io.ReadAll(body)
 	require.NoError(t, err)
-	require.Equal(t, info.UpstreamRequestBodySize, int64(len(gzipBody)))
-
-	reader, err := gzip.NewReader(bytes.NewReader(gzipBody))
-	require.NoError(t, err)
-	defer reader.Close()
-
-	decompressed, err := io.ReadAll(reader)
-	require.NoError(t, err)
-	require.Equal(t, original, decompressed)
+	require.Equal(t, int64(len(original)), info.UpstreamRequestBodySize)
+	require.Equal(t, original, outboundBody)
 }
 
 func TestNewResponsesOutboundJSONBodyDoesNotGzipNormalOpenAIResponses(t *testing.T) {
-	original := []byte(`{"input":"` + strings.Repeat("x", responsesOutboundGzipMinBytes) + `"}`)
+	original := []byte(`{"input":"` + strings.Repeat("x", 900*1024) + `"}`)
 	info := &relaycommon.RelayInfo{
 		RelayMode: relayconstant.RelayModeResponses,
 		ChannelMeta: &relaycommon.ChannelMeta{
@@ -114,11 +86,10 @@ func TestNewResponsesOutboundJSONBodyDoesNotGzipNormalOpenAIResponses(t *testing
 		},
 	}
 
-	body, closer, newAPIError := newResponsesOutboundJSONBody(nil, info, original)
+	body, closer, newAPIError := newResponsesOutboundJSONBody(info, original)
 	require.Nil(t, newAPIError)
 	defer closer.Close()
 
-	require.Empty(t, info.UpstreamRequestBodyEncoding)
 	require.Equal(t, int64(len(original)), info.UpstreamRequestBodySize)
 
 	outboundBody, err := io.ReadAll(body)

--- a/relay/responses_handler_test.go
+++ b/relay/responses_handler_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestShouldUseResponsesTranscriptReplayForCodexAPI(t *testing.T) {
+func TestShouldUseResponsesTranscriptReplayForCodexAPIRequiresChannelSwitch(t *testing.T) {
 	info := &relaycommon.RelayInfo{
 		RelayMode: relayconstant.RelayModeResponses,
 		ChannelMeta: &relaycommon.ChannelMeta{
@@ -20,7 +20,7 @@ func TestShouldUseResponsesTranscriptReplayForCodexAPI(t *testing.T) {
 		},
 	}
 
-	require.True(t, shouldUseResponsesTranscriptReplay(info))
+	require.False(t, shouldUseResponsesTranscriptReplay(info))
 }
 
 func TestShouldUseResponsesTranscriptReplayWhenChannelSwitchEnabled(t *testing.T) {
@@ -28,6 +28,20 @@ func TestShouldUseResponsesTranscriptReplayWhenChannelSwitchEnabled(t *testing.T
 		RelayMode: relayconstant.RelayModeResponses,
 		ChannelMeta: &relaycommon.ChannelMeta{
 			ApiType: constant.APITypeOpenAI,
+			ChannelOtherSettings: dto.ChannelOtherSettings{
+				ResponsesTranscriptReplayEnabled: true,
+			},
+		},
+	}
+
+	require.True(t, shouldUseResponsesTranscriptReplay(info))
+}
+
+func TestShouldUseResponsesTranscriptReplayForCodexAPIWhenChannelSwitchEnabled(t *testing.T) {
+	info := &relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeResponses,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ApiType: constant.APITypeCodex,
 			ChannelOtherSettings: dto.ChannelOtherSettings{
 				ResponsesTranscriptReplayEnabled: true,
 			},

--- a/relay/responses_handler_test.go
+++ b/relay/responses_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/QuantumNous/new-api/dto"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,6 +69,19 @@ func TestShouldRetryResponsesTranscriptReplayIgnoresPayloadTooLarge(t *testing.T
 	require.False(t, shouldRetryResponsesTranscriptReplay(413, []byte(`<html>too large</html>`), []byte(`{
 		"input":[{"type":"reasoning","encrypted_content":"bad-ciphertext","summary":[]}]
 	}`)))
+}
+
+func TestResponsesTranscriptReplayErrorBodyPreservesStreamErrorCodes(t *testing.T) {
+	streamErr := types.WithOpenAIError(types.OpenAIError{
+		Message: `code: invalid_encrypted_content; message: The encrypted content gAAA...V2ln could not be verified. Reason: Encrypted content could not be decrypted or parsed.`,
+		Type:    "invalid_request_error",
+		Code:    "-4003",
+	}, 500)
+
+	body, err := responsesTranscriptReplayErrorBody(streamErr)
+
+	require.NoError(t, err)
+	require.True(t, shouldRetryResponsesTranscriptReplay(streamErr.StatusCode, body, []byte(`{"input":[]}`)))
 }
 
 func TestNewResponsesOutboundJSONBodyKeepsLargeReplayBodyAsJSON(t *testing.T) {

--- a/relay/responses_handler_test.go
+++ b/relay/responses_handler_test.go
@@ -1,0 +1,58 @@
+package relay
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldUseResponsesTranscriptReplayForCodexAPI(t *testing.T) {
+	info := &relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeResponses,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ApiType: constant.APITypeCodex,
+		},
+	}
+
+	require.True(t, shouldUseResponsesTranscriptReplay(info))
+}
+
+func TestShouldUseResponsesTranscriptReplayWhenChannelSwitchEnabled(t *testing.T) {
+	info := &relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeResponses,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ApiType: constant.APITypeOpenAI,
+			ChannelOtherSettings: dto.ChannelOtherSettings{
+				ResponsesTranscriptReplayEnabled: true,
+			},
+		},
+	}
+
+	require.True(t, shouldUseResponsesTranscriptReplay(info))
+}
+
+func TestShouldUseResponsesTranscriptReplayIgnoresNormalOpenAIResponsesChannel(t *testing.T) {
+	info := &relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeResponses,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelType:    constant.ChannelTypeOpenAI,
+			ApiType:        constant.APITypeOpenAI,
+			ChannelBaseUrl: "https://api.openai.com",
+		},
+	}
+
+	require.False(t, shouldUseResponsesTranscriptReplay(info))
+}
+
+func TestShouldRetryResponsesTranscriptReplayForPayloadTooLargeWithEncryptedContent(t *testing.T) {
+	require.True(t, shouldRetryResponsesTranscriptReplay(413, []byte(`<html>too large</html>`), []byte(`{
+		"input":[{"type":"reasoning","encrypted_content":"bad-ciphertext","summary":[]}]
+	}`)))
+	require.False(t, shouldRetryResponsesTranscriptReplay(413, []byte(`<html>too large</html>`), []byte(`{
+		"input":[{"type":"reasoning","summary":[]}]
+	}`)))
+}

--- a/relay/responses_handler_test.go
+++ b/relay/responses_handler_test.go
@@ -48,11 +48,8 @@ func TestShouldUseResponsesTranscriptReplayIgnoresNormalOpenAIResponsesChannel(t
 	require.False(t, shouldUseResponsesTranscriptReplay(info))
 }
 
-func TestShouldRetryResponsesTranscriptReplayForPayloadTooLargeWithEncryptedContent(t *testing.T) {
-	require.True(t, shouldRetryResponsesTranscriptReplay(413, []byte(`<html>too large</html>`), []byte(`{
-		"input":[{"type":"reasoning","encrypted_content":"bad-ciphertext","summary":[]}]
-	}`)))
+func TestShouldRetryResponsesTranscriptReplayIgnoresPayloadTooLarge(t *testing.T) {
 	require.False(t, shouldRetryResponsesTranscriptReplay(413, []byte(`<html>too large</html>`), []byte(`{
-		"input":[{"type":"reasoning","summary":[]}]
+		"input":[{"type":"reasoning","encrypted_content":"bad-ciphertext","summary":[]}]
 	}`)))
 }

--- a/relay/responses_session_verify_test.go
+++ b/relay/responses_session_verify_test.go
@@ -1,0 +1,127 @@
+package relay
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestVerifySession019eOutboundGzip(t *testing.T) {
+	sessionPath := strings.TrimSpace(os.Getenv("CODEX_VERIFY_SESSION_JSONL"))
+	if sessionPath == "" {
+		t.Skip("set CODEX_VERIFY_SESSION_JSONL to run this session-derived verification")
+	}
+
+	requestBody := buildLargestSessionResponsesRequest(t, sessionPath, 286)
+	shape := relaycommon.InspectResponsesTranscriptRequestShape(requestBody)
+	require.Greater(t, len(requestBody), responsesOutboundGzipMinBytes)
+	require.Equal(t, 286, shape.InputItems)
+	require.True(t, shape.LooksReplacementInput)
+
+	sanitizedBody, ok, reason := relaycommon.SanitizeResponsesTranscriptInitialRequest(requestBody)
+	require.True(t, ok, reason)
+	sanitizedShape := relaycommon.InspectResponsesTranscriptRequestShape(sanitizedBody)
+	require.Equal(t, 0, sanitizedShape.ReasoningItems)
+	require.Equal(t, 0, sanitizedShape.EncryptedContentItems)
+	require.Greater(t, len(sanitizedBody), responsesOutboundGzipMinBytes)
+
+	info := &relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeResponses,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelId: 5,
+			ApiType:   constant.APITypeCodex,
+		},
+	}
+	relaycommon.PrepareResponsesTranscriptReplay(info, requestBody)
+	relaycommon.UpdateResponsesTranscriptReplayRequest(info, sanitizedBody, false)
+
+	body, closer, newAPIError := newResponsesOutboundJSONBody(nil, info, sanitizedBody)
+	require.Nil(t, newAPIError)
+	defer closer.Close()
+
+	gzipBody, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, "gzip", info.UpstreamRequestBodyEncoding)
+	require.Equal(t, int64(len(gzipBody)), info.UpstreamRequestBodySize)
+	require.Less(t, len(gzipBody), responsesOutboundGzipMinBytes)
+
+	reader, err := gzip.NewReader(bytes.NewReader(gzipBody))
+	require.NoError(t, err)
+	defer reader.Close()
+
+	decompressed, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, sanitizedBody, decompressed)
+
+	t.Logf(
+		"original_body_bytes=%d sanitized_body_bytes=%d gzip_body_bytes=%d original_items=%d sanitized_items=%d original_reasoning=%d sanitized_reasoning=%d original_encrypted=%d sanitized_encrypted=%d reason=%q",
+		len(requestBody),
+		len(sanitizedBody),
+		len(gzipBody),
+		shape.InputItems,
+		sanitizedShape.InputItems,
+		shape.ReasoningItems,
+		sanitizedShape.ReasoningItems,
+		shape.EncryptedContentItems,
+		sanitizedShape.EncryptedContentItems,
+		reason,
+	)
+}
+
+func buildLargestSessionResponsesRequest(t *testing.T, sessionPath string, inputItems int) []byte {
+	t.Helper()
+
+	file, err := os.Open(sessionPath)
+	require.NoError(t, err)
+	defer file.Close()
+
+	type record struct {
+		Type    string          `json:"type"`
+		Payload json.RawMessage `json:"payload"`
+	}
+
+	var transcriptItems []string
+	reader := bufio.NewReaderSize(file, 1024*1024)
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			var rec record
+			if err := json.Unmarshal(line, &rec); err == nil && rec.Type == "response_item" && len(rec.Payload) > 0 {
+				payload := gjson.ParseBytes(rec.Payload)
+				switch strings.TrimSpace(payload.Get("type").String()) {
+				case "message", "function_call", "function_call_output", "custom_tool_call", "custom_tool_call_output", "reasoning":
+					transcriptItems = append(transcriptItems, strings.TrimSpace(string(rec.Payload)))
+				}
+			}
+		}
+		if readErr != nil {
+			break
+		}
+	}
+	require.GreaterOrEqual(t, len(transcriptItems), inputItems)
+
+	var requestBody []byte
+	for i := 0; i+inputItems <= len(transcriptItems); i++ {
+		candidate := []byte(fmt.Sprintf(`{
+			"model":"gpt-5.5",
+			"prompt_cache_key":"019e5382-dadc-7051-a35d-af12c28baa55",
+			"input":[%s]
+		}`, strings.Join(transcriptItems[i:i+inputItems], ",")))
+		if len(candidate) > len(requestBody) {
+			requestBody = candidate
+		}
+	}
+	return requestBody
+}

--- a/relay/responses_session_verify_test.go
+++ b/relay/responses_session_verify_test.go
@@ -2,8 +2,6 @@ package relay
 
 import (
 	"bufio"
-	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -18,7 +16,9 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func TestVerifySession019eOutboundGzip(t *testing.T) {
+const responsesSessionVerifyGatewayLimit = 900 * 1024
+
+func TestVerifySession019eSanitizedUnderGatewayLimit(t *testing.T) {
 	sessionPath := strings.TrimSpace(os.Getenv("CODEX_VERIFY_SESSION_JSONL"))
 	if sessionPath == "" {
 		t.Skip("set CODEX_VERIFY_SESSION_JSONL to run this session-derived verification")
@@ -26,7 +26,7 @@ func TestVerifySession019eOutboundGzip(t *testing.T) {
 
 	requestBody := buildLargestSessionResponsesRequest(t, sessionPath, 286)
 	shape := relaycommon.InspectResponsesTranscriptRequestShape(requestBody)
-	require.Greater(t, len(requestBody), responsesOutboundGzipMinBytes)
+	require.Greater(t, len(requestBody), responsesSessionVerifyGatewayLimit)
 	require.Equal(t, 286, shape.InputItems)
 	require.True(t, shape.LooksReplacementInput)
 
@@ -35,7 +35,7 @@ func TestVerifySession019eOutboundGzip(t *testing.T) {
 	sanitizedShape := relaycommon.InspectResponsesTranscriptRequestShape(sanitizedBody)
 	require.Equal(t, 0, sanitizedShape.ReasoningItems)
 	require.Equal(t, 0, sanitizedShape.EncryptedContentItems)
-	require.Greater(t, len(sanitizedBody), responsesOutboundGzipMinBytes)
+	require.Less(t, len(sanitizedBody), responsesSessionVerifyGatewayLimit)
 
 	info := &relaycommon.RelayInfo{
 		RelayMode: relayconstant.RelayModeResponses,
@@ -47,35 +47,27 @@ func TestVerifySession019eOutboundGzip(t *testing.T) {
 	relaycommon.PrepareResponsesTranscriptReplay(info, requestBody)
 	relaycommon.UpdateResponsesTranscriptReplayRequest(info, sanitizedBody, false)
 
-	body, closer, newAPIError := newResponsesOutboundJSONBody(nil, info, sanitizedBody)
+	body, closer, newAPIError := newResponsesOutboundJSONBody(info, sanitizedBody)
 	require.Nil(t, newAPIError)
 	defer closer.Close()
 
-	gzipBody, err := io.ReadAll(body)
+	outboundBody, err := io.ReadAll(body)
 	require.NoError(t, err)
-	require.Equal(t, "gzip", info.UpstreamRequestBodyEncoding)
-	require.Equal(t, int64(len(gzipBody)), info.UpstreamRequestBodySize)
-	require.Less(t, len(gzipBody), responsesOutboundGzipMinBytes)
-
-	reader, err := gzip.NewReader(bytes.NewReader(gzipBody))
-	require.NoError(t, err)
-	defer reader.Close()
-
-	decompressed, err := io.ReadAll(reader)
-	require.NoError(t, err)
-	require.Equal(t, sanitizedBody, decompressed)
+	require.Equal(t, int64(len(sanitizedBody)), info.UpstreamRequestBodySize)
+	require.Equal(t, sanitizedBody, outboundBody)
 
 	t.Logf(
-		"original_body_bytes=%d sanitized_body_bytes=%d gzip_body_bytes=%d original_items=%d sanitized_items=%d original_reasoning=%d sanitized_reasoning=%d original_encrypted=%d sanitized_encrypted=%d reason=%q",
+		"original_body_bytes=%d sanitized_body_bytes=%d original_items=%d sanitized_items=%d original_reasoning=%d sanitized_reasoning=%d original_encrypted=%d sanitized_encrypted=%d original_inline_images=%d sanitized_inline_images=%d reason=%q",
 		len(requestBody),
 		len(sanitizedBody),
-		len(gzipBody),
 		shape.InputItems,
 		sanitizedShape.InputItems,
 		shape.ReasoningItems,
 		sanitizedShape.ReasoningItems,
 		shape.EncryptedContentItems,
 		sanitizedShape.EncryptedContentItems,
+		shape.InlineImageItems,
+		sanitizedShape.InlineImageItems,
 		reason,
 	)
 }

--- a/service/http_client.go
+++ b/service/http_client.go
@@ -10,16 +10,21 @@ import (
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/setting/system_setting"
 
 	"golang.org/x/net/proxy"
 )
 
 var (
-	httpClient      *http.Client
-	proxyClientLock sync.Mutex
-	proxyClients    = make(map[string]*http.Client)
+	httpClient         *http.Client
+	streamHttpClient   *http.Client
+	proxyClientLock    sync.Mutex
+	proxyClients       = make(map[string]*http.Client)
+	streamProxyClients = make(map[string]*http.Client)
 )
+
+const defaultStreamingResponseHeaderTimeout = 60 * time.Second
 
 func checkRedirect(req *http.Request, via []*http.Request) error {
 	fetchSetting := system_setting.GetFetchSetting()
@@ -31,6 +36,39 @@ func checkRedirect(req *http.Request, via []*http.Request) error {
 		return fmt.Errorf("stopped after 10 redirects")
 	}
 	return nil
+}
+
+func streamingResponseHeaderTimeout() time.Duration {
+	if constant.StreamingTimeout > 0 {
+		return time.Duration(constant.StreamingTimeout) * time.Second
+	}
+	return defaultStreamingResponseHeaderTimeout
+}
+
+func newHTTPClient(transport *http.Transport, timeout time.Duration) *http.Client {
+	client := &http.Client{
+		Transport:     transport,
+		CheckRedirect: checkRedirect,
+	}
+	if timeout > 0 {
+		client.Timeout = timeout
+	}
+	return client
+}
+
+func newStreamingHTTPClient(transport *http.Transport) *http.Client {
+	streamTransport := transport.Clone()
+	timeout := streamingResponseHeaderTimeout()
+	if streamTransport.DialContext == nil {
+		dialer := &net.Dialer{
+			Timeout:   timeout,
+			KeepAlive: 30 * time.Second,
+		}
+		streamTransport.DialContext = dialer.DialContext
+	}
+	streamTransport.TLSHandshakeTimeout = timeout
+	streamTransport.ResponseHeaderTimeout = timeout
+	return newHTTPClient(streamTransport, 0)
 }
 
 func InitHttpClient() {
@@ -45,22 +83,16 @@ func InitHttpClient() {
 		transport.TLSClientConfig = common.InsecureTLSConfig
 	}
 
-	if common.RelayTimeout == 0 {
-		httpClient = &http.Client{
-			Transport:     transport,
-			CheckRedirect: checkRedirect,
-		}
-	} else {
-		httpClient = &http.Client{
-			Transport:     transport,
-			Timeout:       time.Duration(common.RelayTimeout) * time.Second,
-			CheckRedirect: checkRedirect,
-		}
-	}
+	httpClient = newHTTPClient(transport, time.Duration(common.RelayTimeout)*time.Second)
+	streamHttpClient = newStreamingHTTPClient(transport)
 }
 
 func GetHttpClient() *http.Client {
 	return httpClient
+}
+
+func GetStreamHttpClient() *http.Client {
+	return streamHttpClient
 }
 
 // GetHttpClientWithProxy returns the default client or a proxy-enabled one when proxyURL is provided.
@@ -69,6 +101,14 @@ func GetHttpClientWithProxy(proxyURL string) (*http.Client, error) {
 		return GetHttpClient(), nil
 	}
 	return NewProxyHttpClient(proxyURL)
+}
+
+// GetStreamHttpClientWithProxy returns a streaming client without a total request timeout.
+func GetStreamHttpClientWithProxy(proxyURL string) (*http.Client, error) {
+	if proxyURL == "" {
+		return GetStreamHttpClient(), nil
+	}
+	return NewStreamProxyHttpClient(proxyURL)
 }
 
 // ResetProxyClientCache 清空代理客户端缓存，确保下次使用时重新初始化
@@ -81,19 +121,42 @@ func ResetProxyClientCache() {
 		}
 	}
 	proxyClients = make(map[string]*http.Client)
+	for _, client := range streamProxyClients {
+		if transport, ok := client.Transport.(*http.Transport); ok && transport != nil {
+			transport.CloseIdleConnections()
+		}
+	}
+	streamProxyClients = make(map[string]*http.Client)
 }
 
 // NewProxyHttpClient 创建支持代理的 HTTP 客户端
 func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
+	return newProxyHttpClient(proxyURL, false)
+}
+
+// NewStreamProxyHttpClient 创建支持代理的流式 HTTP 客户端。
+func NewStreamProxyHttpClient(proxyURL string) (*http.Client, error) {
+	return newProxyHttpClient(proxyURL, true)
+}
+
+func newProxyHttpClient(proxyURL string, stream bool) (*http.Client, error) {
 	if proxyURL == "" {
-		if client := GetHttpClient(); client != nil {
+		client := GetHttpClient()
+		if stream {
+			client = GetStreamHttpClient()
+		}
+		if client != nil {
 			return client, nil
 		}
 		return http.DefaultClient, nil
 	}
 
 	proxyClientLock.Lock()
-	if client, ok := proxyClients[proxyURL]; ok {
+	cache := proxyClients
+	if stream {
+		cache = streamProxyClients
+	}
+	if client, ok := cache[proxyURL]; ok {
 		proxyClientLock.Unlock()
 		return client, nil
 	}
@@ -116,13 +179,18 @@ func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
 		if common.TLSInsecureSkipVerify {
 			transport.TLSClientConfig = common.InsecureTLSConfig
 		}
-		client := &http.Client{
-			Transport:     transport,
-			CheckRedirect: checkRedirect,
+		var client *http.Client
+		if stream {
+			client = newStreamingHTTPClient(transport)
+		} else {
+			client = newHTTPClient(transport, time.Duration(common.RelayTimeout)*time.Second)
 		}
-		client.Timeout = time.Duration(common.RelayTimeout) * time.Second
 		proxyClientLock.Lock()
-		proxyClients[proxyURL] = client
+		if stream {
+			streamProxyClients[proxyURL] = client
+		} else {
+			proxyClients[proxyURL] = client
+		}
 		proxyClientLock.Unlock()
 		return client, nil
 
@@ -141,7 +209,14 @@ func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
 
 		// 创建 SOCKS5 代理拨号器
 		// proxy.SOCKS5 使用 tcp 参数，所有 TCP 连接包括 DNS 查询都将通过代理进行。行为与 socks5h 相同
-		dialer, err := proxy.SOCKS5("tcp", parsedURL.Host, auth, proxy.Direct)
+		var forward proxy.Dialer = proxy.Direct
+		if stream {
+			forward = &net.Dialer{
+				Timeout:   streamingResponseHeaderTimeout(),
+				KeepAlive: 30 * time.Second,
+			}
+		}
+		dialer, err := proxy.SOCKS5("tcp", parsedURL.Host, auth, forward)
 		if err != nil {
 			return nil, err
 		}
@@ -159,10 +234,18 @@ func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
 			transport.TLSClientConfig = common.InsecureTLSConfig
 		}
 
-		client := &http.Client{Transport: transport, CheckRedirect: checkRedirect}
-		client.Timeout = time.Duration(common.RelayTimeout) * time.Second
+		var client *http.Client
+		if stream {
+			client = newStreamingHTTPClient(transport)
+		} else {
+			client = newHTTPClient(transport, time.Duration(common.RelayTimeout)*time.Second)
+		}
 		proxyClientLock.Lock()
-		proxyClients[proxyURL] = client
+		if stream {
+			streamProxyClients[proxyURL] = client
+		} else {
+			proxyClients[proxyURL] = client
+		}
 		proxyClientLock.Unlock()
 		return client, nil
 

--- a/service/http_client_test.go
+++ b/service/http_client_test.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitHttpClientSeparatesStreamingTimeouts(t *testing.T) {
+	oldRelayTimeout := common.RelayTimeout
+	oldStreamingTimeout := constant.StreamingTimeout
+	common.RelayTimeout = 120
+	constant.StreamingTimeout = 60
+	t.Cleanup(func() {
+		common.RelayTimeout = oldRelayTimeout
+		constant.StreamingTimeout = oldStreamingTimeout
+		InitHttpClient()
+	})
+
+	InitHttpClient()
+
+	client := GetHttpClient()
+	require.NotNil(t, client)
+	require.Equal(t, 120*time.Second, client.Timeout)
+
+	streamClient := GetStreamHttpClient()
+	require.NotNil(t, streamClient)
+	require.Zero(t, streamClient.Timeout)
+
+	streamTransport, ok := streamClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Equal(t, 60*time.Second, streamTransport.ResponseHeaderTimeout)
+	require.Equal(t, 60*time.Second, streamTransport.TLSHandshakeTimeout)
+	require.NotNil(t, streamTransport.DialContext)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Zero(t, transport.ResponseHeaderTimeout)
+}
+
+func TestStreamProxyHttpClientUsesStreamingTimeout(t *testing.T) {
+	oldRelayTimeout := common.RelayTimeout
+	oldStreamingTimeout := constant.StreamingTimeout
+	common.RelayTimeout = 120
+	constant.StreamingTimeout = 60
+	ResetProxyClientCache()
+	t.Cleanup(func() {
+		common.RelayTimeout = oldRelayTimeout
+		constant.StreamingTimeout = oldStreamingTimeout
+		ResetProxyClientCache()
+	})
+
+	client, err := NewProxyHttpClient("http://127.0.0.1:18080")
+	require.NoError(t, err)
+	require.Equal(t, 120*time.Second, client.Timeout)
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Zero(t, transport.ResponseHeaderTimeout)
+
+	streamClient, err := NewStreamProxyHttpClient("http://127.0.0.1:18080")
+	require.NoError(t, err)
+	require.Zero(t, streamClient.Timeout)
+	streamTransport, ok := streamClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Equal(t, 60*time.Second, streamTransport.ResponseHeaderTimeout)
+	require.Equal(t, 60*time.Second, streamTransport.TLSHandshakeTimeout)
+	require.NotNil(t, streamTransport.DialContext)
+}

--- a/web/classic/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/classic/src/components/table/channels/modals/EditChannelModal.jsx
@@ -206,6 +206,7 @@ const EditChannelModal = (props) => {
     disable_store: false, // false = 允许透传（默认开启）
     allow_safety_identifier: false,
     allow_include_obfuscation: false,
+    responses_transcript_replay_enabled: false,
     allow_inference_geo: false,
     allow_speed: false,
     claude_beta_query: false,
@@ -514,6 +515,7 @@ const EditChannelModal = (props) => {
     thinking_to_content: false,
     proxy: '',
     pass_through_body_enabled: false,
+    responses_transcript_replay_enabled: false,
     system_prompt: '',
   });
   const showApiConfigCard = true; // 控制是否显示 API 配置卡片
@@ -905,6 +907,8 @@ const EditChannelModal = (props) => {
             parsedSettings.allow_safety_identifier || false;
           data.allow_include_obfuscation =
             parsedSettings.allow_include_obfuscation || false;
+          data.responses_transcript_replay_enabled =
+            parsedSettings.responses_transcript_replay_enabled === true;
           data.allow_inference_geo =
             parsedSettings.allow_inference_geo || false;
           data.allow_speed = parsedSettings.allow_speed || false;
@@ -936,6 +940,7 @@ const EditChannelModal = (props) => {
           data.disable_store = false;
           data.allow_safety_identifier = false;
           data.allow_include_obfuscation = false;
+          data.responses_transcript_replay_enabled = false;
           data.allow_inference_geo = false;
           data.allow_speed = false;
           data.claude_beta_query = false;
@@ -954,6 +959,7 @@ const EditChannelModal = (props) => {
         data.disable_store = false;
         data.allow_safety_identifier = false;
         data.allow_include_obfuscation = false;
+        data.responses_transcript_replay_enabled = false;
         data.allow_inference_geo = false;
         data.allow_speed = false;
         data.claude_beta_query = false;
@@ -991,6 +997,8 @@ const EditChannelModal = (props) => {
         thinking_to_content: data.thinking_to_content,
         proxy: data.proxy,
         pass_through_body_enabled: data.pass_through_body_enabled,
+        responses_transcript_replay_enabled:
+          data.responses_transcript_replay_enabled,
         system_prompt: data.system_prompt,
         system_prompt_override: data.system_prompt_override || false,
       });
@@ -1033,6 +1041,7 @@ const EditChannelModal = (props) => {
         (data.system_prompt && data.system_prompt.trim()) ||
         data.thinking_to_content ||
         data.pass_through_body_enabled ||
+        data.responses_transcript_replay_enabled ||
         data.force_format ||
         data.claude_beta_query ||
         data.system_prompt_override;
@@ -1375,6 +1384,7 @@ const EditChannelModal = (props) => {
       thinking_to_content: false,
       proxy: '',
       pass_through_body_enabled: false,
+      responses_transcript_replay_enabled: false,
       system_prompt: '',
       system_prompt_override: false,
     });
@@ -1796,6 +1806,12 @@ const EditChannelModal = (props) => {
       }
     }
 
+    if (localInputs.responses_transcript_replay_enabled === true) {
+      settings.responses_transcript_replay_enabled = true;
+    } else if ('responses_transcript_replay_enabled' in settings) {
+      delete settings.responses_transcript_replay_enabled;
+    }
+
     settings.upstream_model_update_check_enabled =
       localInputs.upstream_model_update_check_enabled === true;
     settings.upstream_model_update_auto_sync_enabled =
@@ -1838,6 +1854,7 @@ const EditChannelModal = (props) => {
     delete localInputs.disable_store;
     delete localInputs.allow_safety_identifier;
     delete localInputs.allow_include_obfuscation;
+    delete localInputs.responses_transcript_replay_enabled;
     delete localInputs.allow_inference_geo;
     delete localInputs.allow_speed;
     delete localInputs.claude_beta_query;
@@ -2518,6 +2535,7 @@ const EditChannelModal = (props) => {
 
                   <Form.Switch field='thinking_to_content' label={t('思考内容转换')} checkedText={t('开')} uncheckedText={t('关')} onChange={(value) => handleChannelSettingsChange('thinking_to_content', value)} extraText={t('将 reasoning_content 转换为 <think> 标签拼接到内容中')} />
                   <Form.Switch field='pass_through_body_enabled' label={t('透传请求体')} checkedText={t('开')} uncheckedText={t('关')} onChange={(value) => handleChannelSettingsChange('pass_through_body_enabled', value)} extraText={t('启用请求体透传功能')} />
+                  <Form.Switch field='responses_transcript_replay_enabled' label={t('响应会话重放')} checkedText={t('开')} uncheckedText={t('关')} onChange={(value) => handleChannelOtherSettingsChange('responses_transcript_replay_enabled', value)} extraText={t('遇到 encrypted_content 校验失败时，移除 previous_response_id 并重放完整会话记录')} />
 
                   <Form.Input field='proxy' label={t('代理地址')} placeholder={t('例如: socks5://user:pass@host:port')} onChange={(value) => handleChannelSettingsChange('proxy', value)} showClear extraText={t('用于配置网络代理，支持 socks5 协议')} />
 

--- a/web/classic/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/classic/src/components/table/channels/modals/EditChannelModal.jsx
@@ -2535,7 +2535,7 @@ const EditChannelModal = (props) => {
 
                   <Form.Switch field='thinking_to_content' label={t('思考内容转换')} checkedText={t('开')} uncheckedText={t('关')} onChange={(value) => handleChannelSettingsChange('thinking_to_content', value)} extraText={t('将 reasoning_content 转换为 <think> 标签拼接到内容中')} />
                   <Form.Switch field='pass_through_body_enabled' label={t('透传请求体')} checkedText={t('开')} uncheckedText={t('关')} onChange={(value) => handleChannelSettingsChange('pass_through_body_enabled', value)} extraText={t('启用请求体透传功能')} />
-                  <Form.Switch field='responses_transcript_replay_enabled' label={t('响应会话重放')} checkedText={t('开')} uncheckedText={t('关')} onChange={(value) => handleChannelOtherSettingsChange('responses_transcript_replay_enabled', value)} extraText={t('遇到 encrypted_content 校验失败时，移除 previous_response_id 并重放完整会话记录')} />
+                  <Form.Switch field='responses_transcript_replay_enabled' label={t('响应会话重放')} checkedText={t('开')} uncheckedText={t('关')} onChange={(value) => handleChannelOtherSettingsChange('responses_transcript_replay_enabled', value)} extraText={t('遇到 encrypted_content 校验失败时，优先保留 previous_response_id 并清理无效推理内容')} />
 
                   <Form.Input field='proxy' label={t('代理地址')} placeholder={t('例如: socks5://user:pass@host:port')} onChange={(value) => handleChannelSettingsChange('proxy', value)} showClear extraText={t('用于配置网络代理，支持 socks5 协议')} />
 

--- a/web/classic/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/classic/src/components/table/channels/modals/EditChannelModal.jsx
@@ -2535,7 +2535,7 @@ const EditChannelModal = (props) => {
 
                   <Form.Switch field='thinking_to_content' label={t('思考内容转换')} checkedText={t('开')} uncheckedText={t('关')} onChange={(value) => handleChannelSettingsChange('thinking_to_content', value)} extraText={t('将 reasoning_content 转换为 <think> 标签拼接到内容中')} />
                   <Form.Switch field='pass_through_body_enabled' label={t('透传请求体')} checkedText={t('开')} uncheckedText={t('关')} onChange={(value) => handleChannelSettingsChange('pass_through_body_enabled', value)} extraText={t('启用请求体透传功能')} />
-                  <Form.Switch field='responses_transcript_replay_enabled' label={t('响应会话重放')} checkedText={t('开')} uncheckedText={t('关')} onChange={(value) => handleChannelOtherSettingsChange('responses_transcript_replay_enabled', value)} extraText={t('遇到 encrypted_content 校验失败时，优先保留 previous_response_id 并清理无效推理内容')} />
+                  <Form.Switch field='responses_transcript_replay_enabled' label={t('加密内容校验重试')} checkedText={t('开')} uncheckedText={t('关')} onChange={(value) => handleChannelOtherSettingsChange('responses_transcript_replay_enabled', value)} extraText={t('遇到加密内容校验失败时，自动清理无效推理内容并重试')} />
 
                   <Form.Input field='proxy' label={t('代理地址')} placeholder={t('例如: socks5://user:pass@host:port')} onChange={(value) => handleChannelSettingsChange('proxy', value)} showClear extraText={t('用于配置网络代理，支持 socks5 协议')} />
 

--- a/web/default/src/features/channels/components/drawers/channel-mutate-drawer.tsx
+++ b/web/default/src/features/channels/components/drawers/channel-mutate-drawer.tsx
@@ -284,6 +284,7 @@ const SENSITIVE_FORM_FIELDS = [
   'disable_store',
   'allow_safety_identifier',
   'allow_include_obfuscation',
+  'responses_transcript_replay_enabled',
   'allow_inference_geo',
   'allow_speed',
   'claude_beta_query',
@@ -331,6 +332,7 @@ function hasAdvancedSettingsValues(values: ChannelFormValues): boolean {
     values.force_format ||
     values.thinking_to_content ||
     values.pass_through_body_enabled ||
+    values.responses_transcript_replay_enabled ||
     values.system_prompt_override ||
     values.claude_beta_query ||
     values.upstream_model_update_check_enabled ||
@@ -720,6 +722,9 @@ export function ChannelMutateDrawer({
   const currentForceFormat = form.watch('force_format')
   const currentThinkingToContent = form.watch('thinking_to_content')
   const currentPassThroughBodyEnabled = form.watch('pass_through_body_enabled')
+  const currentResponsesTranscriptReplayEnabled = form.watch(
+    'responses_transcript_replay_enabled'
+  )
   const currentDisableTaskPollingSleep = form.watch(
     'disable_task_polling_sleep'
   )
@@ -926,6 +931,7 @@ export function ChannelMutateDrawer({
     currentForceFormat ||
     currentThinkingToContent ||
     currentPassThroughBodyEnabled ||
+    currentResponsesTranscriptReplayEnabled ||
     currentDisableTaskPollingSleep ||
     currentProxy?.trim() ||
     currentSystemPrompt?.trim() ||
@@ -3991,6 +3997,31 @@ export function ChannelMutateDrawer({
                                       <FormDescription>
                                         {t(
                                           'Pass request body directly to upstream'
+                                        )}
+                                      </FormDescription>
+                                    </div>
+                                    <FormControl>
+                                      <Switch
+                                        checked={field.value}
+                                        onCheckedChange={field.onChange}
+                                      />
+                                    </FormControl>
+                                  </FormItem>
+                                )}
+                              />
+
+                              <FormField
+                                control={form.control}
+                                name='responses_transcript_replay_enabled'
+                                render={({ field }) => (
+                                  <FormItem className='flex items-center justify-between px-4 py-3'>
+                                    <div className='space-y-0.5'>
+                                      <FormLabel>
+                                        {t('响应会话重放')}
+                                      </FormLabel>
+                                      <FormDescription>
+                                        {t(
+                                          '遇到 encrypted_content 校验失败时，移除 previous_response_id 并重放完整会话记录'
                                         )}
                                       </FormDescription>
                                     </div>

--- a/web/default/src/features/channels/components/drawers/channel-mutate-drawer.tsx
+++ b/web/default/src/features/channels/components/drawers/channel-mutate-drawer.tsx
@@ -4017,11 +4017,11 @@ export function ChannelMutateDrawer({
                                   <FormItem className='flex items-center justify-between px-4 py-3'>
                                     <div className='space-y-0.5'>
                                       <FormLabel>
-                                        {t('响应会话重放')}
+                                        {t('加密内容校验重试')}
                                       </FormLabel>
                                       <FormDescription>
                                         {t(
-                                          '遇到 encrypted_content 校验失败时，优先保留 previous_response_id 并清理无效推理内容'
+                                          '遇到加密内容校验失败时，自动清理无效推理内容并重试'
                                         )}
                                       </FormDescription>
                                     </div>

--- a/web/default/src/features/channels/components/drawers/channel-mutate-drawer.tsx
+++ b/web/default/src/features/channels/components/drawers/channel-mutate-drawer.tsx
@@ -4021,7 +4021,7 @@ export function ChannelMutateDrawer({
                                       </FormLabel>
                                       <FormDescription>
                                         {t(
-                                          '遇到 encrypted_content 校验失败时，移除 previous_response_id 并重放完整会话记录'
+                                          '遇到 encrypted_content 校验失败时，优先保留 previous_response_id 并清理无效推理内容'
                                         )}
                                       </FormDescription>
                                     </div>

--- a/web/default/src/features/channels/lib/channel-form.ts
+++ b/web/default/src/features/channels/lib/channel-form.ts
@@ -201,6 +201,7 @@ export const channelFormSchema = z
     disable_store: z.boolean().optional(), // OpenAI only
     allow_safety_identifier: z.boolean().optional(), // OpenAI only
     allow_include_obfuscation: z.boolean().optional(), // OpenAI: include usage obfuscation
+    responses_transcript_replay_enabled: z.boolean().optional(),
     allow_inference_geo: z.boolean().optional(), // OpenAI/Anthropic: inference geography
     allow_speed: z.boolean().optional(), // Anthropic: speed mode control
     claude_beta_query: z.boolean().optional(), // Anthropic: beta query passthrough
@@ -341,6 +342,7 @@ export const CHANNEL_FORM_DEFAULT_VALUES: ChannelFormValues = {
   disable_store: false,
   allow_safety_identifier: false,
   allow_include_obfuscation: false,
+  responses_transcript_replay_enabled: false,
   allow_inference_geo: false,
   allow_speed: false,
   claude_beta_query: false,
@@ -397,6 +399,7 @@ export function transformChannelToFormDefaults(
   let disableStore = false
   let allowSafetyIdentifier = false
   let allowIncludeObfuscation = false
+  let responsesTranscriptReplayEnabled = false
   let allowInferenceGeo = false
   let allowSpeed = false
   let claudeBetaQuery = false
@@ -417,6 +420,8 @@ export function transformChannelToFormDefaults(
       disableStore = parsed.disable_store === true
       allowSafetyIdentifier = parsed.allow_safety_identifier === true
       allowIncludeObfuscation = parsed.allow_include_obfuscation === true
+      responsesTranscriptReplayEnabled =
+        parsed.responses_transcript_replay_enabled === true
       allowInferenceGeo = parsed.allow_inference_geo === true
       allowSpeed = parsed.allow_speed === true
       claudeBetaQuery = parsed.claude_beta_query === true
@@ -475,6 +480,7 @@ export function transformChannelToFormDefaults(
     allow_service_tier: allowServiceTier,
     disable_store: disableStore,
     allow_include_obfuscation: allowIncludeObfuscation,
+    responses_transcript_replay_enabled: responsesTranscriptReplayEnabled,
     allow_inference_geo: allowInferenceGeo,
     allow_speed: allowSpeed,
     claude_beta_query: claudeBetaQuery,
@@ -570,6 +576,12 @@ function buildSettingsJSON(formData: ChannelFormValues): string {
       delete settingsObj.allow_include_obfuscation
     if (formData.type !== 14 && 'allow_inference_geo' in settingsObj)
       delete settingsObj.allow_inference_geo
+  }
+
+  if (formData.responses_transcript_replay_enabled === true) {
+    settingsObj.responses_transcript_replay_enabled = true
+  } else if ('responses_transcript_replay_enabled' in settingsObj) {
+    delete settingsObj.responses_transcript_replay_enabled
   }
 
   // Anthropic (type 14): claude_beta_query, allow_inference_geo, allow_speed

--- a/web/default/src/features/channels/types.ts
+++ b/web/default/src/features/channels/types.ts
@@ -97,6 +97,7 @@ export interface ChannelOtherSettings {
   disable_store?: boolean
   allow_safety_identifier?: boolean
   allow_include_obfuscation?: boolean
+  responses_transcript_replay_enabled?: boolean
   allow_inference_geo?: boolean
   allow_speed?: boolean
   claude_beta_query?: boolean


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 此描述基于本地 diff、测试结果和代码路径手动整理，方便维护者复核。

## 📝 变更描述 / Description

This PR adds two focused capabilities:

1. Responses API replay hardening for encrypted-content failures. The relay records safe transcript state, sanitizes invalid reasoning/encrypted content when retrying, handles oversized replay payloads, and improves streaming terminal-error handling so retryable failures can be surfaced before partial downstream writes.
2. Optional one-way identity/auth table synchronization for private mirror deployments. The sync is disabled by default and configured only through `IDENTITY_SYNC_*` environment variables. It copies allowlisted identity tables from a remote New API database into the local database, refreshes relevant Redis caches, and reloads custom OAuth providers after changes.

The identity sync implementation intentionally does not embed deployment addresses, DSNs, tokens, or runtime secrets. Table names are allowlisted, identifiers are quoted through GORM dialects, row counts are capped, and the remote DB pool defaults are kept small.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - Responses stream/replay failure handling
- [x] ✨ 新功能 (New feature) - optional identity/auth table sync
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [x] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- N/A

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

Local tests passed:

```bash
GOWORK=off go test ./model ./relay/common ./relay/helper ./relay/channel/openai ./relay ./controller ./service
```

Additional local checks:

```bash
git diff --check origin/main..HEAD
git rev-list --left-right --count HEAD...origin/main
```

Security scan notes:

- No real DSN, token, API key, private key, cloud credential, or runtime address is committed.
- Diff scan hits were limited to allowlisted table/field names, test-only fake values, and existing placeholder text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new channel setting for response transcript replay, with UI support in channel configuration screens.
  * Introduced optional identity synchronization between databases, including sync controls and safety limits.

* **Bug Fixes**
  * Improved streaming error handling so responses are not overwritten after output has already started.
  * Refined retry and completion handling for streamed responses to better handle disconnects and partial outputs.

* **Chores**
  * Updated the default streaming timeout from 300 seconds to 60 seconds across documentation and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->