### PR TITLE
feat(web): use distinct color palette for dashboard model charts

### DIFF
--- a/web/default/src/features/dashboard/lib/charts.ts
+++ b/web/default/src/features/dashboard/lib/charts.ts
@@ -16,14 +16,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { dataScheme as vchartDefaultDataScheme } from '@visactor/vchart/esm/theme/color-scheme/builtin/default'
-
 import { MAX_CHART_TREND_POINTS } from '@/features/dashboard/constants'
 import type {
   QuotaDataItem,
   ProcessedChartData,
   ProcessedUserChartData,
 } from '@/features/dashboard/types'
+import { CHART_COLORS } from '@/lib/colors'
 import { getCurrencyDisplay } from '@/lib/currency'
 import { formatChartTime, type TimeGranularity } from '@/lib/time'
 
@@ -39,14 +38,13 @@ type TooltipLineItem = {
   shapeSize?: number
 }
 
+/**
+ * Build chart color range from the shared chart color palette,
+ * cycling when model count exceeds the palette length.
+ */
 export function getDashboardChartColors(domainLength: number): string[] {
-  const scheme =
-    vchartDefaultDataScheme.find(
-      (item) => !item.maxDomainLength || domainLength <= item.maxDomainLength
-    ) ?? vchartDefaultDataScheme[vchartDefaultDataScheme.length - 1]
-
-  return scheme.scheme.filter(
-    (color): color is string => typeof color === 'string'
+  return Array.from({ length: domainLength }, (_, i) =>
+    CHART_COLORS[i % CHART_COLORS.length]
   )
 }
 


### PR DESCRIPTION
> [!NOTE]
> This PR was drafted with AI assistance and manually reviewed.

## 📝 变更描述 / Description

数据看板（Dashboard）的模型图表使用 VChart 默认的 dataScheme 配色方案，其 20 色为 10 对同色相明暗变体（如 `#1664FF`/`#B2CFFF`、`#7442D4`/`#B48DEB`），超过 5 个模型后多对颜色肉眼难以区分。

本 PR 将其替换为项目已有的 `CHART_COLORS`（`web/default/src/lib/colors.ts`），12 种 HSL 颜色色相均匀分布在色环上，相邻色相差距 ≥27°，大幅提升可辨识性。

- **修改文件**：`web/default/src/features/dashboard/lib/charts.ts`
- **改动**：`getDashboardChartColors()` 从 VChart dataScheme 改为基于 `CHART_COLORS` 循环生成
- **兼容性**：模型数超过 12 时从第 1 个颜色循环复用，满足大多数部署场景；入参签名和返回值类型不变

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- 暂无对应 Issue（GitHub 上未搜到相关 issue/PR，提交前已确认非重复）

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，确认不是重复提交
- [x] **Bug fix 说明:** 颜色相近导致模型无法区分属于预期之外的视觉缺陷
- [x] **变更理解:** `CHART_COLORS` 已在项目中用于其他场景，色相分布合理；`getDashboardChartColors` 的调用方（`modelColor` ordinal scale）不依赖 palette 长度特性
- [x] **范围聚焦:** 仅改动一个文件的颜色生成函数，无其他改动
- [x] **本地验证:** typecheck 通过，lint 无新增 error/warning
- [x] **安全合规:** 无凭据，符合项目代码规范

## 📸 运行证明 / Proof of Work

```
$ bun run typecheck  # pass, zero errors
$ bun run lint -- charts.ts  # no new errors on changed file
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dashboard chart colors to use a consistent shared palette.
  * Chart colors now repeat predictably when more series are shown, improving visual consistency across dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->