### PR TITLE
fix(web): improve dashboard model chart color distinguishability

### DIFF
--- a/web/default/src/features/dashboard/lib/charts.ts
+++ b/web/default/src/features/dashboard/lib/charts.ts
@@ -16,14 +16,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { dataScheme as vchartDefaultDataScheme } from '@visactor/vchart/esm/theme/color-scheme/builtin/default'
-
 import { MAX_CHART_TREND_POINTS } from '@/features/dashboard/constants'
 import type {
   QuotaDataItem,
   ProcessedChartData,
   ProcessedUserChartData,
 } from '@/features/dashboard/types'
+import { CHART_COLORS } from '@/lib/colors'
 import { getCurrencyDisplay } from '@/lib/currency'
 import { formatChartTime, type TimeGranularity } from '@/lib/time'
 
@@ -39,14 +38,13 @@ type TooltipLineItem = {
   shapeSize?: number
 }
 
+/**
+ * Build chart color range from the shared chart color palette,
+ * cycling when model count exceeds the palette length.
+ */
 export function getDashboardChartColors(domainLength: number): string[] {
-  const scheme =
-    vchartDefaultDataScheme.find(
-      (item) => !item.maxDomainLength || domainLength <= item.maxDomainLength
-    ) ?? vchartDefaultDataScheme[vchartDefaultDataScheme.length - 1]
-
-  return scheme.scheme.filter(
-    (color): color is string => typeof color === 'string'
+  return Array.from({ length: domainLength }, (_, i) =>
+    CHART_COLORS[i % CHART_COLORS.length]
   )
 }
 


### PR DESCRIPTION
## Problem

Dashboard model charts use VChart's default `dataScheme`, a 20-color **paired** palette where colors become visually similar beyond ~5 models. When a deployment has 8+ models, the stacked area/line charts and legend entries are hard to tell apart.

## Root cause

`getDashboardChartColors()` in `web/default/src/features/dashboard/lib/charts.ts` picks from VChart's built-in `dataScheme`. The scheme is designed for generic use — not optimized for the "many categories, need quick visual separation" case that dashboards require.

## Fix

Replace VChart `dataScheme` with the project's existing `CHART_COLORS` (12 HSL colors with wide hue separation, already used elsewhere in the app). Colors cycle when model count exceeds 12, which is acceptable for typical deployments.

**Before (VChart dataScheme, 7 models):** adjacent colors have similar hue/saturation → hard to distinguish  
**After (CHART_COLORS, 7+ models):** each color occupies a distinct hue region → easy to identify

## Changes

- **File:** `web/default/src/features/dashboard/lib/charts.ts`
- Remove `dataScheme` import from `@visactor/vchart`
- Import `CHART_COLORS` from `@/lib/colors`
- Simplify `getDashboardChartColors()` to cycle over `CHART_COLORS`

## Test plan

- [ ] Open dashboard with 5 or fewer models → colors should look fine
- [ ] Open dashboard with 8–12 models → each model should be clearly distinguishable in both chart and legend
- [ ] Open dashboard with 15+ models → colors cycle, still acceptable
- [ ] Verify pie chart, stacked bar, area chart, line chart, and rank bar all render correctly