### PR TITLE
fix(web): inject app styles into isolated HTML

### DIFF
--- a/web/default/src/components/html-content.tsx
+++ b/web/default/src/components/html-content.tsx
@@ -142,11 +142,24 @@ function IsolatedHtmlContent(props: {
 
   useEffect(() => {
     const container = containerRef.current
-    if (!container) return
+    if (!container) {
+      return
+    }
 
     const shadowRoot =
       container.shadowRoot ?? container.attachShadow({ mode: 'open' })
-    shadowRoot.innerHTML = `${isolatedContentBaseStyles}${props.html}`
+    const applicationStyleNodes = [
+      ...document.head.querySelectorAll<HTMLLinkElement | HTMLStyleElement>(
+        'style, link[rel="stylesheet"]'
+      ),
+    ].map((node) => node.cloneNode(true))
+    const contentTemplate = document.createElement('template')
+    contentTemplate.innerHTML = `${isolatedContentBaseStyles}${props.html}`
+
+    shadowRoot.replaceChildren(
+      ...applicationStyleNodes,
+      contentTemplate.content
+    )
   }, [props.html])
 
   return (


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
自定义 HTML 使用 Shadow DOM 隔离渲染后，主应用已生成的 CSS 不会自动作用到隔离内容，导致自定义首页中的布局、字号、按钮等样式丢失。

本次在隔离 HTML 渲染时克隆主文档中已加载的 `style` 和 `link[rel="stylesheet"]` 节点到 ShadowRoot，再渲染隔离基础样式和净化后的 HTML。这样保留 Shadow DOM 隔离，同时恢复依赖应用 CSS 的自定义 HTML 样式。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Related to #5795

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ ] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- `bun run typecheck` 通过。
- `bunx oxlint -c .oxlintrc.json src/components/html-content.tsx` 通过。
- 已在 `http://localhost:5173/` 手动验证自定义首页渲染正常，Shadow DOM 内样式注入生效。