### PR TITLE
fix: better redemption i18n message

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -1272,11 +1272,18 @@ func TopUp(c *gin.Context) {
 	}
 	quota, err := model.Redeem(req.Key, id)
 	if err != nil {
-		if errors.Is(err, model.ErrRedeemFailed) {
+		switch {
+		case errors.Is(err, model.ErrRedeemInvalid):
+			common.ApiErrorI18n(c, i18n.MsgRedemptionInvalid)
+		case errors.Is(err, model.ErrRedeemUsed):
+			common.ApiErrorI18n(c, i18n.MsgRedemptionUsed)
+		case errors.Is(err, model.ErrRedeemExpired):
+			common.ApiErrorI18n(c, i18n.MsgRedemptionExpired)
+		case errors.Is(err, model.ErrRedeemNotProvided):
+			common.ApiErrorI18n(c, i18n.MsgRedemptionNotProvided)
+		default:
 			common.ApiErrorI18n(c, i18n.MsgRedeemFailed)
-			return
 		}
-		common.ApiError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{

--- a/model/errors.go
+++ b/model/errors.go
@@ -19,8 +19,5 @@ var (
 	ErrTokenInvalid     = errors.New("token invalid")
 )
 
-// Redemption errors
-var ErrRedeemFailed = errors.New("redeem.failed")
-
 // 2FA errors
 var ErrTwoFANotEnabled = errors.New("2fa not enabled")


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

## 📝 变更描述 / Description
兑换码充值接口 TopUp 之前只识别
  ErrRedeemFailed，其他错误（兑换码无效、已使用、已过期、未提供等）会落到 common.ApiError(c, 
  err)，把内部 error 字符串原样返回给前端——既无法本地化，也可能暴露内部信息。

  本次改为 switch + errors.Is，把 model.Redeem() 已经返回的具体错误逐一映射到对应 i18n
  消息：

  - ErrRedeemInvalid → MsgRedemptionInvalid
  - ErrRedeemUsed → MsgRedemptionUsed
  - ErrRedeemExpired → MsgRedemptionExpired
  - ErrRedeemNotProvided → MsgRedemptionNotProvided
  - 其余未预期错误 → MsgRedeemFailed


## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [X] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
-  

## ✅ 提交前检查项 / Checklist
- [X] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [X] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [X] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [X] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [X] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [X] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [X] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 /
<img width="639" height="359" alt="Screenshot From 2026-07-02 19-46-48" src="https://github.com/user-attachments/assets/5f758291-8415-4041-a054-9320d69209d5" />
 Proof of Work

