### PR TITLE
fix: handle ollama non-stream tool calls

### DIFF
--- a/relay/channel/ollama/stream.go
+++ b/relay/channel/ollama/stream.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/logger"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
@@ -24,15 +25,10 @@ type ollamaChatStreamChunk struct {
 	CreatedAt string `json:"created_at"`
 	// chat
 	Message *struct {
-		Role      string          `json:"role"`
-		Content   string          `json:"content"`
-		Thinking  json.RawMessage `json:"thinking"`
-		ToolCalls []struct {
-			Function struct {
-				Name      string      `json:"name"`
-				Arguments interface{} `json:"arguments"`
-			} `json:"function"`
-		} `json:"tool_calls"`
+		Role      string           `json:"role"`
+		Content   string           `json:"content"`
+		Thinking  json.RawMessage  `json:"thinking"`
+		ToolCalls []OllamaToolCall `json:"tool_calls"`
 	} `json:"message"`
 	// generate
 	Response           string `json:"response"`
@@ -44,6 +40,39 @@ type ollamaChatStreamChunk struct {
 	EvalCount          int    `json:"eval_count"`
 	PromptEvalDuration int64  `json:"prompt_eval_duration"`
 	EvalDuration       int64  `json:"eval_duration"`
+}
+
+func ollamaToolCallsToOpenAI(toolCalls []OllamaToolCall, startIndex int, includeIndex bool) ([]dto.ToolCallResponse, int) {
+	if len(toolCalls) == 0 {
+		return nil, startIndex
+	}
+	result := make([]dto.ToolCallResponse, 0, len(toolCalls))
+	for _, tc := range toolCalls {
+		var argBytes []byte
+		var err error
+		if tc.Function.Arguments == nil {
+			argBytes = []byte("{}")
+		} else {
+			argBytes, err = common.Marshal(tc.Function.Arguments)
+			if err != nil || len(argBytes) == 0 {
+				argBytes = []byte("{}")
+			}
+		}
+		tr := dto.ToolCallResponse{
+			ID:   fmt.Sprintf("call_%d", startIndex),
+			Type: "function",
+			Function: dto.FunctionResponse{
+				Name:      tc.Function.Name,
+				Arguments: string(argBytes),
+			},
+		}
+		if includeIndex {
+			tr.SetIndex(startIndex)
+		}
+		startIndex++
+		result = append(result, tr)
+	}
+	return result, startIndex
 }
 
 func toUnix(ts string) int64 {
@@ -87,7 +116,7 @@ func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 			continue
 		}
 		var chunk ollamaChatStreamChunk
-		if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+		if err := common.Unmarshal([]byte(line), &chunk); err != nil {
 			logger.LogError(c, "ollama stream json decode error: "+err.Error()+" line="+line)
 			return usage, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
 		}
@@ -122,7 +151,7 @@ func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 				if raw != "" && raw != "null" {
 					// Unmarshal the JSON string to get the actual content without quotes
 					var thinkingContent string
-					if err := json.Unmarshal(chunk.Message.Thinking, &thinkingContent); err == nil {
+					if err := common.Unmarshal(chunk.Message.Thinking, &thinkingContent); err == nil {
 						delta.Choices[0].Delta.SetReasoningContent(thinkingContent)
 					} else {
 						// Fallback to raw string if it's not a JSON string
@@ -132,16 +161,7 @@ func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 			}
 			// tool calls
 			if chunk.Message != nil && len(chunk.Message.ToolCalls) > 0 {
-				delta.Choices[0].Delta.ToolCalls = make([]dto.ToolCallResponse, 0, len(chunk.Message.ToolCalls))
-				for _, tc := range chunk.Message.ToolCalls {
-					// arguments -> string
-					argBytes, _ := json.Marshal(tc.Function.Arguments)
-					toolId := fmt.Sprintf("call_%d", toolCallIndex)
-					tr := dto.ToolCallResponse{ID: toolId, Type: "function", Function: dto.FunctionResponse{Name: tc.Function.Name, Arguments: string(argBytes)}}
-					tr.SetIndex(toolCallIndex)
-					toolCallIndex++
-					delta.Choices[0].Delta.ToolCalls = append(delta.Choices[0].Delta.ToolCalls, tr)
-				}
+				delta.Choices[0].Delta.ToolCalls, toolCallIndex = ollamaToolCallsToOpenAI(chunk.Message.ToolCalls, toolCallIndex, true)
 			}
 			if data, err := common.Marshal(delta); err == nil {
 				_ = helper.StringData(c, string(data))
@@ -156,6 +176,9 @@ func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 		finishReason := chunk.DoneReason
 		if finishReason == "" {
 			finishReason = "stop"
+		}
+		if toolCallIndex > 0 {
+			finishReason = constant.FinishReasonToolCalls
 		}
 		// emit stop delta
 		if stop := helper.GenerateStopResponse(responseId, created, model, finishReason); stop != nil {
@@ -197,6 +220,8 @@ func ollamaChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.R
 		reasoningBuilder strings.Builder
 		lastChunk        ollamaChatStreamChunk
 		parsedAny        bool
+		toolCallIndex    int
+		toolCalls        []dto.ToolCallResponse
 	)
 	for _, ln := range lines {
 		ln = strings.TrimSpace(ln)
@@ -204,7 +229,7 @@ func ollamaChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.R
 			continue
 		}
 		var ck ollamaChatStreamChunk
-		if err := json.Unmarshal([]byte(ln), &ck); err != nil {
+		if err := common.Unmarshal([]byte(ln), &ck); err != nil {
 			if len(lines) == 1 {
 				return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
 			}
@@ -217,7 +242,7 @@ func ollamaChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.R
 			if raw != "" && raw != "null" {
 				// Unmarshal the JSON string to get the actual content without quotes
 				var thinkingContent string
-				if err := json.Unmarshal(ck.Message.Thinking, &thinkingContent); err == nil {
+				if err := common.Unmarshal(ck.Message.Thinking, &thinkingContent); err == nil {
 					reasoningBuilder.WriteString(thinkingContent)
 				} else {
 					// Fallback to raw string if it's not a JSON string
@@ -230,11 +255,16 @@ func ollamaChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.R
 		} else if ck.Response != "" {
 			aggContent.WriteString(ck.Response)
 		}
+		if ck.Message != nil && len(ck.Message.ToolCalls) > 0 {
+			var converted []dto.ToolCallResponse
+			converted, toolCallIndex = ollamaToolCallsToOpenAI(ck.Message.ToolCalls, toolCallIndex, false)
+			toolCalls = append(toolCalls, converted...)
+		}
 	}
 
 	if !parsedAny {
 		var single ollamaChatStreamChunk
-		if err := json.Unmarshal(body, &single); err != nil {
+		if err := common.Unmarshal(body, &single); err != nil {
 			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
 		}
 		lastChunk = single
@@ -244,7 +274,7 @@ func ollamaChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.R
 				if raw != "" && raw != "null" {
 					// Unmarshal the JSON string to get the actual content without quotes
 					var thinkingContent string
-					if err := json.Unmarshal(single.Message.Thinking, &thinkingContent); err == nil {
+					if err := common.Unmarshal(single.Message.Thinking, &thinkingContent); err == nil {
 						reasoningBuilder.WriteString(thinkingContent)
 					} else {
 						// Fallback to raw string if it's not a JSON string
@@ -253,6 +283,11 @@ func ollamaChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.R
 				}
 			}
 			aggContent.WriteString(single.Message.Content)
+			if len(single.Message.ToolCalls) > 0 {
+				var converted []dto.ToolCallResponse
+				converted, toolCallIndex = ollamaToolCallsToOpenAI(single.Message.ToolCalls, toolCallIndex, false)
+				toolCalls = append(toolCalls, converted...)
+			}
 		} else {
 			aggContent.WriteString(single.Response)
 		}
@@ -269,8 +304,16 @@ func ollamaChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.R
 	if finishReason == "" {
 		finishReason = "stop"
 	}
+	if len(toolCalls) > 0 {
+		finishReason = constant.FinishReasonToolCalls
+	}
 
 	msg := dto.Message{Role: "assistant", Content: contentPtr(content)}
+	if len(toolCalls) > 0 {
+		if rawToolCalls, err := common.Marshal(toolCalls); err == nil {
+			msg.ToolCalls = rawToolCalls
+		}
+	}
 	if rc := reasoningBuilder.String(); rc != "" {
 		msg.ReasoningContent = &rc
 	}

--- a/relay/channel/ollama/stream_test.go
+++ b/relay/channel/ollama/stream_test.go
@@ -1,0 +1,72 @@
+package ollama
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestOllamaChatHandlerNonStreamToolCalls(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	raw := `{"model":"llama3.1","created_at":"2026-05-27T12:00:00Z","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"Paris","days":0}}}]},"done":true,"done_reason":"stop","prompt_eval_count":5,"eval_count":7}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(raw)),
+	}
+
+	usage, apiErr := ollamaChatHandler(c, &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "fallback-model"},
+	}, resp)
+	if apiErr != nil {
+		t.Fatalf("ollamaChatHandler returned error: %v", apiErr)
+	}
+	if usage.TotalTokens != 12 {
+		t.Fatalf("unexpected usage total: got %d", usage.TotalTokens)
+	}
+
+	var out dto.OpenAITextResponse
+	if err := common.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(out.Choices) != 1 {
+		t.Fatalf("expected one choice, got %d", len(out.Choices))
+	}
+	if out.Choices[0].FinishReason != constant.FinishReasonToolCalls {
+		t.Fatalf("expected finish_reason %q, got %q", constant.FinishReasonToolCalls, out.Choices[0].FinishReason)
+	}
+
+	var toolCalls []dto.ToolCallResponse
+	if err := common.Unmarshal(out.Choices[0].Message.ToolCalls, &toolCalls); err != nil {
+		t.Fatalf("failed to decode tool calls: %v", err)
+	}
+	if len(toolCalls) != 1 {
+		t.Fatalf("expected one tool call, got %d", len(toolCalls))
+	}
+	if toolCalls[0].ID == "" || toolCalls[0].Type != "function" || toolCalls[0].Function.Name != "get_weather" {
+		t.Fatalf("unexpected tool call: %+v", toolCalls[0])
+	}
+	if toolCalls[0].Index != nil {
+		t.Fatalf("non-stream tool call should not include index: %+v", toolCalls[0].Index)
+	}
+
+	var args map[string]any
+	if err := common.Unmarshal([]byte(toolCalls[0].Function.Arguments), &args); err != nil {
+		t.Fatalf("failed to decode tool call arguments: %v", err)
+	}
+	if args["city"] != "Paris" || args["days"] != float64(0) {
+		t.Fatalf("unexpected tool call arguments: %+v", args)
+	}
+}

--- a/relay/channel/ollama/stream_test.go
+++ b/relay/channel/ollama/stream_test.go
@@ -13,60 +13,84 @@ import (
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOllamaChatHandlerNonStreamToolCalls(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
 
-	raw := `{"model":"llama3.1","created_at":"2026-05-27T12:00:00Z","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"Paris","days":0}}}]},"done":true,"done_reason":"stop","prompt_eval_count":5,"eval_count":7}`
-	resp := &http.Response{
-		StatusCode: http.StatusOK,
-		Header:     make(http.Header),
-		Body:       io.NopCloser(strings.NewReader(raw)),
-	}
-
-	usage, apiErr := ollamaChatHandler(c, &relaycommon.RelayInfo{
-		ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "fallback-model"},
-	}, resp)
-	if apiErr != nil {
-		t.Fatalf("ollamaChatHandler returned error: %v", apiErr)
-	}
-	if usage.TotalTokens != 12 {
-		t.Fatalf("unexpected usage total: got %d", usage.TotalTokens)
-	}
-
-	var out dto.OpenAITextResponse
-	if err := common.Unmarshal(w.Body.Bytes(), &out); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
-	if len(out.Choices) != 1 {
-		t.Fatalf("expected one choice, got %d", len(out.Choices))
-	}
-	if out.Choices[0].FinishReason != constant.FinishReasonToolCalls {
-		t.Fatalf("expected finish_reason %q, got %q", constant.FinishReasonToolCalls, out.Choices[0].FinishReason)
-	}
-
-	var toolCalls []dto.ToolCallResponse
-	if err := common.Unmarshal(out.Choices[0].Message.ToolCalls, &toolCalls); err != nil {
-		t.Fatalf("failed to decode tool calls: %v", err)
-	}
-	if len(toolCalls) != 1 {
-		t.Fatalf("expected one tool call, got %d", len(toolCalls))
-	}
-	if toolCalls[0].ID == "" || toolCalls[0].Type != "function" || toolCalls[0].Function.Name != "get_weather" {
-		t.Fatalf("unexpected tool call: %+v", toolCalls[0])
-	}
-	if toolCalls[0].Index != nil {
-		t.Fatalf("non-stream tool call should not include index: %+v", toolCalls[0].Index)
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "compact json per-line parse path",
+			raw:  `{"model":"llama3.1","created_at":"2026-05-27T12:00:00Z","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"Paris","days":0}}}]},"done":true,"done_reason":"stop","prompt_eval_count":5,"eval_count":7}`,
+		},
+		{
+			name: "pretty json fallback parse path",
+			raw: `{
+  "model": "llama3.1",
+  "created_at": "2026-05-27T12:00:00Z",
+  "message": {
+    "role": "assistant",
+    "content": "",
+    "tool_calls": [
+      {
+        "function": {
+          "name": "get_weather",
+          "arguments": {
+            "city": "Paris",
+            "days": 0
+          }
+        }
+      }
+    ]
+  },
+  "done": true,
+  "done_reason": "stop",
+  "prompt_eval_count": 5,
+  "eval_count": 7
+}`,
+		},
 	}
 
-	var args map[string]any
-	if err := common.Unmarshal([]byte(toolCalls[0].Function.Arguments), &args); err != nil {
-		t.Fatalf("failed to decode tool call arguments: %v", err)
-	}
-	if args["city"] != "Paris" || args["days"] != float64(0) {
-		t.Fatalf("unexpected tool call arguments: %+v", args)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(tt.raw)),
+			}
+
+			usage, apiErr := ollamaChatHandler(c, &relaycommon.RelayInfo{
+				ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "fallback-model"},
+			}, resp)
+			require.Nil(t, apiErr)
+			require.NotNil(t, usage)
+			assert.Equal(t, 12, usage.TotalTokens)
+
+			var out dto.OpenAITextResponse
+			require.NoError(t, common.Unmarshal(w.Body.Bytes(), &out))
+			require.Len(t, out.Choices, 1)
+			assert.Equal(t, constant.FinishReasonToolCalls, out.Choices[0].FinishReason)
+
+			var toolCalls []dto.ToolCallResponse
+			require.NoError(t, common.Unmarshal(out.Choices[0].Message.ToolCalls, &toolCalls))
+			require.Len(t, toolCalls, 1)
+			assert.NotEmpty(t, toolCalls[0].ID)
+			assert.Equal(t, "function", toolCalls[0].Type)
+			assert.Equal(t, "get_weather", toolCalls[0].Function.Name)
+			assert.Nil(t, toolCalls[0].Index)
+
+			var args map[string]any
+			require.NoError(t, common.Unmarshal([]byte(toolCalls[0].Function.Arguments), &args))
+			assert.Equal(t, "Paris", args["city"])
+			assert.Equal(t, float64(0), args["days"])
+		})
 	}
 }


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

本次变更增加了新功能，支持了 Ollama 非流式响应中工具调用的功能。

Ollama 在 `/api/chat` 非流式模式下返回工具调用时，会把结果放在 `message.tool_calls` 中，但原有的 `ollamaChatHandler` 只聚合了 `message.content`、`response` 和 reasoning 内容，没有读取并转换 `message.tool_calls`，因此最终返回给 OpenAI 兼容客户端的响应中会丢失工具调用信息，`finish_reason` 也仍然是上游的 `stop`。

本次修改将 Ollama 的 `tool_calls` 统一转换为 OpenAI 兼容的 `ToolCallResponse` 结构，这样客户端在收到非流式响应时，可以正确识别模型触发了工具调用，并继续执行后续 tool call 流程。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)

使用真实 Ollama 上游进行了验证：

- Ollama 上游地址：`http://127.0.0.1:11434`
- 模型：`qwen3:8b`
- 请求接口：`/api/chat`
- 请求模式：`"stream": false`
- 验证场景：Ollama 非流式响应返回 `message.tool_calls`，new-api 应正确转换为 OpenAI 兼容的 `message.tool_calls`，并将 `finish_reason` 设置为 `"tool_calls"`。

执行命令：

```bash
OLLAMA_BASE_URL=http://127.0.0.1:11434 OLLAMA_MODEL=qwen3:8b \
go test ./relay/channel/ollama -run TestLiveOllamaNonStreamToolCallsThroughHandler -count=1 -v
```

补丁前，在 `upstream/main`（`8874d192`）上，同一个 live regression test 会失败：

```text
raw ollama response: ... "tool_calls":[{"id":"call_hj8w65to","function":{"index":0,"name":"get_weather","arguments":{"city":"Paris","days":3}}}] ... "done_reason":"stop"

converted openai response: ... "message":{"role":"assistant","content":null,"reasoning_content":"..."},"finish_reason":"stop" ...

expected finish_reason "tool_calls", got "stop"
--- FAIL: TestLiveOllamaNonStreamToolCallsThroughHandler
FAIL
```

补丁后，在当前提交 `5f183a48` 上，同一个 live regression test 通过：

```text
raw ollama response: ... "tool_calls":[{"id":"call_5hd4f57n","function":{"index":0,"name":"get_weather","arguments":{"city":"Paris","days":3}}}] ... "done_reason":"stop"

converted openai response: ... "message":{"role":"assistant","content":null,"reasoning_content":"...","tool_calls":[{"id":"call_0","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Paris\",\"days\":3}"}}]},"finish_reason":"tool_calls" ...

--- PASS: TestLiveOllamaNonStreamToolCallsThroughHandler
PASS
ok github.com/QuantumNous/new-api/relay/channel/ollama
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ollama chat parsing so tool calls are reliably surfaced in both streaming and non-streaming responses.
  * Corrected completion/finish status reporting when tool calls are present.
  * Standardized tool-call serialization for consistent argument handling, including safer fallbacks for missing fields.
* **Tests**
  * Added coverage for non-stream tool-call responses using both compact and indented upstream payloads, validating finish status, tool-call fields, and decoded arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->