### PR TITLE
fix(settings): 修复保存系统设置时重复弹出成功提示及页面数据状态错乱的问题

### DIFF
--- a/web/default/src/features/system-settings/hooks/use-update-option.ts
+++ b/web/default/src/features/system-settings/hooks/use-update-option.ts
@@ -39,6 +39,65 @@ const STATUS_RELATED_KEYS = [
   'general_setting.custom_currency_exchange_rate',
 ]
 
+// Debounce timers to batch invalidations and toasts across sequential mutations.
+let invalidateOptionsTimer: ReturnType<typeof setTimeout> | null = null
+let invalidateStatusTimer: ReturnType<typeof setTimeout> | null = null
+let successToastTimer: ReturnType<typeof setTimeout> | null = null
+let hasBatchError = false
+let batchErrorTimer: ReturnType<typeof setTimeout> | null = null
+
+function scheduleOptionsInvalidate(
+  queryClient: ReturnType<typeof useQueryClient>,
+) {
+  if (invalidateOptionsTimer) clearTimeout(invalidateOptionsTimer)
+  invalidateOptionsTimer = setTimeout(() => {
+    queryClient.invalidateQueries({ queryKey: ['system-options'] })
+    invalidateOptionsTimer = null
+  }, 100)
+}
+
+function scheduleStatusInvalidate(
+  queryClient: ReturnType<typeof useQueryClient>,
+) {
+  if (invalidateStatusTimer) clearTimeout(invalidateStatusTimer)
+  invalidateStatusTimer = setTimeout(() => {
+    queryClient.invalidateQueries({ queryKey: ['status'] })
+    try {
+      window.localStorage.removeItem('status')
+    } catch {
+      /* empty */
+    }
+    invalidateStatusTimer = null
+  }, 100)
+}
+
+function scheduleSuccessToast() {
+  if (hasBatchError) return
+  if (successToastTimer) clearTimeout(successToastTimer)
+  successToastTimer = setTimeout(() => {
+    toast.success(i18next.t('Setting updated successfully'))
+    successToastTimer = null
+  }, 100)
+}
+
+function handleBatchError(message: string) {
+  // Cancel pending success toast
+  if (successToastTimer) {
+    clearTimeout(successToastTimer)
+    successToastTimer = null
+  }
+
+  // Set error flag to block subsequent success toasts in the current batch
+  hasBatchError = true
+  if (batchErrorTimer) clearTimeout(batchErrorTimer)
+  batchErrorTimer = setTimeout(() => {
+    hasBatchError = false
+  }, 200)
+
+  // Show error immediately
+  toast.error(message)
+}
+
 export function useUpdateOption() {
   const queryClient = useQueryClient()
 
@@ -46,26 +105,20 @@ export function useUpdateOption() {
     mutationFn: (request: UpdateOptionRequest) => updateSystemOption(request),
     onSuccess: (data, variables) => {
       if (data.success) {
-        // Always refresh system-options
-        queryClient.invalidateQueries({ queryKey: ['system-options'] })
+        scheduleOptionsInvalidate(queryClient)
 
-        // If updating frontend-display-related config, also refresh status
         if (STATUS_RELATED_KEYS.includes(variables.key)) {
-          queryClient.invalidateQueries({ queryKey: ['status'] })
-          try {
-            window.localStorage.removeItem('status')
-          } catch {
-            /* empty */
-          }
+          scheduleStatusInvalidate(queryClient)
         }
 
-        toast.success(i18next.t('Setting updated successfully'))
+        scheduleSuccessToast()
       } else {
-        toast.error(data.message || i18next.t('Failed to update setting'))
+        // Errors are shown immediately for instant feedback
+        handleBatchError(data.message || i18next.t('Failed to update setting'))
       }
     },
     onError: (error: Error) => {
-      toast.error(error.message || i18next.t('Failed to update setting'))
+      handleBatchError(error.message || i18next.t('Failed to update setting'))
     },
   })
 }


### PR DESCRIPTION
## 📝 变更描述 / Description

### 功能概述 / Overview
修复在系统设置页面（如基本身份验证、对象存储、支付设置、Worker 设置等）保存时，重复弹出成功提示（Toast 堆叠）以及保存后页面表单数据偶发性回滚、状态错乱的问题。

### 问题分析与复现 / Problem
1. **成功提示重复堆叠**：一次性保存多个设置项时，由于页面采用循环多次调用 `mutateAsync` 的方式保存多个字段的值，导致右下角连续弹出并堆叠多个相同的“设置更新成功”提示（极其影响视觉体验）。
2. **保存后数据状态错乱**：循环保存多个设置项时，每次写入成功都会触发 `invalidateQueries(['system-options'])`。高频的失效会导致前端发起多次查询请求（或在短时间内合并为一个请求），由于网络响应时序的不确定性，如果在所有字段写入完成前就返回了查询结果，前端就会拿到“部分写入”的旧数据。页面挂载的 `useResetForm` 会误将表单重置为该旧值，并且因为请求已被标记为 `fresh`（staleTime 为 5 分钟），页面数据将一直卡在错误状态，必须手动按 F5 强制刷新才能显示正确结果。

### 方案选择与优缺点分析 / Technical Choices
我们对比了两种修复思路：
- **方案 A（本 PR 采用）**：在底层统一的 `useUpdateOption` hook 内部对 `invalidateQueries` 和 `toast.success` 进行 100ms 的去抖（Debounce）合并。
  - **优点**：**只需改动 1 个文件**，极易 Review 和合并；向后兼容，所有现有的 29 个设置页面（约 47 处调用）无需任何修改即自动修复；同时解决了重复 Toast 和数据竞争导致表单回弹的 Bug。
  - **缺点**：Toast 提示会比最后一个字段完成的时间提前约 100ms 触发，但用户无感知，比原来堆叠弹窗体验大幅度提升。
- **方案 B**：为底层 hook 添加 `silent` 参数，并在每个页面循环保存的逻辑里单独处理 Toast 和刷新。
  - **优点**：Toast 弹出的时间完全精确。
  - **缺点**：**需要修改多达 30 个文件**，代码改动范围极大，增加合并阻力，且极易与后续更新产生冲突。

综上，方案 A（底层去抖合并）是性价比最高、改动最小且最稳妥的修复手段。

### 具体变更 / Detailed Changes
- `web/default/src/features/system-settings/hooks/use-update-option.ts`
  - 对系统设置相关的 `invalidateQueries` 增加 100ms 的去抖处理，确保所有字段写入完毕后再执行一次刷新。
  - 对成功 toast 提示进行 100ms 的去抖合并，避免重复弹窗。由于使用的是定时器去抖而非固定 Toast ID，因此多次独立的保存操作（间隔 > 100ms）依然能正常触发新的 Toast 反馈。
  - 错误提示（`toast.error`）保持原样，不进行去抖，确保异常信息能即时反馈。

## 🚀 变更类型 / Type of change

- 🐛 修复 Bug (Bug fix)

## 🔗 关联任务 / Related Issue

- 无 (None)

## ✅ 提交前检查项 / Checklist

- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过手动验证。
- [x] **安全合规:** 符合项目代码规范。
<img width="1726" height="711" alt="786817914ebba82d4e851bf44cbc7468" src="https://github.com/user-attachments/assets/4d818635-b625-40e5-8468-b39516840fd3" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the experience when saving multiple system settings in quick succession by reducing duplicate refreshes and repeated success messages.
  * System status updates now refresh more smoothly, helping the interface feel more responsive after changes.
  * Prevents multiple success notifications from appearing during rapid updates; errors are surfaced without triggering delayed success toasts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->