### PR TITLE
fix: only treat 401 as session expiry in default theme auth guard

### DIFF
--- a/web/default/src/routes/_authenticated/route.tsx
+++ b/web/default/src/routes/_authenticated/route.tsx
@@ -39,13 +39,18 @@ export const Route = createFileRoute('/_authenticated')({
 
     // 本地有用户信息，但需要验证 session 是否有效（每个会话只验证一次）
     if (!sessionVerified) {
-      const res = await getSelf().catch(() => null)
+      // 仅 401 视为 session 失效；网络错误/超时/5xx 返回 null 放行，下次导航重验
+      const res = await getSelf().catch((err: unknown) =>
+        (err as { response?: { status?: number } })?.response?.status === 401
+          ? { success: false }
+          : null
+      )
       if (res?.success && res.data) {
         // 验证成功，更新用户信息（可能有变化）
         auth.setUser(res.data)
         sessionVerified = true
-      } else {
-        // 验证失败或 API 调用失败，清除本地缓存并跳转登录页
+      } else if (res) {
+        // 验证失败，清除本地缓存并跳转登录页
         auth.reset()
         throw redirect({
           to: '/sign-in',


### PR DESCRIPTION
## 📝 变更描述 / Description

新UI打开页面时会请求一次 `/api/user/self` 检查登录是否有效。原来的写法把**任何请求失败**(断网、超时、后端正在重启等)都当成"登录过期",直接清掉本地登录态并踢到登录页——但此时 cookie 其实还有效,用户被迫重新登录。

使用起来就是时间没到经常莫名就过期了

修复:只有服务端明确返回 401 才算登录过期;其他失败(网络问题、5xx)先放行,下次导航再自动重新验证。classic 主题本来就是这么处理的,这次把默认主题对齐。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

本地验证(DevTools 里 Block request URL 阻断 `*/api/user/self` 模拟请求失败):

- 修复前:刷新即被踢到登录页,本地登录态被清,恢复网络也回不去;
- 修复后:刷新仍保持登录,恢复网络后自动验证通过;
- 删除 session cookie(真 401)刷新:照常登出,行为不变。

