### PR TITLE
fix: avoid quota int overflow on 32-bit platforms

### DIFF
--- a/common/gin.go
+++ b/common/gin.go
@@ -167,7 +167,22 @@ func GetContextKeyString(c *gin.Context, key constant.ContextKey) string {
 }
 
 func GetContextKeyInt(c *gin.Context, key constant.ContextKey) int {
-	return c.GetInt(string(key))
+	value, exists := c.Get(string(key))
+	if !exists {
+		return 0
+	}
+	switch v := value.(type) {
+	case int:
+		return v
+	case int64:
+		return SafeInt64ToInt(v)
+	case int32:
+		return int(v)
+	case float64:
+		return SafeInt64ToInt(int64(v))
+	default:
+		return c.GetInt(string(key))
+	}
 }
 
 func GetContextKeyBool(c *gin.Context, key constant.ContextKey) bool {

--- a/common/safe_int.go
+++ b/common/safe_int.go
@@ -1,0 +1,13 @@
+package common
+
+import "math"
+
+func SafeInt64ToInt(value int64) int {
+	if value > int64(math.MaxInt) {
+		return math.MaxInt
+	}
+	if value < int64(math.MinInt) {
+		return math.MinInt
+	}
+	return int(value)
+}

--- a/controller/billing.go
+++ b/controller/billing.go
@@ -18,8 +18,8 @@ func GetSubscription(c *gin.Context) {
 		tokenId := c.GetInt("token_id")
 		token, err = model.GetTokenById(tokenId)
 		expiredTime = token.ExpiredTime
-		remainQuota = token.RemainQuota
-		usedQuota = token.UsedQuota
+		remainQuota = common.SafeInt64ToInt(token.RemainQuota)
+		usedQuota = common.SafeInt64ToInt(token.UsedQuota)
 	} else {
 		userId := c.GetInt("id")
 		remainQuota, err = model.GetUserQuota(userId, false)
@@ -75,7 +75,7 @@ func GetUsage(c *gin.Context) {
 	if common.DisplayTokenStatEnabled {
 		tokenId := c.GetInt("token_id")
 		token, err = model.GetTokenById(tokenId)
-		quota = token.UsedQuota
+		quota = common.SafeInt64ToInt(token.UsedQuota)
 	} else {
 		userId := c.GetInt("id")
 		quota, err = model.GetUserUsedQuota(userId)

--- a/controller/token.go
+++ b/controller/token.go
@@ -181,7 +181,7 @@ func AddToken(c *gin.Context) {
 			common.ApiErrorI18n(c, i18n.MsgTokenQuotaNegative)
 			return
 		}
-		maxQuotaValue := int((1000000000 * common.QuotaPerUnit))
+		maxQuotaValue := int64(1000000000 * common.QuotaPerUnit)
 		if token.RemainQuota > maxQuotaValue {
 			common.ApiErrorI18n(c, i18n.MsgTokenQuotaExceedMax, map[string]any{"Max": maxQuotaValue})
 			return
@@ -265,7 +265,7 @@ func UpdateToken(c *gin.Context) {
 			common.ApiErrorI18n(c, i18n.MsgTokenQuotaNegative)
 			return
 		}
-		maxQuotaValue := int((1000000000 * common.QuotaPerUnit))
+		maxQuotaValue := int64(1000000000 * common.QuotaPerUnit)
 		if token.RemainQuota > maxQuotaValue {
 			common.ApiErrorI18n(c, i18n.MsgTokenQuotaExceedMax, map[string]any{"Max": maxQuotaValue})
 			return

--- a/controller/user.go
+++ b/controller/user.go
@@ -1135,7 +1135,7 @@ func ManageUser(c *gin.Context) {
 				return
 			}
 			recordManageAuditFor(c, user.Id, "user.quota_override", map[string]interface{}{
-				"from": logger.LogQuota(oldQuota),
+				"from": logger.LogQuota(common.SafeInt64ToInt(oldQuota)),
 				"to":   logger.LogQuota(req.Value),
 			})
 		default:

--- a/model/payment_method_guard_test.go
+++ b/model/payment_method_guard_test.go
@@ -15,7 +15,7 @@ func insertUserForPaymentGuardTest(t *testing.T, id int, quota int) {
 		Id:       id,
 		Username: "payment_guard_user",
 		Status:   common.UserStatusEnabled,
-		Quota:    quota,
+		Quota:    int64(quota),
 	}
 	require.NoError(t, DB.Create(user).Error)
 }
@@ -84,7 +84,7 @@ func getUserQuotaForPaymentGuardTest(t *testing.T, userID int) int {
 	t.Helper()
 	var user User
 	require.NoError(t, DB.Select("quota").Where("id = ?", userID).First(&user).Error)
-	return user.Quota
+	return int(user.Quota)
 }
 
 func TestRechargeWaffoPancake_RejectsMismatchedPaymentMethod(t *testing.T) {

--- a/model/quota_int64_test.go
+++ b/model/quota_int64_test.go
@@ -28,7 +28,7 @@ func TestGetUserByIdSupportsLargeQuotaValue(t *testing.T) {
 
 	quota, err := GetUserQuota(userID, true)
 	require.NoError(t, err)
-	require.True(t, quota > 0)
+	require.Equal(t, common.SafeInt64ToInt(largeQuota), quota)
 }
 
 func TestGetTokenByIdSupportsLargeQuotaValue(t *testing.T) {

--- a/model/quota_int64_test.go
+++ b/model/quota_int64_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,11 +25,11 @@ func TestGetUserByIdSupportsLargeQuotaValue(t *testing.T) {
 
 	readBack, err := GetUserById(userID, false)
 	require.NoError(t, err)
-	require.Equal(t, largeQuota, readBack.Quota)
+	assert.Equal(t, largeQuota, readBack.Quota)
 
 	quota, err := GetUserQuota(userID, true)
 	require.NoError(t, err)
-	require.Equal(t, common.SafeInt64ToInt(largeQuota), quota)
+	assert.Equal(t, common.SafeInt64ToInt(largeQuota), quota)
 }
 
 func TestGetTokenByIdSupportsLargeQuotaValue(t *testing.T) {
@@ -61,6 +62,6 @@ func TestGetTokenByIdSupportsLargeQuotaValue(t *testing.T) {
 
 	readBack, err := GetTokenById(tokenID)
 	require.NoError(t, err)
-	require.Equal(t, largeQuota, readBack.RemainQuota)
-	require.Equal(t, largeQuota, readBack.UsedQuota)
+	assert.Equal(t, largeQuota, readBack.RemainQuota)
+	assert.Equal(t, largeQuota, readBack.UsedQuota)
 }

--- a/model/quota_int64_test.go
+++ b/model/quota_int64_test.go
@@ -1,0 +1,66 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUserByIdSupportsLargeQuotaValue(t *testing.T) {
+	const userID = 91001
+	const largeQuota = int64(3542971632)
+
+	require.NoError(t, DB.Where("id = ?", userID).Delete(&User{}).Error)
+
+	user := &User{
+		Id:       userID,
+		Username: "large_quota_user",
+		Status:   common.UserStatusEnabled,
+		Quota:    largeQuota,
+		AffCode:  "uq01",
+	}
+	require.NoError(t, DB.Create(user).Error)
+
+	readBack, err := GetUserById(userID, false)
+	require.NoError(t, err)
+	require.Equal(t, largeQuota, readBack.Quota)
+
+	quota, err := GetUserQuota(userID, true)
+	require.NoError(t, err)
+	require.True(t, quota > 0)
+}
+
+func TestGetTokenByIdSupportsLargeQuotaValue(t *testing.T) {
+	const userID = 91002
+	const tokenID = 91003
+	const largeQuota = int64(3542971632)
+
+	require.NoError(t, DB.Where("id = ?", tokenID).Delete(&Token{}).Error)
+	require.NoError(t, DB.Where("id = ?", userID).Delete(&User{}).Error)
+
+	user := &User{
+		Id:       userID,
+		Username: "large_quota_token_user",
+		Status:   common.UserStatusEnabled,
+		Quota:    largeQuota,
+		AffCode:  "uq02",
+	}
+	require.NoError(t, DB.Create(user).Error)
+
+	token := &Token{
+		Id:          tokenID,
+		UserId:      userID,
+		Key:         "sk-large-token-quota",
+		Name:        "large token quota",
+		Status:      common.TokenStatusEnabled,
+		RemainQuota: largeQuota,
+		UsedQuota:   largeQuota,
+	}
+	require.NoError(t, DB.Create(token).Error)
+
+	readBack, err := GetTokenById(tokenID)
+	require.NoError(t, err)
+	require.Equal(t, largeQuota, readBack.RemainQuota)
+	require.Equal(t, largeQuota, readBack.UsedQuota)
+}

--- a/model/subscription.go
+++ b/model/subscription.go
@@ -754,7 +754,7 @@ func PurchaseSubscriptionWithBalance(userId int, planId int) error {
 		if err := tx.Set("gorm:query_option", "FOR UPDATE").Where("id = ?", userId).First(&user).Error; err != nil {
 			return err
 		}
-		if requiredQuota > 0 && user.Quota < requiredQuota {
+		if requiredQuota > 0 && user.Quota < int64(requiredQuota) {
 			return errors.New("余额不足")
 		}
 		if requiredQuota > 0 {

--- a/model/token.go
+++ b/model/token.go
@@ -20,12 +20,12 @@ type Token struct {
 	CreatedTime        int64          `json:"created_time" gorm:"bigint"`
 	AccessedTime       int64          `json:"accessed_time" gorm:"bigint"`
 	ExpiredTime        int64          `json:"expired_time" gorm:"bigint;default:-1"` // -1 means never expired
-	RemainQuota        int            `json:"remain_quota" gorm:"default:0"`
+	RemainQuota        int64          `json:"remain_quota" gorm:"type:bigint;default:0"`
 	UnlimitedQuota     bool           `json:"unlimited_quota"`
 	ModelLimitsEnabled bool           `json:"model_limits_enabled"`
 	ModelLimits        string         `json:"model_limits" gorm:"type:text"`
 	AllowIps           *string        `json:"allow_ips" gorm:"default:''"`
-	UsedQuota          int            `json:"used_quota" gorm:"default:0"` // used quota
+	UsedQuota          int64          `json:"used_quota" gorm:"type:bigint;default:0"` // used quota
 	Group              string         `json:"group" gorm:"default:''"`
 	CrossGroupRetry    bool           `json:"cross_group_retry"` // 跨分组重试，仅auto分组有效
 	DeletedAt          gorm.DeletedAt `gorm:"index"`

--- a/model/user.go
+++ b/model/user.go
@@ -36,14 +36,14 @@ type User struct {
 	TelegramId       string                     `json:"telegram_id" gorm:"column:telegram_id;index"`
 	VerificationCode string                     `json:"verification_code" gorm:"-:all"`                         // this field is only for Email verification, don't save it to database!
 	AccessToken      *string                    `json:"-" gorm:"type:char(32);column:access_token;uniqueIndex"` // this token is for system management
-	Quota            int                        `json:"quota" gorm:"type:int;default:0"`
-	UsedQuota        int                        `json:"used_quota" gorm:"type:int;default:0;column:used_quota"` // used quota
-	RequestCount     int                        `json:"request_count" gorm:"type:int;default:0;"`               // request number
+	Quota            int64                      `json:"quota" gorm:"type:bigint;default:0"`
+	UsedQuota        int64                      `json:"used_quota" gorm:"type:bigint;default:0;column:used_quota"` // used quota
+	RequestCount     int                        `json:"request_count" gorm:"type:int;default:0;"`                  // request number
 	Group            string                     `json:"group" gorm:"type:varchar(64);default:'default'"`
 	AffCode          string                     `json:"aff_code" gorm:"type:varchar(32);column:aff_code;uniqueIndex"`
 	AffCount         int                        `json:"aff_count" gorm:"type:int;default:0;column:aff_count"`
-	AffQuota         int                        `json:"aff_quota" gorm:"type:int;default:0;column:aff_quota"`           // 邀请剩余额度
-	AffHistoryQuota  int                        `json:"aff_history_quota" gorm:"type:int;default:0;column:aff_history"` // 邀请历史额度
+	AffQuota         int64                      `json:"aff_quota" gorm:"type:bigint;default:0;column:aff_quota"`           // 邀请剩余额度
+	AffHistoryQuota  int64                      `json:"aff_history_quota" gorm:"type:bigint;default:0;column:aff_history"` // 邀请历史额度
 	InviterId        int                        `json:"inviter_id" gorm:"type:int;column:inviter_id;index"`
 	DeletedAt        gorm.DeletedAt             `gorm:"index"`
 	LinuxDOId        string                     `json:"linux_do_id" gorm:"column:linux_do_id;index"`
@@ -59,7 +59,7 @@ func (user *User) ToBaseUser() *UserBase {
 	cache := &UserBase{
 		Id:       user.Id,
 		Group:    user.Group,
-		Quota:    user.Quota,
+		Quota:    common.SafeInt64ToInt(user.Quota),
 		Status:   user.Status,
 		Username: user.Username,
 		Setting:  user.Setting,
@@ -437,8 +437,8 @@ func inviteUser(inviterId int) (err error) {
 		return err
 	}
 	user.AffCount++
-	user.AffQuota += common.QuotaForInviter
-	user.AffHistoryQuota += common.QuotaForInviter
+	user.AffQuota += int64(common.QuotaForInviter)
+	user.AffHistoryQuota += int64(common.QuotaForInviter)
 	return DB.Save(user).Error
 }
 
@@ -462,13 +462,13 @@ func (user *User) TransferAffQuotaToQuota(quota int) error {
 	}
 
 	// 再次检查用户的AffQuota是否足够
-	if user.AffQuota < quota {
+	if user.AffQuota < int64(quota) {
 		return errors.New("邀请额度不足！")
 	}
 
 	// 更新用户额度
-	user.AffQuota -= quota
-	user.Quota += quota
+	user.AffQuota -= int64(quota)
+	user.Quota += int64(quota)
 
 	// 保存用户状态
 	if err := tx.Save(user).Error; err != nil {
@@ -536,7 +536,7 @@ func (user *User) Insert(inviterId int) error {
 			if err := user.prepareForInsert(tx); err != nil {
 				return err
 			}
-			user.Quota = common.QuotaForNewUser
+			user.Quota = int64(common.QuotaForNewUser)
 			user.AffCode = common.GetRandomString(4)
 
 			// 初始化用户设置，包括默认的边栏配置
@@ -600,7 +600,7 @@ func (user *User) InsertWithTx(tx *gorm.DB, inviterId int) error {
 		if err := user.prepareForInsert(tx); err != nil {
 			return err
 		}
-		user.Quota = common.QuotaForNewUser
+		user.Quota = int64(common.QuotaForNewUser)
 		user.AffCode = common.GetRandomString(4)
 
 		// 初始化用户设置
@@ -966,17 +966,18 @@ func GetUserQuota(id int, fromDB bool) (quota int, err error) {
 		// Don't return error - fall through to DB
 	}
 	fromDB = true
-	err = DB.Model(&User{}).Where("id = ?", id).Select("quota").Find(&quota).Error
+	var rawQuota int64
+	err = DB.Model(&User{}).Where("id = ?", id).Select("quota").Find(&rawQuota).Error
 	if err != nil {
 		return 0, err
 	}
-
-	return quota, nil
+	return common.SafeInt64ToInt(rawQuota), nil
 }
 
 func GetUserUsedQuota(id int) (quota int, err error) {
-	err = DB.Model(&User{}).Where("id = ?", id).Select("used_quota").Find(&quota).Error
-	return quota, err
+	var rawQuota int64
+	err = DB.Model(&User{}).Where("id = ?", id).Select("used_quota").Find(&rawQuota).Error
+	return common.SafeInt64ToInt(rawQuota), err
 }
 
 func GetUserEmail(id int) (email string, err error) {

--- a/model/user_cache.go
+++ b/model/user_cache.go
@@ -129,7 +129,7 @@ func GetUserCache(userId int) (userCache *UserBase, err error) {
 	userCache = &UserBase{
 		Id:       user.Id,
 		Group:    user.Group,
-		Quota:    user.Quota,
+		Quota:    common.SafeInt64ToInt(user.Quota),
 		Status:   user.Status,
 		Username: user.Username,
 		Setting:  user.Setting,

--- a/model/user_update_test.go
+++ b/model/user_update_test.go
@@ -57,8 +57,8 @@ func TestUserUpdateDoesNotOverwriteAccountingFields(t *testing.T) {
 	var got User
 	require.NoError(t, DB.First(&got, user.Id).Error)
 	assert.Equal(t, "after", got.DisplayName)
-	assert.Equal(t, 600, got.Quota)
-	assert.Equal(t, 420, got.UsedQuota)
+	assert.Equal(t, int64(600), got.Quota)
+	assert.Equal(t, int64(420), got.UsedQuota)
 	assert.Equal(t, 4, got.RequestCount)
 }
 
@@ -86,8 +86,8 @@ func TestUpdateUserSettingOnlyUpdatesSetting(t *testing.T) {
 
 	var got User
 	require.NoError(t, DB.First(&got, user.Id).Error)
-	assert.Equal(t, 750, got.Quota)
-	assert.Equal(t, 270, got.UsedQuota)
+	assert.Equal(t, int64(750), got.Quota)
+	assert.Equal(t, int64(270), got.UsedQuota)
 	assert.Equal(t, 4, got.RequestCount)
 	assert.Equal(t, "zh", got.GetSetting().Language)
 }

--- a/service/quota.go
+++ b/service/quota.go
@@ -142,8 +142,8 @@ func PreWssConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, usag
 		return fmt.Errorf("user quota is not enough, user quota: %s, need quota: %s", logger.FormatQuota(userQuota), logger.FormatQuota(quota))
 	}
 
-	if !token.UnlimitedQuota && token.RemainQuota < quota {
-		return fmt.Errorf("token quota is not enough, token remain quota: %s, need quota: %s", logger.FormatQuota(token.RemainQuota), logger.FormatQuota(quota))
+	if !token.UnlimitedQuota && token.RemainQuota < int64(quota) {
+		return fmt.Errorf("token quota is not enough, token remain quota: %s, need quota: %s", logger.FormatQuota(common.SafeInt64ToInt(token.RemainQuota)), logger.FormatQuota(quota))
 	}
 
 	err = PostConsumeQuota(relayInfo, quota, 0, false)
@@ -393,8 +393,8 @@ func PreConsumeTokenQuota(relayInfo *relaycommon.RelayInfo, quota int) error {
 	if err != nil {
 		return err
 	}
-	if !relayInfo.TokenUnlimited && token.RemainQuota < quota {
-		return fmt.Errorf("token quota is not enough, token remain quota: %s, need quota: %s", logger.FormatQuota(token.RemainQuota), logger.FormatQuota(quota))
+	if !relayInfo.TokenUnlimited && token.RemainQuota < int64(quota) {
+		return fmt.Errorf("token quota is not enough, token remain quota: %s, need quota: %s", logger.FormatQuota(common.SafeInt64ToInt(token.RemainQuota)), logger.FormatQuota(quota))
 	}
 	err = model.DecreaseTokenQuota(relayInfo.TokenId, relayInfo.TokenKey, quota)
 	if err != nil {

--- a/service/task_billing_test.go
+++ b/service/task_billing_test.go
@@ -74,7 +74,7 @@ func truncate(t *testing.T) {
 
 func seedUser(t *testing.T, id int, quota int) {
 	t.Helper()
-	user := &model.User{Id: id, Username: "test_user", Quota: quota, Status: common.UserStatusEnabled}
+	user := &model.User{Id: id, Username: "test_user", Quota: int64(quota), Status: common.UserStatusEnabled}
 	require.NoError(t, model.DB.Create(user).Error)
 }
 
@@ -86,7 +86,7 @@ func seedToken(t *testing.T, id int, userId int, key string, remainQuota int) {
 		Key:         key,
 		Name:        "test_token",
 		Status:      common.TokenStatusEnabled,
-		RemainQuota: remainQuota,
+		RemainQuota: int64(remainQuota),
 		UsedQuota:   0,
 	}
 	require.NoError(t, model.DB.Create(token).Error)
@@ -147,21 +147,21 @@ func getUserQuota(t *testing.T, id int) int {
 	t.Helper()
 	var user model.User
 	require.NoError(t, model.DB.Select("quota").Where("id = ?", id).First(&user).Error)
-	return user.Quota
+	return int(user.Quota)
 }
 
 func getTokenRemainQuota(t *testing.T, id int) int {
 	t.Helper()
 	var token model.Token
 	require.NoError(t, model.DB.Select("remain_quota").Where("id = ?", id).First(&token).Error)
-	return token.RemainQuota
+	return int(token.RemainQuota)
 }
 
 func getTokenUsedQuota(t *testing.T, id int) int {
 	t.Helper()
 	var token model.Token
 	require.NoError(t, model.DB.Select("used_quota").Where("id = ?", id).First(&token).Error)
-	return token.UsedQuota
+	return int(token.UsedQuota)
 }
 
 func getSubscriptionUsed(t *testing.T, id int) int64 {


### PR DESCRIPTION
Fixes #5877

## Summary
- store persisted user and token quota fields as `int64` so 32-bit runtimes can read large quota values without scan overflow
- keep legacy `int`-based boundaries stable by adding a small `SafeInt64ToInt` helper where older controller/cache paths still require `int`
- add focused regression tests for reading `3542971632` quota values from both `users` and `tokens`

## Testing
- `go test ./model -run 'Test(GetUserByIdSupportsLargeQuotaValue|GetTokenByIdSupportsLargeQuotaValue|UserUpdateDoesNotOverwriteAccountingFields|UpdateUserSettingOnlyUpdatesSetting|RechargeWaffoPancake_RejectsMismatchedPaymentMethod)' -count=1`
- `go test ./model -count=1`
- `go test ./controller -count=1`
- `go test ./service -run TestDoesNotExist -count=1`

## Notes
- `go test ./service -count=1` still fails on `origin/main` in `TestObserveChannelAffinityUsageCacheByRelayFormat_*`; I verified the same baseline failure in a clean worktree at `917a2cff64feed0acd687298252bd400adf293e0`, so it is not introduced by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quota values now support much larger numbers for user and token records, including persistence and retrieval for large balances.
* **Bug Fixes**
  * Fixed quota sufficiency and validation comparisons to use consistent large-number handling, preventing incorrect “insufficient quota” outcomes.
  * Improved quota display, caching, and audit logging to preserve accurate values for large balances and avoid overflow.
* **Tests**
  * Added/updated tests to verify correct behavior with large `int64` quota values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->