### PR TITLE
release: publish linux armv7 binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
           sudo apt-get update
           DEBIAN_FRONTEND=noninteractive sudo apt-get install -y gcc-aarch64-linux-gnu
           CC=aarch64-linux-gnu-gcc CGO_ENABLED=1 GOOS=linux GOARCH=arm64 go build -ldflags "-s -w -X 'new-api/common.Version=$VERSION' -extldflags '-static'" -o new-api-arm64-$VERSION
+      - name: Build Backend (armv7)
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -ldflags "-s -w -X 'new-api/common.Version=$VERSION'" -o new-api-armv7-$VERSION
       - name: Generate checksums
         run: sha256sum new-api-* > checksums-linux.txt
 


### PR DESCRIPTION
Refs #5878

## Summary
- add a Linux release step that publishes a `linux/arm/v7` backend binary alongside the existing `amd64` and `arm64` artifacts
- keep the change minimal by reusing the existing frontend build outputs, checksum generation, and release file globs
- avoid mixing this PR with Docker armv7 publishing or deployment-doc changes

## Verification
- parsed `.github/workflows/release.yml` successfully via PyYAML
- verified local cross-compilation with:
  `CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -ldflags "-s -w -X 'new-api/common.Version=test-armv7'" -o new-api-armv7-test-armv7`
- confirmed the existing `sha256sum new-api-*` and release `new-api-*` globs will automatically include the new armv7 artifact

## Notes
- this PR only adds the binary release path for armv7
- Docker armv7 image publishing and docs can be handled separately if maintainers want to support that path too


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an ARMv7 Linux backend build to release artifacts, expanding support for additional device architectures.
  * The new ARMv7 binary is now included automatically in the release package and checksum generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->