### PR TITLE
fix(web): 修复 Shadow DOM 隔离渲染下自定义 HTML 深浅色失效的问题

### DIFF
--- a/web/default/src/components/html-content.tsx
+++ b/web/default/src/components/html-content.tsx
@@ -134,6 +134,11 @@ function sanitizeHtmlContent(
   return DOMPurify.sanitize(content)
 }
 
+function syncDarkClass(wrapper: HTMLElement): void {
+  const isDark = document.documentElement.classList.contains('dark')
+  wrapper.classList.toggle('dark', isDark)
+}
+
 function IsolatedHtmlContent(props: {
   className?: string
   html: string
@@ -153,13 +158,27 @@ function IsolatedHtmlContent(props: {
         'style, link[rel="stylesheet"]'
       ),
     ].map((node) => node.cloneNode(true))
+
+    const wrapper = document.createElement('div')
+    syncDarkClass(wrapper)
+    wrapper.innerHTML = props.html
+
     const contentTemplate = document.createElement('template')
-    contentTemplate.innerHTML = `${isolatedContentBaseStyles}${props.html}`
+    contentTemplate.innerHTML = isolatedContentBaseStyles
 
     shadowRoot.replaceChildren(
       ...applicationStyleNodes,
-      contentTemplate.content
+      contentTemplate.content,
+      wrapper
     )
+
+    const observer = new MutationObserver(() => syncDarkClass(wrapper))
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    })
+
+    return () => observer.disconnect()
   }, [props.html])
 
   return (


### PR DESCRIPTION

> [!IMPORTANT]
> 请提供人工撰写的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

**核心修复：深浅色模式适配**
修复了自定义 HTML 页面在 Shadow DOM 隔离渲染模式下，无法随系统自动切换深浅色主题的问题。
在 Shadow DOM 内部增加了一层包装容器（`wrapper`），并通过 `MutationObserver` 实时监听外部主文档（`document.documentElement`）的 `class` 变化，将 `dark` 类名动态同步至该包装容器上。这使得被克隆进 Shadow DOM 的 Tailwind 深色模式 CSS 规则能够重新匹配生效。

**🔍 问题背景与根因排查**
关于自定义页面的渲染逻辑，最近经历了数次变更，导致了样式连环失效。经过在本地的详细排查与测试，还原了完整的原因：
1. **最初的初衷 (#5795)**: 最初的考量是，这几个自定义页面完全由管理员在后台控制，本着“充分信任管理员”的原则，应当赋予他们最大的配置自由度。当时采用的直接渲染模式能让自定义 HTML 无缝继承主应用的排版与深浅色变量，表现完美。
2. **样式隔离的副作用 (Commit `1bff599`)**: 出于防止恶意代码影响全局的考虑，核心团队将渲染方案重写为了 **Shadow DOM 隔离渲染** 并严格限制了 `DOMPurify` 规则。虽然杜绝了外部污染，但 Shadow DOM 的“绝对隔离”特性使得系统原本的 Tailwind 样式彻底进不去自定义内容中，导致了“样式白板”现象。
3. **#5860 修复的局限性**: 随后合并的 #5860 试图通过把全局的 `<style>` 标签克隆进 Shadow DOM 来恢复排版。但遗漏了 Tailwind 深浅色生效的核心机制（**依赖祖先元素上的 `.dark` 类名**）。由于 Shadow DOM 内部无法感知外部标签的 class，这些深色 CSS 永远无法命中触发，导致深浅色切换失效。
本 PR 补齐了这“最后一块拼图”。

**🤔 关于技术路线的架构探讨**
虽然本 PR 已彻底修复当前 Shadow DOM 下的深浅色问题，但借此想向核心团队提出一个产品层面的抉择探讨：
采用目前的 **Shadow DOM + 强过滤** 机制，意味着管理员在后台添加的**任何包含 `<script>` 的代码都必定无法执行**。这将导致以下常见场景永远无法在自定义页面中实现：
* 📈 嵌入百度统计 / Google Analytics 等分析代码
* 💬 挂载 Crisp / Intercom 等客服悬浮窗插件
* 🐦 嵌入 Twitter 动态组件或第三方表单

如果团队认为安全性高于一切，本 PR 提供了完善的深浅色修复，可直接合并（预期内隔离）。
如果团队认为应将选择权交还给管理员（毕竟是最高权限后台配置），建议后续考虑退回到 #5795 最初的逻辑，允许管理员自行对其配置的外部代码安全负责。抛砖引玉，供各位定夺。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - 请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug
- [ ] ✨ 新功能 (New feature) - 重大特性建议先通过 Issue 沟通
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Related to #5860
- Related to #5795
- Related to 1bff59969

## ✅ 提交前检查项 / Checklist
- [x] 人工确认: 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] 非重复提交: 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] Bug fix 说明: 若此 PR 标记为 Bug fix，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] 变更理解: 我已理解这些更改的工作原理及可能影响。
- [x] 范围聚焦: 本 PR 未包含任何与当前任务无关的代码改动。
- [x] 本地验证: 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] 安全合规: 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- 已在本地手动验证：在自定义主页配置 HTML 后，多次切换系统深浅色主题，Shadow DOM 内部样式随之流畅切换，无闪烁。
- 检查 `bun run typecheck` 与 `bunx oxlint` 均通过无异常。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Isolated HTML content now stays in sync with the app’s dark mode setting.
  * Embedded content is wrapped more consistently, improving theme handling during updates.
* **Bug Fixes**
  * Fixed isolated HTML rendering so the dark class updates automatically when the page theme changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->