### PR TITLE
fix(classic): fix classic web build failures

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,18 +1,18 @@
 WEB_DIR = ./web/default
 WEB_CLASSIC_DIR = ./web/classic
-BACKEND_DIR = .
+API_DIR = .
 DEV_WEB_DEFAULT_PORT ?= 5173
 DEV_WEB_CLASSIC_PORT ?= 5174
 DEV_COMPOSE_FILE = docker-compose.dev.yml
 DEV_POSTGRES_SERVICE = postgres
-DEV_BACKEND_SERVICE = new-api
+DEV_API_SERVICE = new-api
 DEV_POSTGRES_DB = new-api
 DEV_POSTGRES_USER = root
 DEV_SQLITE_PATH ?= one-api.db
 
-.PHONY: all build-web build-web-classic build-all-web start-backend dev dev-api dev-api-rebuild dev-web dev-web-classic reset-setup
+.PHONY: all build-web build-web-classic build-all-web start-api dev dev-api dev-api-rebuild dev-web dev-web-classic reset-setup
 
-all: build-all-web start-backend
+all: build-all-web start-api
 
 build-web:
 	@echo "Building default web..."
@@ -26,17 +26,17 @@ build-web-classic:
 
 build-all-web: build-web build-web-classic
 
-start-backend:
-	@echo "Starting backend dev server..."
-	@cd $(BACKEND_DIR) && go run main.go &
+start-api:
+	@echo "Starting api dev server..."
+	@cd $(API_DIR) && go run main.go &
 
 dev-api:
-	@echo "Starting backend services (docker)..."
+	@echo "Starting api services (docker)..."
 	@docker compose -f $(DEV_COMPOSE_FILE) up -d
 
 dev-api-rebuild:
-	@echo "Rebuilding and starting backend service (docker)..."
-	@docker compose -f $(DEV_COMPOSE_FILE) up -d --build $(DEV_BACKEND_SERVICE)
+	@echo "Rebuilding and starting api service (docker)..."
+	@docker compose -f $(DEV_COMPOSE_FILE) up -d --build $(DEV_API_SERVICE)
 
 dev-web:
 	@echo "Starting default web dev server..."
@@ -60,15 +60,15 @@ reset-setup:
 			-c 'DELETE FROM setups;' \
 			-c 'DELETE FROM users WHERE role = 100;' \
 			-c "DELETE FROM options WHERE key IN ('SelfUseModeEnabled', 'DemoSiteEnabled');"; \
-		echo "Restarting docker dev backend so setup status is recalculated..."; \
-		docker compose -f $(DEV_COMPOSE_FILE) restart $(DEV_BACKEND_SERVICE); \
+		echo "Restarting docker dev api so setup status is recalculated..."; \
+		docker compose -f $(DEV_COMPOSE_FILE) restart $(DEV_API_SERVICE); \
 	elif db_path="$${SQLITE_PATH:-$(DEV_SQLITE_PATH)}"; db_path="$${db_path%%\?*}"; [ -f "$$db_path" ]; then \
 		db_path="$${SQLITE_PATH:-$(DEV_SQLITE_PATH)}"; \
 		db_path="$${db_path%%\?*}"; \
 		echo "Detected local SQLite database: $$db_path"; \
 		sqlite3 "$$db_path" \
 			"DELETE FROM setups; DELETE FROM users WHERE role = 100; DELETE FROM options WHERE key IN ('SelfUseModeEnabled', 'DemoSiteEnabled');"; \
-		echo "SQLite setup state reset. Restart the local backend process before testing the setup wizard."; \
+		echo "SQLite setup state reset. Restart the local api process before testing the setup wizard."; \
 	else \
 		echo "No running docker dev PostgreSQL or local SQLite database found."; \
 		echo "Start the dev stack with 'make dev-api', or set SQLITE_PATH/DEV_SQLITE_PATH to your local SQLite database."; \

--- a/web/classic/rsbuild.config.ts
+++ b/web/classic/rsbuild.config.ts
@@ -10,6 +10,10 @@ const semiUiDir = path.resolve(
   path.dirname(require.resolve('@douyinfe/semi-ui')),
   '../..',
 )
+const semiDateFnsDir = path.resolve(
+  semiUiDir,
+  '../semi-foundation/node_modules/date-fns',
+)
 
 export default defineConfig(({ envMode }) => {
   const env = loadEnv({ mode: envMode, prefixes: ['VITE_'] })
@@ -47,6 +51,7 @@ export default defineConfig(({ envMode }) => {
           semiUiDir,
           'dist/css/semi.css',
         ),
+        'date-fns': semiDateFnsDir,
       },
     },
     html: {

--- a/web/classic/src/helpers/render.jsx
+++ b/web/classic/src/helpers/render.jsx
@@ -99,13 +99,12 @@ import {
   SiOkta,
   SiOpenid,
   SiReddit,
-  SiSlack,
   SiTelegram,
   SiTwitch,
   SiWechat,
   SiX,
 } from 'react-icons/si';
-import { FaLinkedin } from 'react-icons/fa';
+import { FaLinkedin, FaSlack } from 'react-icons/fa';
 
 // 获取侧边栏Lucide图标组件
 export function getLucideIcon(key, selected = false) {
@@ -512,7 +511,7 @@ const oauthProviderIconMap = {
   linkedin: FaLinkedin,
   x: SiX,
   twitter: SiX,
-  slack: SiSlack,
+  slack: FaSlack,
   telegram: SiTelegram,
   wechat: SiWechat,
   keycloak: SiKeycloak,


### PR DESCRIPTION


# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

### 问题描述
- classic 前端构建会因为 react-icons/si 不存在 SiSlack 导出而失败。
- Semi 依赖的 date-fns-tz@1.3.8 会解析到根部 date-fns@4，触发 package exports 兼容性错误。
- makefile 中仍存在 backend 命名，与现有 web/api 命名约定不一致。

### 修复方式
- 将 Slack OAuth 图标改为 react-icons/fa 提供的 FaSlack。
- 在 classic Rsbuild 配置中将 date-fns alias 到 Semi 自带的 date-fns v2 副本。
- 将 makefile 中 backend 相关变量、目标和提示文案统一改为 api。

### 测试说明
- 已执行 make build-web-classic，构建通过。
- 已执行 make -n all 和 make -n dev-api-rebuild，目标解析正常。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ ] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [ ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [ ] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Slack sign-in icon to use the standard Slack branding.
  * Improved dependency resolution for a UI package to help the app load consistently in the classic web experience.
* **Chores**
  * Renamed local development commands and labels from “backend” to “api” for clearer setup and restart workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->