### PR TITLE
fix(web/classic): use POST /api/channel/:id/status for enable/disable

### DIFF
--- a/web/classic/src/hooks/channels/useChannelsData.jsx
+++ b/web/classic/src/hooks/channels/useChannelsData.jsx
@@ -443,17 +443,20 @@ export const useChannelsData = () => {
   const manageChannel = async (id, action, record, value) => {
     let data = { id };
     let res;
+    // POST /api/channel/:id/status 返回 {data: changed bool}，不再是 channel 对象，
+    // enable/disable 后用本地推断的目标状态更新 record.status
+    let statusAfter;
     switch (action) {
       case 'delete':
         res = await API.delete(`/api/channel/${id}/`);
         break;
       case 'enable':
-        data.status = 1;
-        res = await API.put('/api/channel/', data);
+        statusAfter = 1;
+        res = await API.post(`/api/channel/${id}/status`, { status: 1 });
         break;
       case 'disable':
-        data.status = 2;
-        res = await API.put('/api/channel/', data);
+        statusAfter = 2;
+        res = await API.post(`/api/channel/${id}/status`, { status: 2 });
         break;
       case 'priority':
         if (value === '') return;
@@ -475,10 +478,13 @@ export const useChannelsData = () => {
     const { success, message } = res.data;
     if (success) {
       showSuccess(t('操作成功完成！'));
-      let channel = res.data.data;
       let newChannels = [...channels];
-      if (action !== 'delete') {
-        record.status = channel.status;
+      if (action === 'enable' || action === 'disable') {
+        // POST /api/channel/:id/status -> {success, data: changed bool}
+        record.status = statusAfter;
+      } else if (action !== 'delete') {
+        // PUT /api/channel/ -> {success, data: channel object}
+        record.status = res.data.data.status;
       }
       setChannels(newChannels);
     } else {


### PR DESCRIPTION
## Problem

PR #5755 (4aee5f7d) made the backend reject `status` in `PUT /api/channel/` and migrated the **default** theme to `POST /api/channel/:id/status`. The **classic** theme's `manageChannel` (`web/classic/src/hooks/channels/useChannelsData.jsx`) was left using `PUT /api/channel/` + `body{status}`, so **enable/disable is broken under classic theme on rc.16+** — the PUT handler returns the status-field interceptor's "invalid params" error.

## Fix

Switch classic's enable/disable to the same `POST /api/channel/:id/status` endpoint used by the default theme. `record.status` is derived from the target value (1/2) because POST returns `{data: changed bool}`, not a channel object. `priority` / `weight` / `enable_all` keep PUT (their body has no `status` field, so they don't trip the interceptor).

## Verification

- Built `web/classic` on rc.16 base; grepped the minified bundle:
  - `API.post("/api/channel/"+id+"/status", {status})` present (enable + disable)
  - old `case "disable": data.status=2; API.put("/api/channel/", data)` gone
- End-to-end: deployed the patched classic bundle; under classic theme the disable button now issues `POST /api/channel/:id/status` and the backend returns `{success:true}`.

## Note (pre-existing, not from this PR)

Classic build on current `main` is **independently broken**: `web/classic/src/helpers/render.jsx:483` imports `SiSlack` from `react-icons/si`, which was removed by `f5bba114 chore(web): update default web dependencies`. This PR is authored against `main` but the classic bundle was verified on rc.16 (where it still builds). Happy to send the react-icons fix as a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel enable/disable handling to match the latest backend behavior.
  * Channel status now updates more reliably after enabling, disabling, or making other changes.
  * This helps ensure the channel list shows the correct status after an action completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->