### PR TITLE
fix: use int64 for aggregated usage stats on 32-bit

### DIFF
--- a/model/aggregate_int64_test.go
+++ b/model/aggregate_int64_test.go
@@ -1,0 +1,115 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuotaDataAggregatesSupportInt64Totals(t *testing.T) {
+	truncateTables(t)
+
+	require.NoError(t, DB.Create(&QuotaData{
+		UserID:    1,
+		Username:  "alice",
+		ModelName: "gpt-a",
+		CreatedAt: 1000,
+		Count:     1400000000,
+		Quota:     1500000000,
+		TokenUsed: 1200000000,
+	}).Error)
+	require.NoError(t, DB.Create(&QuotaData{
+		UserID:    2,
+		Username:  "bob",
+		ModelName: "gpt-a",
+		CreatedAt: 1000,
+		Count:     900000000,
+		Quota:     1400000000,
+		TokenUsed: 1100000000,
+	}).Error)
+
+	rows, err := GetAllQuotaDates(900, 2000, "")
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, int64(2300000000), rows[0].Count)
+	require.Equal(t, int64(2900000000), rows[0].Quota)
+	require.Equal(t, int64(2300000000), rows[0].TokenUsed)
+}
+
+func TestFlowQuotaDataAggregatesSupportInt64Totals(t *testing.T) {
+	truncateTables(t)
+
+	require.NoError(t, DB.Create(&QuotaData{
+		UserID:    1,
+		Username:  "alice",
+		ModelName: "gpt-a",
+		CreatedAt: 1000,
+		UseGroup:  "vip",
+		Count:     1500000000,
+		Quota:     1500000000,
+		TokenUsed: 1000000000,
+	}).Error)
+	require.NoError(t, DB.Create(&QuotaData{
+		UserID:    1,
+		Username:  "alice",
+		ModelName: "gpt-a",
+		CreatedAt: 1100,
+		UseGroup:  "vip",
+		Count:     900000000,
+		Quota:     1400000000,
+		TokenUsed: 1300000000,
+	}).Error)
+
+	rows, err := GetFlowQuotaData(900, 2000, "", 1, common.RoleCommonUser)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, int64(2400000000), rows[0].Count)
+	require.Equal(t, int64(2900000000), rows[0].Quota)
+	require.Equal(t, int64(2300000000), rows[0].TokenUsed)
+}
+
+func TestLogStatAggregatesSupportInt64Totals(t *testing.T) {
+	truncateTables(t)
+
+	now := time.Now().Unix()
+	logs := []*Log{
+		{
+			UserId:           1,
+			Username:         "alice",
+			CreatedAt:        now - 10,
+			Type:             LogTypeConsume,
+			ModelName:        "gpt-a",
+			TokenName:        "token-a",
+			Quota:            1500000000,
+			PromptTokens:     700000000,
+			CompletionTokens: 600000000,
+			ChannelId:        7,
+			Group:            "vip",
+		},
+		{
+			UserId:           1,
+			Username:         "alice",
+			CreatedAt:        now - 5,
+			Type:             LogTypeConsume,
+			ModelName:        "gpt-a",
+			TokenName:        "token-a",
+			Quota:            1400000000,
+			PromptTokens:     800000000,
+			CompletionTokens: 500000000,
+			ChannelId:        7,
+			Group:            "vip",
+		},
+	}
+	require.NoError(t, LOG_DB.Create(logs).Error)
+
+	stat, err := SumUsedQuota(LogTypeConsume, now-60, now+1, "gpt-a", "alice", "token-a", 7, "vip")
+	require.NoError(t, err)
+	require.Equal(t, int64(2900000000), stat.Quota)
+	require.Equal(t, int64(2), stat.Rpm)
+	require.Equal(t, int64(2600000000), stat.Tpm)
+
+	tokenTotal := SumUsedToken(LogTypeConsume, now-60, now+1, "gpt-a", "alice", "token-a")
+	require.Equal(t, int64(2600000000), tokenTotal)
+}

--- a/model/aggregate_int64_test.go
+++ b/model/aggregate_int64_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,9 +34,9 @@ func TestQuotaDataAggregatesSupportInt64Totals(t *testing.T) {
 	rows, err := GetAllQuotaDates(900, 2000, "")
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	require.Equal(t, int64(2300000000), rows[0].Count)
-	require.Equal(t, int64(2900000000), rows[0].Quota)
-	require.Equal(t, int64(2300000000), rows[0].TokenUsed)
+	assert.Equal(t, int64(2300000000), rows[0].Count)
+	assert.Equal(t, int64(2900000000), rows[0].Quota)
+	assert.Equal(t, int64(2300000000), rows[0].TokenUsed)
 }
 
 func TestFlowQuotaDataAggregatesSupportInt64Totals(t *testing.T) {
@@ -65,9 +66,9 @@ func TestFlowQuotaDataAggregatesSupportInt64Totals(t *testing.T) {
 	rows, err := GetFlowQuotaData(900, 2000, "", 1, common.RoleCommonUser)
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	require.Equal(t, int64(2400000000), rows[0].Count)
-	require.Equal(t, int64(2900000000), rows[0].Quota)
-	require.Equal(t, int64(2300000000), rows[0].TokenUsed)
+	assert.Equal(t, int64(2400000000), rows[0].Count)
+	assert.Equal(t, int64(2900000000), rows[0].Quota)
+	assert.Equal(t, int64(2300000000), rows[0].TokenUsed)
 }
 
 func TestLogStatAggregatesSupportInt64Totals(t *testing.T) {
@@ -106,10 +107,10 @@ func TestLogStatAggregatesSupportInt64Totals(t *testing.T) {
 
 	stat, err := SumUsedQuota(LogTypeConsume, now-60, now+1, "gpt-a", "alice", "token-a", 7, "vip")
 	require.NoError(t, err)
-	require.Equal(t, int64(2900000000), stat.Quota)
-	require.Equal(t, int64(2), stat.Rpm)
-	require.Equal(t, int64(2600000000), stat.Tpm)
+	assert.Equal(t, int64(2900000000), stat.Quota)
+	assert.Equal(t, int64(2), stat.Rpm)
+	assert.Equal(t, int64(2600000000), stat.Tpm)
 
 	tokenTotal := SumUsedToken(LogTypeConsume, now-60, now+1, "gpt-a", "alice", "token-a")
-	require.Equal(t, int64(2600000000), tokenTotal)
+	assert.Equal(t, int64(2600000000), tokenTotal)
 }

--- a/model/log.go
+++ b/model/log.go
@@ -610,9 +610,9 @@ func GetUserLogs(userId int, logType int, startTimestamp int64, endTimestamp int
 }
 
 type Stat struct {
-	Quota int `json:"quota"`
-	Rpm   int `json:"rpm"`
-	Tpm   int `json:"tpm"`
+	Quota int64 `json:"quota"`
+	Rpm   int64 `json:"rpm"`
+	Tpm   int64 `json:"tpm"`
 }
 
 func SumUsedQuota(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string, channel int, group string) (stat Stat, err error) {
@@ -671,7 +671,7 @@ func SumUsedQuota(logType int, startTimestamp int64, endTimestamp int64, modelNa
 	return stat, nil
 }
 
-func SumUsedToken(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string) (token int) {
+func SumUsedToken(logType int, startTimestamp int64, endTimestamp int64, modelName string, username string, tokenName string) (token int64) {
 	tx := LOG_DB.Table("logs").Select("COALESCE(sum(prompt_tokens), 0) + COALESCE(sum(completion_tokens), 0)")
 	if username != "" {
 		tx = tx.Where("username = ?", username)

--- a/model/usedata.go
+++ b/model/usedata.go
@@ -20,9 +20,19 @@ type QuotaData struct {
 	TokenID   int    `json:"token_id" gorm:"index;default:0"`
 	ChannelID int    `json:"channel_id" gorm:"index;default:0"`
 	NodeName  string `json:"node_name" gorm:"index;size:64;default:''"`
-	TokenUsed int64  `json:"token_used" gorm:"type:bigint;default:0"`
-	Count     int64  `json:"count" gorm:"type:bigint;default:0"`
-	Quota     int64  `json:"quota" gorm:"type:bigint;default:0"`
+	TokenUsed int    `json:"token_used" gorm:"default:0"`
+	Count     int    `json:"count" gorm:"default:0"`
+	Quota     int    `json:"quota" gorm:"default:0"`
+}
+
+type QuotaDataAggregate struct {
+	UserID    int    `json:"user_id,omitempty" gorm:"column:user_id"`
+	Username  string `json:"username,omitempty" gorm:"column:username"`
+	ModelName string `json:"model_name,omitempty" gorm:"column:model_name"`
+	CreatedAt int64  `json:"created_at,omitempty" gorm:"column:created_at"`
+	Count     int64  `json:"count" gorm:"column:count"`
+	Quota     int64  `json:"quota" gorm:"column:quota"`
+	TokenUsed int64  `json:"token_used" gorm:"column:token_used"`
 }
 
 type QuotaDataLogParams struct {
@@ -88,8 +98,8 @@ func LogQuotaData(params QuotaDataLogParams) {
 		ChannelID: params.ChannelID,
 		NodeName:  params.NodeName,
 		Count:     1,
-		Quota:     int64(params.Quota),
-		TokenUsed: int64(params.TokenUsed),
+		Quota:     params.Quota,
+		TokenUsed: params.TokenUsed,
 	}
 
 	CacheQuotaDataLock.Lock()
@@ -106,11 +116,10 @@ func SaveQuotaDataCache() {
 	// 2. 如果有数据，就更新数据
 	// 3. 如果没有数据，就插入数据
 	for _, quotaData := range CacheQuotaData {
-		quotaDataDB := &QuotaData{}
-		DB.Table("quota_data").
-			Where("user_id = ? and username = ? and model_name = ? and created_at = ? and use_group = ? and token_id = ? and channel_id = ? and node_name = ?",
-				quotaData.UserID, quotaData.Username, quotaData.ModelName, quotaData.CreatedAt, quotaData.UseGroup, quotaData.TokenID, quotaData.ChannelID, quotaData.NodeName).
-			First(quotaDataDB)
+		var quotaDataDB struct {
+			Id int `gorm:"column:id"`
+		}
+		quotaDataIdentityQuery(DB, quotaData).First(&quotaDataDB)
 		if quotaDataDB.Id > 0 {
 			//quotaDataDB.Count += quotaData.Count
 			//quotaDataDB.Quota += quotaData.Quota
@@ -122,6 +131,13 @@ func SaveQuotaDataCache() {
 	}
 	CacheQuotaData = make(map[string]*QuotaData)
 	common.SysLog(fmt.Sprintf("保存数据看板数据成功，共保存%d条数据", size))
+}
+
+func quotaDataIdentityQuery(db *gorm.DB, quotaData *QuotaData) *gorm.DB {
+	return db.Table("quota_data").
+		Select("id").
+		Where("user_id = ? and username = ? and model_name = ? and created_at = ? and use_group = ? and token_id = ? and channel_id = ? and node_name = ?",
+			quotaData.UserID, quotaData.Username, quotaData.ModelName, quotaData.CreatedAt, quotaData.UseGroup, quotaData.TokenID, quotaData.ChannelID, quotaData.NodeName)
 }
 
 func increaseQuotaData(quotaData *QuotaData) {
@@ -138,8 +154,8 @@ func increaseQuotaData(quotaData *QuotaData) {
 	}
 }
 
-func GetQuotaDataByUsername(username string, startTime int64, endTime int64) (quotaData []*QuotaData, err error) {
-	var quotaDatas []*QuotaData
+func GetQuotaDataByUsername(username string, startTime int64, endTime int64) (quotaData []*QuotaDataAggregate, err error) {
+	var quotaDatas []*QuotaDataAggregate
 	// 从quota_data表中查询数据
 	err = DB.Table("quota_data").
 		Select("user_id, username, model_name, created_at, sum(count) as count, sum(quota) as quota, sum(token_used) as token_used").
@@ -149,8 +165,8 @@ func GetQuotaDataByUsername(username string, startTime int64, endTime int64) (qu
 	return quotaDatas, err
 }
 
-func GetQuotaDataByUserId(userId int, startTime int64, endTime int64) (quotaData []*QuotaData, err error) {
-	var quotaDatas []*QuotaData
+func GetQuotaDataByUserId(userId int, startTime int64, endTime int64) (quotaData []*QuotaDataAggregate, err error) {
+	var quotaDatas []*QuotaDataAggregate
 	// 从quota_data表中查询数据
 	err = DB.Table("quota_data").
 		Select("user_id, username, model_name, created_at, sum(count) as count, sum(quota) as quota, sum(token_used) as token_used").
@@ -160,8 +176,8 @@ func GetQuotaDataByUserId(userId int, startTime int64, endTime int64) (quotaData
 	return quotaDatas, err
 }
 
-func GetQuotaDataGroupByUser(startTime int64, endTime int64) (quotaData []*QuotaData, err error) {
-	var quotaDatas []*QuotaData
+func GetQuotaDataGroupByUser(startTime int64, endTime int64) (quotaData []*QuotaDataAggregate, err error) {
+	var quotaDatas []*QuotaDataAggregate
 	err = DB.Table("quota_data").
 		Select("username, created_at, sum(count) as count, sum(quota) as quota, sum(token_used) as token_used").
 		Where("created_at >= ? and created_at <= ?", startTime, endTime).
@@ -170,11 +186,11 @@ func GetQuotaDataGroupByUser(startTime int64, endTime int64) (quotaData []*Quota
 	return quotaDatas, err
 }
 
-func GetAllQuotaDates(startTime int64, endTime int64, username string) (quotaData []*QuotaData, err error) {
+func GetAllQuotaDates(startTime int64, endTime int64, username string) (quotaData []*QuotaDataAggregate, err error) {
 	if username != "" {
 		return GetQuotaDataByUsername(username, startTime, endTime)
 	}
-	var quotaDatas []*QuotaData
+	var quotaDatas []*QuotaDataAggregate
 	// 从quota_data表中查询数据
 	// only select model_name, sum(count) as count, sum(quota) as quota, model_name, created_at from quota_data group by model_name, created_at;
 	//err = DB.Table("quota_data").Where("created_at >= ? and created_at <= ?", startTime, endTime).Find(&quotaDatas).Error

--- a/model/usedata.go
+++ b/model/usedata.go
@@ -20,9 +20,9 @@ type QuotaData struct {
 	TokenID   int    `json:"token_id" gorm:"index;default:0"`
 	ChannelID int    `json:"channel_id" gorm:"index;default:0"`
 	NodeName  string `json:"node_name" gorm:"index;size:64;default:''"`
-	TokenUsed int    `json:"token_used" gorm:"default:0"`
-	Count     int    `json:"count" gorm:"default:0"`
-	Quota     int    `json:"quota" gorm:"default:0"`
+	TokenUsed int64  `json:"token_used" gorm:"type:bigint;default:0"`
+	Count     int64  `json:"count" gorm:"type:bigint;default:0"`
+	Quota     int64  `json:"quota" gorm:"type:bigint;default:0"`
 }
 
 type QuotaDataLogParams struct {
@@ -88,8 +88,8 @@ func LogQuotaData(params QuotaDataLogParams) {
 		ChannelID: params.ChannelID,
 		NodeName:  params.NodeName,
 		Count:     1,
-		Quota:     params.Quota,
-		TokenUsed: params.TokenUsed,
+		Quota:     int64(params.Quota),
+		TokenUsed: int64(params.TokenUsed),
 	}
 
 	CacheQuotaDataLock.Lock()

--- a/model/usedata_flow.go
+++ b/model/usedata_flow.go
@@ -17,9 +17,9 @@ type FlowQuotaData struct {
 	ChannelID   int    `json:"channel_id,omitempty" gorm:"column:channel_id"`
 	ChannelName string `json:"channel_name,omitempty" gorm:"-"`
 	ModelName   string `json:"model_name" gorm:"column:model_name"`
-	TokenUsed   int    `json:"token_used" gorm:"column:token_used"`
-	Count       int    `json:"count" gorm:"column:count"`
-	Quota       int    `json:"quota" gorm:"column:quota"`
+	TokenUsed   int64  `json:"token_used" gorm:"column:token_used"`
+	Count       int64  `json:"count" gorm:"column:count"`
+	Quota       int64  `json:"quota" gorm:"column:quota"`
 }
 
 func GetFlowQuotaData(startTime int64, endTime int64, username string, userID int, role int) ([]*FlowQuotaData, error) {

--- a/model/usedata_flow_test.go
+++ b/model/usedata_flow_test.go
@@ -119,7 +119,7 @@ func TestGetFlowQuotaDataUsesQuotaDataRoleSpecificDimensions(t *testing.T) {
 	require.Equal(t, "alice", adminRows[0].Username)
 	require.Equal(t, "vip", adminRows[0].UseGroup)
 	require.Equal(t, "east", adminRows[0].ChannelName)
-	require.Equal(t, 150, adminRows[0].Quota)
+	require.Equal(t, int64(150), adminRows[0].Quota)
 
 	selfRows, err := GetFlowQuotaData(900, 2000, "", 1, common.RoleCommonUser)
 	require.NoError(t, err)
@@ -129,7 +129,7 @@ func TestGetFlowQuotaDataUsesQuotaDataRoleSpecificDimensions(t *testing.T) {
 	require.Empty(t, selfRows[0].ChannelName)
 	require.Empty(t, selfRows[0].TokenName)
 	require.Equal(t, "vip", selfRows[0].UseGroup)
-	require.Equal(t, 175, selfRows[0].Quota)
+	require.Equal(t, int64(175), selfRows[0].Quota)
 }
 
 func TestLogQuotaDataSplitsRowsByUseGroupTokenChannelAndNode(t *testing.T) {
@@ -185,9 +185,9 @@ func TestLogQuotaDataSplitsRowsByUseGroupTokenChannelAndNode(t *testing.T) {
 	require.Equal(t, 11, rows[0].TokenID)
 	require.Equal(t, 1, rows[0].ChannelID)
 	require.Equal(t, "node-a", rows[0].NodeName)
-	require.Equal(t, 2, rows[0].Count)
-	require.Equal(t, 150, rows[0].Quota)
-	require.Equal(t, 60, rows[0].TokenUsed)
+	require.Equal(t, int64(2), rows[0].Count)
+	require.Equal(t, int64(150), rows[0].Quota)
+	require.Equal(t, int64(60), rows[0].TokenUsed)
 	require.Equal(t, "default", rows[1].UseGroup)
-	require.Equal(t, 25, rows[1].Quota)
+	require.Equal(t, int64(25), rows[1].Quota)
 }

--- a/model/usedata_flow_test.go
+++ b/model/usedata_flow_test.go
@@ -1,10 +1,12 @@
 package model
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func seedFlowQuotaData(t *testing.T, quotaData QuotaData) {
@@ -132,6 +134,30 @@ func TestGetFlowQuotaDataUsesQuotaDataRoleSpecificDimensions(t *testing.T) {
 	require.Equal(t, int64(175), selfRows[0].Quota)
 }
 
+func TestQuotaDataIdentityQueryOnlyScansID(t *testing.T) {
+	sql := DB.ToSQL(func(tx *gorm.DB) *gorm.DB {
+		var row struct {
+			Id int `gorm:"column:id"`
+		}
+		return quotaDataIdentityQuery(tx, &QuotaData{
+			UserID:    1,
+			Username:  "alice",
+			ModelName: "gpt-a",
+			CreatedAt: 3600,
+			UseGroup:  "vip",
+			TokenID:   11,
+			ChannelID: 1,
+			NodeName:  "node-a",
+		}).First(&row)
+	})
+
+	normalizedSQL := strings.ToLower(sql)
+	require.Contains(t, normalizedSQL, "select `id`")
+	require.NotContains(t, normalizedSQL, "`quota`")
+	require.NotContains(t, normalizedSQL, "`count`")
+	require.NotContains(t, normalizedSQL, "`token_used`")
+}
+
 func TestLogQuotaDataSplitsRowsByUseGroupTokenChannelAndNode(t *testing.T) {
 	truncateTables(t)
 	CacheQuotaDataLock.Lock()
@@ -185,9 +211,9 @@ func TestLogQuotaDataSplitsRowsByUseGroupTokenChannelAndNode(t *testing.T) {
 	require.Equal(t, 11, rows[0].TokenID)
 	require.Equal(t, 1, rows[0].ChannelID)
 	require.Equal(t, "node-a", rows[0].NodeName)
-	require.Equal(t, int64(2), rows[0].Count)
-	require.Equal(t, int64(150), rows[0].Quota)
-	require.Equal(t, int64(60), rows[0].TokenUsed)
+	require.Equal(t, 2, rows[0].Count)
+	require.Equal(t, 150, rows[0].Quota)
+	require.Equal(t, 60, rows[0].TokenUsed)
 	require.Equal(t, "default", rows[1].UseGroup)
-	require.Equal(t, int64(25), rows[1].Quota)
+	require.Equal(t, 25, rows[1].Quota)
 }


### PR DESCRIPTION
## Summary
- widen `quota_data` aggregate counters (`count`, `quota`, `token_used`) to `int64`
- scan flow quota and log statistic aggregates into `int64` targets
- add regression coverage for aggregate totals above 32-bit `int` range

## Why
This is a follow-up to the 32-bit quota overflow fix for ARMv7 environments. User/token quota fields are covered separately, but the dashboard/statistics paths can still exceed `MaxInt32` because they accumulate persisted usage data and SQL `SUM(...)` results.

The change is intentionally scoped to aggregate/stat scan targets and avoids widening single-request billing fields in this PR.

## Tests
- `go test ./model -run "Test(QuotaDataAggregatesSupportInt64Totals|FlowQuotaDataAggregatesSupportInt64Totals|LogStatAggregatesSupportInt64Totals|GetFlowQuotaDataUsesQuotaDataRoleSpecificDimensions|LogQuotaDataSplitsRowsByUseGroupTokenChannelAndNode)$" -count=1`
- `go test ./service -run "TestObserveChannelAffinityUsageCacheByRelayFormat_(MixedMode|UnsupportedModeKeepsEmpty)$" -count=1`

## Notes
`go test ./service -count=1` currently fails in `channel_affinity_usage_cache_test` when the full service package runs, while the named failing tests pass in isolation. This appears to be an existing shared-state/order issue unrelated to this aggregate-int64 change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota and usage aggregation to correctly handle very large totals by using wider integer values for counts, quotas, and token usage metrics, ensuring accurate reporting across standard and filtered views.

* **Tests**
  * Added new test coverage for int64-based quota/usage aggregation across standard and flow/group-specific scenarios.
  * Updated existing assertions to match int64 numeric outputs and added a SQL validation test for the identity-only lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->