### PR TITLE
perf: add composite index (model_name, created_at) for log queries

### DIFF
--- a/model/log.go
+++ b/model/log.go
@@ -59,12 +59,12 @@ func sanitizeClickHouseLikePattern(input string) (string, error) {
 type Log struct {
 	Id                int    `json:"id" gorm:"index:idx_created_at_id,priority:2;index:idx_user_id_id,priority:2"`
 	UserId            int    `json:"user_id" gorm:"index;index:idx_user_id_id,priority:1"`
-	CreatedAt         int64  `json:"created_at" gorm:"bigint;index:idx_created_at_id,priority:1;index:idx_created_at_type"`
+	CreatedAt         int64  `json:"created_at" gorm:"bigint;index:idx_created_at_id,priority:1;index:idx_created_at_type;index:idx_model_name_created_at,priority:2"`
 	Type              int    `json:"type" gorm:"index:idx_created_at_type"`
 	Content           string `json:"content"`
 	Username          string `json:"username" gorm:"index;index:index_username_model_name,priority:2;default:''"`
 	TokenName         string `json:"token_name" gorm:"index;default:''"`
-	ModelName         string `json:"model_name" gorm:"index;index:index_username_model_name,priority:1;default:''"`
+	ModelName         string `json:"model_name" gorm:"index;index:index_username_model_name,priority:1;index:idx_model_name_created_at,priority:1;default:''"`
 	Quota             int    `json:"quota" gorm:"default:0"`
 	PromptTokens      int    `json:"prompt_tokens" gorm:"default:0"`
 	CompletionTokens  int    `json:"completion_tokens" gorm:"default:0"`


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

logs 表上按模型筛选的查询（管理台日志页 `model_name` 筛选、按模型的用量统计）目前只能依赖 `model_name` 单列索引或倒序遍历 `created_at` 索引逐行过滤。当目标模型累计日志量大、或模型在查询时间窗内分布稀疏时，扫描量等于该模型全部历史行数（生产慢日志实测：扫描 30W 行、返回 16 行，最长一次 18.5s）。

新增 `(model_name, created_at)` 复合索引后，扫描范围收敛为"该模型在时间窗内的行数"，列表查询可利用索引有序性在 `LIMIT` 处提前终止，不再受数据分布和优化器计划选择影响。


## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [x] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

MySQL，logs 表 百万行 同一条 SQL 加索引前后对比：

**列表查询（大模型 + 长时间窗，长尾场景）— 提升100 倍：**

```
修改前: [2421.083ms] [rows:100] SELECT * FROM `logs` WHERE logs.model_name = 'gpt-4.1' AND logs.created_at >= 1743436800 AND logs.created_at <= 1783149000 ORDER BY logs.created_at desc, logs.id desc LIMIT 100
修改后: [  21.125ms] [rows:100] SELECT * FROM `logs` WHERE logs.model_name = 'gpt-4.1' AND logs.created_at >= 1743436800 AND logs.created_at <= 1783149000 ORDER BY logs.created_at desc, logs.id desc LIMIT 100
```

