### PR TITLE
fix: remove sample special usable groups leaking into pricing page

### DIFF
--- a/setting/ratio_setting/group_ratio.go
+++ b/setting/ratio_setting/group_ratio.go
@@ -25,12 +25,7 @@ var defaultGroupGroupRatio = map[string]map[string]float64{
 
 var groupGroupRatioMap = types.NewRWMap[string, map[string]float64]()
 
-var defaultGroupSpecialUsableGroup = map[string]map[string]string{
-	"vip": {
-		"append_1":   "vip_special_group_1",
-		"-:remove_1": "vip_removed_group_1",
-	},
-}
+var defaultGroupSpecialUsableGroup = map[string]map[string]string{}
 
 type GroupRatioSetting struct {
 	GroupRatio              *types.RWMap[string, float64]            `json:"group_ratio"`


### PR DESCRIPTION
## 📝 变更描述 / Description

`defaultGroupSpecialUsableGroup` 里带了一份示例数据（vip 下的 `append_1` / `-:remove_1`），只要管理员没在后台保存过这项配置，示例就会当成真配置生效。结果 vip 用户打开 `/pricing`，分组筛选里会多出一个不存在的 `append_1`（无倍率），而且这个假分组还能通过 token 分组校验。

`/api/user/self/groups` 之所以看不到它，是因为那个接口会跟 `GroupRatio` 求交集过滤掉了，pricing 接口没有这层过滤。

修复：把示例默认值清空。示例配置不该进运行时，已保存过配置的实例走数据库值（`RWMap.UnmarshalJSON` 是整体替换），完全不受影响。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5901

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

本地复现（vip 用户，未保存过 group_special_usable_group）：

- 修复前：/pricing 分组筛选出现 `append_1`，无倍率；
<img width="700" height="356" alt="image" src="https://github.com/user-attachments/assets/fd96b773-d151-41d3-a2b8-40c2ddebc9cf" />

- 修复后：只剩真实分组，正常显示；
<img width="682" height="322" alt="image" src="https://github.com/user-attachments/assets/d9f2a0a0-89ea-47b6-8e6b-04051c92020e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default configuration behavior so no special group settings are preloaded automatically during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->