### PR TITLE
fix(web): 补全首页 URL iframe 的 sandbox token，修复字体失效与 target=_top 菜单跳转 (#5907)

### DIFF
--- a/web/default/src/features/home/index.tsx
+++ b/web/default/src/features/home/index.tsx
@@ -47,11 +47,21 @@ export function Home() {
     if (isUrl) {
       return (
         <PublicLayout showMainContainer={false}>
+          {/*
+            The custom home page URL is admin-configured (trusted).
+            - allow-same-origin: keep the embedded page's real origin so its own
+              same-origin resources (notably @font-face fonts) are not treated as
+              cross-origin and blocked by CORS.
+            - allow-top-navigation-by-user-activation: let the embedded page's
+              target="_top" links navigate the top-level window on user click
+              (e.g. nav/menu links), which the default sandbox otherwise blocks.
+            This mirrors the existing trusted-iframe usage in web-preview.tsx.
+          */}
           <iframe
             src={content}
             className='h-screen w-full border-none'
             title={t('Custom Home Page')}
-            sandbox='allow-forms allow-popups allow-popups-to-escape-sandbox allow-scripts'
+            sandbox='allow-same-origin allow-top-navigation-by-user-activation allow-forms allow-popups allow-popups-to-escape-sandbox allow-scripts'
           />
         </PublicLayout>
       )


### PR DESCRIPTION
## 📝 变更描述 / Description

首页内容（HomePageContent）设置为 URL 时，首页用 `<iframe>` 嵌入该 URL。该 iframe 自 #5760（commit `0b48ad86`）起带上了 `sandbox` 属性，但 token 集不完整，给被嵌页面带来**两个回归**（rc.16 前均无此问题）：

**1. 缺 `allow-same-origin` → 自定义字体失效**
缺该 token 时被嵌文档被放入 opaque origin（`null`），其**同域** `@font-face` 字体请求被当作跨域：字体请求始终以 CORS 模式发起、携带 `Origin: null`，被嵌页面服务器通常不为自家静态字体返回 `Access-Control-Allow-Origin`，于是字体被拦、回退系统字体。表现为"直接打开 URL 字体正常、放进首页 iframe 字体丢失"。

**2. 缺 `allow-top-navigation-by-user-activation` → `target="_top"` 菜单链接点击无跳转**
被嵌页面的导航/菜单链接普遍用 `target="_top"`（意图跳出 iframe、导航顶层窗口）。默认 sandbox 禁止顶层导航，桌面浏览器（Chrome/Edge）严格执行，导致点击这些链接静默无反应；部分移动端浏览器对 sandboxed 导航执行较宽松，故手机端表现为"能跳"，桌面端"不跳"。

本 PR 为该 iframe 补上这两个 token。首页 URL 由管理员配置（可信来源），项目已有同类可信 iframe 用法（`components/ai-elements/web-preview.tsx` 使用 `allow-scripts allow-same-origin` 组合），本改动与之一致，并加注释说明取舍。选用 `allow-top-navigation-by-user-activation`（仅用户点击可触发顶层导航）而非更宽松的 `allow-top-navigation`，以在恢复菜单跳转的同时保持最小授权。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue*

## 🔗 关联任务 / Related Issue
- Closes #5907

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述。（另见下方 AI 协助声明）
- [x] **非重复提交:** 我已搜索现有 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 本 PR 已关联 Issue #5907，两处均为 rc.16 引入的回归，非设计取舍。
- [x] **变更理解:** 我已理解这些更改的工作原理及影响（含 `allow-same-origin` + `allow-scripts` 的安全取舍：仅用于管理员配置的可信 URL；顶层导航采用 user-activation 变体以最小授权）。
- [x] **范围聚焦:** 本 PR 仅改动首页 iframe 的 sandbox 属性一处（及说明注释），无无关改动。
- [x] **本地验证:** 已本地 `bun run typecheck` 通过；`format:check` 对本文件无新增问题。
- [x] **安全合规:** 无敏感凭据，符合项目规范。

## 📸 运行证明 / Proof of Work

- 定位：`web/default/src/features/home/index.tsx` 的 URL iframe。
- 引入回归的 commit：`0b48ad86`（#5760，2026-06-27），`git tag --contains` 仅含 `v1.0.0-rc.16`；rc.13/14/15 该 iframe 无 sandbox。
- 本地 `bun run typecheck`（`tsgo -b`）通过，无类型错误。
- 改动 diff：sandbox 由
  `allow-forms allow-popups allow-popups-to-escape-sandbox allow-scripts`
  改为
  `allow-same-origin allow-top-navigation-by-user-activation allow-forms allow-popups allow-popups-to-escape-sandbox allow-scripts`，并新增说明性注释。

> 关于 oxlint 的 `react/iframe-missing-sandbox`：该规则会对 `allow-scripts` + `allow-same-origin` 组合报 error，但项目 `main` 中既有的 `web-preview.tsx` 同样使用该组合，且 `main` 全量 lint 本就存在多条既有 error，故未额外处理；如维护者希望，我可改用其它豁免方式。

---

> **AI 协助声明:** 本 PR 的问题定位、根因分析与代码改动在 AI（Claude）辅助下完成，所有结论均经源码与 git 历史核对，并已本地 typecheck 验证。提交者非本仓库历史核心开发者，特此声明。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the embedded custom home page so trusted, admin-configured content can load same-origin resources correctly, including fonts.
  * User-initiated link clicks that navigate the top window (e.g., “open in top frame”) now work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->