### PR TITLE
fix(web): 注册页补充已登录重定向守卫，与登录页 / classic 主题保持一致 (#5908)

### DIFF
--- a/web/default/src/routes/(auth)/sign-up.tsx
+++ b/web/default/src/routes/(auth)/sign-up.tsx
@@ -16,10 +16,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 
 import { SignUp } from '@/features/auth/sign-up'
+import { useAuthStore } from '@/stores/auth-store'
 
 export const Route = createFileRoute('/(auth)/sign-up')({
   component: SignUp,
+  beforeLoad: async () => {
+    const { auth } = useAuthStore.getState()
+
+    // 如果已经有用户信息，说明已登录，注册页对其无意义，跳转到 dashboard
+    if (auth.user) {
+      throw redirect({ to: '/dashboard' })
+    }
+  },
 })


### PR DESCRIPTION
## 📝 变更描述 / Description

default 主题下，登录页 `/sign-in` 的 route 已在 `beforeLoad` 中做了"已登录则重定向到 `/dashboard`"的守卫，但注册页 `/sign-up`（以及其别名 `/register`，后者仅 `throw redirect` 到 `/sign-up`）没有等价守卫，导致已登录用户访问注册页时停在注册表单，而非进入主界面。

本 PR 在 `sign-up.tsx` 的 route 增加与 `sign-in.tsx` 一致的 `beforeLoad` 守卫：沿用同一 `useAuthStore` 判断登录态，已登录时 `throw redirect({ to: '/dashboard' })`。守卫加在实际渲染注册页的 `/sign-up`，因此 `/register` 与 `/sign-up` 两个入口都被覆盖。该行为与旧 classic 主题 `web/classic/src/helpers/auth.jsx` 中 `AuthRedirect` 对 `/register` 的处理一致。

说明：这不是 rc.13→rc.16 之间的代码回归（两个 tag 的该路由文件除格式化外无功能差异，`/sign-up` 守卫在 default 前端自 v1.0 起从未存在），因此作为"行为一致性补齐"提交，归类为 Refactor / 一致性修复而非 Bug。

## 🚀 变更类型 / Type of change
- [x] ⚡ 性能优化 / 重构 (Refactor) - *补齐注册页与登录页 / classic 主题一致的已登录重定向行为*

## 🔗 关联任务 / Related Issue
- Closes #5908

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述。（另见下方 AI 协助声明）
- [x] **非重复提交:** 我已搜索现有 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 本 PR 未标记为 Bug fix；已如实说明这是行为一致性补齐而非回归。
- [x] **变更理解:** 我已理解这些更改的工作原理及影响。
- [x] **范围聚焦:** 本 PR 仅改动 `sign-up.tsx` 一处，逻辑复用现有 `sign-in.tsx` 模式，无无关改动。
- [x] **本地验证:** 已本地 `bun run typecheck` 通过；`bunx oxlint` 对本文件零 error；`format:check` 通过。
- [x] **安全合规:** 无敏感凭据，符合项目规范。

## 📸 运行证明 / Proof of Work

- 对照实现：`web/default/src/routes/(auth)/sign-in.tsx:32-41` 已有等价守卫（跳 `/dashboard`）。
- 本 PR diff（`sign-up.tsx`）：新增 `redirect` / `useAuthStore` import，并在 route 增加 `beforeLoad`：
  ```tsx
  beforeLoad: async () => {
    const { auth } = useAuthStore.getState()
    // 如果已经有用户信息，说明已登录，注册页对其无意义，跳转到 dashboard
    if (auth.user) {
      throw redirect({ to: '/dashboard' })
    }
  },
  ```
- 本地校验：`bun run typecheck`（tsgo -b）通过；`bunx oxlint -c .oxlintrc.json "src/routes/(auth)/sign-up.tsx"` 零 error；format 检查通过。

---

> **AI 协助声明:** 本 PR 的问题定位、根因分析与代码改动在 AI（Claude）辅助下完成，所有结论均经源码与 git 历史核对，并已本地 typecheck / lint 验证。提交者非本仓库历史核心开发者，特此声明。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Signed-in users are now redirected away from the sign-up page to the dashboard.
  * Prevents authenticated users from accessing a page meant for new account creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->