### PR TITLE
feat: 透传 Claude thinking tokens 到 reasoning_tokens

### DIFF
--- a/dto/claude.go
+++ b/dto/claude.go
@@ -555,15 +555,27 @@ func (c *ClaudeResponse) GetClaudeError() *types.ClaudeError {
 }
 
 type ClaudeUsage struct {
-	InputTokens              int                       `json:"input_tokens"`
-	CacheCreationInputTokens int                       `json:"cache_creation_input_tokens"`
-	CacheReadInputTokens     int                       `json:"cache_read_input_tokens"`
-	OutputTokens             int                       `json:"output_tokens"`
-	CacheCreation            *ClaudeCacheCreationUsage `json:"cache_creation,omitempty"`
+	InputTokens              int                        `json:"input_tokens"`
+	CacheCreationInputTokens int                        `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int                        `json:"cache_read_input_tokens"`
+	OutputTokens             int                        `json:"output_tokens"`
+	OutputTokensDetails      *ClaudeOutputTokensDetails `json:"output_tokens_details,omitempty"`
+	CacheCreation            *ClaudeCacheCreationUsage  `json:"cache_creation,omitempty"`
 	// claude cache 1h
 	ClaudeCacheCreation5mTokens int                  `json:"claude_cache_creation_5_m_tokens"`
 	ClaudeCacheCreation1hTokens int                  `json:"claude_cache_creation_1_h_tokens"`
 	ServerToolUse               *ClaudeServerToolUse `json:"server_tool_use,omitempty"`
+}
+
+type ClaudeOutputTokensDetails struct {
+	ThinkingTokens int `json:"thinking_tokens,omitempty"`
+}
+
+func (u *ClaudeUsage) GetThinkingTokens() int {
+	if u == nil || u.OutputTokensDetails == nil {
+		return 0
+	}
+	return u.OutputTokensDetails.ThinkingTokens
 }
 
 type ClaudeCacheCreationUsage struct {

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -735,6 +735,7 @@ func FormatClaudeResponseInfo(claudeResponse *dto.ClaudeResponse, oaiResponse *d
 			claudeInfo.Usage.ClaudeCacheCreation5mTokens = claudeResponse.Message.Usage.GetCacheCreation5mTokens()
 			claudeInfo.Usage.ClaudeCacheCreation1hTokens = claudeResponse.Message.Usage.GetCacheCreation1hTokens()
 			claudeInfo.Usage.CompletionTokens = claudeResponse.Message.Usage.OutputTokens
+			claudeInfo.Usage.CompletionTokenDetails.ReasoningTokens = claudeResponse.Message.Usage.GetThinkingTokens()
 		}
 	} else if claudeResponse.Type == "content_block_delta" {
 		if claudeResponse.Delta != nil {
@@ -767,6 +768,9 @@ func FormatClaudeResponseInfo(claudeResponse *dto.ClaudeResponse, oaiResponse *d
 			}
 			if claudeResponse.Usage.OutputTokens > 0 {
 				claudeInfo.Usage.CompletionTokens = claudeResponse.Usage.OutputTokens
+			}
+			if thinkingTokens := claudeResponse.Usage.GetThinkingTokens(); thinkingTokens > 0 {
+				claudeInfo.Usage.CompletionTokenDetails.ReasoningTokens = thinkingTokens
 			}
 			claudeInfo.Usage.TotalTokens = claudeInfo.Usage.PromptTokens + claudeInfo.Usage.CompletionTokens
 		}
@@ -909,6 +913,7 @@ func HandleClaudeResponseData(c *gin.Context, info *relaycommon.RelayInfo, claud
 	if claudeResponse.Usage != nil {
 		claudeInfo.Usage.PromptTokens = claudeResponse.Usage.InputTokens
 		claudeInfo.Usage.CompletionTokens = claudeResponse.Usage.OutputTokens
+		claudeInfo.Usage.CompletionTokenDetails.ReasoningTokens = claudeResponse.Usage.GetThinkingTokens()
 		claudeInfo.Usage.TotalTokens = claudeResponse.Usage.InputTokens + claudeResponse.Usage.OutputTokens
 		claudeInfo.Usage.UsageSemantic = "anthropic"
 		claudeInfo.Usage.PromptTokensDetails.CachedTokens = claudeResponse.Usage.CacheReadInputTokens

--- a/relay/channel/claude/relay_claude_test.go
+++ b/relay/channel/claude/relay_claude_test.go
@@ -223,6 +223,37 @@ func TestFormatClaudeResponseInfo_ContentBlockDelta(t *testing.T) {
 	}
 }
 
+func TestFormatClaudeResponseInfo_ThinkingTokens(t *testing.T) {
+	claudeInfo := &ClaudeResponseInfo{Usage: &dto.Usage{}}
+
+	require.True(t, FormatClaudeResponseInfo(&dto.ClaudeResponse{
+		Type: "message_start",
+		Message: &dto.ClaudeMediaMessage{
+			Id:    "msg_1",
+			Model: "claude-sonnet-5",
+			Usage: &dto.ClaudeUsage{
+				InputTokens:         8,
+				OutputTokens:        1,
+				OutputTokensDetails: &dto.ClaudeOutputTokensDetails{ThinkingTokens: 5},
+			},
+		},
+	}, nil, claudeInfo))
+	require.Equal(t, 5, claudeInfo.Usage.CompletionTokenDetails.ReasoningTokens)
+
+	require.True(t, FormatClaudeResponseInfo(&dto.ClaudeResponse{
+		Type: "message_delta",
+		Usage: &dto.ClaudeUsage{
+			OutputTokens:        66,
+			OutputTokensDetails: &dto.ClaudeOutputTokensDetails{ThinkingTokens: 45},
+		},
+	}, nil, claudeInfo))
+	require.Equal(t, 66, claudeInfo.Usage.CompletionTokens)
+	require.Equal(t, 45, claudeInfo.Usage.CompletionTokenDetails.ReasoningTokens)
+
+	openAIUsage := buildOpenAIStyleUsageFromClaudeUsage(claudeInfo.Usage)
+	require.Equal(t, 45, openAIUsage.CompletionTokenDetails.ReasoningTokens)
+}
+
 func TestBuildOpenAIStyleUsageFromClaudeUsage(t *testing.T) {
 	usage := &dto.Usage{
 		PromptTokens:     100,


### PR DESCRIPTION
## 📝 变更描述 / Description

claude-sonnet-5 起，不传 thinking 字段默认跑 adaptive thinking，思考内容默认不可见（display omitted），但 token 全算在 output_tokens 里。上游其实在 `usage.output_tokens_details.thinking_tokens` 给了细分，只是 `ClaudeUsage` 没这个字段，OpenAI 格式重建响应时被丢掉，`completion_tokens_details.reasoning_tokens` 恒为 0。用户看日志会以为 token 数对不上（正文几百字符却计费上万 output tokens）。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [ ] **Bug fix 说明:** 不适用，本 PR 为新功能。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
修复前:
<img width="2752" height="2304" alt="image" src="https://github.com/user-attachments/assets/dce42e3f-2b38-4fcb-b694-c676a71225ca" />
修复后:
<img width="2792" height="1990" alt="image" src="https://github.com/user-attachments/assets/c445a349-32ab-4059-9750-8dcf3aa36a1f" />

