### PR TITLE
feat: add vLLM channel type with native dual-format routing

### DIFF
--- a/common/api_type.go
+++ b/common/api_type.go
@@ -77,6 +77,8 @@ func ChannelType2APIType(channelType int) (int, bool) {
 		apiType = constant.APITypeCodex
 	case constant.ChannelTypeAdvancedCustom:
 		apiType = constant.APITypeAdvancedCustom
+	case constant.ChannelTypeVLLM:
+		apiType = constant.APITypeVLLM
 	}
 	if apiType == -1 {
 		return constant.APITypeOpenAI, false

--- a/constant/api_type.go
+++ b/constant/api_type.go
@@ -37,5 +37,6 @@ const (
 	APITypeReplicate
 	APITypeCodex
 	APITypeAdvancedCustom
+	APITypeVLLM
 	APITypeDummy // this one is only for count, do not add any channel after this
 )

--- a/constant/channel.go
+++ b/constant/channel.go
@@ -56,6 +56,7 @@ const (
 	ChannelTypeReplicate      = 56
 	ChannelTypeCodex          = 57
 	ChannelTypeAdvancedCustom = 58
+	ChannelTypeVLLM           = 59
 	ChannelTypeDummy          // this one is only for count, do not add any channel after this
 
 )
@@ -120,6 +121,7 @@ var ChannelBaseURLs = []string{
 	"https://api.replicate.com",                 //56
 	"https://chatgpt.com",                       //57
 	"",                                          //58
+	"",                                          //59
 }
 
 var ChannelTypeNames = map[int]string{
@@ -178,6 +180,7 @@ var ChannelTypeNames = map[int]string{
 	ChannelTypeReplicate:      "Replicate",
 	ChannelTypeCodex:          "ChatGPT Subscription (Codex)",
 	ChannelTypeAdvancedCustom: "Advanced Custom",
+	ChannelTypeVLLM:           "vLLM",
 }
 
 func GetChannelTypeName(channelType int) string {

--- a/relay/channel/vllm/adaptor.go
+++ b/relay/channel/vllm/adaptor.go
@@ -1,0 +1,103 @@
+package vllm
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/relay/channel"
+	"github.com/QuantumNous/new-api/relay/channel/claude"
+	"github.com/QuantumNous/new-api/relay/channel/openai"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/types"
+
+	"github.com/gin-gonic/gin"
+)
+
+type Adaptor struct{}
+
+func (a *Adaptor) Init(info *relaycommon.RelayInfo) {}
+
+func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
+	switch info.RelayFormat {
+	case types.RelayFormatClaude:
+		return fmt.Sprintf("%s/v1/messages", info.ChannelBaseUrl), nil
+	default:
+		switch info.RelayMode {
+		case relayconstant.RelayModeEmbeddings:
+			return fmt.Sprintf("%s/v1/embeddings", info.ChannelBaseUrl), nil
+		case relayconstant.RelayModeRerank:
+			return fmt.Sprintf("%s/v1/rerank", info.ChannelBaseUrl), nil
+		case relayconstant.RelayModeCompletions:
+			return fmt.Sprintf("%s/v1/completions", info.ChannelBaseUrl), nil
+		default:
+			return fmt.Sprintf("%s/v1/chat/completions", info.ChannelBaseUrl), nil
+		}
+	}
+}
+
+func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *relaycommon.RelayInfo) error {
+	channel.SetupApiRequestHeader(info, c, req)
+	req.Set("Authorization", fmt.Sprintf("Bearer %s", info.ApiKey))
+	return nil
+}
+
+func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeneralOpenAIRequest) (any, error) {
+	return request, nil
+}
+
+func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, info *relaycommon.RelayInfo, req *dto.ClaudeRequest) (any, error) {
+	adaptor := claude.Adaptor{}
+	return adaptor.ConvertClaudeRequest(c, info, req)
+}
+
+func (a *Adaptor) ConvertGeminiRequest(*gin.Context, *relaycommon.RelayInfo, *dto.GeminiChatRequest) (any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *Adaptor) ConvertAudioRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.AudioRequest) (io.Reader, error) {
+	return nil, errors.New("not supported")
+}
+
+func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.ImageRequest) (any, error) {
+	adaptor := openai.Adaptor{}
+	return adaptor.ConvertImageRequest(c, info, request)
+}
+
+func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *Adaptor) ConvertRerankRequest(c *gin.Context, relayMode int, request dto.RerankRequest) (any, error) {
+	return request, nil
+}
+
+func (a *Adaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.EmbeddingRequest) (any, error) {
+	return request, nil
+}
+
+func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBody io.Reader) (any, error) {
+	return channel.DoApiRequest(a, c, info, requestBody)
+}
+
+func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
+	switch info.RelayFormat {
+	case types.RelayFormatClaude:
+		adaptor := claude.Adaptor{}
+		return adaptor.DoResponse(c, resp, info)
+	default:
+		adaptor := openai.Adaptor{}
+		return adaptor.DoResponse(c, resp, info)
+	}
+}
+
+func (a *Adaptor) GetModelList() []string {
+	return ModelList
+}
+
+func (a *Adaptor) GetChannelName() string {
+	return ChannelName
+}

--- a/relay/channel/vllm/constants.go
+++ b/relay/channel/vllm/constants.go
@@ -1,0 +1,7 @@
+package vllm
+
+// ModelList is intentionally empty: vLLM instances serve whatever models are
+// loaded at runtime. Users configure model names per-channel via model mapping.
+var ModelList = []string{}
+
+var ChannelName = "vLLM"

--- a/relay/relay_adaptor.go
+++ b/relay/relay_adaptor.go
@@ -43,6 +43,7 @@ import (
 	taskVidu "github.com/QuantumNous/new-api/relay/channel/task/vidu"
 	"github.com/QuantumNous/new-api/relay/channel/tencent"
 	"github.com/QuantumNous/new-api/relay/channel/vertex"
+	"github.com/QuantumNous/new-api/relay/channel/vllm"
 	"github.com/QuantumNous/new-api/relay/channel/volcengine"
 	"github.com/QuantumNous/new-api/relay/channel/xai"
 	"github.com/QuantumNous/new-api/relay/channel/xunfei"
@@ -123,6 +124,8 @@ func GetAdaptor(apiType int) channel.Adaptor {
 		return &codex.Adaptor{}
 	case constant.APITypeAdvancedCustom:
 		return &advancedcustom.Adaptor{}
+	case constant.APITypeVLLM:
+		return &vllm.Adaptor{}
 	}
 	return nil
 }

--- a/web/default/src/features/channels/constants.ts
+++ b/web/default/src/features/channels/constants.ts
@@ -77,10 +77,11 @@ export const CHANNEL_TYPES = {
   56: 'Replicate',
   57: 'ChatGPT Subscription (Codex)',
   58: 'Advanced Custom',
+  59: 'vLLM',
 } as const
 
 const CHANNEL_TYPE_DISPLAY_ORDER: number[] = [
-  1, 14, 33, 24, 43, 3, 41, 48, 58, 42, 34, 20, 4, 40, 27, 25, 17, 26, 15, 46,
+  1, 14, 33, 24, 43, 3, 41, 48, 58, 59, 42, 34, 20, 4, 40, 27, 25, 17, 26, 15, 46,
   23, 18, 45, 31, 35, 49, 19, 47, 37, 38, 39, 11, 8, 57, 22, 21, 44, 2, 5, 36,
   50, 51, 52, 53, 54, 55, 56,
 ]

--- a/web/default/src/features/channels/lib/channel-type-config.ts
+++ b/web/default/src/features/channels/lib/channel-type-config.ts
@@ -144,6 +144,16 @@ export const CHANNEL_TYPE_CONFIGS: Record<number, ChannelTypeConfig> = {
       models: 'Models exposed by this channel',
     },
   },
+  59: {
+    id: 59,
+    name: CHANNEL_TYPES[59],
+    icon: 'openai',
+    hints: {
+      baseUrl: 'vLLM instance base URL (e.g. http://host:8000)',
+      key: 'API key (use any string if auth disabled)',
+      models: 'Models served by this vLLM instance',
+    },
+  },
 }
 
 /**

--- a/web/default/src/features/channels/lib/channel-utils.ts
+++ b/web/default/src/features/channels/lib/channel-utils.ts
@@ -52,6 +52,7 @@ export function getChannelTypeIcon(type: number): string {
     7: 'OpenAI', // OhMyGPT
     8: 'OpenAI', // Custom
     58: 'NewAPI', // Advanced Custom
+    59: 'OpenAI', // vLLM
     3: 'Azure', // Azure
 
     // Anthropic


### PR DESCRIPTION
## Summary

- Add a dedicated **vLLM** channel type (ID 59) that routes requests based on relay format without any protocol conversion
- Claude format (Anthropic API) → `{baseURL}/v1/messages` (passthrough, preserves prompt cache headers)
- OpenAI format → `{baseURL}/v1/chat/completions` (or `/v1/embeddings`, `/v1/rerank` by relay mode)

## Motivation

vLLM natively supports both the Anthropic Messages API (`/v1/messages`) and the OpenAI Chat Completions API (`/v1/chat/completions`). When using the generic **Custom (OpenAI)** channel type to point at a local vLLM instance, New API forces all Claude-format requests through `ClaudeToOpenAIRequest`, losing Anthropic prompt cache headers and causing intermittent cache misses.

The existing workaround — using the Moonshot channel type — routes Claude requests to `{baseURL}/anthropic/v1/messages`, which is the Moonshot/Kimi path layout and does not match vLLM's standard `/v1/messages` endpoint.

## Design

The vLLM adaptor mirrors the Moonshot dual-format pattern but uses standard OpenAI-compatible paths:

| Format | Endpoint |
|--------|----------|
| `RelayFormatClaude` | `{baseURL}/v1/messages` |
| `RelayFormatOpenAI` (chat) | `{baseURL}/v1/chat/completions` |
| embeddings | `{baseURL}/v1/embeddings` |
| rerank | `{baseURL}/v1/rerank` |

`ConvertClaudeRequest` delegates to `claude.Adaptor` (passthrough, no conversion). `DoResponse` delegates to `claude.Adaptor` or `openai.Adaptor` based on relay format. No model list is shipped — vLLM serves whatever models are loaded at runtime; users configure model names via channel model mapping.

## Files changed

- `relay/channel/vllm/adaptor.go` — new adaptor
- `relay/channel/vllm/constants.go` — channel name, empty model list
- `constant/channel.go` — `ChannelTypeVLLM = 59`, base URL entry, name entry
- `constant/api_type.go` — `APITypeVLLM`
- `common/api_type.go` — `ChannelTypeVLLM → APITypeVLLM` mapping
- `relay/relay_adaptor.go` — register `APITypeVLLM → &vllm.Adaptor{}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new vLLM channel option (ID 59), including configuration details, ordering, and matching icons.
  * Enabled vLLM request/response routing for chat (including Claude-style), embeddings, rerank, and images.
  * Recognized vLLM across API type and adaptor selection to ensure correct forwarding.
* **Notes / Limitations**
  * Gemini chat, OpenAI response handling, and audio conversions are not supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->