### PR TITLE
fix(classic): load lobe icons from registry

### DIFF
--- a/web/classic/src/helpers/render.jsx
+++ b/web/classic/src/helpers/render.jsx
@@ -27,7 +27,7 @@ import {
   BILLING_VAR_REGEX,
 } from '../constants';
 import { visit } from 'unist-util-visit';
-import * as LobeIcons from '@lobehub/icons';
+import * as LobeIcons from '@lobehub/icons/es/icons.js';
 import {
   OpenAI,
   Claude,
@@ -61,7 +61,7 @@ import {
   Jimeng,
   Perplexity,
   Replicate,
-} from '@lobehub/icons';
+} from '@lobehub/icons/es/icons.js';
 
 import {
   LayoutDashboard,


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> 修复老前端加载部分lobehub图标失败

## 📝 变更描述 / Description
从es中直接加载全部，避开打包时裁剪器的自动过滤优化体积

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) 

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the app’s icon source to a newer module location. This should not change the user experience, but helps keep the UI icon imports aligned with the latest package structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->