### PR TITLE
fix(web): sync home iframe theme and language

### DIFF
--- a/web/default/src/features/home/index.tsx
+++ b/web/default/src/features/home/index.tsx
@@ -16,11 +16,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
+import { useCallback, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { PublicLayout } from '@/components/layout'
 import { Footer } from '@/components/layout/components/footer'
 import { RichContent } from '@/components/rich-content'
+import { useTheme } from '@/context/theme-provider'
 import { isLikelyHtml } from '@/lib/content-format'
 import { useAuthStore } from '@/stores/auth-store'
 
@@ -28,10 +30,33 @@ import { CTA, Features, Hero, HowItWorks, Stats } from './components'
 import { useHomePageContent } from './hooks'
 
 export function Home() {
-  const { t } = useTranslation()
+  const { i18n, t } = useTranslation()
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const { resolvedTheme } = useTheme()
   const { auth } = useAuthStore()
   const isAuthenticated = !!auth.user
   const { content, isLoaded, isUrl } = useHomePageContent()
+
+  const syncIframePreferences = useCallback(() => {
+    try {
+      iframeRef.current?.contentWindow?.postMessage(
+        { themeMode: resolvedTheme },
+        '*'
+      )
+      iframeRef.current?.contentWindow?.postMessage(
+        { lang: i18n.language },
+        '*'
+      )
+    } catch {
+      // Cross-origin frames may reject access while navigating.
+    }
+  }, [i18n.language, resolvedTheme])
+
+  useEffect(() => {
+    if (isUrl) {
+      syncIframePreferences()
+    }
+  }, [isUrl, syncIframePreferences])
 
   if (!isLoaded) {
     return (
@@ -48,10 +73,12 @@ export function Home() {
       return (
         <PublicLayout showMainContainer={false}>
           <iframe
+            ref={iframeRef}
             src={content}
             className='h-screen w-full border-none'
             title={t('Custom Home Page')}
             sandbox='allow-forms allow-popups allow-popups-to-escape-sandbox allow-scripts'
+            onLoad={syncIframePreferences}
           />
         </PublicLayout>
       )


### PR DESCRIPTION
## 📝 变更描述 / Description

旧版前端在使用 URL 形式的自定义首页时，会把当前主题和语言状态传递给 iframe 页面，因此自定义 HTML 可以跟随系统的深色模式和语言切换。

新版默认前端重构后，这部分同步逻辑没有保留下来。当前自定义首页仍然可以通过 iframe 加载，但 iframe 内页面无法感知父页面的主题和语言变化，导致嵌入页面和主界面状态不一致。

本次修改补回这部分逻辑：在自定义首页 iframe 加载完成后，以及主题或语言变化时，向 iframe 发送当前的 `themeMode` 和 `lang`。嵌入的自定义 HTML 页面可以通过 `postMessage` 接收这些状态，并自行同步深色模式和语言显示。

The previous frontend passed the current theme and language state to URL-based custom home page iframes, allowing embedded custom HTML pages to follow the app's dark mode and language changes.

After the new default frontend refactor, this synchronization logic was not carried over. The custom home page can still be loaded through an iframe, but the iframe page cannot detect theme or language changes from the parent page, which may cause inconsistent UI state.

This change restores that behavior by sending the current `themeMode` and `lang` to the custom home iframe on iframe load and when theme or language changes. Embedded custom HTML pages can receive these values through `postMessage` and update their own theme and language accordingly.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- N/A

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

已使用自定义 iframe 页面进行验证。

iframe 页面可以正确接收到父页面传入的两个状态：

- `themeMode`：用于同步浅色 / 深色主题
- `lang`：用于同步当前选择的界面语言

验证结果：嵌入的自定义首页可以跟随主页面的主题和语言切换保持一致。

Verified with a custom iframe page.

The iframe page correctly receives both values from the parent page:

- `themeMode`: used to sync light / dark theme
- `lang`: used to sync the currently selected interface language

Result: the embedded custom home page stays in sync with the parent frontend when theme or language changes.

截图 / Screenshot:

<img width="1291" height="349" alt="image" src="https://github.com/user-attachments/assets/f0ae35f5-8052-4232-a007-279d09702381" />
<img width="1279" height="329" alt="image" src="https://github.com/user-attachments/assets/b17fdf60-786f-4fac-b494-a9f6fba1211d" />
<img width="1251" height="301" alt="image" src="https://github.com/user-attachments/assets/d974d895-ee5c-461c-a367-be4fbc5f57d8" />
<img width="1310" height="335" alt="image" src="https://github.com/user-attachments/assets/ec792ecc-87dc-4327-9712-f5b9ec9a9a36" />
<img width="1282" height="342" alt="image" src="https://github.com/user-attachments/assets/3c08c7bf-58e6-4a55-9f15-87de3302a479" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The embedded page on the Home screen now stays in sync with the app’s current theme and language.
  * Preference updates are applied when the embedded content loads, helping it match the rest of the experience more consistently.

* **Bug Fixes**
  * Improved handling for cases where the embedded content changes location or is temporarily unavailable, reducing sync-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->