### PR TITLE
fix(web): 修复 classic 渠道状态切换接口

### DIFF
--- a/web/classic/src/hooks/channels/useChannelsData.jsx
+++ b/web/classic/src/hooks/channels/useChannelsData.jsx
@@ -443,17 +443,22 @@ export const useChannelsData = () => {
   const manageChannel = async (id, action, record, value) => {
     let data = { id };
     let res;
+    let nextStatus;
     switch (action) {
       case 'delete':
         res = await API.delete(`/api/channel/${id}/`);
         break;
       case 'enable':
-        data.status = 1;
-        res = await API.put('/api/channel/', data);
+        nextStatus = 1;
+        res = await API.post(`/api/channel/${id}/status`, {
+          status: nextStatus,
+        });
         break;
       case 'disable':
-        data.status = 2;
-        res = await API.put('/api/channel/', data);
+        nextStatus = 2;
+        res = await API.post(`/api/channel/${id}/status`, {
+          status: nextStatus,
+        });
         break;
       case 'priority':
         if (value === '') return;
@@ -478,7 +483,7 @@ export const useChannelsData = () => {
       let channel = res.data.data;
       let newChannels = [...channels];
       if (action !== 'delete') {
-        record.status = channel.status;
+        record.status = nextStatus ?? channel.status;
       }
       setChannels(newChannels);
     } else {


### PR DESCRIPTION
## 变更内容

修复 classic 前端渠道管理页单个渠道启用/禁用接口调用。

- 将 classic 的单渠道启用/禁用从 `PUT /api/channel/` 改为 `POST /api/channel/:id/status`
- 成功后按目标状态更新当前行展示
- 保留优先级、权重、删除等其他操作的原有调用方式

## 问题原因

后端已经将渠道状态切换拆分到专用接口，并且 `PUT /api/channel/` 会拒绝请求体中的 `status` 字段。default 前端已经走新接口，但 classic 前端仍然向通用更新接口提交 `{ id, status }`，因此会返回“无效的参数”。

Fixes #5918 #5891

## 验证

- 已执行 `git diff --check`
- 未在本地执行完整前端构建

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Channel enable/disable actions now update status through a more reliable channel-specific request.
  * After a successful change, the channel list reflects the correct updated status instead of sometimes showing an outdated value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->