### PR TITLE
fix(task): support xAI grok-imagine-video task polling

### DIFF
--- a/relay/channel/task/sora/adaptor.go
+++ b/relay/channel/task/sora/adaptor.go
@@ -55,6 +55,12 @@ type responseTask struct {
 		Message string `json:"message"`
 		Code    string `json:"code"`
 	} `json:"error,omitempty"`
+	// xAI grok-imagine-video returns the video URL directly in video.url,
+	// without a separate /content endpoint like OpenAI Sora.
+	Video *struct {
+		URL      string `json:"url"`
+		Duration int    `json:"duration,omitempty"`
+	} `json:"video,omitempty"`
 }
 
 // ============================
@@ -302,10 +308,14 @@ func (a *TaskAdaptor) ParseTaskResult(respBody []byte) (*relaycommon.TaskInfo, e
 		taskResult.Status = model.TaskStatusQueued
 	case "processing", "in_progress":
 		taskResult.Status = model.TaskStatusInProgress
-	case "completed":
+	case "completed", "done":
+		// "done" is the terminal success status returned by xAI grok-imagine-video.
 		taskResult.Status = model.TaskStatusSuccess
-		// Url intentionally left empty — the caller constructs the proxy URL using the public task ID
-	case "failed", "cancelled":
+		// xAI returns the video URL directly in video.url (no separate content endpoint).
+		if resTask.Video != nil && resTask.Video.URL != "" {
+			taskResult.Url = resTask.Video.URL
+		}
+	case "failed", "cancelled", "error":
 		taskResult.Status = model.TaskStatusFailure
 		if resTask.Error != nil {
 			taskResult.Reason = resTask.Error.Message

--- a/service/task_polling.go
+++ b/service/task_polling.go
@@ -502,9 +502,12 @@ func updateVideoSingleTask(ctx context.Context, adaptor TaskPollingAdaptor, ch *
 				// 其他错误认为是任务失败，记录错误信息并更新任务状态
 				taskResult = relaycommon.FailTaskInfo("upstream returned error")
 			} else {
-				// unknown error format, log original response
-				logger.LogError(ctx, fmt.Sprintf("Task %s returned empty status with unrecognized error format, response: %s", taskId, string(responseBody)))
-				taskResult = relaycommon.FailTaskInfo("upstream returned unrecognized message")
+				// Upstream may return a body without a status field in early/intermediate
+				// polling phases (e.g. xAI grok-imagine-video returns {"request_id":"...","id":"..."}
+				// before the task starts). Such a response is not an error — keep the current
+				// task status and wait for the next polling round instead of failing the task.
+				logger.LogInfo(ctx, fmt.Sprintf("Task %s returned empty status, will retry next poll. response: %s", taskId, string(responseBody)))
+				return nil
 			}
 		}
 	}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

xAI `grok-imagine-video`（以及 `grok-imagine-video-preview`、`grok-image-video` 等同系列模型）通过 OpenAI 渠道调用时，任务永远返回 `FAILURE`，错误信息为 `upstream returned unrecognized message`，但实际上游 xAI 已经成功生成视频。

根因是 xAI 的任务响应格式与 OpenAI Sora 存在 3 处差异，sora adaptor 完全没有适配：

### 问题 1：完成状态值不同
- OpenAI Sora 返回 `status: "completed"`
- xAI 返回 `status: "done"`
- sora adaptor 的 `ParseTaskResult` 只匹配 `"completed"`，导致 `"done"` 落入 `default` 分支，状态为空。

### 问题 2：视频 URL 位置不同
- OpenAI Sora 不在任务响应里返回视频地址，需要单独请求 `/v1/videos/{id}/content`
- xAI 直接在任务响应里返回 `video.url`
- sora adaptor 的 `responseTask` struct 没有 `video` 字段，URL 被丢弃 → `result_url` 为空。

### 问题 3：空 status 被误判为失败（最致命）
- xAI 在任务刚提交、尚未开始执行时，返回的响应**完全没有 status 字段**：
  ```json
  {"request_id":"b53c8bb4-...","id":"task_xxx"}
  ```
- 原代码在 `taskResult.Status == ""` 时尝试解析为 OpenAI 错误格式，解析失败后直接调用 `FailTaskInfo("upstream returned unrecognized message")` 判定任务失败。
- 这导致任务在第一轮轮询就被误杀，根本等不到后续的 `"done"` 状态。

### 修复
1. `relay/channel/task/sora/adaptor.go`：`ParseTaskResult` 的 switch 增加 `"done"` case 映射为 `TaskStatusSuccess`；`responseTask` 增加 `Video` 字段，成功时从 `video.url` 提取结果地址。
2. `service/task_polling.go`：空 status 且无法识别为 OpenAI 错误时，`return nil` 保持当前状态等待下一轮轮询，不再判定为失败。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*

## 🔗 关联任务 / Related Issue
- Related to #5045（多级 new-api 级联时上游返回非标准状态同样触发 `upstream returned unrecognized message`，本 PR 的修复 3 直接缓解）
- Complementary to #5805（#5805 在 polling 层做通用兜底，本 PR 在 adaptor 层做协议适配，两者思路互补且可共存）

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，#5805 思路相近但在 polling 层修复，本 PR 在 adaptor 层修复，定位互补；#4217 是新增 xAI 渠道 adaptor（type=48），与本 PR 走 openai 渠道的方案不同。
- [x] **Bug fix 说明:** 关联 #5045。
- [x] **变更理解:** 已理解，详见上方变更描述。
- [x] **范围聚焦:** 仅 2 个文件，19 增 6 删，无无关改动。
- [x] **本地验证:** 已在生产 new-api 实例（v1.0.0-rc.16）编译部署并验证 `grok-imagine-video`、`grok-imagine-video-preview`、`grok-image-video`、`grok-video-1.5`、`grok-imagine-video-1.5-preview` 五个模型全部正常生成视频。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

修复前（任务卡在第一轮就被判失败）：
```
[ERR] Task task_xxx returned empty status with unrecognized error format, response: {"request_id":"...","id":"task_xxx"}
[INFO] Task task_xxx failed: upstream returned unrecognized message
```

修复后（正常完成并提取到视频 URL）：
```
[1] status=NOT_START progress=0%
[2] status=QUEUED progress=1%
[3] status=QUEUED progress=94%
[4] status=SUCCESS progress=100%
result_url: https://vidgen.x.ai/xai-vidgen-bucket/xai-video-xxx.mp4
```

响应对比（修复后 polling 拿到的 xAI 上游响应被正确解析）：
```json
{
  "data": {
    "status": "SUCCESS",
    "result_url": "https://vidgen.x.ai/xai-vidgen-bucket/xai-video-xxx.mp4",
    "data": {
      "status": "done",
      "video": {"url": "https://vidgen.x.ai/.../xxx.mp4", "duration": 8}
    }
  }
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video task results can now include a direct video URL, with duration support when available.
  * Task completion now recognizes both “completed” and “done” as successful terminal states.

* **Bug Fixes**
  * Improved handling of upstream responses that don’t follow the expected error format, reducing false task failures.
  * Preserves task state for retry when polling receives an unstructured intermediate response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->