### PR TITLE
fix(relay/openai): normalize stop field from string to array

### DIFF
--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -231,6 +231,15 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 	if request == nil {
 		return nil, errors.New("request is nil")
 	}
+	// 归一化 stop 字段：某些严格的 OpenAI 兼容上游（基于 Java/Jackson，将 stop 声明为
+	// ArrayList 且未启用 ACCEPT_SINGLE_VALUE_AS_ARRAY）收到单字符串会返回 400。
+	// 转成数组形式，OpenAI 官方/Azure 等主流上游同样接受。
+	if s, ok := request.Stop.(string); ok && s != "" {
+		logger.LogWarn(c.Request.Context(), fmt.Sprintf(
+			"stop field normalized from string to array for channel %d (model: %s)",
+			info.ChannelId, info.UpstreamModelName))
+		request.Stop = []string{s}
+	}
 	if info.ChannelType != constant.ChannelTypeOpenAI && info.ChannelType != constant.ChannelTypeAzure {
 		request.StreamOptions = nil
 	}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
对OpenAI接口的请求体的Stop字段进行归一化处理。将String形式的Stop字段统一转换为Array，以解决部分平台不支持String输入的情况。
但考虑到当前操作涉及对请求体的重写，因此加入了Warn日志以方便排查可能存在的问题，目前本地测试一切正常。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5929

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
```
new-api-codex   | [WARN] 2026/0*/** - **:**:** | 20260**** | stop field normalized from string to array for channel *** (model: glm-5.2)
```
对应请求不再出现400报错。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stop sequences in OpenAI requests by normalizing single-value inputs into the expected format.
  * Added a warning when a stop value is provided in an unsupported form, helping diagnose request issues more easily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->