### PR TITLE
feat(web): 支持渠道列表手动调整列宽

### DIFF
--- a/web/default/src/components/data-table/core/data-table-colgroup.tsx
+++ b/web/default/src/components/data-table/core/data-table-colgroup.tsx
@@ -34,9 +34,12 @@ export function DataTableColgroup<TData>({
   return (
     <colgroup>
       {columns.map((column) => {
-        const width = isContentSizedColumn(column.id)
-          ? undefined
-          : getColumnWidth(column.getSize(), totalSize)
+        const width = getColumnWidth(
+          table,
+          column.id,
+          column.getSize(),
+          totalSize
+        )
 
         return <col key={column.id} style={{ width }} />
       })}
@@ -44,7 +47,20 @@ export function DataTableColgroup<TData>({
   )
 }
 
-function getColumnWidth(columnSize: number, totalSize: number) {
+function getColumnWidth<TData>(
+  table: TanstackTable<TData>,
+  columnId: string,
+  columnSize: number,
+  totalSize: number
+) {
+  if (isContentSizedColumn(columnId)) {
+    return undefined
+  }
+
+  if (table.options.enableColumnResizing === true) {
+    return `${columnSize}px`
+  }
+
   if (totalSize <= 0) {
     return undefined
   }

--- a/web/default/src/components/data-table/core/data-table-header.tsx
+++ b/web/default/src/components/data-table/core/data-table-header.tsx
@@ -21,8 +21,10 @@ import {
   type Header,
   type Table as TanstackTable,
 } from '@tanstack/react-table'
+import { useTranslation } from 'react-i18next'
 
 import { TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { cn } from '@/lib/utils'
 
 import { DataTableColumnHeader } from './column-header'
 import { isContentSizedColumn } from './content-sized-columns'
@@ -43,6 +45,8 @@ export function DataTableHeader<TData>({
   rowClassName,
   getColumnClassName,
 }: DataTableHeaderProps<TData>) {
+  const { t } = useTranslation()
+
   return (
     <TableHeader className={className}>
       {table.getHeaderGroups().map((headerGroup) => (
@@ -51,15 +55,45 @@ export function DataTableHeader<TData>({
             <TableHead
               key={header.id}
               colSpan={header.colSpan}
-              className={getColumnClassName?.(header.column.id, 'header')}
+              className={cn(
+                'relative',
+                getColumnClassName?.(header.column.id, 'header')
+              )}
               style={getHeaderSizeStyle(header, applyHeaderSize)}
             >
               {renderHeaderContent(header)}
+              {shouldRenderColumnResizer(table, header) && (
+                <div
+                  role='separator'
+                  aria-orientation='vertical'
+                  aria-label={t('Resize column')}
+                  onDoubleClick={() => header.column.resetSize()}
+                  onMouseDown={header.getResizeHandler()}
+                  onTouchStart={header.getResizeHandler()}
+                  className={cn(
+                    'absolute top-0 right-0 h-full w-2 cursor-col-resize touch-none select-none',
+                    'after:bg-border hover:after:bg-primary after:absolute after:top-2 after:right-0 after:h-[calc(100%-1rem)] after:w-px after:transition-colors',
+                    header.column.getIsResizing() && 'after:bg-primary'
+                  )}
+                />
+              )}
             </TableHead>
           ))}
         </TableRow>
       ))}
     </TableHeader>
+  )
+}
+
+function shouldRenderColumnResizer<TData>(
+  table: TanstackTable<TData>,
+  header: Header<TData, unknown>
+) {
+  return (
+    table.options.enableColumnResizing === true &&
+    !header.isPlaceholder &&
+    header.column.getCanResize() &&
+    !isContentSizedColumn(header.column.id)
   )
 }
 

--- a/web/default/src/components/data-table/core/data-table-header.tsx
+++ b/web/default/src/components/data-table/core/data-table-header.tsx
@@ -21,6 +21,7 @@ import {
   type Header,
   type Table as TanstackTable,
 } from '@tanstack/react-table'
+import type { KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { TableHead, TableHeader, TableRow } from '@/components/ui/table'
@@ -67,9 +68,13 @@ export function DataTableHeader<TData>({
                   role='separator'
                   aria-orientation='vertical'
                   aria-label={t('Resize column')}
+                  tabIndex={0}
                   onDoubleClick={() => header.column.resetSize()}
                   onMouseDown={header.getResizeHandler()}
                   onTouchStart={header.getResizeHandler()}
+                  onKeyDown={(event) =>
+                    handleColumnResizeKeyDown(event, table, header)
+                  }
                   className={cn(
                     'absolute top-0 right-0 h-full w-2 cursor-col-resize touch-none select-none',
                     'after:bg-border hover:after:bg-primary after:absolute after:top-2 after:right-0 after:h-[calc(100%-1rem)] after:w-px after:transition-colors',
@@ -83,6 +88,60 @@ export function DataTableHeader<TData>({
       ))}
     </TableHeader>
   )
+}
+
+function handleColumnResizeKeyDown<TData>(
+  event: KeyboardEvent<HTMLDivElement>,
+  table: TanstackTable<TData>,
+  header: Header<TData, unknown>
+) {
+  const step = event.shiftKey ? 50 : 10
+
+  if (event.key === 'ArrowLeft') {
+    event.preventDefault()
+    resizeColumnByKeyboard(table, header, -step)
+    return
+  }
+
+  if (event.key === 'ArrowRight') {
+    event.preventDefault()
+    resizeColumnByKeyboard(table, header, step)
+    return
+  }
+
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    header.column.resetSize()
+  }
+}
+
+function resizeColumnByKeyboard<TData>(
+  table: TanstackTable<TData>,
+  header: Header<TData, unknown>,
+  delta: number
+) {
+  table.setColumnSizing((previous) => ({
+    ...previous,
+    [header.column.id]: getClampedColumnSize(header, delta),
+  }))
+}
+
+function getClampedColumnSize<TData>(
+  header: Header<TData, unknown>,
+  delta: number
+) {
+  const { minSize, maxSize } = header.column.columnDef
+  const nextSize = header.column.getSize() + delta
+
+  if (typeof minSize === 'number' && nextSize < minSize) {
+    return minSize
+  }
+
+  if (typeof maxSize === 'number' && nextSize > maxSize) {
+    return maxSize
+  }
+
+  return nextSize
 }
 
 function shouldRenderColumnResizer<TData>(

--- a/web/default/src/components/data-table/core/data-table-header.tsx
+++ b/web/default/src/components/data-table/core/data-table-header.tsx
@@ -21,7 +21,7 @@ import {
   type Header,
   type Table as TanstackTable,
 } from '@tanstack/react-table'
-import type { KeyboardEvent } from 'react'
+import type { KeyboardEvent, MouseEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { TableHead, TableHeader, TableRow } from '@/components/ui/table'
@@ -56,6 +56,7 @@ export function DataTableHeader<TData>({
             <TableHead
               key={header.id}
               colSpan={header.colSpan}
+              data-column-id={header.column.id}
               className={cn(
                 'relative',
                 getColumnClassName?.(header.column.id, 'header')
@@ -68,8 +69,11 @@ export function DataTableHeader<TData>({
                   role='separator'
                   aria-orientation='vertical'
                   aria-label={t('Resize column')}
+                  data-column-resizer
                   tabIndex={0}
-                  onDoubleClick={() => header.column.resetSize()}
+                  onDoubleClick={(event) =>
+                    handleColumnAutoSize(event, table, header)
+                  }
                   onMouseDown={header.getResizeHandler()}
                   onTouchStart={header.getResizeHandler()}
                   onKeyDown={(event) =>
@@ -111,7 +115,7 @@ function handleColumnResizeKeyDown<TData>(
 
   if (event.key === 'Enter' || event.key === ' ') {
     event.preventDefault()
-    header.column.resetSize()
+    autoSizeColumn(event.currentTarget, table, header)
   }
 }
 
@@ -122,16 +126,47 @@ function resizeColumnByKeyboard<TData>(
 ) {
   table.setColumnSizing((previous) => ({
     ...previous,
-    [header.column.id]: getClampedColumnSize(header, delta),
+    [header.column.id]: getClampedColumnSize(
+      header,
+      header.column.getSize() + delta
+    ),
+  }))
+}
+
+function handleColumnAutoSize<TData>(
+  event: MouseEvent<HTMLDivElement>,
+  table: TanstackTable<TData>,
+  header: Header<TData, unknown>
+) {
+  event.preventDefault()
+  autoSizeColumn(event.currentTarget, table, header)
+}
+
+function autoSizeColumn<TData>(
+  resizerElement: HTMLElement,
+  table: TanstackTable<TData>,
+  header: Header<TData, unknown>
+) {
+  const measuredSize = measureColumnContentWidth(
+    resizerElement,
+    header.column.id
+  )
+
+  if (measuredSize === undefined) {
+    return
+  }
+
+  table.setColumnSizing((previous) => ({
+    ...previous,
+    [header.column.id]: getClampedColumnSize(header, measuredSize),
   }))
 }
 
 function getClampedColumnSize<TData>(
   header: Header<TData, unknown>,
-  delta: number
+  nextSize: number
 ) {
   const { minSize, maxSize } = header.column.columnDef
-  const nextSize = header.column.getSize() + delta
 
   if (typeof minSize === 'number' && nextSize < minSize) {
     return minSize
@@ -142,6 +177,64 @@ function getClampedColumnSize<TData>(
   }
 
   return nextSize
+}
+
+function measureColumnContentWidth(
+  resizerElement: HTMLElement,
+  columnId: string
+) {
+  const tableElement = resizerElement.closest('table')
+  if (!tableElement) {
+    return undefined
+  }
+
+  const cells = tableElement.querySelectorAll<HTMLElement>(
+    getColumnElementSelector(columnId)
+  )
+  if (cells.length === 0) {
+    return undefined
+  }
+
+  const measuredWidth = [...cells].reduce(
+    (maxWidth, cell) => Math.max(maxWidth, measureElementWidth(cell)),
+    0
+  )
+
+  return measuredWidth > 0 ? Math.ceil(measuredWidth) : undefined
+}
+
+function measureElementWidth(element: HTMLElement) {
+  const clone = element.cloneNode(true) as HTMLElement
+
+  clone.querySelectorAll('[data-column-resizer]').forEach((resizer) => {
+    resizer.remove()
+  })
+
+  clone.style.position = 'absolute'
+  clone.style.visibility = 'hidden'
+  clone.style.pointerEvents = 'none'
+  clone.style.left = '-10000px'
+  clone.style.top = '0'
+  clone.style.width = 'max-content'
+  clone.style.minWidth = '0'
+  clone.style.maxWidth = 'none'
+  clone.style.height = 'auto'
+  clone.style.whiteSpace = 'nowrap'
+
+  document.body.append(clone)
+  const width = clone.scrollWidth
+  clone.remove()
+
+  return width
+}
+
+function getColumnElementSelector(columnId: string) {
+  const escapedColumnId =
+    typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+      ? CSS.escape(columnId)
+      : columnId.replaceAll('\\', '\\\\').replaceAll('"', '\\"')
+
+  return `[data-column-id="${escapedColumnId}"]`
 }
 
 function shouldRenderColumnResizer<TData>(

--- a/web/default/src/components/data-table/core/data-table-row.tsx
+++ b/web/default/src/components/data-table/core/data-table-row.tsx
@@ -65,6 +65,7 @@ function DataTableRowInner<TData>({
         return (
           <TableCell
             key={cell.id}
+            data-column-id={cell.column.id}
             className={cn(
               'max-w-full min-w-0',
               renderedCell.isPrimitive && 'overflow-hidden',

--- a/web/default/src/components/data-table/hooks/use-data-table.ts
+++ b/web/default/src/components/data-table/hooks/use-data-table.ts
@@ -97,6 +97,19 @@ type UseDataTableOptions<TData> = DataTableFeatureOptions<TData> &
     ensurePageInRange?: (pageCount: number) => void
   }
 
+type ColumnSizingBounds = Record<
+  string,
+  {
+    minSize?: number
+    maxSize?: number
+  }
+>
+
+type ColumnWithSizing<TData> = ColumnDef<TData, unknown> & {
+  accessorKey?: string | number
+  columns?: ColumnDef<TData, unknown>[]
+}
+
 function resolveUpdater<TValue>(
   updater: Updater<TValue>,
   previous: TValue
@@ -155,7 +168,83 @@ function readColumnVisibility(storageKey: string | undefined): VisibilityState {
   }
 }
 
-function readColumnSizing(storageKey: string | undefined): ColumnSizingState {
+function getColumnId<TData>(column: ColumnDef<TData, unknown>) {
+  const columnWithSizing = column as ColumnWithSizing<TData>
+
+  if (typeof columnWithSizing.id === 'string') {
+    return columnWithSizing.id
+  }
+
+  if (typeof columnWithSizing.accessorKey === 'string') {
+    return columnWithSizing.accessorKey.replaceAll('.', '_')
+  }
+
+  if (typeof columnWithSizing.accessorKey === 'number') {
+    return String(columnWithSizing.accessorKey)
+  }
+
+  return undefined
+}
+
+function buildColumnSizingBounds<TData>(
+  columns: ColumnDef<TData, unknown>[]
+): ColumnSizingBounds {
+  return columns.reduce<ColumnSizingBounds>((bounds, column) => {
+    const columnWithSizing = column as ColumnWithSizing<TData>
+    const columnId = getColumnId(column)
+
+    if (columnId) {
+      const minSize =
+        typeof columnWithSizing.minSize === 'number' &&
+        Number.isFinite(columnWithSizing.minSize)
+          ? columnWithSizing.minSize
+          : undefined
+      const maxSize =
+        typeof columnWithSizing.maxSize === 'number' &&
+        Number.isFinite(columnWithSizing.maxSize)
+          ? columnWithSizing.maxSize
+          : undefined
+
+      if (minSize !== undefined || maxSize !== undefined) {
+        bounds[columnId] = { minSize, maxSize }
+      }
+    }
+
+    if (Array.isArray(columnWithSizing.columns)) {
+      Object.assign(bounds, buildColumnSizingBounds(columnWithSizing.columns))
+    }
+
+    return bounds
+  }, {})
+}
+
+function getBoundedColumnSize(
+  columnId: string,
+  value: unknown,
+  bounds: ColumnSizingBounds
+) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return undefined
+  }
+
+  const columnBounds = bounds[columnId]
+  let size = value
+
+  if (columnBounds?.minSize !== undefined && size < columnBounds.minSize) {
+    size = columnBounds.minSize
+  }
+
+  if (columnBounds?.maxSize !== undefined && size > columnBounds.maxSize) {
+    size = columnBounds.maxSize
+  }
+
+  return size > 0 ? size : undefined
+}
+
+function readColumnSizing(
+  storageKey: string | undefined,
+  bounds: ColumnSizingBounds
+): ColumnSizingState {
   if (!storageKey || typeof window === 'undefined') return {}
 
   try {
@@ -169,8 +258,10 @@ function readColumnSizing(storageKey: string | undefined): ColumnSizingState {
 
     return Object.entries(parsed).reduce<ColumnSizingState>(
       (sizing, [key, value]) => {
-        if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
-          sizing[key] = value
+        const boundedSize = getBoundedColumnSize(key, value, bounds)
+
+        if (boundedSize !== undefined) {
+          sizing[key] = boundedSize
         }
         return sizing
       },
@@ -219,12 +310,16 @@ export function useDataTable<TData>(options: UseDataTableOptions<TData>) {
     }),
     [columnVisibilityStorageKey, initialColumnVisibility]
   )
+  const columnSizingBounds = React.useMemo(
+    () => buildColumnSizingBounds(columns),
+    [columns]
+  )
   const resolvedInitialColumnSizing = React.useMemo(
     () => ({
       ...initialColumnSizing,
-      ...readColumnSizing(columnSizingStorageKey),
+      ...readColumnSizing(columnSizingStorageKey, columnSizingBounds),
     }),
-    [columnSizingStorageKey, initialColumnSizing]
+    [columnSizingBounds, columnSizingStorageKey, initialColumnSizing]
   )
 
   const [sorting, onSortingChange] = useControllableTableState(

--- a/web/default/src/components/data-table/hooks/use-data-table.ts
+++ b/web/default/src/components/data-table/hooks/use-data-table.ts
@@ -110,6 +110,8 @@ type ColumnWithSizing<TData> = ColumnDef<TData, unknown> & {
   columns?: ColumnDef<TData, unknown>[]
 }
 
+const COLUMN_SIZING_PERSIST_DELAY_MS = 250
+
 function resolveUpdater<TValue>(
   updater: Updater<TValue>,
   previous: TValue
@@ -344,6 +346,9 @@ export function useDataTable<TData>(options: UseDataTableOptions<TData>) {
   const hydratedColumnSizingStorageKeyRef = React.useRef(columnSizingStorageKey)
   const skipNextColumnVisibilityPersistRef = React.useRef(false)
   const skipNextColumnSizingPersistRef = React.useRef(false)
+  const columnSizingPersistTimerRef = React.useRef<number | undefined>(
+    undefined
+  )
   const [rowSelection, onRowSelectionChange] = useControllableTableState(
     options.rowSelection,
     initialRowSelection,
@@ -484,13 +489,28 @@ export function useDataTable<TData>(options: UseDataTableOptions<TData>) {
       return
     }
 
-    try {
-      window.localStorage.setItem(
-        columnSizingStorageKey,
-        JSON.stringify(columnSizing)
-      )
-    } catch {
-      // Storage can be unavailable in private mode; table controls still work.
+    if (columnSizingPersistTimerRef.current !== undefined) {
+      window.clearTimeout(columnSizingPersistTimerRef.current)
+    }
+
+    columnSizingPersistTimerRef.current = window.setTimeout(() => {
+      try {
+        window.localStorage.setItem(
+          columnSizingStorageKey,
+          JSON.stringify(columnSizing)
+        )
+      } catch {
+        // Storage can be unavailable in private mode; table controls still work.
+      } finally {
+        columnSizingPersistTimerRef.current = undefined
+      }
+    }, COLUMN_SIZING_PERSIST_DELAY_MS)
+
+    return () => {
+      if (columnSizingPersistTimerRef.current !== undefined) {
+        window.clearTimeout(columnSizingPersistTimerRef.current)
+        columnSizingPersistTimerRef.current = undefined
+      }
     }
   }, [columnSizing, columnSizingStorageKey])
 

--- a/web/default/src/components/data-table/hooks/use-data-table.ts
+++ b/web/default/src/components/data-table/hooks/use-data-table.ts
@@ -19,6 +19,7 @@ For commercial licensing, please contact support@quantumnous.com
 import {
   type ColumnDef,
   type ColumnFiltersState,
+  type ColumnSizingState,
   type ExpandedState,
   type OnChangeFn,
   type PaginationState,
@@ -48,6 +49,7 @@ type DataTableFeatureOptions<TData> = Pick<
   | 'manualFiltering'
   | 'manualPagination'
   | 'manualSorting'
+  | 'enableColumnResizing'
 >
 
 type DataTableStateOptions = {
@@ -58,6 +60,10 @@ type DataTableStateOptions = {
   columnVisibilityStorageKey?: string | false
   columnVisibility?: VisibilityState
   onColumnVisibilityChange?: OnChangeFn<VisibilityState>
+  initialColumnSizing?: ColumnSizingState
+  columnSizingStorageKey?: string | false
+  columnSizing?: ColumnSizingState
+  onColumnSizingChange?: OnChangeFn<ColumnSizingState>
   initialRowSelection?: RowSelectionState
   rowSelection?: RowSelectionState
   onRowSelectionChange?: OnChangeFn<RowSelectionState>
@@ -149,6 +155,32 @@ function readColumnVisibility(storageKey: string | undefined): VisibilityState {
   }
 }
 
+function readColumnSizing(storageKey: string | undefined): ColumnSizingState {
+  if (!storageKey || typeof window === 'undefined') return {}
+
+  try {
+    const raw = window.localStorage.getItem(storageKey)
+    if (!raw) return {}
+
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {}
+    }
+
+    return Object.entries(parsed).reduce<ColumnSizingState>(
+      (sizing, [key, value]) => {
+        if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+          sizing[key] = value
+        }
+        return sizing
+      },
+      {}
+    )
+  } catch {
+    return {}
+  }
+}
+
 export function useDataTable<TData>(options: UseDataTableOptions<TData>) {
   const {
     data,
@@ -161,6 +193,7 @@ export function useDataTable<TData>(options: UseDataTableOptions<TData>) {
     manualSorting,
     initialSorting = [],
     initialColumnVisibility = {},
+    initialColumnSizing = {},
     initialRowSelection = {},
     initialExpanded = {},
     initialPagination = { pageIndex: 0, pageSize: 20 },
@@ -175,12 +208,23 @@ export function useDataTable<TData>(options: UseDataTableOptions<TData>) {
     typeof options.columnVisibilityStorageKey === 'string'
       ? options.columnVisibilityStorageKey
       : undefined
+  const columnSizingStorageKey =
+    typeof options.columnSizingStorageKey === 'string'
+      ? options.columnSizingStorageKey
+      : undefined
   const resolvedInitialColumnVisibility = React.useMemo(
     () => ({
       ...initialColumnVisibility,
       ...readColumnVisibility(columnVisibilityStorageKey),
     }),
     [columnVisibilityStorageKey, initialColumnVisibility]
+  )
+  const resolvedInitialColumnSizing = React.useMemo(
+    () => ({
+      ...initialColumnSizing,
+      ...readColumnSizing(columnSizingStorageKey),
+    }),
+    [columnSizingStorageKey, initialColumnSizing]
   )
 
   const [sorting, onSortingChange] = useControllableTableState(
@@ -194,10 +238,17 @@ export function useDataTable<TData>(options: UseDataTableOptions<TData>) {
       resolvedInitialColumnVisibility,
       options.onColumnVisibilityChange
     )
+  const [columnSizing, onColumnSizingChange] = useControllableTableState(
+    options.columnSizing,
+    resolvedInitialColumnSizing,
+    options.onColumnSizingChange
+  )
   const hydratedColumnVisibilityStorageKeyRef = React.useRef(
     columnVisibilityStorageKey
   )
+  const hydratedColumnSizingStorageKeyRef = React.useRef(columnSizingStorageKey)
   const skipNextColumnVisibilityPersistRef = React.useRef(false)
+  const skipNextColumnSizingPersistRef = React.useRef(false)
   const [rowSelection, onRowSelectionChange] = useControllableTableState(
     options.rowSelection,
     initialRowSelection,
@@ -228,6 +279,7 @@ export function useDataTable<TData>(options: UseDataTableOptions<TData>) {
     state: {
       sorting,
       columnVisibility,
+      columnSizing,
       rowSelection,
       expanded,
       columnFilters: options.columnFilters,
@@ -242,8 +294,11 @@ export function useDataTable<TData>(options: UseDataTableOptions<TData>) {
     manualFiltering,
     manualPagination,
     manualSorting,
+    enableColumnResizing: options.enableColumnResizing,
+    columnResizeMode: 'onChange',
     onSortingChange,
     onColumnVisibilityChange,
+    onColumnSizingChange,
     onRowSelectionChange,
     onExpandedChange,
     onColumnFiltersChange: options.onColumnFiltersChange,
@@ -291,6 +346,24 @@ export function useDataTable<TData>(options: UseDataTableOptions<TData>) {
   ])
 
   React.useEffect(() => {
+    if (
+      options.columnSizing !== undefined ||
+      columnSizingStorageKey === hydratedColumnSizingStorageKeyRef.current
+    ) {
+      return
+    }
+
+    hydratedColumnSizingStorageKeyRef.current = columnSizingStorageKey
+    skipNextColumnSizingPersistRef.current = true
+    onColumnSizingChange(() => resolvedInitialColumnSizing)
+  }, [
+    columnSizingStorageKey,
+    onColumnSizingChange,
+    options.columnSizing,
+    resolvedInitialColumnSizing,
+  ])
+
+  React.useEffect(() => {
     if (!columnVisibilityStorageKey || typeof window === 'undefined') return
 
     if (skipNextColumnVisibilityPersistRef.current) {
@@ -307,6 +380,24 @@ export function useDataTable<TData>(options: UseDataTableOptions<TData>) {
       // Storage can be unavailable in private mode; table controls still work.
     }
   }, [columnVisibility, columnVisibilityStorageKey])
+
+  React.useEffect(() => {
+    if (!columnSizingStorageKey || typeof window === 'undefined') return
+
+    if (skipNextColumnSizingPersistRef.current) {
+      skipNextColumnSizingPersistRef.current = false
+      return
+    }
+
+    try {
+      window.localStorage.setItem(
+        columnSizingStorageKey,
+        JSON.stringify(columnSizing)
+      )
+    } catch {
+      // Storage can be unavailable in private mode; table controls still work.
+    }
+  }, [columnSizing, columnSizingStorageKey])
 
   return {
     table,

--- a/web/default/src/features/channels/components/channels-columns.tsx
+++ b/web/default/src/features/channels/components/channels-columns.tsx
@@ -559,6 +559,7 @@ export function useChannelsColumns(
               },
               enableSorting: false,
               enableHiding: false,
+              enableResizing: false,
               size: 40,
             } satisfies ColumnDef<Channel>,
           ]
@@ -623,13 +624,13 @@ export function useChannelsColumns(
           const hasParamOverride = Boolean(channel.param_override?.trim())
 
           return (
-            <div className='flex items-center gap-2'>
-              <div className='flex flex-col gap-1'>
-                <div className='flex items-center gap-1.5'>
+            <div className='flex max-w-full min-w-0 items-center gap-2'>
+              <div className='flex max-w-full min-w-0 flex-col gap-1'>
+                <div className='flex max-w-full min-w-0 items-center gap-1.5'>
                   <TruncatedText
                     text={sensitiveVisible ? name : SENSITIVE_MASK}
                     className='font-medium'
-                    maxWidth='max-w-[180px]'
+                    maxWidth='max-w-full'
                   />
                   {isPassThrough && (
                     <TooltipProvider delay={100}>
@@ -683,6 +684,7 @@ export function useChannelsColumns(
             </div>
           )
         },
+        size: 260,
         minSize: 200,
       },
 

--- a/web/default/src/features/channels/components/channels-table.tsx
+++ b/web/default/src/features/channels/components/channels-table.tsx
@@ -67,6 +67,7 @@ import { DataTableBulkActions } from './data-table-bulk-actions'
 
 const route = getRouteApi('/_authenticated/channels/')
 const CHANNELS_COLUMN_VISIBILITY_STORAGE_KEY = 'channels:column-visibility'
+const CHANNELS_COLUMN_SIZING_STORAGE_KEY = 'channels:column-sizing'
 const CHANNELS_VIEW_MODE_STORAGE_KEY = 'channels:view-mode'
 const CHANNELS_STATUS_FILTER_STORAGE_KEY = 'channel-status-filter'
 
@@ -316,6 +317,7 @@ export function ChannelsTable() {
       tag: false,
     },
     columnVisibilityStorageKey: CHANNELS_COLUMN_VISIBILITY_STORAGE_KEY,
+    columnSizingStorageKey: CHANNELS_COLUMN_SIZING_STORAGE_KEY,
     columnFilters,
     pagination,
     globalFilter,
@@ -331,6 +333,7 @@ export function ChannelsTable() {
     manualSorting: true,
     manualFiltering: true,
     withExpandedRowModel: true,
+    enableColumnResizing: true,
     ensurePageInRange,
   })
 

--- a/web/default/src/features/channels/components/channels-table.tsx
+++ b/web/default/src/features/channels/components/channels-table.tsx
@@ -317,7 +317,9 @@ export function ChannelsTable() {
       tag: false,
     },
     columnVisibilityStorageKey: CHANNELS_COLUMN_VISIBILITY_STORAGE_KEY,
-    columnSizingStorageKey: CHANNELS_COLUMN_SIZING_STORAGE_KEY,
+    columnSizingStorageKey: isMobile
+      ? false
+      : CHANNELS_COLUMN_SIZING_STORAGE_KEY,
     columnFilters,
     pagination,
     globalFilter,
@@ -333,7 +335,7 @@ export function ChannelsTable() {
     manualSorting: true,
     manualFiltering: true,
     withExpandedRowModel: true,
-    enableColumnResizing: true,
+    enableColumnResizing: !isMobile,
     ensurePageInRange,
   })
 


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本说明为人工整理后的摘要，按项目模板填写。

## 📝 变更描述 / Description
渠道列表的字段很多，渠道名称、模型、分组等内容也可能很长。固定列宽时，用户只能看到被截断后的内容，对比和排查渠道不方便。

本 PR 给渠道列表增加了可调整列宽：

- 拖动表头右侧分隔线，可以手动调整列宽。
- 双击分隔线，会按当前可见内容自动调整到合适宽度。
- 调整后的列宽保存在浏览器本地，刷新页面后仍然保留。
- 分隔线支持键盘操作：左右方向键调整宽度，Enter / Space 自动适应内容。

实现上，列宽状态复用通用 DataTable 的 TanStack Table sizing 状态；只有渠道列表传入本地保存 key 并启用列宽调整，不影响未启用该能力的其他表格。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5946

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，未发现渠道列表列宽调整的重复提交。
- [x] **Bug fix 说明:** 此 PR 未标记为 `Bug fix`。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 仅包含渠道列表列宽调整相关改动。
- [x] **本地验证:** 已在本地运行并通过类型检查、相关文件 lint、格式检查和 diff 空白检查。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
当前 PR head 已执行并通过：

```bash
bun run --cwd default typecheck
./node_modules/.bin/oxlint.exe -c default/.oxlintrc.json default/src/components/data-table/core/data-table-colgroup.tsx default/src/components/data-table/core/data-table-header.tsx default/src/components/data-table/core/data-table-row.tsx default/src/components/data-table/hooks/use-data-table.ts default/src/features/channels/components/channels-columns.tsx default/src/features/channels/components/channels-table.tsx
./node_modules/.bin/oxfmt.exe --check default/src/components/data-table/core/data-table-colgroup.tsx default/src/components/data-table/core/data-table-header.tsx default/src/components/data-table/core/data-table-row.tsx default/src/components/data-table/hooks/use-data-table.ts default/src/features/channels/components/channels-columns.tsx default/src/features/channels/components/channels-table.tsx
git diff --check origin/main...HEAD
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resizable table columns with keyboard controls and automatic sizing.
  * Table column widths can now be saved and restored between visits on supported views.

* **Bug Fixes**
  * Improved column sizing behavior for content-based columns and mobile devices.
  * Updated table layouts to better handle narrow content without overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->