### PR TITLE
fix(default): 修复 default 主题下富 HTML 公告(Notice)样式/动画失效

### DIFF
--- a/web/default/src/components/notification-popover.tsx
+++ b/web/default/src/components/notification-popover.tsx
@@ -21,6 +21,7 @@ import { Bell, Megaphone } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { RichContent } from '@/components/rich-content'
+import { isLikelyHtml } from '@/lib/content-format'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -205,7 +206,11 @@ function NoticeContent({
 
   return (
     <ScrollArea className='h-[min(52vh,28rem)] pr-3'>
-      <RichContent breaks content={notice} />
+      <RichContent
+        breaks
+        content={notice}
+        mode={isLikelyHtml(notice) ? 'html' : 'markdown'}
+      />
     </ScrollArea>
   )
 }

--- a/web/default/src/components/notification-popover.tsx
+++ b/web/default/src/components/notification-popover.tsx
@@ -210,6 +210,7 @@ function NoticeContent({
         breaks
         content={notice}
         mode={isLikelyHtml(notice) ? 'html' : 'markdown'}
+        htmlVariant='isolated'
       />
     </ScrollArea>
   )


### PR DESCRIPTION
## 背景 / Context

`default` 主题下,系统公告(`Notice`)中的富 HTML(如包含 `<style>` 的自定义样式块、带动画的按钮卡片)升级后不再渲染,退化为纯文本/样式丢失。这是相对 classic 主题(直接 `dangerouslySetInnerHTML`)的兼容性回退。

关联 issue:#5900

## 根因 / Root cause

`web/default/src/components/notification-popover.tsx` 中 notice 的渲染:

```tsx
<RichContent breaks content={notice} />
```

未传 `mode`,因此 `RichContent` 落入 `Markdown` 分支。`Markdown` 使用 DOMPurify 严格净化,`allowedTags` 白名单面向 Markdown / KaTeX / SVG,不含 `<style>` 与自定义按钮结构,导致历史富 HTML 公告的样式与动画被剥离。

而框架内已存在 `HtmlContent` 组件(`ADD_TAGS` 显式允许 `style`),专用于安全渲染富 HTML,只是 notice 未使用它。

## 改动 / Change

利用已有的 `isLikelyHtml()`(`web/default/src/lib/content-format.ts`)判定内容类型:

- 内容为 HTML → `mode="html"`(走 `HtmlContent`,恢复富 HTML/动画渲染)
- 否则 → 保持 `markdown`(纯 Markdown 公告行为不变)

```tsx
<RichContent
  breaks
  content={notice}
  mode={isLikelyHtml(notice) ? 'html' : 'markdown'}
/>
```

改动最小(1 个文件,+6/-1),仅影响 notice 渲染路径,不改变 Markdown 公告的现有行为,且沿用现有的 `HtmlContent` 净化安全边界。

## 验证 / Verification

- `tsc --noEmit` 类型检查通过(0 error)
- 逻辑上:HTML 公告走 HtmlContent(允许 style)恢复显示;非 HTML(Markdown)公告仍走 Markdown,行为不变


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notice rendering in the notification popover so content displays in the correct format.
  * HTML-like notices are now rendered as HTML, while non-HTML notices continue to render as Markdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->