### PR TITLE
fix(web): allow user-activated top navigation for custom home iframe

### DIFF
--- a/web/default/src/features/home/index.tsx
+++ b/web/default/src/features/home/index.tsx
@@ -72,12 +72,20 @@ export function Home() {
     if (isUrl) {
       return (
         <PublicLayout showMainContainer={false}>
+          {/*
+            allow-top-navigation-by-user-activation: the custom home page URL is
+            admin-configured (trusted); this lets its target="_top" nav/menu links
+            navigate the top-level window on user click. The default sandbox blocks
+            this on desktop, while some mobile browsers allow it via allow-popups,
+            causing inconsistent behavior. This token only permits user-activated
+            top-level navigation and does NOT grant same-origin access.
+          */}
           <iframe
             ref={iframeRef}
             src={content}
             className='h-screen w-full border-none'
             title={t('Custom Home Page')}
-            sandbox='allow-forms allow-popups allow-popups-to-escape-sandbox allow-scripts'
+            sandbox='allow-forms allow-popups allow-popups-to-escape-sandbox allow-scripts allow-top-navigation-by-user-activation'
             onLoad={syncIframePreferences}
           />
         </PublicLayout>


### PR DESCRIPTION
The custom home page URL iframe only allows allow-forms/allow-popups/ allow-popups-to-escape-sandbox/allow-scripts, without allow-top-navigation*. As a result, target="_top" nav/menu links inside the (admin-configured, trusted) embedded page cannot navigate the top-level window on desktop browsers, while some mobile browsers still allow it via allow-popups — causing inconsistent behavior rather than an intended restriction.

Add allow-top-navigation-by-user-activation so user-clicked top-level links work consistently across devices. This token only permits user-activated top navigation and does NOT grant same-origin access, so it avoids the security concern of allow-same-origin.

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ ] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [ ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [ ] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation behavior in the custom home page, allowing admin-configured links inside the embedded view to open the top-level page when triggered by user action.
  * Kept the rest of the home page experience unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->