### PR TITLE
fix: parse standard OpenAI cached_tokens for OpenAI-compatible channels

### DIFF
--- a/relay/channel/openai/usage.go
+++ b/relay/channel/openai/usage.go
@@ -43,7 +43,11 @@ func applyUsagePostProcessing(info *relaycommon.RelayInfo, usage *dto.Usage, res
 		}
 	case constant.ChannelTypeOpenAI:
 		if usage.PromptTokensDetails.CachedTokens == 0 {
-			if cachedTokens, ok := extractLlamaCachedTokensFromBody(responseBody); ok {
+			// Standard OpenAI format: usage.prompt_tokens_details.cached_tokens
+			if cachedTokens, ok := extractCachedTokensFromBody(responseBody); ok {
+				usage.PromptTokensDetails.CachedTokens = cachedTokens
+			} else if cachedTokens, ok := extractLlamaCachedTokensFromBody(responseBody); ok {
+				// Fallback: llama.cpp format (timings.cache_n)
 				usage.PromptTokensDetails.CachedTokens = cachedTokens
 			}
 		}

--- a/relay/channel/openai/usage.go
+++ b/relay/channel/openai/usage.go
@@ -43,8 +43,10 @@ func applyUsagePostProcessing(info *relaycommon.RelayInfo, usage *dto.Usage, res
 		}
 	case constant.ChannelTypeOpenAI:
 		if usage.PromptTokensDetails.CachedTokens == 0 {
-			// Standard OpenAI format: usage.prompt_tokens_details.cached_tokens
-			if cachedTokens, ok := extractCachedTokensFromBody(responseBody); ok {
+			if usage.InputTokensDetails != nil && usage.InputTokensDetails.CachedTokens > 0 {
+				usage.PromptTokensDetails.CachedTokens = usage.InputTokensDetails.CachedTokens
+			} else if cachedTokens, ok := extractCachedTokensFromBody(responseBody); ok {
+				// Standard OpenAI format: usage.prompt_tokens_details.cached_tokens
 				usage.PromptTokensDetails.CachedTokens = cachedTokens
 			} else if cachedTokens, ok := extractLlamaCachedTokensFromBody(responseBody); ok {
 				// Fallback: llama.cpp format (timings.cache_n)


### PR DESCRIPTION
## Problem

The `ChannelTypeOpenAI` case in `applyUsagePostProcessing` only parses cached tokens from llama.cpp's non-standard format (`timings.cache_n`). 

OpenAI-compatible providers like OpenCode Go, and many others, return cached token information in the **standard OpenAI format**:

```json
{
  "usage": {
    "prompt_tokens": 90225,
    "completion_tokens": 735,
    "prompt_tokens_details": {
      "cached_tokens": 89000
    }
  }
}
```

Since `extractCachedTokensFromBody` is not called for `ChannelTypeOpenAI`, these cached tokens are never detected, resulting in `cache_tokens: 0` in logs and incorrect billing calculations.

## Impact

- Cache hit tokens are billed at full price instead of cache-hit price
- For providers with significant caching (e.g., DeepSeek via OpenCode Go), this can overcharge users by 5-10x

## Fix

Add `extractCachedTokensFromBody` as the primary parser for `ChannelTypeOpenAI`, with `extractLlamaCachedTokensFromBody` as a fallback for llama.cpp backends.

This aligns the OpenAI channel behavior with `ChannelTypeZhipu_v4` and `ChannelTypeMoonshot`, which already use the standard format parser.

## Testing

Verified that the `extractCachedTokensFromBody` function already handles:
- `usage.prompt_tokens_details.cached_tokens` (standard)
- `usage.cached_tokens` (alternative)
- `usage.prompt_cache_hit_tokens` (DeepSeek-style)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage accounting for OpenAI responses by prioritizing standard cached-token reporting.
  * Added/strengthened a fallback to capture cached tokens when responses use an alternate (llama.cpp-style) cached-token format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->