### PR TITLE
fix(web): prevent browser translation from mutating React roots

### DIFF
--- a/web/classic/index.html
+++ b/web/classic/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="google" content="notranslate" />
     <meta name="theme-color" content="#ffffff" />
     <meta
       name="description"
@@ -23,6 +24,6 @@
 
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
+    <div id="root" translate="no" class="notranslate"></div>
   </body>
 </html>

--- a/web/default/index.html
+++ b/web/default/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="google" content="notranslate" />
 
     <!-- Primary Meta Tags -->
     <title>New API</title>
@@ -19,6 +20,6 @@
   </head>
 
   <body>
-    <div id="root"></div>
+    <div id="root" translate="no" class="notranslate"></div>
   </body>
 </html>


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

修复浏览器 Google Translate / 网页翻译改写 React 托管 DOM 后，API 密钥创建流程可能进入 500 错误页的问题。

根因是浏览器翻译会把 React 管理的文本节点替换为 `<font>` 包装节点。创建 API 密钥时，保存按钮状态、toast 和表格刷新会触发 React 更新同一批文本节点，从而出现 `NotFoundError: Failed to execute 'removeChild' on 'Node'`，最终由前端错误页表现为 500。服务端 `/api/token/` 请求本身可正常返回 200。

本 PR 在默认前端与 classic 前端入口增加 Google notranslate meta，并给 React root 添加 `translate="no"` 与 `notranslate`，阻止浏览器翻译器改写 React 应用根节点。项目本身已有 i18next 多语言能力，因此不依赖浏览器翻译 React DOM。

AI-assisted disclosure: this PR was prepared with AI assistance by Codex.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5962

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述已整理为简洁摘要，没有直接粘贴未经处理的长输出；本 PR 为 AI-assisted，已在上方披露。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

Local reproduction used `calciumion/new-api:latest` (`X-New-Api-Version: v1.0.0-rc.18`) with an isolated root user.

- Baseline API key creation: success; `/api/token/` returned 200.
- Simulated Chrome Google Translate full-page text wrapping (`<font><font>...</font></font>`): creation flow produced React console error `NotFoundError: Failed to execute 'removeChild' on 'Node'`, and the UI rendered the 500 error page. `/api/token/` still returned 200, confirming this is a frontend DOM mutation crash rather than a backend token API 500.
- Simulated the proposed fix by marking `#root` as `translate="no"` / `notranslate`: the same API key creation flow succeeded, no `removeChild` React error appeared, and `/api/token/` returned 200.
- `git diff --check` passed.
- Static assertion confirmed both `web/default/index.html` and `web/classic/index.html` contain the notranslate meta/root markers.


Screenshots from the local reproduction are also attached in the linked issue and mirrored here for quick PR review:

![Google Translate simulated 500](https://raw.githubusercontent.com/cat0825/new-api/issue-5962-assets/google-translate-500.png)

![notranslate success](https://raw.githubusercontent.com/cat0825/new-api/issue-5962-assets/notranslate-success.png)

Full console stack: https://raw.githubusercontent.com/cat0825/new-api/issue-5962-assets/console-removechild-stack.txt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Google Translate from altering page content on the app’s main entry screens.
  * Marked the root app container as non-translatable to better preserve the original interface text and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->