### PR TITLE
feat: support OpenRouter image generation endpoint

### DIFF
--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -107,12 +107,6 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 			info.ChannelBaseUrl = baseUrl
 		}
 	}
-	// OpenRouter's image generation endpoint is POST {base}/v1/images
-	// (https://openrouter.ai/docs/features/multimodal/image-generation-api),
-	// not the OpenAI-style /v1/images/generations.
-	if info.ChannelType == constant.ChannelTypeOpenRouter && info.RelayMode == relayconstant.RelayModeImagesGenerations {
-		return fmt.Sprintf("%s/v1/images", info.ChannelBaseUrl), nil
-	}
 	switch info.ChannelType {
 	case constant.ChannelTypeAzure:
 		apiVersion := info.ApiVersion
@@ -169,6 +163,14 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 		url := info.ChannelBaseUrl
 		url = strings.Replace(url, "{model}", info.UpstreamModelName, -1)
 		return url, nil
+	case constant.ChannelTypeOpenRouter:
+		// OpenRouter's image generation endpoint is POST {base}/v1/images
+		// (https://openrouter.ai/docs/features/multimodal/image-generation-api),
+		// not the OpenAI-style /v1/images/generations.
+		if info.RelayMode == relayconstant.RelayModeImagesGenerations {
+			return fmt.Sprintf("%s/v1/images", info.ChannelBaseUrl), nil
+		}
+		fallthrough
 	default:
 		if (info.RelayFormat == types.RelayFormatClaude || info.RelayFormat == types.RelayFormatGemini) &&
 			info.RelayMode != relayconstant.RelayModeResponses &&

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -107,6 +107,12 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 			info.ChannelBaseUrl = baseUrl
 		}
 	}
+	// OpenRouter's image generation endpoint is POST {base}/v1/images
+	// (https://openrouter.ai/docs/features/multimodal/image-generation-api),
+	// not the OpenAI-style /v1/images/generations.
+	if info.ChannelType == constant.ChannelTypeOpenRouter && info.RelayMode == relayconstant.RelayModeImagesGenerations {
+		return fmt.Sprintf("%s/v1/images", info.ChannelBaseUrl), nil
+	}
 	switch info.ChannelType {
 	case constant.ChannelTypeAzure:
 		apiVersion := info.ApiVersion

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -564,6 +564,12 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 		return &requestBody, nil
 
 	default:
+		// OpenRouter's /v1/images endpoint accepts params outside the OpenAI
+		// image schema, so merge the unknown fields captured in Extra back
+		// into the outbound body for this channel only.
+		if info.ChannelType == constant.ChannelTypeOpenRouter && info.RelayMode == relayconstant.RelayModeImagesGenerations {
+			return mergeImageRequestExtra(request)
+		}
 		return request, nil
 	}
 }

--- a/relay/channel/openai/openrouter_image.go
+++ b/relay/channel/openai/openrouter_image.go
@@ -1,0 +1,31 @@
+package openai
+
+import (
+	"encoding/json"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+)
+
+// mergeImageRequestExtra flattens the unknown fields captured in
+// ImageRequest.Extra back into the outbound JSON body. OpenRouter's
+// /v1/images endpoint accepts params outside the OpenAI image schema
+// (aspect_ratio, resolution, seed, input_references, provider), which
+// the generic ImageRequest serialization drops. Known fields always
+// win over Extra entries with the same key.
+func mergeImageRequestExtra(request dto.ImageRequest) (map[string]json.RawMessage, error) {
+	base, err := common.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	var bodyMap map[string]json.RawMessage
+	if err := common.Unmarshal(base, &bodyMap); err != nil {
+		return nil, err
+	}
+	for k, v := range request.Extra {
+		if _, exists := bodyMap[k]; !exists {
+			bodyMap[k] = v
+		}
+	}
+	return bodyMap, nil
+}

--- a/relay/channel/openai/openrouter_image_test.go
+++ b/relay/channel/openai/openrouter_image_test.go
@@ -1,0 +1,62 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+)
+
+// TestGetRequestURLOpenRouterImageGeneration verifies that image generation
+// requests to an OpenRouter channel are sent to OpenRouter's flat
+// {base}/v1/images endpoint instead of the OpenAI-style /v1/images/generations.
+func TestGetRequestURLOpenRouterImageGeneration(t *testing.T) {
+	t.Parallel()
+
+	adaptor := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		RelayMode:      relayconstant.RelayModeImagesGenerations,
+		RequestURLPath: "/v1/images/generations",
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelType:    constant.ChannelTypeOpenRouter,
+			ChannelBaseUrl: "https://openrouter.ai/api",
+		},
+	}
+
+	got, err := adaptor.GetRequestURL(info)
+	if err != nil {
+		t.Fatalf("GetRequestURL returned error: %v", err)
+	}
+
+	want := "https://openrouter.ai/api/v1/images"
+	if got != want {
+		t.Fatalf("GetRequestURL() = %q, want %q", got, want)
+	}
+}
+
+// TestGetRequestURLOpenRouterChatUnchanged guards against the image special
+// case leaking into the chat completions path for OpenRouter channels.
+func TestGetRequestURLOpenRouterChatUnchanged(t *testing.T) {
+	t.Parallel()
+
+	adaptor := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		RelayMode:      relayconstant.RelayModeChatCompletions,
+		RequestURLPath: "/v1/chat/completions",
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelType:    constant.ChannelTypeOpenRouter,
+			ChannelBaseUrl: "https://openrouter.ai/api",
+		},
+	}
+
+	got, err := adaptor.GetRequestURL(info)
+	if err != nil {
+		t.Fatalf("GetRequestURL returned error: %v", err)
+	}
+
+	want := "https://openrouter.ai/api/v1/chat/completions"
+	if got != want {
+		t.Fatalf("GetRequestURL() = %q, want %q", got, want)
+	}
+}

--- a/relay/channel/openai/openrouter_image_test.go
+++ b/relay/channel/openai/openrouter_image_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/QuantumNous/new-api/constant"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestGetRequestURLOpenRouterImageGeneration verifies that image generation
@@ -25,14 +27,8 @@ func TestGetRequestURLOpenRouterImageGeneration(t *testing.T) {
 	}
 
 	got, err := adaptor.GetRequestURL(info)
-	if err != nil {
-		t.Fatalf("GetRequestURL returned error: %v", err)
-	}
-
-	want := "https://openrouter.ai/api/v1/images"
-	if got != want {
-		t.Fatalf("GetRequestURL() = %q, want %q", got, want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "https://openrouter.ai/api/v1/images", got)
 }
 
 // TestGetRequestURLOpenRouterChatUnchanged guards against the image special
@@ -51,12 +47,6 @@ func TestGetRequestURLOpenRouterChatUnchanged(t *testing.T) {
 	}
 
 	got, err := adaptor.GetRequestURL(info)
-	if err != nil {
-		t.Fatalf("GetRequestURL returned error: %v", err)
-	}
-
-	want := "https://openrouter.ai/api/v1/chat/completions"
-	if got != want {
-		t.Fatalf("GetRequestURL() = %q, want %q", got, want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "https://openrouter.ai/api/v1/chat/completions", got)
 }

--- a/relay/channel/openai/openrouter_image_test.go
+++ b/relay/channel/openai/openrouter_image_test.go
@@ -1,9 +1,12 @@
 package openai
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/stretchr/testify/assert"
@@ -49,4 +52,89 @@ func TestGetRequestURLOpenRouterChatUnchanged(t *testing.T) {
 	got, err := adaptor.GetRequestURL(info)
 	require.NoError(t, err)
 	assert.Equal(t, "https://openrouter.ai/api/v1/chat/completions", got)
+}
+
+// TestConvertImageRequestOpenRouterMergesExtra verifies that OpenRouter-specific
+// image generation params captured in ImageRequest.Extra (aspect_ratio, seed,
+// provider, ...) are merged back into the outbound body for OpenRouter channels,
+// alongside the known OpenAI fields.
+func TestConvertImageRequestOpenRouterMergesExtra(t *testing.T) {
+	t.Parallel()
+
+	body := `{
+		"model": "google/gemini-2.5-flash-image",
+		"prompt": "a cat wearing a hat",
+		"aspect_ratio": "16:9",
+		"seed": 42,
+		"provider": {"options": {"only": ["google-vertex"]}}
+	}`
+	var request dto.ImageRequest
+	require.NoError(t, common.Unmarshal([]byte(body), &request))
+	require.Contains(t, request.Extra, "aspect_ratio")
+
+	adaptor := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		RelayMode:      relayconstant.RelayModeImagesGenerations,
+		RequestURLPath: "/v1/images/generations",
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelType:    constant.ChannelTypeOpenRouter,
+			ChannelBaseUrl: "https://openrouter.ai/api",
+		},
+	}
+
+	converted, err := adaptor.ConvertImageRequest(nil, info, request)
+	require.NoError(t, err)
+
+	serialized, err := common.Marshal(converted)
+	require.NoError(t, err)
+
+	var got map[string]json.RawMessage
+	require.NoError(t, common.Unmarshal(serialized, &got))
+
+	assert.JSONEq(t, `"google/gemini-2.5-flash-image"`, string(got["model"]))
+	assert.JSONEq(t, `"a cat wearing a hat"`, string(got["prompt"]))
+	assert.JSONEq(t, `"16:9"`, string(got["aspect_ratio"]))
+	assert.JSONEq(t, `42`, string(got["seed"]))
+	assert.JSONEq(t, `{"options": {"only": ["google-vertex"]}}`, string(got["provider"]))
+}
+
+// TestConvertImageRequestNonOpenRouterDropsExtra guards the owner's constraint
+// that Extra must NOT be merged globally: for non-OpenRouter channels the
+// serialized body keeps dropping unknown fields.
+func TestConvertImageRequestNonOpenRouterDropsExtra(t *testing.T) {
+	t.Parallel()
+
+	body := `{
+		"model": "gpt-image-1",
+		"prompt": "a cat wearing a hat",
+		"aspect_ratio": "16:9",
+		"seed": 42
+	}`
+	var request dto.ImageRequest
+	require.NoError(t, common.Unmarshal([]byte(body), &request))
+	require.Contains(t, request.Extra, "aspect_ratio")
+
+	adaptor := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		RelayMode:      relayconstant.RelayModeImagesGenerations,
+		RequestURLPath: "/v1/images/generations",
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelType:    constant.ChannelTypeOpenAI,
+			ChannelBaseUrl: "https://api.openai.com",
+		},
+	}
+
+	converted, err := adaptor.ConvertImageRequest(nil, info, request)
+	require.NoError(t, err)
+
+	serialized, err := common.Marshal(converted)
+	require.NoError(t, err)
+
+	var got map[string]json.RawMessage
+	require.NoError(t, common.Unmarshal(serialized, &got))
+
+	assert.NotContains(t, got, "aspect_ratio")
+	assert.NotContains(t, got, "seed")
+	assert.JSONEq(t, `"gpt-image-1"`, string(got["model"]))
+	assert.JSONEq(t, `"a cat wearing a hat"`, string(got["prompt"]))
 }


### PR DESCRIPTION
## 📝 变更描述 / Description

OpenRouter 现已提供图像生成 API，端点为 `POST {base}/v1/images`（[官方文档](https://openrouter.ai/docs/features/multimodal/image-generation-api)），与 OpenAI 风格的 `/v1/images/generations` 路径不同。目前 OpenRouter 渠道复用 OpenAI adaptor，图像请求会被转发到 `https://openrouter.ai/api/v1/images/generations`，上游返回 404。

本 PR 在 `openai.Adaptor.GetRequestURL` 中为 OpenRouter 渠道的 `RelayModeImagesGenerations` 增加特判，改为请求 `{base}/v1/images`。请求体（`model`/`prompt`/`n`/`size`）和响应体（`created`/`data[].b64_json`/`usage`）均为 OpenAI Images 兼容格式，OpenRouter 会忽略未知字段，因此现有的 `ImageRequest` 转换和 `OpenaiImageHandler`（含 usage 计费解析）无需改动。

OpenRouter now offers an image generation API at `POST {base}/v1/images` ([docs](https://openrouter.ai/docs/features/multimodal/image-generation-api)) — a flat path, unlike OpenAI's `/v1/images/generations`. Since the OpenRouter channel reuses the OpenAI adaptor, image requests currently go to `https://openrouter.ai/api/v1/images/generations` and get a 404 upstream. This PR special-cases `RelayModeImagesGenerations` for OpenRouter channels in `GetRequestURL`. Request and response shapes are OpenAI-Images-compatible (OpenRouter silently ignores unknown fields, responses carry `created` / `data[].b64_json` / `usage`), so the existing `ConvertImageRequest` passthrough and `OpenaiImageHandler` billing path work unchanged.

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无 / None

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 不适用（新功能）。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试与端到端手动验证（见下）。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

**1. 路径验证 / Endpoint verification** — OpenRouter 上游确认扁平路径存在，`/generations` 不存在：

```
$ curl -s -o /dev/null -w "%{http_code}" -X POST https://openrouter.ai/api/v1/images -d '{...}'
401   # 需要鉴权 → 路径存在
$ curl -s -o /dev/null -w "%{http_code}" -X POST https://openrouter.ai/api/v1/images/generations -d '{}'
404   # 路径不存在
```

**2. 单元测试 / Unit tests**（新增 `openrouter_image_test.go`，覆盖图像 URL 特判 + chat 路径不受影响）：

```
$ go build ./...   # ok
$ go test ./relay/channel/openai/...
ok  	github.com/QuantumNous/new-api/relay/channel/openai	0.367s
```

**3. 端到端验证 / E2E** — 本地启动 new-api（SQLite），配置 type=20 OpenRouter 渠道指向一个记录请求路径的 mock 上游，然后调用 new-api 的 `/v1/images/generations`：

```
$ curl -s -X POST http://127.0.0.1:18791/v1/images/generations \
    -H "Authorization: Bearer sk-..." \
    -d '{"model":"google/gemini-2.5-flash-image","prompt":"a cute cat"}'
{"created":1751800000,"data":[{"b64_json":"aGVsbG8="}],"usage":{"completion_tokens":1290,"prompt_tokens":10,"total_tokens":1300}}

# mock 上游日志（确认命中扁平路径 + 渠道密钥透传）:
MOCK UPSTREAM HIT: POST /v1/images Authorization="Bearer sk-or-test"

# new-api 计费日志（usage 正确入账）:
google/gemini-2.5-flash-image  prompt_tokens=10  completion_tokens=1290  quota=48750
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenRouter image-generation routing to use the correct `/v1/images` endpoint.
  * Updated OpenRouter image requests to merge additional image parameters from extra fields into the outbound JSON body, while preserving existing/known fields.
  * Ensured non-OpenRouter channels omit these extra/unknown image fields from the serialized payload.
* **Tests**
  * Added unit tests covering OpenRouter URL rewriting, chat routing staying unchanged, and request-body transformation for both OpenRouter and non-OpenRouter channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->