### PR TITLE
Fix task polling result URLs and reset locking

### DIFF
--- a/model/subscription.go
+++ b/model/subscription.go
@@ -1027,7 +1027,7 @@ func adminResetUserSubscriptionsByPlanTx(tx *gorm.DB, userId int, plan *Subscrip
 		return nil, errors.New("invalid reset args")
 	}
 	var subs []UserSubscription
-	if err := tx.Set("gorm:query_option", "FOR UPDATE").
+	if err := lockForUpdate(tx).
 		Where("user_id = ? AND plan_id = ? AND status = ? AND end_time > ?", userId, plan.Id, "active", now).
 		Order("end_time asc, id asc").
 		Find(&subs).Error; err != nil {
@@ -1049,7 +1049,7 @@ func adminResetPlanSubscriptionsTx(tx *gorm.DB, plan *SubscriptionPlan, now int6
 		return nil, errors.New("invalid reset args")
 	}
 	var subs []UserSubscription
-	if err := tx.Set("gorm:query_option", "FOR UPDATE").
+	if err := lockForUpdate(tx).
 		Where("plan_id = ? AND status = ? AND end_time > ?", plan.Id, "active", now).
 		Order("user_id asc, end_time asc, id asc").
 		Find(&subs).Error; err != nil {

--- a/service/task_polling.go
+++ b/service/task_polling.go
@@ -468,13 +468,16 @@ func updateVideoSingleTask(ctx context.Context, adaptor TaskPollingAdaptor, ch *
 
 	taskResult := &relaycommon.TaskInfo{}
 	// try parse as New API response format
-	var responseItems dto.TaskResponse[model.Task]
+	var responseItems dto.TaskResponse[dto.TaskDto]
 	if err = common.Unmarshal(responseBody, &responseItems); err == nil && responseItems.IsSuccess() {
 		logger.LogDebug(ctx, "updateVideoSingleTask parsed as new api response format: %+v", responseItems)
 		t := responseItems.Data
 		taskResult.TaskID = t.TaskID
-		taskResult.Status = string(t.Status)
-		taskResult.Url = t.GetResultURL()
+		taskResult.Status = t.Status
+		taskResult.Url = strings.TrimSpace(t.ResultURL)
+		if taskResult.Url == "" && model.TaskStatus(t.Status) == model.TaskStatusSuccess {
+			taskResult.Url = strings.TrimSpace(t.FailReason)
+		}
 		taskResult.Progress = t.Progress
 		taskResult.Reason = t.FailReason
 		task.Data = t.Data

--- a/service/task_polling_test.go
+++ b/service/task_polling_test.go
@@ -22,6 +22,7 @@ import (
 type taskPollingFetchAdaptor struct {
 	mu           sync.Mutex
 	taskIDs      []string
+	responseBody map[string][]byte
 	fetched      chan string
 	blockTaskID  string
 	blockStarted chan struct{}
@@ -50,6 +51,12 @@ func (a *taskPollingFetchAdaptor) FetchTask(_ string, _ string, body map[string]
 		case a.fetched <- taskID:
 		default:
 		}
+	}
+	if body, ok := a.responseBody[taskID]; ok {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+		}, nil
 	}
 
 	response := dto.TaskResponse[model.Task]{
@@ -123,6 +130,50 @@ func seedPollingTask(t *testing.T, channelID int, publicID string, upstreamID st
 	}
 	require.NoError(t, model.DB.Create(task).Error)
 	return task
+}
+
+func TestUpdateVideoTasksPreservesNewAPITaskDtoResultURL(t *testing.T) {
+	truncate(t)
+
+	const channelID = 1001
+	const resultURL = "https://cdn.example.com/videos/result.mp4"
+	seedTaskPollingChannel(t, channelID, true)
+	task := seedPollingTask(t, channelID, "task_public_result_url", "upstream_result_url")
+	response := dto.TaskResponse[dto.TaskDto]{
+		Code: dto.TaskSuccessCode,
+		Data: dto.TaskDto{
+			TaskID:    task.TaskID,
+			Status:    string(model.TaskStatusSuccess),
+			ResultURL: resultURL,
+			Progress:  "100%",
+		},
+	}
+	body, err := common.Marshal(response)
+	require.NoError(t, err)
+
+	adaptor := &taskPollingFetchAdaptor{
+		responseBody: map[string][]byte{
+			task.GetUpstreamTaskID(): body,
+		},
+	}
+	previousFactory := GetTaskAdaptorFunc
+	GetTaskAdaptorFunc = func(constant.TaskPlatform) TaskPollingAdaptor { return adaptor }
+	t.Cleanup(func() { GetTaskAdaptorFunc = previousFactory })
+
+	err = UpdateVideoTasks(context.Background(), constant.TaskPlatform("kling"), map[int][]string{
+		channelID: {
+			task.GetUpstreamTaskID(),
+		},
+	}, map[string]*model.Task{
+		task.GetUpstreamTaskID(): task,
+	})
+
+	require.NoError(t, err)
+	var saved model.Task
+	require.NoError(t, model.DB.Where("task_id = ?", task.TaskID).First(&saved).Error)
+	assert.Equal(t, model.TaskStatus(model.TaskStatusSuccess), saved.Status)
+	assert.Equal(t, resultURL, saved.PrivateData.ResultURL)
+	assert.Equal(t, "100%", saved.Progress)
 }
 
 func TestUpdateVideoTasksDefaultSleepWaitsBetweenTasks(t *testing.T) {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本描述已按本次变更人工整理为简洁摘要，没有直接粘贴未经整理的 AI 输出。
> - AI 辅助声明：本 PR 的代码与说明由 Codex 辅助生成，提交者 git 身份不是仓库近期核心作者。
> - 旧 issue #5974 已按维护者建议拆分为 #5977 和 #5978；旧 codex 前缀 PR #5975 已关闭，当前 PR 使用非 codex 分支。

## 📝 变更描述 / Description
修复两个异步任务和订阅重置相关问题：

1. 任务轮询解析 New API 响应时改用 `dto.TaskResponse[dto.TaskDto]`，读取顶层 `result_url` 并保存到任务私有结果 URL。这样 New API 作为上游异步任务服务时，成功任务不会因为按 `model.Task` 解析而丢失结果地址。
2. 管理员重置用户订阅/套餐订阅时改用现有 `lockForUpdate(tx)` helper。GORM v2 会忽略旧的 `Set("gorm:query_option", "FOR UPDATE")`，该 helper 能在支持的数据库上生成行锁，并在 SQLite 下保持兼容。

补充了一个回归测试，覆盖 New API `TaskDto.result_url` 轮询结果保存流程。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5977
- Closes #5978

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。已注意到 #5805/#5927 与任务轮询相关，但它们没有覆盖顶层 `TaskDto.result_url` 解析，也没有覆盖订阅重置行锁问题。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
通过：

```bash
go test ./service -run "TestUpdateVideoTasksPreservesNewAPITaskDtoResultURL|TestUpdateVideoTasks"
go test ./model -run "TestAdminReset|TestLockForUpdate|TestSubscription"
```

补充验证：

```bash
go test ./model ./service
```

结果：`./model` 通过；`./service` 中现有的 channel affinity usage cache 用例失败，失败项为 `TestObserveChannelAffinityUsageCacheByRelayFormat_MixedMode` 和 `TestObserveChannelAffinityUsageCacheByRelayFormat_UnsupportedModeKeepsEmpty`。这两个失败与本 PR 修改的任务轮询和订阅重置代码无关。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription reset handling to use more reliable row locking during admin operations.
  * Fixed video task polling so newer API responses correctly preserve the result URL, status, and completion progress.
  * Added a fallback to use the failure message as the result URL when the upstream success response omits it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->