### PR TITLE
fix(option): Turnstile Site Key 在管理后台回显为空且保存时会清空已存配置

### DIFF
--- a/controller/option.go
+++ b/controller/option.go
@@ -57,6 +57,24 @@ func collectModelNamesFromOptionValue(raw string, modelNames map[string]struct{}
 	}
 }
 
+// optionKeysExposedToAdmin lists option keys that should be returned by
+// GET /api/option/ even though they match sensitive suffix heuristics.
+// TurnstileSiteKey is public (also exposed via /api/status for login widgets).
+var optionKeysExposedToAdmin = map[string]struct{}{
+	"TurnstileSiteKey": {},
+}
+
+func isSensitiveOptionKey(key string) bool {
+	if _, ok := optionKeysExposedToAdmin[key]; ok {
+		return false
+	}
+	return strings.HasSuffix(key, "Token") ||
+		strings.HasSuffix(key, "Secret") ||
+		strings.HasSuffix(key, "Key") ||
+		strings.HasSuffix(key, "secret") ||
+		strings.HasSuffix(key, "api_key")
+}
+
 func buildCompletionRatioMetaValue(optionValues map[string]string) string {
 	modelNames := make(map[string]struct{})
 	for _, key := range completionRatioMetaOptionKeys {
@@ -78,15 +96,11 @@ func buildCompletionRatioMetaValue(optionValues map[string]string) string {
 func GetOptions(c *gin.Context) {
 	var options []*model.Option
 	optionValues := make(map[string]string)
+	turnstileSecretConfigured := false
 	common.OptionMapRWMutex.Lock()
 	for k, v := range common.OptionMap {
 		value := common.Interface2String(v)
-		isSensitiveKey := strings.HasSuffix(k, "Token") ||
-			strings.HasSuffix(k, "Secret") ||
-			strings.HasSuffix(k, "Key") ||
-			strings.HasSuffix(k, "secret") ||
-			strings.HasSuffix(k, "api_key")
-		if isSensitiveKey {
+		if isSensitiveOptionKey(k) {
 			continue
 		}
 		options = append(options, &model.Option{
@@ -100,7 +114,14 @@ func GetOptions(c *gin.Context) {
 			}
 		}
 	}
+	turnstileSecretConfigured = common.TurnstileSecretKey != ""
 	common.OptionMapRWMutex.Unlock()
+	if turnstileSecretConfigured {
+		options = append(options, &model.Option{
+			Key:   "TurnstileSecretKeyConfigured",
+			Value: "true",
+		})
+	}
 	options = append(options, &model.Option{
 		Key:   "CompletionRatioMeta",
 		Value: buildCompletionRatioMetaValue(optionValues),

--- a/controller/option_sensitive_test.go
+++ b/controller/option_sensitive_test.go
@@ -1,0 +1,17 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSensitiveOptionKey(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, isSensitiveOptionKey("TurnstileSiteKey"))
+	assert.True(t, isSensitiveOptionKey("TurnstileSecretKey"))
+	assert.True(t, isSensitiveOptionKey("StripeApiSecret"))
+	assert.True(t, isSensitiveOptionKey("TelegramBotToken"))
+	assert.False(t, isSensitiveOptionKey("TurnstileCheckEnabled"))
+}

--- a/web/default/src/features/system-settings/auth/bot-protection-section.tsx
+++ b/web/default/src/features/system-settings/auth/bot-protection-section.tsx
@@ -47,34 +47,49 @@ const botProtectionSchema = z.object({
   TurnstileCheckEnabled: z.boolean(),
   TurnstileSiteKey: z.string().optional(),
   TurnstileSecretKey: z.string().optional(),
+  TurnstileSecretKeyConfigured: z.boolean().optional(),
 })
 
 type BotProtectionFormValues = z.infer<typeof botProtectionSchema>
 
 type BotProtectionSectionProps = {
-  defaultValues: BotProtectionFormValues
+  defaultValues: Omit<BotProtectionFormValues, 'TurnstileSecretKeyConfigured'>
+  turnstileSecretKeyConfigured?: boolean
 }
 
 export function BotProtectionSection({
   defaultValues,
+  turnstileSecretKeyConfigured = false,
 }: BotProtectionSectionProps) {
   const { t } = useTranslation()
   const updateOption = useUpdateOption()
 
   const form = useForm<BotProtectionFormValues>({
     resolver: zodResolver(botProtectionSchema),
-    defaultValues,
+    defaultValues: {
+      ...defaultValues,
+      TurnstileSecretKeyConfigured: turnstileSecretKeyConfigured,
+    },
   })
 
   useEffect(() => {
-    form.reset(defaultValues)
-  }, [defaultValues, form])
+    form.reset({
+      ...defaultValues,
+      TurnstileSecretKeyConfigured: turnstileSecretKeyConfigured,
+    })
+  }, [defaultValues, form, turnstileSecretKeyConfigured])
 
   const onSubmit = async (data: BotProtectionFormValues) => {
-    const updates = Object.entries(data).filter(
-      ([key, value]) =>
-        value !== defaultValues[key as keyof BotProtectionFormValues]
-    )
+    const updates = Object.entries(data).filter(([key, value]) => {
+      if (key === 'TurnstileSecretKeyConfigured') return false
+      if (
+        key === 'TurnstileSecretKey' &&
+        (value === '' || value === undefined)
+      ) {
+        return false
+      }
+      return value !== defaultValues[key as keyof typeof defaultValues]
+    })
 
     for (const [key, value] of updates) {
       await updateOption.mutateAsync({ key, value: value ?? '' })
@@ -139,11 +154,20 @@ export function BotProtectionSection({
                 <FormControl>
                   <Input
                     type='password'
-                    placeholder={t('Your Turnstile secret key')}
+                    placeholder={
+                      turnstileSecretKeyConfigured
+                        ? t('Leave blank to keep the existing key')
+                        : t('Your Turnstile secret key')
+                    }
                     autoComplete='new-password'
                     {...field}
                   />
                 </FormControl>
+                {turnstileSecretKeyConfigured ? (
+                  <FormDescription>
+                    {t('Leave blank to keep the existing key')}
+                  </FormDescription>
+                ) : null}
                 <FormMessage />
               </FormItem>
             )}

--- a/web/default/src/features/system-settings/auth/index.tsx
+++ b/web/default/src/features/system-settings/auth/index.tsx
@@ -59,6 +59,7 @@ const defaultAuthSettings: AuthSettings = {
   TurnstileCheckEnabled: false,
   TurnstileSiteKey: '',
   TurnstileSecretKey: '',
+  TurnstileSecretKeyConfigured: false,
   'passkey.enabled': false,
   'passkey.rp_display_name': '',
   'passkey.rp_id': '',

--- a/web/default/src/features/system-settings/auth/section-registry.tsx
+++ b/web/default/src/features/system-settings/auth/section-registry.tsx
@@ -109,6 +109,7 @@ const AUTH_SECTIONS = [
           TurnstileSiteKey: settings.TurnstileSiteKey,
           TurnstileSecretKey: settings.TurnstileSecretKey,
         }}
+        turnstileSecretKeyConfigured={settings.TurnstileSecretKeyConfigured}
       />
     ),
   },

--- a/web/default/src/features/system-settings/types.ts
+++ b/web/default/src/features/system-settings/types.ts
@@ -156,6 +156,7 @@ export type AuthSettings = {
   TurnstileCheckEnabled: boolean
   TurnstileSiteKey: string
   TurnstileSecretKey: string
+  TurnstileSecretKeyConfigured: boolean
   'passkey.enabled': boolean
   'passkey.rp_display_name': string
   'passkey.rp_id': string


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

`GET /api/option/` 会过滤所有以 `Key`/`Secret`/`Token` 结尾的配置，`TurnstileSiteKey` 被误伤：管理后台 Bot Protection 表单始终回显为空，且保存表单时空字符串会覆盖数据库里已配置的值，表现为“Turnstile 配置在刷新/重新部署后丢失”（详见关联 Issue）。

修复方式：

1. **后端** `controller/option.go`：把敏感键判断抽为 `isSensitiveOptionKey`，为 `TurnstileSiteKey` 建立白名单——它本身是公开信息（登录/注册页已经通过 `/api/status` 的 `turnstile_site_key` 对匿名用户返回），管理端回显不产生新的暴露面。
2. **后端**：当 `TurnstileSecretKey` 已配置时，响应中追加 `TurnstileSecretKeyConfigured=true` 布尔项（不返回密钥本身），供前端提示“已配置”。
3. **前端** `bot-protection-section.tsx`：Secret Key 留空时不提交，避免覆盖已存密钥；已配置时占位符/描述提示“留空保持不变”（复用已有 i18n key `Leave blank to keep the existing key`，各语言翻译已存在）。该行为与旧版前端 `SystemSetting.jsx` 的 `submitTurnstile`（非空才提交）对齐。
4. 新增 `controller/option_sensitive_test.go` 覆盖白名单与敏感后缀判断。

本 PR 为 AI 辅助完成（Cursor），描述由人工整理撰写。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5989

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```
$ go vet ./controller/
$ go test ./controller/ -run TestIsSensitiveOptionKey -count=1
ok      github.com/QuantumNous/new-api/controller       1.071s

$ cd web/default && bun run typecheck
$ tsgo -b   # 无错误
```

生产环境实测：已配置 Turnstile 的站点，修复前管理后台 Site Key 回显为空；修复后正常回显，Secret Key 显示“留空以保留现有密钥”，登录页 Turnstile 不受影响。

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated bot protection settings to better handle existing secret keys, including clearer guidance when a key is already configured.
  * The settings page now reflects whether a secret key is present, improving form behavior and reducing accidental overwrites.

* **Bug Fixes**
  * Improved handling of visible configuration fields so public values are shown correctly while sensitive values remain protected.
  * Prevents unnecessary updates when the secret key field is left blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->