### PR TITLE
fix(convert): merge text-only Claude content blocks to string for OpenAI-compatible upstreams

### DIFF
--- a/service/convert.go
+++ b/service/convert.go
@@ -146,17 +146,22 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 			contents := content
 			var toolCalls []dto.ToolCallRequest
 			mediaMessages := make([]dto.MediaContent, 0, len(contents))
+			hasNonTextContent := false
 
 			for _, mediaMsg := range contents {
 				switch mediaMsg.Type {
 				case "text", "input_text":
 					message := dto.MediaContent{
-						Type:         "text",
-						Text:         mediaMsg.GetText(),
-						CacheControl: mediaMsg.CacheControl,
+						Type: "text",
+						Text: mediaMsg.GetText(),
+					}
+					// cache_control is an Anthropic extension; only OpenRouter accepts it
+					if isOpenRouter {
+						message.CacheControl = mediaMsg.CacheControl
 					}
 					mediaMessages = append(mediaMessages, message)
 				case "image":
+					hasNonTextContent = true
 					// Handle image conversion (base64 to URL or keep as is)
 					imageData := fmt.Sprintf("data:%s;base64,%s", mediaMsg.Source.MediaType, mediaMsg.Source.Data)
 					//textContent += fmt.Sprintf("[Image: %s]", imageData)
@@ -203,7 +208,17 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 			}
 
 			if len(mediaMessages) > 0 && len(toolCalls) == 0 {
-				openAIMessage.SetMediaContent(mediaMessages)
+				if !isOpenRouter && !hasNonTextContent {
+					// strict OpenAI-compatible upstreams only accept string content;
+					// merge text-only blocks instead of sending a content parts array
+					var textBuilder strings.Builder
+					for _, mediaMessage := range mediaMessages {
+						textBuilder.WriteString(mediaMessage.Text)
+					}
+					openAIMessage.SetStringContent(textBuilder.String())
+				} else {
+					openAIMessage.SetMediaContent(mediaMessages)
+				}
 			}
 		}
 		if len(openAIMessage.ParseContent()) > 0 || len(openAIMessage.ToolCalls) > 0 {

--- a/service/convert_claude_test.go
+++ b/service/convert_claude_test.go
@@ -1,0 +1,115 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newClaudeRelayInfo(channelType int) *relaycommon.RelayInfo {
+	return &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{ChannelType: channelType},
+	}
+}
+
+func parseClaudeRequest(t *testing.T, body string) dto.ClaudeRequest {
+	t.Helper()
+	var claudeRequest dto.ClaudeRequest
+	require.NoError(t, common.UnmarshalJsonStr(body, &claudeRequest))
+	return claudeRequest
+}
+
+// Regression test for #5982: text-only content block arrays must be merged
+// into a string content, and Anthropic-specific cache_control must not leak
+// to generic OpenAI-compatible upstreams.
+func TestClaudeToOpenAIRequestMergesTextBlocksForOpenAICompatible(t *testing.T) {
+	claudeRequest := parseClaudeRequest(t, `{
+		"model": "glm-4.5",
+		"max_tokens": 64,
+		"messages": [
+			{
+				"role": "user",
+				"content": [
+					{"type": "text", "text": "只回复 "},
+					{"type": "text", "text": "OK", "cache_control": {"type": "ephemeral"}}
+				]
+			}
+		]
+	}`)
+
+	openAIRequest, err := ClaudeToOpenAIRequest(claudeRequest, newClaudeRelayInfo(constant.ChannelTypeOpenAI))
+	require.NoError(t, err)
+	require.Len(t, openAIRequest.Messages, 1)
+
+	message := openAIRequest.Messages[0]
+	assert.Equal(t, "user", message.Role)
+	require.True(t, message.IsStringContent())
+	assert.Equal(t, "只回复 OK", message.StringContent())
+
+	encoded, err := common.Marshal(openAIRequest)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "cache_control")
+}
+
+func TestClaudeToOpenAIRequestKeepsContentPartsForMultimodal(t *testing.T) {
+	claudeRequest := parseClaudeRequest(t, `{
+		"model": "glm-4.5",
+		"max_tokens": 64,
+		"messages": [
+			{
+				"role": "user",
+				"content": [
+					{"type": "text", "text": "看图", "cache_control": {"type": "ephemeral"}},
+					{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "iVBORw0KGgo="}}
+				]
+			}
+		]
+	}`)
+
+	openAIRequest, err := ClaudeToOpenAIRequest(claudeRequest, newClaudeRelayInfo(constant.ChannelTypeOpenAI))
+	require.NoError(t, err)
+	require.Len(t, openAIRequest.Messages, 1)
+
+	message := openAIRequest.Messages[0]
+	require.False(t, message.IsStringContent())
+	mediaContents, ok := message.Content.([]dto.MediaContent)
+	require.True(t, ok)
+	require.Len(t, mediaContents, 2)
+	assert.Equal(t, dto.ContentTypeText, mediaContents[0].Type)
+	assert.Empty(t, mediaContents[0].CacheControl)
+	assert.Equal(t, dto.ContentTypeImageURL, mediaContents[1].Type)
+}
+
+func TestClaudeToOpenAIRequestPreservesCacheControlForOpenRouter(t *testing.T) {
+	claudeRequest := parseClaudeRequest(t, `{
+		"model": "anthropic/claude-sonnet-4",
+		"max_tokens": 64,
+		"messages": [
+			{
+				"role": "user",
+				"content": [
+					{"type": "text", "text": "只回复 "},
+					{"type": "text", "text": "OK", "cache_control": {"type": "ephemeral"}}
+				]
+			}
+		]
+	}`)
+
+	openAIRequest, err := ClaudeToOpenAIRequest(claudeRequest, newClaudeRelayInfo(constant.ChannelTypeOpenRouter))
+	require.NoError(t, err)
+	require.Len(t, openAIRequest.Messages, 1)
+
+	message := openAIRequest.Messages[0]
+	require.False(t, message.IsStringContent())
+	mediaContents, ok := message.Content.([]dto.MediaContent)
+	require.True(t, ok)
+	require.Len(t, mediaContents, 2)
+	assert.Empty(t, mediaContents[0].CacheControl)
+	assert.JSONEq(t, `{"type": "ephemeral"}`, string(mediaContents[1].CacheControl))
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本描述为人工整理的简洁摘要，未直接粘贴未经整理的 AI 输出。
> - AI 辅助声明：本 PR 的代码与描述由 AI（Claude Code）辅助生成，提交者 git 身份不属于仓库历史核心开发者。

## 📝 变更描述 / Description

修复 #5982：Claude Messages → OpenAI Compatible 转换时，纯文本 content blocks 数组被原样输出为 OpenAI content parts 数组，并且 Anthropic 专用的 `cache_control` 字段被一并转发。只接受字符串 `messages[].content`、不接受扩展字段的严格 OpenAI Compatible 上游会返回 400。

修改点（`service/convert.go` 的 `ClaudeToOpenAIRequest`，用户消息转换路径）：

1. **`cache_control` 仅对 OpenRouter 渠道保留。** `dto.MediaContent.CacheControl` 本身即标注为 OpenRouter 参数，且 system 消息转换路径已有同样的门控逻辑（仅 OpenRouter Claude 保留 cache_control），本次将用户消息路径与其对齐。
2. **非 OpenRouter 渠道下，若消息内容全部为文本块（`text`/`input_text`），按顺序合并为字符串 content。** 含图片等多模态内容的消息仍保留 content parts 数组。OpenRouter 渠道行为完全不变（保留数组与 cache_control，以支持其 prompt caching）。

生效原理：合并后的字符串 content 是所有 OpenAI Compatible 上游的最大公约数表示，等价于 issue 复现中"字符串 content 可以 200"的对照组；剥离 `cache_control` 则消除了 "Extra inputs are not permitted" 的校验错误。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5982

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

新增回归测试 `service/convert_claude_test.go`（testify，覆盖三个场景）：

```text
=== RUN   TestClaudeToOpenAIRequestMergesTextBlocksForOpenAICompatible
--- PASS: TestClaudeToOpenAIRequestMergesTextBlocksForOpenAICompatible (0.00s)
=== RUN   TestClaudeToOpenAIRequestKeepsContentPartsForMultimodal
--- PASS: TestClaudeToOpenAIRequestKeepsContentPartsForMultimodal (0.00s)
=== RUN   TestClaudeToOpenAIRequestPreservesCacheControlForOpenRouter
--- PASS: TestClaudeToOpenAIRequestPreservesCacheControlForOpenRouter (0.00s)
PASS
ok      github.com/QuantumNous/new-api/service  0.038s
```

- 纯文本块数组 + `cache_control` → 合并为字符串 `"只回复 OK"`，序列化后的上游请求不含 `cache_control`（对应 issue 复现组）。
- 文本 + 图片多模态消息 → 保留 content parts 数组，文本块 `cache_control` 被剥离。
- OpenRouter 渠道 → 保留数组结构与 `cache_control` 原文（现有行为不变）。

全量回归：`go test ./service/... ./dto/... ./relay/...` 全部通过，`go vet ./service/` 无告警。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message conversion so text-only Claude messages are sent as a single text payload for compatible upstreams.
  * Preserved multimodal messages correctly, keeping text and image content together when needed.
  * Ensured cache settings are handled consistently across supported upstreams, including OpenRouter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->