### PR TITLE
fix(convert): forward Claude output_config.effort as reasoning_effort to OpenAI-format upstreams

### DIFF
--- a/service/convert.go
+++ b/service/convert.go
@@ -58,6 +58,9 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 			openAIRequest.Reasoning = reasoningJSON
 		}
 	} else {
+		if effort := claudeRequest.GetEfforts(); effort != "" {
+			openAIRequest.ReasoningEffort = effort
+		}
 		thinkingSuffix := "-thinking"
 		if strings.HasSuffix(info.OriginModelName, thinkingSuffix) &&
 			!strings.HasSuffix(openAIRequest.Model, thinkingSuffix) {

--- a/service/convert_effort_test.go
+++ b/service/convert_effort_test.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression test for #5922: reasoning effort from a Claude-format request
+// (output_config.effort) must be forwarded as reasoning_effort when converting
+// to an OpenAI-format upstream request.
+func TestClaudeToOpenAIRequestForwardsEffortAsReasoningEffort(t *testing.T) {
+	var claudeRequest dto.ClaudeRequest
+	require.NoError(t, common.UnmarshalJsonStr(`{
+		"model": "gpt-5.2",
+		"max_tokens": 64,
+		"output_config": {"effort": "high"},
+		"messages": [
+			{"role": "user", "content": "hi"}
+		]
+	}`, &claudeRequest))
+
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{ChannelType: constant.ChannelTypeOpenAI},
+	}
+	openAIRequest, err := ClaudeToOpenAIRequest(claudeRequest, info)
+	require.NoError(t, err)
+	assert.Equal(t, "high", openAIRequest.ReasoningEffort)
+
+	encoded, err := common.Marshal(openAIRequest)
+	require.NoError(t, err)
+	assert.Contains(t, string(encoded), `"reasoning_effort":"high"`)
+}
+
+func TestClaudeToOpenAIRequestWithoutEffortLeavesReasoningEffortEmpty(t *testing.T) {
+	var claudeRequest dto.ClaudeRequest
+	require.NoError(t, common.UnmarshalJsonStr(`{
+		"model": "gpt-5.2",
+		"max_tokens": 64,
+		"messages": [
+			{"role": "user", "content": "hi"}
+		]
+	}`, &claudeRequest))
+
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{ChannelType: constant.ChannelTypeOpenAI},
+	}
+	openAIRequest, err := ClaudeToOpenAIRequest(claudeRequest, info)
+	require.NoError(t, err)
+	assert.Empty(t, openAIRequest.ReasoningEffort)
+
+	encoded, err := common.Marshal(openAIRequest)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "reasoning_effort")
+}
+
+// OpenRouter conversion keeps its existing effort mapping and must not gain
+// a duplicate reasoning_effort field from this fix.
+func TestClaudeToOpenAIRequestOpenRouterEffortMappingUnchanged(t *testing.T) {
+	var claudeRequest dto.ClaudeRequest
+	require.NoError(t, common.UnmarshalJsonStr(`{
+		"model": "anthropic/claude-sonnet-4",
+		"max_tokens": 64,
+		"output_config": {"effort": "high"},
+		"messages": [
+			{"role": "user", "content": "hi"}
+		]
+	}`, &claudeRequest))
+
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{ChannelType: constant.ChannelTypeOpenRouter},
+	}
+	openAIRequest, err := ClaudeToOpenAIRequest(claudeRequest, info)
+	require.NoError(t, err)
+	assert.Empty(t, openAIRequest.ReasoningEffort)
+	assert.Equal(t, `"high"`, string(openAIRequest.Verbosity))
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本描述为人工整理的简洁摘要，未直接粘贴未经整理的 AI 输出。
> - AI 辅助声明：本 PR 的代码与描述由 AI（Claude Code）辅助生成，提交者 git 身份不属于仓库历史核心开发者。

## 📝 变更描述 / Description

修复 #5922：Claude 格式客户端设置 reasoning effort（请求体中的 `output_config.effort`，如 `high`）后，经 OpenAI 类型渠道转发时该参数被静默丢弃，上游收不到 `reasoning_effort`。

根因：`service/convert.go` 的 `ClaudeToOpenAIRequest` 中，`claudeRequest.GetEfforts()`（解析 `output_config.effort`）只在 OpenRouter 分支被消费；非 OpenRouter 的通用分支（即 OpenAI 类型渠道走的路径）完全没有读取 effort，转换后的 `GeneralOpenAIRequest.ReasoningEffort` 恒为空。

修复：在通用分支中把 effort 赋给 `openAIRequest.ReasoningEffort`（一行改动）。之所以只需要改这一处：OpenAI 渠道 adaptor 的 `ConvertClaudeRequest` 会把转换结果继续送入 `ConvertOpenAIRequest`（`relay/channel/openai/adaptor.go`），后者对 `request.ReasoningEffort` 已有完整的下游处理链（o 系列 / gpt-5 的模型后缀与参数适配、OpenRouter 的 `reasoning` JSON 映射、`info.ReasoningEffort` 日志记录），本次填上字段后即可复用全部既有逻辑。OpenRouter 分支的 effort 映射行为保持不变。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5922

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

新增回归测试 `service/convert_effort_test.go`（testify，三个场景）：

```text
=== RUN   TestClaudeToOpenAIRequestForwardsEffortAsReasoningEffort
--- PASS: TestClaudeToOpenAIRequestForwardsEffortAsReasoningEffort (0.00s)
=== RUN   TestClaudeToOpenAIRequestWithoutEffortLeavesReasoningEffortEmpty
--- PASS: TestClaudeToOpenAIRequestWithoutEffortLeavesReasoningEffortEmpty (0.00s)
=== RUN   TestClaudeToOpenAIRequestOpenRouterEffortMappingUnchanged
--- PASS: TestClaudeToOpenAIRequestOpenRouterEffortMappingUnchanged (0.00s)
PASS
ok      github.com/QuantumNous/new-api/service  0.025s
```

- OpenAI 渠道 + `output_config: {"effort": "high"}` → 转换结果含 `"reasoning_effort":"high"`（对应 issue 复现场景）。
- 无 `output_config` → `reasoning_effort` 不出现（`omitempty`，不污染无推理需求的请求）。
- OpenRouter 渠道 → effort 仍走原有 Verbosity 映射，不会重复产生 `reasoning_effort` 字段。

全量回归：`go test ./service/... ./relay/...` 全部通过，`go vet ./service/` 无告警。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Request conversions now carry effort settings through correctly for standard channels, so upstream requests can include the expected reasoning level.
  * Requests without an effort setting continue to omit that field.
  * OpenRouter behavior remains unchanged, preserving the existing effort-to-verbosity handling.

* **Tests**
  * Added regression coverage for effort forwarding, missing-effort behavior, and OpenRouter compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->