### PR TITLE
fix(option): keep legacy GroupRatio options in sync with group_ratio_setting rows

### DIFF
--- a/model/option.go
+++ b/model/option.go
@@ -204,20 +204,56 @@ func SyncOptions(frequency int) {
 	}
 }
 
-func UpdateOption(key string, value string) error {
-	// Save to database first
-	option := Option{
-		Key: key,
+// legacyConfigOptionAliases maps legacy option keys to the ConfigManager keys
+// that deserialize into the same shared in-memory map (registered in
+// setting/ratio_setting/group_ratio.go). The two keys are persisted as
+// independent rows in the options table, and each row fully reloads the shared
+// map when processed by loadOptionsFromDatabase. If the rows drift apart,
+// whichever row happens to be processed last wins on every sync/restart and
+// edits made through the other key are silently lost (#5933). Updating either
+// key must therefore persist both rows with the same value.
+var legacyConfigOptionAliases = map[string]string{
+	"GroupRatio":      "group_ratio_setting.group_ratio",
+	"GroupGroupRatio": "group_ratio_setting.group_group_ratio",
+}
+
+func aliasedOptionKey(key string) (string, bool) {
+	if modern, ok := legacyConfigOptionAliases[key]; ok {
+		return modern, true
 	}
-	// https://gorm.io/docs/update.html#Save-All-Fields
-	DB.FirstOrCreate(&option, Option{Key: key})
-	option.Value = value
-	// Save is a combination function.
-	// If save value does not contain primary key, it will execute Create,
-	// otherwise it will execute Update (with all fields).
-	DB.Save(&option)
+	for legacy, modern := range legacyConfigOptionAliases {
+		if modern == key {
+			return legacy, true
+		}
+	}
+	return "", false
+}
+
+func UpdateOption(key string, value string) error {
+	keys := []string{key}
+	if alias, ok := aliasedOptionKey(key); ok {
+		keys = append(keys, alias)
+	}
+	// Save to database first
+	for _, k := range keys {
+		option := Option{
+			Key: k,
+		}
+		// https://gorm.io/docs/update.html#Save-All-Fields
+		DB.FirstOrCreate(&option, Option{Key: k})
+		option.Value = value
+		// Save is a combination function.
+		// If save value does not contain primary key, it will execute Create,
+		// otherwise it will execute Update (with all fields).
+		DB.Save(&option)
+	}
 	// Update OptionMap
-	return updateOptionMap(key, value)
+	for _, k := range keys {
+		if err := updateOptionMap(k, value); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // UpdateOptionsBulk persists multiple key/value pairs in a single database

--- a/model/option.go
+++ b/model/option.go
@@ -234,26 +234,39 @@ func UpdateOption(key string, value string) error {
 	if alias, ok := aliasedOptionKey(key); ok {
 		keys = append(keys, alias)
 	}
-	// Save to database first
-	for _, k := range keys {
-		option := Option{
-			Key: k,
+	// Save to database first, atomically across aliased keys so the rows
+	// cannot diverge if one of the writes fails.
+	err := DB.Transaction(func(tx *gorm.DB) error {
+		for _, k := range keys {
+			option := Option{
+				Key: k,
+			}
+			// https://gorm.io/docs/update.html#Save-All-Fields
+			if err := tx.FirstOrCreate(&option, Option{Key: k}).Error; err != nil {
+				return err
+			}
+			option.Value = value
+			// Save is a combination function.
+			// If save value does not contain primary key, it will execute Create,
+			// otherwise it will execute Update (with all fields).
+			if err := tx.Save(&option).Error; err != nil {
+				return err
+			}
 		}
-		// https://gorm.io/docs/update.html#Save-All-Fields
-		DB.FirstOrCreate(&option, Option{Key: k})
-		option.Value = value
-		// Save is a combination function.
-		// If save value does not contain primary key, it will execute Create,
-		// otherwise it will execute Update (with all fields).
-		DB.Save(&option)
+		return nil
+	})
+	if err != nil {
+		return err
 	}
-	// Update OptionMap
+	// Update OptionMap. Refresh every aliased key even if one fails so the
+	// in-memory views stay consistent with the rows already persisted above.
+	var updateErr error
 	for _, k := range keys {
-		if err := updateOptionMap(k, value); err != nil {
-			return err
+		if err := updateOptionMap(k, value); err != nil && updateErr == nil {
+			updateErr = err
 		}
 	}
-	return nil
+	return updateErr
 }
 
 // UpdateOptionsBulk persists multiple key/value pairs in a single database

--- a/model/option_alias_test.go
+++ b/model/option_alias_test.go
@@ -12,11 +12,33 @@ import (
 func setupOptionFixture(t *testing.T) {
 	t.Helper()
 	require.NoError(t, DB.AutoMigrate(&Option{}))
+
 	common.OptionMapRWMutex.Lock()
 	if common.OptionMap == nil {
 		common.OptionMap = make(map[string]string)
 	}
+	optionMapSnapshot := make(map[string]string, len(common.OptionMap))
+	for k, v := range common.OptionMap {
+		optionMapSnapshot[k] = v
+	}
 	common.OptionMapRWMutex.Unlock()
+
+	groupRatioSnapshot := ratio_setting.GroupRatio2JSONString()
+	groupGroupRatioSnapshot := ratio_setting.GroupGroupRatio2JSONString()
+
+	t.Cleanup(func() {
+		require.NoError(t, DB.Where(commonKeyCol+" IN ?", []string{
+			"GroupRatio", "group_ratio_setting.group_ratio",
+			"GroupGroupRatio", "group_ratio_setting.group_group_ratio",
+		}).Delete(&Option{}).Error)
+
+		common.OptionMapRWMutex.Lock()
+		common.OptionMap = optionMapSnapshot
+		common.OptionMapRWMutex.Unlock()
+
+		require.NoError(t, ratio_setting.UpdateGroupRatioByJSONString(groupRatioSnapshot))
+		require.NoError(t, ratio_setting.UpdateGroupGroupRatioByJSONString(groupGroupRatioSnapshot))
+	})
 }
 
 func readOptionValue(t *testing.T, key string) string {

--- a/model/option_alias_test.go
+++ b/model/option_alias_test.go
@@ -1,0 +1,68 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/setting/ratio_setting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupOptionFixture(t *testing.T) {
+	t.Helper()
+	require.NoError(t, DB.AutoMigrate(&Option{}))
+	common.OptionMapRWMutex.Lock()
+	if common.OptionMap == nil {
+		common.OptionMap = make(map[string]string)
+	}
+	common.OptionMapRWMutex.Unlock()
+}
+
+func readOptionValue(t *testing.T, key string) string {
+	t.Helper()
+	var option Option
+	require.NoError(t, DB.First(&option, Option{Key: key}).Error)
+	return option.Value
+}
+
+// Regression test for #5933: GroupRatio (legacy option) and
+// group_ratio_setting.group_ratio (ConfigManager option) deserialize into the
+// same shared in-memory map but were persisted as independent rows. A drifted
+// ConfigManager row silently overwrote frontend edits on the next options
+// sync. Updating either key must persist both rows.
+func TestUpdateOptionSyncsGroupRatioAliasRows(t *testing.T) {
+	setupOptionFixture(t)
+
+	// Seed a drifted ConfigManager row that lacks the group about to be
+	// added — the bug's precondition observed in production databases.
+	stale := Option{Key: "group_ratio_setting.group_ratio"}
+	DB.FirstOrCreate(&stale, Option{Key: "group_ratio_setting.group_ratio"})
+	stale.Value = `{"default":1}`
+	require.NoError(t, DB.Save(&stale).Error)
+
+	require.NoError(t, UpdateOption("GroupRatio", `{"default":1,"TestGroup":2}`))
+
+	assert.JSONEq(t, `{"default":1,"TestGroup":2}`, readOptionValue(t, "GroupRatio"))
+	assert.JSONEq(t, `{"default":1,"TestGroup":2}`, readOptionValue(t, "group_ratio_setting.group_ratio"))
+
+	// The periodic option sync reloads the shared map from every row; the
+	// group added through the legacy key must survive it regardless of row
+	// processing order.
+	loadOptionsFromDatabase()
+	assert.True(t, ratio_setting.ContainsGroupRatio("TestGroup"))
+	assert.Equal(t, float64(2), ratio_setting.GetGroupRatio("TestGroup"))
+}
+
+func TestUpdateOptionSyncsLegacyRowWhenConfigKeyUpdated(t *testing.T) {
+	setupOptionFixture(t)
+
+	require.NoError(t, UpdateOption("group_ratio_setting.group_group_ratio", `{"vip":{"default":0.8}}`))
+
+	assert.JSONEq(t, `{"vip":{"default":0.8}}`, readOptionValue(t, "GroupGroupRatio"))
+	assert.JSONEq(t, `{"vip":{"default":0.8}}`, readOptionValue(t, "group_ratio_setting.group_group_ratio"))
+
+	ratio, ok := ratio_setting.GetGroupGroupRatio("vip", "default")
+	require.True(t, ok)
+	assert.Equal(t, 0.8, ratio)
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本描述为人工整理的简洁摘要，未直接粘贴未经整理的 AI 输出。
> - AI 辅助声明：本 PR 的代码与描述由 AI（Claude Code）辅助生成，提交者 git 身份不属于仓库历史核心开发者。

## 📝 变更描述 / Description

修复 #5933：前端「分组倍率」编辑写入的是旧 option key `GroupRatio`，但同一份内存数据（共享的 `groupRatioMap`，见 `setting/ratio_setting/group_ratio.go` 的 `init()`）还有另一个独立的持久化入口 `group_ratio_setting.group_ratio`（ConfigManager 行）。两行在 `options` 表中互不同步，而 `loadOptionsFromDatabase` 逐行处理时每一行都会**清空式重载**这个共享 map（`RWMap.UnmarshalJSON` / `LoadFromJsonString` 均为先清空再加载）。因此两行一旦漂移，每分钟 sync 和每次重启后"谁最后被处理谁赢"——前端的改动被静默覆盖，请求报 `分组 X 已被弃用`。

修复方式（issue 修复建议 2 的后端实现，无需改前端，classic 主题同时受益）：在 `model/option.go` 的 `UpdateOption` 中把这两对 key 声明为别名——更新任意一个 key 时，两行以同一 value 一起落库、两个 OptionMap 条目一起刷新。由此建立不变量：**别名行永远相等**，行处理顺序不再影响结果；已漂移的存量数据在下一次保存时自愈。

覆盖的别名对（即所有与 ConfigManager 共享同一 RWMap 指针的旧 option）：

| 旧 option key | ConfigManager key |
|---|---|
| `GroupRatio` | `group_ratio_setting.group_ratio` |
| `GroupGroupRatio` | `group_ratio_setting.group_group_ratio` |

同向说明：`ConfigManager.SaveToDB` 当前无任何调用方，`model.UpdateOption`（controller/option.go 的保存入口）是这些 key 唯一的写路径，因此在此处双写即可闭环。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5933

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

新增回归测试 `model/option_alias_test.go`（in-memory SQLite + testify），完整复刻 issue 复现链：预置漂移的 `group_ratio_setting.group_ratio` 行（缺少待新增分组）→ 通过旧 key 保存新分组 → 断言两行落库值一致 → 执行 `loadOptionsFromDatabase()`（即每分钟 sync 的真实代码路径）→ 断言新分组存活且倍率正确。

**未修复时两条测试必红**（先 stash 修复验证过）：

```text
--- FAIL: TestUpdateOptionSyncsGroupRatioAliasRows (0.00s)
--- FAIL: TestUpdateOptionSyncsLegacyRowWhenConfigKeyUpdated (0.00s)
```

修复后：

```text
=== RUN   TestUpdateOptionSyncsGroupRatioAliasRows
--- PASS: TestUpdateOptionSyncsGroupRatioAliasRows (0.00s)
=== RUN   TestUpdateOptionSyncsLegacyRowWhenConfigKeyUpdated
--- PASS: TestUpdateOptionSyncsLegacyRowWhenConfigKeyUpdated (0.00s)
PASS
ok      github.com/QuantumNous/new-api/model    0.024s
```

全量回归：`go test ./model/` 全部通过（6.2s），`go vet ./model/` 无告警。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syncing for group ratio settings so updates stay consistent between legacy and modern option names.
  * Prevented mismatched persisted values when changing a setting via either alias.
  * Ensured reloads reflect the updated ratio configuration correctly, including group ratio lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->