### PR TITLE
fix: 分组倍率 Ratio 输入框保留小数中间态,修复无法输入 0.05

### DIFF
--- a/web/default/src/features/system-settings/models/group-ratio-visual-editor.tsx
+++ b/web/default/src/features/system-settings/models/group-ratio-visual-editor.tsx
@@ -83,7 +83,7 @@ type GroupRatioVisualEditorProps = {
 type GroupPricingRow = {
   _id: string
   name: string
-  ratio: number
+  ratio: string
   topupRatio: string
   selectable: boolean
   description: string
@@ -149,7 +149,7 @@ function buildGroupPricingRows(
   return [...names].map((name) => ({
     _id: createGroupPricingId(),
     name,
-    ratio: normalizeRatio(ratioMap[name]),
+    ratio: String(normalizeRatio(ratioMap[name])),
     topupRatio: Object.hasOwn(topupMap, name) ? String(topupMap[name]) : '',
     selectable: Object.hasOwn(usableMap, name),
     description: String(usableMap[name] ?? ''),
@@ -491,7 +491,7 @@ function GroupPricingTable({
       {
         _id: createGroupPricingId(),
         name,
-        ratio: 1,
+        ratio: '1',
         topupRatio: '',
         selectable: true,
         description: '',
@@ -567,13 +567,9 @@ function GroupPricingTable({
                     type='number'
                     min={0}
                     step={0.1}
-                    value={String(row.ratio)}
+                    value={row.ratio}
                     onChange={(event) =>
-                      updateRow(
-                        row._id,
-                        'ratio',
-                        normalizeRatio(event.target.value)
-                      )
+                      updateRow(row._id, 'ratio', event.target.value)
                     }
                   />
                 ),


### PR DESCRIPTION
## 📝 变更描述 / Description
分组定价表格的 Ratio 列每敲一个键就把输入值 `Number()` 化再回填,输入 0.05 走到 `0.0` 时被折叠成 `0`,小数没法继续输。

改法对齐同文件充值倍率(Top-up ratio)列的既有做法:`GroupPricingRow.ratio` 改成字符串草稿,输入过程不做转换,只在 `serializeGroupPricingRows()` 序列化时经 `normalizeRatio` 转 number。输入期间父组件 props 回流时 `groupPricingSignature` 比较的是序列化后的数值,`0.0` 与 `0` 签名一致,rows 不会被重建,草稿得以保留——这也是充值倍率列一直没这个问题的原因。空值等边界的落库行为与改动前一致。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5986

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
<img width="518" height="248" alt="image" src="https://github.com/user-attachments/assets/37d9a9cd-9868-4d09-9771-85301d6178b6" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editing of group pricing ratios so values entered in the table behave more consistently.
  * New rows now start with a ratio of `1`, matching the displayed input format.
  * Ratio fields now preserve the exact value being typed before saving, reducing unexpected changes while editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->