### PR TITLE
fix(channel): guard nil channel validation

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -465,6 +465,9 @@ func validateTwoFactorAuth(twoFA *model.TwoFA, code string) bool {
 
 // validateChannel 通用的渠道校验函数
 func validateChannel(channel *model.Channel, isAdd bool) error {
+	if channel == nil {
+		return fmt.Errorf("channel cannot be empty")
+	}
 	// 校验 channel settings
 	if err := channel.ValidateSettings(); err != nil {
 		return fmt.Errorf("渠道额外设置[channel setting] 格式错误：%s", err.Error())
@@ -472,7 +475,7 @@ func validateChannel(channel *model.Channel, isAdd bool) error {
 
 	// 如果是添加操作，检查 channel 和 key 是否为空
 	if isAdd {
-		if channel == nil || channel.Key == "" {
+		if channel.Key == "" {
 			return fmt.Errorf("channel cannot be empty")
 		}
 

--- a/controller/channel_test_internal_test.go
+++ b/controller/channel_test_internal_test.go
@@ -16,6 +16,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateChannelRejectsNilChannel(t *testing.T) {
+	err := validateChannel(nil, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "channel cannot be empty")
+
+	err = validateChannel(nil, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "channel cannot be empty")
+}
+
 func TestSettleTestQuotaUsesTieredBilling(t *testing.T) {
 	info := &relaycommon.RelayInfo{
 		TieredBillingSnapshot: &billingexpr.BillingSnapshot{


### PR DESCRIPTION
## Summary

This PR prevents `validateChannel` from dereferencing a nil `*model.Channel`.

## Root cause

`validateChannel` called `channel.ValidateSettings()` before checking whether `channel` itself was nil. A malformed or empty channel payload could therefore panic before returning a normal validation error.

## Changes

- Add an early nil guard at the start of `validateChannel`.
- Keep the existing `channel cannot be empty` validation message.
- Add a regression test covering nil channel validation for both add and update paths.

## Validation

```bash
docker run --rm \
  -v /home/weihao/projects/new-api:/app \
  -v /tmp/new-api-gomodcache:/go/pkg/mod \
  -v /tmp/new-api-gocache:/root/.cache/go-build \
  -w /app \
  golang:1.25.11 \
  /bin/sh -lc '/usr/local/go/bin/go test -count=1 ./controller'
```

Result:

```text
ok  github.com/QuantumNous/new-api/controller  0.238s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel validation so empty channels are rejected immediately with a clear error message.
  * Added coverage to ensure both add and non-add validation paths handle empty channels consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->