### PR TITLE
fix(i18n): correct Chinese translation of redemption 'Create Code' button

### DIFF
--- a/web/default/src/i18n/locales/zh-TW.json
+++ b/web/default/src/i18n/locales/zh-TW.json
@@ -1118,7 +1118,7 @@
     "Create cache ratio": "建立緩存倍率",
     "Create Channel": "建立渠道",
     "Create channels or edit keys, base URLs, and overrides.": "建立渠道或編輯金鑰、基礎 URL 和覆蓋規則。",
-    "Create Code": "建立代碼",
+    "Create Code": "建立兌換碼",
     "Create credentials for the root user": "為管理員建立登入憑證",
     "Create deployment": "建立部署",
     "Create Model": "建立模型",

--- a/web/default/src/i18n/locales/zh.json
+++ b/web/default/src/i18n/locales/zh.json
@@ -1118,7 +1118,7 @@
     "Create cache ratio": "创建缓存倍率",
     "Create Channel": "创建渠道",
     "Create channels or edit keys, base URLs, and overrides.": "创建渠道或编辑密钥、基础 URL 和覆盖规则。",
-    "Create Code": "创建代码",
+    "Create Code": "创建兑换码",
     "Create credentials for the root user": "为管理员创建登录凭据",
     "Create deployment": "创建部署",
     "Create Model": "创建模型",


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

> 说明：本 PR 由 AI 辅助生成（AI-assisted）。

## 📝 变更描述 / Description
新版默认前端「兑换码」页面右上角按钮的英文 key 为 `Create Code`，此处 "Code" 指**兑换码**（redemption code）。但简体/繁体中文被误译为「创建代码」「建立代碼」（意为创建源代码），语义错误。

本 PR 将其修正为：
- `zh.json`: 「创建代码」→「创建兑换码」
- `zh-TW.json`: 「建立代碼」→「建立兌換碼」

与旧版 classic 前端一致（classic 中该按钮为「添加兑换码」）。其余语种（en/ja/ru/fr/vi）语义无误，未改动。

## 🚀 变更类型 / Type of change
- [x] 📝 文档更新 (Documentation) - i18n 文案修正

## 🔗 关联任务 / Related Issue
- Closes # (无)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述已经过人工整理确认。
- [x] **非重复提交:** 已确认不是重复提交。
- [x] **Bug fix 说明:** 不适用（文案修正）。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 仅包含该 i18n 文案修正，无无关改动。
- [x] **本地验证:** 仅为翻译 JSON 值改动，键名未变，不影响功能。
- [x] **安全合规:** 无敏感凭据，符合项目代码规范。

## 📸 运行证明 / Proof of Work
两处改动：

```diff
- "Create Code": "创建代码",   (zh.json)
+ "Create Code": "创建兑换码",

- "Create Code": "建立代碼",   (zh-TW.json)
+ "Create Code": "建立兌換碼",
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Chinese and Traditional Chinese UI translation for “Create Code” to use “Create Redemption Code” wording, improving clarity and consistency in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->