### PR TITLE
feat: optional bounded concurrency for batch channel testing

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -1001,6 +1001,7 @@ func performChannelTests(ctx context.Context, channels []*model.Channel, testUse
 		advanceProgress()
 	}
 
+	dispatched := false
 dispatch:
 	for _, channel := range channels {
 		if ctx != nil && ctx.Err() != nil {
@@ -1009,6 +1010,23 @@ dispatch:
 		if channel.Status == common.ChannelStatusManuallyDisabled {
 			advanceProgress()
 			continue
+		}
+
+		// RequestInterval throttles how fast new tests are dispatched, spacing out
+		// upstream load even when tests run concurrently. Only throttle between
+		// dispatches, never before the first or after the last one.
+		if dispatched && common.RequestInterval > 0 {
+			if ctx == nil {
+				time.Sleep(common.RequestInterval)
+			} else {
+				timer := time.NewTimer(common.RequestInterval)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					break dispatch
+				case <-timer.C:
+				}
+			}
 		}
 
 		// Acquire a worker slot, honoring cancellation so a runner that loses its
@@ -1029,20 +1047,7 @@ dispatch:
 			defer func() { <-sem }()
 			testOne(ch)
 		}(channel)
-
-		// RequestInterval throttles how fast new tests are dispatched, spacing out
-		// upstream load even when tests run concurrently.
-		if common.RequestInterval > 0 {
-			if ctx == nil {
-				time.Sleep(common.RequestInterval)
-			} else {
-				select {
-				case <-ctx.Done():
-					break dispatch
-				case <-time.After(common.RequestInterval):
-				}
-			}
-		}
+		dispatched = true
 	}
 
 	wg.Wait()

--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
@@ -924,11 +923,25 @@ func performChannelTests(ctx context.Context, channels []*model.Channel, testUse
 	}
 
 	var (
-		mu        sync.Mutex
-		wg        sync.WaitGroup
-		processed atomic.Int32
-		sem       = make(chan struct{}, concurrency)
+		mu         sync.Mutex // guards summary
+		progressMu sync.Mutex // serializes report so progress stays monotonic
+		completed  int
+		wg         sync.WaitGroup
+		sem        = make(chan struct{}, concurrency)
 	)
+
+	// advanceProgress reports one more processed channel. report may persist
+	// progress to storage and is not assumed to be concurrency-safe, so calls are
+	// serialized here to keep the reported count ordered and monotonic.
+	advanceProgress := func() {
+		if report == nil {
+			return
+		}
+		progressMu.Lock()
+		completed++
+		report(completed, total)
+		progressMu.Unlock()
+	}
 
 	if report != nil {
 		report(0, total)
@@ -985,9 +998,7 @@ func performChannelTests(ctx context.Context, channels []*model.Channel, testUse
 		}
 		mu.Unlock()
 
-		if report != nil {
-			report(int(processed.Add(1)), total)
-		}
+		advanceProgress()
 	}
 
 dispatch:
@@ -996,9 +1007,7 @@ dispatch:
 			break
 		}
 		if channel.Status == common.ChannelStatusManuallyDisabled {
-			if report != nil {
-				report(int(processed.Add(1)), total)
-			}
+			advanceProgress()
 			continue
 		}
 

--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -12,6 +12,8 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
@@ -908,30 +910,41 @@ func performChannelTests(ctx context.Context, channels []*model.Channel, testUse
 	summary := channelTestSummary{}
 	var disableThreshold = int64(common.ChannelDisableThreshold * 1000)
 	if disableThreshold == 0 {
-		disableThreshold = 10000000 // a impossible value
+		disableThreshold = 10000000 // an impossible value
 	}
 
 	total := len(channels)
-	for index, channel := range channels {
-		if ctx != nil && ctx.Err() != nil {
-			break
-		}
-		if report != nil {
-			report(index, total) // channels completed before this one
-		}
-		if channel.Status == common.ChannelStatusManuallyDisabled {
-			continue
-		}
+
+	concurrency := operation_setting.GetMonitorSetting().ChannelTestConcurrency
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	if concurrency > total && total > 0 {
+		concurrency = total
+	}
+
+	var (
+		mu        sync.Mutex
+		wg        sync.WaitGroup
+		processed atomic.Int32
+		sem       = make(chan struct{}, concurrency)
+	)
+
+	if report != nil {
+		report(0, total)
+	}
+
+	// testOne runs a single channel test and folds its outcome into summary. It is
+	// safe to call from multiple goroutines: every testChannel call builds its own
+	// gin context and recorder, and the shared summary is mutex guarded.
+	testOne := func(channel *model.Channel) {
 		isChannelEnabled := channel.Status == common.ChannelStatusEnabled
 		tik := time.Now()
 		result := testChannel(ctx, channel, testUserID, "", "", shouldUseStreamForAutomaticChannelTest(channel))
-		tok := time.Now()
-		milliseconds := tok.Sub(tik).Milliseconds()
+		milliseconds := time.Since(tik).Milliseconds()
 		if ctx != nil && ctx.Err() != nil {
-			break
+			return
 		}
-
-		summary.Tested++
 
 		shouldBanChannel := false
 		newAPIError := result.newAPIError
@@ -941,45 +954,90 @@ func performChannelTests(ctx context.Context, channels []*model.Channel, testUse
 		}
 
 		// 当错误检查通过，才检查响应时间
-		if common.AutomaticDisableChannelEnabled && !shouldBanChannel {
-			if milliseconds > disableThreshold {
-				err := fmt.Errorf("响应时间 %.2fs 超过阈值 %.2fs", float64(milliseconds)/1000.0, float64(disableThreshold)/1000.0)
-				newAPIError = types.NewOpenAIError(err, types.ErrorCodeChannelResponseTimeExceeded, http.StatusRequestTimeout)
-				shouldBanChannel = true
-			}
+		if common.AutomaticDisableChannelEnabled && !shouldBanChannel && milliseconds > disableThreshold {
+			err := fmt.Errorf("响应时间 %.2fs 超过阈值 %.2fs", float64(milliseconds)/1000.0, float64(disableThreshold)/1000.0)
+			newAPIError = types.NewOpenAIError(err, types.ErrorCodeChannelResponseTimeExceeded, http.StatusRequestTimeout)
+			shouldBanChannel = true
 		}
 
+		banned := allowDisable && isChannelEnabled && shouldBanChannel && channel.GetAutoBan()
+		if banned {
+			processChannelError(result.context, *types.NewChannelError(channel.Id, channel.Type, channel.Name, channel.ChannelInfo.IsMultiKey, common.GetContextKeyString(result.context, constant.ContextKeyChannelKey), channel.GetAutoBan()), newAPIError)
+		}
+		enabled := result.localErr == nil && !isChannelEnabled && service.ShouldEnableChannel(newAPIError, channel.Status)
+		if enabled {
+			service.EnableChannel(channel.Id, common.GetContextKeyString(result.context, constant.ContextKeyChannelKey), channel.Name)
+		}
+		channel.UpdateResponseTime(milliseconds)
+
+		mu.Lock()
+		summary.Tested++
 		if newAPIError == nil {
 			summary.Succeeded++
 		} else {
 			summary.Failed++
 		}
-
-		// disable channel
-		if allowDisable && isChannelEnabled && shouldBanChannel && channel.GetAutoBan() {
-			processChannelError(result.context, *types.NewChannelError(channel.Id, channel.Type, channel.Name, channel.ChannelInfo.IsMultiKey, common.GetContextKeyString(result.context, constant.ContextKeyChannelKey), channel.GetAutoBan()), newAPIError)
+		if banned {
 			summary.Disabled++
 		}
-
-		// enable channel
-		if result.localErr == nil && !isChannelEnabled && service.ShouldEnableChannel(newAPIError, channel.Status) {
-			service.EnableChannel(channel.Id, common.GetContextKeyString(result.context, constant.ContextKeyChannelKey), channel.Name)
+		if enabled {
 			summary.Enabled++
 		}
+		mu.Unlock()
 
-		channel.UpdateResponseTime(milliseconds)
+		if report != nil {
+			report(int(processed.Add(1)), total)
+		}
+	}
+
+dispatch:
+	for _, channel := range channels {
+		if ctx != nil && ctx.Err() != nil {
+			break
+		}
+		if channel.Status == common.ChannelStatusManuallyDisabled {
+			if report != nil {
+				report(int(processed.Add(1)), total)
+			}
+			continue
+		}
+
+		// Acquire a worker slot, honoring cancellation so a runner that loses its
+		// lease stops promptly.
+		if ctx == nil {
+			sem <- struct{}{}
+		} else {
+			select {
+			case <-ctx.Done():
+				break dispatch
+			case sem <- struct{}{}:
+			}
+		}
+
+		wg.Add(1)
+		go func(ch *model.Channel) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			testOne(ch)
+		}(channel)
+
+		// RequestInterval throttles how fast new tests are dispatched, spacing out
+		// upstream load even when tests run concurrently.
 		if common.RequestInterval > 0 {
 			if ctx == nil {
 				time.Sleep(common.RequestInterval)
 			} else {
 				select {
 				case <-ctx.Done():
-					return summary
+					break dispatch
 				case <-time.After(common.RequestInterval):
 				}
 			}
 		}
 	}
+
+	wg.Wait()
+
 	if report != nil && (ctx == nil || ctx.Err() == nil) {
 		report(total, total) // mark complete only when the full set was tested
 	}

--- a/setting/operation_setting/monitor_setting.go
+++ b/setting/operation_setting/monitor_setting.go
@@ -53,7 +53,8 @@ func GetMonitorSetting() *MonitorSetting {
 		monitorSetting.ChannelTestMode = ChannelTestModeScheduledAll
 	}
 	if v, ok := os.LookupEnv("CHANNEL_TEST_CONCURRENCY"); ok {
-		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+		if parsed, err := strconv.Atoi(v); err == nil {
+			// A non-positive override is normalized to 1 by the clamp below.
 			monitorSetting.ChannelTestConcurrency = parsed
 		}
 	}

--- a/setting/operation_setting/monitor_setting.go
+++ b/setting/operation_setting/monitor_setting.go
@@ -11,6 +11,9 @@ type MonitorSetting struct {
 	AutoTestChannelEnabled bool    `json:"auto_test_channel_enabled"`
 	AutoTestChannelMinutes float64 `json:"auto_test_channel_minutes"`
 	ChannelTestMode        string  `json:"channel_test_mode"`
+	// ChannelTestConcurrency is the number of channels tested in parallel during
+	// a batch test run. 1 preserves the original fully sequential behavior.
+	ChannelTestConcurrency int `json:"test_concurrency"`
 }
 
 const (
@@ -23,6 +26,7 @@ var monitorSetting = MonitorSetting{
 	AutoTestChannelEnabled: false,
 	AutoTestChannelMinutes: 10,
 	ChannelTestMode:        ChannelTestModeScheduledAll,
+	ChannelTestConcurrency: 1,
 }
 
 func init() {
@@ -47,6 +51,14 @@ func GetMonitorSetting() *MonitorSetting {
 	}
 	if monitorSetting.ChannelTestMode != ChannelTestModePassiveRecovery {
 		monitorSetting.ChannelTestMode = ChannelTestModeScheduledAll
+	}
+	if v, ok := os.LookupEnv("CHANNEL_TEST_CONCURRENCY"); ok {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+			monitorSetting.ChannelTestConcurrency = parsed
+		}
+	}
+	if monitorSetting.ChannelTestConcurrency < 1 {
+		monitorSetting.ChannelTestConcurrency = 1
 	}
 	return &monitorSetting
 }

--- a/setting/operation_setting/monitor_setting_test.go
+++ b/setting/operation_setting/monitor_setting_test.go
@@ -46,6 +46,11 @@ func TestGetMonitorSetting_ChannelTestConcurrencyNormalizedToAtLeastOne(t *testi
 	orig := monitorSetting
 	t.Cleanup(func() { monitorSetting = orig })
 
+	// Isolate from any ambient env override so the stored value is what is tested.
+	// An empty value makes GetMonitorSetting skip the env branch and fall through
+	// to the clamp.
+	t.Setenv("CHANNEL_TEST_CONCURRENCY", "")
+
 	// A non-positive stored value (e.g. an unset legacy option) must normalize to 1
 	// so the batch test never runs with a zero-sized worker pool.
 	monitorSetting = MonitorSetting{ChannelTestConcurrency: 0}
@@ -67,4 +72,19 @@ func TestGetMonitorSetting_ChannelTestConcurrencyEnvOverride(t *testing.T) {
 
 	require.NotNil(t, setting)
 	assert.Equal(t, 8, setting.ChannelTestConcurrency)
+}
+
+func TestGetMonitorSetting_ChannelTestConcurrencyEnvNonPositiveNormalizedToOne(t *testing.T) {
+	orig := monitorSetting
+	t.Cleanup(func() { monitorSetting = orig })
+
+	// An explicit non-positive env override must be honored (over the stored
+	// value) and then normalized to 1 rather than silently ignored.
+	t.Setenv("CHANNEL_TEST_CONCURRENCY", "0")
+	monitorSetting = MonitorSetting{ChannelTestConcurrency: 5}
+
+	setting := GetMonitorSetting()
+
+	require.NotNil(t, setting)
+	assert.Equal(t, 1, setting.ChannelTestConcurrency)
 }

--- a/setting/operation_setting/monitor_setting_test.go
+++ b/setting/operation_setting/monitor_setting_test.go
@@ -41,3 +41,30 @@ func TestGetMonitorSetting_ChannelTestEnabledEnvCanEnableDisabledConfig(t *testi
 	assert.True(t, setting.AutoTestChannelEnabled)
 	assert.Equal(t, float64(12), setting.AutoTestChannelMinutes)
 }
+
+func TestGetMonitorSetting_ChannelTestConcurrencyNormalizedToAtLeastOne(t *testing.T) {
+	orig := monitorSetting
+	t.Cleanup(func() { monitorSetting = orig })
+
+	// A non-positive stored value (e.g. an unset legacy option) must normalize to 1
+	// so the batch test never runs with a zero-sized worker pool.
+	monitorSetting = MonitorSetting{ChannelTestConcurrency: 0}
+
+	setting := GetMonitorSetting()
+
+	require.NotNil(t, setting)
+	assert.Equal(t, 1, setting.ChannelTestConcurrency)
+}
+
+func TestGetMonitorSetting_ChannelTestConcurrencyEnvOverride(t *testing.T) {
+	orig := monitorSetting
+	t.Cleanup(func() { monitorSetting = orig })
+
+	t.Setenv("CHANNEL_TEST_CONCURRENCY", "8")
+	monitorSetting = MonitorSetting{ChannelTestConcurrency: 1}
+
+	setting := GetMonitorSetting()
+
+	require.NotNil(t, setting)
+	assert.Equal(t, 8, setting.ChannelTestConcurrency)
+}

--- a/web/default/src/features/models/components/drawers/model-mutate-drawer.tsx
+++ b/web/default/src/features/models/components/drawers/model-mutate-drawer.tsx
@@ -212,6 +212,7 @@ export function ModelMutateDrawer({
         '100-199,300-399,401-407,409-499,500-503,505-523,525-599',
       'monitor_setting.auto_test_channel_enabled': false,
       'monitor_setting.auto_test_channel_minutes': 10,
+      'monitor_setting.test_concurrency': 1,
       'monitor_setting.channel_test_mode': 'scheduled_all',
       'channel_affinity_setting.enabled': false,
       'channel_affinity_setting.switch_on_success': true,

--- a/web/default/src/features/system-settings/models/index.tsx
+++ b/web/default/src/features/system-settings/models/index.tsx
@@ -72,6 +72,7 @@ const defaultModelSettings: ModelSettings = {
     '100-199,300-399,401-407,409-499,500-503,505-523,525-599',
   'monitor_setting.auto_test_channel_enabled': false,
   'monitor_setting.auto_test_channel_minutes': 10,
+  'monitor_setting.test_concurrency': 1,
   'monitor_setting.channel_test_mode': 'scheduled_all',
   'channel_affinity_setting.enabled': false,
   'channel_affinity_setting.switch_on_success': true,

--- a/web/default/src/features/system-settings/models/routing-reliability-section.tsx
+++ b/web/default/src/features/system-settings/models/routing-reliability-section.tsx
@@ -81,6 +81,10 @@ const routingReliabilitySchema = z
         .number()
         .int()
         .min(1, 'Interval must be at least 1 minute'),
+      test_concurrency: z.coerce
+        .number()
+        .int()
+        .min(1, 'Concurrency must be at least 1'),
       channel_test_mode: z.enum(channelTestModes),
     }),
   })
@@ -126,6 +130,7 @@ type RoutingReliabilitySectionProps = {
     AutomaticRetryStatusCodes: string
     'monitor_setting.auto_test_channel_enabled': boolean
     'monitor_setting.auto_test_channel_minutes': number
+    'monitor_setting.test_concurrency': number
     'monitor_setting.channel_test_mode': ChannelTestMode
   }
 }
@@ -144,6 +149,7 @@ type NormalizedRoutingReliabilityValues = {
   AutomaticRetryStatusCodes: string
   'monitor_setting.auto_test_channel_enabled': boolean
   'monitor_setting.auto_test_channel_minutes': number
+  'monitor_setting.test_concurrency': number
   'monitor_setting.channel_test_mode': ChannelTestMode
 }
 
@@ -168,6 +174,7 @@ const buildFormDefaults = (
       defaults['monitor_setting.auto_test_channel_enabled'],
     auto_test_channel_minutes:
       defaults['monitor_setting.auto_test_channel_minutes'],
+    test_concurrency: defaults['monitor_setting.test_concurrency'],
     channel_test_mode: normalizeChannelTestMode(
       defaults['monitor_setting.channel_test_mode']
     ),
@@ -194,6 +201,8 @@ const normalizeDefaults = (
     defaults['monitor_setting.auto_test_channel_enabled'],
   'monitor_setting.auto_test_channel_minutes':
     defaults['monitor_setting.auto_test_channel_minutes'],
+  'monitor_setting.test_concurrency':
+    defaults['monitor_setting.test_concurrency'],
   'monitor_setting.channel_test_mode': normalizeChannelTestMode(
     defaults['monitor_setting.channel_test_mode']
   ),
@@ -219,6 +228,7 @@ const normalizeFormValues = (
     values.monitor_setting.auto_test_channel_enabled,
   'monitor_setting.auto_test_channel_minutes':
     values.monitor_setting.auto_test_channel_minutes,
+  'monitor_setting.test_concurrency': values.monitor_setting.test_concurrency,
   'monitor_setting.channel_test_mode': values.monitor_setting.channel_test_mode,
 })
 
@@ -447,6 +457,30 @@ export function RoutingReliabilitySection({
                             'How frequently the system checks auto-disabled channels for recovery'
                           )
                         : t('How frequently the system tests all channels')}
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name='monitor_setting.test_concurrency'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t('Test concurrency')}</FormLabel>
+                    <FormControl>
+                      <Input
+                        type='number'
+                        min={1}
+                        step={1}
+                        {...safeNumberFieldProps(field)}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      {t(
+                        'Number of channels tested in parallel during a batch test (1 = one at a time).'
+                      )}
                     </FormDescription>
                     <FormMessage />
                   </FormItem>

--- a/web/default/src/features/system-settings/models/section-registry.tsx
+++ b/web/default/src/features/system-settings/models/section-registry.tsx
@@ -83,6 +83,8 @@ const MODELS_SECTIONS = [
             settings['monitor_setting.auto_test_channel_enabled'],
           'monitor_setting.auto_test_channel_minutes':
             settings['monitor_setting.auto_test_channel_minutes'],
+          'monitor_setting.test_concurrency':
+            settings['monitor_setting.test_concurrency'],
           'monitor_setting.channel_test_mode':
             settings['monitor_setting.channel_test_mode'],
         }}

--- a/web/default/src/features/system-settings/types.ts
+++ b/web/default/src/features/system-settings/types.ts
@@ -233,6 +233,7 @@ export type ModelSettings = {
   AutomaticRetryStatusCodes: string
   'monitor_setting.auto_test_channel_enabled': boolean
   'monitor_setting.auto_test_channel_minutes': number
+  'monitor_setting.test_concurrency': number
   'monitor_setting.channel_test_mode': 'scheduled_all' | 'passive_recovery'
   'channel_affinity_setting.enabled': boolean
   'channel_affinity_setting.switch_on_success': boolean

--- a/web/default/src/i18n/locales/_reports/_sync-report.json
+++ b/web/default/src/i18n/locales/_reports/_sync-report.json
@@ -9,31 +9,31 @@
     },
     "fr": {
       "file": "fr.json",
-      "missingCount": 0,
+      "missingCount": 2,
       "extrasCount": 0,
       "untranslatedCount": 0
     },
     "ja": {
       "file": "ja.json",
-      "missingCount": 0,
+      "missingCount": 2,
       "extrasCount": 0,
-      "untranslatedCount": 0
+      "untranslatedCount": 2
     },
     "ru": {
       "file": "ru.json",
-      "missingCount": 0,
+      "missingCount": 2,
       "extrasCount": 0,
-      "untranslatedCount": 0
+      "untranslatedCount": 2
     },
     "vi": {
       "file": "vi.json",
-      "missingCount": 0,
+      "missingCount": 2,
       "extrasCount": 0,
       "untranslatedCount": 0
     },
     "zh-TW": {
       "file": "zh-TW.json",
-      "missingCount": 0,
+      "missingCount": 2,
       "extrasCount": 0,
       "untranslatedCount": 0
     },

--- a/web/default/src/i18n/locales/_reports/ja.untranslated.json
+++ b/web/default/src/i18n/locales/_reports/ja.untranslated.json
@@ -1,0 +1,4 @@
+{
+  "Test concurrency": "Test concurrency",
+  "Number of channels tested in parallel during a batch test (1 = one at a time).": "Number of channels tested in parallel during a batch test (1 = one at a time)."
+}

--- a/web/default/src/i18n/locales/_reports/ru.untranslated.json
+++ b/web/default/src/i18n/locales/_reports/ru.untranslated.json
@@ -1,0 +1,4 @@
+{
+  "Test concurrency": "Test concurrency",
+  "Number of channels tested in parallel during a batch test (1 = one at a time).": "Number of channels tested in parallel during a batch test (1 = one at a time)."
+}

--- a/web/default/src/i18n/locales/en.json
+++ b/web/default/src/i18n/locales/en.json
@@ -4352,6 +4352,8 @@
     "Test Connection": "Test Connection",
     "Test connectivity for:": "Test connectivity for:",
     "Test failed": "Test failed",
+    "Test concurrency": "Test concurrency",
+    "Number of channels tested in parallel during a batch test (1 = one at a time).": "Number of channels tested in parallel during a batch test (1 = one at a time).",
     "Test interval (minutes)": "Test interval (minutes)",
     "Test Latency": "Test Latency",
     "Test Mode": "Test Mode",

--- a/web/default/src/i18n/locales/fr.json
+++ b/web/default/src/i18n/locales/fr.json
@@ -4352,6 +4352,8 @@
     "Test Connection": "Tester la connexion",
     "Test connectivity for:": "Tester la connectivité pour :",
     "Test failed": "Échec du test",
+    "Test concurrency": "Test concurrency",
+    "Number of channels tested in parallel during a batch test (1 = one at a time).": "Number of channels tested in parallel during a batch test (1 = one at a time).",
     "Test interval (minutes)": "Intervalle de test (minutes)",
     "Test Latency": "Tester la latence",
     "Test Mode": "Mode test",

--- a/web/default/src/i18n/locales/ja.json
+++ b/web/default/src/i18n/locales/ja.json
@@ -4352,6 +4352,8 @@
     "Test Connection": "接続をテスト",
     "Test connectivity for:": "接続性をテスト:",
     "Test failed": "テストに失敗しました",
+    "Test concurrency": "Test concurrency",
+    "Number of channels tested in parallel during a batch test (1 = one at a time).": "Number of channels tested in parallel during a batch test (1 = one at a time).",
     "Test interval (minutes)": "テスト間隔（分）",
     "Test Latency": "レイテンシをテスト",
     "Test Mode": "テストモード",

--- a/web/default/src/i18n/locales/ru.json
+++ b/web/default/src/i18n/locales/ru.json
@@ -4352,6 +4352,8 @@
     "Test Connection": "Проверить подключение",
     "Test connectivity for:": "Проверить подключение для:",
     "Test failed": "Тест не выполнен",
+    "Test concurrency": "Test concurrency",
+    "Number of channels tested in parallel during a batch test (1 = one at a time).": "Number of channels tested in parallel during a batch test (1 = one at a time).",
     "Test interval (minutes)": "Интервал проверки (минуты)",
     "Test Latency": "Проверить задержку",
     "Test Mode": "Тестовый режим",

--- a/web/default/src/i18n/locales/vi.json
+++ b/web/default/src/i18n/locales/vi.json
@@ -4352,6 +4352,8 @@
     "Test Connection": "Kiểm tra kết nối",
     "Test connectivity for:": "Kiểm tra kết nối cho:",
     "Test failed": "Kiểm tra thất bại",
+    "Test concurrency": "Test concurrency",
+    "Number of channels tested in parallel during a batch test (1 = one at a time).": "Number of channels tested in parallel during a batch test (1 = one at a time).",
     "Test interval (minutes)": "Khoảng thời gian kiểm tra (phút)",
     "Test Latency": "Kiểm tra độ trễ",
     "Test Mode": "Chế độ thử nghiệm",

--- a/web/default/src/i18n/locales/zh-TW.json
+++ b/web/default/src/i18n/locales/zh-TW.json
@@ -4352,6 +4352,8 @@
     "Test Connection": "測試連接",
     "Test connectivity for:": "測試連接性：",
     "Test failed": "測試失敗",
+    "Test concurrency": "Test concurrency",
+    "Number of channels tested in parallel during a batch test (1 = one at a time).": "Number of channels tested in parallel during a batch test (1 = one at a time).",
     "Test interval (minutes)": "測試間隔 (分鐘)",
     "Test Latency": "測試延遲",
     "Test Mode": "測試模式",

--- a/web/default/src/i18n/locales/zh.json
+++ b/web/default/src/i18n/locales/zh.json
@@ -4352,6 +4352,8 @@
     "Test Connection": "测试连接",
     "Test connectivity for:": "测试连接性：",
     "Test failed": "测试失败",
+    "Test concurrency": "测试并发数",
+    "Number of channels tested in parallel during a batch test (1 = one at a time).": "批量测试时并行测试的渠道数量（1 = 逐个测试）。",
     "Test interval (minutes)": "测试间隔 (分钟)",
     "Test Latency": "测试延迟",
     "Test Mode": "测试模式",


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

> This PR is **AI-assisted**: the code was written with AI help, then reviewed, built and tested by me. The description below is written by me based on my understanding of the change.

## 📝 变更描述 / Description

Batch channel testing (`performChannelTests` in `controller/channel-test.go`) tested every channel **strictly sequentially** — one `testChannel` call at a time. On instances with many channels a run takes very long because each slow/dead upstream is waited on one after another.

This PR makes the batch test run channels through a **bounded worker pool** whose size is configurable, while keeping the default behavior identical to today.

**Backend**
- New setting `MonitorSetting.ChannelTestConcurrency` (`json:"test_concurrency"`), **default `1`** → existing deployments are unchanged unless they opt in.
- Optional env override `CHANNEL_TEST_CONCURRENCY` (mirrors `CHANNEL_TEST_FREQUENCY`/`CHANNEL_TEST_ENABLED`); non-positive values normalize to `1`.
- `performChannelTests` dispatches to at most `N` concurrent goroutines: shared `channelTestSummary` is mutex-guarded, progress is reported through a single serialized `advanceProgress` (monotonic), `ctx` cancellation is honored while acquiring a slot, and `RequestInterval` throttles strictly between dispatches (no trailing wait, no leaked timer).

**Frontend (default theme)**
- Adds a **"Test concurrency"** number field to *Model settings → Routing Reliability*, wired to `monitor_setting.test_concurrency` (mirrors the existing test-interval field), with en/zh strings and `i18n:sync` applied to the other locales.

**Why it works**

Per-channel `testChannel` calls each build their own gin context and recorder, so they are independent. The only shared state (summary counters, progress) is synchronized. Per-channel side effects (`processChannelError`, `EnableChannel`, `UpdateResponseTime`, consume-log writes) operate on independent rows through GORM, which is safe for concurrent use.

## 🚀 变更类型 / Type of change

- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature) — opt-in, backward compatible (default `1`)
- [x] ⚡ 性能优化 / 重构 (Refactor)

## 🔗 关联任务 / Related Issue

- N/A

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 描述由我本人撰写整理（AI 辅助编码，已在顶部声明）。
- [x] **非重复提交:** 已搜索现有 Issues/PRs（#5844 仅新增测试超时设置，与本 PR 不重叠）。
- [x] **变更理解:** 我理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 仅涉及批量测试并发（后端 + 前端设置项）。
- [x] **本地验证:** 后端 `go build`/`go vet`/包测试通过；前端 `bun run typecheck` 通过，改动文件 `oxlint` 0 error。
- [x] **安全合规:** 无敏感凭据；默认值 `1` 保持原有行为。

## 📸 运行证明 / Proof of Work

```
# backend
$ go build ./controller/... ./setting/operation_setting/...   -> ok
$ go vet   ./controller/... ./setting/operation_setting/...   -> ok
$ go test  ./setting/operation_setting/ -run ChannelTestConcurrency -v
--- PASS: TestGetMonitorSetting_ChannelTestConcurrencyNormalizedToAtLeastOne
--- PASS: TestGetMonitorSetting_ChannelTestConcurrencyEnvOverride
--- PASS: TestGetMonitorSetting_ChannelTestConcurrencyEnvNonPositiveNormalizedToOne
$ go test  ./controller/ -run 'SelectChannelsForAutomaticTest|SettleTestQuota'  -> ok

# frontend (web/default)
$ bun run typecheck                       -> tsgo -b, no errors
$ bunx oxlint <changed files>             -> 0 warnings, 0 errors
```
