### PR TITLE
fix(web): let channel table fill available width

### DIFF
--- a/web/default/src/components/data-table/core/table-sizing.ts
+++ b/web/default/src/components/data-table/core/table-sizing.ts
@@ -32,6 +32,6 @@ export function getTableSizeStyle<TData>(
   return {
     minWidth: `max(100%, ${width}px)`,
     tableLayout: 'auto',
-    width: 'max-content',
+    width: '100%',
   }
 }


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本 PR 由 AI assistant 协助实现与整理，请维护者在合并前复核。

## 📝 变更描述 / Description
渠道列表开启列宽调整后，表格会按各列默认 `size` 计算总宽，并把 table 宽度设为 `max-content`。在宽屏下，默认列宽之和小于可用容器宽度时，表格不会充分占满横向空间。

本 PR 将通用 DataTable 的 sized table 宽度改为 `100%`，同时保留现有 `minWidth: max(100%, <columns width>px)`：

- 可用宽度更大时，表格默认填满容器，列宽由浏览器按表格布局分配额外空间。
- 列默认总宽超过容器时，仍会保持横向滚动，不压缩到不可用。
- 不改动渠道列定义和手动拖拽逻辑，避免把某个渠道列硬编码得过宽。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Follow-up to #5948
- Addresses review feedback in https://github.com/QuantumNous/new-api/pull/5948#issuecomment-4921318628

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
当前分支已执行并通过：

```bash
bun run --cwd default typecheck
./node_modules/.bin/oxlint.exe -c default/.oxlintrc.json default/src/components/data-table/core/table-sizing.ts
./node_modules/.bin/oxfmt.exe --check default/src/components/data-table/core/table-sizing.ts
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data table sizing so tables now stretch to fit the available width instead of sizing to content.
  * Preserved existing minimum width behavior, helping tables display more consistently across layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->