### PR TITLE
fix: 中转 gpt-realtime 系列 GA 模型时不再发送 realtime beta 标识

### DIFF
--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -194,19 +194,26 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, header *http.Header, info *
 		}
 	}
 	if info.RelayMode == relayconstant.RelayModeRealtime {
+		// OpenAI 已下线 Realtime Beta API,GA 模型收到 beta 标识会以 beta_api_shape_disabled 拒绝;
+		// 仅对遗留 preview 模型保留 beta 标识
+		legacyRealtimeBeta := strings.Contains(info.UpstreamModelName, "-realtime-preview")
 		swp := c.Request.Header.Get("Sec-WebSocket-Protocol")
 		if swp != "" {
 			items := []string{
 				"realtime",
 				"openai-insecure-api-key." + info.ApiKey,
-				"openai-beta.realtime-v1",
+			}
+			if legacyRealtimeBeta {
+				items = append(items, "openai-beta.realtime-v1")
 			}
 			header.Set("Sec-WebSocket-Protocol", strings.Join(items, ","))
 			//req.Header.Set("Sec-WebSocket-Key", c.Request.Header.Get("Sec-WebSocket-Key"))
 			//req.Header.Set("Sec-Websocket-Extensions", c.Request.Header.Get("Sec-Websocket-Extensions"))
 			//req.Header.Set("Sec-Websocket-Version", c.Request.Header.Get("Sec-Websocket-Version"))
 		} else {
-			header.Set("openai-beta", "realtime=v1")
+			if legacyRealtimeBeta {
+				header.Set("openai-beta", "realtime=v1")
+			}
 			if !hasAuthOverride {
 				header.Set("Authorization", "Bearer "+info.ApiKey)
 			}

--- a/relay/channel/openai/constant.go
+++ b/relay/channel/openai/constant.go
@@ -58,6 +58,8 @@ var ModelList = []string{
 	"gpt-realtime", "gpt-realtime-2025-08-28",
 	"gpt-realtime-mini", "gpt-realtime-mini-2025-10-06", "gpt-realtime-mini-2025-12-15",
 	"gpt-realtime-1.5",
+	"gpt-realtime-2", "gpt-realtime-2.1", "gpt-realtime-2.1-mini",
+	"gpt-realtime-whisper", "gpt-realtime-translate",
 	"text-embedding-ada-002", "text-embedding-3-small", "text-embedding-3-large",
 	"text-curie-001", "text-babbage-001", "text-ada-001",
 	"text-moderation-latest", "text-moderation-stable",


### PR DESCRIPTION
## 📝 变更描述 / Description

OpenAI 已经下线 Realtime Beta API。现在网关中转 `/v1/realtime` 时无条件给上游带 `OpenAI-Beta: realtime=v1`会导致最新的正式模型报错

改法:只有模型名含 `-realtime-preview` 的遗留 beta 模型才携带该标识,GA 模型走正常请求

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述,没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs,确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 \`Bug fix\`,我已提交或关联对应 Issue。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证,维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据,且符合项目代码规范。

## 📸 运行证明 / Proof of Work

修复前,OpenAI SDK 直连网关 `/v1/realtime?model=gpt-realtime-2.1-mini`,上游立刻断连:
<img width="1760" height="1282" alt="image" src="https://github.com/user-attachments/assets/15b022cb-ff50-42bc-99b2-cdd0f5aad850" />

修复后: 实时语音识别正常:
<img width="1796" height="1058" alt="image" src="https://github.com/user-attachments/assets/c4fe692f-4cbd-4f1f-ad6b-24625f248bd0" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional realtime model variants.
* **Bug Fixes**
  * Improved WebSocket connection handling so beta negotiation details are only sent when needed for legacy realtime models.
  * Reduced the chance of connection issues with newer realtime models by avoiding unnecessary beta headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->