### PR TITLE
fix(claude): emit tool args before deferring stream close on finish_reason

### DIFF
--- a/service/relayconvert/internal/oai_chat/to_claude_messages_resp.go
+++ b/service/relayconvert/internal/oai_chat/to_claude_messages_resp.go
@@ -293,13 +293,6 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 		doneChunk := chosenChoice.FinishReason != nil && *chosenChoice.FinishReason != ""
 		if doneChunk {
 			info.FinishReason = *chosenChoice.FinishReason
-			oaiUsage := openAIResponse.Usage
-			if oaiUsage == nil {
-				oaiUsage = info.ClaudeConvertInfo.Usage
-				// Some upstreams emit finish_reason first, then send a final usage-only chunk.
-				// Defer closing until usage is available so the final message_delta carries it.
-				return claudeResponses
-			}
 		}
 
 		var claudeResponse dto.ClaudeResponse
@@ -407,20 +400,23 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 		}
 
 		if doneChunk || info.ClaudeConvertInfo.Done {
-			stopOpenBlocks()
 			oaiUsage := openAIResponse.Usage
 			if oaiUsage == nil {
 				oaiUsage = info.ClaudeConvertInfo.Usage
 			}
-			if oaiUsage != nil {
-				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
-					Type:  "message_delta",
-					Usage: buildClaudeUsageFromOpenAIUsage(oaiUsage),
-					Delta: &dto.ClaudeMediaMessage{
-						StopReason: common.GetPointer[string](stopReasonOpenAI2Claude(info.FinishReason)),
-					},
-				})
+			if oaiUsage == nil {
+				// Some upstreams emit finish_reason first, then send a final usage-only chunk.
+				// Defer closing until usage is available so the final message_delta carries it.
+				return claudeResponses
 			}
+			stopOpenBlocks()
+			claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
+				Type:  "message_delta",
+				Usage: buildClaudeUsageFromOpenAIUsage(oaiUsage),
+				Delta: &dto.ClaudeMediaMessage{
+					StopReason: common.GetPointer[string](stopReasonOpenAI2Claude(info.FinishReason)),
+				},
+			})
 			claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
 				Type: "message_stop",
 			})

--- a/service/relayconvert/internal/oai_chat/to_claude_messages_resp_test.go
+++ b/service/relayconvert/internal/oai_chat/to_claude_messages_resp_test.go
@@ -1,6 +1,7 @@
 package oaichat
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/QuantumNous/new-api/dto"
@@ -202,6 +203,141 @@ func TestStreamResponseOpenAI2ClaudeClosesTextThinkingAndToolBlocks(t *testing.T
 	assert.Equal(t, 7, finishResponses[1].Usage.BillingUsage.OpenAIUsage.PromptTokens)
 	assert.Equal(t, 3, finishResponses[1].Usage.BillingUsage.OpenAIUsage.CompletionTokens)
 	assert.Equal(t, "message_stop", finishResponses[2].Type)
+}
+
+func TestStreamResponseOpenAI2Claude_FinishReasonBeforeUsageStillEmitsToolArgs(t *testing.T) {
+	info := &relaycommon.RelayInfo{
+		ClaudeConvertInfo: &relaycommon.ClaudeConvertInfo{
+			LastMessagesType: relaycommon.LastMessageTypeNone,
+		},
+	}
+	info.SendResponseCount = 1
+
+	first := &dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl-test",
+		Model: "glm-5.2",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{{
+			Delta: dto.ChatCompletionsStreamResponseChoiceDelta{
+				ToolCalls: []dto.ToolCallResponse{{
+					Index: ptr(0),
+					ID:    "call_1",
+					Type:  "function",
+					Function: dto.FunctionResponse{
+						Name:      "Bash",
+						Arguments: `{"command": "ls"`,
+					},
+				}},
+			},
+		}},
+	}
+	responses := StreamResponseOpenAI2Claude(first, info)
+	require.NotEmpty(t, responses)
+
+	info.SendResponseCount = 2
+	finishReason := "tool_calls"
+	finishChunk := &dto.ChatCompletionsStreamResponse{
+		Choices: []dto.ChatCompletionsStreamResponseChoice{{
+			Delta: dto.ChatCompletionsStreamResponseChoiceDelta{
+				ToolCalls: []dto.ToolCallResponse{{
+					Index: ptr(0),
+					Function: dto.FunctionResponse{
+						Arguments: `, "description": "done"}`,
+					},
+				}},
+			},
+			FinishReason: &finishReason,
+		}},
+	}
+	responses = StreamResponseOpenAI2Claude(finishChunk, info)
+	require.False(t, info.ClaudeConvertInfo.Done)
+
+	var partial string
+	for _, resp := range responses {
+		if resp.Type == "content_block_delta" && resp.Delta != nil && resp.Delta.Type == "input_json_delta" && resp.Delta.PartialJson != nil {
+			partial += *resp.Delta.PartialJson
+		}
+	}
+	require.Equal(t, `, "description": "done"}`, partial)
+
+	info.SendResponseCount = 3
+	usageChunk := &dto.ChatCompletionsStreamResponse{
+		Usage: &dto.Usage{
+			PromptTokens:     10,
+			CompletionTokens: 5,
+			TotalTokens:      15,
+		},
+	}
+	responses = StreamResponseOpenAI2Claude(usageChunk, info)
+	require.True(t, info.ClaudeConvertInfo.Done)
+	require.NotEmpty(t, responses)
+	last := responses[len(responses)-1]
+	require.Equal(t, "message_stop", last.Type)
+}
+
+func TestStreamResponseOpenAI2Claude_AccumulatedToolArgsAreValidJSON(t *testing.T) {
+	info := &relaycommon.RelayInfo{
+		ClaudeConvertInfo: &relaycommon.ClaudeConvertInfo{
+			LastMessagesType: relaycommon.LastMessageTypeNone,
+		},
+	}
+	chunks := []*dto.ChatCompletionsStreamResponse{
+		{
+			Id:    "chatcmpl-test",
+			Model: "glm-5.2",
+			Choices: []dto.ChatCompletionsStreamResponseChoice{{
+				Delta: dto.ChatCompletionsStreamResponseChoiceDelta{
+					ToolCalls: []dto.ToolCallResponse{{
+						Index: ptr(0),
+						ID:    "call_1",
+						Type:  "function",
+						Function: dto.FunctionResponse{
+							Name:      "Bash",
+							Arguments: `{"command": "ls -la /root 2>/dev/null | head -20"`,
+						},
+					}},
+				},
+			}},
+		},
+		{
+			Choices: []dto.ChatCompletionsStreamResponseChoice{{
+				Delta: dto.ChatCompletionsStreamResponseChoiceDelta{
+					ToolCalls: []dto.ToolCallResponse{{
+						Index: ptr(0),
+						Function: dto.FunctionResponse{
+							Arguments: `, "description": "列出 /root 目录下的文件（前20行）"}`,
+						},
+					}},
+				},
+			}},
+		},
+		{
+			Choices: []dto.ChatCompletionsStreamResponseChoice{{
+				FinishReason: ptr("tool_calls"),
+			}},
+		},
+		{
+			Usage: &dto.Usage{
+				PromptTokens:     10,
+				CompletionTokens: 5,
+				TotalTokens:      15,
+			},
+		},
+	}
+
+	var accumulated string
+	for i, chunk := range chunks {
+		info.SendResponseCount = i + 1
+		responses := StreamResponseOpenAI2Claude(chunk, info)
+		for _, resp := range responses {
+			if resp.Type == "content_block_delta" && resp.Delta != nil && resp.Delta.Type == "input_json_delta" && resp.Delta.PartialJson != nil {
+				accumulated += *resp.Delta.PartialJson
+			}
+		}
+	}
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(accumulated), &parsed))
+	require.Equal(t, "ls -la /root 2>/dev/null | head -20", parsed["command"])
 }
 
 func TestNormalizeCacheCreationSplit(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix intermittent truncated `input_json_delta` streams when converting OpenAI-compatible upstream tool-call SSE to Claude Messages format.
- When upstream sends `finish_reason` without `usage` in the same chunk, the converter now still emits any `tool_calls` argument deltas from that chunk before deferring `message_stop`.
- Add regression tests covering the `finish_reason` → trailing `usage` chunk sequence.

## Related issues
- Partially addresses #4203 (root cause 3: early `return` on `finish_reason` without `usage` drops the last `tool_calls` argument delta). Causes 1–2 in that issue (duplicate `content_block_start`, pointer aliasing) are **not** covered by this PR.
- Related to #4379 (Claude Code → new-api → GLM/vLLM tool failures such as Invalid tool parameters / Error writing file; likely the same OpenAI⇄Claude stream conversion path).

## Problem
Some OpenAI-compatible upstreams (e.g. GLM) emit streaming chunks in this order:

1. multiple `tool_calls[].function.arguments` fragments
2. a chunk with `finish_reason: tool_calls` (often containing the final argument fragment, without `usage`)
3. a final usage-only chunk

Previously, step 2 triggered an early return before processing `tool_calls` in the same chunk, so the final `partial_json` fragments were dropped and clients saw invalid JSON like:

```json
{"command": "ls -la /root 2>/dev/null | head -20", "description": "列出 /root 目录下的文件（前20行）
```

## Test plan
- [x] `go test ./service/ -run TestStreamResponseOpenAI2Claude`
- [x] Manual Claude Messages streaming tool-call loop (20/20 OK after fix)

### Manual reproduction (20-run loop)

Set `BASE` to your new-api endpoint, `KEY` to a valid API key, and `MODEL` to an OpenAI-compatible upstream that supports tool calls (e.g. `glm-5.2`).

```bash
cat >/tmp/check-claude-stream-loop.sh <<'SH'
#!/usr/bin/env bash
set -euo pipefail

BASE="${BASE:-http://127.0.0.1:3000}"
KEY="${KEY:?set KEY to your API key}"
MODEL="${MODEL:-glm-5.2}"

cat >/tmp/claude-tool-test.json <<JSON
{
  "model": "$MODEL",
  "max_tokens": 512,
  "stream": true,
  "tools": [
    {
      "name": "Bash",
      "description": "Run a bash command",
      "input_schema": {
        "type": "object",
        "properties": {
          "command": {"type": "string"},
          "description": {"type": "string"}
        },
        "required": ["command"]
      }
    }
  ],
  "tool_choice": {
    "type": "tool",
    "name": "Bash"
  },
  "messages": [
    {
      "role": "user",
      "content": "调用 Bash 执行：ls -la /root 2>/dev/null | head -20"
    }
  ]
}
JSON

ok=0
fail=0

for i in $(seq 1 20); do
  out="/tmp/claude-tool-test-$i.sse"

  curl -sS -N "$BASE/v1/messages?beta=true" \
    -H "x-api-key: $KEY" \
    -H "anthropic-version: 2023-06-01" \
    -H "Content-Type: application/json" \
    --data-binary @/tmp/claude-tool-test.json \
    > "$out"

  if python3 - "$out" <<'PY'
import json, sys

path = sys.argv[1]
s = ""

for line in open(path, encoding="utf-8"):
    line = line.rstrip("\n")
    if not line.startswith("data: "):
        continue
    data = line[6:].strip()
    if not data or data == "[DONE]":
        continue
    try:
        obj = json.loads(data)
    except Exception:
        continue
    if obj.get("type") == "content_block_delta":
        delta = obj.get("delta") or {}
        if delta.get("type") == "input_json_delta":
            s += delta.get("partial_json") or ""

if not s:
    print("FAIL empty partial_json")
    sys.exit(1)

try:
    json.loads(s)
    print("OK", s)
except Exception as e:
    print("FAIL", repr(e), s)
    sys.exit(1)
PY
  then ok=$((ok+1)); else fail=$((fail+1)); fi
done

echo "summary: ok=$ok fail=$fail"
SH

chmod +x /tmp/check-claude-stream-loop.sh
KEY=sk-your-api-key BASE=http://127.0.0.1:3000 MODEL=glm-5.2 /tmp/check-claude-stream-loop.sh
```

**Expected after fix:** `summary: ok=20 fail=0`

**Typical failure before fix:** intermittent `Unterminated string` / `Expecting ',' delimiter` errors, e.g. `summary: ok=9 fail=11`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming responses when tool calls finish before usage information arrives.
  - Tool-call arguments now continue streaming correctly instead of being cut off prematurely.
  - Ensured arguments accumulated across multiple updates form valid JSON for reliable processing.
  - Final completion and usage details are emitted only after the required usage information is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
