### PR TITLE
fix(wallet): debounce topup amount preview requests

### DIFF
--- a/web/default/src/features/wallet/components/recharge-form-card.tsx
+++ b/web/default/src/features/wallet/components/recharge-form-card.tsx
@@ -131,7 +131,7 @@ export function RechargeFormCard({
 
   const handleAmountChange = (value: string) => {
     setLocalAmount(value)
-    const numValue = parseInt(value) || 0
+    const numValue = parseInt(value, 10) || 0
     if (numValue < 0) return
 
     if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)

--- a/web/default/src/features/wallet/components/recharge-form-card.tsx
+++ b/web/default/src/features/wallet/components/recharge-form-card.tsx
@@ -17,7 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import { Gift, ExternalLink, Loader2, Receipt, WalletCards } from 'lucide-react'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -33,7 +33,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { useDebounce } from '@/hooks/use-debounce'
 import { formatNumber } from '@/lib/format'
 import { cn } from '@/lib/utils'
 
@@ -114,24 +113,31 @@ export function RechargeFormCard({
 }: RechargeFormCardProps) {
   const { t } = useTranslation()
   const [localAmount, setLocalAmount] = useState(topupAmount.toString())
-  const debouncedAmount = useDebounce(localAmount, 500)
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  )
+  const onTopupAmountChangeRef = useRef(onTopupAmountChange)
+  onTopupAmountChangeRef.current = onTopupAmountChange
 
+  // Any externally-driven amount change (preset click, initial load) is
+  // already authoritative — drop a pending debounced push so it can't fire
+  // later and clobber it.
   useEffect(() => {
     setLocalAmount(topupAmount.toString())
-  }, [topupAmount])
-
-  // Only push the recalculated amount upstream once typing/scrolling settles,
-  // so every keystroke or wheel tick on the number input doesn't fire its own
-  // preview request.
-  useEffect(() => {
-    const numValue = parseInt(debouncedAmount) || 0
-    if (numValue >= 0 && numValue !== topupAmount) {
-      onTopupAmountChange(numValue)
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
     }
-  }, [debouncedAmount, topupAmount, onTopupAmountChange])
+  }, [topupAmount])
 
   const handleAmountChange = (value: string) => {
     setLocalAmount(value)
+    const numValue = parseInt(value) || 0
+    if (numValue < 0) return
+
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
+    debounceTimerRef.current = setTimeout(() => {
+      onTopupAmountChangeRef.current(numValue)
+    }, 500)
   }
 
   const hasConfigurableTopup =

--- a/web/default/src/features/wallet/components/recharge-form-card.tsx
+++ b/web/default/src/features/wallet/components/recharge-form-card.tsx
@@ -33,6 +33,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { useDebounce } from '@/hooks/use-debounce'
 import { formatNumber } from '@/lib/format'
 import { cn } from '@/lib/utils'
 
@@ -113,17 +114,24 @@ export function RechargeFormCard({
 }: RechargeFormCardProps) {
   const { t } = useTranslation()
   const [localAmount, setLocalAmount] = useState(topupAmount.toString())
+  const debouncedAmount = useDebounce(localAmount, 500)
 
   useEffect(() => {
     setLocalAmount(topupAmount.toString())
   }, [topupAmount])
 
-  const handleAmountChange = (value: string) => {
-    setLocalAmount(value)
-    const numValue = parseInt(value) || 0
-    if (numValue >= 0) {
+  // Only push the recalculated amount upstream once typing/scrolling settles,
+  // so every keystroke or wheel tick on the number input doesn't fire its own
+  // preview request.
+  useEffect(() => {
+    const numValue = parseInt(debouncedAmount) || 0
+    if (numValue >= 0 && numValue !== topupAmount) {
       onTopupAmountChange(numValue)
     }
+  }, [debouncedAmount, topupAmount, onTopupAmountChange])
+
+  const handleAmountChange = (value: string) => {
+    setLocalAmount(value)
   }
 
   const hasConfigurableTopup =


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

> **AI 生成声明**：本 PR 的代码改动和本说明由 AI coding agent（Claude Code）在人工审阅指导下生成/整理。提交者（xinnyu）不在本仓库历史核心贡献者列表中，按仓库规范在此明确披露。

## 📝 变更描述 / Description

充值页自定义金额输入框（`RechargeFormCard`）的 `onChange` 直接同步调用 `POST /api/user/amount` 换算金额，没有防抖。原生 `<input type="number">` 在输入框聚焦时，鼠标滚轮滚动也会触发 `onChange`（每格一次），所以正常的滚轮操作或连续输入就能在很短时间内打出几百次请求（实测同一浏览器会话 2 分钟内 497 次）。

`GlobalAPIRateLimit` 挂在整个 `/api` 路由组上，是单一按 IP 的限流桶，充值换算接口和页面上其它只读接口（`/api/notice`、`/api/status`、`/api/user/models` 等）共用同一个计数器。这一个输入框把额度打满后，同页面其它接口也会被连带 429，前端弹出一连串错误提示——但实际支付链路（webhook 是服务端到服务端回调）不受影响，纯粹是这一个输入框拖累了自己和邻居。

**修复方式（第 2 个 commit 是对第 1 个 commit 的修正，细节见下方 "⚠️ 修订记录"）**：用一个绑定在 `onChange` 事件处理函数本身的 `setTimeout`/`clearTimeout` ref 做防抖，只有用户真正编辑这个输入框才会安排一次延迟推送；`topupAmount` 从外部变化（预设金额点击、初始加载）时，通过现有同步 effect 的 cleanup 顺手清掉任何还没触发的延迟推送，避免它之后把已经生效的外部值覆盖回去。本地值 `localAmount` 依然逐字符同步更新，输入框本身不卡顿。预设金额按钮等离散点击路径完全不经过这条防抖逻辑，没有引入多余延迟。

### ⚠️ 修订记录（诚实记录一次自我纠正）

第一版实现用的是仓库里现成的 `hooks/use-debounce.ts`（`useDebounce(value, delay)`，防抖一个值，不是防抖一次调用），配合一个额外的 `useEffect` 比较"防抖后的本地值"和 `topupAmount` prop 来决定要不要回调。我在提交后做了一轮独立复核（用一个不知道这个改动意图的 agent 单独看这份 diff），发现这个比较是有竞态的：`topupAmount` 可以从外部（初始加载、预设点击）比本地防抖计时器更快地变化，于是这个 effect 会用还没追上的旧值去跟新的 `topupAmount` 比较，误判为"用户又改了"，反手把 `topupAmount` 推回一个过期值——如果这个过期值恰好是 `0`，会重新触发父组件 `index.tsx` 里 `topupAmount === 0` 的初始化 guard，形成死循环。只要充值最低金额 `> 0`（几乎所有部署都是这样），这个循环在**每次打开充值页时**、用户还没做任何操作前就会自己触发。

已经用最小 React 19 + jsdom 复现脚本验证过：第一版会疯狂重渲染直到 "Maximum update depth exceeded"；改成 `setTimeout` ref 的写法后，同样的复现脚本走查了预设点击打断防抖、卸载时清理、连续输入合并成一次调用、StrictMode 双调用等场景，均正常。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- Closes #6050

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 见上方 AI 生成声明；本描述基于对代码逻辑的实际追踪整理（含一次自我纠正的复核过程），非未处理的原始 AI 输出。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，未见重复。
- [x] **Bug fix 说明:** 已关联 #6050。
- [x] **变更理解:** 完整追踪 mount / 预设点击 / 防抖回显 / 卸载 四条路径，两轮独立复核（含针对第一版的死循环复现）确认当前版本不会产生重复请求、不会丢失/覆盖外部设置的金额、不会引入循环。
- [x] **范围聚焦:** 仅改动 `recharge-form-card.tsx` 一个文件，未顺带修改同文件内其它无关的 pre-existing lint 问题。
- [x] **本地验证:** `tsgo -b` 通过；`oxlint` 对改动行无新增 error；两轮独立 agent 复核 + React 19/jsdom 复现脚本验证关键场景（详见下方）。**未做真实浏览器点击验证**——本地没有可用的后端/鉴权环境跑通充值页完整流程，欢迎 CI 或维护者做实际点击验证。
- [x] **安全合规:** 无凭据/密钥相关改动。

## 📸 运行证明 / Proof of Work

```
$ bun run typecheck
$ tsgo -b
(exit 0, no errors)

$ bun run lint | grep recharge-form-card
(改动行范围内无新增 error，仅有改动前就存在、未改动行上的既有 warning/error)
```

两轮独立复核均包含用最小 React 19 + jsdom 环境搭建的可执行复现脚本（非纯静态代码走查），分别验证了：
- 第一版实现在 mount 时会无限重渲染（"Maximum update depth exceeded"）——促成了第 2 个 commit 的修正
- 修正后版本：预设点击正确打断/覆盖尚未触发的防抖推送、组件卸载时清理不留副作用、连续输入合并为一次网络调用、React StrictMode 双调用下不重复也不丢失推送


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recharge amount input handling by debouncing updates so changes are sent only after typing pauses.
  * Prevented invalid entries by ignoring negative amounts and avoiding repeated or stale updates during rapid typing.
  * When the recharge amount is updated externally (such as from presets/initial load), the input now syncs immediately and cancels any pending debounced update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->