### PR TITLE
fix(skill): quote classic-to-default-sync description as folded block scalar

### DIFF
--- a/.agents/skills/classic-to-default-sync/SKILL.md
+++ b/.agents/skills/classic-to-default-sync/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: classic-to-default-sync
-description: Inspect a given commit's web/classic changes and sync all features/fixes to web/default. Use when the user provides a commit ID and wants to audit whether web/default already has the same features as web/classic, port missing features, improve suboptimal implementations, fix bugs, and remove redundant code. Trigger phrases include: "/classic-to-default-sync <hash>", "classic-to-default-sync <hash>", "sync classic to default", "port from classic", "compare classic commit", "classic 和 default 对比", "把这次 classic 的修改同步到 default", "查看这次提交 classic 中的修改并同步", or any request supplying a commit hash together with classic/default comparison intent.
+description: >-
+  Inspect a given commit's web/classic changes and sync all features/fixes to
+  web/default. Use when the user provides a commit ID and wants to audit whether
+  web/default already has the same features as web/classic, port missing
+  features, improve suboptimal implementations, fix bugs, and remove redundant
+  code. Trigger phrases include: "/classic-to-default-sync <hash>",
+  "classic-to-default-sync <hash>", "sync classic to default", "port from
+  classic", "compare classic commit", "classic 和 default 对比", "把这次 classic
+  的修改同步到 default", "查看这次提交 classic 中的修改并同步", or any request
+  supplying a commit hash together with classic/default comparison intent.
 ---
 
 # Classic-to-Default Sync


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
按照issue里提到的转义问题，修改了classic-to-default-sync的SKILL.md里面的description字段，将格式从单行未加引号改成YAML折叠块标量`>-`。
之前里面的冒号后跟空格会被YAML解析报错，跳过这个skill无法生效。现在就可以正常解析，原本的description内容没有改变。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #4960

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。本 PR 的代码改动在 AI 辅助下完成，已由本人审阅理解后按项目规范整理提交。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 已关联 Issue #4960。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 仅修改 frontmatter 格式，未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地用 `yaml.safe_load` 验证 frontmatter 可正常解析，且折叠后的 description 与原文逐字符一致。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
改前（git 取出的原始版本）：

    [ORIGINAL] PARSE FAILED -> mapping values are not allowed here

改后（当前版本）：

    [FIXED] PARSED OK -> keys=['name', 'description'], name='classic-to-default-sync', desc_len=644

skill 加载器模拟（对应 issue 报的 Skipped loading 1 skill(s)）：

    result: LOADED
    detail: registered: name='classic-to-default-sync', description(644 chars)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reformatted the skill’s front-matter metadata for improved readability with consistent YAML formatting.
  * No changes were made to the skill’s instructions or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->