### PR TITLE
fix(web): respect display currency in model pricing editor

### DIFF
--- a/web/default/src/features/system-settings/models/model-pricing-core.ts
+++ b/web/default/src/features/system-settings/models/model-pricing-core.ts
@@ -20,7 +20,10 @@ import * as z from 'zod'
 
 import { combineBillingExpr } from '@/features/pricing/lib/billing-expr'
 
-import { formatPricingNumber } from './pricing-format'
+import {
+  formatDisplayPriceFromUSD,
+  formatPricingNumber,
+} from './pricing-format'
 
 export const createModelPricingSchema = (t: (key: string) => string) =>
   z.object({
@@ -173,7 +176,10 @@ function deriveLanePrice(
   return formatPricingNumber(ratioNumber * denominatorNumber)
 }
 
-export function createInitialLaneState(data?: ModelRatioData | null) {
+export function createInitialLaneState(
+  data?: ModelRatioData | null,
+  exchangeRate = 1
+) {
   if (!data) {
     return {
       promptPrice: '',
@@ -182,7 +188,10 @@ export function createInitialLaneState(data?: ModelRatioData | null) {
     }
   }
 
-  const promptPrice = ratioToBasePrice(data.ratio)
+  const promptPrice = formatDisplayPriceFromUSD(
+    ratioToBasePrice(data.ratio),
+    exchangeRate
+  )
   const audioInputPrice = deriveLanePrice(data.audioRatio, promptPrice)
   const prices: Record<LaneKey, string> = {
     completion: deriveLanePrice(data.completionRatio, promptPrice),
@@ -215,7 +224,8 @@ export function buildPreviewRows(
   promptPrice: string,
   lanePrices: Record<LaneKey, string>,
   laneEnabled: Record<LaneKey, boolean>,
-  t: (key: string) => string
+  t: (key: string) => string,
+  formatPriceValue: (value: string) => string = (value) => `$${value}`
 ): PreviewRow[] {
   if (mode === 'tiered_expr') {
     const effectiveExpr = combineBillingExpr(billingExpr, requestRuleExpr)
@@ -235,7 +245,7 @@ export function buildPreviewRows(
       {
         key: 'price',
         label: 'ModelPrice',
-        value: values.price || t('Empty'),
+        value: values.price ? formatPriceValue(values.price) : t('Empty'),
       },
     ]
   }
@@ -244,14 +254,14 @@ export function buildPreviewRows(
     {
       key: 'inputPrice',
       label: t('Input price'),
-      value: promptPrice ? `$${promptPrice}` : t('Empty'),
+      value: promptPrice ? formatPriceValue(promptPrice) : t('Empty'),
     },
     {
       key: 'completion',
       label: t('Completion price'),
       value:
         laneEnabled.completion && lanePrices.completion
-          ? `$${lanePrices.completion}`
+          ? formatPriceValue(lanePrices.completion)
           : t('Empty'),
     },
     {
@@ -259,7 +269,7 @@ export function buildPreviewRows(
       label: t('Cache read price'),
       value:
         laneEnabled.cache && lanePrices.cache
-          ? `$${lanePrices.cache}`
+          ? formatPriceValue(lanePrices.cache)
           : t('Empty'),
     },
     {
@@ -267,7 +277,7 @@ export function buildPreviewRows(
       label: t('Cache write price'),
       value:
         laneEnabled.createCache && lanePrices.createCache
-          ? `$${lanePrices.createCache}`
+          ? formatPriceValue(lanePrices.createCache)
           : t('Empty'),
     },
     {
@@ -275,7 +285,7 @@ export function buildPreviewRows(
       label: t('Image input price'),
       value:
         laneEnabled.image && lanePrices.image
-          ? `$${lanePrices.image}`
+          ? formatPriceValue(lanePrices.image)
           : t('Empty'),
     },
     {
@@ -283,7 +293,7 @@ export function buildPreviewRows(
       label: t('Audio input price'),
       value:
         laneEnabled.audioInput && lanePrices.audioInput
-          ? `$${lanePrices.audioInput}`
+          ? formatPriceValue(lanePrices.audioInput)
           : t('Empty'),
     },
     {
@@ -291,7 +301,7 @@ export function buildPreviewRows(
       label: t('Audio output price'),
       value:
         laneEnabled.audioOutput && lanePrices.audioOutput
-          ? `$${lanePrices.audioOutput}`
+          ? formatPriceValue(lanePrices.audioOutput)
           : t('Empty'),
     },
   ]

--- a/web/default/src/features/system-settings/models/model-pricing-inputs.tsx
+++ b/web/default/src/features/system-settings/models/model-pricing-inputs.tsx
@@ -34,11 +34,13 @@ export function PriceInput(props: {
   value: string
   placeholder?: string
   disabled?: boolean
+  prefix?: string
+  suffix?: string
   onChange: (value: string) => void
 }) {
   return (
     <InputGroup>
-      <InputGroupAddon>$</InputGroupAddon>
+      <InputGroupAddon>{props.prefix ?? '$'}</InputGroupAddon>
       <InputGroupInput
         inputMode='decimal'
         value={props.value}
@@ -46,7 +48,9 @@ export function PriceInput(props: {
         disabled={props.disabled}
         onChange={(event) => props.onChange(event.target.value)}
       />
-      <InputGroupAddon align='inline-end'>$/1M</InputGroupAddon>
+      <InputGroupAddon align='inline-end'>
+        {props.suffix ?? '$/1M'}
+      </InputGroupAddon>
     </InputGroup>
   )
 }
@@ -58,6 +62,9 @@ export function PriceLane(props: {
   value: string
   enabled: boolean
   disabled?: boolean
+  prefix?: string
+  suffix?: string
+  hideUnitDescription?: boolean
   onEnabledChange: (checked: boolean) => void
   onChange: (value: string) => void
 }) {
@@ -81,13 +88,17 @@ export function PriceLane(props: {
         value={props.value}
         placeholder={props.placeholder}
         disabled={effectiveDisabled}
+        prefix={props.prefix}
+        suffix={props.suffix}
         onChange={props.onChange}
       />
-      <p className='text-muted-foreground text-xs'>
-        {props.enabled
-          ? t('USD price per 1M tokens.')
-          : t('Disabled lanes are omitted on save.')}
-      </p>
+      {!props.hideUnitDescription && (
+        <p className='text-muted-foreground text-xs'>
+          {props.enabled
+            ? t('USD price per 1M tokens.')
+            : t('Disabled lanes are omitted on save.')}
+        </p>
+      )}
     </SettingsControlGroup>
   )
 }

--- a/web/default/src/features/system-settings/models/model-pricing-sheet.tsx
+++ b/web/default/src/features/system-settings/models/model-pricing-sheet.tsx
@@ -62,6 +62,7 @@ import {
 } from '@/components/ui/sheet'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { cn } from '@/lib/utils'
+import { useSystemConfigStore } from '@/stores/system-config-store'
 
 import {
   EMPTY_LANE_ENABLED,
@@ -80,7 +81,11 @@ import {
   type PricingMode,
 } from './model-pricing-core'
 import { PriceInput, PriceLane } from './model-pricing-inputs'
-import { formatPricingNumber } from './pricing-format'
+import {
+  formatDisplayPriceFromUSD,
+  formatPricingNumber,
+  formatUSDPriceFromDisplay,
+} from './pricing-format'
 import { TieredPricingEditor } from './tiered-pricing-editor'
 
 export type { ModelRatioData } from './model-pricing-core'
@@ -157,6 +162,43 @@ export const ModelPricingEditorPanel = forwardRef<
   const [requestRuleExpr, setRequestRuleExpr] = useState('')
   const [editorReloadToken, setEditorReloadToken] = useState(0)
   const isEditMode = !!editData
+  const currencyConfig = useSystemConfigStore((state) => state.config.currency)
+  const pricingCurrency = useMemo(() => {
+    switch (currencyConfig.quotaDisplayType) {
+      case 'CNY':
+        return {
+          symbol: '¥',
+          label: 'CNY',
+          exchangeRate:
+            currencyConfig.usdExchangeRate > 0
+              ? currencyConfig.usdExchangeRate
+              : 1,
+        }
+      case 'CUSTOM':
+        return {
+          symbol: currencyConfig.customCurrencySymbol || '¤',
+          label: currencyConfig.customCurrencySymbol || 'Custom',
+          exchangeRate:
+            currencyConfig.customCurrencyExchangeRate > 0
+              ? currencyConfig.customCurrencyExchangeRate
+              : 1,
+        }
+      case 'TOKENS':
+      case 'USD':
+      default:
+        return {
+          symbol: '$',
+          label: 'USD',
+          exchangeRate: 1,
+        }
+    }
+  }, [currencyConfig])
+  const priceUnitSuffix =
+    pricingCurrency.label === 'USD' ? '$/1M' : `${pricingCurrency.label}/1M`
+  const formatPreviewPrice = useCallback(
+    (value: string) => `${pricingCurrency.symbol}${value}`,
+    [pricingCurrency.symbol]
+  )
 
   const form = useForm<ModelPricingFormValues>({
     resolver: zodResolver(createModelPricingSchema(t)),
@@ -174,12 +216,18 @@ export const ModelPricingEditorPanel = forwardRef<
   })
 
   useEffect(() => {
-    const nextLaneState = createInitialLaneState(editData)
+    const nextLaneState = createInitialLaneState(
+      editData,
+      pricingCurrency.exchangeRate
+    )
 
     if (editData) {
       form.reset({
         name: editData.name,
-        price: editData.price || '',
+        price: formatDisplayPriceFromUSD(
+          editData.price,
+          pricingCurrency.exchangeRate
+        ),
         ratio: editData.ratio || '',
         cacheRatio: editData.cacheRatio || '',
         createCacheRatio: editData.createCacheRatio || '',
@@ -188,13 +236,13 @@ export const ModelPricingEditorPanel = forwardRef<
         audioRatio: editData.audioRatio || '',
         audioCompletionRatio: editData.audioCompletionRatio || '',
       })
-      setPricingMode(
-        editData.billingMode === 'tiered_expr'
-          ? 'tiered_expr'
-          : editData.price
-            ? 'per-request'
-            : 'per-token'
-      )
+      let nextPricingMode: PricingMode = 'per-token'
+      if (editData.billingMode === 'tiered_expr') {
+        nextPricingMode = 'tiered_expr'
+      } else if (editData.price) {
+        nextPricingMode = 'per-request'
+      }
+      setPricingMode(nextPricingMode)
       setBillingExpr(editData.billingExpr || '')
       setRequestRuleExpr(editData.requestRuleExpr || '')
     } else {
@@ -218,7 +266,7 @@ export const ModelPricingEditorPanel = forwardRef<
     setLanePrices(nextLaneState.prices)
     setLaneEnabled(nextLaneState.enabled)
     setEditorReloadToken((token) => token + 1)
-  }, [editData, form])
+  }, [editData, form, pricingCurrency.exchangeRate])
 
   const setFormValue = (field: keyof ModelPricingFormValues, value: string) => {
     form.setValue(field, value, {
@@ -253,9 +301,15 @@ export const ModelPricingEditorPanel = forwardRef<
     nextLaneEnabled = laneEnabled
   ) => {
     const inputPrice = toNumberOrNull(nextPromptPrice)
+    const inputPriceUSD = formatUSDPriceFromDisplay(
+      nextPromptPrice,
+      pricingCurrency.exchangeRate
+    )
     setFormValue(
       'ratio',
-      inputPrice !== null ? formatPricingNumber(inputPrice / 2) : ''
+      inputPrice !== null && inputPriceUSD
+        ? formatPricingNumber(Number(inputPriceUSD) / 2)
+        : ''
     )
 
     laneConfigs.forEach(({ key }) => {
@@ -351,7 +405,8 @@ export const ModelPricingEditorPanel = forwardRef<
         promptPrice,
         lanePrices,
         laneEnabled,
-        t
+        t,
+        formatPreviewPrice
       ),
     [
       billingExpr,
@@ -361,6 +416,7 @@ export const ModelPricingEditorPanel = forwardRef<
       promptPrice,
       requestRuleExpr,
       t,
+      formatPreviewPrice,
       watchedValues,
     ]
   )
@@ -443,7 +499,13 @@ export const ModelPricingEditorPanel = forwardRef<
       const data: ModelRatioData = {
         name: values.name.trim(),
         billingMode: pricingMode,
-        price: values.price || '',
+        price:
+          pricingMode === 'per-request'
+            ? formatUSDPriceFromDisplay(
+                values.price,
+                pricingCurrency.exchangeRate
+              )
+            : '',
         ratio: values.ratio || '',
         cacheRatio: values.cacheRatio || '',
         createCacheRatio: values.createCacheRatio || '',
@@ -460,7 +522,7 @@ export const ModelPricingEditorPanel = forwardRef<
 
       return data
     },
-    [billingExpr, pricingMode, requestRuleExpr]
+    [billingExpr, pricingCurrency.exchangeRate, pricingMode, requestRuleExpr]
   )
 
   useImperativeHandle(
@@ -563,11 +625,15 @@ export const ModelPricingEditorPanel = forwardRef<
                         <PriceInput
                           value={promptPrice}
                           placeholder='3'
+                          prefix={pricingCurrency.symbol}
+                          suffix={priceUnitSuffix}
                           onChange={handlePromptPriceChange}
                         />
-                        <FieldDescription>
-                          {t('USD price per 1M input tokens.')}
-                        </FieldDescription>
+                        {pricingCurrency.label === 'USD' && (
+                          <FieldDescription>
+                            {t('USD price per 1M input tokens.')}
+                          </FieldDescription>
+                        )}
                       </Field>
 
                       <div className='grid gap-3 sm:grid-cols-[repeat(auto-fit,minmax(400px,1fr))]'>
@@ -585,6 +651,11 @@ export const ModelPricingEditorPanel = forwardRef<
                               value={lanePrices[lane.key]}
                               enabled={laneEnabled[lane.key]}
                               disabled={disabled}
+                              prefix={pricingCurrency.symbol}
+                              suffix={priceUnitSuffix}
+                              hideUnitDescription={
+                                pricingCurrency.label !== 'USD'
+                              }
                               onEnabledChange={(checked) =>
                                 handleLaneToggle(lane.key, checked)
                               }
@@ -609,7 +680,9 @@ export const ModelPricingEditorPanel = forwardRef<
                               <FieldLabel>{t('Fixed price')}</FieldLabel>
                               <FormControl>
                                 <InputGroup>
-                                  <InputGroupAddon>$</InputGroupAddon>
+                                  <InputGroupAddon>
+                                    {pricingCurrency.symbol}
+                                  </InputGroupAddon>
                                   <InputGroupInput
                                     inputMode='decimal'
                                     placeholder='0.01'
@@ -626,11 +699,13 @@ export const ModelPricingEditorPanel = forwardRef<
                                   </InputGroupAddon>
                                 </InputGroup>
                               </FormControl>
-                              <FieldDescription>
-                                {t(
-                                  'Cost in USD per request, regardless of tokens used.'
-                                )}
-                              </FieldDescription>
+                              {pricingCurrency.label === 'USD' && (
+                                <FieldDescription>
+                                  {t(
+                                    'Cost in USD per request, regardless of tokens used.'
+                                  )}
+                                </FieldDescription>
+                              )}
                               <FormMessage />
                             </Field>
                           </FormItem>

--- a/web/default/src/features/system-settings/models/pricing-format.test.ts
+++ b/web/default/src/features/system-settings/models/pricing-format.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import {
+  formatDisplayPriceFromUSD,
+  formatUSDPriceFromDisplay,
+} from './pricing-format.ts'
+
+describe('model pricing display currency conversion', () => {
+  test('converts stored USD model prices to the configured display currency', () => {
+    assert.equal(formatDisplayPriceFromUSD('3', 7), '21')
+  })
+
+  test('converts display currency model prices back to stored USD values', () => {
+    assert.equal(formatUSDPriceFromDisplay('21', 7), '3')
+  })
+})

--- a/web/default/src/features/system-settings/models/pricing-format.ts
+++ b/web/default/src/features/system-settings/models/pricing-format.ts
@@ -59,3 +59,26 @@ export function formatPricingNumber(value: unknown): string {
   const normalized = snapFloatDrift(num)
   return Number.parseFloat(normalized.toFixed(DISPLAY_DECIMALS)).toString()
 }
+
+function normalizeExchangeRate(exchangeRate: unknown): number {
+  const num = toNumberOrNull(exchangeRate)
+  return num !== null && num > 0 ? num : 1
+}
+
+export function formatDisplayPriceFromUSD(
+  value: unknown,
+  exchangeRate: unknown = 1
+): string {
+  const num = toNumberOrNull(value)
+  if (num === null) return ''
+  return formatPricingNumber(num * normalizeExchangeRate(exchangeRate))
+}
+
+export function formatUSDPriceFromDisplay(
+  value: unknown,
+  exchangeRate: unknown = 1
+): string {
+  const num = toNumberOrNull(value)
+  if (num === null) return ''
+  return formatPricingNumber(num / normalizeExchangeRate(exchangeRate))
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
修复新版 UI 的“系统设置 -> 模型定价”编辑器未遵循额度展示货币的问题。

编辑已有模型时，已存储的 USD 价格会按配置汇率转换为展示货币；输入、扩展价格通道和预览使用当前货币的符号与单位；保存时将展示货币价格换回 USD，保持既有后端存储格式和计费逻辑兼容。

实现过程使用 AI 辅助，并基于实际复现、代码逻辑和本地验证整理本 PR。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6058

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 已基于实际复现、代码逻辑和验证结果整理此描述；实现过程使用 AI 辅助。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，确认 #4425/#4426 仅涉及模型广场动态计费展示，未覆盖新版后台模型定价编辑器。
- [x] **Bug fix 说明:** 已关联 Bug Issue #6058。
- [x] **变更理解:** 已确认内部模型价格继续使用 USD 存储，展示层负责双向汇率转换。
- [x] **范围聚焦:** 仅修改新版模型定价编辑器及其转换测试，未包含无关构建或 i18n 改动。
- [x] **本地验证:** 已运行转换测试、TypeScript 检查、定向 lint 和 default 前端构建。
- [x] **安全合规:** 未包含敏感凭据或配置。

## 📸 运行证明 / Proof of Work
```text
node --test web/default/src/features/system-settings/models/pricing-format.test.ts
# 2 passed, 0 failed

bun run typecheck
# passed

oxlint -c .oxlintrc.json <changed model pricing files>
# passed

node ../node_modules/@rsbuild/core/bin/rsbuild.js build
# Rsbuild build completed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pricing displays now support the system’s configured currency and exchange rate.
  - Price inputs and previews show the appropriate currency symbol and unit labels.
  - Pricing values are converted consistently when displayed and submitted.
  - Fixed-price helper text is shown only when applicable to USD pricing.

- **Bug Fixes**
  - Improved consistency across model pricing fields and preview values.
  - Added handling for invalid or unavailable exchange rates.

- **Tests**
  - Added coverage for currency conversion in both directions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->