### PR TITLE
fix: allow adding model names that differ only by case in multi-select

### DIFF
--- a/web/default/src/components/multi-select.tsx
+++ b/web/default/src/components/multi-select.tsx
@@ -145,8 +145,7 @@ export function MultiSelect(props: MultiSelectProps) {
     (selectedSet.has(trimmedInput) ||
       props.options.some(
         (option) =>
-          option.value.toLowerCase() === trimmedInput.toLowerCase() ||
-          option.label.toLowerCase() === trimmedInput.toLowerCase()
+          option.value === trimmedInput || option.label === trimmedInput
       ))
 
   const canCreate =


### PR DESCRIPTION
## 📝 变更描述 / Description

渠道编辑页的模型多选框里，输入 `DeepSeek-V3` 时如果系统已有小写的 `deepseek-v3`，"添加自定义模型"选项不会出现，按回车只能选中小写模型，大写模型名无法录入（上游只认大写时渠道就配不了）。

原因是 `multi-select.tsx` 里判断"输入是否已存在"用了 `toLowerCase()` 忽略大小写。改为精确匹配后，仅大小写不同的模型名也能正常录入；输入与已有选项完全一致时行为不变。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6029

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
修复前:
<img width="435" height="163" alt="image" src="https://github.com/user-attachments/assets/ca2720e8-9c2d-4885-83de-021e9568ee13" />

修复后:
<img width="409" height="186" alt="image" src="https://github.com/user-attachments/assets/e94e2344-b3bb-4446-a87f-2c4d939827bd" />
