### PR TITLE
fix: correct gpt-5.6 completion ratio

### DIFF
--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -504,6 +504,9 @@ func getHardcodedCompletionModelRatio(name string) (float64, bool) {
 		}
 		// gpt-5 匹配
 		if strings.HasPrefix(name, "gpt-5") {
+			if strings.HasPrefix(name, "gpt-5.6") {
+				return 6, true
+			}
 			if strings.HasPrefix(name, "gpt-5.5") {
 				return 6, true
 			}

--- a/setting/ratio_setting/model_ratio_test.go
+++ b/setting/ratio_setting/model_ratio_test.go
@@ -1,0 +1,13 @@
+package ratio_setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCompletionRatioGPT56UsesSpecialRatio(t *testing.T) {
+	assert.Equal(t, 6.0, GetCompletionRatio("gpt-5.6-sol"))
+	assert.Equal(t, 6.0, GetCompletionRatio("gpt-5.6-terra"))
+	assert.Equal(t, 6.0, GetCompletionRatio("gpt-5.6-luna"))
+}


### PR DESCRIPTION
# ?? ???? / PR Notice
> [!IMPORTANT]
>
> - ???**????**????????????????? AI ???

## ?? ???? / Description
? `gpt-5.6*` ????????????????? `gpt-5.5*`?`gpt-5.4*` ???? 6 ????????????? `gpt-5*` ? 8 ????

??????? Token ???????? `$5/M` ???????? `$30/M` ????? `gpt-5.6-sol`?`gpt-5.6-terra`?`gpt-5.6-luna` ???? `$40/M`???????????????????

???? PR ? Codex ?????????????? `gpt-5.6*` ????????????

## ?? ???? / Type of change
- [x] ?? Bug ?? (Bug fix) - *????? Issue???????????????????????? bug*
- [ ] ? ??? (New feature) - *????????? Issue ??*
- [ ] ? ???? / ?? (Refactor)
- [ ] ?? ???? (Documentation)

## ?? ???? / Related Issue
- N/A

## ? ?????? / Checklist
- [ ] **????:** ???????????????????????? AI ???
- [x] **?????:** ??????? [Issues](https://github.com/QuantumNous/new-api/issues) ? [PRs](https://github.com/QuantumNous/new-api/pulls)??????????
- [ ] **Bug fix ??:** ?? PR ??? `Bug fix`?????????? Issue????????????????????????? bug?
- [x] **????:** ???????????????????
- [x] **????:** ? PR ??????????????????
- [x] **????:** ?????????????????????????????
- [x] **????:** ???????????????????

## ?? ???? / Proof of Work
```bash
go test ./setting/ratio_setting -run TestGetCompletionRatioGPT56UsesSpecialRatio -count=1
```

???

```txt
ok  github.com/QuantumNous/new-api/setting/ratio_setting  0.037s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for `gpt-5.6` models with the correct completion ratio.
  * Ensured supported `gpt-5.6` variants consistently use a ratio of 6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->