### PR TITLE
fix: add /pg/chat/completions as advanced custom incoming path option

### DIFF
--- a/web/default/src/features/channels/lib/advanced-custom.ts
+++ b/web/default/src/features/channels/lib/advanced-custom.ts
@@ -77,6 +77,10 @@ export type AdvancedCustomIncomingPathOption = {
 export const ADVANCED_CUSTOM_INCOMING_PATH_OPTIONS: AdvancedCustomIncomingPathOption[] =
   [
     {
+      value: '/pg/chat/completions',
+      label: 'Playground Chat',
+    },
+    {
       value: '/v1/chat/completions',
       label: 'OpenAI Chat',
     },
@@ -144,6 +148,7 @@ export const ADVANCED_CUSTOM_INCOMING_PATH_OPTIONS: AdvancedCustomIncomingPathOp
 
 const ADVANCED_CUSTOM_ROUTE_SUMMARY_LABELS: Record<string, string> = {
   '/v1/chat/completions': 'OpenAI Chat',
+  '/pg/chat/completions': 'Playground Chat',
 }
 
 export type AdvancedCustomValidationError = {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

> 本 PR 由 AI 辅助生成，经本人理解代码链路后整理提交，非直接粘贴未经审核的 AI 输出。

## 📝 变更描述 / Description

**问题现象**
当系统里所有渠道均为「高级自定义（Advanced Custom, type 58）」渠道时，会出现一个矛盾现象：渠道配置里明明加了对应模型，左侧 Playground 广场发送请求却始终拿不到可用渠道（No available channel / 请求不到）。

**根因**
1. Playground 前端发起请求使用的入口路径是 `/pg/chat/completions`（见 `web/default/src/features/playground/constants.ts`）。
2. 后端分发器 `middleware/distributor.go` 对 `/pg/chat/completions` 有特殊处理（读取 `group` 参数），但在为 type 58 渠道选择时，会调用 `channelSupportsRequestPath()` 校验该渠道的路由配置是否覆盖了本次请求路径。
3. 高级自定义渠道的「入口路径」下拉选项 `ADVANCED_CUSTOM_INCOMING_PATH_OPTIONS` 中**缺少 `/pg/chat/completions`**，因此用户无法为渠道配置一条匹配 Playground 入口路径的路由。
4. 结果：所有 type 58 渠道都因「无路由匹配 `/pg/chat/completions`」被判定为不支持该请求路径，Playground 请求在分发阶段即被筛掉，导致广场无法正常请求。

**修复**
在高级自定义渠道的入口路径选项中新增 `Playground Chat`（`/pg/chat/completions`），并补充对应的列表摘要标签。用户只需新增一条路由，入口路径选 `Playground Chat`、`converter: none`（原生转发）即可让 Playground 走通该渠道。后端 `dto/channel_settings.go` 对 `converter: none` 本就不限制路径，无需改动后端逻辑。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - 高级自定义渠道无法被 Playground 选中的场景修复
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes # （暂无，可补充对应 Issue）

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已确认不是重复提交。
- [x] **Bug fix 说明:** 本 PR 标记为 Bug fix，已在上方描述根因（高级自定义渠道缺 `/pg/chat/completions` 入口路径）。
- [x] **变更理解:** 我已理解这些更改的工作原理——补齐入口路径选项后，Playground 的 `/pg/chat/completions` 请求能被 type 58 渠道的路由匹配。
- [x] **范围聚焦:** 本 PR 仅改动 `web/default/src/features/channels/lib/advanced-custom.ts`，未引入无关改动。
- [x] **本地验证:** 在高级自定义渠道的高级路由中已能看到 `Playground Chat` 选项；配置 `incoming_path=/pg/chat/completions` + `converter=none` 后 Playground 广场可正常请求（注：本机未安装 tsgo/oxlint，未跑完整 typecheck/lint）。
- [x] **安全合规:** 代码中无敏感凭据，改动仅新增前端路由选项，符合项目规范。

## 📸 运行证明 / Proof of Work

<img width="2082" height="1568" alt="image" src="https://github.com/user-attachments/assets/ad901a81-4f11-489e-8d18-5bff8c323c23" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Playground Chat” as an advanced custom incoming path option for chat completions.
  * Routes using this path now display the “Playground Chat” label in summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->