### PR TITLE
fix billing refund consistency

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -37,7 +37,7 @@ type Channel struct {
 	Balance            float64 `json:"balance"` // in USD
 	BalanceUpdatedTime int64   `json:"balance_updated_time" gorm:"bigint"`
 	Models             string  `json:"models"`
-	Group              string  `json:"group" gorm:"type:varchar(64);default:'default'"`
+	Group              string  `json:"group" gorm:"type:varchar(1024);default:'default'"`
 	UsedQuota          int64   `json:"used_quota" gorm:"bigint;default:0"`
 	ModelMapping       *string `json:"model_mapping" gorm:"type:text"`
 	//MaxInputTokens     *int    `json:"max_input_tokens" gorm:"default:0"`
@@ -860,8 +860,32 @@ func UpdateChannelUsedQuota(id int, quota int) {
 	updateChannelUsedQuota(id, quota)
 }
 
+func DecreaseChannelUsedQuota(id int, quota int) {
+	if id <= 0 || quota <= 0 {
+		return
+	}
+	if common.BatchUpdateEnabled {
+		addNewRecord(BatchUpdateTypeChannelUsedQuota, id, -quota)
+		return
+	}
+	err := DB.Model(&Channel{}).Where("id = ?", id).Update(
+		"used_quota",
+		gorm.Expr("CASE WHEN used_quota < ? THEN 0 ELSE used_quota - ? END", quota, quota),
+	).Error
+	if err != nil {
+		common.SysLog(fmt.Sprintf("failed to decrease channel used quota: channel_id=%d, delta_quota=%d, error=%v", id, quota, err))
+	}
+}
+
 func updateChannelUsedQuota(id int, quota int) {
-	err := DB.Model(&Channel{}).Where("id = ?", id).Update("used_quota", gorm.Expr("used_quota + ?", quota)).Error
+	var expr clause.Expr
+	if quota < 0 {
+		refund := -quota
+		expr = gorm.Expr("CASE WHEN used_quota < ? THEN 0 ELSE used_quota - ? END", refund, refund)
+	} else {
+		expr = gorm.Expr("used_quota + ?", quota)
+	}
+	err := DB.Model(&Channel{}).Where("id = ?", id).Update("used_quota", expr).Error
 	if err != nil {
 		common.SysLog(fmt.Sprintf("failed to update channel used quota: channel_id=%d, delta_quota=%d, error=%v", id, quota, err))
 	}

--- a/model/subscription.go
+++ b/model/subscription.go
@@ -1271,6 +1271,13 @@ func maybeResetUserSubscriptionWithPlanTx(tx *gorm.DB, sub *UserSubscription, pl
 
 // PreConsumeUserSubscription pre-consumes from any active subscription total quota.
 func PreConsumeUserSubscription(requestId string, userId int, modelName string, quotaType int, amount int64) (*SubscriptionPreConsumeResult, error) {
+	return PreConsumeUserSubscriptionForGroup(requestId, userId, modelName, "", quotaType, amount)
+}
+
+// PreConsumeUserSubscriptionForGroup pre-consumes from an active subscription
+// that is valid for the request group. Plans with an empty UpgradeGroup are
+// usable for any group; scoped plans only cover requests in the same group.
+func PreConsumeUserSubscriptionForGroup(requestId string, userId int, modelName string, requestGroup string, quotaType int, amount int64) (*SubscriptionPreConsumeResult, error) {
 	if userId <= 0 {
 		return nil, errors.New("invalid userId")
 	}
@@ -1281,6 +1288,7 @@ func PreConsumeUserSubscription(requestId string, userId int, modelName string, 
 		return nil, errors.New("amount must be > 0")
 	}
 	now := GetDBTimestamp()
+	requestGroup = strings.TrimSpace(requestGroup)
 
 	returnValue := &SubscriptionPreConsumeResult{}
 
@@ -1324,6 +1332,10 @@ func PreConsumeUserSubscription(requestId string, userId int, modelName string, 
 			}
 			if err := maybeResetUserSubscriptionWithPlanTx(tx, &sub, plan, now); err != nil {
 				return err
+			}
+			planGroup := strings.TrimSpace(plan.UpgradeGroup)
+			if planGroup != "" && requestGroup != "" && planGroup != requestGroup {
+				continue
 			}
 			usedBefore := sub.AmountUsed
 			if sub.AmountTotal > 0 {
@@ -1391,7 +1403,7 @@ func RefundSubscriptionPreConsume(requestId string) error {
 			record.Status = "refunded"
 			return tx.Save(&record).Error
 		}
-		if err := PostConsumeUserSubscriptionDelta(record.UserSubscriptionId, -record.PreConsumed); err != nil {
+		if err := postConsumeUserSubscriptionDeltaTx(tx, record.UserSubscriptionId, -record.PreConsumed); err != nil {
 			return err
 		}
 		record.Status = "refunded"
@@ -1490,20 +1502,33 @@ func PostConsumeUserSubscriptionDelta(userSubscriptionId int, delta int64) error
 		return nil
 	}
 	return DB.Transaction(func(tx *gorm.DB) error {
-		var sub UserSubscription
-		if err := lockForUpdate(tx).
-			Where("id = ?", userSubscriptionId).
-			First(&sub).Error; err != nil {
-			return err
-		}
-		newUsed := sub.AmountUsed + delta
-		if newUsed < 0 {
-			newUsed = 0
-		}
-		if sub.AmountTotal > 0 && newUsed > sub.AmountTotal {
-			return fmt.Errorf("subscription used exceeds total, used=%d total=%d", newUsed, sub.AmountTotal)
-		}
-		sub.AmountUsed = newUsed
-		return tx.Save(&sub).Error
+		return postConsumeUserSubscriptionDeltaTx(tx, userSubscriptionId, delta)
 	})
+}
+
+func postConsumeUserSubscriptionDeltaTx(tx *gorm.DB, userSubscriptionId int, delta int64) error {
+	if tx == nil {
+		return errors.New("tx is nil")
+	}
+	if userSubscriptionId <= 0 {
+		return errors.New("invalid userSubscriptionId")
+	}
+	if delta == 0 {
+		return nil
+	}
+	var sub UserSubscription
+	if err := lockForUpdate(tx).
+		Where("id = ?", userSubscriptionId).
+		First(&sub).Error; err != nil {
+		return err
+	}
+	newUsed := sub.AmountUsed + delta
+	if newUsed < 0 {
+		newUsed = 0
+	}
+	if sub.AmountTotal > 0 && newUsed > sub.AmountTotal {
+		return fmt.Errorf("subscription used exceeds total, used=%d total=%d", newUsed, sub.AmountTotal)
+	}
+	sub.AmountUsed = newUsed
+	return tx.Save(&sub).Error
 }

--- a/model/subscription_preconsume_test.go
+++ b/model/subscription_preconsume_test.go
@@ -1,0 +1,84 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedPreConsumePlan(t *testing.T, id int, upgradeGroup string) {
+	t.Helper()
+	require.NoError(t, DB.Create(&SubscriptionPlan{
+		Id:               id,
+		Title:            "plan",
+		PriceAmount:      1,
+		Currency:         "USD",
+		DurationUnit:     "month",
+		DurationValue:    1,
+		Enabled:          true,
+		UpgradeGroup:     upgradeGroup,
+		TotalAmount:      10000,
+		QuotaResetPeriod: SubscriptionResetNever,
+	}).Error)
+}
+
+func seedPreConsumeSubscription(t *testing.T, id, userID, planID int, used int64) {
+	t.Helper()
+	require.NoError(t, DB.Create(&UserSubscription{
+		Id:          id,
+		UserId:      userID,
+		PlanId:      planID,
+		AmountTotal: 10000,
+		AmountUsed:  used,
+		StartTime:   time.Now().Add(-time.Hour).Unix(),
+		EndTime:     time.Now().Add(time.Hour).Unix(),
+		Status:      "active",
+	}).Error)
+}
+
+func getPreConsumeSubscriptionUsed(t *testing.T, id int) int64 {
+	t.Helper()
+	var sub UserSubscription
+	require.NoError(t, DB.Select("amount_used").Where("id = ?", id).First(&sub).Error)
+	return sub.AmountUsed
+}
+
+func TestPreConsumeUserSubscriptionForGroupSkipsMismatchedPlanGroup(t *testing.T) {
+	truncateTables(t)
+
+	const userID = 6101
+	seedPreConsumePlan(t, 6101, "MiniMax")
+	seedPreConsumePlan(t, 6102, "default")
+	seedPreConsumeSubscription(t, 6101, userID, 6101, 0)
+	seedPreConsumeSubscription(t, 6102, userID, 6102, 0)
+
+	res, err := PreConsumeUserSubscriptionForGroup("req-group-match", userID, "deepseek-v4", "default", 0, 300)
+	require.NoError(t, err)
+
+	assert.Equal(t, 6102, res.UserSubscriptionId)
+	assert.EqualValues(t, 0, getPreConsumeSubscriptionUsed(t, 6101))
+	assert.EqualValues(t, 300, getPreConsumeSubscriptionUsed(t, 6102))
+}
+
+func TestRefundSubscriptionPreConsumeIsIdempotentAndUpdatesRecord(t *testing.T) {
+	truncateTables(t)
+
+	const userID = 6201
+	seedPreConsumePlan(t, 6201, "default")
+	seedPreConsumeSubscription(t, 6201, userID, 6201, 100)
+
+	_, err := PreConsumeUserSubscriptionForGroup("req-refund", userID, "deepseek-v4", "default", 0, 300)
+	require.NoError(t, err)
+	assert.EqualValues(t, 400, getPreConsumeSubscriptionUsed(t, 6201))
+
+	require.NoError(t, RefundSubscriptionPreConsume("req-refund"))
+	require.NoError(t, RefundSubscriptionPreConsume("req-refund"))
+
+	assert.EqualValues(t, 100, getPreConsumeSubscriptionUsed(t, 6201))
+
+	var record SubscriptionPreConsumeRecord
+	require.NoError(t, DB.Where("request_id = ?", "req-refund").First(&record).Error)
+	assert.Equal(t, "refunded", record.Status)
+}

--- a/model/task_cas_test.go
+++ b/model/task_cas_test.go
@@ -46,6 +46,7 @@ func TestMain(m *testing.M) {
 		&SubscriptionPlan{},
 		&SubscriptionOrder{},
 		&UserSubscription{},
+		&SubscriptionPreConsumeRecord{},
 		&UserOAuthBinding{},
 		&PerfMetric{},
 		&SystemInstance{},
@@ -72,6 +73,7 @@ func truncateTables(t *testing.T) {
 		DB.Exec("DELETE FROM subscription_orders")
 		DB.Exec("DELETE FROM subscription_plans")
 		DB.Exec("DELETE FROM user_subscriptions")
+		DB.Exec("DELETE FROM subscription_pre_consume_records")
 		DB.Exec("DELETE FROM user_oauth_bindings")
 		DB.Exec("DELETE FROM perf_metrics")
 		DB.Exec("DELETE FROM system_instances")

--- a/model/user.go
+++ b/model/user.go
@@ -1136,6 +1136,23 @@ func UpdateUserUsedQuotaAndRequestCount(id int, quota int) {
 	updateUserUsedQuotaAndRequestCount(id, quota, 1)
 }
 
+func DecreaseUserUsedQuota(id int, quota int) {
+	if id <= 0 || quota <= 0 {
+		return
+	}
+	if common.BatchUpdateEnabled {
+		addNewRecord(BatchUpdateTypeUsedQuota, id, -quota)
+		return
+	}
+	err := DB.Model(&User{}).Where("id = ?", id).Update(
+		"used_quota",
+		gorm.Expr("CASE WHEN used_quota < ? THEN 0 ELSE used_quota - ? END", quota, quota),
+	).Error
+	if err != nil {
+		common.SysLog("failed to decrease user used quota: " + err.Error())
+	}
+}
+
 func updateUserUsedQuotaAndRequestCount(id int, quota int, count int) {
 	err := DB.Model(&User{}).Where("id = ?", id).Updates(
 		map[string]interface{}{
@@ -1159,13 +1176,21 @@ func updateUserQuotaUsedQuotaAndRequestCount(id int, quota int, usedQuota int, r
 		return
 	}
 
-	err := DB.Model(&User{}).Where("id = ?", id).Updates(
-		map[string]interface{}{
-			"quota":         gorm.Expr("quota + ?", quota),
-			"used_quota":    gorm.Expr("used_quota + ?", usedQuota),
-			"request_count": gorm.Expr("request_count + ?", requestCount),
-		},
-	).Error
+	updates := map[string]interface{}{}
+	if quota != 0 {
+		updates["quota"] = gorm.Expr("quota + ?", quota)
+	}
+	if usedQuota > 0 {
+		updates["used_quota"] = gorm.Expr("used_quota + ?", usedQuota)
+	} else if usedQuota < 0 {
+		refund := -usedQuota
+		updates["used_quota"] = gorm.Expr("CASE WHEN used_quota < ? THEN 0 ELSE used_quota - ? END", refund, refund)
+	}
+	if requestCount != 0 {
+		updates["request_count"] = gorm.Expr("request_count + ?", requestCount)
+	}
+
+	err := DB.Model(&User{}).Where("id = ?", id).Updates(updates).Error
 	if err != nil {
 		common.SysLog("failed to batch update user quota, used quota and request count: " + err.Error())
 	}

--- a/service/billing_session.go
+++ b/service/billing_session.go
@@ -387,6 +387,7 @@ func NewBillingSession(c *gin.Context, relayInfo *relaycommon.RelayInfo, preCons
 				requestId: relayInfo.RequestId,
 				userId:    relayInfo.UserId,
 				modelName: relayInfo.OriginModelName,
+				group:     relayInfo.UsingGroup,
 				amount:    subConsume,
 			},
 		}

--- a/service/funding_source.go
+++ b/service/funding_source.go
@@ -71,6 +71,7 @@ type SubscriptionFunding struct {
 	requestId      string
 	userId         int
 	modelName      string
+	group          string
 	amount         int64 // 预扣的订阅额度（subConsume）
 	subscriptionId int
 	preConsumed    int64
@@ -85,7 +86,7 @@ func (s *SubscriptionFunding) Source() string { return BillingSourceSubscription
 
 func (s *SubscriptionFunding) PreConsume(_ int) error {
 	// amount 参数被忽略，使用内部 s.amount（已在构造时根据 preConsumedQuota 计算）
-	res, err := model.PreConsumeUserSubscription(s.requestId, s.userId, s.modelName, 0, s.amount)
+	res, err := model.PreConsumeUserSubscriptionForGroup(s.requestId, s.userId, s.modelName, s.group, 0, s.amount)
 	if err != nil {
 		return err
 	}

--- a/service/task_billing.go
+++ b/service/task_billing.go
@@ -165,7 +165,11 @@ func RefundTaskQuota(ctx context.Context, task *model.Task, reason string) {
 	// 2. 退还令牌额度
 	taskAdjustTokenQuota(ctx, task, -quota)
 
-	// 3. 记录日志
+	// 3. 回退已用额度统计，避免退款后“剩余额度 + 已用额度”虚增。
+	model.DecreaseUserUsedQuota(task.UserId, quota)
+	model.DecreaseChannelUsedQuota(task.ChannelId, quota)
+
+	// 4. 记录日志
 	other := taskBillingOther(task)
 	other["task_id"] = task.TaskID
 	other["reason"] = reason
@@ -231,6 +235,8 @@ func RecalculateTaskQuota(ctx context.Context, task *model.Task, actualQuota int
 	} else {
 		logType = model.LogTypeRefund
 		logQuota = -quotaDelta
+		model.DecreaseUserUsedQuota(task.UserId, logQuota)
+		model.DecreaseChannelUsedQuota(task.ChannelId, logQuota)
 	}
 	other := taskBillingOther(task)
 	other["task_id"] = task.TaskID

--- a/service/task_billing_test.go
+++ b/service/task_billing_test.go
@@ -150,6 +150,20 @@ func getUserQuota(t *testing.T, id int) int {
 	return user.Quota
 }
 
+func getUserUsedQuota(t *testing.T, id int) int {
+	t.Helper()
+	var user model.User
+	require.NoError(t, model.DB.Select("used_quota").Where("id = ?", id).First(&user).Error)
+	return user.UsedQuota
+}
+
+func getChannelUsedQuota(t *testing.T, id int) int64 {
+	t.Helper()
+	var channel model.Channel
+	require.NoError(t, model.DB.Select("used_quota").Where("id = ?", id).First(&channel).Error)
+	return channel.UsedQuota
+}
+
 func getTokenRemainQuota(t *testing.T, id int) int {
 	t.Helper()
 	var token model.Token
@@ -293,6 +307,29 @@ func TestRefundTaskQuota_NoToken(t *testing.T) {
 	assert.Equal(t, model.LogTypeRefund, log.Type)
 }
 
+func TestRefundTaskQuota_DecreasesUsageTotals(t *testing.T) {
+	truncate(t)
+	ctx := context.Background()
+
+	const userID, tokenID, channelID = 5, 5, 5
+	const initQuota, preConsumed = 10000, 1500
+	const tokenRemain = 5000
+
+	seedUser(t, userID, initQuota)
+	seedToken(t, tokenID, userID, "sk-usage-refund", tokenRemain)
+	seedChannel(t, channelID)
+	require.NoError(t, model.DB.Model(&model.User{}).Where("id = ?", userID).Update("used_quota", preConsumed).Error)
+	require.NoError(t, model.DB.Model(&model.Channel{}).Where("id = ?", channelID).Update("used_quota", preConsumed).Error)
+
+	task := makeTask(userID, channelID, preConsumed, tokenID, BillingSourceWallet, 0)
+
+	RefundTaskQuota(ctx, task, "failed task should not inflate total quota")
+
+	assert.Equal(t, initQuota+preConsumed, getUserQuota(t, userID))
+	assert.Zero(t, getUserUsedQuota(t, userID))
+	assert.Zero(t, getChannelUsedQuota(t, channelID))
+}
+
 // ===========================================================================
 // RecalculateTaskQuota tests
 // ===========================================================================
@@ -342,6 +379,8 @@ func TestRecalculate_NegativeDelta(t *testing.T) {
 	seedUser(t, userID, initQuota)
 	seedToken(t, tokenID, userID, "sk-recalc-neg", tokenRemain)
 	seedChannel(t, channelID)
+	require.NoError(t, model.DB.Model(&model.User{}).Where("id = ?", userID).Update("used_quota", preConsumed).Error)
+	require.NoError(t, model.DB.Model(&model.Channel{}).Where("id = ?", channelID).Update("used_quota", preConsumed).Error)
 
 	task := makeTask(userID, channelID, preConsumed, tokenID, BillingSourceWallet, 0)
 
@@ -355,6 +394,8 @@ func TestRecalculate_NegativeDelta(t *testing.T) {
 
 	// task.Quota updated
 	assert.Equal(t, actualQuota, task.Quota)
+	assert.Equal(t, actualQuota, getUserUsedQuota(t, userID))
+	assert.EqualValues(t, actualQuota, getChannelUsedQuota(t, channelID))
 
 	// Log type should be Refund
 	log := getLastLog(t)

--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -188,7 +188,9 @@ func calculateTextQuotaSummary(ctx *gin.Context, relayInfo *relaycommon.RelayInf
 	}
 	summary.IsClaudeUsageSemantic = summary.UsageSemantic == "anthropic"
 
-	if usage == nil {
+	if usage == nil && shouldSkipEstimatedUsageForAbnormalStream(relayInfo) {
+		usage = &dto.Usage{}
+	} else if usage == nil {
 		usage = &dto.Usage{
 			PromptTokens:     relayInfo.GetEstimatePromptTokens(),
 			CompletionTokens: 0,
@@ -327,6 +329,13 @@ func calculateTextQuotaSummary(ctx *gin.Context, relayInfo *relaycommon.RelayInf
 	return summary
 }
 
+func shouldSkipEstimatedUsageForAbnormalStream(relayInfo *relaycommon.RelayInfo) bool {
+	if relayInfo == nil || !relayInfo.IsStream || relayInfo.StreamStatus == nil {
+		return false
+	}
+	return !relayInfo.StreamStatus.IsNormalEnd()
+}
+
 func usageSemanticFromUsage(relayInfo *relaycommon.RelayInfo, usage *dto.Usage) string {
 	if usage != nil && usage.UsageSemantic != "" {
 		return usage.UsageSemantic
@@ -341,6 +350,9 @@ func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, us
 	originUsage := usage
 	if usage == nil {
 		extraContent = append(extraContent, "上游无计费信息")
+		if shouldSkipEstimatedUsageForAbnormalStream(relayInfo) {
+			extraContent = append(extraContent, "流式响应异常结束，未返回计费信息，跳过扣费")
+		}
 	}
 	if originUsage != nil {
 		ObserveChannelAffinityUsageCacheByRelayFormat(ctx, usage, relayInfo.GetFinalRequestRelayFormat())

--- a/service/text_quota_test.go
+++ b/service/text_quota_test.go
@@ -150,6 +150,62 @@ func TestCalculateTextQuotaSummaryUsesAnthropicUsageSemanticFromUpstreamUsage(t 
 	require.Equal(t, 1488, summary.Quota)
 }
 
+func TestCalculateTextQuotaSummarySkipsEstimateForAbnormalStreamWithoutUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+
+	streamStatus := relaycommon.NewStreamStatus()
+	streamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, nil)
+	relayInfo := &relaycommon.RelayInfo{
+		IsStream:        true,
+		StreamStatus:    streamStatus,
+		OriginModelName: "gpt-test",
+		PriceData: types.PriceData{
+			ModelRatio:      1,
+			CompletionRatio: 1,
+			GroupRatioInfo: types.GroupRatioInfo{
+				GroupRatio: 1,
+			},
+		},
+		StartTime: time.Now(),
+	}
+	relayInfo.SetEstimatePromptTokens(1000)
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, nil)
+
+	require.Zero(t, summary.TotalTokens)
+	require.Zero(t, summary.Quota)
+}
+
+func TestCalculateTextQuotaSummaryUsesEstimateForNormalStreamWithoutUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+
+	streamStatus := relaycommon.NewStreamStatus()
+	streamStatus.SetEndReason(relaycommon.StreamEndReasonDone, nil)
+	relayInfo := &relaycommon.RelayInfo{
+		IsStream:        true,
+		StreamStatus:    streamStatus,
+		OriginModelName: "gpt-test",
+		PriceData: types.PriceData{
+			ModelRatio:      1,
+			CompletionRatio: 1,
+			GroupRatioInfo: types.GroupRatioInfo{
+				GroupRatio: 1,
+			},
+		},
+		StartTime: time.Now(),
+	}
+	relayInfo.SetEstimatePromptTokens(1000)
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, nil)
+
+	require.Equal(t, 1000, summary.TotalTokens)
+	require.Equal(t, 1000, summary.Quota)
+}
+
 func TestCacheWriteTokensTotal(t *testing.T) {
 	t.Run("split cache creation", func(t *testing.T) {
 		summary := textQuotaSummary{


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
修复几处计费、退款和订阅隔离问题：

- 订阅预扣退款现在在同一个数据库事务内同时回退 `user_subscriptions.amount_used` 并标记 `subscription_pre_consume_records` 为 refunded，避免额度已回退但记录状态更新失败后重试导致重复退款。
- 订阅预扣增加请求分组校验，带 `upgrade_group` 的订阅计划只覆盖同分组请求，避免跨分组模型错误扣订阅额度。
- 异步任务失败退款和负差额结算会同步回退用户/渠道 `used_quota`，避免退款后“剩余额度 + 已用额度”虚增。
- 异常结束的流式响应如果没有上游 usage，不再用估算 prompt tokens 扣费；正常结束或上游返回 usage 的路径不变。
- 将 `channels.group` 扩到 `varchar(1024)`，避免多分组渠道保存失败或升级时被迁移回 64 字符。

This PR was AI-assisted and manually reviewed before submission.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5556
- Closes #5200
- Closes #4211
- Closes #4168
- Closes #6017

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```text
docker run --rm -v "$PWD":/work -v /tmp/new-api-gomod:/gomod -v /tmp/new-api-gocache:/gocache -w /work -e GOMODCACHE=/gomod -e GOCACHE=/gocache golang:1.25.1 go test ./model ./service
ok  	github.com/QuantumNous/new-api/model	5.210s
ok  	github.com/QuantumNous/new-api/service	0.327s
```

Additional check:

```text
git merge-tree --write-tree upstream/main HEAD
# completed without merge conflicts
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for matching subscription plans to the requested group.
  * Expanded supported channel group values.
  * Added safeguards for reducing user and channel usage totals without going below zero.

* **Bug Fixes**
  * Refunds now correctly restore usage totals and remain idempotent.
  * Prevented quota estimates from being applied when streaming ends abnormally without usage data.
  * Improved billing consistency during failed or recalculated quota operations.

* **Tests**
  * Added coverage for group-based subscription selection, refunds, usage restoration, and abnormal stream handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->