### PR TITLE
fix(models): merge endpoint template instead of replacing all

### DIFF
--- a/web/default/src/features/models/components/drawers/model-mutate-drawer.tsx
+++ b/web/default/src/features/models/components/drawers/model-mutate-drawer.tsx
@@ -654,10 +654,21 @@ export function ModelMutateDrawer({
 
   const handleFillEndpointTemplate = (templateKey: string) => {
     const template = ENDPOINT_TEMPLATES[templateKey]
-    if (template) {
-      const templateJson = JSON.stringify({ [templateKey]: template }, null, 2)
-      form.setValue('endpoints', templateJson)
+    if (!template) return
+    const currentValue = form.getValues('endpoints')
+    let existingEndpoints: Record<string, unknown> = {}
+    if (currentValue?.trim()) {
+      const parsed = safeJsonParse<Record<string, unknown>>(currentValue, {
+        fallback: {},
+        silent: true,
+      })
+      if (parsed) {
+        existingEndpoints = parsed
+      }
     }
+    const merged = { ...existingEndpoints, [templateKey]: template }
+    const templateJson = JSON.stringify(merged, null, 2)
+    form.setValue('endpoints', templateJson)
   }
 
   return (

--- a/web/default/src/features/models/components/drawers/model-mutate-drawer.tsx
+++ b/web/default/src/features/models/components/drawers/model-mutate-drawer.tsx
@@ -658,10 +658,15 @@ export function ModelMutateDrawer({
     const currentValue = form.getValues('endpoints')
     let existingEndpoints: Record<string, unknown> = {}
     if (currentValue?.trim()) {
-      const parsed = safeJsonParse<Record<string, unknown>>(currentValue, {
-        fallback: {},
-        silent: true,
-      })
+      let parsed: Record<string, unknown> | null = null
+      try {
+        const raw = JSON.parse(currentValue)
+        if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+          parsed = raw as Record<string, unknown>
+        }
+      } catch {
+        toast.warning(t('Existing endpoint configuration is invalid and will be replaced'))
+      }
       if (parsed) {
         existingEndpoints = parsed
       }


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
模型编辑抽屉中，"端点配置"区域的"加载模板"下拉菜单在选择模板时，会将 `endpoints` 字段整体替换为 `{ [templateKey]: template }`，导致用户之前已添加的其他端点全部丢失。

修复：在应用模板前先读取当前 `endpoints` 的值，解析为对象后以模板 key 为键合并，再写回。这样已有端点保留，新选择的模板端点追加进去（key 已存在则覆盖）。

改动位置：`web/default/src/features/models/components/drawers/model-mutate-drawer.tsx` 中的 `handleFillEndpointTemplate` 函数。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] 我已亲自整理并撰写此描述
- [x] 非重复提交
- [x] 变更理解
- [x] 范围聚焦
- [x] 本地验证通过（typecheck 零错误，lint 零 error）
- [x] 安全合规

## 📸 运行证明 / Proof of Work
- `bun run typecheck` 通过，无类型错误
- `npx oxlint model-mutate-drawer.tsx` 通过，无 lint error

https://github.com/user-attachments/assets/52cd97bb-7d75-4ec8-b153-18123f448304



---

⚠️ 注意：此 PR 由 AI 生成/协助编写。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Selecting an endpoint template now preserves existing endpoint configurations.
  * Endpoint templates are merged into the current configuration instead of replacing it entirely.
  * Missing templates or invalid endpoint data no longer overwrite current settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->