### PR TITLE
fix(web): redirect legacy /console/token route to /keys

### DIFF
--- a/web/default/src/routeTree.gen.ts
+++ b/web/default/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as PricingIndexRouteImport } from './routes/pricing/index'
 import { Route as AboutIndexRouteImport } from './routes/about/index'
 import { Route as OauthProviderRouteImport } from './routes/oauth/$provider'
 import { Route as ConsoleTopupRouteImport } from './routes/console/topup'
+import { Route as ConsoleTokenRouteImport } from './routes/console/token'
 import { Route as ConsoleLogRouteImport } from './routes/console/log'
 import { Route as AuthenticatedChat2linkRouteImport } from './routes/_authenticated/chat2link'
 import { Route as errors503RouteImport } from './routes/(errors)/503'
@@ -121,6 +122,11 @@ const OauthProviderRoute = OauthProviderRouteImport.update({
 const ConsoleTopupRoute = ConsoleTopupRouteImport.update({
   id: '/console/topup',
   path: '/console/topup',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ConsoleTokenRoute = ConsoleTokenRouteImport.update({
+  id: '/console/token',
+  path: '/console/token',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ConsoleLogRoute = ConsoleLogRouteImport.update({
@@ -418,6 +424,7 @@ export interface FileRoutesByFullPath {
   '/503': typeof errors503Route
   '/chat2link': typeof AuthenticatedChat2linkRoute
   '/console/log': typeof ConsoleLogRoute
+  '/console/token': typeof ConsoleTokenRoute
   '/console/topup': typeof ConsoleTopupRoute
   '/oauth/$provider': typeof OauthProviderRoute
   '/about/': typeof AboutIndexRoute
@@ -477,6 +484,7 @@ export interface FileRoutesByTo {
   '/503': typeof errors503Route
   '/chat2link': typeof AuthenticatedChat2linkRoute
   '/console/log': typeof ConsoleLogRoute
+  '/console/token': typeof ConsoleTokenRoute
   '/console/topup': typeof ConsoleTopupRoute
   '/oauth/$provider': typeof OauthProviderRoute
   '/about': typeof AboutIndexRoute
@@ -540,6 +548,7 @@ export interface FileRoutesById {
   '/(errors)/503': typeof errors503Route
   '/_authenticated/chat2link': typeof AuthenticatedChat2linkRoute
   '/console/log': typeof ConsoleLogRoute
+  '/console/token': typeof ConsoleTokenRoute
   '/console/topup': typeof ConsoleTopupRoute
   '/oauth/$provider': typeof OauthProviderRoute
   '/about/': typeof AboutIndexRoute
@@ -602,6 +611,7 @@ export interface FileRouteTypes {
     | '/503'
     | '/chat2link'
     | '/console/log'
+    | '/console/token'
     | '/console/topup'
     | '/oauth/$provider'
     | '/about/'
@@ -661,6 +671,7 @@ export interface FileRouteTypes {
     | '/503'
     | '/chat2link'
     | '/console/log'
+    | '/console/token'
     | '/console/topup'
     | '/oauth/$provider'
     | '/about'
@@ -723,6 +734,7 @@ export interface FileRouteTypes {
     | '/(errors)/503'
     | '/_authenticated/chat2link'
     | '/console/log'
+    | '/console/token'
     | '/console/topup'
     | '/oauth/$provider'
     | '/about/'
@@ -777,6 +789,7 @@ export interface RootRouteChildren {
   errors500Route: typeof errors500Route
   errors503Route: typeof errors503Route
   ConsoleLogRoute: typeof ConsoleLogRoute
+  ConsoleTokenRoute: typeof ConsoleTokenRoute
   ConsoleTopupRoute: typeof ConsoleTopupRoute
   OauthProviderRoute: typeof OauthProviderRoute
   AboutIndexRoute: typeof AboutIndexRoute
@@ -863,6 +876,13 @@ declare module '@tanstack/react-router' {
       path: '/console/topup'
       fullPath: '/console/topup'
       preLoaderRoute: typeof ConsoleTopupRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/console/token': {
+      id: '/console/token'
+      path: '/console/token'
+      fullPath: '/console/token'
+      preLoaderRoute: typeof ConsoleTokenRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/console/log': {
@@ -1355,6 +1375,7 @@ const rootRouteChildren: RootRouteChildren = {
   errors500Route: errors500Route,
   errors503Route: errors503Route,
   ConsoleLogRoute: ConsoleLogRoute,
+  ConsoleTokenRoute: ConsoleTokenRoute,
   ConsoleTopupRoute: ConsoleTopupRoute,
   OauthProviderRoute: OauthProviderRoute,
   AboutIndexRoute: AboutIndexRoute,

--- a/web/default/src/routes/console/-token.test.ts
+++ b/web/default/src/routes/console/-token.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import { Route } from './token'
+
+describe('legacy token route compatibility', () => {
+  test('redirects /console/token to /keys and preserves search parameters', () => {
+    const beforeLoad = Route.options.beforeLoad
+    assert.ok(beforeLoad)
+
+    const search = { token: 'legacy-key', page: '2' }
+    assert.throws(
+      () => beforeLoad({ search } as never),
+      (error: unknown) => {
+        assert.ok(error && typeof error === 'object' && 'options' in error)
+        const options = error.options as {
+          search?: Record<string, unknown>
+          to?: string
+        }
+        assert.equal(options.to, '/keys')
+        assert.deepEqual(options.search, search)
+        return true
+      }
+    )
+  })
+})

--- a/web/default/src/routes/console/token.tsx
+++ b/web/default/src/routes/console/token.tsx
@@ -1,0 +1,29 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import z from 'zod'
+
+const tokenSearchSchema = z.record(z.string(), z.unknown()).catch({})
+
+export const Route = createFileRoute('/console/token')({
+  validateSearch: tokenSearchSchema,
+  beforeLoad: ({ search }) => {
+    throw redirect({ to: '/keys', search })
+  },
+})


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

新版前端已经为 `/console/log` 和 `/console/topup` 提供旧路由兼容，但 classic frontend 的
令牌管理入口 `/console/token` 尚未映射。用户切换到新版前端后再次访问旧书签，会进入 404。

本变更新增一个与现有兼容路由一致的 TanStack Router route：将 `/console/token` 跳转到
`/keys`，同时保留 search parameters。route tree 随构建流程自动更新，并增加回归测试覆盖
跳转目标和参数保留。

AI-assisted disclosure：问题定位、补丁实现和测试由 Codex 辅助完成；提交者已结合实际部署复现、
上游现有路由模式和本地测试逐项复核代码与结论。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6072

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并审阅此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 已关联 #6072；该问题是旧版公开路由在新版前端进入 404 的明确兼容回归。
- [x] **变更理解:** 已确认 route 在 `beforeLoad` 阶段跳转，并将解析后的 search parameters 传递给 `/keys`。
- [x] **范围聚焦:** 仅新增兼容 route、回归测试和自动生成 route tree。
- [x] **本地验证:** 已运行并通过全量前端测试、typecheck、build 以及变更文件 lint/format。
- [x] **安全合规:** 代码中无敏感凭据，未修改 protected project information。

## 📸 运行证明 / Proof of Work

修复前，新增回归测试因缺少 `/console/token` compatibility route 而失败。

修复后：

- `bun test`：34 pass / 0 fail
- `bun run typecheck`：通过
- `bun run build`：通过
- changed-file oxlint / oxfmt：通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the legacy `/console/token` route.
  * Automatically redirects visitors to `/keys` while preserving token and other query parameters.

* **Bug Fixes**
  * Improved compatibility for existing links using the legacy token URL.
  * Added validation to ensure search parameters are retained during redirection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->