### PR TITLE
fix(web): prevent duplicate system setting notifications

### DIFF
--- a/web/default/src/features/system-settings/api.test.ts
+++ b/web/default/src/features/system-settings/api.test.ts
@@ -1,0 +1,54 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { api } from '@/lib/api'
+
+import { updateSystemOption } from './api'
+
+test('system option updates use one notification owner', async () => {
+  const originalPut = api.put
+  let requestConfig: Parameters<typeof api.put>[2]
+
+  try {
+    api.put = (async (_url, _request, config) => {
+      requestConfig = config
+      return {
+        data: { success: true, message: '' },
+      }
+    }) as typeof api.put
+
+    await updateSystemOption({ key: 'SystemName', value: 'Example' })
+
+    assert.equal(requestConfig?.skipBusinessError, true)
+    assert.equal(requestConfig?.skipErrorHandler, true)
+
+    api.put = (async () => ({
+      data: { success: false, message: 'Update rejected' },
+    })) as typeof api.put
+
+    await assert.rejects(
+      updateSystemOption({ key: 'SystemName', value: 'Example' }),
+      /Update rejected/
+    )
+  } finally {
+    api.put = originalPut
+  }
+})

--- a/web/default/src/features/system-settings/api.ts
+++ b/web/default/src/features/system-settings/api.ts
@@ -37,7 +37,15 @@ export async function getSystemOptions() {
 }
 
 export async function updateSystemOption(request: UpdateOptionRequest) {
-  const res = await api.put<UpdateOptionResponse>('/api/option/', request)
+  const res = await api.put<UpdateOptionResponse>('/api/option/', request, {
+    skipBusinessError: true,
+    skipErrorHandler: true,
+  })
+
+  if (!res.data.success) {
+    throw new Error(res.data.message)
+  }
+
   return res.data
 }
 

--- a/web/default/src/features/system-settings/content/announcements-section.tsx
+++ b/web/default/src/features/system-settings/content/announcements-section.tsx
@@ -180,11 +180,14 @@ export function AnnouncementsSection({
       await updateOption.mutateAsync({
         key: 'console_setting.announcements_enabled',
         value: checked,
+        notification: {
+          success: t('Setting saved'),
+          error: t('Failed to update setting'),
+        },
       })
       setIsEnabled(checked)
-      toast.success(t('Setting saved'))
     } catch {
-      toast.error(t('Failed to update setting'))
+      return
     }
   }
 
@@ -270,11 +273,14 @@ export function AnnouncementsSection({
       await updateOption.mutateAsync({
         key: 'console_setting.announcements',
         value: JSON.stringify(announcements),
+        notification: {
+          success: t('Announcements saved successfully'),
+          error: t('Failed to save announcements'),
+        },
       })
       setHasChanges(false)
-      toast.success(t('Announcements saved successfully'))
     } catch {
-      toast.error(t('Failed to save announcements'))
+      return
     }
   }
 

--- a/web/default/src/features/system-settings/content/api-info-section.tsx
+++ b/web/default/src/features/system-settings/content/api-info-section.tsx
@@ -154,11 +154,14 @@ export function ApiInfoSection({ enabled, data }: ApiInfoSectionProps) {
       await updateOption.mutateAsync({
         key: 'console_setting.api_info_enabled',
         value: checked,
+        notification: {
+          success: t('Setting saved'),
+          error: t('Failed to update setting'),
+        },
       })
       setIsEnabledDraft(checked)
-      toast.success(t('Setting saved'))
     } catch {
-      toast.error(t('Failed to update setting'))
+      return
     }
   }
 
@@ -241,12 +244,15 @@ export function ApiInfoSection({ enabled, data }: ApiInfoSectionProps) {
       const result = await updateOption.mutateAsync({
         key: 'console_setting.api_info',
         value: JSON.stringify(apiInfoList),
+        notification: {
+          error: t('Failed to save API info'),
+        },
       })
       if (result.success) {
         setDraftApiInfoList(null)
       }
     } catch {
-      toast.error(t('Failed to save API info'))
+      return
     }
   }
 

--- a/web/default/src/features/system-settings/content/faq-section.tsx
+++ b/web/default/src/features/system-settings/content/faq-section.tsx
@@ -126,11 +126,14 @@ export function FAQSection({ enabled, data }: FAQSectionProps) {
       await updateOption.mutateAsync({
         key: 'console_setting.faq_enabled',
         value: checked,
+        notification: {
+          success: t('Setting saved'),
+          error: t('Failed to update setting'),
+        },
       })
       setIsEnabled(checked)
-      toast.success(t('Setting saved'))
     } catch {
-      toast.error(t('Failed to update setting'))
+      return
     }
   }
 
@@ -210,11 +213,14 @@ export function FAQSection({ enabled, data }: FAQSectionProps) {
       await updateOption.mutateAsync({
         key: 'console_setting.faq',
         value: JSON.stringify(faqList),
+        notification: {
+          success: t('FAQ saved successfully'),
+          error: t('Failed to save FAQ'),
+        },
       })
       setHasChanges(false)
-      toast.success(t('FAQ saved successfully'))
     } catch {
-      toast.error(t('Failed to save FAQ'))
+      return
     }
   }
 

--- a/web/default/src/features/system-settings/content/uptime-kuma-section.tsx
+++ b/web/default/src/features/system-settings/content/uptime-kuma-section.tsx
@@ -135,11 +135,14 @@ export function UptimeKumaSection({ enabled, data }: UptimeKumaSectionProps) {
       await updateOption.mutateAsync({
         key: 'console_setting.uptime_kuma_enabled',
         value: checked,
+        notification: {
+          success: t('Setting saved'),
+          error: t('Failed to update setting'),
+        },
       })
       setIsEnabled(checked)
-      toast.success(t('Setting saved'))
     } catch {
-      toast.error(t('Failed to update setting'))
+      return
     }
   }
 
@@ -219,11 +222,14 @@ export function UptimeKumaSection({ enabled, data }: UptimeKumaSectionProps) {
       await updateOption.mutateAsync({
         key: 'console_setting.uptime_kuma_groups',
         value: JSON.stringify(groups),
+        notification: {
+          success: t('Uptime Kuma groups saved successfully'),
+          error: t('Failed to save Uptime Kuma groups'),
+        },
       })
       setHasChanges(false)
-      toast.success(t('Uptime Kuma groups saved successfully'))
     } catch {
-      toast.error(t('Failed to save Uptime Kuma groups'))
+      return
     }
   }
 

--- a/web/default/src/features/system-settings/general/channel-affinity/index.tsx
+++ b/web/default/src/features/system-settings/general/channel-affinity/index.tsx
@@ -320,11 +320,17 @@ export function ChannelAffinitySection(props: Props) {
       }
 
       for (const u of updates) {
-        await updateOption.mutateAsync(u)
+        await updateOption.mutateAsync({
+          ...u,
+          notification: {
+            success: false,
+            error: t('Failed to save'),
+          },
+        })
       }
       toast.success(t('Saved successfully'))
     } catch {
-      toast.error(t('Failed to save'))
+      return
     } finally {
       setSaving(false)
     }

--- a/web/default/src/features/system-settings/hooks/update-option-notification.test.ts
+++ b/web/default/src/features/system-settings/hooks/update-option-notification.test.ts
@@ -1,0 +1,77 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import { toast } from 'sonner'
+
+import {
+  showUpdateOptionError,
+  showUpdateOptionSuccess,
+} from './update-option-notification'
+
+describe('system option notifications', () => {
+  test('reuses one toast for all updates in the same save action', () => {
+    const toastId = 'update-option-batch-success-test'
+
+    showUpdateOptionSuccess({ success: 'First update saved' }, toastId)
+    showUpdateOptionSuccess({ success: 'Settings saved' }, toastId)
+
+    const matchingToasts = toast
+      .getHistory()
+      .filter((item) => item.id === toastId)
+    const matchingToast = matchingToasts[0]
+
+    assert.equal(matchingToasts.length, 1)
+    assert.ok(matchingToast && 'title' in matchingToast)
+    assert.equal(matchingToast.title, 'Settings saved')
+  })
+
+  test('allows composite save flows to suppress intermediate success toasts', () => {
+    const toastId = 'update-option-suppressed-success-test'
+
+    showUpdateOptionSuccess({ success: false }, toastId)
+
+    assert.equal(
+      toast.getHistory().some((item) => item.id === toastId),
+      false
+    )
+  })
+
+  test('replaces a partial success with the save error', () => {
+    const toastId = 'update-option-error-test'
+
+    showUpdateOptionSuccess(undefined, toastId)
+    showUpdateOptionError(
+      { response: { data: { message: 'Backend rejected the setting' } } },
+      undefined,
+      toastId
+    )
+
+    const matchingToasts = toast
+      .getHistory()
+      .filter((item) => item.id === toastId)
+    const matchingToast = matchingToasts[0]
+
+    assert.equal(matchingToasts.length, 1)
+    assert.ok(matchingToast && 'title' in matchingToast)
+    assert.equal(matchingToast.title, 'Backend rejected the setting')
+    assert.equal(matchingToast.type, 'error')
+  })
+})

--- a/web/default/src/features/system-settings/hooks/update-option-notification.ts
+++ b/web/default/src/features/system-settings/hooks/update-option-notification.ts
@@ -1,0 +1,69 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import i18next from 'i18next'
+import { toast } from 'sonner'
+
+export type UpdateOptionNotification = {
+  success?: string | false
+  error?: string | false
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function getErrorMessage(error: unknown): string | undefined {
+  if (isRecord(error)) {
+    const response = error.response
+    if (isRecord(response) && isRecord(response.data)) {
+      const message = response.data.message
+      if (typeof message === 'string' && message) return message
+    }
+  }
+
+  if (error instanceof Error && error.message) return error.message
+  return undefined
+}
+
+export function showUpdateOptionSuccess(
+  notification: UpdateOptionNotification | undefined,
+  toastId: string
+) {
+  if (notification?.success === false) return
+
+  toast.success(
+    notification?.success || i18next.t('Setting updated successfully'),
+    { id: toastId }
+  )
+}
+
+export function showUpdateOptionError(
+  error: unknown,
+  notification: UpdateOptionNotification | undefined,
+  toastId: string
+) {
+  if (notification?.error === false) return
+
+  toast.error(
+    getErrorMessage(error) ||
+      notification?.error ||
+      i18next.t('Failed to update setting'),
+    { id: toastId }
+  )
+}

--- a/web/default/src/features/system-settings/hooks/use-update-option.ts
+++ b/web/default/src/features/system-settings/hooks/use-update-option.ts
@@ -17,14 +17,22 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import i18next from 'i18next'
-import { toast } from 'sonner'
+import { useId } from 'react'
 
 import { updateSystemOption } from '../api'
 import type { UpdateOptionRequest } from '../types'
+import {
+  showUpdateOptionError,
+  showUpdateOptionSuccess,
+  type UpdateOptionNotification,
+} from './update-option-notification'
+
+type UpdateOptionMutationRequest = UpdateOptionRequest & {
+  notification?: UpdateOptionNotification
+}
 
 // Configuration keys that require status refresh
-const STATUS_RELATED_KEYS = [
+const STATUS_RELATED_KEYS = new Set([
   'theme.frontend',
   'HeaderNavModules',
   'SidebarModulesAdmin',
@@ -37,35 +45,33 @@ const STATUS_RELATED_KEYS = [
   'general_setting.quota_display_type',
   'general_setting.custom_currency_symbol',
   'general_setting.custom_currency_exchange_rate',
-]
+])
 
 export function useUpdateOption() {
   const queryClient = useQueryClient()
+  const toastId = useId()
 
   return useMutation({
-    mutationFn: (request: UpdateOptionRequest) => updateSystemOption(request),
-    onSuccess: (data, variables) => {
-      if (data.success) {
-        // Always refresh system-options
-        queryClient.invalidateQueries({ queryKey: ['system-options'] })
+    mutationFn: (request: UpdateOptionMutationRequest) =>
+      updateSystemOption({ key: request.key, value: request.value }),
+    onSuccess: (_data, variables) => {
+      // Always refresh system-options
+      queryClient.invalidateQueries({ queryKey: ['system-options'] })
 
-        // If updating frontend-display-related config, also refresh status
-        if (STATUS_RELATED_KEYS.includes(variables.key)) {
-          queryClient.invalidateQueries({ queryKey: ['status'] })
-          try {
-            window.localStorage.removeItem('status')
-          } catch {
-            /* empty */
-          }
+      // If updating frontend-display-related config, also refresh status
+      if (STATUS_RELATED_KEYS.has(variables.key)) {
+        queryClient.invalidateQueries({ queryKey: ['status'] })
+        try {
+          window.localStorage.removeItem('status')
+        } catch {
+          /* empty */
         }
-
-        toast.success(i18next.t('Setting updated successfully'))
-      } else {
-        toast.error(data.message || i18next.t('Failed to update setting'))
       }
+
+      showUpdateOptionSuccess(variables.notification, toastId)
     },
-    onError: (error: Error) => {
-      toast.error(error.message || i18next.t('Failed to update setting'))
+    onError: (error, variables) => {
+      showUpdateOptionError(error, variables.notification, toastId)
     },
   })
 }

--- a/web/default/src/features/system-settings/integrations/payment-settings-section.tsx
+++ b/web/default/src/features/system-settings/integrations/payment-settings-section.tsx
@@ -714,7 +714,10 @@ export function PaymentSettingsSection({
     }
 
     for (const update of updates) {
-      await updateOption.mutateAsync(update)
+      await updateOption.mutateAsync({
+        ...update,
+        notification: hasWaffoPancakeChanges ? { success: false } : undefined,
+      })
     }
 
     if (!hasWaffoPancakeChanges) {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
修复新版系统设置页面保存配置时重复显示提示的问题。

系统设置表单会逐项提交发生变化的配置。此前每次更新都会独立显示成功提示；部分页面还会额外显示自己的提示，错误响应也可能同时经过 Axios 拦截器和 mutation 处理，因此一次保存可能产生多条重复通知。

本次调整包括：

- 同一个设置表单实例使用稳定的 toast ID，多项配置更新只保留一条提示。
- 系统配置更新由共享 mutation 统一处理错误，避免与 Axios 全局拦截器重复提示。
- 业务失败转换为 rejection，防止保存失败后继续重置表单状态。
- 页面可以覆盖或抑制共享提示，避免组合保存流程产生额外通知。
- 增加通知去重和 API 错误处理的回归测试。

AI-assisted disclosure: 本变更由 AI 辅助实现，并已完成本地代码检查和测试。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Related: #5866

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 已存在同类 PR #5866，本 PR 提供不同且覆盖范围更完整的实现。
- [ ] **Bug fix 说明:** 当前没有单独关联 Issue。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- `bun test`: 37 passed, 0 failed
- `bun run typecheck`: passed
- 变更文件 `oxlint`: passed
- 变更文件 `oxfmt --check`: passed
- `bun run build`: passed

仓库全量 lint、format 和 copyright 检查仍受 `main` 上已有的无关问题影响，本 PR 涉及文件均已通过对应检查。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system settings update feedback with consistent success and error notifications.
  * Prevented duplicate notifications when saving multiple settings together.
  * Ensured backend rejection messages are shown when an update fails.
  * Reduced unnecessary success messages during composite save actions.
  * Updated announcements, API information, FAQs, uptime monitoring, channel affinity, and payment settings to use the unified notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->