### PR TITLE
feat: add channel API address column

### DIFF
--- a/web/default/src/features/channels/components/channels-columns.tsx
+++ b/web/default/src/features/channels/components/channels-columns.tsx
@@ -23,6 +23,7 @@ import {
   AlertTriangle,
   ChevronDown,
   ChevronRight,
+  ExternalLink,
   ListOrdered,
   Shuffle,
   SlidersHorizontal,
@@ -46,12 +47,12 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { toIntlLocale } from '@/i18n/languages'
 import {
   formatCurrencyFromUSD,
   formatQuotaWithCurrency,
   getCurrencyLabel,
 } from '@/lib/currency'
-import { toIntlLocale } from '@/i18n/languages'
 import { formatTimestampToDate } from '@/lib/format'
 import { truncateText } from '@/lib/utils'
 
@@ -74,6 +75,7 @@ import {
   isTagAggregateRow,
   type TagRow,
 } from '../lib'
+import { formatChannelApiAddress } from '../lib/channel-api-address'
 import { parseUpstreamUpdateMeta } from '../lib/upstream-update-utils'
 import type { Channel } from '../types'
 import { ChannelRowActionsLayoutContext } from './channel-row-actions-context'
@@ -819,6 +821,81 @@ export function useChannelsColumns(
             return true
           }
           return value.includes(String(row.getValue(id)))
+        },
+        size: 220,
+        enableSorting: false,
+      },
+
+      // API address column
+      {
+        accessorKey: 'base_url',
+        header: t('Base URL'),
+        meta: { mobileHidden: true },
+        cell: ({ row }) => {
+          const isTagRow = isTagAggregateRow(row.original)
+          const apiAddress = formatChannelApiAddress(
+            row.getValue('base_url') as string | null | undefined
+          )
+
+          if (isTagRow || !apiAddress) {
+            return <span className='text-muted-foreground text-xs'>-</span>
+          }
+
+          if (!sensitiveVisible) {
+            return (
+              <span className='text-muted-foreground text-xs'>
+                {SENSITIVE_MASK}
+              </span>
+            )
+          }
+
+          if (!apiAddress.href) {
+            return (
+              <TooltipProvider delay={300}>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <span className='text-muted-foreground block max-w-full truncate font-mono text-xs' />
+                    }
+                  >
+                    {apiAddress.displayText}
+                  </TooltipTrigger>
+                  <TooltipContent side='top' className='max-w-sm break-all'>
+                    {apiAddress.displayText}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )
+          }
+
+          return (
+            <TooltipProvider delay={300}>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <a
+                      href={apiAddress.href}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='text-primary hover:text-primary/80 flex max-w-full items-center gap-1 overflow-hidden text-xs font-medium underline-offset-4 hover:underline'
+                      onClick={(event) => event.stopPropagation()}
+                    />
+                  }
+                >
+                  <span className='truncate font-mono'>
+                    {apiAddress.displayText}
+                  </span>
+                  <ExternalLink
+                    className='h-3 w-3 shrink-0'
+                    aria-hidden='true'
+                  />
+                </TooltipTrigger>
+                <TooltipContent side='top' className='max-w-sm break-all'>
+                  {apiAddress.displayText}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )
         },
         size: 220,
         enableSorting: false,

--- a/web/default/src/features/channels/components/channels-table.tsx
+++ b/web/default/src/features/channels/components/channels-table.tsx
@@ -313,6 +313,7 @@ export function ChannelsTable() {
     totalCount,
     sorting,
     initialColumnVisibility: {
+      base_url: false,
       models: false,
       tag: false,
     },

--- a/web/default/src/features/channels/lib/channel-api-address.test.ts
+++ b/web/default/src/features/channels/lib/channel-api-address.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import { formatChannelApiAddress } from './channel-api-address'
+
+describe('channel API address formatting', () => {
+  test('returns null for empty channel base URLs', () => {
+    assert.equal(formatChannelApiAddress(null), null)
+    assert.equal(formatChannelApiAddress(undefined), null)
+    assert.equal(formatChannelApiAddress('   '), null)
+  })
+
+  test('trims visible API addresses and uses the same value as the link target', () => {
+    assert.deepEqual(formatChannelApiAddress('  https://api.example.com  '), {
+      displayText: 'https://api.example.com',
+      href: 'https://api.example.com',
+    })
+  })
+
+  test('does not create link targets for non-http API addresses', () => {
+    assert.deepEqual(formatChannelApiAddress('javascript:alert(1)'), {
+      displayText: 'javascript:alert(1)',
+      href: null,
+    })
+  })
+})

--- a/web/default/src/features/channels/lib/channel-api-address.ts
+++ b/web/default/src/features/channels/lib/channel-api-address.ts
@@ -16,13 +16,21 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-// Re-export all library functions
-export * from './channel-actions'
-export * from './channel-api-address'
-export * from './advanced-custom'
-export * from './channel-form-errors'
-export * from './channel-form'
-export * from './channel-type-config'
-export * from './channel-utils'
-export * from './multi-key-utils'
-export * from './model-mapping-validation'
+export type ChannelApiAddress = {
+  displayText: string
+  href: string | null
+}
+
+export function formatChannelApiAddress(
+  baseUrl: string | null | undefined
+): ChannelApiAddress | null {
+  const address = baseUrl?.trim()
+  if (!address) {
+    return null
+  }
+
+  return {
+    displayText: address,
+    href: /^https?:\/\//i.test(address) ? address : null,
+  }
+}


### PR DESCRIPTION
#6077  

# ⚠️ 提交说明 / PR Notice
  > [!IMPORTANT]
  >
  > - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

  ## 📝 变更描述 / Description

  本 PR 在渠道列表中新增可选的 `API 地址` 列，用于展示渠道配置的 `base_url`。

  实现上，新增列使用现有表格列配置接入，位置放在 `类型 / Type` 与 `状态 / Status` 之间；同时在渠道表格的 `initialColumnVisibility` 中将 `base_url` 默认设为隐藏，因此它会先出现在“切换列”菜单中，用户勾选后才显示到列表里。

  地址渲染逻辑单独抽到 `formatChannelApiAddress`：空地址显示为 `-`，`http/https` 地址会作为链接在新标签页打开，非 `http/https` 地址仅按文本展示，避免把不安全协议写入可点击链接。敏感信息隐藏状态下，该列也会显示掩码，保持与渠道列表现有敏感信息展示逻辑一致。

  本次实现由 AI 协助完成，并经过整理、验证后提交。

  ## 🚀 变更类型 / Type of change
  - [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
  - [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
  - [ ] ⚡ 性能优化 / 重构 (Refactor)
  - [ ] 📝 文档更新 (Documentation)

  ## 🔗 关联任务 / Related Issue
  - Closes #6077

  ## ✅ 提交前检查项 / Checklist
  - [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
  - [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
  - [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
  - [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
  - [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
  - [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
  - [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

  ## 📸 运行证明 / Proof of Work

  ```text
  $ npx --yes tsx --test src/features/channels/lib/channel-api-address.test.ts

  ✔ returns null for empty channel base URLs
  ✔ trims visible API addresses and uses the same value as the link target
  ✔ does not create link targets for non-http API addresses

  tests 3
  pass 3
  fail 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API address column to the channels table.
  - API addresses are displayed with masking, truncation, tooltips, and clickable links when valid.
  - The column is hidden by default and can be enabled through table settings.

- **Bug Fixes**
  - Invalid or unsafe API addresses are shown without clickable links.
  - Whitespace and empty API address values are handled consistently.

- **Tests**
  - Added coverage for valid, empty, whitespace-only, and unsafe API addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->