### PR TITLE
fix(xai): strip presence/frequency_penalty for grok-4+ models

### DIFF
--- a/relay/channel/xai/adaptor.go
+++ b/relay/channel/xai/adaptor.go
@@ -64,6 +64,14 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 	if request == nil {
 		return nil, errors.New("request is nil")
 	}
+	// grok-4 and newer (incl. grok-4.5) reject sampling-penalty parameters and will 400 with
+	// "Model <name> does not support parameter presencePenalty/frequencyPenalty". Strip them so
+	// clients that always send these params still work. Done before the -search branch below so
+	// both the search and non-search paths are covered (ToMap() marshals the same struct).
+	if strings.HasPrefix(request.Model, "grok-4") {
+		request.PresencePenalty = nil
+		request.FrequencyPenalty = nil
+	}
 	if strings.HasSuffix(info.UpstreamModelName, "-search") {
 		info.UpstreamModelName = strings.TrimSuffix(info.UpstreamModelName, "-search")
 		request.Model = info.UpstreamModelName


### PR DESCRIPTION
## 📝 变更描述 / Description

xAI 的 grok-4 系列（含 `grok-4.5`）这类推理模型不再接受采样惩罚参数，上游会直接返回 400：

```
Request error occurred: Model grok-4.5 does not support parameter presencePenalty.
```

而 grok-3 仍支持这些参数。当前 `xai` 渠道的 `ConvertOpenAIRequest` 只对 `grok-3-mini` 做了特判，会把客户端传来的 `presence_penalty` / `frequency_penalty` 原样转发给 grok-4，导致凡是默认带这两个参数的客户端（如很多 SDK/前端）都无法使用 grok-4 系列。

本 PR 在 `ConvertOpenAIRequest` 开头，对 `grok-4` 前缀的模型（覆盖 `grok-4`、`grok-4-0709`、`grok-4-fast-*`、`grok-4-1-fast-*`、`grok-4.5` 及其 `-search` 变体）把 `PresencePenalty` / `FrequencyPenalty` 置为 `nil`，使其在 marshal 时被 `omitempty` 略去，从而不再发送给上游。

关键实现点：
- 剥离动作放在 `-search` 分支**之前**，因为 search 路径通过 `request.ToMap()` 序列化同一个结构体，提前置 `nil` 可同时覆盖普通与 `-search` 两条路径。
- 字段本就是 `*float64` + `omitempty`（符合仓库对可选请求字段用指针的约定），置 `nil` 即等价于"不发送"，不会误伤显式传 0 的其它模型。
- 仅在 `grok-4` 前缀命中时生效，`grok-3` / `grok-2` 行为不变。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- 无（未检索到相关 Issue/PR）

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述由人工整理撰写。
- [x] **非重复提交:** 已搜索 Issues 与 PRs，未见相同提交。
- [x] **Bug fix 说明:** 该问题为上游返回 400 的确定性错误，非设计取舍。
- [x] **变更理解:** 已理解改动原理与影响范围。
- [x] **范围聚焦:** 仅改动 `relay/channel/xai/adaptor.go` 一处，8 行新增。
- [x] **本地验证:** `go build ./relay/channel/xai/` 通过；已在生产环境（arm64）部署后用 grok-4.5 请求验证不再报错。
- [x] **安全合规:** 无敏感凭据，符合规范。

## 📸 运行证明 / Proof of Work

**修复前**：客户端携带 `presence_penalty` 请求 `grok-4.5` →
```
Request error occurred: Model grok-4.5 does not support parameter presencePenalty.
```

**修复后**：同一请求正常返回（`presence_penalty` / `frequency_penalty` 被自动剥离），`grok-3` 系列不受影响。

diff（`relay/channel/xai/adaptor.go`）：
```go
if strings.HasPrefix(request.Model, "grok-4") {
    request.PresencePenalty = nil
    request.FrequencyPenalty = nil
}
```

---
> 说明：本 PR 由项目维护者在 AI 辅助下完成（代码与描述经人工审阅、本地构建并在生产环境验证）。
