### PR TITLE
fix: skip estimated tokens for abnormal streams without usage (#4168)

### DIFF
--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -188,7 +188,9 @@ func calculateTextQuotaSummary(ctx *gin.Context, relayInfo *relaycommon.RelayInf
 	}
 	summary.IsClaudeUsageSemantic = summary.UsageSemantic == "anthropic"
 
-	if usage == nil {
+	if usage == nil && shouldSkipEstimatedUsageForAbnormalStream(relayInfo) {
+		usage = &dto.Usage{}
+	} else if usage == nil {
 		usage = &dto.Usage{
 			PromptTokens:     relayInfo.GetEstimatePromptTokens(),
 			CompletionTokens: 0,
@@ -327,6 +329,13 @@ func calculateTextQuotaSummary(ctx *gin.Context, relayInfo *relaycommon.RelayInf
 	return summary
 }
 
+func shouldSkipEstimatedUsageForAbnormalStream(relayInfo *relaycommon.RelayInfo) bool {
+	if relayInfo == nil || !relayInfo.IsStream || relayInfo.StreamStatus == nil {
+		return false
+	}
+	return !relayInfo.StreamStatus.IsNormalEnd()
+}
+
 func usageSemanticFromUsage(relayInfo *relaycommon.RelayInfo, usage *dto.Usage) string {
 	if usage != nil && usage.UsageSemantic != "" {
 		return usage.UsageSemantic
@@ -341,6 +350,9 @@ func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, us
 	originUsage := usage
 	if usage == nil {
 		extraContent = append(extraContent, "上游无计费信息")
+		if shouldSkipEstimatedUsageForAbnormalStream(relayInfo) {
+			extraContent = append(extraContent, "流式响应异常结束，未返回计费信息，跳过扣费")
+		}
 	}
 	if originUsage != nil {
 		ObserveChannelAffinityUsageCacheByRelayFormat(ctx, usage, relayInfo.GetFinalRequestRelayFormat())

--- a/service/text_quota_test.go
+++ b/service/text_quota_test.go
@@ -150,6 +150,62 @@ func TestCalculateTextQuotaSummaryUsesAnthropicUsageSemanticFromUpstreamUsage(t 
 	require.Equal(t, 1488, summary.Quota)
 }
 
+func TestCalculateTextQuotaSummarySkipsEstimateForAbnormalStreamWithoutUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+
+	streamStatus := relaycommon.NewStreamStatus()
+	streamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, nil)
+	relayInfo := &relaycommon.RelayInfo{
+		IsStream:        true,
+		StreamStatus:    streamStatus,
+		OriginModelName: "gpt-test",
+		PriceData: types.PriceData{
+			ModelRatio:      1,
+			CompletionRatio: 1,
+			GroupRatioInfo: types.GroupRatioInfo{
+				GroupRatio: 1,
+			},
+		},
+		StartTime: time.Now(),
+	}
+	relayInfo.SetEstimatePromptTokens(1000)
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, nil)
+
+	require.Zero(t, summary.TotalTokens)
+	require.Zero(t, summary.Quota)
+}
+
+func TestCalculateTextQuotaSummaryUsesEstimateForNormalStreamWithoutUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+
+	streamStatus := relaycommon.NewStreamStatus()
+	streamStatus.SetEndReason(relaycommon.StreamEndReasonDone, nil)
+	relayInfo := &relaycommon.RelayInfo{
+		IsStream:        true,
+		StreamStatus:    streamStatus,
+		OriginModelName: "gpt-test",
+		PriceData: types.PriceData{
+			ModelRatio:      1,
+			CompletionRatio: 1,
+			GroupRatioInfo: types.GroupRatioInfo{
+				GroupRatio: 1,
+			},
+		},
+		StartTime: time.Now(),
+	}
+	relayInfo.SetEstimatePromptTokens(1000)
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, nil)
+
+	require.Equal(t, 1000, summary.TotalTokens)
+	require.Equal(t, 1000, summary.Quota)
+}
+
 func TestCacheWriteTokensTotal(t *testing.T) {
 	t.Run("split cache creation", func(t *testing.T) {
 		summary := textQuotaSummary{


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
当流式请求异常结束（client_gone/timeout 等）且上游未返回 usage 时，不再使用估算 prompt tokens 结算扣费。正常结束或上游提供 usage 的路径保持不变，避免误伤。

This PR was AI-assisted and manually reviewed before submission.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #4168

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```text
docker run --rm -v "$PWD":/work -w /work -e GOMODCACHE=/gomod -e GOCACHE=/gocache golang:1.25.1 go test ./service -run 'TestCalculateTextQuotaSummary'
ok  	github.com/QuantumNous/new-api/service	0.021s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota handling when streaming responses end unexpectedly without billing information.
  * Prevented estimated usage from being charged in abnormal stream termination cases.
  * Added clearer audit details when quota consumption is skipped or adjusted.
  * Preserved estimated usage calculations for normally completed streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->