### PR TITLE
fix(channel-test): auto-detect image generation models

### DIFF
--- a/common/model.go
+++ b/common/model.go
@@ -12,7 +12,7 @@ var (
 	ImageGenerationModels = []string{
 		"dall-e-3",
 		"dall-e-2",
-		"gpt-image-1",
+		"gpt-image-",
 		"prefix:imagen-",
 		"flux-",
 		"flux.1-",

--- a/common/model_test.go
+++ b/common/model_test.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsImageGenerationModelRecognizesGPTImageFamily(t *testing.T) {
+	tests := []struct {
+		modelName string
+		want      bool
+	}{
+		{modelName: "gpt-image-1", want: true},
+		{modelName: "gpt-image-2", want: true},
+		{modelName: "openai/gpt-image-3", want: true},
+		{modelName: "GPT-IMAGE-2", want: true},
+		{modelName: "gpt-5.6-terra", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.modelName, func(t *testing.T) {
+			require.Equal(t, tt.want, IsImageGenerationModel(tt.modelName))
+		})
+	}
+}
+
+func TestGPTImageFamilyPrefersImageGenerationEndpoint(t *testing.T) {
+	endpoints := GetEndpointTypesByChannelType(constant.ChannelTypeOpenAI, "gpt-image-2")
+
+	require.Equal(t, []constant.EndpointType{
+		constant.EndpointTypeImageGeneration,
+		constant.EndpointTypeOpenAI,
+	}, endpoints)
+}

--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -49,6 +49,10 @@ func normalizeChannelTestEndpoint(channel *model.Channel, modelName, endpointTyp
 	if strings.HasSuffix(modelName, ratio_setting.CompactModelSuffix) {
 		return string(constant.EndpointTypeOpenAIResponseCompact)
 	}
+	if common.IsImageGenerationModel(modelName) ||
+		(channel != nil && channel.Type == constant.ChannelTypeVolcEngine && strings.Contains(strings.ToLower(modelName), "seedream")) {
+		return string(constant.EndpointTypeImageGeneration)
+	}
 	if channel != nil && channel.Type == constant.ChannelTypeCodex {
 		return string(constant.EndpointTypeOpenAIResponse)
 	}
@@ -133,11 +137,6 @@ func testChannel(ctx context.Context, channel *model.Channel, testUserID int, te
 			strings.Contains(testModel, "embed") ||
 			channel.Type == constant.ChannelTypeMokaAI { // 其他 embedding 模型
 			requestPath = "/v1/embeddings" // 修改请求路径
-		}
-
-		// VolcEngine 图像生成模型
-		if channel.Type == constant.ChannelTypeVolcEngine && strings.Contains(testModel, "seedream") {
-			requestPath = "/v1/images/generations"
 		}
 
 		// responses-only models

--- a/controller/channel_test_internal_test.go
+++ b/controller/channel_test_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/pkg/billingexpr"
@@ -15,6 +16,73 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNormalizeChannelTestEndpointDetectsImageGeneration(t *testing.T) {
+	tests := []struct {
+		name         string
+		channel      *model.Channel
+		modelName    string
+		endpointType string
+		want         string
+	}{
+		{
+			name:      "gpt image family",
+			channel:   &model.Channel{Type: constant.ChannelTypeOpenAI},
+			modelName: "gpt-image-2",
+			want:      string(constant.EndpointTypeImageGeneration),
+		},
+		{
+			name:      "namespaced gpt image family",
+			channel:   &model.Channel{Type: constant.ChannelTypeOpenAI},
+			modelName: "openai/gpt-image-3",
+			want:      string(constant.EndpointTypeImageGeneration),
+		},
+		{
+			name:      "volcengine seedream compatibility",
+			channel:   &model.Channel{Type: constant.ChannelTypeVolcEngine},
+			modelName: "Seedream-4.0",
+			want:      string(constant.EndpointTypeImageGeneration),
+		},
+		{
+			name:         "explicit endpoint wins",
+			channel:      &model.Channel{Type: constant.ChannelTypeOpenAI},
+			modelName:    "gpt-image-2",
+			endpointType: string(constant.EndpointTypeOpenAI),
+			want:         string(constant.EndpointTypeOpenAI),
+		},
+		{
+			name:      "chat model remains automatic",
+			channel:   &model.Channel{Type: constant.ChannelTypeOpenAI},
+			modelName: "gpt-5.6-terra",
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeChannelTestEndpoint(tt.channel, tt.modelName, tt.endpointType)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestImageGenerationAutoDetectionBuildsMatchingProbe(t *testing.T) {
+	endpointType := normalizeChannelTestEndpoint(
+		&model.Channel{Type: constant.ChannelTypeOpenAI},
+		"gpt-image-2",
+		"",
+	)
+
+	endpointInfo, ok := common.GetDefaultEndpointInfo(constant.EndpointType(endpointType))
+	require.True(t, ok)
+	require.Equal(t, "/v1/images/generations", endpointInfo.Path)
+
+	request := buildTestRequest("gpt-image-2", endpointType, nil, false)
+	imageRequest, ok := request.(*dto.ImageRequest)
+	require.True(t, ok)
+	require.Equal(t, "gpt-image-2", imageRequest.Model)
+	require.Equal(t, "1024x1024", imageRequest.Size)
+}
 
 func TestSettleTestQuotaUsesTieredBilling(t *testing.T) {
 	info := &relaycommon.RelayInfo{


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

渠道测试使用「自动检测」时，`gpt-image-2` 会被当成聊天模型，请求发到 `/v1/chat/completions`，导致上游报错（#6121）。

本 PR 做了这些调整：

- 将 `gpt-image-1` 的精确匹配改为匹配整个 `gpt-image-*` 系列，同时支持 `openai/gpt-image-3` 这类带命名空间的名称。
- 渠道测试统一使用模型分类器。识别为图像模型后，会同时使用 `/v1/images/generations` 和 `dto.ImageRequest`，避免请求路径与请求体不一致。
- 手动指定的端点仍然优先。
- 保留火山引擎 Seedream 的自动识别，并改为不区分大小写，`Seedream-4.0` 也能正常识别。

自动检测会对所有渠道类型生效。`dall-e`、`flux`、`imagen` 等已知图像模型也会自动走图像端点。如果个别上游通过聊天接口代理图像模型，仍可手动指定端点覆盖。

定价页复用同一个分类器，因此 `gpt-image-2` 的端点类型也会显示为 `[image-generation, openai]`。

本 PR 在 AI 辅助下完成，实现、测试、影响范围与本描述均经本人复核。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6121

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

以下测试已通过：

```text
go test ./common ./controller -count=1
ok github.com/QuantumNous/new-api/common
ok github.com/QuantumNous/new-api/controller
```

回归测试覆盖：

- `gpt-image-1`、`gpt-image-2`、带命名空间及未来的 `gpt-image-*` 名称
- 手动指定端点的优先级
- 图像请求路径与 `dto.ImageRequest` 保持一致
- 火山引擎 Seedream，包括 `Seedream-4.0` 的大小写场景
- 普通聊天模型行为不变
- 定价元数据正确返回 `[image-generation, openai]`

其余 Go 包的测试也已通过。只有仓库根目录的 setup 因本地缺少生成产物 `web/classic/dist` 无法运行，与本次改动无关。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added broader support for GPT image model variants, including newer and differently formatted model names.
  - Image-generation requests are now automatically detected and routed to the appropriate image endpoint.
  - Image model testing now uses the expected image request format and default settings.

- **Bug Fixes**
  - Improved endpoint selection for image-generation models across supported providers, while preserving automatic handling for chat models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
