### PR TITLE
fix: list only channel models in unset price models tab

### DIFF
--- a/web/default/src/features/system-settings/models/model-ratio-visual-editor.tsx
+++ b/web/default/src/features/system-settings/models/model-ratio-visual-editor.tsx
@@ -216,11 +216,10 @@ const ModelRatioVisualEditorComponent = forwardRef<
 
     const savedByName = new Map(savedRows.map((row) => [row.name, row]))
     const draftByName = new Map(draftRows.map((row) => [row.name, row]))
-    const modelNames = new Set([
-      ...(candidateModelNames ?? []),
-      ...savedByName.keys(),
-      ...draftByName.keys(),
-    ])
+    const modelNames =
+      filterMode === 'unset'
+        ? new Set(candidateModelNames ?? [])
+        : new Set([...savedByName.keys(), ...draftByName.keys()])
 
     return [...modelNames]
       .map((name) => {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
`未设置价格模型`列表目前的行来源是 渠道启用模型 ∪ 各倍率表出现过的模型名。后者会把一批"只在缓存/音频等次级倍率表里有 key、没有基础价、且不在任何渠道里"的历史遗留条目也列出来

改动：只取渠道设置的启用模型,显示更干净
## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- #6124 的后续收敛，问题背景见 #5779

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
优化前: 会显示在硬编码但未在渠道里配置的模型
<img width="1642" height="1526" alt="image" src="https://github.com/user-attachments/assets/072ce8c2-d358-4723-a818-8b0db2a9bc2f" />
优化后: 只显示真正的未设置价格模型
<img width="1606" height="816" alt="image" src="https://github.com/user-attachments/assets/866cc041-dbe0-4886-a84e-d900be4c58ff" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model ratio editor filtering by showing only candidate models when viewing unset ratios.
  * Preserved existing model lists for other filter modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->