### PR TITLE
fix(users): prevent large quota values from overflowing

### DIFF
--- a/web/default/src/features/users/components/user-quota-cell.tsx
+++ b/web/default/src/features/users/components/user-quota-cell.tsx
@@ -1,0 +1,98 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { useTranslation } from 'react-i18next'
+
+import { StatusBadge } from '@/components/status-badge'
+import { Progress } from '@/components/ui/progress'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { formatQuota } from '@/lib/format'
+import { cn } from '@/lib/utils'
+
+type UserQuotaCellProps = {
+  used: number
+  remaining: number
+}
+
+function getQuotaProgressColor(percentage: number): string {
+  if (percentage <= 10) return '[&_[data-slot=progress-indicator]]:bg-rose-500'
+  if (percentage <= 30) return '[&_[data-slot=progress-indicator]]:bg-amber-500'
+  return '[&_[data-slot=progress-indicator]]:bg-emerald-500'
+}
+
+export function UserQuotaCell(props: UserQuotaCellProps) {
+  const { t } = useTranslation()
+  const total = props.used + props.remaining
+  const percentage = total > 0 ? (props.remaining / total) * 100 : 0
+  const formattedRemaining = formatQuota(props.remaining)
+  const formattedTotal = formatQuota(total)
+
+  if (total === 0) {
+    return (
+      <StatusBadge
+        label={t('No Quota')}
+        variant='neutral'
+        copyable={false}
+        className='-ml-1.5'
+      />
+    )
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <div className='w-full min-w-0 cursor-help space-y-1.5 overflow-hidden' />
+        }
+      >
+        <div className='grid min-w-0 grid-cols-2 gap-x-4 text-xs'>
+          <span className='min-w-0 truncate font-medium tabular-nums'>
+            {formattedRemaining}
+          </span>
+          <span className='text-muted-foreground min-w-0 truncate text-right tabular-nums'>
+            {formattedTotal}
+          </span>
+        </div>
+        <Progress
+          value={percentage}
+          className={cn('h-1.5', getQuotaProgressColor(percentage))}
+        />
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className='space-y-1 text-xs'>
+          <div>
+            {t('Used:')} {formatQuota(props.used)}
+          </div>
+          <div>
+            {t('Remaining:')} {formattedRemaining}
+          </div>
+          <div>
+            {t('Total:')} {formattedTotal}
+          </div>
+          <div>
+            {t('Percentage:')} {percentage.toFixed(1)}%
+          </div>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/web/default/src/features/users/components/users-columns.tsx
+++ b/web/default/src/features/users/components/users-columns.tsx
@@ -25,14 +25,12 @@ import { LongText } from '@/components/long-text'
 import { StatusBadge } from '@/components/status-badge'
 import { TableId } from '@/components/table-id'
 import { Checkbox } from '@/components/ui/checkbox'
-import { Progress } from '@/components/ui/progress'
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { formatQuota, formatTimestamp } from '@/lib/format'
-import { cn } from '@/lib/utils'
 
 import {
   USER_STATUS,
@@ -42,12 +40,7 @@ import {
 } from '../constants'
 import type { User } from '../types'
 import { DataTableRowActions } from './data-table-row-actions'
-
-function getQuotaProgressColor(percentage: number): string {
-  if (percentage <= 10) return '[&_[data-slot=progress-indicator]]:bg-rose-500'
-  if (percentage <= 30) return '[&_[data-slot=progress-indicator]]:bg-amber-500'
-  return '[&_[data-slot=progress-indicator]]:bg-emerald-500'
-}
+import { UserQuotaCell } from './user-quota-cell'
 
 export function useUsersColumns(): ColumnDef<User>[] {
   const { t } = useTranslation()
@@ -173,60 +166,10 @@ export function useUsersColumns(): ColumnDef<User>[] {
       header: t('Quota'),
       cell: ({ row }) => {
         const user = row.original
-        const used = user.used_quota
-        const remaining = user.quota
-        const total = used + remaining
-        const percentage = total > 0 ? (remaining / total) * 100 : 0
-
-        if (total === 0) {
-          return (
-            <StatusBadge
-              label={t('No Quota')}
-              variant='neutral'
-              copyable={false}
-              className='-ml-1.5'
-            />
-          )
-        }
-
-        return (
-          <Tooltip>
-            <TooltipTrigger
-              render={<div className='w-[150px] cursor-help space-y-1' />}
-            >
-              <div className='flex justify-between text-xs'>
-                <span className='font-medium tabular-nums'>
-                  {formatQuota(remaining)}
-                </span>
-                <span className='text-muted-foreground tabular-nums'>
-                  {formatQuota(total)}
-                </span>
-              </div>
-              <Progress
-                value={percentage}
-                className={cn('h-1.5', getQuotaProgressColor(percentage))}
-              />
-            </TooltipTrigger>
-            <TooltipContent>
-              <div className='space-y-1 text-xs'>
-                <div>
-                  {t('Used:')} {formatQuota(used)}
-                </div>
-                <div>
-                  {t('Remaining:')} {formatQuota(remaining)}
-                </div>
-                <div>
-                  {t('Total:')} {formatQuota(total)}
-                </div>
-                <div>
-                  {t('Percentage:')} {percentage.toFixed(1)}%
-                </div>
-              </div>
-            </TooltipContent>
-          </Tooltip>
-        )
+        return <UserQuotaCell used={user.used_quota} remaining={user.quota} />
       },
-      size: 170,
+      size: 300,
+      minSize: 260,
       meta: { mobileOrder: 40 },
     },
     {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

### 问题描述
- 用户列表中的额度列宽度不足。
- 当剩余额度和总额度数值较大时，文本会相互挤压并溢出到相邻列。

### 修复方式
- 将额度列默认宽度调整为 300px，并设置 260px 的最小宽度。
- 使用双列网格展示剩余额度和总额度，增加固定间距并分别左右对齐。
- 将超长额度文本限制在单元格内截断，完整数值仍可通过 Tooltip 查看。
- 将额度展示逻辑提取为独立的 `UserQuotaCell` 组件。
- 保留零额度状态、额度百分比和进度条颜色逻辑。

### 测试说明
- 目标文件格式检查通过。
- 目标文件 oxlint 检查通过。
- TypeScript 类型检查通过。
- 前端生产构建通过。
- 已完成登录后页面的视觉验证。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6123

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- `bunx oxfmt --check src/features/users/components/users-columns.tsx src/features/users/components/user-quota-cell.tsx`
- `bunx oxlint -c .oxlintrc.json src/features/users/components/users-columns.tsx src/features/users/components/user-quota-cell.tsx`
- `bun run typecheck`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated quota status display for users.
  * Quota usage now shows remaining and total amounts, usage percentage, and a color-coded progress indicator.
  * Users with no assigned quota see a clear “No Quota” status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->