### PR TITLE
feat(relay): add RELAY_DISABLE_HTTP2 to force upstream HTTP/1.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,11 @@
 # RELAY_TIMEOUT=0
 # Relay HTTP 客户端空闲连接超时时间，单位秒，默认跟随 Go 标准库，设置为0表示不限制
 # RELAY_IDLE_CONN_TIMEOUT=90
+# 强制上游 relay 客户端使用 HTTP/1.1 而非 HTTP/2。默认 false（用 HTTP/2）。
+# Go 会把发往同一上游的所有请求多路复用到少量共享 HTTP/2 连接上；
+# 当大并发流式请求打到同一上游时，这些共享连接会阻塞延迟敏感的小请求。
+# 开启后每个在飞请求各占一条独立连接（受 RELAY_MAX_IDLE_CONNS_PER_HOST 约束）。
+# RELAY_DISABLE_HTTP2=false
 # 流模式无响应超时时间，单位秒，如果出现空补全可以尝试改为更大值
 # STREAMING_TIMEOUT=300
 

--- a/common/constants.go
+++ b/common/constants.go
@@ -189,6 +189,13 @@ var RelayIdleConnTimeout int // unit is second
 var RelayMaxIdleConns int
 var RelayMaxIdleConnsPerHost int
 
+// RelayDisableHTTP2 forces upstream relay clients to use HTTP/1.1 instead of
+// HTTP/2. Go multiplexes all requests to one host onto a small pool of shared
+// HTTP/2 connections; under heavy concurrent streaming to the same upstream,
+// those shared connections head-of-line-block latency-sensitive requests. When
+// true, each in-flight request gets its own pooled HTTP/1.1 connection.
+var RelayDisableHTTP2 bool
+
 var GeminiSafetySetting string
 
 // https://docs.cohere.com/docs/safety-modes Type; NONE/CONTEXTUAL/STRICT

--- a/common/init.go
+++ b/common/init.go
@@ -110,6 +110,7 @@ func InitEnv() {
 	RelayIdleConnTimeout = GetEnvOrDefault("RELAY_IDLE_CONN_TIMEOUT", 90)
 	RelayMaxIdleConns = GetEnvOrDefault("RELAY_MAX_IDLE_CONNS", 500)
 	RelayMaxIdleConnsPerHost = GetEnvOrDefault("RELAY_MAX_IDLE_CONNS_PER_HOST", 100)
+	RelayDisableHTTP2 = GetEnvOrDefaultBool("RELAY_DISABLE_HTTP2", false)
 
 	// Initialize string variables with GetEnvOrDefaultString
 	GeminiSafetySetting = GetEnvOrDefaultString("GEMINI_SAFETY_SETTING", "BLOCK_NONE")

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -118,6 +118,7 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	logger.LogDebug(c, "relay timeout seconds: %d", common.RelayTimeout)
 	logger.LogDebug(c, "relay max idle conns: %d", common.RelayMaxIdleConns)
 	logger.LogDebug(c, "relay max idle conns per host: %d", common.RelayMaxIdleConnsPerHost)
+	logger.LogDebug(c, "relay disable http2: %t", common.RelayDisableHTTP2)
 	logger.LogDebug(c, "streaming timeout seconds: %d", int64(streamingTimeout.Seconds()))
 	logger.LogDebug(c, "ping interval seconds: %d", int64(pingInterval.Seconds()))
 

--- a/service/http_client.go
+++ b/service/http_client.go
@@ -22,6 +22,21 @@ var (
 	proxyClients            = make(map[string]*http.Client)
 )
 
+// applyRelayHTTP2Setting downgrades an upstream relay transport to HTTP/1.1 when
+// RELAY_DISABLE_HTTP2 is enabled. By default Go multiplexes all requests to a
+// host onto a small pool of shared HTTP/2 connections; under heavy concurrent
+// streaming to the same upstream those shared connections head-of-line-block
+// latency-sensitive requests. Forcing HTTP/1.1 gives each in-flight request its
+// own pooled connection (bounded by MaxIdleConnsPerHost), removing the drag.
+func applyRelayHTTP2Setting(transport *http.Transport) {
+	if !common.RelayDisableHTTP2 {
+		return
+	}
+	var protocols http.Protocols
+	protocols.SetHTTP1(true)
+	transport.Protocols = &protocols
+}
+
 func checkRedirect(req *http.Request, via []*http.Request) error {
 	urlStr := req.URL.String()
 	if err := validateURLWithCurrentFetchSetting(urlStr, true); err != nil {
@@ -61,6 +76,7 @@ func InitHttpClient() {
 		ForceAttemptHTTP2:   true,
 		Proxy:               http.ProxyFromEnvironment, // Support HTTP_PROXY, HTTPS_PROXY, NO_PROXY env vars
 	}
+	applyRelayHTTP2Setting(transport)
 	if common.TLSInsecureSkipVerify {
 		transport.TLSClientConfig = common.InsecureTLSConfig
 	}
@@ -150,6 +166,7 @@ func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
 			ForceAttemptHTTP2:   true,
 			Proxy:               http.ProxyURL(parsedURL),
 		}
+		applyRelayHTTP2Setting(transport)
 		if common.TLSInsecureSkipVerify {
 			transport.TLSClientConfig = common.InsecureTLSConfig
 		}
@@ -192,6 +209,7 @@ func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
 				return dialer.Dial(network, addr)
 			},
 		}
+		applyRelayHTTP2Setting(transport)
 		if common.TLSInsecureSkipVerify {
 			transport.TLSClientConfig = common.InsecureTLSConfig
 		}


### PR DESCRIPTION
## 📝 变更描述 / Description

出站 relay 的 `http.Transport` 都设了 `ForceAttemptHTTP2: true`，于是 Go 会把发往同一上游的**所有请求多路复用到少量共享 HTTP/2 连接**上（实测每个上游 host 恒定 ~2 条）。当大量长时流式请求（典型如 coding-agent / 长 reasoning）打到同一个渠道时，这几条共享连接在**连接级**被大流量占满，会**队头阻塞**延迟敏感的小请求——一个本该 ~3s 的请求，排在承载重流的连接上会被拖到 30–240s。而对同一上游**新建一条独立连接**始终很快，这正是 HTTP/1.1 的行为（每个在飞请求各占一条池化连接）。

The outbound relay transports use `ForceAttemptHTTP2: true`, so Go multiplexes every request to a given upstream onto a small shared HTTP/2 connection pool. Under heavy concurrent streaming to one upstream, those shared connections saturate at the connection level and head-of-line-block small latency-sensitive requests (a ~3s call can stall 30–240s), while a fresh dedicated connection stays fast.

这与 #2351（"high concurrency issue to a single host"）是同一类问题；但 #2351 加的 `RELAY_MAX_IDLE_CONNS*` 只对 HTTP/1.1 生效——HTTP/2 下 Go 无论如何只保持极少连接，那些旋钮不起作用。

本 PR 新增一个**默认关闭**的开关 `RELAY_DISABLE_HTTP2`（默认 `false`，行为不变）。开启后，三条 relay transport（默认 / HTTP(S) 代理 / SOCKS5 代理）都通过 `http.Protocols` 固定为 HTTP/1.1，让并发请求分散到独立连接、不再在共享 h2 管道上互相拖累。

## 🚀 变更类型 / Type of change
- [x] ⚡ 性能优化 / 重构 (Refactor)

## 🔗 关联任务 / Related Issue
- Related: #2351（同类问题；其 `RELAY_MAX_IDLE_CONNS*` 仅对 HTTP/1.1 有效）

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述为人工整理撰写。
- [x] **非重复提交:** 已搜索 Issues/PRs，无 `RELAY_DISABLE_HTTP2` / 关闭 HTTP2 的现有实现（#5308 是 h2 PING 保活，属另一问题）。
- [x] **变更理解:** 默认值 `false`，不改变现有行为；仅在显式开启时降级为 HTTP/1.1。
- [x] **范围聚焦:** 仅新增该开关及其应用点。
- [x] **本地验证:** `gofmt` / `go vet` / `go build ./service/... ./common/... ./relay/helper/...` 均通过。
- [x] **安全合规:** 无敏感凭据。

## 📸 运行证明 / Proof of Work

复现（40 条并发重流式请求打到同一上游 + 1 个小探测请求，同一时刻）：

| 场景 | 小请求耗时 |
|------|-----------|
| 共享 HTTP/2（默认） | 30–90s |
| `RELAY_DISABLE_HTTP2=true`（HTTP/1.1） | ~2–6s |

开启后容器到上游的连接数随并发上涨（不再恒定 ~2 条），小请求不再被重流阻塞。`debug` 日志新增 `relay disable http2: %t` 一行便于确认生效。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `RELAY_DISABLE_HTTP2` configuration option to force relay connections to use HTTP/1.1 instead of HTTP/2.
  * Applied the setting consistently to direct and proxy connections.
  * Documented configuration guidance for high-concurrency and streaming scenarios, including idle connection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->