### PR TITLE
fix(relayconvert): OpenAIResponsesResponse.response.created_at unmarshal error

### DIFF
--- a/dto/openai_compaction.go
+++ b/dto/openai_compaction.go
@@ -9,7 +9,7 @@ import (
 type OpenAIResponsesCompactionResponse struct {
 	ID        string          `json:"id"`
 	Object    string          `json:"object"`
-	CreatedAt int             `json:"created_at"`
+	CreatedAt UnixTimestamp   `json:"created_at"`
 	Output    json.RawMessage `json:"output"`
 	Usage     *Usage          `json:"usage"`
 	Error     any             `json:"error,omitempty"`

--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -293,7 +293,7 @@ type OutputTokenDetails struct {
 type OpenAIResponsesResponse struct {
 	ID                 string             `json:"id"`
 	Object             string             `json:"object"`
-	CreatedAt          int                `json:"created_at"`
+	CreatedAt          UnixTimestamp      `json:"created_at"`
 	Status             json.RawMessage    `json:"status"`
 	Error              any                `json:"error,omitempty"`
 	IncompleteDetails  *IncompleteDetails `json:"incomplete_details,omitempty"`

--- a/dto/openai_responses_created_at_test.go
+++ b/dto/openai_responses_created_at_test.go
@@ -1,0 +1,64 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIResponsesResponseCreatedAtAcceptsFloat(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		payload  string
+		expected int64
+	}{
+		{
+			name:     "float with zero fraction",
+			payload:  `{"id":"resp_1","object":"response","created_at":1783476848.0}`,
+			expected: 1783476848,
+		},
+		{
+			name:     "float with fraction",
+			payload:  `{"id":"resp_1","object":"response","created_at":1783476848.2598}`,
+			expected: 1783476848,
+		},
+		{
+			name:     "string float",
+			payload:  `{"id":"resp_1","object":"response","created_at":"1783476848.2598"}`,
+			expected: 1783476848,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var resp OpenAIResponsesResponse
+			err := common.UnmarshalJsonStr(tc.payload, &resp)
+			require.NoError(t, err)
+			assert.Equal(t, UnixTimestamp(tc.expected), resp.CreatedAt)
+		})
+	}
+}
+
+func TestOpenAIResponsesCompactionCreatedAtAcceptsFloat(t *testing.T) {
+	t.Parallel()
+
+	payload := `{"id":"resp_1","object":"response","created_at":1783476848.2598}`
+	var resp OpenAIResponsesCompactionResponse
+	err := common.UnmarshalJsonStr(payload, &resp)
+	require.NoError(t, err)
+	assert.Equal(t, UnixTimestamp(1783476848), resp.CreatedAt)
+}
+
+func TestOpenAIResponsesResponseCreatedAtRejectsInvalidString(t *testing.T) {
+	t.Parallel()
+
+	payload := `{"id":"resp_1","object":"response","created_at":"not-a-number"}`
+	var resp OpenAIResponsesResponse
+	err := common.UnmarshalJsonStr(payload, &resp)
+	require.Error(t, err)
+}

--- a/dto/values.go
+++ b/dto/values.go
@@ -2,7 +2,10 @@ package dto
 
 import (
 	"encoding/json"
+	"fmt"
+	"math"
 	"strconv"
+	"strings"
 )
 
 type StringValue string
@@ -74,4 +77,72 @@ func (b *BoolValue) UnmarshalJSON(data []byte) error {
 }
 func (b BoolValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(bool(b))
+}
+
+// UnixTimestamp stores epoch seconds and accepts integer, float, and numeric string JSON values.
+// Fractional values are truncated toward zero.
+type UnixTimestamp int64
+
+func (u *UnixTimestamp) UnmarshalJSON(data []byte) error {
+	value, err := parseUnixTimestampJSON(data)
+	if err != nil {
+		return err
+	}
+	*u = UnixTimestamp(value)
+	return nil
+}
+
+func (u UnixTimestamp) MarshalJSON() ([]byte, error) {
+	return json.Marshal(int64(u))
+}
+
+func parseUnixTimestampJSON(data []byte) (int64, error) {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return 0, fmt.Errorf("empty timestamp")
+	}
+	if trimmed == "null" {
+		return 0, nil
+	}
+
+	var number json.Number
+	if err := json.Unmarshal(data, &number); err == nil {
+		if parsed, parseErr := number.Int64(); parseErr == nil {
+			return parsed, nil
+		}
+		parsed, parseErr := strconv.ParseFloat(number.String(), 64)
+		if parseErr != nil {
+			return 0, parseErr
+		}
+		if math.IsNaN(parsed) || math.IsInf(parsed, 0) {
+			return 0, fmt.Errorf("invalid timestamp number: %s", number.String())
+		}
+		if parsed > math.MaxInt64 || parsed < math.MinInt64 {
+			return 0, fmt.Errorf("timestamp out of int64 range: %s", number.String())
+		}
+		return int64(math.Trunc(parsed)), nil
+	}
+
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return 0, err
+	}
+	str = strings.TrimSpace(str)
+	if str == "" {
+		return 0, fmt.Errorf("empty timestamp string")
+	}
+	if parsed, err := strconv.ParseInt(str, 10, 64); err == nil {
+		return parsed, nil
+	}
+	parsed, err := strconv.ParseFloat(str, 64)
+	if err != nil {
+		return 0, err
+	}
+	if math.IsNaN(parsed) || math.IsInf(parsed, 0) {
+		return 0, fmt.Errorf("invalid timestamp string: %s", str)
+	}
+	if parsed > math.MaxInt64 || parsed < math.MinInt64 {
+		return 0, fmt.Errorf("timestamp out of int64 range: %s", str)
+	}
+	return int64(math.Trunc(parsed)), nil
 }

--- a/dto/values.go
+++ b/dto/values.go
@@ -117,7 +117,7 @@ func parseUnixTimestampJSON(data []byte) (int64, error) {
 		if math.IsNaN(parsed) || math.IsInf(parsed, 0) {
 			return 0, fmt.Errorf("invalid timestamp number: %s", number.String())
 		}
-		if parsed > math.MaxInt64 || parsed < math.MinInt64 {
+		if parsed >= float64(math.MaxInt64) || parsed < math.MinInt64 {
 			return 0, fmt.Errorf("timestamp out of int64 range: %s", number.String())
 		}
 		return int64(math.Trunc(parsed)), nil
@@ -141,7 +141,7 @@ func parseUnixTimestampJSON(data []byte) (int64, error) {
 	if math.IsNaN(parsed) || math.IsInf(parsed, 0) {
 		return 0, fmt.Errorf("invalid timestamp string: %s", str)
 	}
-	if parsed > math.MaxInt64 || parsed < math.MinInt64 {
+	if parsed >= float64(math.MaxInt64) || parsed < math.MinInt64 {
 		return 0, fmt.Errorf("timestamp out of int64 range: %s", str)
 	}
 	return int64(math.Trunc(parsed)), nil

--- a/relay/channel/openai/chat_via_responses.go
+++ b/relay/channel/openai/chat_via_responses.go
@@ -143,7 +143,7 @@ func OaiResponsesToChatBufferedStreamHandler(c *gin.Context, info *relaycommon.R
 	if finalResponse == nil {
 		finalResponse = &dto.OpenAIResponsesResponse{
 			ID:        helper.GetResponseID(c),
-			CreatedAt: int(time.Now().Unix()),
+			CreatedAt: dto.UnixTimestamp(time.Now().Unix()),
 			Model:     info.UpstreamModelName,
 			Status:    []byte(`"completed"`),
 		}

--- a/service/relayconvert/internal/oai_chat/to_oai_responses_resp.go
+++ b/service/relayconvert/internal/oai_chat/to_oai_responses_resp.go
@@ -201,22 +201,24 @@ func chatArgumentsRawMessage(arguments string) []byte {
 	return raw
 }
 
-func chatCreatedAt(created any) int {
+func chatCreatedAt(created any) dto.UnixTimestamp {
 	switch v := created.(type) {
-	case int:
+	case dto.UnixTimestamp:
 		return v
+	case int:
+		return dto.UnixTimestamp(v)
 	case int64:
-		return int(v)
+		return dto.UnixTimestamp(v)
 	case float64:
-		return int(v)
+		return dto.UnixTimestamp(v)
 	case float32:
-		return int(v)
+		return dto.UnixTimestamp(v)
 	case string:
 		if parsed := common.String2Int(v); parsed != 0 {
-			return parsed
+			return dto.UnixTimestamp(parsed)
 		}
 	}
-	return int(time.Now().Unix())
+	return dto.UnixTimestamp(time.Now().Unix())
 }
 
 func responsesStreamEvent(eventType string, payload dto.ResponsesStreamResponse) ChatToResponsesStreamEvent {

--- a/service/relayconvert/internal/oai_chat/to_oai_responses_resp.go
+++ b/service/relayconvert/internal/oai_chat/to_oai_responses_resp.go
@@ -3,6 +3,8 @@ package oaichat
 import (
 	"errors"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 	"time"
 
@@ -210,11 +212,22 @@ func chatCreatedAt(created any) dto.UnixTimestamp {
 	case int64:
 		return dto.UnixTimestamp(v)
 	case float64:
-		return dto.UnixTimestamp(v)
+		if !math.IsNaN(v) && !math.IsInf(v, 0) && v < float64(math.MaxInt64) && v >= float64(math.MinInt64) {
+			return dto.UnixTimestamp(v)
+		}
 	case float32:
-		return dto.UnixTimestamp(v)
+		f := float64(v)
+		if !math.IsNaN(f) && !math.IsInf(f, 0) && f < float64(math.MaxInt64) && f >= float64(math.MinInt64) {
+			return dto.UnixTimestamp(f)
+		}
 	case string:
-		if parsed := common.String2Int(v); parsed != 0 {
+		s := strings.TrimSpace(v)
+		if parsed, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return dto.UnixTimestamp(parsed)
+		}
+		if parsed, err := strconv.ParseFloat(s, 64); err == nil &&
+			!math.IsNaN(parsed) && !math.IsInf(parsed, 0) &&
+			parsed < float64(math.MaxInt64) && parsed >= float64(math.MinInt64) {
 			return dto.UnixTimestamp(parsed)
 		}
 	}

--- a/service/relayconvert/internal/oai_chat/to_oai_responses_resp_test.go
+++ b/service/relayconvert/internal/oai_chat/to_oai_responses_resp_test.go
@@ -138,3 +138,23 @@ func mustResponsesEventsFromChatChunk(t *testing.T, state *ChatToResponsesStream
 	require.NoError(t, err)
 	return events
 }
+
+// TestChatCreatedAtHandlesUnixTimestamp guards against a round-trip regression where
+// ResponsesResponseToChatCompletionsResponse stores a dto.UnixTimestamp in
+// OpenAITextResponse.Created (any), and that value is later re-consumed by
+// ChatCompletionsResponseToResponsesResponse → chatCreatedAt.
+func TestChatCreatedAtHandlesUnixTimestamp(t *testing.T) {
+	t.Parallel()
+
+	const ts = dto.UnixTimestamp(1783476848)
+
+	chat := &dto.OpenAITextResponse{
+		Id:      "chatcmpl_1",
+		Model:   "gpt-test",
+		Created: ts, // in-process round-trip: Created holds a dto.UnixTimestamp
+	}
+
+	resp, _, err := ChatCompletionsResponseToResponsesResponse(chat, "resp_1")
+	require.NoError(t, err)
+	assert.Equal(t, ts, resp.CreatedAt)
+}

--- a/service/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
+++ b/service/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
@@ -320,7 +320,7 @@ func (s *ChatToResponsesStreamState) finalResponse() *dto.OpenAIResponsesRespons
 	return &dto.OpenAIResponsesResponse{
 		ID:                s.ID,
 		Object:            "response",
-		CreatedAt:         int(s.Created),
+		CreatedAt:         dto.UnixTimestamp(s.Created),
 		Status:            []byte(fmt.Sprintf("%q", s.status)),
 		IncompleteDetails: s.incompleteDetails,
 		Model:             s.Model,
@@ -333,7 +333,7 @@ func (s *ChatToResponsesStreamState) createdResponse() *dto.OpenAIResponsesRespo
 	return &dto.OpenAIResponsesResponse{
 		ID:        s.ID,
 		Object:    "response",
-		CreatedAt: int(s.Created),
+		CreatedAt: dto.UnixTimestamp(s.Created),
 		Status:    []byte(`"in_progress"`),
 		Model:     s.Model,
 		Output:    []dto.ResponsesOutput{},


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
经过/v1/responses的请求报错，相关报错信息如下
```
json: cannot unmarshal number 1783440046.0 into Go struct field OpenAIResponsesResponse.response.created_at of type int
json: cannot unmarshal number 1783440046.0 into Go struct field OpenAIResponsesResponse.response.created_at of type int
json: cannot unmarshal number 1783440046.0 into Go struct field OpenAIResponsesResponse.response.created_at of type int
```

## 📝 变更描述 / Description
上游返回的created_at时间存在小数的情况，导致反序列化失败报错，本PR把created_at统一为int64，截断到整数秒，解决了类型反序列化错误。本次变更覆盖了/v1/responses、/v1/responses/compact、以及 responses<->chat 互转链路

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) 

## 🔗 关联任务 / Related Issue
可能有关的PR https://github.com/QuantumNous/new-api/pull/5787

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
dto/openai_responses_created_at_test.go 增加了测试用例
```
go test ./dto ./relay/channel/openai ./service/relayconvert/... -count=1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `created_at` timestamp handling across responses and streams when provided as integers, decimals, numeric strings, or fractional values.
  * Added stricter validation to reject non-numeric strings and `NaN`/`±Inf`, while enforcing valid Unix-second ranges and truncating fractional seconds toward zero.
  * Standardized outgoing timestamp serialization to integer Unix seconds.

* **Tests**
  * Added unit tests covering float and string unmarshalling, invalid string rejection, and a regression test for round-trip timestamp conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->