### PR TITLE
fix(auth): harden passkey and 2FA verification flows

### DIFF
--- a/controller/login_verification.go
+++ b/controller/login_verification.go
@@ -1,0 +1,200 @@
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/setting/system_setting"
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	legacyPendingLoginUsernameSessionKey = "pending_username"
+	pendingLoginUserIDSessionKey         = "pending_user_id"
+	pendingLoginCreatedAtSessionKey      = "pending_login_created_at"
+	pendingLoginSourceSessionKey         = "pending_login_source"
+	pendingLoginAllow2FASessionKey       = "pending_login_allow_2fa"
+	pendingLoginAllowPasskeySessionKey   = "pending_login_allow_passkey"
+	pendingPasskeyUserIDSessionKey       = "pending_passkey_login_user_id"
+	loginMethodContextKey                = "login_method"
+	pendingLoginTimeout                  = 5 * time.Minute
+	pendingLoginFutureSkew               = 30 * time.Second
+)
+
+var errPendingLoginUnavailable = errors.New("登录验证会话不存在或已过期，请重新登录")
+
+type pendingLogin struct {
+	UserID       int
+	CreatedAt    int64
+	Source       string
+	Allow2FA     bool
+	AllowPasskey bool
+}
+
+type pendingLoginResponse struct {
+	RequireVerification bool  `json:"require_verification"`
+	Require2FA          bool  `json:"require_2fa"`
+	RequirePasskey      bool  `json:"require_passkey"`
+	ExpiresAt           int64 `json:"expires_at"`
+}
+
+func completeExternalLogin(user *model.User, c *gin.Context, source string) {
+	if user == nil || user.Id == 0 {
+		common.ApiErrorMsg(c, "用户不存在")
+		return
+	}
+	if user.Status != common.UserStatusEnabled {
+		common.ApiErrorI18n(c, i18n.MsgOAuthUserBanned)
+		return
+	}
+
+	twoFA, err := model.GetTwoFAByUserId(user.Id)
+	if err != nil {
+		common.SysLog(fmt.Sprintf("External login failed to load 2FA status for user %d: %v", user.Id, err))
+		common.ApiErrorI18n(c, i18n.MsgDatabaseError)
+		return
+	}
+	has2FA := twoFA != nil && twoFA.IsEnabled
+
+	hasPasskey := false
+	// A bound Passkey is an active login factor only while Passkey login is enabled globally.
+	if system_setting.GetPasskeySettings().Enabled {
+		credential, err := model.GetPasskeyByUserID(user.Id)
+		switch {
+		case err == nil:
+			hasPasskey = credential != nil
+		case errors.Is(err, model.ErrPasskeyNotFound):
+		case err != nil:
+			common.SysLog(fmt.Sprintf("External login failed to load Passkey status for user %d: %v", user.Id, err))
+			common.ApiErrorI18n(c, i18n.MsgDatabaseError)
+			return
+		}
+	}
+
+	if !has2FA && !hasPasskey {
+		c.Set(loginMethodContextKey, source)
+		setupLogin(user, c)
+		return
+	}
+
+	pending, err := startPendingLogin(c, user, source, has2FA, hasPasskey)
+	if err != nil {
+		common.ApiErrorI18n(c, i18n.MsgUserSessionSaveFailed)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "需要完成登录安全验证",
+		"data":    pending.response(),
+	})
+}
+
+func startPendingLogin(c *gin.Context, user *model.User, source string, allow2FA, allowPasskey bool) (*pendingLogin, error) {
+	if user == nil || user.Id == 0 || source == "" || (!allow2FA && !allowPasskey) {
+		return nil, errors.New("无效的登录验证状态")
+	}
+
+	session := sessions.Default(c)
+	session.Clear()
+	pending := &pendingLogin{
+		UserID:       user.Id,
+		CreatedAt:    time.Now().Unix(),
+		Source:       source,
+		Allow2FA:     allow2FA,
+		AllowPasskey: allowPasskey,
+	}
+	session.Set(pendingLoginUserIDSessionKey, pending.UserID)
+	session.Set(pendingLoginCreatedAtSessionKey, pending.CreatedAt)
+	session.Set(pendingLoginSourceSessionKey, pending.Source)
+	session.Set(pendingLoginAllow2FASessionKey, pending.Allow2FA)
+	session.Set(pendingLoginAllowPasskeySessionKey, pending.AllowPasskey)
+	if err := session.Save(); err != nil {
+		return nil, err
+	}
+	return pending, nil
+}
+
+func getPendingLogin(c *gin.Context) (*pendingLogin, error) {
+	session := sessions.Default(c)
+	pending, ok := pendingLoginFromSession(session)
+	if !ok {
+		clearPendingLogin(session)
+		_ = session.Save()
+		return nil, errPendingLoginUnavailable
+	}
+
+	now := time.Now().Unix()
+	if pending.CreatedAt > now+int64(pendingLoginFutureSkew/time.Second) ||
+		now-pending.CreatedAt >= int64(pendingLoginTimeout/time.Second) {
+		clearPendingLogin(session)
+		_ = session.Save()
+		return nil, errPendingLoginUnavailable
+	}
+	return pending, nil
+}
+
+func pendingLoginFromSession(session sessions.Session) (*pendingLogin, bool) {
+	userID, userIDOK := session.Get(pendingLoginUserIDSessionKey).(int)
+	createdAt, createdAtOK := session.Get(pendingLoginCreatedAtSessionKey).(int64)
+	source, sourceOK := session.Get(pendingLoginSourceSessionKey).(string)
+	allow2FA, allow2FAOK := session.Get(pendingLoginAllow2FASessionKey).(bool)
+	allowPasskey, allowPasskeyOK := session.Get(pendingLoginAllowPasskeySessionKey).(bool)
+	if !userIDOK || userID == 0 || !createdAtOK || !sourceOK || source == "" || !allow2FAOK || !allowPasskeyOK ||
+		(!allow2FA && !allowPasskey) {
+		return nil, false
+	}
+	return &pendingLogin{
+		UserID:       userID,
+		CreatedAt:    createdAt,
+		Source:       source,
+		Allow2FA:     allow2FA,
+		AllowPasskey: allowPasskey,
+	}, true
+}
+
+func (p *pendingLogin) response() pendingLoginResponse {
+	return pendingLoginResponse{
+		RequireVerification: true,
+		Require2FA:          p.Allow2FA,
+		RequirePasskey:      p.AllowPasskey,
+		ExpiresAt:           p.CreatedAt + int64(pendingLoginTimeout/time.Second),
+	}
+}
+
+func clearPendingLogin(session sessions.Session) {
+	session.Delete(legacyPendingLoginUsernameSessionKey)
+	session.Delete(pendingLoginUserIDSessionKey)
+	session.Delete(pendingLoginCreatedAtSessionKey)
+	session.Delete(pendingLoginSourceSessionKey)
+	session.Delete(pendingLoginAllow2FASessionKey)
+	session.Delete(pendingLoginAllowPasskeySessionKey)
+	session.Delete(pendingPasskeyUserIDSessionKey)
+}
+
+func completePendingLogin(c *gin.Context, pending *pendingLogin, user *model.User, factor string) {
+	if pending == nil || user == nil || pending.UserID != user.Id {
+		common.ApiError(c, fmt.Errorf("登录验证用户不匹配"))
+		return
+	}
+	if user.Status != common.UserStatusEnabled {
+		common.ApiErrorMsg(c, "该用户已被禁用")
+		return
+	}
+	c.Set(loginMethodContextKey, pending.Source+"+"+factor)
+	setupLogin(user, c)
+}
+
+func GetPendingLoginVerification(c *gin.Context) {
+	pending, err := getPendingLogin(c)
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	common.ApiSuccess(c, pending.response())
+}

--- a/controller/oauth.go
+++ b/controller/oauth.go
@@ -130,8 +130,8 @@ func HandleOAuth(c *gin.Context) {
 		return
 	}
 
-	// 9. Setup login
-	setupLogin(user, c)
+	// 9. Apply the shared local-factor gate before creating a login session.
+	completeExternalLogin(user, c, "oauth:"+providerName)
 }
 
 // handleOAuthBind handles binding OAuth account to existing user

--- a/controller/passkey.go
+++ b/controller/passkey.go
@@ -229,10 +229,47 @@ func PasskeyLoginBegin(c *gin.Context) {
 		return
 	}
 
-	assertion, sessionData, err := wa.BeginDiscoverableLogin()
-	if err != nil {
-		common.ApiError(c, err)
-		return
+	session := sessions.Default(c)
+	var assertion *protocol.CredentialAssertion
+	var sessionData *webauthnlib.SessionData
+	if c.Query("pending") == "true" {
+		pending, err := getPendingLogin(c)
+		if err != nil {
+			common.ApiError(c, err)
+			return
+		}
+		if !pending.AllowPasskey {
+			common.ApiErrorMsg(c, "当前登录验证不允许使用Passkey")
+			return
+		}
+
+		user, err := model.GetUserById(pending.UserID, false)
+		if err != nil {
+			common.ApiError(c, err)
+			return
+		}
+		if user.Status != common.UserStatusEnabled {
+			common.ApiErrorMsg(c, "该用户已被禁用")
+			return
+		}
+		credential, err := model.GetPasskeyByUserID(user.Id)
+		if err != nil {
+			common.ApiError(c, err)
+			return
+		}
+		assertion, sessionData, err = wa.BeginLogin(passkeysvc.NewWebAuthnUser(user, credential))
+		if err != nil {
+			common.ApiError(c, err)
+			return
+		}
+		session.Set(pendingPasskeyUserIDSessionKey, pending.UserID)
+	} else {
+		assertion, sessionData, err = wa.BeginDiscoverableLogin()
+		if err != nil {
+			common.ApiError(c, err)
+			return
+		}
+		session.Delete(pendingPasskeyUserIDSessionKey)
 	}
 
 	if err := passkeysvc.SaveSessionData(c, passkeysvc.LoginSessionKey, sessionData); err != nil {
@@ -264,58 +301,87 @@ func PasskeyLoginFinish(c *gin.Context) {
 		return
 	}
 
+	session := sessions.Default(c)
+	pendingUserID, isPendingLogin := session.Get(pendingPasskeyUserIDSessionKey).(int)
+	session.Delete(pendingPasskeyUserIDSessionKey)
 	sessionData, err := passkeysvc.PopSessionData(c, passkeysvc.LoginSessionKey)
 	if err != nil {
 		common.ApiError(c, err)
 		return
 	}
 
-	handler := func(rawID, userHandle []byte) (webauthnlib.User, error) {
-		// 首先通过凭证ID查找用户
-		credential, err := model.GetPasskeyByCredentialID(rawID)
+	var pending *pendingLogin
+	var modelUser *model.User
+	var credential *webauthnlib.Credential
+	if isPendingLogin {
+		pending, err = getPendingLogin(c)
 		if err != nil {
-			return nil, fmt.Errorf("未找到 Passkey 凭证: %w", err)
+			common.ApiError(c, err)
+			return
+		}
+		if !pending.AllowPasskey || pending.UserID != pendingUserID {
+			common.ApiErrorMsg(c, "Passkey 登录验证状态不匹配")
+			return
 		}
 
-		// 通过凭证获取用户
-		user := &model.User{Id: credential.UserID}
-		if err := user.FillUserById(); err != nil {
-			return nil, fmt.Errorf("用户信息获取失败: %w", err)
+		modelUser, err = model.GetUserById(pending.UserID, false)
+		if err != nil {
+			common.ApiError(c, err)
+			return
 		}
-
-		if user.Status != common.UserStatusEnabled {
-			return nil, errors.New("该用户已被禁用")
+		credentialRecord, err := model.GetPasskeyByUserID(modelUser.Id)
+		if err != nil {
+			common.ApiError(c, err)
+			return
 		}
-
-		if len(userHandle) > 0 {
-			userID, parseErr := strconv.Atoi(string(userHandle))
-			if parseErr != nil {
-				// 记录异常但继续验证，因为某些客户端可能使用非数字格式
-				common.SysLog(fmt.Sprintf("PasskeyLogin: userHandle parse error for credential, length: %d", len(userHandle)))
-			} else if userID != user.Id {
-				return nil, errors.New("用户句柄与凭证不匹配")
+		credential, err = wa.FinishLogin(passkeysvc.NewWebAuthnUser(modelUser, credentialRecord), *sessionData, c.Request)
+		if err != nil {
+			common.ApiError(c, err)
+			return
+		}
+	} else {
+		handler := func(rawID, userHandle []byte) (webauthnlib.User, error) {
+			credential, err := model.GetPasskeyByCredentialID(rawID)
+			if err != nil {
+				return nil, fmt.Errorf("未找到 Passkey 凭证: %w", err)
 			}
+
+			user := &model.User{Id: credential.UserID}
+			if err := user.FillUserById(); err != nil {
+				return nil, fmt.Errorf("用户信息获取失败: %w", err)
+			}
+			if user.Status != common.UserStatusEnabled {
+				return nil, errors.New("该用户已被禁用")
+			}
+
+			if len(userHandle) > 0 {
+				userID, parseErr := strconv.Atoi(string(userHandle))
+				if parseErr != nil {
+					common.SysLog(fmt.Sprintf("PasskeyLogin: userHandle parse error for credential, length: %d", len(userHandle)))
+				} else if userID != user.Id {
+					return nil, errors.New("用户句柄与凭证不匹配")
+				}
+			}
+
+			return passkeysvc.NewWebAuthnUser(user, credential), nil
 		}
 
-		return passkeysvc.NewWebAuthnUser(user, credential), nil
-	}
-
-	waUser, credential, err := wa.FinishPasskeyLogin(handler, *sessionData, c.Request)
-	if err != nil {
-		common.ApiError(c, err)
-		return
-	}
-
-	userWrapper, ok := waUser.(*passkeysvc.WebAuthnUser)
-	if !ok {
-		common.ApiErrorMsg(c, "Passkey 登录状态异常")
-		return
-	}
-
-	modelUser := userWrapper.ModelUser()
-	if modelUser == nil {
-		common.ApiErrorMsg(c, "Passkey 登录状态异常")
-		return
+		waUser, validatedCredential, err := wa.FinishPasskeyLogin(handler, *sessionData, c.Request)
+		if err != nil {
+			common.ApiError(c, err)
+			return
+		}
+		userWrapper, ok := waUser.(*passkeysvc.WebAuthnUser)
+		if !ok {
+			common.ApiErrorMsg(c, "Passkey 登录状态异常")
+			return
+		}
+		modelUser = userWrapper.ModelUser()
+		credential = validatedCredential
+		if modelUser == nil {
+			common.ApiErrorMsg(c, "Passkey 登录状态异常")
+			return
+		}
 	}
 
 	if modelUser.Status != common.UserStatusEnabled {
@@ -336,6 +402,10 @@ func PasskeyLoginFinish(c *gin.Context) {
 		return
 	}
 
+	if pending != nil {
+		completePendingLogin(c, pending, modelUser, "passkey")
+		return
+	}
 	setupLogin(modelUser, c)
 }
 

--- a/controller/telegram.go
+++ b/controller/telegram.go
@@ -95,7 +95,7 @@ func TelegramLogin(c *gin.Context) {
 		})
 		return
 	}
-	setupLogin(&user, c)
+	completeExternalLogin(&user, c, "telegram")
 }
 
 func checkTelegramAuthorization(params map[string][]string, token string) bool {

--- a/controller/twofa.go
+++ b/controller/twofa.go
@@ -8,7 +8,6 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/model"
 
-	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 )
 
@@ -405,31 +404,32 @@ func Verify2FALogin(c *gin.Context) {
 		return
 	}
 
-	// 从会话中获取pending用户信息
-	session := sessions.Default(c)
-	pendingUserId := session.Get("pending_user_id")
-	if pendingUserId == nil {
+	pending, err := getPendingLogin(c)
+	if err != nil {
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,
-			"message": "会话已过期，请重新登录",
+			"message": err.Error(),
 		})
 		return
 	}
-	userId, ok := pendingUserId.(int)
-	if !ok {
+	if !pending.Allow2FA {
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,
-			"message": "会话数据无效，请重新登录",
+			"message": "当前登录验证不允许使用2FA",
 		})
 		return
 	}
 	// 获取用户信息
-	user, err := model.GetUserById(userId, false)
+	user, err := model.GetUserById(pending.UserID, false)
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,
 			"message": "用户不存在",
 		})
+		return
+	}
+	if user.Status != common.UserStatusEnabled {
+		common.ApiErrorMsg(c, "该用户已被禁用")
 		return
 	}
 
@@ -477,12 +477,7 @@ func Verify2FALogin(c *gin.Context) {
 		return
 	}
 
-	// 2FA验证成功，清理pending会话信息并完成登录
-	session.Delete("pending_username")
-	session.Delete("pending_user_id")
-	session.Save()
-
-	setupLogin(user, c)
+	completePendingLogin(c, pending, user, "2fa")
 }
 
 // Admin2FAStats 管理员获取2FA统计信息

--- a/controller/user.go
+++ b/controller/user.go
@@ -74,11 +74,7 @@ func Login(c *gin.Context) {
 
 	// 检查是否启用2FA
 	if model.IsTwoFAEnabled(user.Id) {
-		// 设置pending session，等待2FA验证
-		session := sessions.Default(c)
-		session.Set("pending_username", user.Username)
-		session.Set("pending_user_id", user.Id)
-		err := session.Save()
+		pending, err := startPendingLogin(c, &user, "password", true, false)
 		if err != nil {
 			common.ApiErrorI18n(c, i18n.MsgUserSessionSaveFailed)
 			return
@@ -87,9 +83,7 @@ func Login(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
 			"message": i18n.T(c, i18n.MsgUserRequire2FA),
 			"success": true,
-			"data": map[string]interface{}{
-				"require_2fa": true,
-			},
+			"data":    pending.response(),
 		})
 		return
 	}
@@ -99,6 +93,11 @@ func Login(c *gin.Context) {
 
 // loginMethodFromContext 根据请求路径推导登录方式，用于登录审计日志。
 func loginMethodFromContext(c *gin.Context) string {
+	if method, ok := c.Get(loginMethodContextKey); ok {
+		if value, ok := method.(string); ok && value != "" {
+			return value
+		}
+	}
 	switch c.FullPath() {
 	case "/api/user/login":
 		return "password"
@@ -138,6 +137,7 @@ func recordLoginAudit(user *model.User, c *gin.Context) {
 func setupLogin(user *model.User, c *gin.Context) {
 	model.UpdateUserLastLoginAt(user.Id)
 	session := sessions.Default(c)
+	clearPendingLogin(session)
 	session.Set("id", user.Id)
 	session.Set("username", user.Username)
 	session.Set("role", user.Role)

--- a/controller/wechat.go
+++ b/controller/wechat.go
@@ -119,7 +119,7 @@ func WeChatAuth(c *gin.Context) {
 		})
 		return
 	}
-	setupLogin(&user, c)
+	completeExternalLogin(&user, c, "wechat")
 }
 
 type wechatBindRequest struct {

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -69,6 +69,7 @@ func SetApiRouter(router *gin.Engine) {
 			userRoute.POST("/register", middleware.CriticalRateLimit(), anonymousRequestBodyLimit, middleware.TurnstileCheck(), controller.Register)
 			userRoute.POST("/login", middleware.CriticalRateLimit(), anonymousRequestBodyLimit, middleware.TurnstileCheck(), controller.Login)
 			userRoute.POST("/login/2fa", middleware.CriticalRateLimit(), anonymousRequestBodyLimit, controller.Verify2FALogin)
+			userRoute.GET("/login/verification", middleware.CriticalRateLimit(), controller.GetPendingLoginVerification)
 			userRoute.POST("/passkey/login/begin", middleware.CriticalRateLimit(), anonymousRequestBodyLimit, controller.PasskeyLoginBegin)
 			userRoute.POST("/passkey/login/finish", middleware.CriticalRateLimit(), anonymousRequestBodyLimit, controller.PasskeyLoginFinish)
 			//userRoute.POST("/tokenlog", middleware.CriticalRateLimit(), controller.TokenLog)

--- a/web/default/src/features/auth/api.ts
+++ b/web/default/src/features/auth/api.ts
@@ -22,6 +22,7 @@ import type {
   LoginPayload,
   LoginResponse,
   Login2FAResponse,
+  LoginVerificationRequirements,
   TwoFAPayload,
   RegisterPayload,
   ApiResponse,
@@ -51,6 +52,19 @@ export async function login(payload: LoginPayload) {
 // Two-factor authentication login
 export async function login2fa(payload: TwoFAPayload) {
   const res = await api.post<Login2FAResponse>('/api/user/login/2fa', payload)
+  return res.data
+}
+
+export async function getPendingLoginVerification(): Promise<
+  ApiResponse<LoginVerificationRequirements>
+> {
+  const res = await api.get<ApiResponse<LoginVerificationRequirements>>(
+    '/api/user/login/verification',
+    {
+      skipBusinessError: true,
+      skipErrorHandler: true,
+    }
+  )
   return res.data
 }
 

--- a/web/default/src/features/auth/hooks/use-auth-redirect.ts
+++ b/web/default/src/features/auth/hooks/use-auth-redirect.ts
@@ -93,9 +93,9 @@ export function useAuthRedirect() {
   }
 
   /**
-   * Redirect to 2FA page
+   * Redirect to the local login verification page
    */
-  const redirectTo2FA = () => {
+  const redirectToVerification = () => {
     navigate({ to: '/otp', replace: true })
   }
 
@@ -115,7 +115,7 @@ export function useAuthRedirect() {
 
   return {
     handleLoginSuccess,
-    redirectTo2FA,
+    redirectToVerification,
     redirectToLogin,
     redirectToRegister,
   }

--- a/web/default/src/features/auth/hooks/use-passkey-login.ts
+++ b/web/default/src/features/auth/hooks/use-passkey-login.ts
@@ -1,0 +1,103 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { beginPasskeyLogin, finishPasskeyLogin } from '@/features/auth/passkey'
+import {
+  buildAssertionResult,
+  isPasskeySupported,
+  prepareCredentialRequestOptions,
+} from '@/lib/passkey'
+
+type PasskeyLoginUser = { id?: number } & Record<string, unknown>
+
+interface UsePasskeyLoginOptions {
+  pending?: boolean
+  onSuccess: (user: PasskeyLoginUser) => void | Promise<void>
+}
+
+export function usePasskeyLogin({
+  pending = false,
+  onSuccess,
+}: UsePasskeyLoginOptions) {
+  const { t } = useTranslation()
+  const [isSupported, setIsSupported] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    isPasskeySupported()
+      .then(setIsSupported)
+      .catch(() => setIsSupported(false))
+  }, [])
+
+  const login = async () => {
+    if (!isSupported || !navigator?.credentials) {
+      toast.error(t('Passkey is not available in this browser'))
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      const begin = await beginPasskeyLogin(pending)
+      if (!begin.success) {
+        throw new Error(begin.message || t('Failed to start Passkey login'))
+      }
+
+      const publicKey = prepareCredentialRequestOptions(
+        begin.data?.options ?? begin.data
+      )
+      const credential = (await navigator.credentials.get({
+        publicKey,
+      })) as PublicKeyCredential | null
+      if (!credential) {
+        toast.info(t('Passkey login was cancelled'))
+        return
+      }
+
+      const assertion = buildAssertionResult(credential)
+      if (!assertion) {
+        throw new Error(t('Invalid Passkey response'))
+      }
+
+      const finish = await finishPasskeyLogin(assertion)
+      if (!finish.success) {
+        throw new Error(finish.message || t('Failed to complete Passkey login'))
+      }
+      if (!finish.data || typeof finish.data !== 'object') {
+        throw new Error(t('Missing user data from Passkey login response'))
+      }
+
+      await onSuccess(finish.data as PasskeyLoginUser)
+    } catch (error: unknown) {
+      if (error instanceof DOMException && error.name === 'NotAllowedError') {
+        toast.info(t('Passkey login was cancelled or timed out'))
+      } else if (error instanceof Error) {
+        toast.error(error.message)
+      } else {
+        toast.error(t('Passkey login failed'))
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return { isSupported, isLoading, login }
+}

--- a/web/default/src/features/auth/otp/components/otp-form.tsx
+++ b/web/default/src/features/auth/otp/components/otp-form.tsx
@@ -16,223 +16,114 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { zodResolver } from '@hookform/resolvers/zod'
-import { Loader2 } from 'lucide-react'
 import { useState } from 'react'
-import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
-import type { z } from 'zod'
 
-import { Button } from '@/components/ui/button'
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-  FormDescription,
-} from '@/components/ui/form'
-import { Input } from '@/components/ui/input'
-import {
-  InputOTP,
-  InputOTPGroup,
-  InputOTPSlot,
-  InputOTPSeparator,
-} from '@/components/ui/input-otp'
 import { login2fa } from '@/features/auth/api'
-import {
-  otpFormSchema,
-  OTP_LENGTH,
-  BACKUP_CODE_LENGTH,
-} from '@/features/auth/constants'
 import { useAuthRedirect } from '@/features/auth/hooks/use-auth-redirect'
-import { saveUserId } from '@/features/auth/lib/storage'
+import { usePasskeyLogin } from '@/features/auth/hooks/use-passkey-login'
 import {
-  isValidOTP,
-  isValidBackupCode,
-  formatBackupCode,
-  cleanBackupCode,
-} from '@/features/auth/lib/validation'
-import type { User } from '@/features/users/types'
-import { cn } from '@/lib/utils'
-import { useAuthStore } from '@/stores/auth-store'
+  SecureVerificationDialog,
+  type SecureVerificationState,
+  type VerificationMethod,
+  type VerificationMethods,
+} from '@/features/auth/secure-verification'
+import type { LoginVerificationRequirements } from '@/features/auth/types'
 
-type OtpFormProps = React.HTMLAttributes<HTMLFormElement>
+type LoginVerificationProps = {
+  requirements: LoginVerificationRequirements
+}
 
-export function OtpForm({ className, ...props }: OtpFormProps) {
+export function LoginVerification(props: LoginVerificationProps) {
   const { t } = useTranslation()
-  const [isLoading, setIsLoading] = useState(false)
-  const [useBackupCode, setUseBackupCode] = useState(false)
-
-  const { auth } = useAuthStore()
-  const { redirectToLogin } = useAuthRedirect()
-
-  const form = useForm<z.infer<typeof otpFormSchema>>({
-    resolver: zodResolver(otpFormSchema),
-    defaultValues: { otp: '' },
+  const [method, setMethod] = useState<VerificationMethod | null>(null)
+  const [code, setCode] = useState('')
+  const [twoFALoading, setTwoFALoading] = useState(false)
+  const { handleLoginSuccess, redirectToLogin } = useAuthRedirect()
+  const has2FA = Boolean(props.requirements.require_2fa)
+  const hasPasskey = Boolean(props.requirements.require_passkey)
+  const {
+    isSupported: passkeySupported,
+    isLoading: passkeyLoading,
+    login: verifyPasskey,
+  } = usePasskeyLogin({
+    pending: true,
+    onSuccess: async (userData) => {
+      await handleLoginSuccess(userData)
+      toast.success(t('Signed in'))
+    },
   })
 
-  const otp = form.watch('otp')
+  let description = t(
+    'Use an authenticator code or Passkey to complete sign-in.'
+  )
+  if (has2FA && !hasPasskey) {
+    description = t('Please enter the authentication code.')
+  } else if (hasPasskey && !has2FA) {
+    description = t('Sign in with Passkey')
+  }
 
-  async function onSubmit(data: z.infer<typeof otpFormSchema>) {
-    // Validate based on mode
-    if (useBackupCode) {
-      if (!isValidBackupCode(data.otp)) {
-        toast.error(t('Backup code must be in format XXXX-XXXX'))
-        return
-      }
-    } else {
-      if (!isValidOTP(data.otp)) {
-        toast.error(t('Verification code must be 6 digits'))
-        return
-      }
+  const methods: VerificationMethods = {
+    has2FA,
+    hasPasskey,
+    passkeySupported,
+  }
+  const state: SecureVerificationState = {
+    method,
+    loading: twoFALoading || passkeyLoading,
+    code,
+    title: t('Additional verification required'),
+    description,
+  }
+
+  async function handleVerify(
+    verificationMethod: VerificationMethod,
+    verificationCode?: string
+  ) {
+    if (verificationMethod === 'passkey') {
+      await verifyPasskey()
+      return
     }
 
-    setIsLoading(true)
+    setTwoFALoading(true)
     try {
-      // Remove all hyphens from backup code before sending to backend
-      const code = useBackupCode ? cleanBackupCode(data.otp) : data.otp
-      const res = await login2fa({ code })
-
+      const res = await login2fa({ code: verificationCode?.trim() ?? '' })
       if (!res.success) {
-        toast.error(res.message || t('Invalid code'))
-        return
+        throw new Error(res.message || t('Invalid code'))
       }
-
-      // Handle user data from 2FA login response
-      const userData = res.data
-      if (!userData) {
+      if (!res.data) {
         throw new Error('No user data received from login')
       }
 
-      // Update auth store
-      auth.setUser(userData as User)
-
-      // Store user ID in localStorage for compatibility
-      if (userData.id) {
-        saveUserId(userData.id)
-      }
-
+      await handleLoginSuccess(res.data)
       toast.success(t('Signed in'))
-      redirectToLogin() // This will redirect to dashboard via the redirect logic
     } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('2FA verification error:', error)
-      const errorMessage =
+      toast.error(
         error instanceof Error ? error.message : t('Verification failed')
-      toast.error(errorMessage)
+      )
     } finally {
-      setIsLoading(false)
+      setTwoFALoading(false)
     }
   }
 
-  function handleToggleMode() {
-    setUseBackupCode(!useBackupCode)
-    form.setValue('otp', '')
-  }
-
-  function handleBackToLogin() {
-    redirectToLogin()
-  }
-
-  const isFormValid = useBackupCode
-    ? otp.length >= BACKUP_CODE_LENGTH
-    : otp.length >= OTP_LENGTH
-
   return (
-    <Form {...form}>
-      <form
-        onSubmit={form.handleSubmit(onSubmit)}
-        className={cn('grid gap-4', className)}
-        {...props}
-      >
-        <FormField
-          control={form.control}
-          name='otp'
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>
-                {useBackupCode ? t('Backup Code') : t('Verification Code')}
-              </FormLabel>
-              <FormControl>
-                {useBackupCode ? (
-                  <Input
-                    placeholder={t('Enter backup code (e.g., CAWD-OQDV)')}
-                    {...field}
-                    maxLength={BACKUP_CODE_LENGTH}
-                    autoComplete='off'
-                    className='font-mono uppercase'
-                    onChange={(e) => {
-                      const formatted = formatBackupCode(e.target.value)
-                      field.onChange(formatted)
-                    }}
-                  />
-                ) : (
-                  <InputOTP
-                    maxLength={OTP_LENGTH}
-                    {...field}
-                    containerClassName='justify-between sm:[&>[data-slot="input-otp-group"]>div]:w-12'
-                  >
-                    <InputOTPGroup>
-                      <InputOTPSlot index={0} />
-                      <InputOTPSlot index={1} />
-                    </InputOTPGroup>
-                    <InputOTPSeparator />
-                    <InputOTPGroup>
-                      <InputOTPSlot index={2} />
-                      <InputOTPSlot index={3} />
-                    </InputOTPGroup>
-                    <InputOTPSeparator />
-                    <InputOTPGroup>
-                      <InputOTPSlot index={4} />
-                      <InputOTPSlot index={5} />
-                    </InputOTPGroup>
-                  </InputOTP>
-                )}
-              </FormControl>
-              <FormDescription className='text-muted-foreground text-xs'>
-                {useBackupCode
-                  ? t('Each backup code can only be used once.')
-                  : t('Verification code updates every 30 seconds.')}
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <Button
-          type='submit'
-          className='mt-2 w-full'
-          disabled={!isFormValid || isLoading}
-        >
-          {isLoading ? <Loader2 className='h-4 w-4 animate-spin' /> : null}
-          {t('Verify and Sign In')}
-        </Button>
-
-        <div className='flex items-center justify-center gap-2 text-sm'>
-          <Button
-            type='button'
-            variant='link'
-            size='sm'
-            className='text-primary h-auto p-0'
-            onClick={handleToggleMode}
-          >
-            {useBackupCode ? t('Use authenticator code') : t('Use backup code')}
-          </Button>
-          <span className='text-muted-foreground'>·</span>
-          <Button
-            type='button'
-            variant='link'
-            size='sm'
-            className='text-primary h-auto p-0'
-            onClick={handleBackToLogin}
-          >
-            {t('Back to login')}
-          </Button>
-        </div>
-      </form>
-    </Form>
+    <SecureVerificationDialog
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          redirectToLogin()
+        }
+      }}
+      methods={methods}
+      state={state}
+      onVerify={handleVerify}
+      onCancel={redirectToLogin}
+      onCodeChange={setCode}
+      onMethodChange={(nextMethod) => {
+        setMethod(nextMethod)
+        setCode('')
+      }}
+    />
   )
 }

--- a/web/default/src/features/auth/otp/index.tsx
+++ b/web/default/src/features/auth/otp/index.tsx
@@ -16,37 +16,55 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { Link } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
+import { Loader2 } from 'lucide-react'
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { getPendingLoginVerification } from '@/features/auth/api'
 
 import { AuthLayout } from '../auth-layout'
-import { OtpForm } from './components/otp-form'
+import { LoginVerification } from './components/otp-form'
 
 export function Otp() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
+  const verificationQuery = useQuery({
+    queryKey: ['auth', 'pending-login-verification'],
+    queryFn: async () => {
+      const response = await getPendingLoginVerification()
+      if (!response.success || !response.data?.require_verification) {
+        throw new Error(response.message || t('Login session has expired'))
+      }
+      return response.data
+    },
+    retry: false,
+    gcTime: 0,
+  })
+  const requirements = verificationQuery.data
+
+  useEffect(() => {
+    if (!verificationQuery.error) {
+      return
+    }
+    toast.error(
+      verificationQuery.error instanceof Error
+        ? verificationQuery.error.message
+        : t('Login session has expired')
+    )
+    navigate({ to: '/sign-in', replace: true })
+  }, [navigate, t, verificationQuery.error])
+
   return (
     <AuthLayout>
-      <div className='w-full space-y-8'>
-        <div className='space-y-3'>
-          <h2 className='text-center text-2xl font-semibold tracking-tight sm:text-left'>
-            {t('Two-factor Authentication')}
-          </h2>
-          <p className='text-muted-foreground text-left text-sm sm:text-base'>
-            {t('Please enter the authentication code.')}
-          </p>
-          <p className='text-muted-foreground text-left text-sm sm:text-base'>
-            {t('Session expired?')}{' '}
-            <Link
-              to='/sign-in'
-              className='hover:text-primary font-medium underline underline-offset-4'
-            >
-              {t('Re-login')}
-            </Link>
-            .
-          </p>
-        </div>
-
-        <OtpForm />
+      <div className='flex min-h-48 w-full items-center justify-center'>
+        {requirements ? (
+          <LoginVerification requirements={requirements} />
+        ) : (
+          <Loader2 className='text-muted-foreground h-5 w-5 animate-spin' />
+        )}
       </div>
     </AuthLayout>
   )

--- a/web/default/src/features/auth/passkey/api.ts
+++ b/web/default/src/features/auth/passkey/api.ts
@@ -49,11 +49,13 @@ export async function deletePasskey(): Promise<ApiResponse> {
   return res.data
 }
 
-export async function beginPasskeyLogin(): Promise<
-  ApiResponse<PasskeyOptionsPayload>
-> {
+export async function beginPasskeyLogin(
+  pending = false
+): Promise<ApiResponse<PasskeyOptionsPayload>> {
   const res = await api.post<ApiResponse<PasskeyOptionsPayload>>(
-    '/api/user/passkey/login/begin'
+    '/api/user/passkey/login/begin',
+    undefined,
+    pending ? { params: { pending: true } } : undefined
   )
   return res.data
 }

--- a/web/default/src/features/auth/secure-verification/components/secure-verification-dialog.tsx
+++ b/web/default/src/features/auth/secure-verification/components/secure-verification-dialog.tsx
@@ -24,6 +24,13 @@ import { Dialog } from '@/components/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { BACKUP_CODE_LENGTH } from '@/features/auth/constants'
+import {
+  cleanBackupCode,
+  formatBackupCode,
+  isValidBackupCode,
+  isValidOTP,
+} from '@/features/auth/lib/validation'
 
 import type {
   SecureVerificationState,
@@ -56,7 +63,7 @@ export function SecureVerificationDialog({
   const availableTabs: VerificationMethod[] = useMemo(() => {
     const tabs: VerificationMethod[] = []
     if (methods.has2FA) tabs.push('2fa')
-    if (methods.hasPasskey && methods.passkeySupported) tabs.push('passkey')
+    if (methods.hasPasskey) tabs.push('passkey')
     return tabs
   }, [methods])
 
@@ -75,15 +82,23 @@ export function SecureVerificationDialog({
       ? 'Confirm your identity before accessing this sensitive action.'
       : 'Enable Two-factor Authentication or Passkey in your profile settings to continue.')
 
+  const verificationCode = state.code.trim()
+  const verificationCodeIsValid =
+    isValidOTP(verificationCode) || isValidBackupCode(verificationCode)
+
   const handleVerify = () => {
     if (!activeMethod) return
-    const payload = activeMethod === '2fa' ? state.code : undefined
+    const payload =
+      activeMethod === '2fa'
+        ? cleanBackupCode(verificationCode)
+        : undefined
     onVerify(activeMethod, payload)
   }
 
   const verifyDisabled =
     state.loading ||
-    (activeMethod === '2fa' && (!state.code.trim() || state.code.length < 6))
+    (activeMethod === 'passkey' && !methods.passkeySupported) ||
+    (activeMethod === '2fa' && !verificationCodeIsValid)
 
   return (
     <Dialog
@@ -146,7 +161,7 @@ export function SecureVerificationDialog({
             {methods.has2FA && (
               <TabsTrigger value='2fa'>{t('Authenticator code')}</TabsTrigger>
             )}
-            {methods.hasPasskey && methods.passkeySupported && (
+            {methods.hasPasskey && (
               <TabsTrigger value='passkey'>{t('Passkey')}</TabsTrigger>
             )}
           </TabsList>
@@ -158,13 +173,23 @@ export function SecureVerificationDialog({
               )}
             </p>
             <Input
-              inputMode='numeric'
-              maxLength={8}
+              inputMode='text'
+              maxLength={BACKUP_CODE_LENGTH}
               value={state.code}
-              onChange={(event) => onCodeChange(event.target.value)}
+              onChange={(event) => {
+                const nextCode = event.target.value
+                onCodeChange(
+                  /^\d{0,6}$/.test(nextCode)
+                    ? nextCode
+                    : formatBackupCode(nextCode)
+                )
+              }}
               placeholder={t('Enter verification code')}
               disabled={state.loading}
+              autoComplete='one-time-code'
+              autoCapitalize='characters'
               autoFocus={activeMethod === '2fa'}
+              className='font-mono uppercase'
               onKeyDown={(event) => {
                 if (event.key === 'Enter' && !verifyDisabled) {
                   event.preventDefault()

--- a/web/default/src/features/auth/sign-in/components/user-auth-form.tsx
+++ b/web/default/src/features/auth/sign-in/components/user-auth-form.tsx
@@ -44,15 +44,13 @@ import { LegalConsent } from '@/features/auth/components/legal-consent'
 import { OAuthProviders } from '@/features/auth/components/oauth-providers'
 import { loginFormSchema } from '@/features/auth/constants'
 import { useAuthRedirect } from '@/features/auth/hooks/use-auth-redirect'
+import { usePasskeyLogin } from '@/features/auth/hooks/use-passkey-login'
 import { useTurnstile } from '@/features/auth/hooks/use-turnstile'
-import { beginPasskeyLogin, finishPasskeyLogin } from '@/features/auth/passkey'
-import type { AuthFormProps } from '@/features/auth/types'
+import type {
+  AuthFormProps,
+  LoginVerificationRequirements,
+} from '@/features/auth/types'
 import { useStatus } from '@/hooks/use-status'
-import {
-  buildAssertionResult,
-  prepareCredentialRequestOptions,
-  isPasskeySupported as detectPasskeySupport,
-} from '@/lib/passkey'
 import { cn } from '@/lib/utils'
 
 export function UserAuthForm({
@@ -64,8 +62,6 @@ export function UserAuthForm({
   const [isLoading, setIsLoading] = useState(false)
   const [wechatCode, setWeChatCode] = useState('')
   const [agreedToLegal, setAgreedToLegal] = useState(false)
-  const [passkeySupported, setPasskeySupported] = useState(false)
-  const [isPasskeyLoading, setIsPasskeyLoading] = useState(false)
   const [isWeChatDialogOpen, setIsWeChatDialogOpen] = useState(false)
   const [isWeChatSubmitting, setIsWeChatSubmitting] = useState(false)
   const legalConsentErrorMessage = t('Please agree to the legal terms first')
@@ -86,7 +82,17 @@ export function UserAuthForm({
     setTurnstileToken,
     validateTurnstile,
   } = useTurnstile()
-  const { handleLoginSuccess, redirectTo2FA } = useAuthRedirect()
+  const { handleLoginSuccess, redirectToVerification } = useAuthRedirect()
+  const {
+    isSupported: passkeySupported,
+    isLoading: isPasskeyLoading,
+    login: executePasskeyLogin,
+  } = usePasskeyLogin({
+    onSuccess: async (userData) => {
+      await handleLoginSuccess(userData, redirectTo)
+      toast.success(t('Signed in with Passkey'))
+    },
+  })
 
   const hasUserAgreement = Boolean(status?.user_agreement_enabled)
   const hasPrivacyPolicy = Boolean(status?.privacy_policy_enabled)
@@ -114,12 +120,6 @@ export function UserAuthForm({
       setAgreedToLegal(true)
     }
   }, [requiresLegalConsent])
-
-  useEffect(() => {
-    detectPasskeySupport()
-      .then(setPasskeySupported)
-      .catch(() => setPasskeySupported(false))
-  }, [])
 
   const form = useForm<z.infer<typeof loginFormSchema>>({
     resolver: zodResolver(loginFormSchema),
@@ -160,8 +160,8 @@ export function UserAuthForm({
       })
 
       if (res.success) {
-        if (res.data?.require_2fa) {
-          redirectTo2FA()
+        if (res.data?.require_verification) {
+          redirectToVerification()
           return
         }
 
@@ -202,6 +202,12 @@ export function UserAuthForm({
     try {
       const res = await wechatLoginByCode(wechatCode)
       if (res?.success) {
+        const loginData = res.data as LoginVerificationRequirements | undefined
+        if (loginData?.require_verification) {
+          handleWeChatDialogChange(false)
+          redirectToVerification()
+          return
+        }
         await handleLoginSuccess(res.data as { id?: number } | null, redirectTo)
         toast.success(t('Signed in via WeChat'))
         handleWeChatDialogChange(false)
@@ -221,66 +227,7 @@ export function UserAuthForm({
       return
     }
 
-    if (!passkeySupported) {
-      toast.error(t('Passkey is not supported on this device'))
-      return
-    }
-
-    if (!navigator?.credentials) {
-      toast.error(t('Passkey is not available in this browser'))
-      return
-    }
-
-    setIsPasskeyLoading(true)
-    try {
-      const begin = await beginPasskeyLogin()
-      if (!begin.success) {
-        throw new Error(begin.message || t('Failed to start Passkey login'))
-      }
-
-      const publicKey = prepareCredentialRequestOptions(
-        begin.data?.options ?? begin.data
-      )
-
-      const credential = (await navigator.credentials.get({
-        publicKey,
-      })) as PublicKeyCredential | null
-
-      if (!credential) {
-        toast.info(t('Passkey login was cancelled'))
-        return
-      }
-
-      const assertion = buildAssertionResult(credential)
-      if (!assertion) {
-        throw new Error(t('Invalid Passkey response'))
-      }
-
-      const finish = await finishPasskeyLogin(assertion)
-      if (!finish.success) {
-        throw new Error(finish.message || t('Failed to complete Passkey login'))
-      }
-
-      if (!finish.data) {
-        throw new Error(t('Missing user data from Passkey login response'))
-      }
-
-      await handleLoginSuccess(
-        finish.data as { id?: number } | null,
-        redirectTo
-      )
-      toast.success(t('Signed in with Passkey'))
-    } catch (error: unknown) {
-      if (error instanceof DOMException && error.name === 'NotAllowedError') {
-        toast.info(t('Passkey login was cancelled or timed out'))
-      } else if (error instanceof Error) {
-        toast.error(error.message)
-      } else {
-        toast.error(t('Passkey login failed'))
-      }
-    } finally {
-      setIsPasskeyLoading(false)
-    }
+    await executePasskeyLogin()
   }
 
   const alternativeLoginMethods = (

--- a/web/default/src/features/auth/sign-up/components/sign-up-form.tsx
+++ b/web/default/src/features/auth/sign-up/components/sign-up-form.tsx
@@ -49,6 +49,7 @@ import {
   getAffiliateCode,
   saveAffiliateCode,
 } from '@/features/auth/lib/storage'
+import type { LoginVerificationRequirements } from '@/features/auth/types'
 import { useStatus } from '@/hooks/use-status'
 import { cn } from '@/lib/utils'
 
@@ -73,7 +74,8 @@ export function SignUpForm({
     setTurnstileToken,
     validateTurnstile,
   } = useTurnstile()
-  const { redirectToLogin, handleLoginSuccess } = useAuthRedirect()
+  const { redirectToLogin, redirectToVerification, handleLoginSuccess } =
+    useAuthRedirect()
   const {
     isSending: isSendingCode,
     secondsLeft,
@@ -210,6 +212,12 @@ export function SignUpForm({
     try {
       const res = await wechatLoginByCode(wechatCode)
       if (res?.success) {
+        const loginData = res.data as LoginVerificationRequirements | undefined
+        if (loginData?.require_verification) {
+          handleWeChatDialogChange(false)
+          redirectToVerification()
+          return
+        }
         await handleLoginSuccess(res.data as { id?: number } | null)
         toast.success(t('Signed in via WeChat'))
         handleWeChatDialogChange(false)

--- a/web/default/src/features/auth/types.ts
+++ b/web/default/src/features/auth/types.ts
@@ -63,10 +63,14 @@ export interface BindEmailPayload {
 export interface LoginResponse {
   success: boolean
   message: string
-  data?: {
-    require_2fa?: boolean
-    id?: number
-  }
+  data?: LoginVerificationRequirements & { id?: number }
+}
+
+export interface LoginVerificationRequirements {
+  require_verification?: boolean
+  require_2fa?: boolean
+  require_passkey?: boolean
+  expires_at?: number
 }
 
 export interface Login2FAResponse {
@@ -75,10 +79,10 @@ export interface Login2FAResponse {
   data?: User
 }
 
-export interface ApiResponse {
+export interface ApiResponse<T = unknown> {
   success: boolean
   message: string
-  data?: unknown
+  data?: T
 }
 
 // ============================================================================

--- a/web/default/src/i18n/locales/en.json
+++ b/web/default/src/i18n/locales/en.json
@@ -5178,6 +5178,9 @@
     "Zero retention": "Zero retention",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Additional verification required": "Additional verification required",
+    "Use an authenticator code or Passkey to complete sign-in.": "Use an authenticator code or Passkey to complete sign-in.",
+    "Login session has expired": "Login session has expired"
   }
 }

--- a/web/default/src/i18n/locales/fr.json
+++ b/web/default/src/i18n/locales/fr.json
@@ -5178,6 +5178,9 @@
     "Zero retention": "Aucune rétention",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Additional verification required": "Vérification supplémentaire requise",
+    "Use an authenticator code or Passkey to complete sign-in.": "Utilisez un code d’authentification ou une Passkey pour terminer la connexion.",
+    "Login session has expired": "La session de connexion a expiré"
   }
 }

--- a/web/default/src/i18n/locales/ja.json
+++ b/web/default/src/i18n/locales/ja.json
@@ -5178,6 +5178,9 @@
     "Zero retention": "データ保持なし",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V 4",
-    "Zoom": "ズーム"
+    "Zoom": "ズーム",
+    "Additional verification required": "追加の認証が必要です",
+    "Use an authenticator code or Passkey to complete sign-in.": "認証アプリのコードまたは Passkey を使用してログインを完了してください。",
+    "Login session has expired": "ログインセッションの有効期限が切れました"
   }
 }

--- a/web/default/src/i18n/locales/ru.json
+++ b/web/default/src/i18n/locales/ru.json
@@ -5178,6 +5178,9 @@
     "Zero retention": "Без хранения данных",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Additional verification required": "Требуется дополнительная проверка",
+    "Use an authenticator code or Passkey to complete sign-in.": "Используйте код аутентификатора или Passkey, чтобы завершить вход.",
+    "Login session has expired": "Сеанс входа истёк"
   }
 }

--- a/web/default/src/i18n/locales/vi.json
+++ b/web/default/src/i18n/locales/vi.json
@@ -5178,6 +5178,9 @@
     "Zero retention": "Không lưu dữ liệu",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Additional verification required": "Cần xác minh bổ sung",
+    "Use an authenticator code or Passkey to complete sign-in.": "Dùng mã xác thực hoặc Passkey để hoàn tất đăng nhập.",
+    "Login session has expired": "Phiên đăng nhập đã hết hạn"
   }
 }

--- a/web/default/src/i18n/locales/zh-TW.json
+++ b/web/default/src/i18n/locales/zh-TW.json
@@ -5178,6 +5178,9 @@
     "Zero retention": "零數據保留",
     "Zhipu": "智譜",
     "Zhipu V4": "智譜 V4",
-    "Zoom": "縮放"
+    "Zoom": "縮放",
+    "Additional verification required": "需要額外驗證",
+    "Use an authenticator code or Passkey to complete sign-in.": "使用驗證器代碼或 Passkey 完成登入。",
+    "Login session has expired": "登入工作階段已過期"
   }
 }

--- a/web/default/src/i18n/locales/zh.json
+++ b/web/default/src/i18n/locales/zh.json
@@ -5178,6 +5178,9 @@
     "Zero retention": "零数据保留",
     "Zhipu": "智谱",
     "Zhipu V4": "智谱 V4",
-    "Zoom": "缩放"
+    "Zoom": "缩放",
+    "Additional verification required": "需要额外验证",
+    "Use an authenticator code or Passkey to complete sign-in.": "使用身份验证器代码或 Passkey 完成登录。",
+    "Login session has expired": "登录会话已过期"
   }
 }

--- a/web/default/src/routes/(auth)/oauth.tsx
+++ b/web/default/src/routes/(auth)/oauth.tsx
@@ -22,6 +22,7 @@ import { useEffect } from 'react'
 import { toast } from 'sonner'
 
 import { wechatLoginByCode } from '@/features/auth/api'
+import type { LoginVerificationRequirements } from '@/features/auth/types'
 import { getSelf } from '@/lib/api'
 import { useAuthStore, type AuthUser } from '@/stores/auth-store'
 
@@ -38,7 +39,14 @@ function OAuthComponent() {
     ;(async () => {
       try {
         if (search?.provider === 'wechat' && search.code) {
-          await wechatLoginByCode(search.code)
+          const response = await wechatLoginByCode(search.code)
+          const loginData = response.data as
+            | LoginVerificationRequirements
+            | undefined
+          if (response.success && loginData?.require_verification) {
+            navigate({ to: '/otp', replace: true })
+            return
+          }
         }
         const res = await getSelf()
         if (res?.success) {

--- a/web/default/src/routes/oauth/$provider.tsx
+++ b/web/default/src/routes/oauth/$provider.tsx
@@ -29,6 +29,7 @@ import { toast } from 'sonner'
 
 import { OAuthCallbackScreen } from '@/features/auth/components/oauth-callback-screen'
 import { OAUTH_BIND_STORAGE_KEY } from '@/features/auth/constants'
+import type { LoginVerificationRequirements } from '@/features/auth/types'
 import { api, getSelf } from '@/lib/api'
 import { useAuthStore, type AuthUser } from '@/stores/auth-store'
 
@@ -171,7 +172,9 @@ function OAuthCallback() {
         const res = await api.get(`/api/oauth/${provider}`, config)
         if (res?.data?.success) {
           const { message } = res.data
-          const loginUser = (res.data?.data ?? null) as AuthUser | null
+          const loginUser = (res.data?.data ?? null) as
+            | (AuthUser & LoginVerificationRequirements)
+            | null
           // Check if this is a bind operation
           if (message === 'bind') {
             toast.success(i18next.t('Binding successful!'))
@@ -182,6 +185,10 @@ function OAuthCallback() {
             } else {
               safeNavigate('/_authenticated/profile/')
             }
+            return
+          }
+          if (loginUser?.require_verification) {
+            safeNavigate('/otp')
             return
           }
           // Otherwise it's a login, use payload user if available


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

oauth和常规auth都需要2fa和passkey

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified login verification flow for authenticator codes and Passkeys.
  * External sign-ins may now require additional verification before access is granted.
  * Added verification status checks, session expiration handling, and automatic redirect to sign-in when sessions expire.
  * Added Passkey verification support during pending logins.
  * Added localized messages for verification requirements and expired login sessions.

* **Improvements**
  * Enhanced verification forms with backup-code formatting and validation.
  * Improved Passkey login feedback for unsupported browsers, cancellations, and failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->