### PR TITLE
修复异步视频输出 Token 计费

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -588,6 +588,7 @@ func RelayTask(c *gin.Context) {
 			ModelPrice:      relayInfo.PriceData.ModelPrice,
 			GroupRatio:      relayInfo.PriceData.GroupRatioInfo.GroupRatio,
 			ModelRatio:      relayInfo.PriceData.ModelRatio,
+			CompletionRatio: common.GetPointer(relayInfo.PriceData.CompletionRatio),
 			OtherRatios:     relayInfo.PriceData.OtherRatios(),
 			OriginModelName: relayInfo.OriginModelName,
 			PerCallBilling:  common.StringsContains(constant.TaskPricePatches, relayInfo.OriginModelName) || relayInfo.PriceData.UsePrice,

--- a/model/task.go
+++ b/model/task.go
@@ -113,6 +113,7 @@ type TaskBillingContext struct {
 	ModelPrice      float64            `json:"model_price,omitempty"`       // 模型单价
 	GroupRatio      float64            `json:"group_ratio,omitempty"`       // 分组倍率
 	ModelRatio      float64            `json:"model_ratio,omitempty"`       // 模型倍率
+	CompletionRatio *float64           `json:"completion_ratio,omitempty"`  // 输出倍率；指针用于兼容未保存该字段的历史任务
 	OtherRatios     map[string]float64 `json:"other_ratios,omitempty"`      // 附加倍率（时长、分辨率等）
 	OriginModelName string             `json:"origin_model_name,omitempty"` // 模型名称，必须为OriginModelName
 	PerCallBilling  bool               `json:"per_call_billing,omitempty"`  // 按次计费：跳过轮询阶段的差额结算

--- a/relay/helper/price.go
+++ b/relay/helper/price.go
@@ -189,6 +189,7 @@ func ModelPriceHelperPerCall(c *gin.Context, info *relaycommon.RelayInfo) (types
 	modelPrice, success := ratio_setting.GetModelPrice(info.OriginModelName, true)
 	usePrice := success
 	var modelRatio float64
+	var completionRatio float64
 
 	if !success {
 		defaultPrice, ok := ratio_setting.GetDefaultModelPriceMap()[info.OriginModelName]
@@ -199,6 +200,7 @@ func ModelPriceHelperPerCall(c *gin.Context, info *relaycommon.RelayInfo) (types
 			var ratioSuccess bool
 			var matchName string
 			modelRatio, ratioSuccess, matchName = ratio_setting.GetModelRatio(info.OriginModelName)
+			completionRatio = ratio_setting.GetCompletionRatio(info.OriginModelName)
 			acceptUnsetRatio := false
 			if info.UserSetting.AcceptUnsetRatioModel {
 				acceptUnsetRatio = true
@@ -244,6 +246,7 @@ func ModelPriceHelperPerCall(c *gin.Context, info *relaycommon.RelayInfo) (types
 		FreeModel:      freeModel,
 		ModelPrice:     modelPrice,
 		ModelRatio:     modelRatio,
+		CompletionRatio: completionRatio,
 		UsePrice:       usePrice,
 		Quota:          quota,
 		GroupRatioInfo: groupRatioInfo,

--- a/relay/helper/price.go
+++ b/relay/helper/price.go
@@ -227,12 +227,9 @@ func ModelPriceHelperPerCall(c *gin.Context, info *relaycommon.RelayInfo) (types
 			}
 		}
 	} else {
-		// 按量计费：以模型倍率的一半作为预扣额度
-		var err error
-		quota, err = common.QuotaFromFloatStrict(modelRatio / 2 * common.QuotaPerUnit * groupRatioInfo.GroupRatio)
-		if err != nil {
-			return types.PriceData{}, err
-		}
+		// 按 Token 计费的异步任务只能在上游返回 usage 后确定费用，提交时不预扣。
+		// 任务完成后由 RecalculateTaskQuotaByTokens 按输入、输出 Token 差额结算。
+		quota = 0
 		modelPrice = -1
 		if !operation_setting.GetQuotaSetting().EnableFreeModelPreConsume {
 			if groupRatioInfo.GroupRatio == 0 || modelRatio == 0 {

--- a/relay/helper/price.go
+++ b/relay/helper/price.go
@@ -227,9 +227,12 @@ func ModelPriceHelperPerCall(c *gin.Context, info *relaycommon.RelayInfo) (types
 			}
 		}
 	} else {
-		// 按 Token 计费的异步任务只能在上游返回 usage 后确定费用，提交时不预扣。
-		// 任务完成后由 RecalculateTaskQuotaByTokens 按输入、输出 Token 差额结算。
-		quota = 0
+		// 按量计费：以模型倍率的一半作为预扣额度，任务完成后按实际 usage 差额结算。
+		var err error
+		quota, err = common.QuotaFromFloatStrict(modelRatio / 2 * common.QuotaPerUnit * groupRatioInfo.GroupRatio)
+		if err != nil {
+			return types.PriceData{}, err
+		}
 		modelPrice = -1
 		if !operation_setting.GetQuotaSetting().EnableFreeModelPreConsume {
 			if groupRatioInfo.GroupRatio == 0 || modelRatio == 0 {

--- a/relay/helper/price_test.go
+++ b/relay/helper/price_test.go
@@ -300,7 +300,7 @@ func TestModelPriceHelperPerCallIncludesCompletionRatio(t *testing.T) {
 
 	require.NoError(t, err)
 	require.False(t, priceData.UsePrice)
-	require.Zero(t, priceData.Quota)
+	require.Equal(t, 125000, priceData.Quota)
 	require.Equal(t, 0.5, priceData.ModelRatio)
 	require.Equal(t, 4.0, priceData.CompletionRatio)
 }

--- a/relay/helper/price_test.go
+++ b/relay/helper/price_test.go
@@ -300,6 +300,7 @@ func TestModelPriceHelperPerCallIncludesCompletionRatio(t *testing.T) {
 
 	require.NoError(t, err)
 	require.False(t, priceData.UsePrice)
+	require.Zero(t, priceData.Quota)
 	require.Equal(t, 0.5, priceData.ModelRatio)
 	require.Equal(t, 4.0, priceData.CompletionRatio)
 }

--- a/relay/helper/price_test.go
+++ b/relay/helper/price_test.go
@@ -272,3 +272,34 @@ func TestModelPriceHelperRequestBillingRatiosOnlyApplyToFixedPrice(t *testing.T)
 	require.Equal(t, common.QuotaClampOverflow, clamp.Kind)
 	require.Nil(t, info.Billing)
 }
+
+func TestModelPriceHelperPerCallIncludesCompletionRatio(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	savedModelPrices := ratio_setting.ModelPrice2JSONString()
+	savedModelRatios := ratio_setting.ModelRatio2JSONString()
+	savedCompletionRatios := ratio_setting.CompletionRatio2JSONString()
+	t.Cleanup(func() {
+		require.NoError(t, ratio_setting.UpdateModelPriceByJSONString(savedModelPrices))
+		require.NoError(t, ratio_setting.UpdateModelRatioByJSONString(savedModelRatios))
+		require.NoError(t, ratio_setting.UpdateCompletionRatioByJSONString(savedCompletionRatios))
+	})
+
+	require.NoError(t, ratio_setting.UpdateModelPriceByJSONString(`{}`))
+	require.NoError(t, ratio_setting.UpdateModelRatioByJSONString(`{"task-output-model":0.5}`))
+	require.NoError(t, ratio_setting.UpdateCompletionRatioByJSONString(`{"task-output-model":4}`))
+
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Set("group", "default")
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "task-output-model",
+		UserGroup:       "default",
+		UsingGroup:      "default",
+	}
+
+	priceData, err := ModelPriceHelperPerCall(ctx, info)
+
+	require.NoError(t, err)
+	require.False(t, priceData.UsePrice)
+	require.Equal(t, 0.5, priceData.ModelRatio)
+	require.Equal(t, 4.0, priceData.CompletionRatio)
+}

--- a/service/task_billing.go
+++ b/service/task_billing.go
@@ -126,6 +126,9 @@ func taskBillingOther(task *model.Task) map[string]interface{} {
 		if bc.ModelRatio > 0 {
 			other["model_ratio"] = bc.ModelRatio
 		}
+		if bc.CompletionRatio != nil {
+			other["completion_ratio"] = *bc.CompletionRatio
+		}
 		other["group_ratio"] = bc.GroupRatio
 		if priceData := taskBillingContextPriceData(bc); priceData != nil {
 			for k, v := range priceData.OtherRatios() {
@@ -266,42 +269,48 @@ func RecalculateTaskQuota(ctx context.Context, task *model.Task, actualQuota int
 }
 
 // RecalculateTaskQuotaByTokens 根据实际 token 消耗重新计费（异步差额结算）。
-// 当任务成功且返回了 totalTokens 时，根据模型倍率和分组倍率重新计算实际扣费额度，
-// 与预扣费的差额进行补扣或退还。支持钱包和订阅计费来源。
-func RecalculateTaskQuotaByTokens(ctx context.Context, task *model.Task, totalTokens int) {
-	if totalTokens <= 0 {
+// 上游返回 completionTokens 时区分输入和输出计费；仅返回 totalTokens 时保留历史语义。
+func RecalculateTaskQuotaByTokens(ctx context.Context, task *model.Task, totalTokens, completionTokens int) {
+	if totalTokens <= 0 && completionTokens <= 0 {
 		return
 	}
 
 	modelName := taskModelName(task)
+	modelRatio := 0.0
+	completionRatio := ratio_setting.GetCompletionRatio(modelName)
+	finalGroupRatio := 0.0
 
-	// 获取模型价格和倍率
-	modelRatio, hasRatioSetting, _ := ratio_setting.GetModelRatio(modelName)
-	// 只有配置了倍率(非固定价格)时才按 token 重新计费
-	if !hasRatioSetting || modelRatio <= 0 {
-		return
-	}
+	if billingContext := task.PrivateData.BillingContext; billingContext != nil {
+		modelRatio = billingContext.ModelRatio
+		finalGroupRatio = billingContext.GroupRatio
+		if billingContext.CompletionRatio != nil {
+			completionRatio = *billingContext.CompletionRatio
+		}
+	} else {
+		var hasRatioSetting bool
+		modelRatio, hasRatioSetting, _ = ratio_setting.GetModelRatio(modelName)
+		if !hasRatioSetting {
+			return
+		}
 
-	// 获取用户和组的倍率信息
-	group := task.Group
-	if group == "" {
-		user, err := model.GetUserById(task.UserId, false)
-		if err == nil {
-			group = user.Group
+		group := task.Group
+		if group == "" {
+			user, err := model.GetUserById(task.UserId, false)
+			if err == nil {
+				group = user.Group
+			}
+		}
+		if group == "" {
+			return
+		}
+
+		finalGroupRatio = ratio_setting.GetGroupRatio(group)
+		if userGroupRatio, ok := ratio_setting.GetGroupGroupRatio(group, group); ok {
+			finalGroupRatio = userGroupRatio
 		}
 	}
-	if group == "" {
+	if modelRatio <= 0 {
 		return
-	}
-
-	groupRatio := ratio_setting.GetGroupRatio(group)
-	userGroupRatio, hasUserGroupRatio := ratio_setting.GetGroupGroupRatio(group, group)
-
-	var finalGroupRatio float64
-	if hasUserGroupRatio {
-		finalGroupRatio = userGroupRatio
-	} else {
-		finalGroupRatio = groupRatio
 	}
 
 	// 计算 OtherRatios 乘积（视频折扣、时长等）
@@ -310,9 +319,20 @@ func RecalculateTaskQuotaByTokens(ctx context.Context, task *model.Task, totalTo
 		otherMultiplier = priceData.OtherRatioMultiplier()
 	}
 
-	// 计算实际应扣费额度: totalTokens * modelRatio * groupRatio * otherMultiplier（饱和转换，防止溢出成负数）
-	actualQuota, clamp := common.QuotaFromFloatChecked(float64(totalTokens) * modelRatio * finalGroupRatio * otherMultiplier)
+	billableTokens := float64(totalTokens)
+	inputTokens := totalTokens
+	if completionTokens > 0 {
+		inputTokens = totalTokens - completionTokens
+		if inputTokens < 0 {
+			inputTokens = 0
+		}
+		billableTokens = float64(inputTokens) + float64(completionTokens)*completionRatio
+	}
 
-	reason := fmt.Sprintf("token重算：tokens=%d, modelRatio=%.2f, groupRatio=%.2f, otherMultiplier=%.4f", totalTokens, modelRatio, finalGroupRatio, otherMultiplier)
+	// 计算实际应扣费额度并使用饱和转换，防止异常 usage 导致额度回绕为负数。
+	actualQuota, clamp := common.QuotaFromFloatChecked(billableTokens * modelRatio * finalGroupRatio * otherMultiplier)
+
+	reason := fmt.Sprintf("token重算：totalTokens=%d, inputTokens=%d, completionTokens=%d, modelRatio=%.2f, completionRatio=%.2f, groupRatio=%.2f, otherMultiplier=%.4f",
+		totalTokens, inputTokens, completionTokens, modelRatio, completionRatio, finalGroupRatio, otherMultiplier)
 	RecalculateTaskQuota(ctx, task, actualQuota, reason, clamp)
 }

--- a/service/task_billing_test.go
+++ b/service/task_billing_test.go
@@ -817,3 +817,67 @@ func TestSettle_NonPerCallBilling_AppliesAdaptorAdjustment(t *testing.T) {
 	require.NotNil(t, log)
 	assert.Equal(t, model.LogTypeRefund, log.Type)
 }
+
+func TestSettle_TokenBilling_AppliesCompletionRatioSnapshot(t *testing.T) {
+	truncate(t)
+	ctx := context.Background()
+
+	const userID, tokenID, channelID = 33, 33, 33
+	const initQuota, preConsumed, tokenRemain = 10000, 100, 8000
+
+	seedUser(t, userID, initQuota)
+	seedToken(t, tokenID, userID, "sk-token-output-ratio", tokenRemain)
+	seedChannel(t, channelID)
+
+	task := makeTask(userID, channelID, preConsumed, tokenID, BillingSourceWallet, 0)
+	task.PrivateData.BillingContext.ModelRatio = 2
+	task.PrivateData.BillingContext.CompletionRatio = common.GetPointer(3.0)
+	task.PrivateData.BillingContext.GroupRatio = 0.5
+	task.PrivateData.BillingContext.OtherRatios = map[string]float64{"resolution": 2}
+
+	adaptor := &mockAdaptor{}
+	taskResult := &relaycommon.TaskInfo{
+		Status:           model.TaskStatusSuccess,
+		TotalTokens:      100,
+		CompletionTokens: 80,
+	}
+
+	settleTaskBillingOnComplete(ctx, adaptor, task, taskResult)
+
+	// ((100-80)*2 + 80*2*3) * 0.5 * 2 = 520
+	const actualQuota = 520
+	assert.Equal(t, actualQuota, task.Quota)
+	assert.Equal(t, initQuota-(actualQuota-preConsumed), getUserQuota(t, userID))
+	assert.Equal(t, tokenRemain-(actualQuota-preConsumed), getTokenRemainQuota(t, tokenID))
+}
+
+func TestSettle_TokenBilling_FallsBackToTotalTokens(t *testing.T) {
+	truncate(t)
+	ctx := context.Background()
+
+	const userID, tokenID, channelID = 34, 34, 34
+	const initQuota, preConsumed, tokenRemain = 10000, 100, 8000
+
+	seedUser(t, userID, initQuota)
+	seedToken(t, tokenID, userID, "sk-token-total-fallback", tokenRemain)
+	seedChannel(t, channelID)
+
+	task := makeTask(userID, channelID, preConsumed, tokenID, BillingSourceWallet, 0)
+	task.PrivateData.BillingContext.ModelRatio = 2
+	task.PrivateData.BillingContext.CompletionRatio = common.GetPointer(3.0)
+	task.PrivateData.BillingContext.GroupRatio = 1
+
+	adaptor := &mockAdaptor{}
+	taskResult := &relaycommon.TaskInfo{
+		Status:      model.TaskStatusSuccess,
+		TotalTokens: 100,
+	}
+
+	settleTaskBillingOnComplete(ctx, adaptor, task, taskResult)
+
+	// 上游没有拆分 completion_tokens 时保持原有 total_tokens 计费语义。
+	const actualQuota = 200
+	assert.Equal(t, actualQuota, task.Quota)
+	assert.Equal(t, initQuota-(actualQuota-preConsumed), getUserQuota(t, userID))
+	assert.Equal(t, tokenRemain-(actualQuota-preConsumed), getTokenRemainQuota(t, tokenID))
+}

--- a/service/task_polling.go
+++ b/service/task_polling.go
@@ -642,8 +642,8 @@ func settleTaskBillingOnComplete(ctx context.Context, adaptor TaskPollingAdaptor
 		return
 	}
 	// 2. 回退到 token 重算
-	if taskResult.TotalTokens > 0 {
-		RecalculateTaskQuotaByTokens(ctx, task, taskResult.TotalTokens)
+	if taskResult.TotalTokens > 0 || taskResult.CompletionTokens > 0 {
+		RecalculateTaskQuotaByTokens(ctx, task, taskResult.TotalTokens, taskResult.CompletionTokens)
 		return
 	}
 	// 3. 无调整，保持预扣额度


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

本变更由 AI 辅助实现，提交者已结合实际异步视频 `usage` 与计费日志核对根因、结算公式和变更范围。

## 📝 变更描述 / Description

异步视频任务完成时，原逻辑只按 `total_tokens * ModelRatio` 重新结算。虽然任务适配器已解析 `completion_tokens`，结算层没有使用该字段，也没有应用 `CompletionRatio`，导致输出 Token 按输入价格计费。

本 PR 做了三点调整：

- 按 `total_tokens - completion_tokens` 计算输入 Token，输出 Token 应用 `CompletionRatio`；
- 上游未返回 `completion_tokens` 时继续按 `total_tokens` 使用原有计费逻辑；
- 在任务提交时保存模型倍率、输出倍率和分组倍率快照，完成结算使用快照，避免任务运行期间修改配置影响既有任务。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6172

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已核对生产计费日志、上游 `usage` 和最终公式，并确认描述与改动一致。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 已提交并关联 Issue #6172，Issue 中包含实际 `usage`、现行公式和复现步骤。
- [x] **变更理解:** 已确认任务提交、计费快照、轮询解析、差额结算和历史回退的完整数据流。
- [x] **范围聚焦:** 仅修改异步任务按 Token 计费及其回归测试。
- [x] **本地验证:** 受本地 Windows 资源限制，按照项目部署约定在 GitHub Actions 运行目标 Go 测试并通过。
- [x] **安全合规:** 代码和测试中不包含真实模型密钥、用户信息或其他敏感凭据。

## 📸 运行证明 / Proof of Work

GitHub Actions 已执行：

```text
go test ./controller ./service ./relay/helper
```

目标测试任务通过，覆盖以下行为：

- 按 Token 计费的异步任务保留提交预扣，完成后按实际用量补扣或退款；
- 输入、输出 Token 分开计费并应用输出倍率；
- 结算使用任务提交时的倍率快照；
- 缺少 `completion_tokens` 时回退到原有 `total_tokens` 计费；
- 按次价格任务仍跳过 Token 差额结算。

测试记录：https://github.com/zuiho-kai/new-api/actions/runs/29258682684/job/86845761821


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional completion ratio to task billing context and surfaced it in billing “Other” details when available.
  * Updated per-call pricing to include completion ratio data in pricing calculations.
* **Bug Fixes**
  * Improved quota accuracy for completion-ratio–based billing and completion-token–aware quota recalculation.
  * Adjusted completion billing fallback to use both total and completion tokens when present.
* **Tests**
  * Added unit tests covering completion-ratio inclusion, token billing semantics, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->