### PR TITLE
fix: accept fractional usage.duration in Ali video task results

### DIFF
--- a/dto/values.go
+++ b/dto/values.go
@@ -30,20 +30,20 @@ func (s StringValue) MarshalJSON() ([]byte, error) {
 type IntValue int
 
 func (i *IntValue) UnmarshalJSON(b []byte) error {
-	var n int
-	if err := json.Unmarshal(b, &n); err == nil {
-		*i = IntValue(n)
+	var f float64
+	if err := json.Unmarshal(b, &f); err == nil {
+		*i = IntValue(int(f))
 		return nil
 	}
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	v, err := strconv.Atoi(s)
+	v, err := strconv.ParseFloat(s, 64)
 	if err != nil {
 		return err
 	}
-	*i = IntValue(v)
+	*i = IntValue(int(v))
 	return nil
 }
 

--- a/dto/values_test.go
+++ b/dto/values_test.go
@@ -1,0 +1,36 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Ali task usage durations arrive as int, float, or numeric string; any form must decode without failing the whole response (#6166).
+func TestIntValueUnmarshalNumericForms(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"int", `5`, 5},
+		{"float", `13.93`, 13},
+		{"whole float", `5.0`, 5},
+		{"int string", `"5"`, 5},
+		{"float string", `"13.93"`, 13},
+		{"negative float", `-2.5`, -2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var v IntValue
+			require.NoError(t, common.Unmarshal([]byte(tt.in), &v))
+			assert.Equal(t, tt.want, int(v))
+		})
+	}
+
+	var v IntValue
+	require.Error(t, common.Unmarshal([]byte(`"abc"`), &v))
+	require.Error(t, common.Unmarshal([]byte(`true`), &v))
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

阿里视频任务(如 happyhorse-1.0-video-edit)成功后，查询响应里的 `usage.duration` 可能是浮点数(实测返回过 `13.93`、`20.02`)。`dto.IntValue` 之前只按 int → string 两步解析，无法解析小数。

改为先按 float64 解析再截断取整，字符串分支同样换成 ParseFloat，int / 浮点 / 数字字符串三种形式都能解。这条路径的 usage 不参与计费(ParseTaskResult 只读状态和 URL)，截断没有计费影响。附了表驱动测试。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6166

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```text
$ go test ./dto/... -run TestIntValue -v
--- PASS: TestIntValueUnmarshalNumericForms (0.00s)
    --- PASS: TestIntValueUnmarshalNumericForms/int (0.00s)
    --- PASS: TestIntValueUnmarshalNumericForms/float (0.00s)
    --- PASS: TestIntValueUnmarshalNumericForms/whole_float (0.00s)
    --- PASS: TestIntValueUnmarshalNumericForms/int_string (0.00s)
    --- PASS: TestIntValueUnmarshalNumericForms/float_string (0.00s)
    --- PASS: TestIntValueUnmarshalNumericForms/negative_float (0.00s)
PASS
ok  	github.com/QuantumNous/new-api/dto	0.299s
```
