### PR TITLE
fix(pricing): trim enable_groups to the user's usable groups

### DIFF
--- a/controller/pricing.go
+++ b/controller/pricing.go
@@ -23,12 +23,19 @@ func filterPricingByUsableGroups(pricing []model.Pricing, usableGroup map[string
 			filtered = append(filtered, item)
 			continue
 		}
+		usableEnableGroups := make([]string, 0, len(item.EnableGroup))
 		for _, group := range item.EnableGroup {
 			if _, ok := usableGroup[group]; ok {
-				filtered = append(filtered, item)
-				break
+				usableEnableGroups = append(usableEnableGroups, group)
 			}
 		}
+		if len(usableEnableGroups) == 0 {
+			continue
+		}
+		// item is a copy of the shared pricing cache entry; assign a fresh
+		// slice so the cached EnableGroup is never mutated across requests.
+		item.EnableGroup = usableEnableGroups
+		filtered = append(filtered, item)
 	}
 	return filtered
 }

--- a/controller/pricing_test.go
+++ b/controller/pricing_test.go
@@ -1,0 +1,42 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterPricingByUsableGroupsTrimsEnableGroups(t *testing.T) {
+	pricing := []model.Pricing{
+		{ModelName: "model-mixed", EnableGroup: []string{"default", "internal"}},
+		{ModelName: "model-internal-only", EnableGroup: []string{"internal"}},
+		{ModelName: "model-all", EnableGroup: []string{"all", "internal"}},
+	}
+	usableGroup := map[string]string{"default": "default group"}
+
+	filtered := filterPricingByUsableGroups(pricing, usableGroup)
+
+	require.Len(t, filtered, 2)
+
+	assert.Equal(t, "model-mixed", filtered[0].ModelName)
+	assert.Equal(t, []string{"default"}, filtered[0].EnableGroup,
+		"groups outside the user's usable groups must not be exposed")
+
+	assert.Equal(t, "model-all", filtered[1].ModelName)
+	assert.Equal(t, []string{"all", "internal"}, filtered[1].EnableGroup,
+		"entries enabled for all groups keep their original group list")
+
+	assert.Equal(t, []string{"default", "internal"}, pricing[0].EnableGroup,
+		"the shared pricing cache must stay untouched")
+}
+
+func TestFilterPricingByUsableGroupsEmptyInputs(t *testing.T) {
+	pricing := []model.Pricing{
+		{ModelName: "model-a", EnableGroup: []string{"default"}},
+	}
+
+	assert.Empty(t, filterPricingByUsableGroups(pricing, map[string]string{}))
+	assert.Empty(t, filterPricingByUsableGroups(nil, map[string]string{"default": ""}))
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

`GetPricing` 之前只按用户可用分组过滤返回哪些模型（#4123），但每个模型条目里的 `enable_groups` 仍是渠道原始分组列表。default 主题会在模型详情页底部「分组」栏和表格视图分组列原样渲染，导致对用户隐藏的分组名（不在 `UserUsableGroups`、或被 `-:分组` 特殊规则移除）虽然选不了，却仍然展示了出来。

本次在 `filterPricingByUsableGroups` 里把每个条目的 `enable_groups` 裁剪为与用户可用分组的交集，这样能生效的原因是 default 主题的分组徽章、表格分组列都直接读这个字段，服务端裁剪后两个主题一起修好：

- 含 `all` 的条目保持原有列表与语义不变；
- 交集为空的条目本来就不会返回，返回的模型集合与之前完全一致，只有 `enable_groups` 字段内容变化；
- 遍历中的 `item` 是共享定价缓存的值拷贝，写入的是新建 slice，不会改动缓存；
- classic 主题前端本来就按交集展示（`ModelPricingTable.jsx`），行为不变。

按仓库贡献规范说明：本次修改在 AI 辅助下完成，我已逐行审阅代码，并在本地构建后按下方运行证明实测验证（前后端同配置对照 + 单测）。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6175

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

新增单测 `controller/pricing_test.go`（覆盖：交集裁剪、`all` 保持原样、缓存不被改动、空输入）：

```text
$ go test ./controller/ -run TestFilterPricingByUsableGroups -v
=== RUN   TestFilterPricingByUsableGroupsTrimsEnableGroups
--- PASS: TestFilterPricingByUsableGroupsTrimsEnableGroups (0.00s)
=== RUN   TestFilterPricingByUsableGroupsEmptyInputs
--- PASS: TestFilterPricingByUsableGroupsEmptyInputs (0.00s)
PASS
ok      github.com/QuantumNous/new-api/controller       0.874s
```

本地实测（`UserUsableGroups` 只有 default/vip，渠道分组 `default,internal`）：

修复前——「按分组定价」只有 default，底部「分组」却显示 internal：

![修复前](https://raw.githubusercontent.com/Dashsoap/new-api/assets/pricing-group-leak/before-detail.png)

修复后——同一份配置与前端构建，只换后端，internal 不再展示：

![修复后](https://raw.githubusercontent.com/Dashsoap/new-api/assets/pricing-group-leak/after-detail.png)

`/api/pricing` 响应对比（同一请求）：

```diff
-  "enable_groups": ["default", "internal"]
+  "enable_groups": ["default"]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pricing results now include only groups available to the current user.
  * Entries without usable groups are excluded.
  * Shared pricing data remains unchanged between requests.

* **Tests**
  * Added coverage for group filtering, empty inputs, and preserving cached pricing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->