### PR TITLE
fix: 修复模型广场显示未定价的模型

### DIFF
--- a/controller/model_list_test.go
+++ b/controller/model_list_test.go
@@ -255,20 +255,14 @@ func TestListModelsIncludesTieredBillingModel(t *testing.T) {
 	require.NotContains(t, ids, "zz-unpriced-model")
 
 	pricingByName := pricingByModelName(model.GetPricing())
+	assert.NotContains(t, pricingByName, "zz-unpriced-model")
+	assert.NotContains(t, pricingByName, "zz-tiered-empty-expr-model")
+	assert.NotContains(t, pricingByName, "zz-tiered-missing-expr-model")
+
 	visiblePricing, ok := pricingByName["zz-tiered-visible-model"]
 	require.True(t, ok)
 	require.Equal(t, "tiered_expr", visiblePricing.BillingMode)
 	require.NotEmpty(t, visiblePricing.BillingExpr)
-
-	emptyExprPricing, ok := pricingByName["zz-tiered-empty-expr-model"]
-	require.True(t, ok)
-	require.Empty(t, emptyExprPricing.BillingMode)
-	require.Empty(t, emptyExprPricing.BillingExpr)
-
-	missingExprPricing, ok := pricingByName["zz-tiered-missing-expr-model"]
-	require.True(t, ok)
-	require.Empty(t, missingExprPricing.BillingMode)
-	require.Empty(t, missingExprPricing.BillingExpr)
 }
 
 func TestListModelsUsesAdvancedCustomEndpointTypesFromPricingCache(t *testing.T) {

--- a/model/pricing.go
+++ b/model/pricing.go
@@ -356,6 +356,10 @@ func updatePricing() {
 
 	pricingMap = make([]Pricing, 0)
 	for model, groups := range modelGroupsMap {
+		if !billing_setting.HasModelBillingConfig(model) {
+			continue
+		}
+
 		pricing := Pricing{
 			ModelName:              model,
 			EnableGroup:            groups.Items(),

--- a/relay/helper/price.go
+++ b/relay/helper/price.go
@@ -2,7 +2,6 @@ package helper
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/logger"
@@ -252,17 +251,7 @@ func ModelPriceHelperPerCall(c *gin.Context, info *relaycommon.RelayInfo) (types
 }
 
 func HasModelBillingConfig(modelName string) bool {
-	if _, ok := ratio_setting.GetModelPrice(modelName, false); ok {
-		return true
-	}
-	if _, ok, _ := ratio_setting.GetModelRatio(modelName); ok {
-		return true
-	}
-	if billing_setting.GetBillingMode(modelName) != billing_setting.BillingModeTieredExpr {
-		return false
-	}
-	expr, ok := billing_setting.GetBillingExpr(modelName)
-	return ok && strings.TrimSpace(expr) != ""
+	return billing_setting.HasModelBillingConfig(modelName)
 }
 
 func modelPriceHelperTiered(c *gin.Context, info *relaycommon.RelayInfo, promptTokens int, meta *types.TokenCountMeta, groupRatioInfo types.GroupRatioInfo) (types.PriceData, error) {

--- a/setting/billing_setting/tiered_billing.go
+++ b/setting/billing_setting/tiered_billing.go
@@ -2,9 +2,11 @@ package billing_setting
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/QuantumNous/new-api/pkg/billingexpr"
 	"github.com/QuantumNous/new-api/setting/config"
+	"github.com/QuantumNous/new-api/setting/ratio_setting"
 	"github.com/samber/lo"
 )
 
@@ -45,6 +47,22 @@ func GetBillingMode(model string) string {
 func GetBillingExpr(model string) (string, bool) {
 	expr, ok := billingSetting.BillingExpr[model]
 	return expr, ok
+}
+
+// HasModelBillingConfig reports whether a model has usable ratio, fixed-price,
+// or expression-based billing configured.
+func HasModelBillingConfig(model string) bool {
+	if _, ok := ratio_setting.GetModelPrice(model, false); ok {
+		return true
+	}
+	if _, ok, _ := ratio_setting.GetModelRatio(model); ok {
+		return true
+	}
+	if GetBillingMode(model) != BillingModeTieredExpr {
+		return false
+	}
+	expr, ok := GetBillingExpr(model)
+	return ok && strings.TrimSpace(expr) != ""
 }
 
 func GetBillingModeCopy() map[string]string {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
模型广场会显示未定价的模型，提交修复了只显示已定价的模型

## 📝 变更描述 / Description
统一新增模型计费配置判断，支持固定价格、倍率配置和有效的阶梯计费表达式。模型广场构建定价列表时会跳过未配置任何有效计费规则的模型，避免使用默认倍率 37.5 生成错误价格；同时复用该判断逻辑，确保模型列表与模型广场的可见性保持一致。补充回归断言，覆盖未定价模型、空阶梯表达式模型和缺失阶梯表达式模型。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
<img width="2560" height="1380" alt="5f9d4cdee52d1038c0cdb79966548d83" src="https://github.com/user-attachments/assets/47a38511-e8d6-4c16-bfdc-5d4ea7d7d061" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Models without valid billing configuration are no longer included in pricing data.
  * Tiered billing models are recognized only when they have a non-empty billing expression.
  * Pricing listings now exclude unpriced or incompletely configured models while retaining properly configured tiered models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->