### PR TITLE
fix: make RWMap JSON loads atomic

### DIFF
--- a/types/rw_map.go
+++ b/types/rw_map.go
@@ -12,10 +12,12 @@ type RWMap[K comparable, V any] struct {
 }
 
 func (m *RWMap[K, V]) UnmarshalJSON(b []byte) error {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	m.data = make(map[K]V)
-	return common.Unmarshal(b, &m.data)
+	var next map[K]V
+	if err := common.Unmarshal(b, &next); err != nil {
+		return err
+	}
+	m.replace(next)
+	return nil
 }
 
 func (m *RWMap[K, V]) MarshalJSON() ([]byte, error) {
@@ -74,23 +76,33 @@ func (m *RWMap[K, V]) Len() int {
 	return len(m.data)
 }
 
-func LoadFromJsonString[K comparable, V any](m *RWMap[K, V], jsonStr string) error {
+func (m *RWMap[K, V]) replace(next map[K]V) {
+	if next == nil {
+		next = make(map[K]V)
+	}
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	m.data = make(map[K]V)
-	return common.Unmarshal([]byte(jsonStr), &m.data)
+	m.data = next
+}
+
+func LoadFromJsonString[K comparable, V any](m *RWMap[K, V], jsonStr string) error {
+	var next map[K]V
+	if err := common.Unmarshal([]byte(jsonStr), &next); err != nil {
+		return err
+	}
+	m.replace(next)
+	return nil
 }
 
 // LoadFromJsonStringWithCallback loads a JSON string into the RWMap and calls the callback on success.
 func LoadFromJsonStringWithCallback[K comparable, V any](m *RWMap[K, V], jsonStr string, onSuccess func()) error {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	m.data = make(map[K]V)
-	err := common.Unmarshal([]byte(jsonStr), &m.data)
-	if err == nil && onSuccess != nil {
+	if err := LoadFromJsonString(m, jsonStr); err != nil {
+		return err
+	}
+	if onSuccess != nil {
 		onSuccess()
 	}
-	return err
+	return nil
 }
 
 // MarshalJSONString returns the JSON string representation of the RWMap.

--- a/types/rw_map_test.go
+++ b/types/rw_map_test.go
@@ -1,0 +1,67 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRWMapUnmarshalJSONPreservesExistingDataOnDecodeError(t *testing.T) {
+	m := NewRWMap[string, int]()
+	m.Set("existing", 1)
+
+	err := m.UnmarshalJSON([]byte(`{"replacement":2,"invalid":"not-an-int"}`))
+
+	require.Error(t, err)
+	require.Equal(t, map[string]int{"existing": 1}, m.ReadAll())
+}
+
+func TestLoadFromJsonStringPreservesExistingDataOnDecodeError(t *testing.T) {
+	m := NewRWMap[string, int]()
+	m.Set("existing", 1)
+
+	err := LoadFromJsonString(m, `{"replacement":2,"invalid":"not-an-int"}`)
+
+	require.Error(t, err)
+	require.Equal(t, map[string]int{"existing": 1}, m.ReadAll())
+}
+
+func TestLoadFromJsonStringWithCallbackCommitsAtomically(t *testing.T) {
+	t.Run("success replaces data and invokes callback once", func(t *testing.T) {
+		m := NewRWMap[string, int]()
+		m.Set("existing", 1)
+		callbackCount := 0
+
+		err := LoadFromJsonStringWithCallback(m, `{"replacement":2}`, func() {
+			callbackCount++
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, map[string]int{"replacement": 2}, m.ReadAll())
+		require.Equal(t, 1, callbackCount)
+	})
+
+	t.Run("failure preserves data and skips callback", func(t *testing.T) {
+		m := NewRWMap[string, int]()
+		m.Set("existing", 1)
+		callbackCount := 0
+
+		err := LoadFromJsonStringWithCallback(m, `{"replacement":2,"invalid":"not-an-int"}`, func() {
+			callbackCount++
+		})
+
+		require.Error(t, err)
+		require.Equal(t, map[string]int{"existing": 1}, m.ReadAll())
+		require.Zero(t, callbackCount)
+	})
+
+	t.Run("nil callback still loads successfully", func(t *testing.T) {
+		m := NewRWMap[string, int]()
+		m.Set("existing", 1)
+
+		err := LoadFromJsonStringWithCallback(m, `{"replacement":2}`, nil)
+
+		require.NoError(t, err)
+		require.Equal(t, map[string]int{"replacement": 2}, m.ReadAll())
+	})
+}


### PR DESCRIPTION
## Summary
- decode replacement maps before acquiring the write lock
- preserve the current map when JSON decoding fails
- normalize JSON `null` to an initialized empty map
- invoke cache-invalidation callbacks only after a successful commit

## Why
A malformed persisted ratio option could partially replace or clear the live map before returning an error. Option synchronization then logged the decode error while readers observed corrupted pricing configuration.

## Validation
- `go test ./types -count=1`
- `go test -race ./types -run 'Test(RWMapUnmarshalJSON|LoadFromJsonString)' -count=1`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON loading reliability by preserving existing map data when decoding fails.
  * Ensured successful loads replace the map contents atomically.
  * Callbacks now run only after a successful load and are invoked exactly once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->