### PR TITLE
fix: 修复 Gemini 风格 /v1/models 列表请求

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -336,7 +336,8 @@ func TokenAuth() func(c *gin.Context) {
 			}
 		}
 		// gemini api 从query中获取key
-		if strings.HasPrefix(c.Request.URL.Path, "/v1beta/models") ||
+		if c.Request.URL.Path == "/v1/models" ||
+			strings.HasPrefix(c.Request.URL.Path, "/v1beta/models") ||
 			strings.HasPrefix(c.Request.URL.Path, "/v1beta/openai/models") ||
 			strings.HasPrefix(c.Request.URL.Path, "/v1/models/") {
 			skKey := c.Query("key")

--- a/router/relay-router.go
+++ b/router/relay-router.go
@@ -25,7 +25,7 @@ func SetRelayRouter(router *gin.Engine) {
 			case c.GetHeader("x-api-key") != "" && c.GetHeader("anthropic-version") != "":
 				controller.ListModels(c, constant.ChannelTypeAnthropic)
 			case c.GetHeader("x-goog-api-key") != "" || c.Query("key") != "": // 单独的适配
-				controller.RetrieveModel(c, constant.ChannelTypeGemini)
+				controller.ListModels(c, constant.ChannelTypeGemini)
 			default:
 				controller.ListModels(c, constant.ChannelTypeOpenAI)
 			}

--- a/router/relay_router_test.go
+++ b/router/relay_router_test.go
@@ -38,19 +38,27 @@ func TestListModelsSupportsOpenAIAndGeminiAuthentication(t *testing.T) {
 
 	tests := []struct {
 		name           string
+		path           string
 		headerName     string
 		expectedObject string
 		expectedField  string
 	}{
 		{
 			name:           "OpenAI bearer token",
+			path:           "/v1/models",
 			headerName:     "Authorization",
 			expectedObject: "list",
 			expectedField:  "data",
 		},
 		{
 			name:          "Gemini API key header",
+			path:          "/v1/models",
 			headerName:    "x-goog-api-key",
+			expectedField: "models",
+		},
+		{
+			name:          "Gemini API key query",
+			path:          "/v1/models?key=modelstestkey",
 			expectedField: "models",
 		},
 	}
@@ -58,12 +66,14 @@ func TestListModelsSupportsOpenAIAndGeminiAuthentication(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			recorder := httptest.NewRecorder()
-			request := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
-			value := "modelstestkey"
-			if test.headerName == "Authorization" {
-				value = "Bearer " + value
+			request := httptest.NewRequest(http.MethodGet, test.path, nil)
+			if test.headerName != "" {
+				value := "modelstestkey"
+				if test.headerName == "Authorization" {
+					value = "Bearer " + value
+				}
+				request.Header.Set(test.headerName, value)
 			}
-			request.Header.Set(test.headerName, value)
 
 			engine.ServeHTTP(recorder, request)
 

--- a/router/relay_router_test.go
+++ b/router/relay_router_test.go
@@ -1,0 +1,116 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListModelsSupportsOpenAIAndGeminiAuthentication(t *testing.T) {
+	setupRelayRouterTestDB(t)
+
+	user := model.User{
+		Username: "models-user",
+		Status:   common.UserStatusEnabled,
+		Group:    "default",
+		Quota:    100,
+	}
+	require.NoError(t, model.DB.Create(&user).Error)
+	require.NoError(t, model.DB.Create(&model.Token{
+		UserId:         user.Id,
+		Key:            "modelstestkey",
+		Status:         common.TokenStatusEnabled,
+		ExpiredTime:    -1,
+		UnlimitedQuota: true,
+	}).Error)
+
+	engine := gin.New()
+	SetRelayRouter(engine)
+
+	tests := []struct {
+		name           string
+		headerName     string
+		expectedObject string
+		expectedField  string
+	}{
+		{
+			name:           "OpenAI bearer token",
+			headerName:     "Authorization",
+			expectedObject: "list",
+			expectedField:  "data",
+		},
+		{
+			name:          "Gemini API key header",
+			headerName:    "x-goog-api-key",
+			expectedField: "models",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+			value := "modelstestkey"
+			if test.headerName == "Authorization" {
+				value = "Bearer " + value
+			}
+			request.Header.Set(test.headerName, value)
+
+			engine.ServeHTTP(recorder, request)
+
+			require.Equal(t, http.StatusOK, recorder.Code)
+			var payload map[string]any
+			require.NoError(t, common.Unmarshal(recorder.Body.Bytes(), &payload))
+			assert.Contains(t, payload, test.expectedField)
+			assert.NotContains(t, payload, "error")
+			if test.expectedObject != "" {
+				assert.Equal(t, test.expectedObject, payload["object"])
+			}
+		})
+	}
+}
+
+func setupRelayRouterTestDB(t *testing.T) {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	originalIsMasterNode := common.IsMasterNode
+	originalRedisEnabled := common.RedisEnabled
+	originalSQLitePath := common.SQLitePath
+	originalMainDatabaseType := common.MainDatabaseType()
+	originalLogDatabaseType := common.LogDatabaseType()
+	originalSQLDSN, hadSQLDSN := os.LookupEnv("SQL_DSN")
+
+	common.IsMasterNode = false
+	common.RedisEnabled = false
+	common.SQLitePath = fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "_"))
+	common.SetDatabaseTypes(common.DatabaseTypeSQLite, common.DatabaseTypeSQLite)
+	require.NoError(t, os.Setenv("SQL_DSN", "local"))
+	require.NoError(t, model.InitDB())
+	model.LOG_DB = model.DB
+	require.NoError(t, model.DB.AutoMigrate(&model.User{}, &model.Token{}, &model.Ability{}))
+
+	t.Cleanup(func() {
+		if sqlDB, err := model.DB.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+		common.IsMasterNode = originalIsMasterNode
+		common.RedisEnabled = originalRedisEnabled
+		common.SQLitePath = originalSQLitePath
+		common.SetDatabaseTypes(originalMainDatabaseType, originalLogDatabaseType)
+		if hadSQLDSN {
+			require.NoError(t, os.Setenv("SQL_DSN", originalSQLDSN))
+		} else {
+			require.NoError(t, os.Unsetenv("SQL_DSN"))
+		}
+	})
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
修复 Gemini 风格的 `GET /v1/models` 列表请求：

- 让认证中间件在不带尾斜杠的 `/v1/models` 上读取 `x-goog-api-key` 或 `key` 查询参数。
- 将 Gemini 列表请求交给 `ListModels`，避免因缺少 `:model` 参数进入 `RetrieveModel` 并返回空模型名错误。
- 添加 HTTP 回归测试，覆盖 OpenAI Bearer、Gemini `x-goog-api-key` 和 `?key=` 的响应契约。

> AI disclosure: 本次修改由 AI 辅助分析、实现和测试，请维护者按常规流程审阅。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6198

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```text
$ go test ./router -run TestListModelsSupportsOpenAIAndGeminiAuthentication -v
--- PASS: TestListModelsSupportsOpenAIAndGeminiAuthentication
    --- PASS: TestListModelsSupportsOpenAIAndGeminiAuthentication/OpenAI_bearer_token
    --- PASS: TestListModelsSupportsOpenAIAndGeminiAuthentication/Gemini_API_key_header
    --- PASS: TestListModelsSupportsOpenAIAndGeminiAuthentication/Gemini_API_key_query
PASS

$ go test ./middleware ./router
ok  github.com/QuantumNous/new-api/middleware
ok  github.com/QuantumNous/new-api/router

$ go test ./...
PASS
```

本地启动完整 HTTP 服务后的实际请求结果：

```text
Authorization: Bearer <key>  -> 200 {"data":[],"object":"list","success":true}
x-goog-api-key: <key>        -> 200 {"models":[],"nextPageToken":null}
/v1/models?key=<key>         -> 200 {"models":[],"nextPageToken":null}
未携带任何凭据               -> 401 Invalid token
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated model authentication logic so `/v1/models` properly recognizes and handles Gemini API key input from headers and `key` query parameters.
  * Adjusted the Gemini-specific behavior of the root models endpoint to return a model list (instead of a single-model result).

* **Tests**
  * Added coverage for `GET /v1/models` validating successful responses for OpenAI bearer auth, Gemini header auth, and Gemini `?key=...` query auth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->