### PR TITLE
fix: stabilize channel pagination ordering

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -103,9 +103,16 @@ func NewChannelSortOptions(sortBy string, sortOrder string, idSort bool) Channel
 
 func (options ChannelSortOptions) Apply(query *gorm.DB) *gorm.DB {
 	if columnName, ok := channelSortColumns[options.SortBy]; ok {
-		return query.Order(clause.OrderByColumn{
+		query = query.Order(clause.OrderByColumn{
 			Column: clause.Column{Name: columnName},
 			Desc:   options.SortOrder != "asc",
+		})
+		if columnName == "id" {
+			return query
+		}
+		return query.Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "id"},
+			Desc:   true,
 		})
 	}
 	if options.IDSort {
@@ -116,6 +123,9 @@ func (options ChannelSortOptions) Apply(query *gorm.DB) *gorm.DB {
 	}
 	return query.Order(clause.OrderByColumn{
 		Column: clause.Column{Name: "priority"},
+		Desc:   true,
+	}).Order(clause.OrderByColumn{
+		Column: clause.Column{Name: "id"},
 		Desc:   true,
 	})
 }
@@ -928,6 +938,7 @@ func SearchTags(keyword string, group string, model string, idSort bool) ([]*str
 
 	err := DB.Table("(?) as sub", subQuery).
 		Select("DISTINCT tag").
+		Order(clause.OrderByColumn{Column: clause.Column{Name: "tag"}}).
 		Find(&tags).Error
 
 	if err != nil {

--- a/model/channel.go
+++ b/model/channel.go
@@ -102,29 +102,23 @@ func NewChannelSortOptions(sortBy string, sortOrder string, idSort bool) Channel
 }
 
 func (options ChannelSortOptions) Apply(query *gorm.DB) *gorm.DB {
-	if columnName, ok := channelSortColumns[options.SortBy]; ok {
-		query = query.Order(clause.OrderByColumn{
-			Column: clause.Column{Name: columnName},
-			Desc:   options.SortOrder != "asc",
-		})
-		if columnName == "id" {
-			return query
-		}
-		return query.Order(clause.OrderByColumn{
-			Column: clause.Column{Name: "id"},
-			Desc:   true,
-		})
+	columnName := "priority"
+	descending := true
+	if requestedColumn, ok := channelSortColumns[options.SortBy]; ok {
+		columnName = requestedColumn
+		descending = options.SortOrder != "asc"
+	} else if options.IDSort {
+		columnName = "id"
 	}
-	if options.IDSort {
-		return query.Order(clause.OrderByColumn{
-			Column: clause.Column{Name: "id"},
-			Desc:   true,
-		})
+
+	query = query.Order(clause.OrderByColumn{
+		Column: clause.Column{Name: columnName},
+		Desc:   descending,
+	})
+	if columnName == "id" {
+		return query
 	}
 	return query.Order(clause.OrderByColumn{
-		Column: clause.Column{Name: "priority"},
-		Desc:   true,
-	}).Order(clause.OrderByColumn{
 		Column: clause.Column{Name: "id"},
 		Desc:   true,
 	})

--- a/model/channel_sort_test.go
+++ b/model/channel_sort_test.go
@@ -7,9 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetAllChannelsUsesIDAsStablePageTiebreaker(t *testing.T) {
-	truncateTables(t)
+func resetChannelSortTestChannels(t *testing.T) {
+	t.Helper()
 	require.NoError(t, DB.Exec("DELETE FROM channels").Error)
+	t.Cleanup(func() {
+		require.NoError(t, DB.Exec("DELETE FROM channels").Error)
+	})
+}
+
+func TestGetAllChannelsUsesIDAsStablePageTiebreaker(t *testing.T) {
+	resetChannelSortTestChannels(t)
 	priority10 := int64(10)
 	priority5 := int64(5)
 	require.NoError(t, DB.Create([]*Channel{
@@ -36,8 +43,7 @@ func TestGetAllChannelsUsesIDAsStablePageTiebreaker(t *testing.T) {
 }
 
 func TestSearchTagsReturnsStableAlphabeticalOrder(t *testing.T) {
-	truncateTables(t)
-	require.NoError(t, DB.Exec("DELETE FROM channels").Error)
+	resetChannelSortTestChannels(t)
 	zeta := "zeta"
 	alpha := "alpha"
 	beta := "beta"
@@ -48,6 +54,7 @@ func TestSearchTagsReturnsStableAlphabeticalOrder(t *testing.T) {
 		{Id: 31, Name: "channel-zeta", Priority: &priority30, Tag: &zeta},
 		{Id: 32, Name: "channel-alpha", Priority: &priority20, Tag: &alpha},
 		{Id: 33, Name: "channel-beta", Priority: &priority10, Tag: &beta},
+		{Id: 34, Name: "channel-beta-duplicate", Priority: &priority10, Tag: &beta},
 	}).Error)
 
 	tags, err := SearchTags("", "", "", false)

--- a/model/channel_sort_test.go
+++ b/model/channel_sort_test.go
@@ -1,0 +1,57 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAllChannelsUsesIDAsStablePageTiebreaker(t *testing.T) {
+	truncateTables(t)
+	require.NoError(t, DB.Exec("DELETE FROM channels").Error)
+	priority10 := int64(10)
+	priority5 := int64(5)
+	require.NoError(t, DB.Create([]*Channel{
+		{Id: 11, Name: "beta", Priority: &priority10},
+		{Id: 20, Name: "beta", Priority: &priority5},
+		{Id: 12, Name: "alpha", Priority: &priority10},
+		{Id: 15, Name: "alpha", Priority: &priority10},
+	}).Error)
+
+	firstPage, err := GetAllChannels(0, 2, false, false)
+	require.NoError(t, err)
+	require.Len(t, firstPage, 2)
+	assert.Equal(t, []int{15, 12}, []int{firstPage[0].Id, firstPage[1].Id})
+
+	secondPage, err := GetAllChannels(2, 2, false, false)
+	require.NoError(t, err)
+	require.Len(t, secondPage, 2)
+	assert.Equal(t, []int{11, 20}, []int{secondPage[0].Id, secondPage[1].Id})
+
+	byName, err := GetAllChannels(0, 4, false, false, NewChannelSortOptions("name", "asc", false))
+	require.NoError(t, err)
+	require.Len(t, byName, 4)
+	assert.Equal(t, []int{15, 12, 20, 11}, []int{byName[0].Id, byName[1].Id, byName[2].Id, byName[3].Id})
+}
+
+func TestSearchTagsReturnsStableAlphabeticalOrder(t *testing.T) {
+	truncateTables(t)
+	require.NoError(t, DB.Exec("DELETE FROM channels").Error)
+	zeta := "zeta"
+	alpha := "alpha"
+	beta := "beta"
+	priority30 := int64(30)
+	priority20 := int64(20)
+	priority10 := int64(10)
+	require.NoError(t, DB.Create([]*Channel{
+		{Id: 31, Name: "channel-zeta", Priority: &priority30, Tag: &zeta},
+		{Id: 32, Name: "channel-alpha", Priority: &priority20, Tag: &alpha},
+		{Id: 33, Name: "channel-beta", Priority: &priority10, Tag: &beta},
+	}).Error)
+
+	tags, err := SearchTags("", "", "", false)
+	require.NoError(t, err)
+	require.Len(t, tags, 3)
+	assert.Equal(t, []string{"alpha", "beta", "zeta"}, []string{*tags[0], *tags[1], *tags[2]})
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
渠道按非唯一字段排序时，并列记录顺序不固定，`LIMIT`/`OFFSET` 分页可能重复或遗漏记录。

为非 ID 排序追加 `id DESC`，标签搜索按 `tag ASC` 排序。测试覆盖默认排序、自定义排序和标签搜索。

AI-assisted change.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6241
- Related to #11

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```text
$ go test ./model ./controller
ok  github.com/QuantumNous/new-api/model
ok  github.com/QuantumNous/new-api/controller
```
