### PR TITLE
fix(build): failed to make build-all-web

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -18,6 +18,8 @@
         "@visactor/vchart-semi-theme": "~1.8.8",
         "axios": "catalog:",
         "clsx": "catalog:",
+        "date-fns": "2.30.0",
+        "date-fns-tz": "1.3.8",
         "dayjs": "catalog:",
         "highlight.js": "^11.11.1",
         "history": "^5.3.0",
@@ -1512,7 +1514,7 @@
 
     "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
 
-    "date-fns": ["date-fns@4.4.0", "", {}, "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="],
+    "date-fns": ["date-fns@2.30.0", "", { "dependencies": { "@babel/runtime": "^7.21.0" } }, "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw=="],
 
     "date-fns-tz": ["date-fns-tz@1.3.8", "", { "peerDependencies": { "date-fns": ">=2.0.0" } }, "sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ=="],
 
@@ -2938,6 +2940,8 @@
 
     "@codemirror/lint/@codemirror/view": ["@codemirror/view@6.43.3", "", { "dependencies": { "@codemirror/state": "^6.7.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-MwEwCAr/o0agJefhC2+reBv5kfOQpMcDRUNQrRYZgWlhH8IwQcerMZrpqWyUFSyO0ebgN2cnh/w87F7G4BGSng=="],
 
+    "@base-ui/react/date-fns": ["date-fns@4.4.0", "", {}, "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="],
+
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
@@ -3211,6 +3215,8 @@
     "react-template/@visactor/react-vchart": ["@visactor/react-vchart@1.8.11", "", { "dependencies": { "@visactor/vchart": "1.8.11", "@visactor/vgrammar-core": "0.10.11", "@visactor/vrender-core": "0.17.17", "@visactor/vrender-kits": "0.17.17", "@visactor/vutils": "~0.17.3", "react-is": "^18.2.0" }, "peerDependencies": { "react": ">=16.0.0", "react-dom": ">=16.0.0" } }, "sha512-wHnCex9gOpnttTtSu04ozKJhTveUk8Ln2KX/7PZyCJxqlXq+eWvW4zvM6Ja8T8kGXfXtFYVVNh9zBMQ7y2T/Sw=="],
 
     "react-template/@visactor/vchart": ["@visactor/vchart@1.8.11", "", { "dependencies": { "@visactor/vdataset": "~0.17.3", "@visactor/vgrammar-core": "0.10.11", "@visactor/vgrammar-hierarchy": "0.10.11", "@visactor/vgrammar-projection": "0.10.11", "@visactor/vgrammar-sankey": "0.10.11", "@visactor/vgrammar-util": "0.10.11", "@visactor/vgrammar-wordcloud": "0.10.11", "@visactor/vgrammar-wordcloud-shape": "0.10.11", "@visactor/vrender-components": "0.17.17", "@visactor/vrender-core": "0.17.17", "@visactor/vrender-kits": "0.17.17", "@visactor/vscale": "~0.17.3", "@visactor/vutils": "~0.17.3", "@visactor/vutils-extension": "1.8.11" } }, "sha512-RdQ822J02GgAQNXvO1LiT0T3O6FjdgPdcm9hVBFyrpBBmuI8MH02IE7Y1kGe9NiFTH4tDwP0ixRgBmqNSGSLZQ=="],
+
+    "react-day-picker/date-fns": ["date-fns@4.4.0", "", {}, "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="],
 
     "react-template/i18next": ["i18next@23.16.8", "", { "dependencies": { "@babel/runtime": "^7.23.2" } }, "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg=="],
 

--- a/web/classic/package.json
+++ b/web/classic/package.json
@@ -13,6 +13,8 @@
     "@visactor/vchart-semi-theme": "~1.8.8",
     "axios": "catalog:",
     "clsx": "catalog:",
+    "date-fns": "2.30.0",
+    "date-fns-tz": "1.3.8",
     "dayjs": "catalog:",
     "history": "^5.3.0",
     "highlight.js": "^11.11.1",

--- a/web/classic/rsbuild.config.ts
+++ b/web/classic/rsbuild.config.ts
@@ -10,6 +10,8 @@ const semiUiDir = path.resolve(
   path.dirname(require.resolve('@douyinfe/semi-ui')),
   '../..',
 )
+const dateFnsDir = path.dirname(require.resolve('date-fns/package.json'))
+const dateFnsTzDir = path.dirname(require.resolve('date-fns-tz/package.json'))
 
 export default defineConfig(({ envMode }) => {
   const env = loadEnv({ mode: envMode, prefixes: ['VITE_'] })
@@ -47,6 +49,8 @@ export default defineConfig(({ envMode }) => {
           semiUiDir,
           'dist/css/semi.css',
         ),
+        'date-fns': dateFnsDir,
+        'date-fns-tz': dateFnsTzDir,
       },
     },
     html: {


### PR DESCRIPTION
  ## 📝 变更描述 / Description

  修复 `make build-all-web` 在 Classic Web 构建阶段的依赖解析错误:
```
Rsbuild v2.1.4

info    build started...
error   Build errors: 
File: ../node_modules/date-fns-tz/format/index.js:8:45-71
  × Package subpath './format/index.js' is not defined by "exports" in /Users/wangshibiao/data/code/aihubkit/zmodel/web/node_modules/date-fns/package.json
Import traces (entry → error):
  ./src/index.jsx
  ./src/components/layout/PageLayout.jsx
  ... (5 hidden)
  ../node_modules/date-fns-tz/index.js
  ../node_modules/date-fns-tz/format/index.js ×

File: ../node_modules/date-fns-tz/formatInTimeZone/index.js:8:45-81
  × Package subpath './_lib/cloneObject/index.js' is not defined by "exports" in /Users/wangshibiao/data/code/aihubkit/zmodel/web/node_modules/date-fns/package.json
```

  `@douyinfe/semi-ui@2.99.3` 使用的 `date-fns-tz@1.3.8` 依赖 `date-fns@2` 的内部模块路径，而 workspace 默认提升了 `date-fns@4`。由于 `date-fns@4` 通过 `exports` 限制了这些
  内部路径，Rspack 无法完成模块解析。

  本次为 Classic Web 显式固定 `date-fns@2.30.0` 和 `date-fns-tz@1.3.8`，并在 Rsbuild 中指定对应依赖的解析路径。同时保留 Default Web 所需的 `date-fns@4.4.0`，避免影响另一套
  前端的现有依赖。

  ## 🚀 变更类型 / Type of change

  - [x] 🐛 Bug 修复 (Bug fix)
  - [ ] ✨ 新功能 (New feature)
  - [ ] ⚡ 性能优化 / 重构 (Refactor)
  - [ ] 📝 文档更新 (Documentation)

  ## 🔗 关联任务 / Related Issue

  - 无关联 Issue

  ## ✅ 提交前检查项 / Checklist

  - [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
  - [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
  - [x] **Bug fix 说明:** 此 PR 修复的是实际存在的构建失败问题，不涉及设计取舍、理解偏差或预期不一致。
  - [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
  - [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
  - [x] **本地验证:** 已在本地运行并通过构建验证，维护者可以据此复核结果。
  - [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

  ## 📸 运行证明 / Proof of Work

  已在本地执行：

  ```bash
  make build-all-web

  验证结果：

  Building default web...
  ready   built in 4.80s

  Building classic web...
  ready   built in 2.73s

  make 返回码：0

  Default Web 和 Classic Web 均构建成功，原先的：

  Package subpath ... is not defined by "exports"

  错误已不再出现。

  同时执行：

  git diff --check

  检查通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced date and time support in the Classic web experience.
  - Improved compatibility and reliability for date-related features across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->