### PR TITLE
fix: prevent duplicate tool calls in Responses-to-Chat streaming

### DIFF
--- a/service/relayconvert/internal/oai_responses/to_oai_chat_resp_test.go
+++ b/service/relayconvert/internal/oai_responses/to_oai_chat_resp_test.go
@@ -281,6 +281,64 @@ func TestResponsesStreamEventToChatChunksUsesTerminalDoneOutput(t *testing.T) {
 	assert.Equal(t, "tool_calls", *chunks[3].Choices[0].FinishReason)
 }
 
+func TestResponsesStreamEventToChatChunksDoesNotResendToolOnTerminalOutput(t *testing.T) {
+	state := newTestResponsesStreamState()
+	outputIndex := 0
+
+	var chunks []dto.ChatCompletionsStreamResponse
+	chunks = append(chunks, mustStreamChunks(t, state, &dto.ResponsesStreamResponse{Type: responsesEventCreated})...)
+	chunks = append(chunks, mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type:        responsesEventOutputItemAdded,
+		OutputIndex: &outputIndex,
+		Item: &dto.ResponsesOutput{
+			Type:   responsesOutputTypeFunctionCall,
+			ID:     "fc_1",
+			CallId: "call_1",
+			Name:   "lookup",
+		},
+	})...)
+	chunks = append(chunks, mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type:        responsesEventFunctionArgsDelta,
+		OutputIndex: &outputIndex,
+		Delta:       `{"q":"x"}`,
+	})...)
+	chunks = append(chunks, mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type: responsesEventCompleted,
+		Response: &dto.OpenAIResponsesResponse{
+			Status: []byte(`"completed"`),
+			Output: []dto.ResponsesOutput{
+				{
+					Type:      responsesOutputTypeFunctionCall,
+					ID:        "fc_1",
+					CallId:    "call_1",
+					Name:      "lookup",
+					Arguments: []byte(`{"q":"x"}`),
+				},
+			},
+		},
+	})...)
+
+	totalArgs := ""
+	toolIndexes := map[int]bool{}
+	var finishReason string
+	for _, chunk := range chunks {
+		for _, choice := range chunk.Choices {
+			for _, tc := range choice.Delta.ToolCalls {
+				require.NotNil(t, tc.Index)
+				toolIndexes[*tc.Index] = true
+				totalArgs += tc.Function.Arguments
+			}
+			if choice.FinishReason != nil {
+				finishReason = *choice.FinishReason
+			}
+		}
+	}
+
+	assert.Equal(t, map[int]bool{0: true}, toolIndexes)
+	assert.Equal(t, `{"q":"x"}`, totalArgs)
+	assert.Equal(t, "tool_calls", finishReason)
+}
+
 func TestFinalizeResponsesToChatStreamFlushesPendingDeltaOnlyArguments(t *testing.T) {
 	state := newTestResponsesStreamState()
 	outputIndex := 2

--- a/service/relayconvert/internal/oai_responses/to_oai_chat_stream_resp.go
+++ b/service/relayconvert/internal/oai_responses/to_oai_chat_stream_resp.go
@@ -270,6 +270,23 @@ func (s *ResponsesToChatStreamState) ensureToolForEvent(event *dto.ResponsesStre
 
 	tool := s.toolByKey[key]
 	if tool == nil {
+		if itemID := responseStreamEventItemID(event); itemID != "" {
+			if existingKey := s.itemIDToKey[itemID]; existingKey != "" {
+				tool = s.toolByKey[existingKey]
+			}
+		}
+		if tool == nil {
+			if callID := strings.TrimSpace(event.Item.CallId); callID != "" {
+				if existingKey := s.callIDToKey[callID]; existingKey != "" {
+					tool = s.toolByKey[existingKey]
+				}
+			}
+		}
+		if tool != nil {
+			s.toolByKey[key] = tool
+		}
+	}
+	if tool == nil {
 		tool = &responsesStreamTool{Key: key, Index: s.nextToolIndex}
 		s.nextToolIndex++
 		s.toolByKey[key] = tool


### PR DESCRIPTION
## 📝 变更描述 / Description

Responses-to-Chat 流式转换里，工具调用的 key 有两种形态：流式事件带 `output_index`，注册成 `output:<n>`；`response.completed` 的完整 `output` 在 `terminalOutputChunks` 里被构造成没有 `output_index` 的合成事件，算出来是 `item:<id>`。`ensureToolForEvent` 之前只查 `toolByKey`，key 对不上就直接建新 tool——于是同一个 function call 拿到第二个 `tool_calls` index，完整 arguments 被重发一遍。对自动执行工具的 Agent 客户端，这等于同一个工具被调用两次。

而 OpenAI 官方的 `response.completed` 本来就携带完整 `output`（含已流式发送过的 function_call item），这是必须正确处理的正常事件形态。

修复：`ensureToolForEvent` 在直接 key 未命中时，先用已登记的 `itemIDToKey`、`callIDToKey` 反查已存在的 tool，找到就把新 key alias 过去；全部未命中才创建新 tool。这和同文件里非流式路径 `ResponsesBufferedAccumulator.findToolIndex` 的既有语义一致（它本来就会按 item ID 反查再新建）。terminal-only 工具调用（部分兼容上游只在终止事件里给出工具调用）不受影响，反查不到时仍走原有新建逻辑，对应的既有测试保持通过。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6223
- Related to #5745, #5772

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

新增回归测试 `TestResponsesStreamEventToChatChunksDoesNotResendToolOnTerminalOutput`（事件序列：`output_item.added` -> `function_call_arguments.delta` -> 携带完整 output 的 `response.completed`），修复前失败、修复后通过。

修复前（main @ a63364d1）：

```text
--- FAIL: TestResponsesStreamEventToChatChunksDoesNotResendToolOnTerminalOutput (0.00s)
    Error: Not equal:
           expected: "{\"q\":\"x\"}"
           actual  : "{\"q\":\"x\"}{\"q\":\"x\"}"
```

修复后：

```text
--- PASS: TestResponsesStreamEventToChatChunksDoesNotResendToolOnTerminalOutput (0.00s)

$ go vet ./service/relayconvert/...
$ go test ./service/relayconvert/... -count=1
ok      github.com/QuantumNous/new-api/service/relayconvert                           1.790s
ok      github.com/QuantumNous/new-api/service/relayconvert/internal/oai_chat        2.709s
ok      github.com/QuantumNous/new-api/service/relayconvert/internal/oai_responses   2.221s
```

既有测试全部通过，terminal-only 工具调用场景（`TestResponsesStreamEventToChatChunksUsesTerminalDoneOutput`）不受影响。另已本地验证：多个不同工具仍分配不同 index；流式只发送部分 arguments、终止事件携带完整 arguments 时，只在同一 index 下补发差量。

本 PR 由 AI 辅助完成（AI-assisted），我已逐行审阅并在本地验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate tool calls from appearing when a response stream ends with a completed event.
  * Preserved tool call arguments and final completion status correctly across streamed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->