### PR TITLE
feat: add configurable current-request tool billing

### DIFF
--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -221,13 +221,14 @@ type CompletionsStreamResponse struct {
 }
 
 type Usage struct {
-	PromptTokens         int           `json:"prompt_tokens"`
-	CompletionTokens     int           `json:"completion_tokens"`
-	TotalTokens          int           `json:"total_tokens"`
-	PromptCacheHitTokens int           `json:"prompt_cache_hit_tokens,omitempty"`
-	UsageSemantic        string        `json:"usage_semantic,omitempty"`
-	UsageSource          string        `json:"usage_source,omitempty"`
-	BillingUsage         *BillingUsage `json:"billing_usage,omitempty"`
+	PromptTokens         int            `json:"prompt_tokens"`
+	CompletionTokens     int            `json:"completion_tokens"`
+	TotalTokens          int            `json:"total_tokens"`
+	PromptCacheHitTokens int            `json:"prompt_cache_hit_tokens,omitempty"`
+	UsageSemantic        string         `json:"usage_semantic,omitempty"`
+	UsageSource          string         `json:"usage_source,omitempty"`
+	BillingUsage         *BillingUsage  `json:"billing_usage,omitempty"`
+	ToolUsage            map[string]int `json:"tool_usage,omitempty"`
 
 	PromptTokensDetails    InputTokenDetails  `json:"prompt_tokens_details"`
 	CompletionTokenDetails OutputTokenDetails `json:"completion_tokens_details"`

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -49,6 +49,7 @@ func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 		usage.PromptTokens = responsesResponse.Usage.InputTokens
 		usage.CompletionTokens = responsesResponse.Usage.OutputTokens
 		usage.TotalTokens = responsesResponse.Usage.TotalTokens
+		usage.ToolUsage = responsesResponse.Usage.ToolUsage
 		if responsesResponse.Usage.InputTokensDetails != nil {
 			usage.PromptTokensDetails.CachedTokens = responsesResponse.Usage.InputTokensDetails.CachedTokens
 			usage.PromptTokensDetails.CacheWriteTokens = responsesResponse.Usage.InputTokensDetails.CacheWriteTokens
@@ -57,15 +58,13 @@ func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 	if info == nil || info.ResponsesUsageInfo == nil || info.ResponsesUsageInfo.BuiltInTools == nil {
 		return &usage, nil
 	}
-	// 解析 Tools 用量
-	for _, tool := range responsesResponse.Tools {
-		buildToolinfo, ok := info.ResponsesUsageInfo.BuiltInTools[common.Interface2String(tool["type"])]
-		if !ok || buildToolinfo == nil {
-			logger.LogError(c, fmt.Sprintf("BuiltInTools not found for tool type: %v", tool["type"]))
-			continue
-		}
-		buildToolinfo.CallCount++
+	// Only output call items prove that an upstream tool was actually used.
+	// responsesResponse.Tools merely echoes the configured tools.
+	for _, output := range responsesResponse.Output {
+		info.ResponsesUsageInfo.RecordToolCall(output.Type)
 	}
+	// usage.tool_usage is the current response's final tool-usage snapshot.
+	info.ResponsesUsageInfo.RecordCurrentToolUsage(usage.ToolUsage)
 	return &usage, nil
 }
 
@@ -107,6 +106,10 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 						usage.PromptTokensDetails.CachedTokens = streamResponse.Response.Usage.InputTokensDetails.CachedTokens
 						usage.PromptTokensDetails.CacheWriteTokens = streamResponse.Response.Usage.InputTokensDetails.CacheWriteTokens
 					}
+					usage.ToolUsage = streamResponse.Response.Usage.ToolUsage
+					if info != nil && info.ResponsesUsageInfo != nil {
+						info.ResponsesUsageInfo.RecordCurrentToolUsage(usage.ToolUsage)
+					}
 				}
 				if streamResponse.Response.HasImageGenerationCall() {
 					c.Set("image_generation_call", true)
@@ -118,16 +121,8 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 			// 处理输出文本
 			responseTextBuilder.WriteString(streamResponse.Delta)
 		case dto.ResponsesOutputTypeItemDone:
-			// 函数调用处理
-			if streamResponse.Item != nil {
-				switch streamResponse.Item.Type {
-				case dto.BuildInCallWebSearchCall:
-					if info != nil && info.ResponsesUsageInfo != nil && info.ResponsesUsageInfo.BuiltInTools != nil {
-						if webSearchTool, exists := info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolWebSearchPreview]; exists && webSearchTool != nil {
-							webSearchTool.CallCount++
-						}
-					}
-				}
+			if streamResponse.Item != nil && info != nil && info.ResponsesUsageInfo != nil {
+				info.ResponsesUsageInfo.RecordToolCall(streamResponse.Item.Type)
 			}
 		}
 	})

--- a/relay/channel/openai/relay_responses_test.go
+++ b/relay/channel/openai/relay_responses_test.go
@@ -1,0 +1,88 @@
+package openai
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOaiResponsesHandlerCountsOnlyActualToolCalls(t *testing.T) {
+	oldMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(oldMode) })
+
+	tests := []struct {
+		name      string
+		body      string
+		callCount int
+	}{
+		{
+			name: "configured tool without call is not billed",
+			body: `{
+				"output":[{"type":"message"}],
+				"tools":[{"type":"web_search"}],
+				"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}
+			}`,
+			callCount: 0,
+		},
+		{
+			name: "actual output call is counted",
+			body: `{
+				"output":[{"type":"web_search_call"}],
+				"tools":[{"type":"web_search"}],
+				"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}
+			}`,
+			callCount: 1,
+		},
+		{
+			name: "provider reported current tool usage is counted",
+			body: `{
+				"output":[{"type":"message"}],
+				"tools":[{"type":"web_search"}],
+				"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"tool_usage":{"web_search":2}}
+			}`,
+			callCount: 2,
+		},
+		{
+			name: "provider usage replaces output item count",
+			body: `{
+				"output":[{"type":"web_search_call"},{"type":"web_search_call"}],
+				"tools":[{"type":"web_search"}],
+				"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"tool_usage":{"web_search":1}}
+			}`,
+			callCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(recorder)
+			info := &relaycommon.RelayInfo{
+				ResponsesUsageInfo: &relaycommon.ResponsesUsageInfo{
+					BuiltInTools: map[string]*relaycommon.BuildInToolInfo{
+						"web_search": {ToolName: "web_search"},
+					},
+				},
+			}
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(tt.body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}
+
+			usage, apiErr := OaiResponsesHandler(ctx, info, resp)
+
+			require.Nil(t, apiErr)
+			require.Equal(t, 2, usage.TotalTokens)
+			require.Equal(t, tt.callCount, info.ResponsesUsageInfo.BuiltInTools["web_search"].CallCount)
+		})
+	}
+}

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -60,6 +60,55 @@ type ResponsesUsageInfo struct {
 	BuiltInTools map[string]*BuildInToolInfo
 }
 
+// RecordToolCall records an actual built-in tool call emitted by a Responses
+// upstream. A tool is charged only when its call output can be matched to a
+// tool type declared in the original request.
+func (r *ResponsesUsageInfo) RecordToolCall(outputType string) bool {
+	if r == nil || r.BuiltInTools == nil || !strings.HasSuffix(outputType, "_call") {
+		return false
+	}
+
+	// image_generation_call has its own quality/size-based pricing path.
+	if outputType == dto.ResponsesOutputTypeImageGenerationCall {
+		return false
+	}
+
+	toolName := strings.TrimSuffix(outputType, "_call")
+	if tool, ok := r.BuiltInTools[toolName]; ok && tool != nil {
+		tool.CallCount++
+		return true
+	}
+
+	// OpenAI's web_search_preview emits web_search_call, so only use this
+	// fallback when the request did not declare the current web_search type.
+	if outputType == dto.BuildInCallWebSearchCall {
+		if tool, ok := r.BuiltInTools[dto.BuildInToolWebSearchPreview]; ok && tool != nil {
+			tool.CallCount++
+			return true
+		}
+	}
+
+	return false
+}
+
+// RecordCurrentToolUsage records the provider-reported tool usage for the
+// current request. The usage field is the final snapshot for that request, so
+// it replaces any provisional count collected from streamed output items.
+func (r *ResponsesUsageInfo) RecordCurrentToolUsage(toolUsage map[string]int) {
+	if r == nil || r.BuiltInTools == nil {
+		return
+	}
+
+	for toolName, callCount := range toolUsage {
+		if callCount < 0 {
+			continue
+		}
+		if tool, ok := r.BuiltInTools[toolName]; ok && tool != nil {
+			tool.CallCount = callCount
+		}
+	}
+}
+
 type ChannelMeta struct {
 	ChannelType          int
 	ChannelId            int

--- a/relay/common/relay_info_test.go
+++ b/relay/common/relay_info_test.go
@@ -3,9 +3,58 @@ package common
 import (
 	"testing"
 
+	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/types"
 	"github.com/stretchr/testify/require"
 )
+
+func TestResponsesUsageInfoRecordToolCall(t *testing.T) {
+	t.Run("matches declared generic tools", func(t *testing.T) {
+		usageInfo := &ResponsesUsageInfo{BuiltInTools: map[string]*BuildInToolInfo{
+			"web_search":       {ToolName: "web_search"},
+			"code_interpreter": {ToolName: "code_interpreter"},
+		}}
+
+		require.True(t, usageInfo.RecordToolCall("web_search_call"))
+		require.True(t, usageInfo.RecordToolCall("code_interpreter_call"))
+		require.Equal(t, 1, usageInfo.BuiltInTools["web_search"].CallCount)
+		require.Equal(t, 1, usageInfo.BuiltInTools["code_interpreter"].CallCount)
+	})
+
+	t.Run("uses preview fallback only when web search is absent", func(t *testing.T) {
+		usageInfo := &ResponsesUsageInfo{BuiltInTools: map[string]*BuildInToolInfo{
+			dto.BuildInToolWebSearchPreview: {ToolName: dto.BuildInToolWebSearchPreview},
+		}}
+
+		require.True(t, usageInfo.RecordToolCall(dto.BuildInCallWebSearchCall))
+		require.Equal(t, 1, usageInfo.BuiltInTools[dto.BuildInToolWebSearchPreview].CallCount)
+	})
+
+	t.Run("does not bill special image generation through generic pricing", func(t *testing.T) {
+		usageInfo := &ResponsesUsageInfo{BuiltInTools: map[string]*BuildInToolInfo{
+			"image_generation": {ToolName: "image_generation"},
+		}}
+
+		require.False(t, usageInfo.RecordToolCall(dto.ResponsesOutputTypeImageGenerationCall))
+		require.Zero(t, usageInfo.BuiltInTools["image_generation"].CallCount)
+	})
+
+	t.Run("provider usage replaces provisional output count for the current request", func(t *testing.T) {
+		usageInfo := &ResponsesUsageInfo{BuiltInTools: map[string]*BuildInToolInfo{
+			"web_search": {ToolName: "web_search", CallCount: 2},
+		}}
+
+		usageInfo.RecordCurrentToolUsage(map[string]int{
+			"web_search": 1,
+			"toutiao":    9,
+		})
+
+		require.Equal(t, 1, usageInfo.BuiltInTools["web_search"].CallCount)
+
+		usageInfo.RecordCurrentToolUsage(map[string]int{"web_search": 0})
+		require.Zero(t, usageInfo.BuiltInTools["web_search"].CallCount)
+	})
+}
 
 func TestRelayInfoGetFinalRequestRelayFormatPrefersExplicitFinal(t *testing.T) {
 	info := &RelayInfo{

--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -46,15 +47,16 @@ type textQuotaSummary struct {
 	Quota                    int
 	IsClaudeUsageSemantic    bool
 	UsageSemantic            string
-	WebSearchPrice           float64
-	WebSearchCallCount       int
-	ClaudeWebSearchPrice     float64
-	ClaudeWebSearchCallCount int
-	FileSearchPrice          float64
-	FileSearchCallCount      int
+	ToolCallItems            []toolCallSurchargeItem
 	AudioInputPrice          float64
 	ImageGenerationCallPrice float64
 	ToolCallSurchargeQuota   decimal.Decimal
+}
+
+type toolCallSurchargeItem struct {
+	Name       string  `json:"name"`
+	CallCount  int     `json:"call_count"`
+	PricePer1K float64 `json:"price_per_1k"`
 }
 
 func cacheWriteTokensTotal(summary textQuotaSummary) int {
@@ -81,6 +83,29 @@ func isLegacyClaudeDerivedOpenAIUsage(relayInfo *relaycommon.RelayInfo, usage *d
 	return usage.ClaudeCacheCreation5mTokens > 0 || usage.ClaudeCacheCreation1hTokens > 0
 }
 
+func addTextToolCallSurcharge(summary *textQuotaSummary, toolName string, callCount int) decimal.Decimal {
+	if callCount <= 0 {
+		return decimal.Zero
+	}
+
+	pricePer1K := operation_setting.GetToolPriceForModel(toolName, summary.ModelName)
+	if pricePer1K <= 0 {
+		return decimal.Zero
+	}
+
+	summary.ToolCallItems = append(summary.ToolCallItems, toolCallSurchargeItem{
+		Name:       toolName,
+		CallCount:  callCount,
+		PricePer1K: pricePer1K,
+	})
+
+	return decimal.NewFromFloat(pricePer1K).
+		Mul(decimal.NewFromInt(int64(callCount))).
+		Div(decimal.NewFromInt(1000)).
+		Mul(decimal.NewFromFloat(summary.GroupRatio)).
+		Mul(decimal.NewFromFloat(common.QuotaPerUnit))
+}
+
 func calculateTextToolCallSurcharge(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, summary *textQuotaSummary) decimal.Decimal {
 	dGroupRatio := decimal.NewFromFloat(summary.GroupRatio)
 	dQuotaPerUnit := decimal.NewFromFloat(common.QuotaPerUnit)
@@ -88,45 +113,22 @@ func calculateTextToolCallSurcharge(ctx *gin.Context, relayInfo *relaycommon.Rel
 	var surcharge decimal.Decimal
 
 	if relayInfo.ResponsesUsageInfo != nil {
-		if webSearchTool, exists := relayInfo.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolWebSearchPreview]; exists && webSearchTool.CallCount > 0 {
-			summary.WebSearchCallCount = webSearchTool.CallCount
-			summary.WebSearchPrice = operation_setting.GetToolPriceForModel("web_search_preview", summary.ModelName)
-			surcharge = surcharge.Add(decimal.NewFromFloat(summary.WebSearchPrice).
-				Mul(decimal.NewFromInt(int64(webSearchTool.CallCount))).
-				Div(decimal.NewFromInt(1000)).
-				Mul(dGroupRatio).
-				Mul(dQuotaPerUnit))
+		toolNames := make([]string, 0, len(relayInfo.ResponsesUsageInfo.BuiltInTools))
+		for toolName := range relayInfo.ResponsesUsageInfo.BuiltInTools {
+			toolNames = append(toolNames, toolName)
+		}
+		sort.Strings(toolNames)
+		for _, toolName := range toolNames {
+			tool := relayInfo.ResponsesUsageInfo.BuiltInTools[toolName]
+			if tool != nil {
+				surcharge = surcharge.Add(addTextToolCallSurcharge(summary, toolName, tool.CallCount))
+			}
 		}
 	} else if strings.HasSuffix(summary.ModelName, "search-preview") {
-		summary.WebSearchCallCount = 1
-		summary.WebSearchPrice = operation_setting.GetToolPriceForModel("web_search_preview", summary.ModelName)
-		surcharge = surcharge.Add(decimal.NewFromFloat(summary.WebSearchPrice).
-			Div(decimal.NewFromInt(1000)).
-			Mul(dGroupRatio).
-			Mul(dQuotaPerUnit))
+		surcharge = surcharge.Add(addTextToolCallSurcharge(summary, dto.BuildInToolWebSearchPreview, 1))
 	}
 
-	summary.ClaudeWebSearchCallCount = ctx.GetInt("claude_web_search_requests")
-	if summary.ClaudeWebSearchCallCount > 0 {
-		summary.ClaudeWebSearchPrice = operation_setting.GetToolPrice("web_search")
-		surcharge = surcharge.Add(decimal.NewFromFloat(summary.ClaudeWebSearchPrice).
-			Div(decimal.NewFromInt(1000)).
-			Mul(dGroupRatio).
-			Mul(dQuotaPerUnit).
-			Mul(decimal.NewFromInt(int64(summary.ClaudeWebSearchCallCount))))
-	}
-
-	if relayInfo.ResponsesUsageInfo != nil {
-		if fileSearchTool, exists := relayInfo.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolFileSearch]; exists && fileSearchTool.CallCount > 0 {
-			summary.FileSearchCallCount = fileSearchTool.CallCount
-			summary.FileSearchPrice = operation_setting.GetToolPrice("file_search")
-			surcharge = surcharge.Add(decimal.NewFromFloat(summary.FileSearchPrice).
-				Mul(decimal.NewFromInt(int64(fileSearchTool.CallCount))).
-				Div(decimal.NewFromInt(1000)).
-				Mul(dGroupRatio).
-				Mul(dQuotaPerUnit))
-		}
-	}
+	surcharge = surcharge.Add(addTextToolCallSurcharge(summary, "web_search", ctx.GetInt("claude_web_search_requests")))
 
 	if ctx.GetBool("image_generation_call") {
 		summary.ImageGenerationCallPrice = operation_setting.GetGPTImage1PriceOnceCall(ctx.GetString("image_generation_call_quality"), ctx.GetString("image_generation_call_size"))
@@ -372,14 +374,13 @@ func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, us
 		}
 	}
 
-	if summary.WebSearchCallCount > 0 {
-		extraContent = append(extraContent, fmt.Sprintf("Web Search 调用 %d 次，调用花费 %s", summary.WebSearchCallCount, decimal.NewFromFloat(summary.WebSearchPrice).Mul(decimal.NewFromInt(int64(summary.WebSearchCallCount))).Div(decimal.NewFromInt(1000)).Mul(decimal.NewFromFloat(summary.GroupRatio)).Mul(decimal.NewFromFloat(common.QuotaPerUnit)).String()))
-	}
-	if summary.ClaudeWebSearchCallCount > 0 {
-		extraContent = append(extraContent, fmt.Sprintf("Claude Web Search 调用 %d 次，调用花费 %s", summary.ClaudeWebSearchCallCount, decimal.NewFromFloat(summary.ClaudeWebSearchPrice).Div(decimal.NewFromInt(1000)).Mul(decimal.NewFromFloat(summary.GroupRatio)).Mul(decimal.NewFromFloat(common.QuotaPerUnit)).Mul(decimal.NewFromInt(int64(summary.ClaudeWebSearchCallCount))).String()))
-	}
-	if summary.FileSearchCallCount > 0 {
-		extraContent = append(extraContent, fmt.Sprintf("File Search 调用 %d 次，调用花费 %s", summary.FileSearchCallCount, decimal.NewFromFloat(summary.FileSearchPrice).Mul(decimal.NewFromInt(int64(summary.FileSearchCallCount))).Div(decimal.NewFromInt(1000)).Mul(decimal.NewFromFloat(summary.GroupRatio)).Mul(decimal.NewFromFloat(common.QuotaPerUnit)).String()))
+	for _, toolCall := range summary.ToolCallItems {
+		toolQuota := decimal.NewFromFloat(toolCall.PricePer1K).
+			Mul(decimal.NewFromInt(int64(toolCall.CallCount))).
+			Div(decimal.NewFromInt(1000)).
+			Mul(decimal.NewFromFloat(summary.GroupRatio)).
+			Mul(decimal.NewFromFloat(common.QuotaPerUnit))
+		extraContent = append(extraContent, fmt.Sprintf("%s 调用 %d 次，调用花费 %s", toolCall.Name, toolCall.CallCount, toolQuota.String()))
 	}
 	if summary.AudioInputPrice > 0 && summary.AudioTokens > 0 {
 		extraContent = append(extraContent, fmt.Sprintf("Audio Input 花费 %s", decimal.NewFromFloat(summary.AudioInputPrice).Div(decimal.NewFromInt(1000000)).Mul(decimal.NewFromInt(int64(summary.AudioTokens))).Mul(decimal.NewFromFloat(summary.GroupRatio)).Mul(decimal.NewFromFloat(common.QuotaPerUnit)).String()))
@@ -433,19 +434,20 @@ func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, us
 		other["image_ratio"] = summary.ImageRatio
 		other["image_output"] = summary.ImageTokens
 	}
-	if summary.WebSearchCallCount > 0 {
-		other["web_search"] = true
-		other["web_search_call_count"] = summary.WebSearchCallCount
-		other["web_search_price"] = summary.WebSearchPrice
-	} else if summary.ClaudeWebSearchCallCount > 0 {
-		other["web_search"] = true
-		other["web_search_call_count"] = summary.ClaudeWebSearchCallCount
-		other["web_search_price"] = summary.ClaudeWebSearchPrice
-	}
-	if summary.FileSearchCallCount > 0 {
-		other["file_search"] = true
-		other["file_search_call_count"] = summary.FileSearchCallCount
-		other["file_search_price"] = summary.FileSearchPrice
+	if len(summary.ToolCallItems) > 0 {
+		other["tool_calls"] = summary.ToolCallItems
+		for _, toolCall := range summary.ToolCallItems {
+			switch toolCall.Name {
+			case "web_search", dto.BuildInToolWebSearchPreview:
+				other["web_search"] = true
+				other["web_search_call_count"] = toolCall.CallCount
+				other["web_search_price"] = toolCall.PricePer1K
+			case dto.BuildInToolFileSearch:
+				other["file_search"] = true
+				other["file_search_call_count"] = toolCall.CallCount
+				other["file_search_price"] = toolCall.PricePer1K
+			}
+		}
 	}
 	if summary.AudioInputPrice > 0 && summary.AudioTokens > 0 {
 		other["audio_input_seperate_price"] = true

--- a/service/text_quota_test.go
+++ b/service/text_quota_test.go
@@ -559,7 +559,7 @@ func TestComposeTieredTextQuotaKeepsToolCallSurcharges(t *testing.T) {
 		},
 		ResponsesUsageInfo: &relaycommon.ResponsesUsageInfo{
 			BuiltInTools: map[string]*relaycommon.BuildInToolInfo{
-				dto.BuildInToolWebSearchPreview: &relaycommon.BuildInToolInfo{
+				"web_search": &relaycommon.BuildInToolInfo{
 					CallCount: 1,
 				},
 				dto.BuildInToolFileSearch: &relaycommon.BuildInToolInfo{
@@ -588,6 +588,9 @@ func TestComposeTieredTextQuotaKeepsToolCallSurcharges(t *testing.T) {
 	})
 
 	require.Equal(t, int64(13000), summary.ToolCallSurchargeQuota.Round(0).IntPart())
+	require.Len(t, summary.ToolCallItems, 2)
+	require.Equal(t, "file_search", summary.ToolCallItems[0].Name)
+	require.Equal(t, "web_search", summary.ToolCallItems[1].Name)
 	require.Equal(t, 14000, quota)
 }
 

--- a/setting/operation_setting/tools.go
+++ b/setting/operation_setting/tools.go
@@ -22,6 +22,8 @@ import (
 var defaultToolPrices = map[string]float64{
 	"web_search":         10.0, // OpenAI web search (all models) / Claude web search
 	"web_search_preview": 10.0, // OpenAI web search preview (default: reasoning models)
+	"web_extractor":      0.0,  // Configure before enabling billing.
+	"code_interpreter":   0.0,  // Configure before enabling billing.
 	"file_search":        2.5,  // OpenAI file search (Responses API)
 	"google_search":      14.0, // Gemini Grounding with Google Search
 }

--- a/setting/operation_setting/tools_test.go
+++ b/setting/operation_setting/tools_test.go
@@ -1,0 +1,26 @@
+package operation_setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetToolPriceForModelSupportsConfiguredToolNames(t *testing.T) {
+	originalPrices := toolPriceSetting.Prices
+	t.Cleanup(func() {
+		toolPriceSetting.Prices = originalPrices
+		RebuildToolPriceIndex()
+	})
+
+	toolPriceSetting.Prices = map[string]float64{
+		"toutiao":                       4,
+		"toutiao:deepseek-v4-flash*":    2,
+		"web_search:deepseek-v4-flash*": 8,
+	}
+	RebuildToolPriceIndex()
+
+	require.Equal(t, 2.0, GetToolPriceForModel("toutiao", "deepseek-v4-flash"))
+	require.Equal(t, 4.0, GetToolPriceForModel("toutiao", "other-model"))
+	require.Equal(t, 8.0, GetToolPriceForModel("web_search", "deepseek-v4-flash"))
+}

--- a/web/default/src/features/system-settings/models/tool-price-settings.tsx
+++ b/web/default/src/features/system-settings/models/tool-price-settings.tsx
@@ -34,6 +34,8 @@ const OPTION_KEY = 'tool_price_setting.prices'
 const DEFAULT_PRICES: Record<string, number> = {
   web_search: 10.0,
   web_search_preview: 10.0,
+  web_extractor: 0.0,
+  code_interpreter: 0.0,
   'web_search_preview:gpt-4o*': 25.0,
   'web_search_preview:gpt-4.1*': 25.0,
   'web_search_preview:gpt-4o-mini*': 25.0,
@@ -78,7 +80,7 @@ function parseInitialPrices(
       !Array.isArray(parsed) &&
       Object.keys(parsed as object).length > 0
     ) {
-      return parsed as Record<string, number>
+      return { ...DEFAULT_PRICES, ...(parsed as Record<string, number>) }
     }
   } catch {
     // fall through to defaults
@@ -198,7 +200,7 @@ export const ToolPriceSettings = memo(function ToolPriceSettings({
         <AlertDescription className='space-y-1 text-sm'>
           <div>
             {t(
-              'Configure per-tool unit prices ($/1K calls). Per-request models do not incur additional tool fees.'
+              'Configure per-tool unit prices ($/1K calls). Only tool calls confirmed by the upstream are billed.'
             )}
           </div>
           <div>

--- a/web/default/src/features/usage-logs/components/dialogs/details-dialog.tsx
+++ b/web/default/src/features/usage-logs/components/dialogs/details-dialog.tsx
@@ -1,3 +1,4 @@
+import type { TFunction } from 'i18next'
 /*
 Copyright (C) 2023-2026 QuantumNous
 
@@ -31,7 +32,6 @@ import {
   Info,
   LogIn,
 } from 'lucide-react'
-import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 
 import { Dialog } from '@/components/dialog'
@@ -179,7 +179,9 @@ function getUsageBillingPathLabel(
   }
 }
 
-function isUsageBillingPathLocal(adminInfo: LogOtherData['admin_info']): boolean {
+function isUsageBillingPathLocal(
+  adminInfo: LogOtherData['admin_info']
+): boolean {
   if (adminInfo?.usage_billing_path) {
     return adminInfo.usage_billing_path === USAGE_BILLING_PATH.LOCAL
   }
@@ -332,18 +334,28 @@ function BillingBreakdown(props: {
     }
   }
 
-  if (other.web_search && other.web_search_call_count) {
-    rows.push({
-      label: t('Web Search'),
-      value: `${other.web_search_call_count}x${other.web_search_price ? ` (${fmtPrice(other.web_search_price)})` : ''}`,
-    })
-  }
+  if (other.tool_calls?.length) {
+    for (const toolCall of other.tool_calls) {
+      if (!toolCall.name || toolCall.call_count <= 0) continue
+      rows.push({
+        label: toolCall.name,
+        value: `${toolCall.call_count}x${toolCall.price_per_1k ? ` (${fmtPrice(toolCall.price_per_1k)})` : ''}`,
+      })
+    }
+  } else {
+    if (other.web_search && other.web_search_call_count) {
+      rows.push({
+        label: t('Web Search'),
+        value: `${other.web_search_call_count}x${other.web_search_price ? ` (${fmtPrice(other.web_search_price)})` : ''}`,
+      })
+    }
 
-  if (other.file_search && other.file_search_call_count) {
-    rows.push({
-      label: t('File Search'),
-      value: `${other.file_search_call_count}x${other.file_search_price ? ` (${fmtPrice(other.file_search_price)})` : ''}`,
-    })
+    if (other.file_search && other.file_search_call_count) {
+      rows.push({
+        label: t('File Search'),
+        value: `${other.file_search_call_count}x${other.file_search_price ? ` (${fmtPrice(other.file_search_price)})` : ''}`,
+      })
+    }
   }
 
   if (other.image_generation_call && other.image_generation_call_price) {

--- a/web/default/src/features/usage-logs/types.ts
+++ b/web/default/src/features/usage-logs/types.ts
@@ -197,6 +197,11 @@ export interface LogOtherData {
   file_search?: boolean
   file_search_call_count?: number
   file_search_price?: number
+  tool_calls?: Array<{
+    name: string
+    call_count: number
+    price_per_1k: number
+  }>
   audio_input_seperate_price?: boolean
   audio_input_token_count?: number
   audio_input_price?: number

--- a/web/default/src/i18n/locales/en.json
+++ b/web/default/src/i18n/locales/en.json
@@ -970,6 +970,7 @@
     "Configure monitoring status page groups for the dashboard": "Configure monitoring status page groups for the dashboard",
     "Configure NODE_NAME": "Configure NODE_NAME",
     "Configure per-model ratio for image inputs or outputs.": "Configure per-model ratio for image inputs or outputs.",
+    "Configure per-tool unit prices ($/1K calls). Only tool calls confirmed by the upstream are billed.": "Configure per-tool unit prices ($/1K calls). Only tool calls confirmed by the upstream are billed.",
     "Configure per-tool unit prices ($/1K calls). Per-request models do not incur additional tool fees.": "Configure per-tool unit prices ($/1K calls). Per-request models do not incur additional tool fees.",
     "Configure pricing ratios for a specific model.": "Configure pricing ratios for a specific model.",
     "Configure rate limiting rules for a specific user group.": "Configure rate limiting rules for a specific user group.",

--- a/web/default/src/i18n/locales/fr.json
+++ b/web/default/src/i18n/locales/fr.json
@@ -970,6 +970,7 @@
     "Configure monitoring status page groups for the dashboard": "Configurer les groupes de pages d'état de surveillance pour le tableau de bord",
     "Configure NODE_NAME": "Configurer NODE_NAME",
     "Configure per-model ratio for image inputs or outputs.": "Configurer le ratio par modèle pour les entrées ou sorties d'images.",
+    "Configure per-tool unit prices ($/1K calls). Only tool calls confirmed by the upstream are billed.": "Configurez le prix unitaire par outil ($/1K appels). Seuls les appels d’outils confirmés par le fournisseur sont facturés.",
     "Configure per-tool unit prices ($/1K calls). Per-request models do not incur additional tool fees.": "Définissez le prix unitaire de chaque outil ($/1K appels). Les modèles facturés à la requête n'entraînent pas de frais d'outils supplémentaires.",
     "Configure pricing ratios for a specific model.": "Configurer les ratios de tarification pour un modèle spécifique.",
     "Configure rate limiting rules for a specific user group.": "Configurer les règles de limitation de débit pour un groupe d'utilisateurs spécifique.",

--- a/web/default/src/i18n/locales/ja.json
+++ b/web/default/src/i18n/locales/ja.json
@@ -970,6 +970,7 @@
     "Configure monitoring status page groups for the dashboard": "ダッシュボードの監視ステータスページグループを設定します。",
     "Configure NODE_NAME": "NODE_NAME を設定",
     "Configure per-model ratio for image inputs or outputs.": "画像の入力または出力のモデルごとの比率を設定します。",
+    "Configure per-tool unit prices ($/1K calls). Only tool calls confirmed by the upstream are billed.": "ツールごとの単価（$/1K 回）を設定します。上流が実際に実行したことを確認したツール呼び出しのみ課金されます。",
     "Configure per-tool unit prices ($/1K calls). Per-request models do not incur additional tool fees.": "ツールごとの単価（$/1K 回）を設定します。リクエスト課金モデルでは追加工具料金はかかりません。",
     "Configure pricing ratios for a specific model.": "特定のモデルの料金比率を設定します。",
     "Configure rate limiting rules for a specific user group.": "特定のユーザーグループのレート制限ルールを設定します。",

--- a/web/default/src/i18n/locales/ru.json
+++ b/web/default/src/i18n/locales/ru.json
@@ -970,6 +970,7 @@
     "Configure monitoring status page groups for the dashboard": "Настроить группы страниц состояния мониторинга для панели управления",
     "Configure NODE_NAME": "Настроить NODE_NAME",
     "Configure per-model ratio for image inputs or outputs.": "Настроить коэффициент для каждой модели для ввода или вывода изображений.",
+    "Configure per-tool unit prices ($/1K calls). Only tool calls confirmed by the upstream are billed.": "Настройте цену за единицу для каждого инструмента ($/1K вызовов). Оплачиваются только вызовы инструментов, подтверждённые вышестоящим сервисом.",
     "Configure per-tool unit prices ($/1K calls). Per-request models do not incur additional tool fees.": "Настройте стоимость единицы на инструмент ($/1K вызовов). Для моделей с оплатой за запрос доп. плата за инструменты не взимается.",
     "Configure pricing ratios for a specific model.": "Настроить коэффициенты ценообразования для конкретной модели.",
     "Configure rate limiting rules for a specific user group.": "Настроить правила ограничения скорости для конкретной группы пользователей.",

--- a/web/default/src/i18n/locales/vi.json
+++ b/web/default/src/i18n/locales/vi.json
@@ -970,6 +970,7 @@
     "Configure monitoring status page groups for the dashboard": "Cấu hình các nhóm trang trạng thái giám sát cho bảng điều khiển",
     "Configure NODE_NAME": "Cấu hình NODE_NAME",
     "Configure per-model ratio for image inputs or outputs.": "Cấu hình tỷ lệ theo mô hình cho đầu vào hoặc đầu ra hình ảnh.",
+    "Configure per-tool unit prices ($/1K calls). Only tool calls confirmed by the upstream are billed.": "Cấu hình đơn giá cho từng công cụ ($/1K lượt gọi). Chỉ tính phí các lượt gọi công cụ được upstream xác nhận.",
     "Configure per-tool unit prices ($/1K calls). Per-request models do not incur additional tool fees.": "Cấu hình giá theo từng công cụ ($/1K lần gọi). Mô hình tính phí theo request không phát sinh thêm phí công cụ.",
     "Configure pricing ratios for a specific model.": "Cấu hình tỷ lệ định giá cho một mô hình cụ thể.",
     "Configure rate limiting rules for a specific user group.": "Cấu hình quy tắc giới hạn tốc độ cho một nhóm người dùng cụ thể.",

--- a/web/default/src/i18n/locales/zh-TW.json
+++ b/web/default/src/i18n/locales/zh-TW.json
@@ -970,6 +970,7 @@
     "Configure monitoring status page groups for the dashboard": "設定用於儀表板的監控狀態頁面分組",
     "Configure NODE_NAME": "設定 NODE_NAME",
     "Configure per-model ratio for image inputs or outputs.": "設定圖像輸入或輸出的每模型比例。",
+    "Configure per-tool unit prices ($/1K calls). Only tool calls confirmed by the upstream are billed.": "為每個工具設定單價（$/1K 次呼叫）。僅對上游確認實際呼叫的工具收費。",
     "Configure per-tool unit prices ($/1K calls). Per-request models do not incur additional tool fees.": "為每個工具設定單價（$/1K 次呼叫）。按請求收費的模型不額外收取工具費用。",
     "Configure pricing ratios for a specific model.": "設定特定模型的定價比例。",
     "Configure rate limiting rules for a specific user group.": "設定特定用戶分組的速率限制規則。",

--- a/web/default/src/i18n/locales/zh.json
+++ b/web/default/src/i18n/locales/zh.json
@@ -970,6 +970,7 @@
     "Configure monitoring status page groups for the dashboard": "配置用于仪表板的监控状态页面分组",
     "Configure NODE_NAME": "配置 NODE_NAME",
     "Configure per-model ratio for image inputs or outputs.": "配置图像输入或输出的每模型比例。",
+    "Configure per-tool unit prices ($/1K calls). Only tool calls confirmed by the upstream are billed.": "为每个工具配置单价（$/1K 次调用）。仅对上游确认实际调用的工具收费。",
     "Configure per-tool unit prices ($/1K calls). Per-request models do not incur additional tool fees.": "为每个工具配置单价（$/1K 次调用）。按请求计费的模型不额外收取工具费用。",
     "Configure pricing ratios for a specific model.": "配置特定模型的定价比例。",
     "Configure rate limiting rules for a specific user group.": "配置特定用户分组的速率限制规则。",


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
针对于火山/百炼的response api请求, 实现工具调用的计费, 原平台中只能识别web_search_preview的工具调用计费.

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)

<img width="1636" height="1130" alt="image" src="https://github.com/user-attachments/assets/749ce3c5-c109-4aac-8b5b-870ea7bd0a81" />


<img width="2032" height="1618" alt="image" src="https://github.com/user-attachments/assets/dcee85fe-cedd-419f-8b9e-825747e9fc19" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed per-tool usage tracking for supported tools.
  - Usage logs now display individual tool call counts and applicable prices.
  - Added pricing support for Web Extractor and Code Interpreter tools.
  - Tool pricing settings now retain default entries when saved configurations omit them.
- **Bug Fixes**
  - Billing now counts only tool calls confirmed by the upstream provider.
  - Provider-reported usage totals take precedence over provisional call counts.
- **Documentation**
  - Updated billing guidance and translations across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->