### PR TITLE
fix(relay): apply header_override to task API requests

### DIFF
--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -542,6 +542,13 @@ func DoTaskApiRequest(a TaskAdaptor, c *gin.Context, info *common.RelayInfo, req
 	if err != nil {
 		return nil, fmt.Errorf("setup request header failed: %w", err)
 	}
+	// Apply header override after BuildRequestHeader to ensure user settings take precedence.
+	// This matches the behavior of DoApiRequest, DoFormRequest, and DoWssRequest.
+	headerOverride, err := processHeaderOverride(info, c)
+	if err != nil {
+		return nil, err
+	}
+	applyHeaderOverrideToRequest(req, headerOverride)
 	resp, err := doRequest(c, req, info)
 	if err != nil {
 		return nil, fmt.Errorf("do request failed: %w", err)


### PR DESCRIPTION
## Problem

`DoTaskApiRequest` was missing the `processHeaderOverride` + `applyHeaderOverrideToRequest` call chain that `DoApiRequest`, `DoFormRequest`, and `DoWssRequest` all have.

This meant task-type channels (doubao video, kling, sora, hailuo, etc.) could not use the channel's `header_override` setting ("请求头覆盖" in the UI).

## Impact

Some providers (e.g., doubao-seedance) return incorrect `Content-Encoding: gzip` headers on plain JSON bodies. The documented workaround is to set `Accept-Encoding: identity` via `header_override` to prevent the provider from attempting gzip compression. However, this workaround was silently ignored for task channels, causing `gzip: invalid header` errors.

## Solution

Apply header overrides after `BuildRequestHeader` in `DoTaskApiRequest`, matching the behavior of other `DoXxxRequest` helpers. This ensures user settings take precedence over adapter defaults.

## Testing

Tested with doubao-seedance-2-0-fast-260128:
- **Before**: `gzip: invalid header` error when submitting video generation tasks
- **After**: task submission succeeds with `Accept-Encoding: identity` override applied

## Changes

- Added `processHeaderOverride` + `applyHeaderOverrideToRequest` calls in `DoTaskApiRequest` after `BuildRequestHeader`
- This brings task API requests in line with the existing behavior of `DoApiRequest`, `DoFormRequest`, and `DoWssRequest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Channel header overrides now apply correctly to task requests.
  * Supported placeholders, passthrough rules, and explicit header overrides are honored before requests are sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->