### PR TITLE
feat: support Tencent TokenHub API key via OpenAI-compatible protocol

### DIFF
--- a/relay/channel/tencent/dispatch.go
+++ b/relay/channel/tencent/dispatch.go
@@ -3,10 +3,13 @@ package tencent
 import (
 	"strings"
 
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/relay/channel"
 	"github.com/QuantumNous/new-api/relay/channel/openai"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 )
+
+const tokenHubBaseURL = "https://tokenhub.tencentmaas.com"
 
 // DispatchAdaptor 按密钥格式分流:三段式 ak/sk 走原生 TC3,单段 TokenHub key 走 OpenAI 兼容。
 type DispatchAdaptor struct {
@@ -18,6 +21,9 @@ func (a *DispatchAdaptor) Init(info *relaycommon.RelayInfo) {
 		a.Adaptor = &Adaptor{}
 	} else {
 		a.Adaptor = &openai.Adaptor{}
+		if info.ChannelBaseUrl == "" || info.ChannelBaseUrl == constant.ChannelBaseURLs[constant.ChannelTypeTencent] {
+			info.ChannelBaseUrl = tokenHubBaseURL
+		}
 	}
 	a.Adaptor.Init(info)
 }

--- a/relay/channel/tencent/dispatch.go
+++ b/relay/channel/tencent/dispatch.go
@@ -1,0 +1,31 @@
+package tencent
+
+import (
+	"strings"
+
+	"github.com/QuantumNous/new-api/relay/channel"
+	"github.com/QuantumNous/new-api/relay/channel/openai"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+)
+
+// DispatchAdaptor 按密钥格式分流:三段式 ak/sk 走原生 TC3,单段 TokenHub key 走 OpenAI 兼容。
+type DispatchAdaptor struct {
+	channel.Adaptor
+}
+
+func (a *DispatchAdaptor) Init(info *relaycommon.RelayInfo) {
+	if strings.Contains(info.ApiKey, "|") {
+		a.Adaptor = &Adaptor{}
+	} else {
+		a.Adaptor = &openai.Adaptor{}
+	}
+	a.Adaptor.Init(info)
+}
+
+func (a *DispatchAdaptor) GetModelList() []string {
+	return ModelList
+}
+
+func (a *DispatchAdaptor) GetChannelName() string {
+	return ChannelName
+}

--- a/relay/channel/tencent/dispatch_test.go
+++ b/relay/channel/tencent/dispatch_test.go
@@ -1,0 +1,72 @@
+package tencent
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/relay/channel/openai"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDispatchAdaptorInit(t *testing.T) {
+	tests := []struct {
+		name        string
+		apiKey      string
+		baseURL     string
+		wantTC3     bool
+		wantBaseURL string
+	}{
+		{
+			name:        "legacy three-segment key selects TC3 adaptor and keeps base url",
+			apiKey:      "1300000000|AKIDxxxxxxxx|secretxxxxxxxx",
+			baseURL:     constant.ChannelBaseURLs[constant.ChannelTypeTencent],
+			wantTC3:     true,
+			wantBaseURL: constant.ChannelBaseURLs[constant.ChannelTypeTencent],
+		},
+		{
+			name:        "tokenhub key with default base url rewrites to tokenhub",
+			apiKey:      "sk-xxxxxxxxxxxxxxxx",
+			baseURL:     constant.ChannelBaseURLs[constant.ChannelTypeTencent],
+			wantTC3:     false,
+			wantBaseURL: tokenHubBaseURL,
+		},
+		{
+			name:        "tokenhub key with empty base url rewrites to tokenhub",
+			apiKey:      "sk-xxxxxxxxxxxxxxxx",
+			baseURL:     "",
+			wantTC3:     false,
+			wantBaseURL: tokenHubBaseURL,
+		},
+		{
+			name:        "tokenhub key with custom base url is preserved",
+			apiKey:      "sk-xxxxxxxxxxxxxxxx",
+			baseURL:     "https://proxy.example.com",
+			wantTC3:     false,
+			wantBaseURL: "https://proxy.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{
+				ChannelType:    constant.ChannelTypeTencent,
+				ApiKey:         tt.apiKey,
+				ChannelBaseUrl: tt.baseURL,
+			}}
+
+			dispatch := &DispatchAdaptor{}
+			dispatch.Init(info)
+
+			require.NotNil(t, dispatch.Adaptor)
+			if tt.wantTC3 {
+				assert.IsType(t, &Adaptor{}, dispatch.Adaptor)
+			} else {
+				assert.IsType(t, &openai.Adaptor{}, dispatch.Adaptor)
+			}
+			assert.Equal(t, tt.wantBaseURL, info.ChannelBaseUrl)
+		})
+	}
+}

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -342,6 +342,7 @@ var streamSupportedChannels = map[int]bool{
 	constant.ChannelTypeMiniMax:        true,
 	constant.ChannelTypeSiliconFlow:    true,
 	constant.ChannelTypeAdvancedCustom: true,
+	constant.ChannelTypeTencent:        true,
 }
 
 func GenRelayInfoWs(c *gin.Context, ws *websocket.Conn) *RelayInfo {

--- a/relay/relay_adaptor.go
+++ b/relay/relay_adaptor.go
@@ -66,7 +66,7 @@ func GetAdaptor(apiType int) channel.Adaptor {
 	case constant.APITypePaLM:
 		return &palm.Adaptor{}
 	case constant.APITypeTencent:
-		return &tencent.Adaptor{}
+		return &tencent.DispatchAdaptor{}
 	case constant.APITypeXunfei:
 		return &xunfei.Adaptor{}
 	case constant.APITypeZhipu:

--- a/web/src/features/channels/constants.ts
+++ b/web/src/features/channels/constants.ts
@@ -386,7 +386,7 @@ export const TYPE_TO_KEY_PROMPT: Record<number, string> = {
   15: 'Format: APIKey|SecretKey',
   18: 'Format: APPID|APISecret|APIKey',
   22: 'Format: APIKey-AppId, e.g., fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041',
-  23: 'Format: AppId|SecretId|SecretKey',
+  23: 'Format: TokenHub API Key, or legacy AppId|SecretId|SecretKey',
   33: 'Format: Ak|Sk|Region',
   50: 'Format: AccessKey|SecretKey (or just ApiKey if upstream is New API)',
   51: 'Format: Access Key ID|Secret Access Key',

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2052,7 +2052,7 @@
     "Format: APIKey-AppId, e.g., fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041": "Format: APIKey-AppId, e.g., fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041",
     "Format: APIKey|SecretKey": "Format: APIKey|SecretKey",
     "Format: APPID|APISecret|APIKey": "Format: APPID|APISecret|APIKey",
-    "Format: AppId|SecretId|SecretKey": "Format: AppId|SecretId|SecretKey",
+    "Format: TokenHub API Key, or legacy AppId|SecretId|SecretKey": "Format: TokenHub API Key, or legacy AppId|SecretId|SecretKey",
     "Forward requests directly to upstream providers without any post-processing.": "Forward requests directly to upstream providers without any post-processing.",
     "Frames per second": "Frames per second",
     "Free": "Free",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -2052,7 +2052,7 @@
     "Format: APIKey-AppId, e.g., fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041": "Format : APIKey-AppId, par ex. fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041",
     "Format: APIKey|SecretKey": "Format : APIKey|SecretKey",
     "Format: APPID|APISecret|APIKey": "Format : APPID|APISecret|APIKey",
-    "Format: AppId|SecretId|SecretKey": "Format : AppId|SecretId|SecretKey",
+    "Format: TokenHub API Key, or legacy AppId|SecretId|SecretKey": "Format : TokenHub API Key, ou l'ancien format AppId|SecretId|SecretKey",
     "Forward requests directly to upstream providers without any post-processing.": "Transférer les requêtes directement aux fournisseurs amont sans aucun post-traitement.",
     "Frames per second": "Images par seconde",
     "Free": "Libre",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -2052,7 +2052,7 @@
     "Format: APIKey-AppId, e.g., fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041": "形式: APIKey-AppId、例: fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041",
     "Format: APIKey|SecretKey": "形式: APIKey|SecretKey",
     "Format: APPID|APISecret|APIKey": "形式: APPID|APISecret|APIKey",
-    "Format: AppId|SecretId|SecretKey": "形式: AppId|SecretId|SecretKey",
+    "Format: TokenHub API Key, or legacy AppId|SecretId|SecretKey": "形式: TokenHub API Key、または旧形式の AppId|SecretId|SecretKey",
     "Forward requests directly to upstream providers without any post-processing.": "ポストプロセスなしで、リクエストをアップストリームプロバイダーに直接転送します。",
     "Frames per second": "フレームレート",
     "Free": "空き",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -2052,7 +2052,7 @@
     "Format: APIKey-AppId, e.g., fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041": "Формат: APIKey-AppId, напр., fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041",
     "Format: APIKey|SecretKey": "Формат: APIKey|SecretKey",
     "Format: APPID|APISecret|APIKey": "Формат: APPID|APISecret|APIKey",
-    "Format: AppId|SecretId|SecretKey": "Формат: AppId|SecretId|SecretKey",
+    "Format: TokenHub API Key, or legacy AppId|SecretId|SecretKey": "Формат: TokenHub API Key или устаревший AppId|SecretId|SecretKey",
     "Forward requests directly to upstream providers without any post-processing.": "Перенаправлять запросы напрямую upstream-провайдерам без какой-либо постобработки.",
     "Frames per second": "Кадров в секунду",
     "Free": "Свободно",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -2052,7 +2052,7 @@
     "Format: APIKey-AppId, e.g., fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041": "Định dạng: APIKey-AppId, ví dụ: fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041",
     "Format: APIKey|SecretKey": "Định dạng: APIKey|SecretKey",
     "Format: APPID|APISecret|APIKey": "Định dạng: APPID|APISecret|APIKey",
-    "Format: AppId|SecretId|SecretKey": "Định dạng: AppId|SecretId|SecretKey",
+    "Format: TokenHub API Key, or legacy AppId|SecretId|SecretKey": "Định dạng: TokenHub API Key, hoặc định dạng cũ AppId|SecretId|SecretKey",
     "Forward requests directly to upstream providers without any post-processing.": "Chuyển tiếp các yêu cầu trực tiếp đến các nhà cung cấp ngược dòng mà không cần xử lý hậu kỳ nào.",
     "Frames per second": "Khung hình / giây",
     "Free": "Trống",

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -2052,7 +2052,7 @@
     "Format: APIKey-AppId, e.g., fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041": "格式：APIKey-AppId，例如：fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041",
     "Format: APIKey|SecretKey": "格式：APIKey|SecretKey",
     "Format: APPID|APISecret|APIKey": "格式：APPID|APISecret|APIKey",
-    "Format: AppId|SecretId|SecretKey": "格式：AppId|SecretId|SecretKey",
+    "Format: TokenHub API Key, or legacy AppId|SecretId|SecretKey": "格式：TokenHub API Key，或舊版 AppId|SecretId|SecretKey",
     "Forward requests directly to upstream providers without any post-processing.": "將請求直接轉發給上游供應商，不進行任何後處理。",
     "Frames per second": "幀率",
     "Free": "可用",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -2052,7 +2052,7 @@
     "Format: APIKey-AppId, e.g., fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041": "格式：APIKey-AppId，例如：fastgpt-0sp2gtvfdgyi4k30jwlgwf1i-64f335d84283f05518e9e041",
     "Format: APIKey|SecretKey": "格式：APIKey|SecretKey",
     "Format: APPID|APISecret|APIKey": "格式：APPID|APISecret|APIKey",
-    "Format: AppId|SecretId|SecretKey": "格式：AppId|SecretId|SecretKey",
+    "Format: TokenHub API Key, or legacy AppId|SecretId|SecretKey": "格式：TokenHub API Key，或旧版 AppId|SecretId|SecretKey",
     "Forward requests directly to upstream providers without any post-processing.": "将请求直接转发给上游提供商，不进行任何后处理。",
     "Frames per second": "帧率",
     "Free": "可用",


### PR DESCRIPTION
## 📝 变更描述 / Description

腾讯云新的 TokenHub 平台发的是单段 sk 密钥,走 OpenAI 兼容协议,和旧混元三段式 AppId|SecretId|SecretKey(TC3 签名)不是一套东西。旧混元平台2026-06-22已开始下线,  2026-09-30 停服,新购只能用 TokenHub 的 api key。

改法: 因为新版兼容oai格式, 因此改法比较简单, key 含 `|` 走原来 TC3逻辑,api key 走 OpenAI 兼容的实现即可, 代码改动较小

迁服新闻: https://cloud.tencent.com/announce/detail/2310
新版平台: https://console.cloud.tencent.com/tokenhub/models

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述,没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls),确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`,我已提交或关联对应 Issue,且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证,维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据,且符合项目代码规范。

## 📸 运行证明 / Proof of Work
新建渠道,优化提示:
<img width="1526" height="202" alt="image" src="https://github.com/user-attachments/assets/4f6191d1-9e45-4018-b22b-e7e1e09024a1" />
新版渠道,自测通过:
<img width="1752" height="852" alt="image" src="https://github.com/user-attachments/assets/91bc2b6f-f08f-49b3-bde7-0cceeb4c56f5" />

由于旧版渠道已无法新建,因此无法自测, 通过断点验证了旧的的url 和 tc3段key和签名正常

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Tencent services using both native and OpenAI-compatible API formats.
  * Tencent channels now support streaming responses.
  * Added automatic routing based on API key format and sensible default endpoint handling.

* **Tests**
  * Added coverage for native Tencent, TokenHub-compatible, default endpoint, and custom endpoint configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->