### PR TITLE
fix(dashboard): 总 TOKEN 数统计补全 Anthropic 缓存 token

### DIFF
--- a/model/log.go
+++ b/model/log.go
@@ -329,6 +329,10 @@ type RecordConsumeLogParams struct {
 	ChannelId        int                    `json:"channel_id"`
 	PromptTokens     int                    `json:"prompt_tokens"`
 	CompletionTokens int                    `json:"completion_tokens"`
+	// TotalTokens 用于汇总统计（如 quota_data.token_used）。
+	// Anthropic 语义下 PromptTokens 不含缓存 token，需要把 cache_read/cache_creation 加回来后写入此处，
+	// 避免数据看板的总 TOKEN 数漏算缓存。OpenAI 语义下 PromptTokens 已含缓存，此处与 Prompt+Completion 相同。
+	TotalTokens      int                    `json:"total_tokens"`
 	ModelName        string                 `json:"model_name"`
 	TokenName        string                 `json:"token_name"`
 	Quota            int                    `json:"quota"`
@@ -388,13 +392,19 @@ func RecordConsumeLog(c *gin.Context, userId int, params RecordConsumeLogParams)
 		logger.LogError(c, "failed to record log: "+err.Error())
 	}
 	if common.DataExportEnabled {
+		// Anthropic 语义下 PromptTokens 不含缓存，优先使用调用方已计算好的 TotalTokens；
+		// 未提供时回退到 PromptTokens + CompletionTokens，保持旧行为兼容。
+		tokenUsed := params.TotalTokens
+		if tokenUsed <= 0 {
+			tokenUsed = params.PromptTokens + params.CompletionTokens
+		}
 		LogQuotaData(QuotaDataLogParams{
 			UserID:    userId,
 			Username:  username,
 			ModelName: params.ModelName,
 			Quota:     params.Quota,
 			CreatedAt: createdAt,
-			TokenUsed: params.PromptTokens + params.CompletionTokens,
+			TokenUsed: tokenUsed,
 			UseGroup:  params.Group,
 			TokenID:   params.TokenId,
 			ChannelID: params.ChannelId,

--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -344,6 +344,17 @@ func usageSemanticFromUsage(relayInfo *relaycommon.RelayInfo, usage *dto.Usage) 
 	return "openai"
 }
 
+// logTotalTokensFromSummary 计算用于数据看板统计的总 token 数。
+// Anthropic 语义下 PromptTokens 仅表示未命中缓存的 fresh token，需要把 cache_read/cache_creation 加回；
+// OpenAI 语义下 PromptTokens 已包含缓存，直接使用 PromptTokens + CompletionTokens 即可。
+func logTotalTokensFromSummary(summary textQuotaSummary) int {
+	total := summary.PromptTokens + summary.CompletionTokens
+	if summary.IsClaudeUsageSemantic {
+		total += summary.CacheTokens + summary.CacheCreationTokens
+	}
+	return total
+}
+
 func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, usage *dto.Usage, extraContent []string) {
 	originUsage := usage
 	billingUsage := effectiveBillingUsage(usage)
@@ -487,11 +498,13 @@ func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, us
 	}
 
 	attachQuotaSaturation(ctx, relayInfo, other)
+	logTotalTokens := logTotalTokensFromSummary(summary)
 
 	model.RecordConsumeLog(ctx, relayInfo.UserId, model.RecordConsumeLogParams{
 		ChannelId:        relayInfo.ChannelId,
 		PromptTokens:     summary.PromptTokens,
 		CompletionTokens: summary.CompletionTokens,
+		TotalTokens:      logTotalTokens,
 		ModelName:        logModel,
 		TokenName:        summary.TokenName,
 		Quota:            summary.Quota,

--- a/service/text_quota_test.go
+++ b/service/text_quota_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/QuantumNous/new-api/types"
 
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -739,4 +740,34 @@ func TestCalculateTextQuotaSummaryFixedPriceAppliesImageCountOnceAndAllowsOverri
 	relayInfo.PriceData.AddOtherRatio("n", 2)
 	summary = calculateTextQuotaSummary(ctx, relayInfo, usage)
 	require.Equal(t, 120000, summary.Quota)
+}
+
+func TestLogTotalTokensFromSummary(t *testing.T) {
+	// OpenAI 语义：PromptTokens 已包含缓存，总 token 不应再加缓存部分，避免重复计算。
+	openAISummary := textQuotaSummary{
+		PromptTokens:          1000,
+		CompletionTokens:      200,
+		CacheTokens:           800,
+		CacheCreationTokens:   100,
+		IsClaudeUsageSemantic: false,
+	}
+	require.Equal(t, 1200, logTotalTokensFromSummary(openAISummary))
+
+	// Anthropic 语义：PromptTokens 仅表示 fresh token，需要把 cache_read/cache_creation 加回。
+	claudeSummary := textQuotaSummary{
+		PromptTokens:          100,
+		CompletionTokens:      50,
+		CacheTokens:           200,
+		CacheCreationTokens:   30,
+		IsClaudeUsageSemantic: true,
+	}
+	assert.Equal(t, 380, logTotalTokensFromSummary(claudeSummary))
+
+	// Anthropic 语义但无缓存：结果与 PromptTokens + CompletionTokens 相同。
+	claudeNoCacheSummary := textQuotaSummary{
+		PromptTokens:          100,
+		CompletionTokens:      50,
+		IsClaudeUsageSemantic: true,
+	}
+	assert.Equal(t, 150, logTotalTokensFromSummary(claudeNoCacheSummary))
 }


### PR DESCRIPTION
## 📝 变更描述 / Description

数据看板 Models 视图的“总 TOKEN 数”取自 `quota_data.token_used`，原写入值为 `prompt_tokens + completion_tokens`。

对于走 `/v1/messages`（Anthropic 语义）的上游（如 DeepSeek、Anthropic 官方），`input_tokens` 仅表示**未命中缓存的 fresh token**，`cache_read_input_tokens` / `cache_creation_input_tokens` 未被计入，导致看板数字系统性偏低（实测某日看板约 900 万，而上游面板约 1.2 亿，主要差异来自大量命中的上下文缓存）。

本 PR 做最小修复：在 Anthropic 语义下把缓存 token 加回到 `token_used`，让看板“总 TOKEN 数”反映真实消耗。

为什么这样改生效：
- 在 `service/text_quota.go` 新增 `logTotalTokensFromSummary`，按 `UsageSemantic` 判断：
  - Anthropic 语义：`PromptTokens + CompletionTokens + CacheTokens + CacheCreationTokens`
  - OpenAI 语义：`PromptTokens + CompletionTokens`（`prompt_tokens` 已含缓存，不再重复加，避免双计）
- 该总值通过 `RecordConsumeLogParams.TotalTokens` 传给日志层，`RecordConsumeLog` 写入 `quota_data.token_used` 时优先使用，未提供时回退原逻辑，保持其它调用路径兼容。
- **计费逻辑未改动**：`summary.PromptTokens` 仍按原语义参与计费，本次只调整看板统计口径。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- Related to #5069（数据看板增加 cache_tokens 统计；本 PR 为其最小子集，将缓存 token 并入既有 `token_used`，不新增列、不改数据库；如需单独展示缓存列可在此基础上继续）
- Related to #4395（`/v1/messages` 下 input_tokens 与缓存 token 语义）

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已搜索 Issues/PRs，确认与 #5069 / #4395 方向一致但非重复（本 PR 不新增统计列）。
- [x] **Bug fix 说明:** 关联 #5069 / #4395；问题是既有统计口径漏算缓存 token，非设计取舍或理解偏差。
- [x] **变更理解:** 已理解计费口径不变，仅 `quota_data.token_used` 统计口径变化。
- [x] **范围聚焦:** 仅 3 个文件（model/log.go、service/text_quota.go、service/text_quota_test.go），无无关改动。
- [x] **本地验证:** `go test ./service ./model` 通过（见下方运行证明）。
- [x] **安全合规:** 无敏感凭据，符合项目代码规范（JSON 走 common.*、跨库兼容）。

## 📸 运行证明 / Proof of Work

新增测试 `TestLogTotalTokensFromSummary` 覆盖两种语义与无缓存场景：
```
=== RUN   TestLogTotalTokensFromSummary
--- PASS: TestLogTotalTokensFromSummary (0.00s)
ok  	github.com/QuantumNous/new-api/service	0.239s
```

`model` 包全量通过：
```
ok  	github.com/QuantumNous/new-api/model	18.354s
```

说明：`service` 包中 `TestObserveChannelAffinityUsageCacheByRelayFormat_*` 2 个测试在本分支与 origin/main 上均失败（既有 flaky/全局计数器污染，与本次改动无关，本 PR 未触碰 channel_affinity 相关代码）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota/consumption token reporting by using an explicit total token value when available.
  * Corrected how cached tokens are counted across different provider usage semantics, ensuring cached read and cache creation tokens are included when appropriate.
* **Tests**
  * Added coverage to validate total token calculations with OpenAI-style and Anthropic/Claude-style semantics, including scenarios with and without cached token fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->