### PR TITLE
修复 Claude Messages 流式响应中 message_delta.usage.output_tokens 可能为零的问题。

### DIFF
--- a/relay/channel/claude/message_delta_usage_patch_test.go
+++ b/relay/channel/claude/message_delta_usage_patch_test.go
@@ -30,6 +30,15 @@ func TestPatchClaudeMessageDeltaUsageDataPreserveUnknownFields(t *testing.T) {
 	require.EqualValues(t, 50, gjson.Get(patchedData, "usage.cache_creation_input_tokens").Int())
 }
 
+func TestPatchClaudeMessageDeltaUsageDataPatchMissingOutputTokens(t *testing.T) {
+	originalData := `{"type":"message_delta","usage":{}}`
+	usage := &dto.ClaudeUsage{OutputTokens: 99}
+
+	patchedData := patchClaudeMessageDeltaUsageData(originalData, usage)
+
+	require.EqualValues(t, 99, gjson.Get(patchedData, "usage.output_tokens").Int())
+}
+
 func TestPatchClaudeMessageDeltaUsageDataZeroValueChecks(t *testing.T) {
 	originalData := `{"type":"message_delta","usage":{"output_tokens":53,"input_tokens":9,"cache_read_input_tokens":0}}`
 	usage := &dto.ClaudeUsage{
@@ -87,6 +96,16 @@ func TestBuildMessageDeltaPatchUsage(t *testing.T) {
 		require.NotNil(t, usage.CacheCreation)
 		require.EqualValues(t, 30, usage.CacheCreation.Ephemeral5mInputTokens)
 		require.EqualValues(t, 20, usage.CacheCreation.Ephemeral1hInputTokens)
+	})
+
+	t.Run("patch missing OutputTokens from CompletionTokens", func(t *testing.T) {
+		claudeResponse := &dto.ClaudeResponse{Usage: &dto.ClaudeUsage{}}
+		claudeInfo := &ClaudeResponseInfo{Usage: &dto.Usage{
+			CompletionTokens: 99,
+		}}
+
+		usage := buildMessageDeltaPatchUsage(claudeResponse, claudeInfo)
+		require.EqualValues(t, 99, usage.OutputTokens)
 	})
 
 	t.Run("keep upstream non-zero values", func(t *testing.T) {

--- a/relay/channel/claude/message_delta_usage_patch_test.go
+++ b/relay/channel/claude/message_delta_usage_patch_test.go
@@ -108,6 +108,18 @@ func TestBuildMessageDeltaPatchUsage(t *testing.T) {
 		require.EqualValues(t, 99, usage.OutputTokens)
 	})
 
+	t.Run("keep upstream OutputTokens when CompletionTokens is available", func(t *testing.T) {
+		claudeResponse := &dto.ClaudeResponse{Usage: &dto.ClaudeUsage{
+			OutputTokens: 53,
+		}}
+		claudeInfo := &ClaudeResponseInfo{Usage: &dto.Usage{
+			CompletionTokens: 99,
+		}}
+
+		usage := buildMessageDeltaPatchUsage(claudeResponse, claudeInfo)
+		require.EqualValues(t, 53, usage.OutputTokens)
+	})
+
 	t.Run("keep upstream non-zero values", func(t *testing.T) {
 		claudeResponse := &dto.ClaudeResponse{Usage: &dto.ClaudeUsage{
 			InputTokens:              9,

--- a/service/relayconvert/internal/claude_messages/to_oai_chat_resp.go
+++ b/service/relayconvert/internal/claude_messages/to_oai_chat_resp.go
@@ -241,6 +241,9 @@ func BuildMessageDeltaPatchUsage(claudeResponse *dto.ClaudeResponse, claudeInfo 
 	if usage.InputTokens == 0 && claudeInfo.Usage.PromptTokens > 0 {
 		usage.InputTokens = claudeInfo.Usage.PromptTokens
 	}
+	if usage.OutputTokens == 0 && claudeInfo.Usage.CompletionTokens > 0 {
+		usage.OutputTokens = claudeInfo.Usage.CompletionTokens
+	}
 	if usage.CacheReadInputTokens == 0 && claudeInfo.Usage.PromptTokensDetails.CachedTokens > 0 {
 		usage.CacheReadInputTokens = claudeInfo.Usage.PromptTokensDetails.CachedTokens
 	}
@@ -301,6 +304,7 @@ func PatchClaudeMessageDeltaUsageData(data string, usage *dto.ClaudeUsage) strin
 	}
 
 	data = setMessageDeltaUsageInt(data, "usage.input_tokens", usage.InputTokens)
+	data = setMessageDeltaUsageInt(data, "usage.output_tokens", usage.OutputTokens)
 	data = setMessageDeltaUsageInt(data, "usage.cache_read_input_tokens", usage.CacheReadInputTokens)
 	data = setMessageDeltaUsageInt(data, "usage.cache_creation_input_tokens", usage.CacheCreationInputTokens)
 


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

修复 Claude Messages 流式响应中 `message_delta.usage.output_tokens` 可能为零的问题。

当上游未在最终 `message_delta` 中提供输出 token、但转换过程中已经累计得到 `CompletionTokens` 时，现在会使用累计值补全 `OutputTokens`，并将其同步写回客户端收到的 `usage.output_tokens`。

补全过程仅在原值为零且累计值大于零时执行，不会覆盖上游已经返回的有效输出 token。这样可以确保日志、结算用量和客户端收到的最终 usage 保持一致。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #（请填写对应 Issue 编号）

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

新增两个回归测试，分别覆盖：

1. 从累计 `CompletionTokens` 恢复缺失的 `OutputTokens`。
2. 将恢复后的值写入 `message_delta.usage.output_tokens`。

修复前，两个测试均能稳定复现问题：

```text
expected: 99
actual:   0

修复后通过以下验证：
go test ./relay/channel/claude -count=1
ok  github.com/QuantumNous/new-api/relay/channel/claude

go test ./service/relayconvert/... -count=1
ok  github.com/QuantumNous/new-api/service/relayconvert
ok  github.com/QuantumNous/new-api/service/relayconvert/internal/oai_chat
ok  github.com/QuantumNous/new-api/service/relayconvert/internal/oai_responses

go vet ./relay/channel/claude ./service/relayconvert/...
通过，无警告

git diff --check
通过，无格式错误

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude usage reporting for message deltas.
  * Now includes `output_tokens` in usage updates when it was previously missing.
  * If Claude provides completion token counts, those are used to populate missing output token values.
  * Preserves upstream output token values when already present, while maintaining accurate input and cache token details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->