### PR TITLE
fix: fall back to lower priority channels

### DIFF
--- a/model/ability.go
+++ b/model/ability.go
@@ -3,6 +3,7 @@ package model
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -60,87 +61,67 @@ func GetAllEnableAbilities() []Ability {
 	return abilities
 }
 
-func getPriority(group string, model string, retry int) (int, error) {
-
-	var priorities []int
-	err := DB.Model(&Ability{}).
-		Select("DISTINCT(priority)").
-		Where(commonGroupCol+" = ? and model = ? and enabled = ?", group, model, true).
-		Order("priority DESC").              // 按优先级降序排序
-		Pluck("priority", &priorities).Error // Pluck用于将查询的结果直接扫描到一个切片中
-
-	if err != nil {
-		// 处理错误
-		return 0, err
+func abilityPriority(ability Ability) int64 {
+	if ability.Priority == nil {
+		return 0
 	}
-
-	if len(priorities) == 0 {
-		// 如果没有查询到优先级，则返回错误
-		return 0, errors.New("数据库一致性被破坏")
-	}
-
-	// 确定要使用的优先级
-	var priorityToUse int
-	if retry >= len(priorities) {
-		// 如果重试次数大于优先级数，则使用最小的优先级
-		priorityToUse = priorities[len(priorities)-1]
-	} else {
-		priorityToUse = priorities[retry]
-	}
-	return priorityToUse, nil
+	return *ability.Priority
 }
 
-func getChannelQuery(group string, model string, retry int) (*gorm.DB, error) {
-	maxPrioritySubQuery := DB.Model(&Ability{}).Select("MAX(priority)").Where(commonGroupCol+" = ? and model = ? and enabled = ?", group, model, true)
-	channelQuery := DB.Where(commonGroupCol+" = ? and model = ? and enabled = ? and priority = (?)", group, model, true, maxPrioritySubQuery)
-	if retry != 0 {
-		priority, err := getPriority(group, model, retry)
-		if err != nil {
-			return nil, err
-		} else {
-			channelQuery = DB.Where(commonGroupCol+" = ? and model = ? and enabled = ? and priority = ?", group, model, true, priority)
-		}
+func selectAbilityPriority(abilities []Ability, retry int) int64 {
+	priorities := make(map[int64]struct{}, len(abilities))
+	for _, ability := range abilities {
+		priorities[abilityPriority(ability)] = struct{}{}
 	}
-
-	return channelQuery, nil
+	sortedPriorities := make([]int64, 0, len(priorities))
+	for priority := range priorities {
+		sortedPriorities = append(sortedPriorities, priority)
+	}
+	sort.Slice(sortedPriorities, func(i, j int) bool { return sortedPriorities[i] > sortedPriorities[j] })
+	if retry >= len(sortedPriorities) {
+		retry = len(sortedPriorities) - 1
+	}
+	return sortedPriorities[retry]
 }
 
 func GetChannel(group string, model string, retry int, requestPath string) (*Channel, error) {
 	var abilities []Ability
+	err := DB.Where(commonGroupCol+" = ? and model = ? and enabled = ?", group, model, true).
+		Order("weight DESC").
+		Find(&abilities).Error
+	if err != nil {
+		return nil, err
+	}
 
-	var err error = nil
-	channelQuery, err := getChannelQuery(group, model, retry)
-	if err != nil {
-		return nil, err
-	}
-	if common.UsingMainDatabase(common.DatabaseTypeSQLite) || common.UsingMainDatabase(common.DatabaseTypePostgreSQL) {
-		err = channelQuery.Order("weight DESC").Find(&abilities).Error
-	} else {
-		err = channelQuery.Order("weight DESC").Find(&abilities).Error
-	}
-	if err != nil {
-		return nil, err
-	}
+	// Path eligibility must be determined before priority selection. Otherwise a
+	// priority with no route for this request shifts the retry index and can cause
+	// the next retry to select the same eligible priority again.
 	abilities = filterAbilitiesByRequestPathAndModel(abilities, requestPath, model)
-	channel := Channel{}
-	if len(abilities) > 0 {
-		// Randomly choose one
-		weightSum := uint(0)
-		for _, ability_ := range abilities {
-			weightSum += ability_.Weight + 10
-		}
-		// Randomly choose one
-		weight := common.GetRandomInt(int(weightSum))
-		for _, ability_ := range abilities {
-			weight -= int(ability_.Weight) + 10
-			//log.Printf("weight: %d, ability weight: %d", weight, *ability_.Weight)
-			if weight <= 0 {
-				channel.Id = ability_.ChannelId
-				break
-			}
-		}
-	} else {
+	if len(abilities) == 0 {
 		return nil, nil
+	}
+	targetPriority := selectAbilityPriority(abilities, retry)
+	priorityAbilities := make([]Ability, 0, len(abilities))
+	for _, ability := range abilities {
+		if abilityPriority(ability) == targetPriority {
+			priorityAbilities = append(priorityAbilities, ability)
+		}
+	}
+	abilities = priorityAbilities
+
+	channel := Channel{}
+	// Randomly choose one
+	weightSum := uint(0)
+	for _, ability := range abilities {
+		weightSum += ability.Weight + 10
+	}
+	weight := common.GetRandomInt(int(weightSum))
+	for _, ability := range abilities {
+		weight -= int(ability.Weight) + 10
+		if weight <= 0 {
+			channel.Id = ability.ChannelId
+			break
+		}
 	}
 	err = DB.First(&channel, "id = ?", channel.Id).Error
 	return &channel, err

--- a/model/channel_cache.go
+++ b/model/channel_cache.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -17,7 +16,8 @@ import (
 )
 
 var group2model2channels map[string]map[string][]int // enabled channel
-var channelsIDM map[int]*Channel                     // all channels include disabled
+var group2model2channelPriorities map[string]map[string]map[int]int64
+var channelsIDM map[int]*Channel // all channels include disabled
 // channel2advancedCustomConfig caches parsed Advanced Custom (type 58) configs so
 // path-aware selection avoids re-parsing JSON per request. Refreshed on full sync.
 var channel2advancedCustomConfig map[int]*dto.AdvancedCustomConfig
@@ -42,35 +42,36 @@ func InitChannelCache() {
 	}
 	var abilities []*Ability
 	DB.Find(&abilities)
-	groups := make(map[string]bool)
-	for _, ability := range abilities {
-		groups[ability.Group] = true
-	}
 	newGroup2model2channels := make(map[string]map[string][]int)
-	for group := range groups {
-		newGroup2model2channels[group] = make(map[string][]int)
-	}
-	for _, channel := range channels {
-		if channel.Status != common.ChannelStatusEnabled {
-			continue // skip disabled channels
+	newGroup2model2channelPriorities := make(map[string]map[string]map[int]int64)
+	for _, ability := range abilities {
+		if !ability.Enabled {
+			continue
 		}
-		groups := strings.Split(channel.Group, ",")
-		for _, group := range groups {
-			models := strings.Split(channel.Models, ",")
-			for _, model := range models {
-				if _, ok := newGroup2model2channels[group][model]; !ok {
-					newGroup2model2channels[group][model] = make([]int, 0)
-				}
-				newGroup2model2channels[group][model] = append(newGroup2model2channels[group][model], channel.Id)
-			}
+		channel, ok := newChannelId2channel[ability.ChannelId]
+		if !ok || channel.Status != common.ChannelStatusEnabled {
+			continue
 		}
+		if _, ok := newGroup2model2channels[ability.Group]; !ok {
+			newGroup2model2channels[ability.Group] = make(map[string][]int)
+			newGroup2model2channelPriorities[ability.Group] = make(map[string]map[int]int64)
+		}
+		if _, ok := newGroup2model2channelPriorities[ability.Group][ability.Model]; !ok {
+			newGroup2model2channelPriorities[ability.Group][ability.Model] = make(map[int]int64)
+		}
+		newGroup2model2channels[ability.Group][ability.Model] = append(
+			newGroup2model2channels[ability.Group][ability.Model],
+			ability.ChannelId,
+		)
+		newGroup2model2channelPriorities[ability.Group][ability.Model][ability.ChannelId] = abilityPriority(*ability)
 	}
 
 	// sort by priority
 	for group, model2channels := range newGroup2model2channels {
 		for model, channels := range model2channels {
+			priorities := newGroup2model2channelPriorities[group][model]
 			sort.Slice(channels, func(i, j int) bool {
-				return newChannelId2channel[channels[i]].GetPriority() > newChannelId2channel[channels[j]].GetPriority()
+				return priorities[channels[i]] > priorities[channels[j]]
 			})
 			newGroup2model2channels[group][model] = channels
 		}
@@ -78,6 +79,7 @@ func InitChannelCache() {
 
 	channelSyncLock.Lock()
 	group2model2channels = newGroup2model2channels
+	group2model2channelPriorities = newGroup2model2channelPriorities
 	//channelsIDM = newChannelId2channel
 	for i, channel := range newChannelId2channel {
 		if channel.ChannelInfo.IsMultiKey {
@@ -140,31 +142,43 @@ func GetRandomSatisfiedChannel(group string, model string, retry int, requestPat
 		return nil, fmt.Errorf("数据库一致性错误，渠道# %d 不存在，请联系管理员修复", channels[0])
 	}
 
-	uniquePriorities := make(map[int]bool)
+	channelPriorities := group2model2channelPriorities[group][model]
+	if len(channelPriorities) == 0 {
+		normalizedModel := ratio_setting.FormatMatchingModelName(model)
+		channelPriorities = group2model2channelPriorities[group][normalizedModel]
+	}
+	uniquePriorities := make(map[int64]struct{})
 	for _, channelId := range channels {
-		if channel, ok := channelsIDM[channelId]; ok {
-			uniquePriorities[int(channel.GetPriority())] = true
-		} else {
+		if _, ok := channelsIDM[channelId]; !ok {
 			return nil, fmt.Errorf("数据库一致性错误，渠道# %d 不存在，请联系管理员修复", channelId)
 		}
+		priority, ok := channelPriorities[channelId]
+		if !ok {
+			priority = channelsIDM[channelId].GetPriority()
+		}
+		uniquePriorities[priority] = struct{}{}
 	}
-	var sortedUniquePriorities []int
+	sortedUniquePriorities := make([]int64, 0, len(uniquePriorities))
 	for priority := range uniquePriorities {
 		sortedUniquePriorities = append(sortedUniquePriorities, priority)
 	}
-	sort.Sort(sort.Reverse(sort.IntSlice(sortedUniquePriorities)))
+	sort.Slice(sortedUniquePriorities, func(i, j int) bool { return sortedUniquePriorities[i] > sortedUniquePriorities[j] })
 
-	if retry >= len(uniquePriorities) {
-		retry = len(uniquePriorities) - 1
+	if retry >= len(sortedUniquePriorities) {
+		retry = len(sortedUniquePriorities) - 1
 	}
-	targetPriority := int64(sortedUniquePriorities[retry])
+	targetPriority := sortedUniquePriorities[retry]
 
 	// get the priority for the given retry number
 	var sumWeight = 0
 	var targetChannels []*Channel
 	for _, channelId := range channels {
 		if channel, ok := channelsIDM[channelId]; ok {
-			if channel.GetPriority() == targetPriority {
+			priority, exists := channelPriorities[channelId]
+			if !exists {
+				priority = channel.GetPriority()
+			}
+			if priority == targetPriority {
 				sumWeight += channel.GetWeight()
 				targetChannels = append(targetChannels, channel)
 			}

--- a/model/channel_priority_test.go
+++ b/model/channel_priority_test.go
@@ -1,0 +1,216 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelSelectionUsesLowerPriorityAfterRetry(t *testing.T) {
+	const (
+		group     = "priority-selection-test"
+		modelName = "priority-selection-model"
+	)
+
+	originalMemoryCacheEnabled := common.MemoryCacheEnabled
+	common.MemoryCacheEnabled = false
+	t.Cleanup(func() {
+		common.MemoryCacheEnabled = originalMemoryCacheEnabled
+		DB.Where(commonGroupCol+" = ? AND model = ?", group, modelName).Delete(&Ability{})
+		DB.Where("id IN ?", []int{9101, 9102}).Delete(&Channel{})
+	})
+
+	insertPrioritySelectionCandidate(t, 9101, group, modelName, 100)
+	insertPrioritySelectionCandidate(t, 9102, group, modelName, 10)
+
+	channel, err := GetChannel(group, modelName, 0, "")
+	require.NoError(t, err)
+	require.NotNil(t, channel)
+	require.Equal(t, 9101, channel.Id)
+
+	channel, err = GetChannel(group, modelName, 1, "")
+	require.NoError(t, err)
+	require.NotNil(t, channel)
+	require.Equal(t, 9102, channel.Id)
+}
+
+func TestChannelCacheUsesLowerPriorityAfterRetry(t *testing.T) {
+	const (
+		group     = "priority-cache-retry-test"
+		modelName = "priority-cache-retry-model"
+	)
+
+	originalMemoryCacheEnabled := common.MemoryCacheEnabled
+	common.MemoryCacheEnabled = true
+	t.Cleanup(func() {
+		common.MemoryCacheEnabled = originalMemoryCacheEnabled
+		DB.Where(commonGroupCol+" = ? AND model = ?", group, modelName).Delete(&Ability{})
+		DB.Where("id IN ?", []int{9251, 9252}).Delete(&Channel{})
+		InitChannelCache()
+	})
+
+	insertPrioritySelectionCandidate(t, 9251, group, modelName, 100)
+	insertPrioritySelectionCandidate(t, 9252, group, modelName, 10)
+	InitChannelCache()
+
+	channel, err := GetRandomSatisfiedChannel(group, modelName, 0, "")
+	require.NoError(t, err)
+	require.NotNil(t, channel)
+	require.Equal(t, 9251, channel.Id)
+
+	channel, err = GetRandomSatisfiedChannel(group, modelName, 1, "")
+	require.NoError(t, err)
+	require.NotNil(t, channel)
+	require.Equal(t, 9252, channel.Id)
+}
+
+func TestChannelCacheIgnoresDisabledAbilitiesWhenSelectingPriority(t *testing.T) {
+	const (
+		group     = "priority-cache-test"
+		modelName = "priority-cache-model"
+	)
+
+	originalMemoryCacheEnabled := common.MemoryCacheEnabled
+	common.MemoryCacheEnabled = true
+	t.Cleanup(func() {
+		common.MemoryCacheEnabled = originalMemoryCacheEnabled
+		DB.Where(commonGroupCol+" = ? AND model = ?", group, modelName).Delete(&Ability{})
+		DB.Where("id IN ?", []int{9201, 9202}).Delete(&Channel{})
+		InitChannelCache()
+	})
+
+	insertPrioritySelectionCandidate(t, 9201, group, modelName, 100)
+	insertPrioritySelectionCandidate(t, 9202, group, modelName, 10)
+	require.NoError(t, DB.Model(&Ability{}).
+		Where("channel_id = ? AND "+commonGroupCol+" = ? AND model = ?", 9201, group, modelName).
+		Update("enabled", false).Error)
+
+	InitChannelCache()
+	channel, err := GetRandomSatisfiedChannel(group, modelName, 0, "")
+	require.NoError(t, err)
+	require.NotNil(t, channel)
+	require.Equal(t, 9202, channel.Id)
+}
+
+func insertPrioritySelectionCandidate(t *testing.T, channelID int, group string, modelName string, priority int64) {
+	t.Helper()
+	channel := &Channel{
+		Id:       channelID,
+		Key:      fmt.Sprintf("priority-key-%d", channelID),
+		Status:   common.ChannelStatusEnabled,
+		Models:   modelName,
+		Group:    group,
+		Priority: &priority,
+	}
+	require.NoError(t, DB.Create(channel).Error)
+	require.NoError(t, DB.Create(&Ability{
+		Group:     group,
+		Model:     modelName,
+		ChannelId: channelID,
+		Enabled:   true,
+		Priority:  &priority,
+		Weight:    0,
+	}).Error)
+}
+
+func TestChannelCacheUsesAbilityPriority(t *testing.T) {
+	const (
+		group     = "priority-cache-source-test"
+		modelName = "priority-cache-source-model"
+	)
+
+	originalMemoryCacheEnabled := common.MemoryCacheEnabled
+	common.MemoryCacheEnabled = true
+	t.Cleanup(func() {
+		common.MemoryCacheEnabled = originalMemoryCacheEnabled
+		DB.Where(commonGroupCol+" = ? AND model = ?", group, modelName).Delete(&Ability{})
+		DB.Where("id IN ?", []int{9271, 9272}).Delete(&Channel{})
+		InitChannelCache()
+	})
+
+	channelPriority := int64(0)
+	reversedChannelPriority := int64(100)
+	require.NoError(t, DB.Create(&Channel{Id: 9271, Key: "priority-source-key-9271", Status: common.ChannelStatusEnabled, Models: modelName, Group: group, Priority: &channelPriority}).Error)
+	require.NoError(t, DB.Create(&Channel{Id: 9272, Key: "priority-source-key-9272", Status: common.ChannelStatusEnabled, Models: modelName, Group: group, Priority: &reversedChannelPriority}).Error)
+	abilityPriority := int64(100)
+	lowerAbilityPriority := int64(10)
+	require.NoError(t, DB.Create(&Ability{Group: group, Model: modelName, ChannelId: 9271, Enabled: true, Priority: &abilityPriority}).Error)
+	require.NoError(t, DB.Create(&Ability{Group: group, Model: modelName, ChannelId: 9272, Enabled: true, Priority: &lowerAbilityPriority}).Error)
+
+	InitChannelCache()
+	channel, err := GetRandomSatisfiedChannel(group, modelName, 0, "")
+	require.NoError(t, err)
+	require.NotNil(t, channel)
+	require.Equal(t, 9271, channel.Id)
+
+	channel.Name = "updated-priority-source-channel"
+	CacheUpdateChannel(channel)
+	channel, err = GetRandomSatisfiedChannel(group, modelName, 0, "")
+	require.NoError(t, err)
+	require.NotNil(t, channel)
+	require.Equal(t, 9271, channel.Id)
+}
+
+func TestChannelSelectionFallsBackWhenHigherPriorityRouteIsIneligible(t *testing.T) {
+	const (
+		group     = "priority-route-test"
+		modelName = "priority-route-model"
+	)
+
+	originalMemoryCacheEnabled := common.MemoryCacheEnabled
+	common.MemoryCacheEnabled = false
+	t.Cleanup(func() {
+		common.MemoryCacheEnabled = originalMemoryCacheEnabled
+		DB.Where(commonGroupCol+" = ? AND model = ?", group, modelName).Delete(&Ability{})
+		DB.Where("id IN ?", []int{9301, 9302, 9303}).Delete(&Channel{})
+	})
+
+	higherPriority := &Channel{
+		Id:       9301,
+		Type:     constant.ChannelTypeAdvancedCustom,
+		Key:      "priority-route-key-9301",
+		Status:   common.ChannelStatusEnabled,
+		Models:   modelName,
+		Group:    group,
+		Priority: common.GetPointer(int64(100)),
+	}
+	higherPriority.SetOtherSettings(dto.ChannelOtherSettings{AdvancedCustom: &dto.AdvancedCustomConfig{
+		Routes: []dto.AdvancedCustomRoute{{IncomingPath: "/v1/responses", UpstreamPath: "/v1/responses"}},
+	}})
+	mediumPriority := &Channel{
+		Id:       9302,
+		Key:      "priority-route-key-9302",
+		Status:   common.ChannelStatusEnabled,
+		Models:   modelName,
+		Group:    group,
+		Priority: common.GetPointer(int64(20)),
+	}
+	lowerPriority := &Channel{
+		Id:       9303,
+		Key:      "priority-route-key-9303",
+		Status:   common.ChannelStatusEnabled,
+		Models:   modelName,
+		Group:    group,
+		Priority: common.GetPointer(int64(10)),
+	}
+	require.NoError(t, DB.Create(higherPriority).Error)
+	require.NoError(t, DB.Create(mediumPriority).Error)
+	require.NoError(t, DB.Create(lowerPriority).Error)
+	require.NoError(t, DB.Create(&Ability{Group: group, Model: modelName, ChannelId: 9301, Enabled: true, Priority: common.GetPointer(int64(100))}).Error)
+	require.NoError(t, DB.Create(&Ability{Group: group, Model: modelName, ChannelId: 9302, Enabled: true, Priority: common.GetPointer(int64(20))}).Error)
+	require.NoError(t, DB.Create(&Ability{Group: group, Model: modelName, ChannelId: 9303, Enabled: true, Priority: common.GetPointer(int64(10))}).Error)
+
+	channel, err := GetChannel(group, modelName, 0, "/v1/chat/completions")
+	require.NoError(t, err)
+	require.NotNil(t, channel)
+	require.Equal(t, 9302, channel.Id)
+
+	channel, err = GetChannel(group, modelName, 1, "/v1/chat/completions")
+	require.NoError(t, err)
+	require.NotNil(t, channel)
+	require.Equal(t, 9303, channel.Id)
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ ] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [ ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [ ] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved channel selection to consistently honor ability-level priorities.
  * Retry attempts can now move selection to lower-priority eligible channels.
  * Channel selection better respects request paths and models before choosing a channel.
  * Disabled abilities are excluded from cached channel selection.
  * Selection now falls back to the next eligible channel when a higher-priority option cannot handle the request.

* **Bug Fixes**
  * Corrected priority handling after channel cache updates.
  * Improved consistency between cached and non-cached channel selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->