### PR TITLE
fix: reduce affiliate code collisions

### DIFF
--- a/controller/oauth.go
+++ b/controller/oauth.go
@@ -281,6 +281,9 @@ func findOrCreateOAuthUser(c *gin.Context, provider oauth.Provider, oauthUser *o
 	if affCode != nil {
 		inviterId, _ = model.GetUserIdByAffCode(affCode.(string))
 	}
+	if err := user.PrepareAffCode(); err != nil {
+		return nil, err
+	}
 
 	// Use transaction to ensure user creation and OAuth binding are atomic
 	if genericProvider, ok := provider.(*oauth.GenericOAuthProvider); ok {

--- a/controller/user.go
+++ b/controller/user.go
@@ -448,22 +448,18 @@ func GetAffCode(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
-	if user.AffCode == "" {
-		user.AffCode = common.GetRandomString(4)
-		if err := user.Update(false); err != nil {
-			c.JSON(http.StatusOK, gin.H{
-				"success": false,
-				"message": err.Error(),
-			})
-			return
-		}
+	if err := user.EnsureAffCode(); err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",
 		"data":    user.AffCode,
 	})
-	return
 }
 
 func GetSelf(c *gin.Context) {
@@ -984,6 +980,10 @@ func CreateUser(c *gin.Context) {
 		Password:    user.Password,
 		DisplayName: user.DisplayName,
 		Role:        user.Role, // 保持管理员设置的角色
+	}
+	if err := cleanUser.PrepareAffCode(); err != nil {
+		common.ApiError(c, err)
+		return
 	}
 	authzTouched := false
 	if err := model.DB.Transaction(func(tx *gorm.DB) error {

--- a/model/user.go
+++ b/model/user.go
@@ -16,7 +16,15 @@ import (
 	"gorm.io/gorm"
 )
 
-const UserNameMaxLength = 20
+const (
+	UserNameMaxLength  = 20
+	affCodeLength      = 8
+	affCodeMaxAttempts = 10
+)
+
+var affCodeGenerator = func() string {
+	return common.GetRandomString(affCodeLength)
+}
 
 // User if you add sensitive fields, don't forget to clean them in setupLogin function.
 // Otherwise, the sensitive information will be saved on local storage in plain text!
@@ -411,6 +419,73 @@ func GetUserIdByAffCode(affCode string) (int, error) {
 	return user.Id, err
 }
 
+func generateAvailableAffCode(db *gorm.DB) (string, error) {
+	for range affCodeMaxAttempts {
+		affCode := affCodeGenerator()
+		if affCode == "" {
+			continue
+		}
+
+		var existing User
+		result := db.Unscoped().
+			Select("id").
+			Where("aff_code = ?", affCode).
+			Limit(1).
+			Find(&existing)
+		if result.Error != nil {
+			return "", result.Error
+		}
+		if result.RowsAffected == 0 {
+			return affCode, nil
+		}
+	}
+
+	return "", errors.New("failed to find an available affiliate code")
+}
+
+// PrepareAffCode selects a currently unused code before a write transaction
+// starts. The unique index remains the final guard for a concurrent collision.
+func (user *User) PrepareAffCode() error {
+	affCode, err := generateAvailableAffCode(DB)
+	if err != nil {
+		return err
+	}
+	user.AffCode = affCode
+	return nil
+}
+
+// EnsureAffCode assigns a code to a legacy user that does not already have one.
+func (user *User) EnsureAffCode() error {
+	if user.AffCode != "" {
+		return nil
+	}
+
+	affCode, err := generateAvailableAffCode(DB)
+	if err != nil {
+		return err
+	}
+
+	result := DB.Model(&User{}).
+		Where("id = ? AND (aff_code = ? OR aff_code IS NULL)", user.Id, "").
+		Update("aff_code", affCode)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected > 0 {
+		user.AffCode = affCode
+		return nil
+	}
+
+	// Another request assigned the code first. The conditional update is already
+	// complete, so this read cannot cause a SQLite lock upgrade.
+	var current User
+	if err := DB.Select("aff_code").First(&current, user.Id).Error; err != nil {
+		return err
+	}
+	user.AffCode = current.AffCode
+	return nil
+}
+
 func DeleteUserById(id int) (err error) {
 	if id == 0 {
 		return errors.New("id 为空！")
@@ -527,13 +602,15 @@ func ensureEmailAvailableWithTx(tx *gorm.DB, email string, excludeUserID int) er
 }
 
 func (user *User) Insert(inviterId int) error {
+	if err := user.PrepareAffCode(); err != nil {
+		return err
+	}
 	if err := DB.Transaction(func(tx *gorm.DB) error {
 		return withNormalizedEmailLock(tx, user.Email, func(tx *gorm.DB) error {
 			if err := user.prepareForInsert(tx); err != nil {
 				return err
 			}
 			user.Quota = common.QuotaForNewUser
-			user.AffCode = common.GetRandomString(4)
 
 			// 初始化用户设置，包括默认的边栏配置
 			if user.Setting == "" {
@@ -597,7 +674,6 @@ func (user *User) InsertWithTx(tx *gorm.DB, inviterId int) error {
 			return err
 		}
 		user.Quota = common.QuotaForNewUser
-		user.AffCode = common.GetRandomString(4)
 
 		// 初始化用户设置
 		if user.Setting == "" {
@@ -605,6 +681,9 @@ func (user *User) InsertWithTx(tx *gorm.DB, inviterId int) error {
 			user.SetSetting(defaultSetting)
 		}
 
+		if user.AffCode == "" {
+			return errors.New("affiliate code is not prepared")
+		}
 		return tx.Create(user).Error
 	})
 }

--- a/model/user_aff_code_test.go
+++ b/model/user_aff_code_test.go
@@ -1,0 +1,110 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func useAffCodeSequence(t *testing.T, codes ...string) {
+	t.Helper()
+	original := affCodeGenerator
+	next := 0
+	affCodeGenerator = func() string {
+		if next >= len(codes) {
+			return codes[len(codes)-1]
+		}
+		code := codes[next]
+		next++
+		return code
+	}
+	t.Cleanup(func() {
+		affCodeGenerator = original
+	})
+}
+
+func TestInsertRetriesAffCodeReservedBySoftDeletedUser(t *testing.T) {
+	setupUserUpdateTestState(t)
+
+	deletedUser := User{
+		Username: "deleted-aff-owner",
+		Password: "password",
+		AffCode:  "Taken001",
+		Status:   common.UserStatusEnabled,
+	}
+	require.NoError(t, DB.Create(&deletedUser).Error)
+	require.NoError(t, DB.Delete(&deletedUser).Error)
+	useAffCodeSequence(t, "Taken001", "Unique01")
+
+	user := User{
+		Username: "new-aff-owner",
+		Password: "password",
+		Status:   common.UserStatusEnabled,
+	}
+	require.NoError(t, user.Insert(0))
+
+	var stored User
+	require.NoError(t, DB.Where("username = ?", user.Username).First(&stored).Error)
+	assert.Equal(t, "Unique01", stored.AffCode)
+}
+
+func TestInsertGeneratesEightCharacterAffCode(t *testing.T) {
+	setupUserUpdateTestState(t)
+
+	user := User{
+		Username: "new-aff-code-length",
+		Password: "password",
+		Status:   common.UserStatusEnabled,
+	}
+	require.NoError(t, user.Insert(0))
+	assert.Len(t, user.AffCode, affCodeLength)
+}
+
+func TestInsertWithTxSelectsAvailableAffCode(t *testing.T) {
+	setupUserUpdateTestState(t)
+
+	require.NoError(t, DB.Create(&User{
+		Username: "existing-aff-owner",
+		Password: "password",
+		AffCode:  "Taken002",
+		Status:   common.UserStatusEnabled,
+	}).Error)
+	useAffCodeSequence(t, "Taken002", "Unique02")
+
+	user := User{
+		Username: "oauth-aff-owner",
+		Status:   common.UserStatusEnabled,
+	}
+	require.NoError(t, user.PrepareAffCode())
+	require.NoError(t, DB.Transaction(func(tx *gorm.DB) error {
+		return user.InsertWithTx(tx, 0)
+	}))
+	assert.Equal(t, "Unique02", user.AffCode)
+}
+
+func TestEnsureUserAffCodeRetriesTakenCodeAndKeepsExistingCode(t *testing.T) {
+	setupUserUpdateTestState(t)
+
+	require.NoError(t, DB.Create(&User{
+		Username: "existing-aff-owner",
+		Password: "password",
+		AffCode:  "Taken003",
+		Status:   common.UserStatusEnabled,
+	}).Error)
+	user := User{
+		Username: "legacy-user-without-aff-code",
+		Password: "password",
+		Status:   common.UserStatusEnabled,
+	}
+	require.NoError(t, DB.Create(&user).Error)
+	useAffCodeSequence(t, "Taken003", "Unique03")
+
+	require.NoError(t, user.EnsureAffCode())
+	assert.Equal(t, "Unique03", user.AffCode)
+
+	require.NoError(t, user.EnsureAffCode())
+	assert.Equal(t, "Unique03", user.AffCode)
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。
> - 本 PR 由 AI 辅助实现与整理，提交者已审阅变更逻辑、测试结果及下述设计取舍。

## 📝 变更描述 / Description
将新用户推广码从 4 位扩展为 8 位，并在写入前有限次数查询候选码是否已被占用；查询包含软删除记录，兼容已有 4 位推广码。普通注册、OAuth 注册、后台创建用户及旧用户补码统一使用模型层分配逻辑，旧用户补码通过条件更新避免同一用户的并发请求互相覆盖。

数据库唯一索引继续作为最终一致性约束。本次有意不处理“候选码查询完成后、写入前被另一请求抢占”的极端竞态：PostgreSQL 需要保存点恢复失败事务，而 MySQL 与 SQLite 的锁及错误语义不同，跨数据库事务内重试会显著扩大改动范围；该竞态发生时仍返回原始数据库错误，但不会写入重复推广码。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Related to #6215

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- `go test ./model ./controller -count=1`
- `go vet ./model ./controller`
- `go test ./model -run 'AffCode' -count=10`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Affiliate codes are now generated more reliably, avoiding conflicts with existing or previously removed codes.
  - Existing accounts without affiliate codes can receive one automatically when requested.
  - Affiliate codes remain consistent after being assigned.

- **Bug Fixes**
  - User and OAuth account creation now stops cleanly when an affiliate code cannot be prepared, preventing incomplete account setup.
  - Improved handling of affiliate code assignment during account creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->