### PR TITLE
feat(i18n): localize middleware and quota-notify user-facing messages

### DIFF
--- a/i18n/keys.go
+++ b/i18n/keys.go
@@ -38,6 +38,34 @@ const (
 	MsgAuthUserIdMismatch        = "auth.user_id_mismatch"
 	MsgAuthUserBanned            = "auth.user_banned"
 	MsgAuthInsufficientPrivilege = "auth.insufficient_privilege"
+	MsgAuthIpParseFailed         = "auth.ip_parse_failed"
+	MsgAuthIpNotAllowed          = "auth.ip_not_allowed"
+	MsgAuthGroupNoAccess         = "auth.group_no_access"
+	MsgAuthGroupDeprecated       = "auth.group_deprecated"
+	MsgAuthSpecificChannelDenied = "auth.specific_channel_denied"
+)
+
+// Rate limit middleware messages
+const (
+	MsgRateLimitSuccessExceeded = "rate_limit.success_exceeded"
+	MsgRateLimitTotalExceeded   = "rate_limit.total_exceeded"
+	MsgEmailSendTooFrequentWait = "rate_limit.email_too_frequent_wait"
+	MsgEmailSendTooFrequent     = "rate_limit.email_too_frequent"
+)
+
+// Secure verification middleware messages
+const (
+	MsgSecureVerifyNotLoggedIn = "secure_verify.not_logged_in"
+	MsgSecureVerifyRequired    = "secure_verify.required"
+	MsgSecureVerifyInvalid     = "secure_verify.invalid"
+	MsgSecureVerifyExpired     = "secure_verify.expired"
+)
+
+// Turnstile middleware messages
+const (
+	MsgTurnstileTokenEmpty        = "turnstile.token_empty"
+	MsgTurnstileCheckFailed       = "turnstile.check_failed"
+	MsgTurnstileSessionSaveFailed = "turnstile.session_save_failed"
 )
 
 // Token related messages

--- a/i18n/locales/en.yaml
+++ b/i18n/locales/en.yaml
@@ -32,6 +32,28 @@ auth.user_id_format_error: "Unauthorized, New-Api-User header format error"
 auth.user_id_mismatch: "Unauthorized, New-Api-User does not match logged in user"
 auth.user_banned: "User has been banned"
 auth.insufficient_privilege: "Unauthorized, insufficient privileges"
+auth.ip_parse_failed: "Unable to parse client IP address"
+auth.ip_not_allowed: "Your IP is not in the token's allowed IP list"
+auth.group_no_access: "No permission to access group {{.Group}}"
+auth.group_deprecated: "Group {{.Group}} has been deprecated"
+auth.specific_channel_denied: "Specifying a channel is not supported for regular users"
+
+# Rate limit middleware messages
+rate_limit.success_exceeded: "You have reached the request limit: at most {{.Count}} requests within {{.Minutes}} minutes"
+rate_limit.total_exceeded: "You have reached the total request limit: at most {{.Count}} requests within {{.Minutes}} minutes (including failed requests), please check your requests"
+rate_limit.email_too_frequent_wait: "Sending too frequently, please wait {{.Seconds}} seconds and try again"
+rate_limit.email_too_frequent: "Sending too frequently, please try again later"
+
+# Secure verification middleware messages
+secure_verify.not_logged_in: "Not logged in"
+secure_verify.required: "Security verification required"
+secure_verify.invalid: "Verification state invalid, please verify again"
+secure_verify.expired: "Verification expired, please verify again"
+
+# Turnstile middleware messages
+turnstile.token_empty: "Turnstile token is empty"
+turnstile.check_failed: "Turnstile verification failed, please refresh and try again!"
+turnstile.session_save_failed: "Unable to save session information, please try again"
 
 # Token messages
 token.name_too_long: "Token name is too long"

--- a/i18n/locales/zh-CN.yaml
+++ b/i18n/locales/zh-CN.yaml
@@ -33,6 +33,28 @@ auth.user_id_format_error: "无权进行此操作，New-Api-User 格式错误"
 auth.user_id_mismatch: "无权进行此操作，New-Api-User 与登录用户不匹配"
 auth.user_banned: "用户已被封禁"
 auth.insufficient_privilege: "无权进行此操作，权限不足"
+auth.ip_parse_failed: "无法解析客户端 IP 地址"
+auth.ip_not_allowed: "您的 IP 不在令牌允许访问的列表中"
+auth.group_no_access: "无权访问 {{.Group}} 分组"
+auth.group_deprecated: "分组 {{.Group}} 已被弃用"
+auth.specific_channel_denied: "普通用户不支持指定渠道"
+
+# Rate limit middleware messages
+rate_limit.success_exceeded: "您已达到请求数限制：{{.Minutes}}分钟内最多请求{{.Count}}次"
+rate_limit.total_exceeded: "您已达到总请求数限制：{{.Minutes}}分钟内最多请求{{.Count}}次，包括失败次数，请检查您的请求是否正确"
+rate_limit.email_too_frequent_wait: "发送过于频繁，请等待 {{.Seconds}} 秒后再试"
+rate_limit.email_too_frequent: "发送过于频繁，请稍后再试"
+
+# Secure verification middleware messages
+secure_verify.not_logged_in: "未登录"
+secure_verify.required: "需要安全验证"
+secure_verify.invalid: "验证状态异常，请重新验证"
+secure_verify.expired: "验证已过期，请重新验证"
+
+# Turnstile middleware messages
+turnstile.token_empty: "Turnstile token 为空"
+turnstile.check_failed: "Turnstile 校验失败，请刷新重试！"
+turnstile.session_save_failed: "无法保存会话信息，请重试"
 
 # Token messages
 token.name_too_long: "令牌名称过长"

--- a/i18n/locales/zh-TW.yaml
+++ b/i18n/locales/zh-TW.yaml
@@ -33,6 +33,28 @@ auth.user_id_format_error: "無權進行此操作，New-Api-User 格式錯誤"
 auth.user_id_mismatch: "無權進行此操作，New-Api-User 與登入使用者不匹配"
 auth.user_banned: "使用者已被封禁"
 auth.insufficient_privilege: "無權進行此操作，權限不足"
+auth.ip_parse_failed: "無法解析客戶端 IP 位址"
+auth.ip_not_allowed: "您的 IP 不在令牌允許訪問的列表中"
+auth.group_no_access: "無權訪問 {{.Group}} 分組"
+auth.group_deprecated: "分組 {{.Group}} 已被棄用"
+auth.specific_channel_denied: "普通用戶不支持指定渠道"
+
+# Rate limit middleware messages
+rate_limit.success_exceeded: "您已達到請求數限制：{{.Minutes}}分鐘內最多請求{{.Count}}次"
+rate_limit.total_exceeded: "您已達到總請求數限制：{{.Minutes}}分鐘內最多請求{{.Count}}次，包括失敗次數，請檢查您的請求是否正確"
+rate_limit.email_too_frequent_wait: "發送過於頻繁，請等待 {{.Seconds}} 秒後再試"
+rate_limit.email_too_frequent: "發送過於頻繁，請稍後再試"
+
+# Secure verification middleware messages
+secure_verify.not_logged_in: "未登錄"
+secure_verify.required: "需要安全驗證"
+secure_verify.invalid: "驗證狀態異常，請重新驗證"
+secure_verify.expired: "驗證已過期，請重新驗證"
+
+# Turnstile middleware messages
+turnstile.token_empty: "Turnstile token 為空"
+turnstile.check_failed: "Turnstile 校驗失敗，請刷新重試！"
+turnstile.session_save_failed: "無法保存會話信息，請重試"
 
 # Token messages
 token.name_too_long: "令牌名稱過長"

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -392,11 +392,11 @@ func TokenAuth() func(c *gin.Context) {
 			logger.LogDebug(c, "Token has IP restrictions, checking client IP %s", clientIp)
 			ip := net.ParseIP(clientIp)
 			if ip == nil {
-				abortWithOpenAiMessage(c, http.StatusForbidden, "无法解析客户端 IP 地址")
+				abortWithOpenAiMessage(c, http.StatusForbidden, common.TranslateMessage(c, i18n.MsgAuthIpParseFailed))
 				return
 			}
 			if common.IsIpInCIDRList(ip, allowIps) == false {
-				abortWithOpenAiMessage(c, http.StatusForbidden, "您的 IP 不在令牌允许访问的列表中", types.ErrorCodeAccessDenied)
+				abortWithOpenAiMessage(c, http.StatusForbidden, common.TranslateMessage(c, i18n.MsgAuthIpNotAllowed), types.ErrorCodeAccessDenied)
 				return
 			}
 			logger.LogDebug(c, "Client IP %s passed the token IP restrictions check", clientIp)
@@ -422,13 +422,13 @@ func TokenAuth() func(c *gin.Context) {
 		if tokenGroup != "" {
 			// check common.UserUsableGroups[userGroup]
 			if _, ok := service.GetUserUsableGroups(userGroup)[tokenGroup]; !ok {
-				abortWithOpenAiMessage(c, http.StatusForbidden, fmt.Sprintf("无权访问 %s 分组", tokenGroup))
+				abortWithOpenAiMessage(c, http.StatusForbidden, common.TranslateMessage(c, i18n.MsgAuthGroupNoAccess, map[string]any{"Group": tokenGroup}))
 				return
 			}
 			// check group in common.GroupRatio
 			if !ratio_setting.ContainsGroupRatio(tokenGroup) {
 				if tokenGroup != "auto" {
-					abortWithOpenAiMessage(c, http.StatusForbidden, fmt.Sprintf("分组 %s 已被弃用", tokenGroup))
+					abortWithOpenAiMessage(c, http.StatusForbidden, common.TranslateMessage(c, i18n.MsgAuthGroupDeprecated, map[string]any{"Group": tokenGroup}))
 					return
 				}
 			}
@@ -469,7 +469,7 @@ func SetupContextForToken(c *gin.Context, token *model.Token, parts ...string) e
 			c.Set("specific_channel_id", parts[1])
 		} else {
 			c.Header("specific_channel_version", "701e3ae1dc3f7975556d354e0675168d004891c8")
-			abortWithOpenAiMessage(c, http.StatusForbidden, "普通用户不支持指定渠道")
+			abortWithOpenAiMessage(c, http.StatusForbidden, common.TranslateMessage(c, i18n.MsgAuthSpecificChannelDenied))
 			return fmt.Errorf("普通用户不支持指定渠道")
 		}
 	}

--- a/middleware/email-verification-rate-limit.go
+++ b/middleware/email-verification-rate-limit.go
@@ -2,11 +2,11 @@ package middleware
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
 
 	"github.com/gin-gonic/gin"
 )
@@ -49,7 +49,7 @@ func redisEmailVerificationRateLimiter(c *gin.Context) {
 
 	c.JSON(http.StatusTooManyRequests, gin.H{
 		"success": false,
-		"message": fmt.Sprintf("发送过于频繁，请等待 %d 秒后再试", waitSeconds),
+		"message": common.TranslateMessage(c, i18n.MsgEmailSendTooFrequentWait, map[string]any{"Seconds": waitSeconds}),
 	})
 	c.Abort()
 }
@@ -60,7 +60,7 @@ func memoryEmailVerificationRateLimiter(c *gin.Context) {
 	if !inMemoryRateLimiter.Request(key, EmailVerificationMaxRequests, EmailVerificationDuration) {
 		c.JSON(http.StatusTooManyRequests, gin.H{
 			"success": false,
-			"message": "发送过于频繁，请稍后再试",
+			"message": common.TranslateMessage(c, i18n.MsgEmailSendTooFrequent),
 		})
 		c.Abort()
 		return

--- a/middleware/model-rate-limit.go
+++ b/middleware/model-rate-limit.go
@@ -10,6 +10,7 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/common/limiter"
 	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/setting"
 
 	"github.com/gin-gonic/gin"
@@ -90,7 +91,7 @@ func redisRateLimitHandler(duration int64, totalMaxCount, successMaxCount int) g
 			return
 		}
 		if !allowed {
-			abortWithOpenAiMessage(c, http.StatusTooManyRequests, fmt.Sprintf("您已达到请求数限制：%d分钟内最多请求%d次", setting.ModelRequestRateLimitDurationMinutes, successMaxCount))
+			abortWithOpenAiMessage(c, http.StatusTooManyRequests, common.TranslateMessage(c, i18n.MsgRateLimitSuccessExceeded, map[string]any{"Minutes": setting.ModelRequestRateLimitDurationMinutes, "Count": successMaxCount}))
 			return
 		}
 
@@ -114,7 +115,7 @@ func redisRateLimitHandler(duration int64, totalMaxCount, successMaxCount int) g
 			}
 
 			if !allowed {
-				abortWithOpenAiMessage(c, http.StatusTooManyRequests, fmt.Sprintf("您已达到总请求数限制：%d分钟内最多请求%d次，包括失败次数，请检查您的请求是否正确", setting.ModelRequestRateLimitDurationMinutes, totalMaxCount))
+				abortWithOpenAiMessage(c, http.StatusTooManyRequests, common.TranslateMessage(c, i18n.MsgRateLimitTotalExceeded, map[string]any{"Minutes": setting.ModelRequestRateLimitDurationMinutes, "Count": totalMaxCount}))
 			}
 		}
 

--- a/middleware/secure_verification.go
+++ b/middleware/secure_verification.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
+
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 )
@@ -26,7 +29,7 @@ func SecureVerificationRequired() gin.HandlerFunc {
 		if userId == 0 {
 			c.JSON(http.StatusUnauthorized, gin.H{
 				"success": false,
-				"message": "未登录",
+				"message": common.TranslateMessage(c, i18n.MsgSecureVerifyNotLoggedIn),
 			})
 			c.Abort()
 			return
@@ -39,7 +42,7 @@ func SecureVerificationRequired() gin.HandlerFunc {
 		if verifiedAtRaw == nil {
 			c.JSON(http.StatusForbidden, gin.H{
 				"success": false,
-				"message": "需要安全验证",
+				"message": common.TranslateMessage(c, i18n.MsgSecureVerifyRequired),
 				"code":    "VERIFICATION_REQUIRED",
 			})
 			c.Abort()
@@ -52,7 +55,7 @@ func SecureVerificationRequired() gin.HandlerFunc {
 			clearSecureVerificationSession(session)
 			c.JSON(http.StatusForbidden, gin.H{
 				"success": false,
-				"message": "验证状态异常，请重新验证",
+				"message": common.TranslateMessage(c, i18n.MsgSecureVerifyInvalid),
 				"code":    "VERIFICATION_INVALID",
 			})
 			c.Abort()
@@ -66,7 +69,7 @@ func SecureVerificationRequired() gin.HandlerFunc {
 			clearSecureVerificationSession(session)
 			c.JSON(http.StatusForbidden, gin.H{
 				"success": false,
-				"message": "验证已过期，请重新验证",
+				"message": common.TranslateMessage(c, i18n.MsgSecureVerifyExpired),
 				"code":    "VERIFICATION_EXPIRED",
 			})
 			c.Abort()

--- a/middleware/turnstile-check.go
+++ b/middleware/turnstile-check.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 )
@@ -27,7 +28,7 @@ func TurnstileCheck() gin.HandlerFunc {
 			if response == "" {
 				c.JSON(http.StatusOK, gin.H{
 					"success": false,
-					"message": "Turnstile token 为空",
+					"message": common.TranslateMessage(c, i18n.MsgTurnstileTokenEmpty),
 				})
 				c.Abort()
 				return
@@ -61,7 +62,7 @@ func TurnstileCheck() gin.HandlerFunc {
 			if !res.Success {
 				c.JSON(http.StatusOK, gin.H{
 					"success": false,
-					"message": "Turnstile 校验失败，请刷新重试！",
+					"message": common.TranslateMessage(c, i18n.MsgTurnstileCheckFailed),
 				})
 				c.Abort()
 				return
@@ -70,7 +71,7 @@ func TurnstileCheck() gin.HandlerFunc {
 			err = session.Save()
 			if err != nil {
 				c.JSON(http.StatusOK, gin.H{
-					"message": "无法保存会话信息，请重试",
+					"message": common.TranslateMessage(c, i18n.MsgTurnstileSessionSaveFailed),
 					"success": false,
 				})
 				return

--- a/service/quota.go
+++ b/service/quota.go
@@ -469,7 +469,12 @@ func checkAndSendQuotaNotify(relayInfo *relaycommon.RelayInfo, quota int, preCon
 			quotaTooLow = true
 		}
 		if quotaTooLow {
+			// 根据用户语言偏好选择通知语言，未设置时保持默认中文
+			useEnglish := strings.HasPrefix(strings.ToLower(userSetting.Language), "en")
 			prompt := "您的额度即将用尽"
+			if useEnglish {
+				prompt = "Your quota is running low"
+			}
 			topUpLink := PaymentReturnURL("/console/topup")
 
 			// 根据通知方式生成不同的内容格式
@@ -484,13 +489,22 @@ func checkAndSendQuotaNotify(relayInfo *relaycommon.RelayInfo, quota int, preCon
 			if notifyType == dto.NotifyTypeBark {
 				// Bark推送使用简短文本，不支持HTML
 				content = "{{value}}，剩余额度：{{value}}，请及时充值"
+				if useEnglish {
+					content = "{{value}}, remaining quota: {{value}}, please top up in time"
+				}
 				values = []interface{}{prompt, logger.FormatQuota(relayInfo.UserQuota)}
 			} else if notifyType == dto.NotifyTypeGotify {
 				content = "{{value}}，当前剩余额度为 {{value}}，请及时充值。"
+				if useEnglish {
+					content = "{{value}}, your current remaining quota is {{value}}, please top up in time."
+				}
 				values = []interface{}{prompt, logger.FormatQuota(relayInfo.UserQuota)}
 			} else {
 				// 默认内容格式，适用于Email和Webhook（支持HTML）
 				content = "{{value}}，当前剩余额度为 {{value}}，为了不影响您的使用，请及时充值。<br/>充值链接：<a href='{{value}}'>{{value}}</a>"
+				if useEnglish {
+					content = "{{value}}, your current remaining quota is {{value}}. To avoid service interruption, please top up in time.<br/>Top-up link: <a href='{{value}}'>{{value}}</a>"
+				}
 				values = []interface{}{prompt, logger.FormatQuota(relayInfo.UserQuota), topUpLink, topUpLink}
 			}
 


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

## 📝 变更描述 / Description

### English

**Motivation**

The backend already has an i18n framework (`common.TranslateMessage` + `i18n/locales/{en,zh-CN,zh-TW}.yaml`, resolving per request as: user's saved language setting → `Accept-Language` header → default), but 16 user-facing messages in the middleware layer bypassed it and were hardcoded in Chinese. They were returned in Chinese regardless of the caller's language — which matters for API consumers (the `middleware/auth.go` messages are OpenAI-format API error responses seen by end customers) and for non-Chinese deployments.

**What changed** (10 files, +130/−17)

| File | Change |
|---|---|
| `i18n/keys.go` | 16 new message-key constants, following the existing naming style |
| `i18n/locales/en.yaml` / `zh-CN.yaml` / `zh-TW.yaml` | +22 lines each: translations for all new keys; templated params use go-i18n syntax (`{{.Group}}`, `{{.Minutes}}`, `{{.Count}}`, `{{.Seconds}}`) |
| `middleware/auth.go` | 5 sites: IP parse failed, IP not in allowlist, group no access, group deprecated, specific-channel denied. The internal `fmt.Errorf` return value was deliberately left unchanged (not user-visible) |
| `middleware/model-rate-limit.go` | 2 sites: both HTTP 429 rate-limit messages |
| `middleware/email-verification-rate-limit.go` | 2 sites: send-too-frequent messages |
| `middleware/secure_verification.go` | 4 sites: not logged in / verification required / invalid / expired |
| `middleware/turnstile-check.go` | 3 sites: token empty / check failed / session save failed |
| `service/quota.go` | quota-warning notification (email/webhook/Bark/Gotify) — see note below |

**Behavior guarantees**

- The `zh-CN.yaml` values are the exact original hardcoded strings, so Chinese-language users see **byte-identical** text — nothing was removed or reworded.
- Language resolution order is unchanged (it uses the existing framework as-is).
- The frontend detects `secure_verification.go` responses by the `code` field, **not** by message text (verified in `web/classic/src/helpers/secureApiCall.js`), so translating those messages is safe.

**Why `service/quota.go` uses a language switch instead of the bundle**

The quota-warning notification runs in an async goroutine with no gin context, and its strings contain the notify system's `{{value}}` placeholders, which would collide with go-i18n's `{{.Var}}` template syntax. It therefore uses a simple switch on `userSetting.Language`: English only when the user's saved setting starts with `en`, otherwise the original Chinese — preserving the default behavior exactly.

**Verification**

- All non-root packages build (the root `main` package's embed of `web/*/dist` requires a frontend build — pre-existing, unrelated to this change)
- `go vet ./i18n/ ./middleware/ ./service/` clean
- `go test ./middleware/ ./service/` pass
- A test exercising the new key/language combinations through the i18n bundle confirmed every key resolves in en / zh-CN / zh-TW, including templated params
- `gofmt` applied
- grep confirms zero remaining hardcoded-Chinese message fields in the 5 modified middleware files

---

### 中文

**动机**

后端已有 i18n 框架（`common.TranslateMessage` + `i18n/locales/{en,zh-CN,zh-TW}.yaml`，按请求解析顺序：用户保存的语言设置 → `Accept-Language` 请求头 → 默认语言），但中间件层有 16 条面向用户的消息绕过了该框架，直接硬编码为中文。无论调用方使用什么语言，这些消息都以中文返回——这对 API 消费者（`middleware/auth.go` 中的消息是终端客户可见的 OpenAI 格式 API 错误响应）以及非中文部署环境影响较大。

**变更内容**（10 个文件，+130/−17）

| 文件 | 变更 |
|---|---|
| `i18n/keys.go` | 新增 16 个消息键常量，沿用现有命名风格 |
| `i18n/locales/en.yaml` / `zh-CN.yaml` / `zh-TW.yaml` | 各 +22 行：所有新键的翻译；模板参数使用 go-i18n 语法（`{{.Group}}`、`{{.Minutes}}`、`{{.Count}}`、`{{.Seconds}}`） |
| `middleware/auth.go` | 5 处：IP 解析失败、IP 不在白名单、分组无权访问、分组已弃用、指定渠道被拒绝。内部 `fmt.Errorf` 返回值有意保持不变（用户不可见） |
| `middleware/model-rate-limit.go` | 2 处：两条 HTTP 429 限流消息 |
| `middleware/email-verification-rate-limit.go` | 2 处：发送过于频繁的提示 |
| `middleware/secure_verification.go` | 4 处：未登录 / 需要验证 / 验证无效 / 验证过期 |
| `middleware/turnstile-check.go` | 3 处：token 为空 / 校验失败 / session 保存失败 |
| `service/quota.go` | 额度预警通知（邮件/webhook/Bark/Gotify）——见下方说明 |

**行为保证**

- `zh-CN.yaml` 中的值与原硬编码字符串**逐字节一致**，中文用户看到的文本与之前完全相同——没有删除或改写任何内容。
- 语言解析顺序不变（直接复用现有框架）。
- 前端通过 `code` 字段而**非**消息文本识别 `secure_verification.go` 的响应（已在 `web/classic/src/helpers/secureApiCall.js` 中核实），因此翻译这些消息是安全的。

**为什么 `service/quota.go` 使用语言 switch 而不是 i18n bundle**

额度预警通知在异步 goroutine 中运行，没有 gin context，且其字符串包含通知系统自身的 `{{value}}` 占位符，会与 go-i18n 的 `{{.Var}}` 模板语法冲突。因此改为对 `userSetting.Language` 做简单判断：仅当用户保存的语言设置以 `en` 开头时输出英文，否则输出原有中文——默认行为完全保持不变。

**验证**

- 所有非根包均可编译（根 `main` 包 embed `web/*/dist` 需要前端构建——为既有情况，与本变更无关）
- `go vet ./i18n/ ./middleware/ ./service/` 无警告
- `go test ./middleware/ ./service/` 通过
- 通过 i18n bundle 对所有新增键/语言组合进行了测试，确认每个键在 en / zh-CN / zh-TW 下均能解析，包括模板参数
- 已执行 `gofmt`
- grep 确认 5 个被修改的中间件文件中不再有硬编码中文消息字段

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [x] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无 / None

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 不适用 / N/A（非 Bug fix）
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```
$ go vet ./i18n/ ./middleware/ ./service/
(clean, no output)

$ go test ./middleware/ ./service/
ok  	github.com/QuantumNous/new-api/middleware
ok  	github.com/QuantumNous/new-api/service

$ git diff --stat main
 i18n/keys.go                                | 28 ++++++++++++++++++++++++++++
 i18n/locales/en.yaml                        | 22 ++++++++++++++++++++++
 i18n/locales/zh-CN.yaml                     | 22 ++++++++++++++++++++++
 i18n/locales/zh-TW.yaml                     | 22 ++++++++++++++++++++++
 middleware/auth.go                          | 10 +++++-----
 middleware/email-verification-rate-limit.go |  6 +++---
 middleware/model-rate-limit.go              |  5 +++--
 middleware/secure_verification.go           | 11 +++++++----
 middleware/turnstile-check.go               |  7 ++++---
 service/quota.go                            | 14 ++++++++++++++
 10 files changed, 130 insertions(+), 17 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized messages for authentication, rate limits, secure verification, and Turnstile checks.
  * Added English, Simplified Chinese, and Traditional Chinese translations for middleware errors.
  * Added English quota-warning notifications based on the configured language.

* **Bug Fixes**
  * Replaced hardcoded middleware error messages with translated responses.
  * Included clearer access-denied responses for restricted IPs, groups, and channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->