### PR TITLE
fix(data-table): update table body immediately when toggling columns

### DIFF
--- a/web/default/src/components/data-table/core/data-table-row.tsx
+++ b/web/default/src/components/data-table/core/data-table-row.tsx
@@ -39,6 +39,12 @@ type DataTableRowProps<TData> = {
 
 type DataTableRowInnerProps<TData> = DataTableRowProps<TData> & {
   isSelected: boolean
+  /**
+   * Stable signature of currently visible leaf columns for this row.
+   * Captured outside the memo comparator so visibility toggles re-render
+   * even when the TanStack row object reference stays the same.
+   */
+  visibleColumnIds: string
 }
 
 function DataTableRowInner<TData>({
@@ -47,11 +53,13 @@ function DataTableRowInner<TData>({
   className,
   getColumnClassName,
   cellRenderColumns,
+  visibleColumnIds,
   ...rowProps
 }: DataTableRowInnerProps<TData>) {
-  // Destructured only to keep it out of `rowProps` (it is not a valid DOM attr)
-  // and to feed the memo comparator below; it is intentionally unused here.
+  // Destructured only to keep them out of `rowProps` (not valid DOM attrs)
+  // and to feed the memo comparator below; intentionally unused here.
   void cellRenderColumns
+  void visibleColumnIds
 
   return (
     <TableRow
@@ -81,10 +89,11 @@ function DataTableRowInner<TData>({
 }
 
 const MemoizedDataTableRow = React.memo(DataTableRowInner, (prev, next) => {
-  // Do not read row.getIsSelected() inside the comparator: TanStack row objects
-  // keep a stable reference while their selection state mutates, so reading it
-  // here compares identical live values and misses selection changes. Selection
-  // is lifted to the `isSelected` prop, captured per render in DataTableRow.
+  // Do not read row.getIsSelected() / row.getVisibleCells() inside the
+  // comparator: TanStack row objects keep a stable reference while selection
+  // and columnVisibility mutate on the table instance. Reading them here would
+  // compare identical live values and miss those updates. Both are lifted to
+  // explicit props, captured per render in DataTableRow.
   //
   // Column cell renderers (and getColumnClassName) can close over external
   // state while the row stays stable, so column definitions and the class
@@ -93,14 +102,24 @@ const MemoizedDataTableRow = React.memo(DataTableRowInner, (prev, next) => {
     prev.row === next.row &&
     prev.className === next.className &&
     prev.isSelected === next.isSelected &&
+    prev.visibleColumnIds === next.visibleColumnIds &&
     prev.getColumnClassName === next.getColumnClassName &&
     prev.cellRenderColumns === next.cellRenderColumns
   )
 }) as typeof DataTableRowInner
 
 export function DataTableRow<TData>(props: DataTableRowProps<TData>) {
+  const visibleColumnIds = props.row
+    .getVisibleCells()
+    .map((cell) => cell.column.id)
+    .join('\0')
+
   return (
-    <MemoizedDataTableRow {...props} isSelected={props.row.getIsSelected()} />
+    <MemoizedDataTableRow
+      {...props}
+      isSelected={props.row.getIsSelected()}
+      visibleColumnIds={visibleColumnIds}
+    />
   )
 }
 


### PR DESCRIPTION
# ⚠️ PR Notice
> [!IMPORTANT]
>
> - This PR is AI-assisted. The root cause, fix scope, and typecheck results were reviewed before submission.

## 📝 Description

On list pages such as Channels, using **View → Toggle columns** updates the header, but the table body does not follow right away. A full refresh, or another action that rebuilds column definitions (for example the sensitive-data visibility button on Channels), is needed before the body matches the selected columns.

This is the same class of bug as #5524 (row selection not updating). `DataTableRow` uses a custom `React.memo` comparator, and TanStack Table row objects keep a stable reference when `columnVisibility` changes. Without a visible-column dependency, the memo skips the update and `getVisibleCells()` does not run again.

Fix, aligned with the `isSelected` snapshot in #5524:

- In the outer `DataTableRow`, build a `visibleColumnIds` signature from `row.getVisibleCells()` on each render
- Pass that signature into the memoized inner row and include it in the comparator
- When the visible column set or order changes, the signature changes and the body re-renders immediately

Change is limited to the shared `data-table-row.tsx`. Every table that renders through `DataTableRow` (Channels, API Keys, Users, usage logs custom `renderRow`, etc.) benefits; feature-specific table logic is unchanged.

## 🚀 Type of change
- [x] 🐛 Bug fix - *Link a related Issue when possible; do not classify design trade-offs or expectation mismatches as bugs*
- [ ] ✨ New feature - *Large features should be discussed in an Issue first*
- [ ] ⚡ Performance / refactor
- [ ] 📝 Documentation

## 🔗 Related Issue
- No dedicated Issue. Related historical fix: #5524

## ✅ Checklist
- [x] **Human-reviewed:** Description was written and checked; not a raw dump of unedited AI output.
- [x] **Not a duplicate:** Searched Issues and PRs; no open item for this bug. Related history: merged #5524 (row selection memo), closed #5363 (persist column visibility)—different from "body not refreshing after toggle".
- [x] **Bug fix note:** Real render bug from a missing memo dependency, not a design trade-off or misunderstood expectation.
- [x] **Understood:** Change behavior and impact are understood.
- [x] **Focused scope:** No unrelated code changes.
- [x] **Local verification:** Typecheck passed; oxlint on the touched file reported no new issues.
- [x] **Security:** No secrets; follows project conventions.

## 📸 Proof of Work

Local checks:

```bash
cd web/default
bun run typecheck
bunx oxlint -c .oxlintrc.json src/components/data-table/core/data-table-row.tsx
```

- `bun run typecheck` passed
- oxlint on the target file clean

Suggested manual check:

1. Open Channels in table view
2. View → Toggle columns and show/hide several columns
3. Table body should match the header immediately, without refresh or the sensitive-data toggle
4. Other tables with View options (API Keys, usage logs) should behave the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated data table rows to refresh correctly when visible columns change.
  * Ensured column visibility updates are reflected immediately, even when row data remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->