### PR TITLE
fix(relay): detect upstream SSE when Content-Type header is missing (fixes #6075)

### DIFF
--- a/relay/chat_completions_via_responses.go
+++ b/relay/chat_completions_via_responses.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"net/http"
@@ -151,6 +152,13 @@ func chatCompletionsViaResponses(c *gin.Context, info *relaycommon.RelayInfo, ad
 	httpResp = resp.(*http.Response)
 	clientStream := info.IsStream
 	upstreamStream := isResponsesEventStreamContentType(httpResp.Header.Get("Content-Type"))
+	if !upstreamStream {
+		// Some backends (e.g. the ChatGPT Codex /responses endpoint) return a
+		// 200 SSE stream with no Content-Type header at all. The header check
+		// above misses this and the caller then treats the SSE body as JSON,
+		// failing with "invalid character 'e'". Sniff the body prefix instead.
+		upstreamStream = isResponsesEventStreamSSEBody(httpResp.Body, &httpResp.Body)
+	}
 	info.IsStream = clientStream || upstreamStream
 	if httpResp.StatusCode != http.StatusOK {
 		newApiErr := service.RelayErrorHandler(c.Request.Context(), httpResp, false)
@@ -186,4 +194,57 @@ func chatCompletionsViaResponses(c *gin.Context, info *relaycommon.RelayInfo, ad
 
 func isResponsesEventStreamContentType(contentType string) bool {
 	return strings.Contains(strings.ToLower(contentType), "text/event-stream")
+}
+
+// isResponsesEventStreamSSEBody detects an SSE response body (a leading
+// "event:" or "data:" prefix, after an optional BOM and/or whitespace) when
+// the upstream omits the Content-Type header. It peeks the body one byte at a
+// time so a short live SSE prefix (e.g. "event: ping\n\n") is recognized before
+// EOF, and it restores every consumed byte via a fresh bufio.Reader so the
+// downstream stream handlers receive the full original body. JSON-like bodies
+// (leading '{', '[', '"') are rejected early. The (possibly repopulated) body
+// is written back through out; the caller must use out for subsequent reads.
+func isResponsesEventStreamSSEBody(rc io.ReadCloser, out *io.ReadCloser) bool {
+	if rc == nil {
+		return false
+	}
+	br := bufio.NewReader(rc)
+	buf := make([]byte, 0, 64)
+	for len(buf) < cap(buf) {
+		b, err := br.ReadByte()
+		if err != nil {
+			break // EOF or read error: not enough to confirm SSE
+		}
+		buf = append(buf, b)
+		trimmed := strings.TrimPrefix(string(buf), "\xef\xbb\xbf")
+		trimmed = strings.TrimLeft(trimmed, " 	\r\n")
+		if strings.HasPrefix(trimmed, "event:") || strings.HasPrefix(trimmed, "data:") {
+			*out = &peekReadCloser{Reader: br, closer: rc}
+			return true
+		}
+		// JSON-like start → definitely not SSE, stop probing.
+		if len(buf) >= 1 && (buf[0] == '{' || buf[0] == '[' || buf[0] == '"') {
+			break
+		}
+	}
+	// Not SSE (or inconclusive): hand the still-buffered body back so the
+	// non-stream JSON handler reads the complete original response.
+	*out = &peekReadCloser{Reader: br, closer: rc}
+	return false
+}
+
+// peekReadCloser wraps a bufio.Reader plus the original closer so downstream
+// consumers read from the buffer (which still holds every byte) and close
+// correctly.
+type peekReadCloser struct {
+	Reader *bufio.Reader
+	closer io.ReadCloser
+}
+
+func (p *peekReadCloser) Read(b []byte) (int, error) {
+	return p.Reader.Read(b)
+}
+
+func (p *peekReadCloser) Close() error {
+	return p.closer.Close()
 }


### PR DESCRIPTION
## Summary
- Fixes #6075 — using a Codex (OpenAI `/responses`) channel via the `/chat/completions` adaptor returns `status_code=500, invalid character 'e' looking for beginning of value`.
- Root cause: `isResponsesEventStreamContentType()` only inspects the `Content-Type` header. The ChatGPT Codex `/responses` endpoint returns a 200 SSE stream **without** a `Content-Type: text/event-stream` header, so new-api classified it as non-stream and passed the raw SSE body to the JSON handler, which failed on `event: ...` → `invalid character 'e'`.
- Fix: after the header check fails, sniff the body prefix one byte at a time. A leading `event:` / `data:` (after optional BOM/whitespace) is treated as SSE; a JSON-like start (`{`, `[`, `"`) is rejected early. Every consumed byte is preserved via a `bufio.Reader` (`peekReadCloser`) so downstream stream handlers still read the full original body.

## Why incremental peeking (not `Peek(64)`)
A fixed `Reader.Peek(64)` can block until 64 bytes arrive or EOF on a slow SSE prefix (e.g. `event: ping\n\n`). Reading one byte at a time recognizes the SSE prefix as soon as it appears and never blocks beyond the data actually sent.

## Behavior
- Upstream SSE with no `Content-Type` → correctly routed to the SSE handler.
- Upstream JSON (normal chat completions) → unchanged, still treated as non-stream.

## Verification
- `go build ./relay/...` passes on `main`.
- Standalone unit test of the sniff helper: 5/5 cases pass (Codex SSE `event:`/`data:` detected incl. BOM+whitespace; plain JSON `{"..."}` not mistaken for SSE).
- Built a patched `v1.0.0-rc.21` arm64 image and deployed to a live instance; the Codex channel now streams correctly through `/chat/completions` (issue reporter confirmed).

## Test plan
- [ ] Add a regression test in `relay/` for `isResponsesEventStreamSSEBody` (SSE w/o Content-Type vs JSON).
- [ ] Manually verify a Codex-type channel via `/chat/completions` with streaming enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with upstream streaming responses that omit the `Content-Type` header.
  * SSE streams are now correctly detected and processed instead of being misinterpreted as JSON.
  * Preserved response data and connection cleanup during stream detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->