### PR TITLE
fix: convert OpenAI tool result images for Claude

### DIFF
--- a/service/relayconvert/internal/oai_chat/to_claude_messages_req.go
+++ b/service/relayconvert/internal/oai_chat/to_claude_messages_req.go
@@ -27,6 +27,56 @@ type openRouterRequestReasoning struct {
 	Exclude   bool   `json:"exclude,omitempty"`
 }
 
+func convertOpenAIToolResultContentToClaude(c *gin.Context, message dto.Message) (any, error) {
+	contentItems, ok := message.Content.([]any)
+	if !ok {
+		return message.Content, nil
+	}
+
+	convertedContent := make([]any, 0, len(contentItems))
+	convertedAnyImage := false
+	for _, contentItem := range contentItems {
+		contentMap, ok := contentItem.(map[string]any)
+		if !ok || contentMap["type"] != dto.ContentTypeImageURL {
+			convertedContent = append(convertedContent, contentItem)
+			continue
+		}
+
+		mediaMessages := (&dto.Message{Content: []any{contentItem}}).ParseContent()
+		if len(mediaMessages) != 1 {
+			return nil, fmt.Errorf("invalid image_url tool result content")
+		}
+		source := mediaMessages[0].ToFileSource()
+		if source == nil {
+			return nil, fmt.Errorf("invalid image_url tool result source")
+		}
+
+		base64Data, mimeType, err := relaymedia.ResolveBase64Data(c, source, "formatting tool result image for Claude")
+		if err != nil {
+			return nil, fmt.Errorf("get tool result file data failed: %s", err.Error())
+		}
+
+		contentType := "image"
+		if strings.HasPrefix(mimeType, "application/pdf") {
+			contentType = "document"
+		}
+		convertedContent = append(convertedContent, dto.ClaudeMediaMessage{
+			Type: contentType,
+			Source: &dto.ClaudeMessageSource{
+				Type:      "base64",
+				MediaType: mimeType,
+				Data:      base64Data,
+			},
+		})
+		convertedAnyImage = true
+	}
+
+	if !convertedAnyImage {
+		return message.Content, nil
+	}
+	return convertedContent, nil
+}
+
 func OpenAIChatRequestToClaudeMessages(c *gin.Context, textRequest dto.GeneralOpenAIRequest) (*dto.ClaudeRequest, error) {
 	claudeTools := make([]any, 0, len(textRequest.Tools))
 
@@ -299,6 +349,10 @@ func OpenAIChatRequestToClaudeMessages(c *gin.Context, textRequest dto.GeneralOp
 			Role: message.Role,
 		}
 		if message.Role == "tool" {
+			toolResultContent, err := convertOpenAIToolResultContentToClaude(c, message)
+			if err != nil {
+				return nil, err
+			}
 			if len(claudeMessages) > 0 && claudeMessages[len(claudeMessages)-1].Role == "user" {
 				lastClaudeMessage := claudeMessages[len(claudeMessages)-1]
 				if content, ok := lastClaudeMessage.Content.(string); ok {
@@ -312,7 +366,7 @@ func OpenAIChatRequestToClaudeMessages(c *gin.Context, textRequest dto.GeneralOp
 				lastClaudeMessage.Content = append(lastClaudeMessage.Content.([]dto.ClaudeMediaMessage), dto.ClaudeMediaMessage{
 					Type:      "tool_result",
 					ToolUseId: message.ToolCallId,
-					Content:   message.Content,
+					Content:   toolResultContent,
 				})
 				claudeMessages[len(claudeMessages)-1] = lastClaudeMessage
 				continue
@@ -323,7 +377,7 @@ func OpenAIChatRequestToClaudeMessages(c *gin.Context, textRequest dto.GeneralOp
 				{
 					Type:      "tool_result",
 					ToolUseId: message.ToolCallId,
-					Content:   message.Content,
+					Content:   toolResultContent,
 				},
 			}
 		} else if message.IsStringContent() && message.ToolCalls == nil {

--- a/service/relayconvert/internal/oai_chat/to_claude_messages_req_test.go
+++ b/service/relayconvert/internal/oai_chat/to_claude_messages_req_test.go
@@ -1,0 +1,106 @@
+package oaichat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	relaymedia "github.com/QuantumNous/new-api/service/relayconvert/internal/media"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIChatRequestToClaudeMessagesConvertsToolResultImageURL(t *testing.T) {
+	relaymedia.SetMediaResolver(relaymedia.MediaResolver{
+		GetBase64Data: func(_ *gin.Context, source types.FileSource, _ ...string) (string, string, error) {
+			assert.Equal(t, "https://example.com/tool-result.png", source.GetRawData())
+			return "resolved-image-data", "image/png", nil
+		},
+	})
+	t.Cleanup(func() {
+		relaymedia.SetMediaResolver(relaymedia.MediaResolver{})
+	})
+
+	request := toolResultConversionRequest([]any{
+		map[string]any{"type": "text", "text": "Image result:"},
+		map[string]any{
+			"type": dto.ContentTypeImageURL,
+			"image_url": map[string]any{
+				"url": "https://example.com/tool-result.png",
+			},
+		},
+	})
+
+	claudeRequest, err := OpenAIChatRequestToClaudeMessages(nil, request)
+	require.NoError(t, err)
+	require.Len(t, claudeRequest.Messages, 3)
+
+	toolResultBlocks, ok := claudeRequest.Messages[2].Content.([]dto.ClaudeMediaMessage)
+	require.True(t, ok)
+	require.Len(t, toolResultBlocks, 1)
+	assert.Equal(t, "tool_result", toolResultBlocks[0].Type)
+	assert.Equal(t, "call_1", toolResultBlocks[0].ToolUseId)
+
+	toolContent, ok := toolResultBlocks[0].Content.([]any)
+	require.True(t, ok)
+	require.Len(t, toolContent, 2)
+	assert.Equal(t, map[string]any{"type": "text", "text": "Image result:"}, toolContent[0])
+
+	imageBlock, ok := toolContent[1].(dto.ClaudeMediaMessage)
+	require.True(t, ok)
+	assert.Equal(t, "image", imageBlock.Type)
+	require.NotNil(t, imageBlock.Source)
+	assert.Equal(t, "base64", imageBlock.Source.Type)
+	assert.Equal(t, "image/png", imageBlock.Source.MediaType)
+	assert.Equal(t, "resolved-image-data", imageBlock.Source.Data)
+
+	payload, err := common.Marshal(claudeRequest)
+	require.NoError(t, err)
+	assert.NotContains(t, string(payload), `"image_url"`)
+	assert.Contains(t, string(payload), `"type":"image"`)
+}
+
+func TestOpenAIChatRequestToClaudeMessagesPreservesNonImageURLToolContent(t *testing.T) {
+	original := []any{
+		map[string]any{"type": "text", "text": "plain result"},
+		map[string]any{
+			"type": "image",
+			"source": map[string]any{
+				"type":       "base64",
+				"media_type": "image/png",
+				"data":       "already-converted",
+			},
+		},
+		map[string]any{"type": "custom", "value": "preserve me"},
+	}
+
+	claudeRequest, err := OpenAIChatRequestToClaudeMessages(nil, toolResultConversionRequest(original))
+	require.NoError(t, err)
+	require.Len(t, claudeRequest.Messages, 3)
+
+	toolResultBlocks, ok := claudeRequest.Messages[2].Content.([]dto.ClaudeMediaMessage)
+	require.True(t, ok)
+	require.Len(t, toolResultBlocks, 1)
+	assert.Equal(t, original, toolResultBlocks[0].Content)
+}
+
+func toolResultConversionRequest(toolContent any) dto.GeneralOpenAIRequest {
+	return dto.GeneralOpenAIRequest{
+		Model: "test-model",
+		Messages: []dto.Message{
+			{Role: "user", Content: "Use read_image."},
+			{
+				Role:      "assistant",
+				ToolCalls: json.RawMessage(`[{"id":"call_1","type":"function","function":{"name":"read_image","arguments":"{}"}}]`),
+			},
+			{
+				Role:       "tool",
+				ToolCallId: "call_1",
+				Content:    toolContent,
+			},
+		},
+	}
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

> [!NOTE]
>
> This change was AI-assisted. The scope, root cause, generated payload, and test results were reviewed during preparation; the PR has been reviewed by the submitter and marked ready for review.

## 📝 变更描述 / Description

OpenAI Chat Completions 的普通消息在转换到 Claude Messages 时，会将 `image_url` 解析为 Claude 原生的 `image/source`。但 `role: tool` 分支此前直接把 `message.Content` 写入 `tool_result.content`，导致工具返回的图片仍以 OpenAI `image_url` 结构发送给 Claude 兼容上游并触发参数校验错误。

本修改仅转换工具结果内容中的 `image_url`：沿用现有媒体解析逻辑读取 URL 或 Base64 数据，并输出 Claude `image`（PDF 输出为 `document`）内容块。文本、已经是 Claude 格式的图片块及未知内容保持原样。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6260

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。PR #4873 处理的是相反的 Claude → OpenAI 转换方向。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```text
go test ./service/relayconvert/internal/oai_chat
ok  github.com/QuantumNous/new-api/service/relayconvert/internal/oai_chat

go test ./service/relayconvert/...
ok  github.com/QuantumNous/new-api/service/relayconvert
ok  github.com/QuantumNous/new-api/service/relayconvert/internal/oai_chat
ok  github.com/QuantumNous/new-api/service/relayconvert/internal/oai_responses
```

新增回归测试验证：

- `tool_result.content` 中的 OpenAI `image_url` 会序列化为 Claude `image/source`，最终请求不再包含 `image_url`。
- 文本、已有 Claude 图片块和未知内容保持不变。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved compatibility when sending OpenAI tool results containing images or PDFs to Claude.
  - Media content is converted into Claude-compatible formats with the correct type and embedded data.
  - Non-media tool content remains unchanged.

- **Bug Fixes**
  - Conversion errors for invalid media references are now surfaced instead of producing incomplete requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->