### PR TITLE
fix(cloudflare): preserve upstream reasoning token usage

### DIFF
--- a/relay/channel/cloudflare/adaptor.go
+++ b/relay/channel/cloudflare/adaptor.go
@@ -57,6 +57,9 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 	if request == nil {
 		return nil, errors.New("request is nil")
 	}
+	if info.RelayMode == constant.RelayModeChatCompletions && info.SupportStreamOptions && info.IsStream {
+		request.StreamOptions = &dto.StreamOptions{IncludeUsage: true}
+	}
 	switch info.RelayMode {
 	case constant.RelayModeCompletions:
 		return convertCf2CompletionsRequest(*request), nil

--- a/relay/channel/cloudflare/relay_cloudflare.go
+++ b/relay/channel/cloudflare/relay_cloudflare.go
@@ -2,12 +2,12 @@ package cloudflare
 
 import (
 	"bufio"
-	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/logger"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
@@ -35,7 +35,8 @@ func cfStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Res
 
 	helper.SetEventStreamHeaders(c)
 	id := helper.GetResponseID(c)
-	var responseText string
+	var responseText strings.Builder
+	var usage *dto.Usage
 	isFirst := true
 
 	for scanner.Scan() {
@@ -51,17 +52,30 @@ func cfStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Res
 		}
 
 		var response dto.ChatCompletionsStreamResponse
-		err := json.Unmarshal([]byte(data), &response)
+		err := common.UnmarshalJsonStr(data, &response)
 		if err != nil {
 			logger.LogError(c, "error_unmarshalling_stream_response: "+err.Error())
 			continue
 		}
+		if response.Usage != nil {
+			validUsage := service.ValidUsage(response.Usage)
+			if validUsage {
+				usage = response.Usage
+			}
+			if !validUsage || !info.ShouldIncludeUsage {
+				response.Usage = nil
+			}
+		}
 		for _, choice := range response.Choices {
 			choice.Delta.Role = "assistant"
-			responseText += choice.Delta.GetContentString()
+			responseText.WriteString(choice.Delta.GetContentString())
+			responseText.WriteString(choice.Delta.GetReasoningContent())
 		}
 		response.Id = id
 		response.Model = info.UpstreamModelName
+		if len(response.Choices) == 0 && response.Usage == nil {
+			continue
+		}
 		err = helper.ObjectData(c, response)
 		if isFirst {
 			isFirst = false
@@ -75,8 +89,11 @@ func cfStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Res
 	if err := scanner.Err(); err != nil {
 		logger.LogError(c, "error_scanning_stream_response: "+err.Error())
 	}
-	usage := service.ResponseText2Usage(c, responseText, info.UpstreamModelName, info.GetEstimatePromptTokens())
-	if info.ShouldIncludeUsage {
+	containStreamUsage := service.ValidUsage(usage)
+	if !containStreamUsage {
+		usage = service.ResponseText2Usage(c, responseText.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
+	}
+	if info.ShouldIncludeUsage && !containStreamUsage {
 		response := helper.GenerateFinalUsageResponse(id, info.StartTime.Unix(), info.UpstreamModelName, *usage)
 		err := helper.ObjectData(c, response)
 		if err != nil {
@@ -97,19 +114,30 @@ func cfHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response)
 	}
 	service.CloseResponseBodyGracefully(resp)
 	var response dto.TextResponse
-	err = json.Unmarshal(responseBody, &response)
+	err = common.Unmarshal(responseBody, &response)
 	if err != nil {
 		return types.NewError(err, types.ErrorCodeBadResponseBody), nil
 	}
 	response.Model = info.UpstreamModelName
-	var responseText string
-	for _, choice := range response.Choices {
-		responseText += choice.Message.StringContent()
+	var usageEnvelope struct {
+		Usage *dto.Usage `json:"usage"`
 	}
-	usage := service.ResponseText2Usage(c, responseText, info.UpstreamModelName, info.GetEstimatePromptTokens())
+	err = common.Unmarshal(responseBody, &usageEnvelope)
+	if err != nil {
+		return types.NewError(err, types.ErrorCodeBadResponseBody), nil
+	}
+	usage := usageEnvelope.Usage
+	if !service.ValidUsage(usage) {
+		var responseText strings.Builder
+		for _, choice := range response.Choices {
+			responseText.WriteString(choice.Message.StringContent())
+			responseText.WriteString(choice.Message.GetReasoningContent())
+		}
+		usage = service.ResponseText2Usage(c, responseText.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
+	}
 	response.Usage = *usage
 	response.Id = helper.GetResponseID(c)
-	jsonResponse, err := json.Marshal(response)
+	jsonResponse, err := common.Marshal(response)
 	if err != nil {
 		return types.NewError(err, types.ErrorCodeBadResponseBody), nil
 	}
@@ -126,7 +154,7 @@ func cfSTTHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respon
 		return types.NewError(err, types.ErrorCodeBadResponseBody), nil
 	}
 	service.CloseResponseBodyGracefully(resp)
-	err = json.Unmarshal(responseBody, &cfResp)
+	err = common.Unmarshal(responseBody, &cfResp)
 	if err != nil {
 		return types.NewError(err, types.ErrorCodeBadResponseBody), nil
 	}
@@ -135,7 +163,7 @@ func cfSTTHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respon
 		Text: cfResp.Result.Text,
 	}
 
-	jsonResponse, err := json.Marshal(audioResp)
+	jsonResponse, err := common.Marshal(audioResp)
 	if err != nil {
 		return types.NewError(err, types.ErrorCodeBadResponseBody), nil
 	}

--- a/relay/channel/cloudflare/relay_cloudflare_test.go
+++ b/relay/channel/cloudflare/relay_cloudflare_test.go
@@ -1,0 +1,226 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCfHandlerUsesValidUpstreamUsageExactly(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	c.Set(common.RequestIdKey, "cf-usage-test")
+
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "@cf/openai/gpt-oss-20b"},
+	}
+	info.SetEstimatePromptTokens(999)
+
+	body := `{"id":"upstream-id","model":"upstream-model","choices":[{"index":0,"message":{"role":"assistant","content":"visible answer"},"finish_reason":"stop"}],"usage":{"prompt_tokens":11,"completion_tokens":31,"total_tokens":42,"completion_tokens_details":{"reasoning_tokens":23}}}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	newAPIError, usage := cfHandler(c, info, resp)
+
+	require.Nil(t, newAPIError)
+	require.NotNil(t, usage)
+	assert.Equal(t, 11, usage.PromptTokens)
+	assert.Equal(t, 31, usage.CompletionTokens)
+	assert.Equal(t, 23, usage.CompletionTokenDetails.ReasoningTokens)
+	assert.False(t, common.GetContextKeyBool(c, constant.ContextKeyLocalCountTokens))
+
+	var downstream dto.TextResponse
+	require.NoError(t, common.Unmarshal(recorder.Body.Bytes(), &downstream))
+	assert.Equal(t, 11, downstream.Usage.PromptTokens)
+	assert.Equal(t, 31, downstream.Usage.CompletionTokens)
+	assert.Equal(t, 23, downstream.Usage.CompletionTokenDetails.ReasoningTokens)
+}
+
+func TestCfHandlerFallsBackForZeroUsage(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	c.Set(common.RequestIdKey, "cf-zero-usage-test")
+
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "@cf/openai/gpt-oss-20b"},
+	}
+	info.SetEstimatePromptTokens(999)
+
+	body := `{"id":"upstream-id","model":"upstream-model","choices":[{"index":0,"message":{"role":"assistant","content":"visible answer","reasoning_content":"hidden reasoning"},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	newAPIError, usage := cfHandler(c, info, resp)
+
+	require.Nil(t, newAPIError)
+	require.NotNil(t, usage)
+	assert.Equal(t, 999, usage.PromptTokens)
+	expectedCompletionTokens := service.EstimateTokenByModel("@cf/openai/gpt-oss-20b", "visible answerhidden reasoning")
+	assert.Equal(t, expectedCompletionTokens, usage.CompletionTokens)
+	assert.Equal(t, usage.PromptTokens+usage.CompletionTokens, usage.TotalTokens)
+	assert.True(t, common.GetContextKeyBool(c, constant.ContextKeyLocalCountTokens))
+
+	var downstream dto.TextResponse
+	require.NoError(t, common.Unmarshal(recorder.Body.Bytes(), &downstream))
+	assert.Equal(t, usage.PromptTokens, downstream.Usage.PromptTokens)
+	assert.Equal(t, usage.CompletionTokens, downstream.Usage.CompletionTokens)
+	assert.Equal(t, usage.TotalTokens, downstream.Usage.TotalTokens)
+}
+
+func TestCfStreamHandlerUsesFinalUpstreamUsage(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	c.Set(common.RequestIdKey, "cf-stream-usage-test")
+
+	info := &relaycommon.RelayInfo{
+		StartTime:          time.Unix(1_700_000_000, 0),
+		ShouldIncludeUsage: true,
+		ChannelMeta:        &relaycommon.ChannelMeta{UpstreamModelName: "@cf/openai/gpt-oss-20b"},
+	}
+	info.SetEstimatePromptTokens(999)
+
+	body := strings.Join([]string{
+		`data: {"id":"upstream-id","object":"chat.completion.chunk","model":"upstream-model","choices":[{"index":0,"delta":{"content":"visible answer"}}]}`,
+		`data: {"id":"upstream-id","object":"chat.completion.chunk","model":"upstream-model","choices":[],"usage":{"prompt_tokens":11,"completion_tokens":31,"total_tokens":42,"completion_tokens_details":{"reasoning_tokens":23}}}`,
+		`data: [DONE]`,
+		"",
+	}, "\n")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	newAPIError, usage := cfStreamHandler(c, info, resp)
+
+	require.Nil(t, newAPIError)
+	require.NotNil(t, usage)
+	assert.Equal(t, 11, usage.PromptTokens)
+	assert.Equal(t, 31, usage.CompletionTokens)
+	assert.Equal(t, 23, usage.CompletionTokenDetails.ReasoningTokens)
+	assert.False(t, common.GetContextKeyBool(c, constant.ContextKeyLocalCountTokens))
+	assert.Equal(t, 1, strings.Count(recorder.Body.String(), `"completion_tokens":31`))
+	assert.Equal(t, 1, strings.Count(recorder.Body.String(), `"reasoning_tokens":23`))
+}
+
+func TestCfStreamHandlerFallsBackForZeroUsage(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	c.Set(common.RequestIdKey, "cf-stream-zero-usage-test")
+
+	info := &relaycommon.RelayInfo{
+		StartTime:          time.Unix(1_700_000_000, 0),
+		ShouldIncludeUsage: true,
+		ChannelMeta:        &relaycommon.ChannelMeta{UpstreamModelName: "@cf/openai/gpt-oss-20b"},
+	}
+	info.SetEstimatePromptTokens(999)
+
+	body := strings.Join([]string{
+		`data: {"id":"upstream-id","object":"chat.completion.chunk","model":"upstream-model","choices":[{"index":0,"delta":{"reasoning_content":"hidden reasoning"}}]}`,
+		`data: {"id":"upstream-id","object":"chat.completion.chunk","model":"upstream-model","choices":[{"index":0,"delta":{"content":"visible answer"}}]}`,
+		`data: {"id":"upstream-id","object":"chat.completion.chunk","model":"upstream-model","choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+		`data: [DONE]`,
+		"",
+	}, "\n")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	newAPIError, usage := cfStreamHandler(c, info, resp)
+
+	require.Nil(t, newAPIError)
+	require.NotNil(t, usage)
+	assert.Equal(t, 999, usage.PromptTokens)
+	expectedCompletionTokens := service.EstimateTokenByModel("@cf/openai/gpt-oss-20b", "hidden reasoningvisible answer")
+	assert.Equal(t, expectedCompletionTokens, usage.CompletionTokens)
+	assert.Equal(t, usage.PromptTokens+usage.CompletionTokens, usage.TotalTokens)
+	assert.True(t, common.GetContextKeyBool(c, constant.ContextKeyLocalCountTokens))
+	assert.NotContains(t, recorder.Body.String(), `"prompt_tokens":0`)
+	assert.Contains(t, recorder.Body.String(), `"prompt_tokens":999`)
+}
+
+func TestCfStreamHandlerOmitsUsageOnlyChunkWhenNotRequested(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	c.Set(common.RequestIdKey, "cf-stream-no-usage-test")
+
+	info := &relaycommon.RelayInfo{
+		StartTime:          time.Unix(1_700_000_000, 0),
+		ShouldIncludeUsage: false,
+		ChannelMeta:        &relaycommon.ChannelMeta{UpstreamModelName: "@cf/openai/gpt-oss-20b"},
+	}
+	info.SetEstimatePromptTokens(999)
+
+	body := strings.Join([]string{
+		`data: {"id":"upstream-id","object":"chat.completion.chunk","model":"upstream-model","choices":[{"index":0,"delta":{"content":"visible answer"}}]}`,
+		`data: {"id":"upstream-id","object":"chat.completion.chunk","model":"upstream-model","choices":[],"usage":{"prompt_tokens":11,"completion_tokens":31,"total_tokens":42,"completion_tokens_details":{"reasoning_tokens":23}}}`,
+		`data: [DONE]`,
+		"",
+	}, "\n")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	newAPIError, usage := cfStreamHandler(c, info, resp)
+
+	require.Nil(t, newAPIError)
+	require.NotNil(t, usage)
+	assert.Equal(t, 11, usage.PromptTokens)
+	assert.Equal(t, 31, usage.CompletionTokens)
+	assert.Equal(t, 23, usage.CompletionTokenDetails.ReasoningTokens)
+	assert.False(t, common.GetContextKeyBool(c, constant.ContextKeyLocalCountTokens))
+	assert.Contains(t, recorder.Body.String(), "visible answer")
+	assert.NotContains(t, recorder.Body.String(), `"choices":[]`)
+	assert.NotContains(t, recorder.Body.String(), `"completion_tokens":31`)
+}
+
+func TestConvertOpenAIRequestForcesUpstreamStreamUsage(t *testing.T) {
+	adaptor := &Adaptor{}
+	request := &dto.GeneralOpenAIRequest{
+		Stream:        common.GetPointer(true),
+		StreamOptions: &dto.StreamOptions{IncludeUsage: false},
+	}
+	info := &relaycommon.RelayInfo{
+		IsStream:  true,
+		RelayMode: relayconstant.RelayModeChatCompletions,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			SupportStreamOptions: true,
+		},
+	}
+
+	converted, err := adaptor.ConvertOpenAIRequest(nil, info, request)
+
+	require.NoError(t, err)
+	require.Same(t, request, converted)
+	require.NotNil(t, request.StreamOptions)
+	assert.True(t, request.StreamOptions.IncludeUsage)
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
Cloudflare Chat Completions 可能在 `completion_tokens` 中包含 Reasoning Token，但原处理逻辑会根据输出文本重新估算用量，导致本地消费记录与 Cloudflare AI Gateway Usage 不一致。

本次修改：

- 流式与非流式响应优先采用有效的上游 Usage，保留 `completion_tokens_details.reasoning_tokens`。
- 流式请求在渠道支持时始终向上游请求 Usage，但仍遵循客户端的 `include_usage` 返回偏好。
- 将全零 Usage 视为无效数据，回退本地计算，避免成功请求零扣费。
- 本地回退计算同时包含可见内容和 Reasoning Content。
- 当客户端关闭 Usage 时，内部仍保留 Usage 用于计费，但不转发 usage-only 空 Choice chunk。
- 增加非流式、流式、全零 Usage 和下游过滤场景的回归测试。

> AI-assisted disclosure: 此变更由 AI 协助实现、测试和整理，提交者已要求按仓库流程提交。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6265

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

本地自动化测试：

```text
go test ./relay/channel/cloudflare ./service
ok github.com/QuantumNous/new-api/relay/channel/cloudflare
ok github.com/QuantumNous/new-api/service
```

Cloudflare AI Gateway 实际流式请求验证：

```text
prompt_tokens: 126
completion_tokens: 495
reasoning_tokens: 477
total_tokens: 621
```

new-api 本地消费日志记录 `prompt_tokens=126`、`completion_tokens=495`，与上游 Usage 一致，且计费路径为 `usage_billing_path=upstream`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved token usage reporting for Cloudflare-backed chat and streaming responses.
  - Preserves valid upstream prompt, completion, and reasoning token counts when available.
  - Falls back to locally estimated usage when upstream counts are missing or invalid.
  - Prevents unnecessary usage-only streaming events when usage reporting is not requested.
  - Streaming requests now consistently request usage details from supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->