### PR TITLE
fix: 避免 Responses 流重复输出同一工具调用

### DIFF
--- a/service/relayconvert/internal/oai_responses/to_oai_chat_resp_test.go
+++ b/service/relayconvert/internal/oai_responses/to_oai_chat_resp_test.go
@@ -281,6 +281,68 @@ func TestResponsesStreamEventToChatChunksUsesTerminalDoneOutput(t *testing.T) {
 	assert.Equal(t, "tool_calls", *chunks[3].Choices[0].FinishReason)
 }
 
+func TestResponsesStreamEventToChatChunksDoesNotDuplicateToolFromTerminalOutput(t *testing.T) {
+	state := newTestResponsesStreamState()
+	outputIndex := 1
+	item := dto.ResponsesOutput{
+		Type:      responsesOutputTypeFunctionCall,
+		ID:        "fc_1",
+		CallId:    "call_1",
+		Name:      "lookup",
+		Arguments: []byte(`{"q":"x"}`),
+	}
+
+	var chunks []dto.ChatCompletionsStreamResponse
+	chunks = append(chunks, mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type:        responsesEventOutputItemAdded,
+		OutputIndex: &outputIndex,
+		Item: &dto.ResponsesOutput{
+			Type:   item.Type,
+			ID:     item.ID,
+			CallId: item.CallId,
+			Name:   item.Name,
+		},
+	})...)
+	chunks = append(chunks, mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type:        responsesEventFunctionArgsDelta,
+		OutputIndex: &outputIndex,
+		ItemID:      item.ID,
+		Delta:       `{"q":"x"}`,
+	})...)
+	chunks = append(chunks, mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type:        responsesEventOutputItemDone,
+		OutputIndex: &outputIndex,
+		Item:        &item,
+	})...)
+	chunks = append(chunks, mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type: responsesEventCompleted,
+		Response: &dto.OpenAIResponsesResponse{
+			Status: []byte(`"completed"`),
+			Output: []dto.ResponsesOutput{item},
+		},
+	})...)
+
+	var toolIndexes []int
+	totalArgs := ""
+	var finishReason string
+	for _, chunk := range chunks {
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+		for _, toolCall := range chunk.Choices[0].Delta.ToolCalls {
+			require.NotNil(t, toolCall.Index)
+			toolIndexes = append(toolIndexes, *toolCall.Index)
+			totalArgs += toolCall.Function.Arguments
+		}
+		if chunk.Choices[0].FinishReason != nil {
+			finishReason = *chunk.Choices[0].FinishReason
+		}
+	}
+	assert.Equal(t, []int{0, 0}, toolIndexes)
+	assert.Equal(t, `{"q":"x"}`, totalArgs)
+	assert.Equal(t, "tool_calls", finishReason)
+}
+
 func TestFinalizeResponsesToChatStreamFlushesPendingDeltaOnlyArguments(t *testing.T) {
 	state := newTestResponsesStreamState()
 	outputIndex := 2

--- a/service/relayconvert/internal/oai_responses/to_oai_chat_stream_resp.go
+++ b/service/relayconvert/internal/oai_responses/to_oai_chat_stream_resp.go
@@ -270,6 +270,23 @@ func (s *ResponsesToChatStreamState) ensureToolForEvent(event *dto.ResponsesStre
 
 	tool := s.toolByKey[key]
 	if tool == nil {
+		if itemID := responseStreamEventItemID(event); itemID != "" {
+			if existingKey := s.itemIDToKey[itemID]; existingKey != "" {
+				tool = s.toolByKey[existingKey]
+			}
+		}
+		if tool == nil {
+			if callID := strings.TrimSpace(event.Item.CallId); callID != "" {
+				if existingKey := s.callIDToKey[callID]; existingKey != "" {
+					tool = s.toolByKey[existingKey]
+				}
+			}
+		}
+		if tool != nil {
+			s.toolByKey[key] = tool
+		}
+	}
+	if tool == nil {
 		tool = &responsesStreamTool{Key: key, Index: s.nextToolIndex}
 		s.nextToolIndex++
 		s.toolByKey[key] = tool


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
Responses 流在增量事件中已经输出工具调用后，终止事件的完整 response.output 可能再次携带同一 function_call。此前状态机在终止阶段因缺少 output_index，会按 item_id 创建第二个工具状态。

本 PR 在创建工具状态前先查询已有的 output_index、item_id 和 call_id 映射，命中时复用原状态；只有均未命中时才沿用原逻辑创建新 key。同时加入完整事件序列的回归测试。

本 PR 的代码与测试由 AI 辅助生成，提交者已对改动范围、状态机逻辑和测试结果进行审查。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6278

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 Bug fix，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
修复前，真实事件序列生成的工具 index 为：

    [0, 0, 1]

修复后回归测试结果为：

    [0, 0]

已通过：

    go test ./service/relayconvert/...
    go test ./relay/channel/openai


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming tool-call tracking to prevent duplicate tool entries when terminal responses repeat previously emitted tool calls.
  - Enhanced tool-call identity preservation so tool calls stay consistently associated across related stream events.
- **Tests**
  - Added coverage verifying that terminal output repeating prior tool calls does not introduce unexpected duplicate tool-call entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->