### PR TITLE
feat: use channel proxy for model discovery

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -1285,6 +1285,11 @@ func FetchModels(c *gin.Context) {
 			Key:     key,
 			BaseURL: &baseURL,
 		}
+		if req.Proxy != nil {
+			settings := channel.GetSetting()
+			settings.Proxy = strings.TrimSpace(*req.Proxy)
+			channel.SetSetting(settings)
+		}
 	}
 
 	models, err := fetchChannelUpstreamModelIDs(channel)

--- a/controller/channel_upstream_update.go
+++ b/controller/channel_upstream_update.go
@@ -340,7 +340,7 @@ func fetchChannelUpstreamModelIDs(channel *model.Channel) ([]string, error) {
 
 	if channel.Type == constant.ChannelTypeOllama {
 		key := strings.TrimSpace(strings.Split(channel.Key, "\n")[0])
-		models, err := ollama.FetchOllamaModels(baseURL, key)
+		models, err := ollama.FetchOllamaModels(baseURL, key, channel.GetSetting().Proxy)
 		if err != nil {
 			return nil, err
 		}

--- a/controller/channel_upstream_update_test.go
+++ b/controller/channel_upstream_update_test.go
@@ -384,6 +384,64 @@ func TestFetchModelsUsesSharedChannelFetchBehavior(t *testing.T) {
 	require.JSONEq(t, `{"success":true,"message":"","data":["claude-sonnet"]}`, recorder.Body.String())
 }
 
+func TestFetchModelsUsesConfiguredProxyForUnsavedChannel(t *testing.T) {
+	tests := []struct {
+		name             string
+		channelType      int
+		wantPath         string
+		proxyResponse    string
+		wantResponseBody string
+	}{
+		{
+			name:             "OpenAI-compatible channel",
+			channelType:      constant.ChannelTypeOpenAI,
+			wantPath:         "/v1/models",
+			proxyResponse:    `{"data":[{"id":"proxied-openai-model"}]}`,
+			wantResponseBody: `{"success":true,"message":"","data":["proxied-openai-model"]}`,
+		},
+		{
+			name:             "Ollama channel",
+			channelType:      constant.ChannelTypeOllama,
+			wantPath:         "/api/tags",
+			proxyResponse:    `{"models":[{"name":"proxied-ollama-model"}]}`,
+			wantResponseBody: `{"success":true,"message":"","data":["proxied-ollama-model"]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			proxiedRequest := make(chan *http.Request, 1)
+			proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				proxiedRequest <- r.Clone(r.Context())
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(test.proxyResponse))
+			}))
+			t.Cleanup(proxyServer.Close)
+
+			body, err := common.Marshal(map[string]any{
+				"base_url": "http://upstream.invalid",
+				"type":     test.channelType,
+				"key":      "test-key",
+				"proxy":    proxyServer.URL,
+			})
+			require.NoError(t, err)
+
+			recorder := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(recorder)
+			ctx.Request = httptest.NewRequest(http.MethodPost, "/api/channel/fetch_models", bytes.NewReader(body))
+			ctx.Request.Header.Set("Content-Type", "application/json")
+
+			FetchModels(ctx)
+
+			require.Equal(t, http.StatusOK, recorder.Code)
+			require.JSONEq(t, test.wantResponseBody, recorder.Body.String())
+			request := <-proxiedRequest
+			require.Equal(t, "upstream.invalid", request.URL.Host)
+			require.Equal(t, test.wantPath, request.URL.Path)
+		})
+	}
+}
+
 func TestNormalizeModelNames(t *testing.T) {
 	result := normalizeModelNames([]string{
 		" gpt-4o ",

--- a/relay/channel/ollama/relay-ollama.go
+++ b/relay/channel/ollama/relay-ollama.go
@@ -278,10 +278,13 @@ func ollamaEmbeddingHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *h
 	return usage, nil
 }
 
-func FetchOllamaModels(baseURL, apiKey string) ([]OllamaModel, error) {
+func FetchOllamaModels(baseURL, apiKey, proxyURL string) ([]OllamaModel, error) {
 	url := fmt.Sprintf("%s/api/tags", baseURL)
 
-	client := &http.Client{}
+	client, err := service.NewProxyHttpClient(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("创建 HTTP 客户端失败: %v", err)
+	}
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("创建请求失败: %v", err)

--- a/web/classic/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/classic/src/components/table/channels/modals/EditChannelModal.jsx
@@ -1078,6 +1078,7 @@ const EditChannelModal = (props) => {
               base_url: inputs['base_url'],
               type: inputs['type'],
               key: inputs['key'],
+              proxy: inputs['proxy'],
             },
             { skipErrorHandler: true },
           );


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
新增渠道在保存前通过 `POST /api/channel/fetch_models` 获取上游模型。此前默认界面虽然已提交 `proxy`，但后端构造临时渠道时没有保留该设置；经典界面也没有提交代理字段。此外，Ollama 模型发现使用独立的 `http.Client`，未复用渠道代理客户端。

本次变更在临时渠道设置中保留代理地址，让普通、Gemini、Codex 和高级自定义渠道继续通过现有共享模型发现流程使用代理；同时让 Ollama 模型发现改用 `service.NewProxyHttpClient`，并让经典界面提交当前代理配置。回归测试使用本地 HTTP 代理直接返回 OpenAI 与 Ollama 两种模型列表，确认请求确实经过配置的代理。

本次代码实现与 PR 描述由 Codex AI 辅助完成。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无关联 Issue；这是对新增渠道模型发现行为的小型完善。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 本 PR 未标记为 `Bug fix`。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过相关测试，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
通过：

```text
go test ./controller ./relay/channel/ollama -count=1
ok  github.com/QuantumNous/new-api/controller
ok  github.com/QuantumNous/new-api/relay/channel/ollama

go test ./controller -run '^TestFetchModelsUsesConfiguredProxyForUnsavedChannel$' -count=1
ok  github.com/QuantumNous/new-api/controller
```

经典主题构建仍被现有依赖组合阻塞：`date-fns-tz` 引用了当前 `date-fns` 未通过 `exports` 暴露的内部路径。该错误发生在 Semi UI 依赖链中，与本次新增的请求字段无关。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added proxy support when previewing available models for new channels.
  - Proxy settings are now applied when fetching model lists from OpenAI-compatible and Ollama endpoints.
  - The channel setup form forwards the configured proxy while loading model options.

- **Bug Fixes**
  - Fixed model discovery to honor proxy settings consistently, including unsaved channel configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->