### PR TITLE
fix(channel-test): honor Responses compatibility policy

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -52,6 +52,13 @@ func normalizeChannelTestEndpoint(channel *model.Channel, modelName, endpointTyp
 	if channel != nil && channel.Type == constant.ChannelTypeCodex {
 		return string(constant.EndpointTypeOpenAIResponse)
 	}
+	if channel != nil && service.ShouldChatCompletionsUseResponsesGlobal(
+		channel.Id,
+		channel.Type,
+		modelName,
+	) {
+		return string(constant.EndpointTypeOpenAIResponse)
+	}
 	return normalized
 }
 

--- a/controller/channel_test_endpoint_test.go
+++ b/controller/channel_test_endpoint_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/setting/model_setting"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNormalizeChannelTestEndpointUsesResponsesCompatibilityPolicy(t *testing.T) {
@@ -23,16 +23,16 @@ func TestNormalizeChannelTestEndpointUsesResponsesCompatibilityPolicy(t *testing
 	})
 
 	channel := &model.Channel{Id: 4, Type: constant.ChannelTypeOpenAI}
-	require.Equal(
+	assert.Equal(
 		t,
 		string(constant.EndpointTypeOpenAIResponse),
 		normalizeChannelTestEndpoint(channel, "gpt-5.6-sol", ""),
 	)
-	require.Empty(
+	assert.Empty(
 		t,
 		normalizeChannelTestEndpoint(channel, "claude-3-7-sonnet", ""),
 	)
-	require.Empty(
+	assert.Empty(
 		t,
 		normalizeChannelTestEndpoint(
 			&model.Channel{Id: 5, Type: constant.ChannelTypeOpenAI},
@@ -44,7 +44,7 @@ func TestNormalizeChannelTestEndpointUsesResponsesCompatibilityPolicy(t *testing
 
 func TestNormalizeChannelTestEndpointKeepsExplicitEndpoint(t *testing.T) {
 	channel := &model.Channel{Id: 4, Type: constant.ChannelTypeOpenAI}
-	require.Equal(
+	assert.Equal(
 		t,
 		string(constant.EndpointTypeOpenAI),
 		normalizeChannelTestEndpoint(

--- a/controller/channel_test_endpoint_test.go
+++ b/controller/channel_test_endpoint_test.go
@@ -1,0 +1,56 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/setting/model_setting"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeChannelTestEndpointUsesResponsesCompatibilityPolicy(t *testing.T) {
+	settings := model_setting.GetGlobalSettings()
+	previous := settings.ChatCompletionsToResponsesPolicy
+	settings.ChatCompletionsToResponsesPolicy = model_setting.ChatCompletionsToResponsesPolicy{
+		Enabled:       true,
+		ChannelIDs:    []int{4},
+		ModelPatterns: []string{"^gpt-5.*$"},
+	}
+	t.Cleanup(func() {
+		settings.ChatCompletionsToResponsesPolicy = previous
+	})
+
+	channel := &model.Channel{Id: 4, Type: constant.ChannelTypeOpenAI}
+	require.Equal(
+		t,
+		string(constant.EndpointTypeOpenAIResponse),
+		normalizeChannelTestEndpoint(channel, "gpt-5.6-sol", ""),
+	)
+	require.Empty(
+		t,
+		normalizeChannelTestEndpoint(channel, "claude-3-7-sonnet", ""),
+	)
+	require.Empty(
+		t,
+		normalizeChannelTestEndpoint(
+			&model.Channel{Id: 5, Type: constant.ChannelTypeOpenAI},
+			"gpt-5.6-sol",
+			"",
+		),
+	)
+}
+
+func TestNormalizeChannelTestEndpointKeepsExplicitEndpoint(t *testing.T) {
+	channel := &model.Channel{Id: 4, Type: constant.ChannelTypeOpenAI}
+	require.Equal(
+		t,
+		string(constant.EndpointTypeOpenAI),
+		normalizeChannelTestEndpoint(
+			channel,
+			"gpt-5.6-sol",
+			string(constant.EndpointTypeOpenAI),
+		),
+	)
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

> [!NOTE]
>
> AI-assisted disclosure: 此实现和初始 PR 草稿由 OpenAI Codex 在仓库所有者请求下协助完成；仓库所有者已人工确认变更内容和影响范围。

## 📝 变更描述 / Description

渠道测试在未显式选择 endpoint 时，会处理 Compact 模型和 Codex 渠道，但没有复用正常转发链路的 `chat_completions_to_responses_policy`。因此命中该策略的渠道和模型在实际请求中走 Responses API，渠道测试却仍可能走 Chat Completions 并误报失败。

本变更让 endpoint 自动选择调用现有全局兼容策略：只有渠道和模型同时命中时才选择 Responses；显式 endpoint 仍具有最高优先级，Compact 与 Codex 的既有行为不变。测试覆盖命中、模型不匹配、渠道不匹配和显式 endpoint 覆盖场景。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6293

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 已关联 #6293；该问题会让渠道测试与正常转发策略不一致并产生误报。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

以下命令已通过：

```text
go test ./controller
```
