### PR TITLE
feat(usage-logs): add optional live refresh

### DIFF
--- a/web/default/src/features/usage-logs/components/common-logs-stats.tsx
+++ b/web/default/src/features/usage-logs/components/common-logs-stats.tsx
@@ -25,7 +25,10 @@ import { formatLogQuota } from '@/lib/format'
 import { cn } from '@/lib/utils'
 
 import { getLogStats, getUserLogStats } from '../api'
-import { DEFAULT_LOG_STATS } from '../constants'
+import {
+  DEFAULT_LOG_STATS,
+  USAGE_LOGS_AUTO_REFRESH_INTERVAL_MS,
+} from '../constants'
 import { buildApiParams } from '../lib/utils'
 import { useLogsViewScope, useUsageLogsContext } from './usage-logs-provider'
 
@@ -51,7 +54,7 @@ export function CommonLogsStats() {
   const { t } = useTranslation()
   const { isAdminView: isAdmin } = useLogsViewScope()
   const searchParams = route.useSearch()
-  const { sensitiveVisible } = useUsageLogsContext()
+  const { sensitiveVisible, autoRefresh } = useUsageLogsContext()
 
   const { data: stats, isLoading } = useQuery({
     queryKey: ['usage-logs-stats', isAdmin, searchParams],
@@ -73,6 +76,11 @@ export function CommonLogsStats() {
         : DEFAULT_LOG_STATS
     },
     placeholderData: (previousData) => previousData,
+    refetchInterval:
+      autoRefresh && (searchParams.page ?? 1) === 1
+        ? USAGE_LOGS_AUTO_REFRESH_INTERVAL_MS
+        : false,
+    refetchIntervalInBackground: false,
   })
 
   if (isLoading) {

--- a/web/default/src/features/usage-logs/components/usage-logs-provider.tsx
+++ b/web/default/src/features/usage-logs/components/usage-logs-provider.tsx
@@ -36,6 +36,8 @@ interface UsageLogsContextValue {
   setAffinityDialogOpen: (open: boolean) => void
   sensitiveVisible: boolean
   setSensitiveVisible: (visible: boolean) => void
+  autoRefresh: boolean
+  setAutoRefresh: (enabled: boolean) => void
   viewScope: LogsViewScope
   setViewScope: (scope: LogsViewScope) => void
 }
@@ -51,6 +53,7 @@ export function UsageLogsProvider({ children }: { children: ReactNode }) {
     useState<ChannelAffinityInfo | null>(null)
   const [affinityDialogOpen, setAffinityDialogOpen] = useState(false)
   const [sensitiveVisible, setSensitiveVisible] = useState(true)
+  const [autoRefresh, setAutoRefresh] = useState(false)
   const [viewScope, setViewScope] = useState<LogsViewScope>('all')
 
   return (
@@ -66,6 +69,8 @@ export function UsageLogsProvider({ children }: { children: ReactNode }) {
         setAffinityDialogOpen,
         sensitiveVisible,
         setSensitiveVisible,
+        autoRefresh,
+        setAutoRefresh,
         viewScope,
         setViewScope,
       }}

--- a/web/default/src/features/usage-logs/components/usage-logs-table.tsx
+++ b/web/default/src/features/usage-logs/components/usage-logs-table.tsx
@@ -18,7 +18,12 @@ For commercial licensing, please contact support@quantumnous.com
 */
 import { useQuery } from '@tanstack/react-query'
 import { getRouteApi } from '@tanstack/react-router'
-import { type ColumnDef } from '@tanstack/react-table'
+import type {
+  ColumnDef,
+  OnChangeFn,
+  PaginationState,
+} from '@tanstack/react-table'
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -35,6 +40,7 @@ import {
   DEFAULT_LOGS_DATA,
   LOG_TYPE_ALL_VALUE,
   LOG_TYPE_ENUM,
+  USAGE_LOGS_AUTO_REFRESH_INTERVAL_MS,
 } from '../constants'
 import { useColumnsByCategory } from '../lib/columns'
 import { parseLogOther } from '../lib/format'
@@ -43,7 +49,7 @@ import type { LogCategory } from '../types'
 import { CommonLogsFilterBar } from './common-logs-filter-bar'
 import { TaskLogsFilterBar } from './task-logs-filter-bar'
 import { UsageLogsMobileList } from './usage-logs-mobile-card'
-import { useLogsViewScope } from './usage-logs-provider'
+import { useLogsViewScope, useUsageLogsContext } from './usage-logs-provider'
 
 const route = getRouteApi('/_authenticated/usage-logs/$section')
 
@@ -64,7 +70,14 @@ function getColumnVisibilityStorageKey(
 }
 
 function deserializeLogTypeFilter(value: unknown): unknown[] {
-  const values = Array.isArray(value) ? value : value ? [value] : []
+  let values: unknown[]
+  if (Array.isArray(value)) {
+    values = value
+  } else if (value) {
+    values = [value]
+  } else {
+    values = []
+  }
   return values.filter((item) => String(item) !== LOG_TYPE_ALL_VALUE)
 }
 
@@ -75,6 +88,7 @@ interface UsageLogsTableProps {
 export function UsageLogsTable({ logCategory }: UsageLogsTableProps) {
   const { t } = useTranslation()
   const { isAdminView: isAdmin } = useLogsViewScope()
+  const { autoRefresh, setAutoRefresh } = useUsageLogsContext()
   const isMobile = useMediaQuery('(max-width: 640px)')
   const searchParams = route.useSearch()
 
@@ -150,7 +164,23 @@ export function UsageLogsTable({ logCategory }: UsageLogsTableProps) {
       }
       return undefined
     },
+    refetchInterval:
+      autoRefresh && pagination.pageIndex === 0
+        ? USAGE_LOGS_AUTO_REFRESH_INTERVAL_MS
+        : false,
+    refetchIntervalInBackground: false,
   })
+
+  const handlePaginationChange = useCallback<OnChangeFn<PaginationState>>(
+    (updater) => {
+      const next = typeof updater === 'function' ? updater(pagination) : updater
+      if (autoRefresh && next.pageIndex > 0) {
+        setAutoRefresh(false)
+      }
+      onPaginationChange(updater)
+    },
+    [autoRefresh, onPaginationChange, pagination, setAutoRefresh]
+  )
 
   const logs = data?.items || []
   const columns = useColumnsByCategory(logCategory, isAdmin)
@@ -166,7 +196,7 @@ export function UsageLogsTable({ logCategory }: UsageLogsTableProps) {
     ),
     pagination,
     enableRowSelection: false,
-    onPaginationChange,
+    onPaginationChange: handlePaginationChange,
     onColumnFiltersChange,
     manualPagination: true,
     manualFiltering: true,

--- a/web/default/src/features/usage-logs/constants.ts
+++ b/web/default/src/features/usage-logs/constants.ts
@@ -44,6 +44,9 @@ export const DEFAULT_LOGS_DATA = {
   total: 0,
 }
 
+/** Polling interval used while live refresh is enabled. */
+export const USAGE_LOGS_AUTO_REFRESH_INTERVAL_MS = 5_000
+
 // ============================================================================
 // Log Type Enum
 // ============================================================================

--- a/web/default/src/features/usage-logs/index.tsx
+++ b/web/default/src/features/usage-logs/index.tsx
@@ -124,11 +124,11 @@ function UsageLogsContent() {
   )
 
   const handleAutoRefreshChange = useCallback(
-    (enabled: boolean) => {
+    async (enabled: boolean) => {
       setAutoRefresh(enabled)
       if (!enabled) return
 
-      void navigate({
+      await navigate({
         to: '/usage-logs/$section',
         params: { section: activeCategory },
         search: { ...searchParams, page: 1 },
@@ -163,11 +163,15 @@ function UsageLogsContent() {
                 </TabsList>
               </Tabs>
             )}
-            <label className='border-border/70 bg-card flex items-center gap-2 rounded-md border px-3 py-1.5'>
+            <label
+              htmlFor='usage-logs-auto-refresh'
+              className='border-border/70 bg-card flex items-center gap-2 rounded-md border px-3 py-1.5'
+            >
               <span className='text-muted-foreground text-xs'>
                 {t('Auto refresh')}
               </span>
               <Switch
+                id='usage-logs-auto-refresh'
                 checked={autoRefresh}
                 onCheckedChange={handleAutoRefreshChange}
               />

--- a/web/default/src/features/usage-logs/index.tsx
+++ b/web/default/src/features/usage-logs/index.tsx
@@ -16,12 +16,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
+import { useQueryClient } from '@tanstack/react-query'
 import { getRouteApi, useNavigate } from '@tanstack/react-router'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { SectionPageLayout } from '@/components/layout'
 import type { NavGroup } from '@/components/layout/types'
+import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { CacheStatsDialog } from '@/features/system-settings/general/channel-affinity/cache-stats-dialog'
 import { useSidebarConfig } from '@/hooks/use-sidebar-config'
@@ -58,7 +60,9 @@ const SECTION_META: Record<UsageLogsSectionId, { titleKey: string }> = {
 function UsageLogsContent() {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const params = route.useParams()
+  const searchParams = route.useSearch()
   const activeCategory: UsageLogsSectionId =
     params.section && isUsageLogsSectionId(params.section)
       ? params.section
@@ -70,6 +74,8 @@ function UsageLogsContent() {
     affinityTarget,
     affinityDialogOpen,
     setAffinityDialogOpen,
+    autoRefresh,
+    setAutoRefresh,
   } = useUsageLogsContext()
   const { canManageScope, viewScope, setViewScope } = useLogsViewScope()
   const tabNavGroups = useMemo<NavGroup[]>(
@@ -117,6 +123,25 @@ function UsageLogsContent() {
     [setViewScope]
   )
 
+  const handleAutoRefreshChange = useCallback(
+    (enabled: boolean) => {
+      setAutoRefresh(enabled)
+      if (!enabled) return
+
+      void navigate({
+        to: '/usage-logs/$section',
+        params: { section: activeCategory },
+        search: { ...searchParams, page: 1 },
+        replace: true,
+      })
+      void queryClient.invalidateQueries({ queryKey: ['logs'] })
+      void queryClient.invalidateQueries({
+        queryKey: ['usage-logs-stats'],
+      })
+    },
+    [activeCategory, navigate, queryClient, searchParams, setAutoRefresh]
+  )
+
   const pageMeta =
     activeCategory === 'common' ? SECTION_META.common : SECTION_META.task
   const showTaskSwitcher =
@@ -128,16 +153,27 @@ function UsageLogsContent() {
         <SectionPageLayout.Title>
           {t(pageMeta.titleKey)}
         </SectionPageLayout.Title>
-        {canManageScope && (
-          <SectionPageLayout.Actions>
-            <Tabs value={viewScope} onValueChange={handleViewScopeChange}>
-              <TabsList>
-                <TabsTrigger value='all'>{t('All')}</TabsTrigger>
-                <TabsTrigger value='self'>{t('Only Mine')}</TabsTrigger>
-              </TabsList>
-            </Tabs>
-          </SectionPageLayout.Actions>
-        )}
+        <SectionPageLayout.Actions>
+          <div className='flex flex-wrap items-center gap-3'>
+            {canManageScope && (
+              <Tabs value={viewScope} onValueChange={handleViewScopeChange}>
+                <TabsList>
+                  <TabsTrigger value='all'>{t('All')}</TabsTrigger>
+                  <TabsTrigger value='self'>{t('Only Mine')}</TabsTrigger>
+                </TabsList>
+              </Tabs>
+            )}
+            <label className='border-border/70 bg-card flex items-center gap-2 rounded-md border px-3 py-1.5'>
+              <span className='text-muted-foreground text-xs'>
+                {t('Auto refresh')}
+              </span>
+              <Switch
+                checked={autoRefresh}
+                onCheckedChange={handleAutoRefreshChange}
+              />
+            </label>
+          </div>
+        </SectionPageLayout.Actions>
         <SectionPageLayout.Content>
           <div className='flex h-full min-h-0 flex-col gap-4'>
             {showTaskSwitcher && (


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

> [!NOTE]
>
> AI-assisted disclosure: 此实现和初始 PR 草稿由 OpenAI Codex 在仓库所有者请求下协助完成；仓库所有者已人工确认变更内容和影响范围。

## 📝 变更描述 / Description

在新版使用日志页面增加一个默认关闭的自动刷新开关。开启时会先回到第一页并立即使日志列表、统计查询失效；随后列表和统计每 5 秒重新获取一次，浏览器处于后台时停止轮询。

自动刷新仅在第一页生效。用户通过表格分页进入后续页面时，开关会自动关闭，避免历史分页持续产生请求。现有管理员/个人视图、筛选条件和敏感字段显示逻辑保持不变。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6295

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 此 PR 为已关联 Issue 的小型前端功能，不归类为 Bug fix。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

以下命令均已通过：

```text
oxfmt --check <5 个变更文件>
oxlint -c .oxlintrc.json <5 个变更文件>
bun run typecheck
bun run build
```
