### PR TITLE
feat(security): trusted proxies, CORS allowlist, HTTPS security headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,3 +97,11 @@ LINUX_DO_USER_ENDPOINT=https://connect.linux.do/api/user
 # 用于验证支付成功/取消回调URL的域名安全性
 # 示例: example.com,myapp.io 将允许 example.com, sub.example.com, myapp.io 等
 # TRUSTED_REDIRECT_DOMAINS=example.com,myapp.io
+
+# --- Security (B1) ---
+# 允许浏览器跨域访问 API 的可信来源；默认不允许跨域（同源反代无需配置）
+# CORS_ALLOWED_ORIGINS=https://console.example.com,https://admin.example.com
+# 可信任的反代 CIDR；未配置时忽略 X-Forwarded-For / X-Real-IP
+# 仅当 3000 不直接暴露时使用，例如 127.0.0.1/32,::1/128
+# TRUSTED_PROXY_CIDRS=
+

--- a/main.go
+++ b/main.go
@@ -173,6 +173,10 @@ func main() {
 
 	// Initialize HTTP server
 	server := gin.New()
+	if err := configureTrustedProxies(server); err != nil {
+		common.FatalLog("failed to configure trusted proxies: " + err.Error())
+		return
+	}
 	server.Use(gin.CustomRecovery(func(c *gin.Context, err any) {
 		common.SysLog(fmt.Sprintf("panic detected: %v", err))
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -184,6 +188,8 @@ func main() {
 	}))
 	// This will cause SSE not to work!!!
 	//server.Use(gzip.Gzip(gzip.DefaultCompression))
+	server.Use(middleware.SecurityHeaders())
+
 	server.Use(middleware.RequestId())
 	server.Use(middleware.Version())
 	server.Use(middleware.I18n())

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -1,18 +1,91 @@
 package middleware
 
 import (
+	"net/url"
+	"os"
+	"strings"
+
 	"github.com/QuantumNous/new-api/common"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 )
 
 func CORS() gin.HandlerFunc {
+	allowedOrigins := parseAllowedOrigins("CORS_ALLOWED_ORIGINS")
+	if len(allowedOrigins) == 0 {
+		// Reuse the explicitly trusted HTTPS frontends when secure session cookies
+		// are configured. With neither setting present, cross-origin access is
+		// denied; normal same-origin requests do not require CORS headers.
+		allowedOrigins = parseAllowedOrigins("SESSION_COOKIE_TRUSTED_URL")
+	}
+	if len(allowedOrigins) == 0 {
+		return func(c *gin.Context) {
+			c.Next()
+		}
+	}
+
 	config := cors.DefaultConfig()
-	config.AllowAllOrigins = true
+	config.AllowOrigins = allowedOrigins
 	config.AllowCredentials = true
-	config.AllowMethods = []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}
-	config.AllowHeaders = []string{"*"}
+	config.AllowMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"}
+	config.AllowHeaders = []string{
+		"Accept",
+		"Authorization",
+		"Content-Type",
+		"New-Api-Key",
+		"New-Api-User",
+		"X-Request-Id",
+		"X-Trace-Id",
+		"X-Thread-Id",
+		"AH-Trace-Id",
+		"AH-Thread-Id",
+	}
+	config.ExposeHeaders = []string{
+		"X-Oneapi-Request-Id",
+		"X-Request-Id",
+		"X-Trace-Id",
+		"X-Thread-Id",
+		"AH-Trace-Id",
+		"AH-Thread-Id",
+	}
 	return cors.New(config)
+}
+
+func parseAllowedOrigins(name string) []string {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	values := make([]string, 0)
+	for _, item := range strings.Split(raw, ",") {
+		value, ok := normalizeAllowedOrigin(item)
+		if !ok {
+			common.SysError("ignoring invalid " + name + " origin entry")
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	return values
+}
+
+func normalizeAllowedOrigin(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.Contains(value, "*") {
+		return "", false
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return "", false
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || (parsed.Path != "" && parsed.Path != "/") {
+		return "", false
+	}
+	return parsed.Scheme + "://" + parsed.Host, true
 }
 
 func Version() gin.HandlerFunc {

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -1,0 +1,83 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func corsTestRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(CORS())
+	router.GET("/resource", func(c *gin.Context) { c.Status(http.StatusNoContent) })
+	return router
+}
+
+func performCORSPreflight(t *testing.T, router *gin.Engine, origin string) *httptest.ResponseRecorder {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodOptions, "/resource", nil)
+	request.Header.Set("Origin", origin)
+	request.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	request.Header.Set("Access-Control-Request-Headers", "authorization,content-type")
+	router.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func TestCORSRejectsCrossOriginByDefault(t *testing.T) {
+	t.Setenv("CORS_ALLOWED_ORIGINS", "")
+	t.Setenv("SESSION_COOKIE_TRUSTED_URL", "")
+
+	recorder := performCORSPreflight(t, corsTestRouter(), "https://evil.example")
+	require.Empty(t, recorder.Header().Get("Access-Control-Allow-Origin"))
+	require.NotEqual(t, http.StatusNoContent, recorder.Code)
+}
+
+func TestCORSRejectsOriginOutsideConfiguredAllowlist(t *testing.T) {
+	t.Setenv("CORS_ALLOWED_ORIGINS", "https://console.example")
+	t.Setenv("SESSION_COOKIE_TRUSTED_URL", "")
+
+	recorder := performCORSPreflight(t, corsTestRouter(), "https://evil.example")
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	require.Empty(t, recorder.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSAllowsConfiguredCredentialOrigin(t *testing.T) {
+	t.Setenv("CORS_ALLOWED_ORIGINS", "https://console.example, https://admin.example")
+	t.Setenv("SESSION_COOKIE_TRUSTED_URL", "")
+
+	recorder := performCORSPreflight(t, corsTestRouter(), "https://console.example")
+	require.Equal(t, http.StatusNoContent, recorder.Code)
+	require.Equal(t, "https://console.example", recorder.Header().Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "true", recorder.Header().Get("Access-Control-Allow-Credentials"))
+}
+
+func TestCORSFallsBackToTrustedSessionURLs(t *testing.T) {
+	t.Setenv("CORS_ALLOWED_ORIGINS", "")
+	t.Setenv("SESSION_COOKIE_TRUSTED_URL", "https://console.example")
+
+	recorder := performCORSPreflight(t, corsTestRouter(), "https://console.example")
+	require.Equal(t, "https://console.example", recorder.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSRejectsWildcardAndInvalidOrigins(t *testing.T) {
+	t.Setenv("CORS_ALLOWED_ORIGINS", "*,javascript:alert(1),https://console.example/path")
+	t.Setenv("SESSION_COOKIE_TRUSTED_URL", "")
+
+	recorder := performCORSPreflight(t, corsTestRouter(), "https://evil.example")
+	require.Empty(t, recorder.Header().Get("Access-Control-Allow-Origin"))
+	require.NotEqual(t, http.StatusNoContent, recorder.Code)
+}
+
+func TestCORSNormalizesTrailingSlash(t *testing.T) {
+	t.Setenv("CORS_ALLOWED_ORIGINS", "https://console.example/")
+	t.Setenv("SESSION_COOKIE_TRUSTED_URL", "")
+
+	recorder := performCORSPreflight(t, corsTestRouter(), "https://console.example")
+	require.Equal(t, http.StatusNoContent, recorder.Code)
+	require.Equal(t, "https://console.example", recorder.Header().Get("Access-Control-Allow-Origin"))
+}

--- a/middleware/security_headers.go
+++ b/middleware/security_headers.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SecurityHeaders 为经 HTTPS 到达的请求附加安全响应头。
+// 当反向代理/Tunnel 终止 TLS 时，通过 X-Forwarded-Proto 识别 HTTPS。
+// HSTS 仅在判定为 HTTPS 时发送，避免本机 http://127.0.0.1 被浏览器错误 HSTS。
+func SecurityHeaders() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("X-Content-Type-Options", "nosniff")
+		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
+		c.Header("X-Frame-Options", "SAMEORIGIN")
+
+		if isHTTPSRequest(c.Request) {
+			// 6 months; no includeSubDomains/preload — single-host production default.
+			c.Header("Strict-Transport-Security", "max-age=15768000")
+		}
+		c.Next()
+	}
+}
+
+// isHTTPSRequest 判断客户端侧是否为 HTTPS（含反代转发头）。
+func isHTTPSRequest(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto"))
+	if proto == "" {
+		return false
+	}
+	// 取最左（最靠近客户端）的协议标记。
+	if i := strings.IndexByte(proto, ','); i >= 0 {
+		proto = proto[:i]
+	}
+	return strings.EqualFold(strings.TrimSpace(proto), "https")
+}

--- a/middleware/security_headers_test.go
+++ b/middleware/security_headers_test.go
@@ -1,0 +1,48 @@
+package middleware
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecurityHeadersSetsHSTSOnlyForHTTPS(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("plain http no hsts", func(t *testing.T) {
+		engine := gin.New()
+		engine.Use(SecurityHeaders())
+		engine.GET("/x", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+		rec := httptest.NewRecorder()
+		engine.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Empty(t, rec.Header().Get("Strict-Transport-Security"))
+		require.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+	})
+
+	t.Run("x-forwarded-proto https sets hsts", func(t *testing.T) {
+		engine := gin.New()
+		engine.Use(SecurityHeaders())
+		engine.GET("/x", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/x", nil)
+		req.Header.Set("X-Forwarded-Proto", "https")
+		engine.ServeHTTP(rec, req)
+		require.Equal(t, "max-age=15768000", rec.Header().Get("Strict-Transport-Security"))
+	})
+
+	t.Run("direct tls sets hsts", func(t *testing.T) {
+		engine := gin.New()
+		engine.Use(SecurityHeaders())
+		engine.GET("/x", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/x", nil)
+		req.TLS = &tls.ConnectionState{}
+		engine.ServeHTTP(rec, req)
+		require.Equal(t, "max-age=15768000", rec.Header().Get("Strict-Transport-Security"))
+	})
+}

--- a/trusted_proxy.go
+++ b/trusted_proxy.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+func configureTrustedProxies(engine *gin.Engine) error {
+	raw := strings.TrimSpace(os.Getenv("TRUSTED_PROXY_CIDRS"))
+	if raw == "" {
+		return engine.SetTrustedProxies(nil)
+	}
+
+	items := strings.Split(raw, ",")
+	trustedProxies := make([]string, 0, len(items))
+	for _, item := range items {
+		proxy := strings.TrimSpace(item)
+		if proxy == "" {
+			return fmt.Errorf("TRUSTED_PROXY_CIDRS contains an empty entry")
+		}
+		trustedProxies = append(trustedProxies, proxy)
+	}
+	return engine.SetTrustedProxies(trustedProxies)
+}

--- a/trusted_proxy_test.go
+++ b/trusted_proxy_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigureTrustedProxiesDisablesForwardedHeadersByDefault(t *testing.T) {
+	t.Setenv("TRUSTED_PROXY_CIDRS", "")
+	engine := gin.New()
+	require.NoError(t, configureTrustedProxies(engine))
+
+	require.Equal(t, "203.0.113.10", requestClientIP(engine, "203.0.113.10:4321", "198.51.100.20"))
+}
+
+func TestConfigureTrustedProxiesUsesConfiguredCIDRs(t *testing.T) {
+	t.Setenv("TRUSTED_PROXY_CIDRS", "127.0.0.1/32, ::1/128")
+	engine := gin.New()
+	require.NoError(t, configureTrustedProxies(engine))
+
+	require.Equal(t, "198.51.100.20", requestClientIP(engine, "127.0.0.1:4321", "198.51.100.20"))
+}
+
+func TestConfigureTrustedProxiesRejectsInvalidCIDR(t *testing.T) {
+	t.Setenv("TRUSTED_PROXY_CIDRS", "not-a-cidr")
+	require.Error(t, configureTrustedProxies(gin.New()))
+}
+
+func requestClientIP(engine *gin.Engine, remoteAddr string, forwardedFor string) string {
+	var clientIP string
+	engine.GET("/", func(c *gin.Context) {
+		clientIP = c.ClientIP()
+		c.Status(http.StatusNoContent)
+	})
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.RemoteAddr = remoteAddr
+	request.Header.Set("X-Forwarded-For", forwardedFor)
+	engine.ServeHTTP(httptest.NewRecorder(), request)
+	return clientIP
+}


### PR DESCRIPTION
## Summary
Small, independently reviewable security middleware PR (extracted from the withdrawn large hardening effort).

- **Trusted proxies**: `TRUSTED_PROXY_CIDRS` configures Gin `SetTrustedProxies` (default empty = do not trust `X-Forwarded-For` / `X-Real-IP`).
- **CORS**: replace `AllowAllOrigins` with explicit `CORS_ALLOWED_ORIGINS` allowlist (comma-separated origins; no wildcards). Same-origin deployments need no config.
- **Security headers**: `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`; `Strict-Transport-Security` only when the request is HTTPS (including `X-Forwarded-Proto` from a reverse proxy).

Default behavior stays safe for single-host / same-origin deploys. Operators behind Cloudflare/Tunnel should set `TRUSTED_PROXY_CIDRS` appropriately (e.g. `127.0.0.1/32` when only local reverse proxy terminates TLS).

## Test plan
- [x] `go test ./middleware ./`
- [ ] Manual: with empty env, no `Access-Control-Allow-Origin: *`
- [ ] Manual: `CORS_ALLOWED_ORIGINS=https://example.com` only allows that origin
- [ ] Manual: HTTPS (or `X-Forwarded-Proto: https`) sets HSTS; plain HTTP does not

## Notes
- No UI / channel / billing changes.
- Does not include session-refresh, SPA routing, adaptive balance, or delivery-seam work (those will be separate PRs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable CORS origin allowlists with credential support and stricter validation.
  * Added standard security response headers, including HTTPS-only HSTS protection.
  * Added trusted reverse-proxy configuration for safer client IP handling.
  * Documented the new security-related environment settings and their defaults.

* **Bug Fixes**
  * Prevented unrestricted cross-origin access when no trusted origins are configured.
  * Rejected invalid or wildcard origin and proxy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->