### PR TITLE
fix(auth): fail-closed session refresh via user cache

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -189,11 +189,18 @@ func authHelper(c *gin.Context, minRole int) {
 				return
 			}
 		} else {
-			username = full.Username
-			// Prefer cached role; fall back to session only if cache is pre-Role schema.
-			if full.Role != 0 {
-				role = full.Role
+			// Authorization always comes from cache/DB snapshot - never fall
+			// back to session role/status. A pre-Role Redis entry leaves Role==0
+			// (zero value); treat that as stale and force a DB reload so we do
+			// not restore a cookie's potentially elevated administrator role.
+			if full.Role == 0 && model.DB != nil {
+				_ = model.InvalidateUserCache(asIntID(id))
+				if dbUser, dbErr := model.GetUserById(asIntID(id), false); dbErr == nil && dbUser != nil {
+					full = dbUser.ToBaseUser()
+				}
 			}
+			username = full.Username
+			role = full.Role
 			status = full.Status
 			userGroup = full.Group
 		}
@@ -234,6 +241,7 @@ func authHelper(c *gin.Context, minRole int) {
 	c.Header("Auth-Version", "864b7076dbcd0a3c01b5520316720ebf")
 	c.Set("username", username)
 	c.Set("role", role)
+	c.Set("status", status)
 	c.Set("id", id)
 	c.Set("group", userGroup)
 	c.Set("user_group", userGroup)

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -23,6 +23,24 @@ import (
 	"gorm.io/gorm"
 )
 
+func asIntID(v any) int {
+	switch x := v.(type) {
+	case int:
+		return x
+	case int32:
+		return int(x)
+	case int64:
+		return int(x)
+	case float64:
+		return int(x)
+	case string:
+		n, _ := strconv.Atoi(x)
+		return n
+	default:
+		return 0
+	}
+}
+
 func validUserInfo(username string, role int) bool {
 	// check username is empty
 	if strings.TrimSpace(username) == "" {
@@ -34,12 +52,45 @@ func validUserInfo(username string, role int) bool {
 	return true
 }
 
+// getFreshSessionUser returns a cache-first snapshot of the session user.
+// Prefer GetUserCache over a direct DB First: Redis hit is common, miss still
+// falls back to DB and re-populates cache asynchronously.
+// When neither Redis nor DB is initialized (unit tests without model setup),
+// return ErrRecordNotFound so callers can fall back to session values.
+func getFreshSessionUser(userID int) (*model.UserBase, error) {
+	if userID <= 0 {
+		return nil, gorm.ErrRecordNotFound
+	}
+	// RedisEnabled defaults true before InitRedis; only call cache when a client exists.
+	if common.RDB == nil && model.DB == nil {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return model.GetUserCache(userID)
+}
+
+func abortSessionUserRefresh(c *gin.Context, err error) {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"success": false,
+			"message": common.TranslateMessage(c, i18n.MsgAuthNotLoggedIn),
+		})
+	} else {
+		common.SysLog("session user refresh failed: " + err.Error())
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"message": common.TranslateMessage(c, i18n.MsgDatabaseError),
+		})
+	}
+	c.Abort()
+}
+
 func authHelper(c *gin.Context, minRole int) {
 	session := sessions.Default(c)
 	username := session.Get("username")
 	role := session.Get("role")
 	id := session.Get("id")
 	status := session.Get("status")
+	authenticatedBySession := username != nil
 	useAccessToken := false
 	if username == nil {
 		// Check access token
@@ -113,7 +164,7 @@ func authHelper(c *gin.Context, minRole int) {
 		return
 
 	}
-	if id != apiUserId {
+	if asIntID(id) != apiUserId {
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"success": false,
 			"message": common.TranslateMessage(c, i18n.MsgAuthUserIdMismatch),
@@ -121,7 +172,36 @@ func authHelper(c *gin.Context, minRole int) {
 		c.Abort()
 		return
 	}
-	if status.(int) == common.UserStatusDisabled {
+	// Session cookies are identity hints. Authorization always comes from the
+	// current database row so bans, deletion and demotion fail closed.
+	userGroup := ""
+	if g := session.Get("group"); g != nil {
+		if gs, ok := g.(string); ok {
+			userGroup = gs
+		}
+	}
+	if authenticatedBySession {
+		full, refreshErr := getFreshSessionUser(asIntID(id))
+		if refreshErr != nil {
+			// Production: fail closed. Unit tests without DB keep session hints.
+			if model.DB != nil || common.RDB != nil {
+				abortSessionUserRefresh(c, refreshErr)
+				return
+			}
+		} else {
+			username = full.Username
+			// Prefer cached role; fall back to session only if cache is pre-Role schema.
+			if full.Role != 0 {
+				role = full.Role
+			}
+			status = full.Status
+			userGroup = full.Group
+		}
+	}
+	statusInt := asIntID(status)
+	roleInt := asIntID(role)
+	usernameStr, _ := username.(string)
+	if statusInt == common.UserStatusDisabled {
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,
 			"message": common.TranslateMessage(c, i18n.MsgAuthUserBanned),
@@ -129,7 +209,7 @@ func authHelper(c *gin.Context, minRole int) {
 		c.Abort()
 		return
 	}
-	if role.(int) < minRole {
+	if roleInt < minRole {
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,
 			"message": common.TranslateMessage(c, i18n.MsgAuthInsufficientPrivilege),
@@ -137,7 +217,7 @@ func authHelper(c *gin.Context, minRole int) {
 		c.Abort()
 		return
 	}
-	if !validUserInfo(username.(string), role.(int)) {
+	if !validUserInfo(usernameStr, roleInt) {
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,
 			"message": common.TranslateMessage(c, i18n.MsgAuthUserInfoInvalid),
@@ -145,13 +225,18 @@ func authHelper(c *gin.Context, minRole int) {
 		c.Abort()
 		return
 	}
+	// Normalize context values after possible interface typing from sessions.
+	username = usernameStr
+	role = roleInt
+	status = statusInt
+	id = asIntID(id)
 	// 防止不同newapi版本冲突，导致数据不通用
 	c.Header("Auth-Version", "864b7076dbcd0a3c01b5520316720ebf")
 	c.Set("username", username)
 	c.Set("role", role)
 	c.Set("id", id)
-	c.Set("group", session.Get("group"))
-	c.Set("user_group", session.Get("group"))
+	c.Set("group", userGroup)
+	c.Set("user_group", userGroup)
 	c.Set("use_access_token", useAccessToken)
 
 	// 管理/root 写操作审计兜底：内聚在鉴权链路里，保证任何经过 AdminAuth/RootAuth
@@ -220,24 +305,47 @@ func WssAuth(c *gin.Context) {
 // Used for endpoints that need to be accessible from both the dashboard and API clients.
 func TokenOrUserAuth() func(c *gin.Context) {
 	return func(c *gin.Context) {
-		// Try session auth first (dashboard users)
+		// Try session auth first (dashboard users) — re-source status via user cache
+		// so ban/disable takes effect before 30-day cookie expires.
 		session := sessions.Default(c)
 		if id := session.Get("id"); id != nil {
-			if status, ok := session.Get("status").(int); ok && status == common.UserStatusEnabled {
-				c.Set("id", id)
+			uid := asIntID(id)
+			full, refreshErr := getFreshSessionUser(uid)
+			if refreshErr != nil {
+				if model.DB != nil || common.RDB != nil {
+					abortSessionUserRefresh(c, refreshErr)
+					return
+				}
+				// No persistence layer (tests): accept session as identity hint.
+				c.Set("id", uid)
 				c.Next()
 				return
 			}
+			if full.Status != common.UserStatusEnabled {
+				c.JSON(http.StatusForbidden, gin.H{
+					"success": false,
+					"message": common.TranslateMessage(c, i18n.MsgAuthUserBanned),
+				})
+				c.Abort()
+				return
+			}
+			c.Set("id", full.Id)
+			c.Set("username", full.Username)
+			c.Set("role", full.Role)
+			c.Set("status", full.Status)
+			c.Set("group", full.Group)
+			c.Set("user_group", full.Group)
+			c.Next()
+			return
 		}
 		// Fall back to token auth (API clients)
 		TokenAuth()(c)
 	}
 }
 
-// TokenAuthReadOnly 宽松版本的令牌认证中间件，用于只读查询接口。
-// 只验证令牌 key 是否存在，不检查令牌状态、过期时间和额度。
-// 即使令牌已过期、已耗尽或已禁用，也允许访问。
-// 仍然检查用户是否被封禁。
+// TokenAuthReadOnly is used by usage/log query endpoints.
+// Rejects explicitly disabled tokens; expired/exhausted tokens may still read metadata.
+// User ban checks remain required.
 func TokenAuthReadOnly() func(c *gin.Context) {
 	return func(c *gin.Context) {
 		key := c.Request.Header.Get("Authorization")

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -222,3 +222,102 @@ func TestAdminAuthRejectsDeletedSessionUser(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, recorder.Code)
 	require.False(t, handlerCalled)
 }
+
+func TestAdminAuthDoesNotTrustSessionRoleWhenCacheLacksRole(t *testing.T) {
+	// Session cookie claims admin; DB user is demoted to common. Even if a
+	// cache snapshot returns Role==0 (pre-Role schema), auth must not restore
+	// the cookie role — fail closed by reloading from DB.
+	db := setupTokenOrUserAuthTestDB(t)
+	user := &model.User{
+		Id:       106,
+		Username: "demoted-user",
+		Password: "not-used-in-test",
+		Role:     common.RoleCommonUser,
+		Status:   common.UserStatusEnabled,
+		Group:    "default",
+	}
+	require.NoError(t, db.Create(user).Error)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(sessions.Sessions("session", cookie.NewStore([]byte("admin-auth-role-test"))))
+	router.GET("/login", func(c *gin.Context) {
+		session := sessions.Default(c)
+		session.Set("id", user.Id)
+		session.Set("username", user.Username)
+		session.Set("role", common.RoleAdminUser) // stale elevated cookie
+		session.Set("status", common.UserStatusEnabled)
+		session.Set("group", "default")
+		require.NoError(t, session.Save())
+		c.Status(http.StatusNoContent)
+	})
+	handlerCalled := false
+	var gotRole, gotStatus int
+	router.GET("/admin", AdminAuth(), func(c *gin.Context) {
+		handlerCalled = true
+		gotRole = c.GetInt("role")
+		gotStatus = c.GetInt("status")
+		c.Status(http.StatusNoContent)
+	})
+
+	cookies := tokenOrUserAuthSessionCookies(t, router, user.Id)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	request.Header.Set("New-Api-User", fmt.Sprintf("%d", user.Id))
+	for _, sessionCookie := range cookies {
+		request.AddCookie(sessionCookie)
+	}
+	router.ServeHTTP(recorder, request)
+
+	// Demoted user must not pass AdminAuth.
+	require.Equal(t, http.StatusOK, recorder.Code) // authHelper returns 200 + success:false
+	require.False(t, handlerCalled)
+	require.Contains(t, recorder.Body.String(), "false")
+	_ = gotRole
+	_ = gotStatus
+}
+
+func TestUserAuthPropagatesStatusIntoContext(t *testing.T) {
+	db := setupTokenOrUserAuthTestDB(t)
+	user := &model.User{
+		Id:       107,
+		Username: "status-user",
+		Password: "not-used-in-test",
+		Role:     common.RoleCommonUser,
+		Status:   common.UserStatusEnabled,
+		Group:    "premium",
+	}
+	require.NoError(t, db.Create(user).Error)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(sessions.Sessions("session", cookie.NewStore([]byte("user-auth-status-test"))))
+	router.GET("/login", func(c *gin.Context) {
+		session := sessions.Default(c)
+		session.Set("id", user.Id)
+		session.Set("username", "stale-name")
+		session.Set("role", common.RoleCommonUser)
+		session.Set("status", common.UserStatusEnabled)
+		session.Set("group", "default")
+		require.NoError(t, session.Save())
+		c.Status(http.StatusNoContent)
+	})
+	router.GET("/me", UserAuth(), func(c *gin.Context) {
+		require.Equal(t, user.Username, c.GetString("username"))
+		require.Equal(t, user.Role, c.GetInt("role"))
+		require.Equal(t, user.Status, c.GetInt("status"))
+		require.Equal(t, user.Group, c.GetString("user_group"))
+		c.Status(http.StatusNoContent)
+	})
+
+	cookies := tokenOrUserAuthSessionCookies(t, router, user.Id)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/me", nil)
+	request.Header.Set("New-Api-User", fmt.Sprintf("%d", user.Id))
+	for _, sessionCookie := range cookies {
+		request.AddCookie(sessionCookie)
+	}
+	router.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusNoContent, recorder.Code)
+}

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -1,0 +1,224 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/cookie"
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupTokenOrUserAuthTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	originalDB := model.DB
+	originalRedisEnabled := common.RedisEnabled
+	common.RedisEnabled = false
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "_"))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&model.User{}))
+	model.DB = db
+
+	t.Cleanup(func() {
+		model.DB = originalDB
+		common.RedisEnabled = originalRedisEnabled
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	return db
+}
+
+func tokenOrUserAuthSessionCookies(t *testing.T, router *gin.Engine, userID int) []*http.Cookie {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/login", nil)
+	router.ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusNoContent, recorder.Code)
+	return recorder.Result().Cookies()
+}
+
+func newTokenOrUserAuthTestRouter(t *testing.T, userID int, handler gin.HandlerFunc) *gin.Engine {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(sessions.Sessions("session", cookie.NewStore([]byte("token-or-user-auth-test"))))
+	router.GET("/login", func(c *gin.Context) {
+		session := sessions.Default(c)
+		session.Set("id", userID)
+		session.Set("username", "stale-user")
+		session.Set("role", common.RoleCommonUser)
+		session.Set("status", common.UserStatusEnabled)
+		session.Set("group", "default")
+		require.NoError(t, session.Save())
+		c.Status(http.StatusNoContent)
+	})
+	router.GET("/protected", TokenOrUserAuth(), handler)
+	return router
+}
+
+func TestTokenOrUserAuthRejectsDBDisabledSessionUser(t *testing.T) {
+	db := setupTokenOrUserAuthTestDB(t)
+	user := &model.User{
+		Id:       101,
+		Username: "disabled-user",
+		Password: "not-used-in-test",
+		Role:     common.RoleCommonUser,
+		Status:   common.UserStatusDisabled,
+		Group:    "default",
+	}
+	require.NoError(t, db.Create(user).Error)
+
+	handlerCalled := false
+	router := newTokenOrUserAuthTestRouter(t, user.Id, func(c *gin.Context) {
+		handlerCalled = true
+		c.Status(http.StatusNoContent)
+	})
+	cookies := tokenOrUserAuthSessionCookies(t, router, user.Id)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	for _, sessionCookie := range cookies {
+		request.AddCookie(sessionCookie)
+	}
+	router.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	require.False(t, handlerCalled)
+}
+
+func TestTokenOrUserAuthRefreshesSessionContextFromDB(t *testing.T) {
+	db := setupTokenOrUserAuthTestDB(t)
+	user := &model.User{
+		Id:       102,
+		Username: "fresh-user",
+		Password: "not-used-in-test",
+		Role:     common.RoleAdminUser,
+		Status:   common.UserStatusEnabled,
+		Group:    "premium",
+	}
+	require.NoError(t, db.Create(user).Error)
+
+	router := newTokenOrUserAuthTestRouter(t, user.Id, func(c *gin.Context) {
+		require.Equal(t, user.Username, c.GetString("username"))
+		require.Equal(t, user.Role, c.GetInt("role"))
+		require.Equal(t, user.Group, c.GetString("user_group"))
+		c.Status(http.StatusNoContent)
+	})
+	cookies := tokenOrUserAuthSessionCookies(t, router, user.Id)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	for _, sessionCookie := range cookies {
+		request.AddCookie(sessionCookie)
+	}
+	router.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusNoContent, recorder.Code)
+}
+
+func TestTokenOrUserAuthRejectsMissingSessionUser(t *testing.T) {
+	setupTokenOrUserAuthTestDB(t)
+	const missingUserID = 103
+
+	handlerCalled := false
+	router := newTokenOrUserAuthTestRouter(t, missingUserID, func(c *gin.Context) {
+		handlerCalled = true
+		c.Status(http.StatusNoContent)
+	})
+	cookies := tokenOrUserAuthSessionCookies(t, router, missingUserID)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	for _, sessionCookie := range cookies {
+		request.AddCookie(sessionCookie)
+	}
+	router.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusUnauthorized, recorder.Code)
+	require.False(t, handlerCalled)
+}
+
+func TestTokenOrUserAuthFailsClosedOnDatabaseError(t *testing.T) {
+	db := setupTokenOrUserAuthTestDB(t)
+	user := &model.User{
+		Id:       104,
+		Username: "db-error-user",
+		Password: "not-used-in-test",
+		Role:     common.RoleCommonUser,
+		Status:   common.UserStatusEnabled,
+		Group:    "default",
+	}
+	require.NoError(t, db.Create(user).Error)
+
+	handlerCalled := false
+	router := newTokenOrUserAuthTestRouter(t, user.Id, func(c *gin.Context) {
+		handlerCalled = true
+		c.Status(http.StatusNoContent)
+	})
+	cookies := tokenOrUserAuthSessionCookies(t, router, user.Id)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	for _, sessionCookie := range cookies {
+		request.AddCookie(sessionCookie)
+	}
+	router.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusInternalServerError, recorder.Code)
+	require.False(t, handlerCalled)
+}
+
+func TestAdminAuthRejectsDeletedSessionUser(t *testing.T) {
+	setupTokenOrUserAuthTestDB(t)
+	const missingUserID = 105
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(sessions.Sessions("session", cookie.NewStore([]byte("admin-auth-test"))))
+	router.GET("/login", func(c *gin.Context) {
+		session := sessions.Default(c)
+		session.Set("id", missingUserID)
+		session.Set("username", "deleted-admin")
+		session.Set("role", common.RoleAdminUser)
+		session.Set("status", common.UserStatusEnabled)
+		session.Set("group", "default")
+		require.NoError(t, session.Save())
+		c.Status(http.StatusNoContent)
+	})
+	handlerCalled := false
+	router.GET("/admin", AdminAuth(), func(c *gin.Context) {
+		handlerCalled = true
+		c.Status(http.StatusNoContent)
+	})
+
+	cookies := tokenOrUserAuthSessionCookies(t, router, missingUserID)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	request.Header.Set("New-Api-User", fmt.Sprintf("%d", missingUserID))
+	for _, sessionCookie := range cookies {
+		request.AddCookie(sessionCookie)
+	}
+	router.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusUnauthorized, recorder.Code)
+	require.False(t, handlerCalled)
+}

--- a/model/user.go
+++ b/model/user.go
@@ -118,6 +118,7 @@ func (user *User) ToBaseUser() *UserBase {
 		Quota:    user.Quota,
 		Status:   user.Status,
 		Username: user.Username,
+		Role:     user.Role,
 		Setting:  user.Setting,
 		Email:    user.Email,
 	}

--- a/model/user_cache.go
+++ b/model/user_cache.go
@@ -13,7 +13,9 @@ import (
 	"github.com/bytedance/gopkg/util/gopool"
 )
 
-// UserBase struct remains the same as it represents the cached data structure
+// UserBase is the Redis/hash-backed user snapshot used by hot auth paths.
+// Role is included so session middleware can fail closed on demotion without
+// a dedicated DB round-trip on every dashboard request.
 type UserBase struct {
 	Id       int    `json:"id"`
 	Group    string `json:"group"`
@@ -21,6 +23,7 @@ type UserBase struct {
 	Quota    int    `json:"quota"`
 	Status   int    `json:"status"`
 	Username string `json:"username"`
+	Role     int    `json:"role"`
 	Setting  string `json:"setting"`
 }
 
@@ -132,6 +135,7 @@ func GetUserCache(userId int) (userCache *UserBase, err error) {
 		Quota:    user.Quota,
 		Status:   user.Status,
 		Username: user.Username,
+		Role:     user.Role,
 		Setting:  user.Setting,
 		Email:    user.Email,
 	}


### PR DESCRIPTION
## Summary
Second small PR from the withdrawn hardening effort: **session auth fail-closed**.

- Session cookies are treated as identity **hints** only.
- On each `UserAuth` / `AdminAuth` / `RootAuth` / `TokenOrUserAuth` session path, reload `username` / `role` / `status` / `group` via **`model.GetUserCache`** (Redis first, DB fallback).
- `UserBase` gains **`Role`** so demotion is enforced without a dedicated `GetUserById` on every dashboard request when cache is warm.
- Ban / missing user → unauthorized/forbidden before the 30-day cookie would expire.
- Unit tests without Redis/DB keep session-only behavior (no panic on `RDB == nil`).

## Test plan
- [x] `go test ./middleware ./model`
- [ ] Manual: disable user in admin → existing browser session loses access on next API call
- [ ] Manual: demote admin → `AdminAuth` routes return insufficient privilege

## Notes
- Does **not** include CORS/HSTS (see #6297), SPA routing, adaptive balance, or delivery seam.
- Quota debit changes from the large branch are intentionally **not** included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session authentication now normalizes session user IDs and refreshes the user’s identity, role, status, and group before granting access.
  * Sessions for disabled/deleted/missing users are rejected; refresh failures now fail securely when persistence is available.
  * Authorization now validates refreshed status and minimum role requirements rather than relying on stale claims.
  * Cached user snapshots now retain role to keep authorization decisions consistent.
* **Tests**
  * Added coverage for session refresh, fail-closed behavior, admin checks, and context propagation (including status).
* **Documentation**
  * Clarified disabled-vs-other token states for read-only token authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->