### PR TITLE
fix(router): do not serve SPA HTML for API and ops paths

### DIFF
--- a/router/web-router.go
+++ b/router/web-router.go
@@ -13,12 +13,67 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// ThemeAssets holds the embedded frontend assets for both themes.
+// ThemeAssets 保存默认主题与经典主题的一体化嵌入资源。
 type ThemeAssets struct {
 	DefaultBuildFS   embed.FS
 	DefaultIndexPage []byte
 	ClassicBuildFS   embed.FS
 	ClassicIndexPage []byte
+}
+
+// Available 判断两个主题的首页是否同时存在，防止纯后端构建误入嵌入模式后 panic。
+func (assets ThemeAssets) Available() bool {
+	return len(assets.DefaultIndexPage) > 0 && len(assets.ClassicIndexPage) > 0
+}
+
+// nonSPAPathPrefixes 是绝不能回退到 SPA HTML 的后端/运维路径前缀。
+// 未注册时必须返回 API 风格 404，避免 /metrics 等被 index.html 伪装成 200。
+//
+// 注意：前端控制台路由是 /dashboard 与 /dashboard/$section（如 /dashboard/overview）。
+// 这里只能拦截 OpenAI 兼容账单 API 前缀 /dashboard/billing，不能把整个 /dashboard
+// 标成 non-SPA，否则登录后跳转会拿到 JSON 404 而不是 SPA HTML。
+var nonSPAPathPrefixes = []string{
+	"/api",
+	"/v1",
+	"/v1beta",
+	"/assets",
+	"/metrics",
+	"/pg",
+	"/mj",
+	"/suno",
+	"/kling",
+	"/jimeng",
+	"/dashboard/billing",
+	"/healthz",
+	"/livez",
+	"/readyz",
+	"/frontend-healthz",
+}
+
+// isNonSPARequestPath 判断路径是否属于 API/Relay/运维端点，禁止 SPA NoRoute 接管。
+func isNonSPARequestPath(requestURI string) bool {
+	path := requestURI
+	if i := strings.IndexByte(path, '?'); i >= 0 {
+		path = path[:i]
+	}
+	if path == "" {
+		path = "/"
+	}
+	for _, prefix := range nonSPAPathPrefixes {
+		if path == prefix || strings.HasPrefix(path, prefix+"/") {
+			return true
+		}
+	}
+	// Midjourney 模式前缀：/:mode/mj 或 /:mode/mj/...
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return false
+	}
+	parts := strings.Split(trimmed, "/")
+	if len(parts) >= 2 && parts[1] == "mj" {
+		return true
+	}
+	return false
 }
 
 func SetWebRouter(router *gin.Engine, assets ThemeAssets) {
@@ -32,7 +87,8 @@ func SetWebRouter(router *gin.Engine, assets ThemeAssets) {
 	router.Use(static.Serve("/", themeFS))
 	router.NoRoute(func(c *gin.Context) {
 		c.Set(middleware.RouteTagKey, "web")
-		if strings.HasPrefix(c.Request.RequestURI, "/v1") || strings.HasPrefix(c.Request.RequestURI, "/api") || strings.HasPrefix(c.Request.RequestURI, "/assets") {
+		if isNonSPARequestPath(c.Request.RequestURI) {
+			// 未注册的后端/运维路径返回 JSON 404，禁止回退 HTML。
 			controller.RelayNotFound(c)
 			return
 		}

--- a/router/web_router_nonspa_test.go
+++ b/router/web_router_nonspa_test.go
@@ -1,0 +1,69 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNonSPARequestPath(t *testing.T) {
+	for _, path := range []string{
+		"/metrics",
+		"/metrics?foo=1",
+		"/v1/models",
+		"/v1beta/models",
+		"/api/status",
+		"/pg/chat/completions",
+		"/mj/submit",
+		"/suno/submit",
+		"/kling/v1/videos/text2video",
+		"/jimeng/",
+		"/dashboard/billing/usage",
+		"/frontend-healthz",
+		"/readyz",
+		"/livez",
+		"/healthz",
+		"/fast/mj/task",
+	} {
+		require.Truef(t, isNonSPARequestPath(path), "expected non-SPA: %s", path)
+	}
+	for _, path := range []string{
+		"/",
+		"/console",
+		"/pricing",
+		"/about",
+		"/sign-in",
+		"/static/js/index.js",
+		"/dashboard",
+		"/dashboard/overview",
+		"/dashboard/detail",
+	} {
+		require.Falsef(t, isNonSPARequestPath(path), "expected SPA-capable: %s", path)
+	}
+}
+
+func TestSetWebRouterDoesNotServeSPAForMetrics(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	assets := ThemeAssets{
+		DefaultIndexPage: []byte("<html>default</html>"),
+		ClassicIndexPage: []byte("<html>classic</html>"),
+	}
+	engine := gin.New()
+	SetWebRouter(engine, assets)
+
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusNotFound, recorder.Code)
+	require.NotContains(t, recorder.Header().Get("Content-Type"), "text/html")
+	require.NotContains(t, recorder.Body.String(), "<html>default</html>")
+
+	// Console SPA routes still fall back to index (theme-dependent).
+	home := httptest.NewRecorder()
+	engine.ServeHTTP(home, httptest.NewRequest(http.MethodGet, "/dashboard/overview", nil))
+	require.Equal(t, http.StatusOK, home.Code)
+	body := home.Body.String()
+	require.True(t, body == "<html>default</html>" || body == "<html>classic</html>", "body=%q", body)
+}


### PR DESCRIPTION
## Summary
Third small PR from the withdrawn hardening effort: **SPA NoRoute hygiene**.

Embedded frontend `NoRoute` previously only excluded `/api`, `/v1`, and `/assets`. Unregistered ops/relay paths such as **`/metrics`** could fall through to `index.html` with **HTTP 200**, which breaks monitoring and masks missing routes.

This PR:

- Adds an explicit **non-SPA prefix list** (`/metrics`, relay prefixes, health probes, `/dashboard/billing`, …).
- Returns API-style **404** for those paths instead of SPA HTML.
- **Keeps** `/dashboard` and `/dashboard/{section}` as SPA routes (console), while still treating OpenAI-compatible **`/dashboard/billing`** as non-SPA.

## Test plan
- [x] `go test ./router -run 'NonSPA|Metrics'`
- [ ] Manual embedded mode: `GET /metrics` → non-HTML 404 when metrics disabled
- [ ] Manual: `GET /dashboard/overview` still serves SPA after login redirect

## Notes
- Does not enable Prometheus metrics or change auth (see #6297 / #6298).
- Does not include delivery-seam / `FRONTEND_MODE` work (separate PR later).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backend, metrics, and API requests now return appropriate 404 responses instead of displaying the web app.
  * Valid SPA routes continue to load the selected default or classic theme correctly.
  * Theme asset availability is now detected more reliably.

* **Tests**
  * Added coverage for non-SPA endpoint handling, metrics responses, and SPA route fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->