### PR TITLE
fix(http): shared outbound transport; no Client.Timeout for streams

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,11 @@
 # RELAY_TIMEOUT=0
 # Relay HTTP 客户端空闲连接超时时间，单位秒，默认跟随 Go 标准库，设置为0表示不限制
 # RELAY_IDLE_CONN_TIMEOUT=90
+# RELAY_DIAL_TIMEOUT=10
+# RELAY_TLS_HANDSHAKE_TIMEOUT=10
+# RELAY_RESPONSE_HEADER_TIMEOUT=120
+# RELAY_EXPECT_CONTINUE_TIMEOUT=1
+# Note: do not use RELAY_TIMEOUT as http.Client.Timeout for streaming; body reads would be cut off.
 # 流模式无响应超时时间，单位秒，如果出现空补全可以尝试改为更大值
 # STREAMING_TIMEOUT=300
 

--- a/common/constants.go
+++ b/common/constants.go
@@ -186,6 +186,10 @@ var BatchUpdateInterval int
 var RelayTimeout int // unit is second
 
 var RelayIdleConnTimeout int // unit is second
+var RelayDialTimeout int
+var RelayTLSHandshakeTimeout int
+var RelayResponseHeaderTimeout int
+var RelayExpectContinueTimeout int
 var RelayMaxIdleConns int
 var RelayMaxIdleConnsPerHost int
 

--- a/common/http_client.go
+++ b/common/http_client.go
@@ -1,0 +1,39 @@
+package common
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type DialContextFunc func(context.Context, string, string) (net.Conn, error)
+
+// NewOutboundHTTPTransport applies the shared connection lifecycle policy.
+// ResponseHeaderTimeout bounds an upstream that never responds while leaving
+// response-body streaming governed by request context and streaming timeouts.
+func NewOutboundHTTPTransport(proxy func(*http.Request) (*url.URL, error), dialContext DialContextFunc) *http.Transport {
+	if dialContext == nil {
+		dialer := &net.Dialer{
+			Timeout:   time.Duration(RelayDialTimeout) * time.Second,
+			KeepAlive: 30 * time.Second,
+		}
+		dialContext = dialer.DialContext
+	}
+	transport := &http.Transport{
+		Proxy:                 proxy,
+		DialContext:           dialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          RelayMaxIdleConns,
+		MaxIdleConnsPerHost:   RelayMaxIdleConnsPerHost,
+		IdleConnTimeout:       time.Duration(RelayIdleConnTimeout) * time.Second,
+		TLSHandshakeTimeout:   time.Duration(RelayTLSHandshakeTimeout) * time.Second,
+		ResponseHeaderTimeout: time.Duration(RelayResponseHeaderTimeout) * time.Second,
+		ExpectContinueTimeout: time.Duration(RelayExpectContinueTimeout) * time.Second,
+	}
+	if TLSInsecureSkipVerify {
+		transport.TLSClientConfig = InsecureTLSConfig.Clone()
+	}
+	return transport
+}

--- a/common/http_client_test.go
+++ b/common/http_client_test.go
@@ -1,0 +1,99 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOutboundHTTPTransportUsesLifecycleTimeouts(t *testing.T) {
+	previousDial := RelayDialTimeout
+	previousTLS := RelayTLSHandshakeTimeout
+	previousHeader := RelayResponseHeaderTimeout
+	previousExpect := RelayExpectContinueTimeout
+	previousIdle := RelayIdleConnTimeout
+	previousMaxIdle := RelayMaxIdleConns
+	previousMaxIdleHost := RelayMaxIdleConnsPerHost
+	t.Cleanup(func() {
+		RelayDialTimeout = previousDial
+		RelayTLSHandshakeTimeout = previousTLS
+		RelayResponseHeaderTimeout = previousHeader
+		RelayExpectContinueTimeout = previousExpect
+		RelayIdleConnTimeout = previousIdle
+		RelayMaxIdleConns = previousMaxIdle
+		RelayMaxIdleConnsPerHost = previousMaxIdleHost
+	})
+
+	RelayDialTimeout = 7
+	RelayTLSHandshakeTimeout = 8
+	RelayResponseHeaderTimeout = 9
+	RelayExpectContinueTimeout = 2
+	RelayIdleConnTimeout = 90
+	RelayMaxIdleConns = 200
+	RelayMaxIdleConnsPerHost = 50
+
+	transport := NewOutboundHTTPTransport(http.ProxyFromEnvironment, nil)
+	require.Equal(t, 8*time.Second, transport.TLSHandshakeTimeout)
+	require.Equal(t, 9*time.Second, transport.ResponseHeaderTimeout)
+	require.Equal(t, 2*time.Second, transport.ExpectContinueTimeout)
+	require.Equal(t, 90*time.Second, transport.IdleConnTimeout)
+	require.Equal(t, 200, transport.MaxIdleConns)
+	require.Equal(t, 50, transport.MaxIdleConnsPerHost)
+	require.NotNil(t, transport.DialContext)
+}
+
+func TestOutboundTransportTimesOutWaitingForResponseHeaders(t *testing.T) {
+	previousHeader := RelayResponseHeaderTimeout
+	previousDial := RelayDialTimeout
+	RelayResponseHeaderTimeout = 1
+	RelayDialTimeout = 2
+	t.Cleanup(func() {
+		RelayResponseHeaderTimeout = previousHeader
+		RelayDialTimeout = previousDial
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(1500 * time.Millisecond)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := &http.Client{Transport: NewOutboundHTTPTransport(nil, nil)}
+	started := time.Now()
+	_, err := client.Get(server.URL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timeout awaiting response headers")
+	require.Less(t, time.Since(started), 1400*time.Millisecond)
+}
+
+func TestOutboundTransportHonorsRequestCancellation(t *testing.T) {
+	previousHeader := RelayResponseHeaderTimeout
+	RelayResponseHeaderTimeout = 0
+	t.Cleanup(func() { RelayResponseHeaderTimeout = previousHeader })
+
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		close(started)
+		<-request.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	result := make(chan error, 1)
+	client := &http.Client{Transport: NewOutboundHTTPTransport(nil, nil)}
+	go func() {
+		_, requestErr := client.Do(request)
+		result <- requestErr
+	}()
+	<-started
+	cancel()
+	require.ErrorIs(t, <-result, context.Canceled)
+	require.True(t, errors.Is(ctx.Err(), context.Canceled))
+}

--- a/common/init.go
+++ b/common/init.go
@@ -108,6 +108,10 @@ func InitEnv() {
 	BatchUpdateInterval = GetEnvOrDefault("BATCH_UPDATE_INTERVAL", 5)
 	RelayTimeout = GetEnvOrDefault("RELAY_TIMEOUT", 0)
 	RelayIdleConnTimeout = GetEnvOrDefault("RELAY_IDLE_CONN_TIMEOUT", 90)
+	RelayDialTimeout = GetEnvOrDefault("RELAY_DIAL_TIMEOUT", 10)
+	RelayTLSHandshakeTimeout = GetEnvOrDefault("RELAY_TLS_HANDSHAKE_TIMEOUT", 10)
+	RelayResponseHeaderTimeout = GetEnvOrDefault("RELAY_RESPONSE_HEADER_TIMEOUT", 120)
+	RelayExpectContinueTimeout = GetEnvOrDefault("RELAY_EXPECT_CONTINUE_TIMEOUT", 1)
 	RelayMaxIdleConns = GetEnvOrDefault("RELAY_MAX_IDLE_CONNS", 500)
 	RelayMaxIdleConnsPerHost = GetEnvOrDefault("RELAY_MAX_IDLE_CONNS_PER_HOST", 100)
 

--- a/oauth/http_client.go
+++ b/oauth/http_client.go
@@ -1,0 +1,21 @@
+package oauth
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+var (
+	oauthTransportOnce sync.Once
+	oauthTransport     *http.Transport
+)
+
+func newHTTPClient(timeout time.Duration) *http.Client {
+	oauthTransportOnce.Do(func() {
+		oauthTransport = common.NewOutboundHTTPTransport(http.ProxyFromEnvironment, nil)
+	})
+	return &http.Client{Transport: oauthTransport, Timeout: timeout}
+}

--- a/service/http_client.go
+++ b/service/http_client.go
@@ -54,30 +54,21 @@ func ValidateSSRFProtectedFetchURL(urlStr string) error {
 }
 
 func InitHttpClient() {
-	transport := &http.Transport{
-		MaxIdleConns:        common.RelayMaxIdleConns,
-		MaxIdleConnsPerHost: common.RelayMaxIdleConnsPerHost,
-		IdleConnTimeout:     time.Duration(common.RelayIdleConnTimeout) * time.Second,
-		ForceAttemptHTTP2:   true,
-		Proxy:               http.ProxyFromEnvironment, // Support HTTP_PROXY, HTTPS_PROXY, NO_PROXY env vars
-	}
-	if common.TLSInsecureSkipVerify {
-		transport.TLSClientConfig = common.InsecureTLSConfig
-	}
-
-	if common.RelayTimeout == 0 {
-		httpClient = &http.Client{
-			Transport:     transport,
-			CheckRedirect: checkRedirect,
-		}
-	} else {
-		httpClient = &http.Client{
-			Transport:     transport,
-			Timeout:       time.Duration(common.RelayTimeout) * time.Second,
-			CheckRedirect: checkRedirect,
-		}
-	}
+	transport := common.NewOutboundHTTPTransport(http.ProxyFromEnvironment, nil)
+	httpClient = newOutboundHTTPClient(transport, checkRedirect)
 	ssrfProtectedHTTPClient = newProtectedFetchHTTPClient()
+}
+
+func newOutboundHTTPClient(transport http.RoundTripper, redirect func(*http.Request, []*http.Request) error) *http.Client {
+	// Keep client.Timeout unbounded (0). RelayTimeout must not be applied here:
+	// http.Client.Timeout covers the whole request lifecycle including response-body
+	// reads, so it aborts long-lived AI streaming once RELAY_TIMEOUT elapses.
+	// Upstream stall protection already lives on the transport via
+	// ResponseHeaderTimeout (see common.NewOutboundHTTPTransport). Per-request
+	// deadlines and streaming cutoffs continue to use request context.
+	// Callers that need a hard wall-clock limit for non-streaming fetches should
+	// use GetHttpClientWithTimeout instead.
+	return &http.Client{Transport: transport, CheckRedirect: redirect}
 }
 
 // GetHttpClient returns the general outbound client used by relay/provider
@@ -91,6 +82,16 @@ func GetHttpClient() *http.Client {
 	return httpClient
 }
 
+func GetHttpClientWithTimeout(timeout time.Duration) *http.Client {
+	base := GetHttpClient()
+	if base == nil {
+		return &http.Client{Timeout: timeout}
+	}
+	client := *base
+	client.Timeout = timeout
+	return &client
+}
+
 // GetSSRFProtectedHTTPClient 返回带拨号时 SSRF 校验的客户端。
 // ssrfProtectedHTTPClient 由 InitHttpClient 在启动时初始化，运行期只读。
 func GetSSRFProtectedHTTPClient() *http.Client {
@@ -98,6 +99,16 @@ func GetSSRFProtectedHTTPClient() *http.Client {
 		return GetHttpClient()
 	}
 	return ssrfProtectedHTTPClient
+}
+
+func GetSSRFProtectedHTTPClientWithTimeout(timeout time.Duration) *http.Client {
+	base := GetSSRFProtectedHTTPClient()
+	if base == nil {
+		return &http.Client{Timeout: timeout}
+	}
+	client := *base
+	client.Timeout = timeout
+	return &client
 }
 
 // GetHttpClientWithProxy returns the default client or a proxy-enabled one when proxyURL is provided.
@@ -143,21 +154,8 @@ func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
 
 	switch parsedURL.Scheme {
 	case "http", "https":
-		transport := &http.Transport{
-			MaxIdleConns:        common.RelayMaxIdleConns,
-			MaxIdleConnsPerHost: common.RelayMaxIdleConnsPerHost,
-			IdleConnTimeout:     time.Duration(common.RelayIdleConnTimeout) * time.Second,
-			ForceAttemptHTTP2:   true,
-			Proxy:               http.ProxyURL(parsedURL),
-		}
-		if common.TLSInsecureSkipVerify {
-			transport.TLSClientConfig = common.InsecureTLSConfig
-		}
-		client := &http.Client{
-			Transport:     transport,
-			CheckRedirect: checkRedirect,
-		}
-		client.Timeout = time.Duration(common.RelayTimeout) * time.Second
+		transport := common.NewOutboundHTTPTransport(http.ProxyURL(parsedURL), nil)
+		client := newOutboundHTTPClient(transport, checkRedirect)
 		proxyClientLock.Lock()
 		proxyClients[proxyURL] = client
 		proxyClientLock.Unlock()
@@ -183,21 +181,14 @@ func NewProxyHttpClient(proxyURL string) (*http.Client, error) {
 			return nil, err
 		}
 
-		transport := &http.Transport{
-			MaxIdleConns:        common.RelayMaxIdleConns,
-			MaxIdleConnsPerHost: common.RelayMaxIdleConnsPerHost,
-			IdleConnTimeout:     time.Duration(common.RelayIdleConnTimeout) * time.Second,
-			ForceAttemptHTTP2:   true,
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return dialer.Dial(network, addr)
-			},
+		dialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if contextDialer, ok := dialer.(proxy.ContextDialer); ok {
+				return contextDialer.DialContext(ctx, network, addr)
+			}
+			return dialer.Dial(network, addr)
 		}
-		if common.TLSInsecureSkipVerify {
-			transport.TLSClientConfig = common.InsecureTLSConfig
-		}
-
-		client := &http.Client{Transport: transport, CheckRedirect: checkRedirect}
-		client.Timeout = time.Duration(common.RelayTimeout) * time.Second
+		transport := common.NewOutboundHTTPTransport(nil, dialContext)
+		client := newOutboundHTTPClient(transport, checkRedirect)
 		proxyClientLock.Lock()
 		proxyClients[proxyURL] = client
 		proxyClientLock.Unlock()

--- a/service/protected_fetch_client.go
+++ b/service/protected_fetch_client.go
@@ -69,7 +69,7 @@ func newProtectedFetchHTTPClientWithProxy(resolver ssrfResolver, dialContext fun
 	}
 	if dialContext == nil {
 		netDialer := &net.Dialer{
-			Timeout:   30 * time.Second,
+			Timeout:   time.Duration(common.RelayDialTimeout) * time.Second,
 			KeepAlive: 30 * time.Second,
 		}
 		dialContext = netDialer.DialContext
@@ -153,18 +153,7 @@ func (t *ssrfProtectedRoundTripper) newTransport(proxyURL *url.URL) *http.Transp
 		proxyFunc = nil
 	}
 
-	transport := &http.Transport{
-		MaxIdleConns:        common.RelayMaxIdleConns,
-		MaxIdleConnsPerHost: common.RelayMaxIdleConnsPerHost,
-		IdleConnTimeout:     time.Duration(common.RelayIdleConnTimeout) * time.Second,
-		ForceAttemptHTTP2:   true,
-		Proxy:               proxyFunc,
-		DialContext:         dialContext,
-	}
-	if common.TLSInsecureSkipVerify {
-		transport.TLSClientConfig = common.InsecureTLSConfig
-	}
-	return transport
+	return common.NewOutboundHTTPTransport(proxyFunc, dialContext)
 }
 
 func (d *protectedFetchDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/service/protected_fetch_client.go
+++ b/service/protected_fetch_client.go
@@ -81,7 +81,11 @@ func newProtectedFetchHTTPClientWithProxy(resolver ssrfResolver, dialContext fun
 		proxy = http.ProxyFromEnvironment
 	}
 
-	client := &http.Client{
+	// Keep client.Timeout unbounded (0), matching newOutboundHTTPClient.
+	// RelayTimeout must not cover response-body reads: long-lived streams would
+	// be aborted once RELAY_TIMEOUT elapses. Dial/header stall protection lives
+	// on the dialer and transport (ResponseHeaderTimeout).
+	return &http.Client{
 		Transport: &ssrfProtectedRoundTripper{
 			resolver:      resolver,
 			dialContext:   dialContext,
@@ -91,10 +95,6 @@ func newProtectedFetchHTTPClientWithProxy(resolver ssrfResolver, dialContext fun
 		},
 		CheckRedirect: checkProtectedFetchRedirect,
 	}
-	if common.RelayTimeout != 0 {
-		client.Timeout = time.Duration(common.RelayTimeout) * time.Second
-	}
-	return client
 }
 
 func (t *ssrfProtectedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/service/protected_fetch_client_test.go
+++ b/service/protected_fetch_client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/setting/system_setting"
@@ -211,6 +212,14 @@ func TestGetSSRFProtectedHTTPClientFallsBackToDefaultClientWhenProtectionDisable
 	ssrfProtectedHTTPClient = &http.Client{}
 
 	require.Same(t, expected, GetSSRFProtectedHTTPClient())
+}
+
+func TestProtectedFetchHTTPClientTimeoutUnbounded(t *testing.T) {
+	originalTimeout := common.RelayTimeout
+	t.Cleanup(func() { common.RelayTimeout = originalTimeout })
+	common.RelayTimeout = 30
+	client := newProtectedFetchHTTPClientWithProxy(nil, nil, nil, nil)
+	require.Equal(t, time.Duration(0), client.Timeout)
 }
 
 func TestProtectedFetchRoundTripperUsesConfiguredProxy(t *testing.T) {


### PR DESCRIPTION
## Summary
Fourth small PR from the withdrawn hardening effort: **outbound HTTP client lifecycle**.

### Problem
Applying `RELAY_TIMEOUT` as `http.Client.Timeout` covers the **entire** request including response-body reads, so long-lived **streaming** completions get aborted mid-body.

### Change
- Introduce `common.NewOutboundHTTPTransport` with dial / TLS / response-header / idle / expect-continue timeouts
- Wire relay + OAuth + SSRF-protected fetch to this shared transport
- Keep **`http.Client.Timeout = 0`** for the general relay client; stall protection is `ResponseHeaderTimeout` + request context
- Non-streaming callers that need a wall clock can use `GetHttpClientWithTimeout`

### Env (optional)
`RELAY_DIAL_TIMEOUT`, `RELAY_TLS_HANDSHAKE_TIMEOUT`, `RELAY_RESPONSE_HEADER_TIMEOUT`, `RELAY_EXPECT_CONTINUE_TIMEOUT` (documented in `.env.example`).

## Test plan
- [x] `go test ./common` (outbound transport timeout tests)
- [x] `go test ./service -run 'Http|HTTP|Client|SSRF|Protected|Timeout|Transport|Outbound'`
- [ ] Manual: long streaming chat is not cut at `RELAY_TIMEOUT` wall while hung upstreams still time out on headers

## Notes
- No channel selection / auth / SPA routing changes (see #6297–#6299).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more granular, configurable relay timeout settings (dial, TLS handshake, response headers, and expect-continue) and expanded environment examples.
  * Added timeout-scoped HTTP client helpers for both standard and SSRF-protected requests.
  * Improved outbound HTTP connection handling and pooling across direct and proxy modes (including SOCKS variants).

* **Bug Fixes**
  * Prevented streaming interruptions from an overly broad global client timeout.
  * Requests now reliably enforce response-header timeouts and honor request cancellation.

* **Documentation**
  * Updated guidance explaining how relay timeouts should be used (including streaming-safe recommendations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->