### PR TITLE
feat: 屏蔽上游余额不足类报错中的金额明细

### DIFF
--- a/service/error.go
+++ b/service/error.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -83,6 +84,37 @@ func ClaudeErrorWrapperLocal(err error, code string, statusCode int) *dto.Claude
 	return claudeErr
 }
 
+// upstreamQuotaErrPatterns 匹配上游 new-api 实例返回的各类余额/额度不足报错，
+// 这些报错会向最终用户暴露上游账户的余额明细。
+var upstreamQuotaErrPatterns = []*regexp.Regexp{
+	// 预扣费额度失败, 用户剩余额度: ¥0.230000, 需要预扣费额度: ¥0.290000
+	regexp.MustCompile(`预扣费额度失败, 用户剩余额度: [^,]+, 需要预扣费额度: [^\s(]+`),
+	// 用户额度不足, 剩余额度: ¥0.000000
+	regexp.MustCompile(`用户额度不足, 剩余额度: [^\s(]+`),
+	// token quota is not enough, token remain quota: ¥0.100000, need quota: ¥0.290000
+	regexp.MustCompile(`token quota is not enough, token remain quota: [^,]+, need quota: [^\s(]+`),
+	// 订阅额度不足或未配置订阅: subscription quota insufficient, need=290000 / no active subscription
+	regexp.MustCompile(`订阅额度不足或未配置订阅: (no active subscription|subscription quota insufficient(, need=\d+)?)`),
+}
+
+const upstreamQuotaErrReplacement = "预扣费额度失败, 可能是上游余额不足"
+
+// rewriteUpstreamPreConsumeError 将上游返回的余额/额度不足类报错统一改写为
+// "预扣费额度失败, 可能是上游余额不足"，隐藏上游账户的实际金额，request id 等其余内容原样保留。
+// 本地生成的同类报错（用户自身余额不足）不经过 RelayErrorHandler，不受影响。
+func rewriteUpstreamPreConsumeError(message string) string {
+	if !strings.Contains(message, "预扣费额度失败") &&
+		!strings.Contains(message, "用户额度不足") &&
+		!strings.Contains(message, "token quota is not enough") &&
+		!strings.Contains(message, "订阅额度不足") {
+		return message
+	}
+	for _, pattern := range upstreamQuotaErrPatterns {
+		message = pattern.ReplaceAllString(message, upstreamQuotaErrReplacement)
+	}
+	return message
+}
+
 func RelayErrorHandler(ctx context.Context, resp *http.Response, showBodyWhenFail bool) (newApiErr *types.NewAPIError) {
 	newApiErr = types.InitOpenAIError(types.ErrorCodeBadResponseStatusCode, resp.StatusCode)
 
@@ -116,6 +148,7 @@ func RelayErrorHandler(ctx context.Context, resp *http.Response, showBodyWhenFai
 		// General format error (OpenAI, Anthropic, Gemini, etc.)
 		oaiError := errResponse.TryToOpenAIError()
 		if oaiError != nil {
+			oaiError.Message = rewriteUpstreamPreConsumeError(oaiError.Message)
 			newApiErr = types.WithOpenAIError(*oaiError, resp.StatusCode)
 			if showBodyWhenFail {
 				newApiErr.Err = buildErrWithBody(newApiErr.Error())
@@ -123,7 +156,7 @@ func RelayErrorHandler(ctx context.Context, resp *http.Response, showBodyWhenFai
 			return
 		}
 	}
-	newApiErr = types.NewOpenAIError(errors.New(errResponse.ToMessage()), types.ErrorCodeBadResponseStatusCode, resp.StatusCode)
+	newApiErr = types.NewOpenAIError(errors.New(rewriteUpstreamPreConsumeError(errResponse.ToMessage())), types.ErrorCodeBadResponseStatusCode, resp.StatusCode)
 	if showBodyWhenFail {
 		newApiErr.Err = buildErrWithBody(newApiErr.Error())
 	}

--- a/service/error_test.go
+++ b/service/error_test.go
@@ -122,6 +122,83 @@ func TestRelayErrorHandlerKeepsOpenAIErrorMessage(t *testing.T) {
 	require.Equal(t, message, newAPIError.Error())
 }
 
+func TestRelayErrorHandlerRewritesUpstreamPreConsumeError(t *testing.T) {
+	body := `{"error":{"message":"预扣费额度失败, 用户剩余额度: ¥0.230000, 需要预扣费额度: ¥0.290000 (request id: 202607161100477844560988268d9d6uYrgwk77)","type":"new_api_error","code":"insufficient_user_quota"}}`
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	newAPIError := RelayErrorHandler(context.Background(), resp, false)
+
+	require.NotNil(t, newAPIError)
+	expected := "预扣费额度失败, 可能是上游余额不足 (request id: 202607161100477844560988268d9d6uYrgwk77)"
+	require.Equal(t, expected, newAPIError.Error())
+	require.Equal(t, http.StatusForbidden, newAPIError.StatusCode)
+	// 返回给最终用户的消息（RelayError）同样被改写
+	require.Equal(t, expected, newAPIError.ToOpenAIError().Message)
+	require.Equal(t, "insufficient_user_quota", fmt.Sprintf("%v", newAPIError.ToOpenAIError().Code))
+}
+
+func TestRewriteUpstreamPreConsumeError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "CNY 金额带 request id",
+			input:    "预扣费额度失败, 用户剩余额度: ¥0.230000, 需要预扣费额度: ¥0.290000 (request id: 202607161100477844560988268d9d6uYrgwk77)",
+			expected: "预扣费额度失败, 可能是上游余额不足 (request id: 202607161100477844560988268d9d6uYrgwk77)",
+		},
+		{
+			name:     "USD 金额不带 request id",
+			input:    "预扣费额度失败, 用户剩余额度: $0.23, 需要预扣费额度: $0.29",
+			expected: "预扣费额度失败, 可能是上游余额不足",
+		},
+		{
+			name:     "token 数量格式",
+			input:    "预扣费额度失败, 用户剩余额度: 115000, 需要预扣费额度: 145000",
+			expected: "预扣费额度失败, 可能是上游余额不足",
+		},
+		{
+			name:     "上游账户余额为零",
+			input:    "用户额度不足, 剩余额度: ¥0.000000 (request id: 202607161100477844560988268d9d6uYrgwk77)",
+			expected: "预扣费额度失败, 可能是上游余额不足 (request id: 202607161100477844560988268d9d6uYrgwk77)",
+		},
+		{
+			name:     "上游令牌额度不足",
+			input:    "token quota is not enough, token remain quota: ¥0.100000, need quota: ¥0.290000 (request id: 202607161100477844560988268d9d6uYrgwk77)",
+			expected: "预扣费额度失败, 可能是上游余额不足 (request id: 202607161100477844560988268d9d6uYrgwk77)",
+		},
+		{
+			name:     "上游订阅额度不足",
+			input:    "订阅额度不足或未配置订阅: subscription quota insufficient, need=290000 (request id: 202607161100477844560988268d9d6uYrgwk77)",
+			expected: "预扣费额度失败, 可能是上游余额不足 (request id: 202607161100477844560988268d9d6uYrgwk77)",
+		},
+		{
+			name:     "上游未配置订阅",
+			input:    "订阅额度不足或未配置订阅: no active subscription (request id: 202607161100477844560988268d9d6uYrgwk77)",
+			expected: "预扣费额度失败, 可能是上游余额不足 (request id: 202607161100477844560988268d9d6uYrgwk77)",
+		},
+		{
+			name:     "普通报错不改写",
+			input:    "bad response status code 403",
+			expected: "bad response status code 403",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, rewriteUpstreamPreConsumeError(tc.input))
+		})
+	}
+}
+
 func TestRelayErrorHandlerKeepsInvalidJSONBodyInDebugLog(t *testing.T) {
 	withDebugEnabled(t, true)
 


### PR DESCRIPTION
> [!NOTE]
> 声明：本 PR 的代码与描述由 AI（Claude Code）辅助生成，提交者已阅读，并已在自己的生产环境部署验证。

## 📝 变更描述 / Description

当渠道上游同为 new-api 时，上游返回的"余额/额度不足"类报错会原样透传给终端用户，例如：

```
status_code=403, 预扣费额度失败, 用户剩余额度: ¥0.230000, 需要预扣费额度: ¥0.290000 (request id: ...)
```

这会暴露站点运营者在上游账户的余额明细，且"用户额度不足"等文案会误导终端用户以为是自身余额不足。

**改动方式**：在上游错误的统一解析入口 `service.RelayErrorHandler` 中新增 `rewriteUpstreamPreConsumeError`，用正则匹配 new-api 自身会产生的四类余额/额度不足报错（预扣费额度失败 / 用户额度不足 / token quota is not enough / 订阅额度不足或未配置订阅），统一改写为 `预扣费额度失败, 可能是上游余额不足`，隐藏具体金额，request id 等其余内容原样保留。

**为什么这样改能生效且不误伤**：所有格式（chat/claude/gemini/embedding/image/audio 等）的非 200 上游响应都经过 `RelayErrorHandler` 解析，是天然的统一改写点；而本实例自身生成的余额不足报错（`service/billing_session.go` 中直接构造 `NewAPIError` 返回）不经过该函数，因此用户自身余额不足时仍能看到原始明细提示，两条路径天然隔离。改写同时作用于 `oaiError.Message`（构造 `RelayError` 前），保证错误日志与返回给终端用户的 JSON 消息一致。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6306

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述由 AI 辅助生成（如上声明），提交者已逐条审阅、修订并确认内容准确，非未经处理的 AI 输出
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交（相关历史 issue #1488 已被 stale 关闭且未修复）
- [x] **Bug fix 说明:** 本 PR 为新功能，已关联 issue #6306
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动
- [x] **本地验证:** 已在本地运行并通过测试，且已在提交者自己的生产环境实际验证（见下方运行证明）
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范

## 📸 运行证明 / Proof of Work

新增 8 个改写用例的表驱动测试 + 1 个 `RelayErrorHandler` 端到端测试，连同既有测试全部通过：

```
--- PASS: TestRelayErrorHandlerTruncatesInvalidJSONBodyInLog (0.01s)
--- PASS: TestRelayErrorHandlerKeepsStructuredErrorMessage (0.00s)
--- PASS: TestRelayErrorHandlerKeepsOpenAIErrorMessage (0.00s)
--- PASS: TestRelayErrorHandlerRewritesUpstreamPreConsumeError (0.00s)
--- PASS: TestRelayErrorHandlerKeepsInvalidJSONBodyInDebugLog (0.00s)
--- PASS: TestRewriteUpstreamPreConsumeError (0.00s)
    --- PASS: TestRewriteUpstreamPreConsumeError/CNY_金额带_request_id (0.00s)
    --- PASS: TestRewriteUpstreamPreConsumeError/token_数量格式 (0.00s)
    --- PASS: TestRewriteUpstreamPreConsumeError/上游令牌额度不足 (0.00s)
    --- PASS: TestRewriteUpstreamPreConsumeError/USD_金额不带_request_id (0.00s)
    --- PASS: TestRewriteUpstreamPreConsumeError/普通报错不改写 (0.00s)
    --- PASS: TestRewriteUpstreamPreConsumeError/上游账户余额为零 (0.00s)
    --- PASS: TestRewriteUpstreamPreConsumeError/上游订阅额度不足 (0.00s)
    --- PASS: TestRewriteUpstreamPreConsumeError/上游未配置订阅 (0.00s)
ok      github.com/QuantumNous/new-api/service  1.752s
```

此改动已在提交者自己的**生产环境**（多级分发部署，上游为其他 new-api 站点）运行验证：上游余额不足时终端用户收到 `status_code=403, 预扣费额度失败, 可能是上游余额不足 (request id: ...)`，用户自身余额不足时报错保持原样返回。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3FyqndF859SY5YwE7noo8
