### PR TITLE
feat(aws): support STS temporary credentials via 4-segment key

### DIFF
--- a/relay/channel/aws/relay-aws.go
+++ b/relay/channel/aws/relay-aws.go
@@ -81,6 +81,19 @@ func newAwsClient(c *gin.Context, info *relaycommon.RelayInfo) (*bedrockruntime.
 			Credentials: aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(ak, sk, "")),
 			HTTPClient:  httpClient,
 		})
+	case 4:
+		// STS temporary credentials: accessKey|secretKey|region|sessionToken.
+		// Supports credential brokers (AssumeRole / SSO) whose creds carry a
+		// session token and expire; keep the channel Key fresh with a refresher.
+		ak := awsSecret[0]
+		sk := awsSecret[1]
+		region := awsSecret[2]
+		sessionToken := awsSecret[3]
+		client = bedrockruntime.New(bedrockruntime.Options{
+			Region:      region,
+			Credentials: aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(ak, sk, sessionToken)),
+			HTTPClient:  httpClient,
+		})
 	default:
 		return nil, errors.New("invalid aws secret key")
 	}


### PR DESCRIPTION
## 📝 变更描述 / Description

`newAwsClient` (`relay/channel/aws/relay-aws.go`) currently accepts only two key
forms for the AWS Bedrock channel:

- `apiKey|region` — bearer token
- `accessKey|secretKey|region` — long-term IAM keys

The 3-segment path hardcodes an empty session token
(`credentials.NewStaticCredentialsProvider(ak, sk, "")`), so **AWS STS temporary
credentials cannot be used**. STS credentials (issued via AssumeRole, IAM
Identity Center, or a credential broker) always carry a `SessionToken`, and
Bedrock rejects a request that omits it (`The security token included in the
request is invalid`).

This adds a 4-segment key form `accessKey|secretKey|region|sessionToken` that
passes the session token through to the SDK's static credential provider. The
change is fully backward compatible — the existing 2- and 3-segment forms are
untouched.

## 🚀 变更类型 / Type of change
- [x] ✨ 新功能 (New feature)

## 🔗 关联任务 / Related Issue
- N/A

## ✅ 提交前检查项 / Checklist
- [x] **变更理解:** 已理解改动原理及影响,行为向后兼容。
- [x] **范围聚焦:** 仅新增 AWS 4 段式凭证支持,无无关改动。
- [x] **本地验证:** `go build` 通过;已用每小时轮换的 STS 临时凭证在真实 AWS Bedrock 账号上验证——渠道测试与经 `/v1/messages` 的真实推理请求均返回 200。
- [x] **安全合规:** 代码中无敏感凭据。

## 📸 运行证明 / Proof of Work

- `go build ./relay/channel/aws/...` 通过。
- 新增 `case 4`:`NewStaticCredentialsProvider(ak, sk, sessionToken)`。
- 用 STS 临时凭证(每小时刷新)配置的 Bedrock 渠道,`GET /api/channel/test/<id>?model=claude-*` 与真实 `/v1/messages` 请求均 200 成功。

---

> **披露 / Disclosure:** 本改动为 AI 辅助生成(Claude Code),已经过人工 review 与本地验证后提交。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AWS temporary security credentials, including session tokens.
  * AWS connections can now authenticate using four-part credential configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->