### PR TITLE
fix(distributor): return 404 (not 503) when a model has no available channel

### DIFF
--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -150,11 +150,11 @@ func Distribute() func(c *gin.Context) {
 						//	common.SysError(fmt.Sprintf("渠道不存在：%d", channel.Id))
 						//	message = "数据库一致性已被破坏，请联系管理员"
 						//}
-						abortWithOpenAiMessage(c, http.StatusServiceUnavailable, message, types.ErrorCodeModelNotFound)
+						abortWithOpenAiMessage(c, modelUnavailableStatus(modelRequest.Model), message, types.ErrorCodeModelNotFound)
 						return
 					}
 					if channel == nil {
-						abortWithOpenAiMessage(c, http.StatusServiceUnavailable, i18n.T(c, i18n.MsgDistributorNoAvailableChannel, map[string]any{"Group": usingGroup, "Model": modelRequest.Model}), types.ErrorCodeModelNotFound)
+						abortWithOpenAiMessage(c, modelUnavailableStatus(modelRequest.Model), i18n.T(c, i18n.MsgDistributorNoAvailableChannel, map[string]any{"Group": usingGroup, "Model": modelRequest.Model}), types.ErrorCodeModelNotFound)
 						return
 					}
 				}
@@ -167,6 +167,19 @@ func Distribute() func(c *gin.Context) {
 			service.RecordChannelAffinity(c, channel.Id)
 		}
 	}
+}
+
+// modelUnavailableStatus picks the HTTP status for a "no channel for this model"
+// failure: 404 when the model is served by no enabled channel at all (a client
+// error — the model is not offered here, so clients/SDKs must not retry), and 503
+// when the model exists but its channels are currently unavailable (a transient
+// condition worth retrying). new-api historically returned 503 for both, which
+// made SDKs retry permanently-unsupported models.
+func modelUnavailableStatus(modelName string) int {
+	if len(model.GetModelSupportEndpointTypes(modelName)) == 0 {
+		return http.StatusNotFound
+	}
+	return http.StatusServiceUnavailable
 }
 
 // channelSupportsRequestPath reports whether a channel can serve the request path.


### PR DESCRIPTION
## 📝 变更描述 / Description

When channel selection finds no channel for the requested `(group, model)`, the
distributor aborts with **HTTP 503** and `code: model_not_found`.

503 is a *server* error, and the official OpenAI / Anthropic SDKs retry 5xx
responses by default. So a client that requests an unknown or unsupported model
triggers several automatic retries before it ever surfaces the real cause,
wasting requests and delaying the error.

This changes the status for the `model_not_found` path:

- **404** when the model is served by no enabled channel at all — a client error
  (the model is not offered here), so SDKs should not retry.
- **503** is kept only when the model *is* served somewhere but its channel(s)
  are currently unavailable — a genuinely transient condition worth retrying.

`model.GetModelSupportEndpointTypes(model)` (empty ⇒ served by no enabled
channel) distinguishes the two cases.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- N/A —— 若维护者认为现有 503 为有意设计,欢迎讨论后关闭本 PR。

## ✅ 提交前检查项 / Checklist
- [x] **变更理解:** 已理解改动原理及影响。
- [x] **范围聚焦:** 仅调整 `model_not_found` 分支的 HTTP 状态码,无无关改动。
- [x] **本地验证:** `go build` 通过;请求未配置的模型现返回 404,已配置模型照常 200。
- [x] **安全合规:** 代码中无敏感凭据。

## 📸 运行证明 / Proof of Work

- 请求一个未被任何 enabled 渠道服务的模型 → 现返回 `404` + `model_not_found`(原 `503`),SDK 不再自动重试。
- 已配置的模型请求照常返回 200。

---

> **披露 / Disclosure:** 本改动为 AI 辅助生成(Claude Code),已经过人工 review 与本地验证后提交。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses when a requested model is unavailable.
  * Returns a not-found status when the model is unsupported, and a service-unavailable status when supported endpoints are temporarily unavailable.
  * Added a consistent model-not-found error code for these responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->