### PR TITLE
fix(model): handle string-typed ChannelInfo scan for SQLite

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -168,6 +168,11 @@ func (c ChannelInfo) Value() (driver.Value, error) {
 
 // Scan implements sql.Scanner interface
 func (c *ChannelInfo) Scan(value interface{}) error {
+	// SQLite drivers return TEXT columns as strings.
+	if stringValue, ok := value.(string); ok {
+		return common.UnmarshalJsonStr(stringValue, c)
+	}
+
 	bytesValue, _ := value.([]byte)
 	return common.Unmarshal(bytesValue, c)
 }


### PR DESCRIPTION
## 📝 Description

`ChannelInfo` is a JSON custom type attached to `Channel` (`model/channel.go:54`, `gorm:"type:json"`), read/written through `driver.Valuer` / `sql.Scanner`. The original `Scan` only asserted a single type, `[]byte`:

```go
func (c *ChannelInfo) Scan(value interface{}) error {
    bytesValue, _ := value.([]byte)
    return common.Unmarshal(bytesValue, c)
}
```

But the `value` passed to `Scan` is determined by the underlying driver, not by GORM:

- MySQL (go-sql-driver) and Postgres (lib/pq) hand back `[]byte` for JSON columns — the assertion succeeds and everything works.
- SQLite drivers (mattn / modernc) hand back a Go `string` for TEXT columns — the assertion fails, `bytesValue` is `nil`, `common.Unmarshal(nil, c)` returns immediately, and `ChannelInfo` stays at its zero value. The field is silently dropped.

Trigger scenario: importing a MySQL database into a SQLite deployment. The MySQL `JSON` column is materialized by migration tooling as a SQLite `TEXT` column (SQLite has no native JSON type), still holding valid JSON text. On read, the SQLite driver returns a `string`, which never enters the `[]byte` branch. As a result, all multi-key fields on the channel — `IsMultiKey`, `MultiKeySize`, `MultiKeyStatusList`, `MultiKeyPollingIndex`, etc. — come back empty, and every multi-key branch in `middleware/distributor.go` and `controller/channel.go` (key polling, disable state, recovery) stops taking effect.

Fix: add a `string` branch at the top of `Scan` and decode via the project's standard `common.UnmarshalJsonStr` wrapper; the `[]byte` path is unchanged.

```go
func (c *ChannelInfo) Scan(value interface{}) error {
    // SQLite drivers return TEXT columns as strings.
    if stringValue, ok := value.(string); ok {
        return common.UnmarshalJsonStr(stringValue, c)
    }
    bytesValue, _ := value.([]byte)
    return common.Unmarshal(bytesValue, c)
}
```

## 🚀 Type of change
- [x] 🐛 Bug fix

## 🔗 Related Issue
- None. Upstream `model/channel.go` on `main` still has the `[]byte`-only `Scan`, and there is no matching issue/PR. Happy to open one if the maintainers prefer.

## ✅ Checklist
- [x] **Manually authored:** I wrote and reviewed this description myself (drafted with AI assistance, then manually verified against the code).
- [x] **Not a duplicate:** Searched upstream Issues / PRs — no existing fix; upstream `ChannelInfo.Scan` still does not handle the `string` type.
- [x] **Bug fix context:** Root cause explained above; can attach an issue on request.
- [x] **Understood impact:** The `string` / `[]byte` branches correspond to the SQLite vs. MySQL/Postgres driver return types per the `database/sql` Scanner contract; behavior on MySQL/Postgres is unchanged.
- [x] **Scoped:** A single file (`model/channel.go`), +5 lines, no unrelated changes.
- [x] **Locally verified:** On a SQLite deployment populated by importing from MySQL, reading channel info no longer silently loses the `ChannelInfo` fields.
- [x] **Security & compliance:** No credentials; uses the project's `common.UnmarshalJsonStr` wrapper per the JSON convention.

## 📸 Proof of Work
(to be attached: before/after logs from a SQLite deployment whose DB was imported from MySQL)

---

> Note: PR authored from a fork; submitter is not a historical core contributor upstream. Description + change drafted with AI assistance and manually reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with SQLite-like database drivers when reading channel information stored as JSON text.
  * Preserved existing handling for binary JSON data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->