### PR TITLE
feat(billing): debt accounting for negative-settle & topup offset (FR-015/016/017)

### DIFF
--- a/controller/topup.go
+++ b/controller/topup.go
@@ -398,7 +398,7 @@ func EpayNotify(c *gin.Context) {
 			dAmount := decimal.NewFromInt(int64(topUp.Amount))
 			dQuotaPerUnit := decimal.NewFromFloat(common.QuotaPerUnit)
 			quotaToAdd := int(dAmount.Mul(dQuotaPerUnit).IntPart())
-			err = model.IncreaseUserQuota(topUp.UserId, quotaToAdd, true)
+			_, _, err = model.OffsetUserDebtOnTopUp(topUp.UserId, quotaToAdd)
 			if err != nil {
 				logger.LogError(c.Request.Context(), fmt.Sprintf("易支付 更新用户额度失败 trade_no=%s user_id=%d client_ip=%s quota_to_add=%d error=%q topup=%q", topUp.TradeNo, topUp.UserId, c.ClientIP(), quotaToAdd, err.Error(), common.GetJsonString(topUp)))
 				return

--- a/controller/user.go
+++ b/controller/user.go
@@ -1115,7 +1115,7 @@ func ManageUser(c *gin.Context) {
 				common.ApiErrorI18n(c, i18n.MsgUserQuotaChangeZero)
 				return
 			}
-			if err := model.IncreaseUserQuota(user.Id, req.Value, true); err != nil {
+			if _, _, err := model.OffsetUserDebtOnTopUp(user.Id, req.Value); err != nil {
 				common.ApiError(c, err)
 				return
 			}

--- a/model/checkin.go
+++ b/model/checkin.go
@@ -93,6 +93,7 @@ func UserCheckin(userId int) (*Checkin, error) {
 
 // userCheckinWithTransaction 使用事务执行签到（适用于 MySQL 和 PostgreSQL）
 func userCheckinWithTransaction(checkin *Checkin, userId int, quotaAwarded int) (*Checkin, error) {
+	var checkinNet int
 	err := DB.Transaction(func(tx *gorm.DB) error {
 		// 步骤1: 创建签到记录
 		// 数据库有唯一约束 (user_id, checkin_date)，可以防止并发重复签到
@@ -100,11 +101,12 @@ func userCheckinWithTransaction(checkin *Checkin, userId int, quotaAwarded int) 
 			return errors.New("签到失败，请稍后重试")
 		}
 
-		// 步骤2: 在事务中增加用户额度
-		if err := tx.Model(&User{}).Where("id = ?", userId).
-			Update("quota", gorm.Expr("quota + ?", quotaAwarded)).Error; err != nil {
+		// 步骤2: 在事务中增加用户额度（FR-017：优先抵扣 debt，剩余进入 quota）
+		net, _, err := applyTopUpWithDebtTx(tx, userId, quotaAwarded)
+		if err != nil {
 			return errors.New("签到失败：更新额度出错")
 		}
+		checkinNet = net
 
 		return nil
 	})
@@ -113,10 +115,8 @@ func userCheckinWithTransaction(checkin *Checkin, userId int, quotaAwarded int) 
 		return nil, err
 	}
 
-	// 事务成功后，异步更新缓存
-	go func() {
-		_ = cacheIncrUserQuota(userId, int64(quotaAwarded))
-	}()
+	// 事务提交后同步缓存：仅增加真正进入 quota 的净额（与 Redeem/Recharge 等路径一致）
+	syncTopUpQuotaCache(userId, checkinNet)
 
 	return checkin, nil
 }

--- a/model/checkin.go
+++ b/model/checkin.go
@@ -129,9 +129,8 @@ func userCheckinWithoutTransaction(checkin *Checkin, userId int, quotaAwarded in
 		return nil, errors.New("签到失败，请稍后重试")
 	}
 
-	// 步骤2: 增加用户额度
-	// 使用 db=true 强制直接写入数据库，不使用批量更新
-	if err := IncreaseUserQuota(userId, quotaAwarded, true); err != nil {
+	// 步骤2: 增加用户额度（FR-017：优先抵扣 debt，剩余进入 quota）
+	if _, _, err := OffsetUserDebtOnTopUp(userId, quotaAwarded); err != nil {
 		// 如果增加额度失败，需要回滚签到记录
 		DB.Delete(checkin)
 		return nil, errors.New("签到失败：更新额度出错")

--- a/model/debt.go
+++ b/model/debt.go
@@ -1,0 +1,126 @@
+package model
+
+import (
+	"errors"
+
+	"github.com/QuantumNous/new-api/common"
+
+	"gorm.io/gorm"
+)
+
+// GetUserDebt 返回用户当前欠额（debt）。debt > 0 表示上次结算实际消耗超过余额，
+// 需在下次充值时优先抵扣，且在抵扣清零前阻止新的计费请求。
+func GetUserDebt(id int) (debt int, err error) {
+	err = DB.Model(&User{}).Where("id = ?", id).Select("debt").Find(&debt).Error
+	return debt, err
+}
+
+// SettleWalletChargeWithDebt 在一个事务内原子地从钱包扣除 charge：
+//   - 余额足够：quota -= charge，debt 不变
+//   - 余额不足：quota 置 0，不足部分累加到 debt（余额永不为负）
+//
+// 返回本次实际转入 debt 的数量（shortfall），供调用方记录/审计。
+// charge 必须 >= 0（FR-008：写入的额度值必须为正）。
+func SettleWalletChargeWithDebt(id int, charge int) (shortfall int, err error) {
+	if charge < 0 {
+		return 0, errors.New("charge 不能为负数")
+	}
+	if charge == 0 {
+		return 0, nil
+	}
+	err = DB.Transaction(func(tx *gorm.DB) error {
+		var user User
+		if err := lockForUpdate(tx).Where("id = ?", id).First(&user).Error; err != nil {
+			return err
+		}
+		if user.Quota >= charge {
+			return tx.Model(&User{}).Where("id = ?", id).
+				Update("quota", gorm.Expr("quota - ?", charge)).Error
+		}
+		// 余额不足：余额清零，不足部分记入 debt
+		shortfall = charge - user.Quota
+		return tx.Model(&User{}).Where("id = ?", id).
+			Updates(map[string]interface{}{
+				"quota": 0,
+				"debt":  gorm.Expr("debt + ?", shortfall),
+			}).Error
+	})
+	if err != nil {
+		shortfall = 0
+		return shortfall, err
+	}
+	// 同步 Redis 缓存：仅扣减真正从 quota 里扣掉的部分（charge - shortfall）。
+	if quotaDecreased := charge - shortfall; quotaDecreased > 0 {
+		if cacheErr := cacheDecrUserQuota(id, int64(quotaDecreased)); cacheErr != nil {
+			common.SysLog("failed to sync user quota cache after debt settle: " + cacheErr.Error())
+		}
+	}
+	return shortfall, nil
+}
+
+// applyTopUpWithDebtTx 在给定事务内把入账 amount 优先抵扣 user.Debt，剩余部分进入 quota。
+// 返回真正进入 quota 的净额（net）与抵扣掉的 debt（repaid）。
+// 该函数不开启新事务、不同步缓存 —— 调用方负责在事务提交后按 net 同步 Redis 缓存
+// （见 syncTopUpQuotaCache）。amount 必须为正。
+func applyTopUpWithDebtTx(tx *gorm.DB, userId int, amount int) (net int, repaid int, err error) {
+	if amount <= 0 {
+		return 0, 0, errors.New("amount 必须为正数")
+	}
+	var user User
+	if err := lockForUpdate(tx).Where("id = ?", userId).First(&user).Error; err != nil {
+		return 0, 0, err
+	}
+	if user.Debt <= 0 {
+		if err := tx.Model(&User{}).Where("id = ?", userId).
+			Update("quota", gorm.Expr("quota + ?", amount)).Error; err != nil {
+			return 0, 0, err
+		}
+		return amount, 0, nil
+	}
+	if amount >= user.Debt {
+		repaid = user.Debt
+		net = amount - user.Debt
+		if err := tx.Model(&User{}).Where("id = ?", userId).
+			Updates(map[string]interface{}{
+				"debt":  0,
+				"quota": gorm.Expr("quota + ?", net),
+			}).Error; err != nil {
+			return 0, 0, err
+		}
+		return net, repaid, nil
+	}
+	// amount < debt：全部用于偿还 debt，quota 不变
+	if err := tx.Model(&User{}).Where("id = ?", userId).
+		Update("debt", gorm.Expr("debt - ?", amount)).Error; err != nil {
+		return 0, 0, err
+	}
+	return 0, amount, nil
+}
+
+// syncTopUpQuotaCache 在入账事务提交后同步 Redis 缓存：仅增加真正进入 quota 的净额。
+func syncTopUpQuotaCache(userId int, net int) {
+	if net <= 0 {
+		return
+	}
+	if cacheErr := cacheIncrUserQuota(userId, int64(net)); cacheErr != nil {
+		common.SysLog("failed to sync user quota cache after topup: " + cacheErr.Error())
+	}
+}
+
+// OffsetUserDebtOnTopUp 在充值时优先抵扣 debt：
+//   - amount 先偿还 debt，剩余部分才进入 quota
+//   - 返回实际进入 quota 的净额（net）与抵扣掉的 debt（repaid）
+//
+// 该函数原子执行并同步缓存，供充值/兑换/管理员加额等入账路径调用。
+// 注意：此函数仅用于「入账」路径，不可用于失败退款（退款不应被 debt 吞掉）。
+func OffsetUserDebtOnTopUp(id int, amount int) (net int, repaid int, err error) {
+	err = DB.Transaction(func(tx *gorm.DB) error {
+		net, repaid, err = applyTopUpWithDebtTx(tx, id, amount)
+		return err
+	})
+	if err != nil {
+		return 0, 0, err
+	}
+	syncTopUpQuotaCache(id, net)
+	return net, repaid, nil
+}

--- a/model/debt_test.go
+++ b/model/debt_test.go
@@ -109,3 +109,44 @@ func TestGetUserDebt(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 123, debt)
 }
+
+// FR-017 checkin 路径：userCheckinWithTransaction (MySQL/PG) 必须走 applyTopUpWithDebtTx
+// —— 签到奖励优先偿还 debt，剩余进入 quota，缓存按 net 同步。守护该路径不再回退为
+// 直接 `quota + ?`（那会在 MySQL/PG 上漏掉 debt 抵扣，导致 FR-016 持续阻塞）。
+func TestCheckinWithTransactionOffsetsDebt(t *testing.T) {
+	require.NoError(t, DB.AutoMigrate(&Checkin{}))
+
+	cases := []struct {
+		name      string
+		uid       int
+		quota     int
+		debt      int
+		award     int
+		wantQuota int
+		wantDebt  int
+	}{
+		{name: "debt>0 ưu tiên trả debt", uid: 7100, quota: 10, debt: 30, award: 50, wantQuota: 30, wantDebt: 0},
+		{name: "award<debt trả hết award", uid: 7101, quota: 5, debt: 40, award: 20, wantQuota: 5, wantDebt: 20},
+		{name: "không debt full vào quota", uid: 7102, quota: 10, debt: 0, award: 50, wantQuota: 60, wantDebt: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			seedDebtUser(t, tc.uid, tc.quota, tc.debt)
+			t.Cleanup(func() { _ = DB.Where("user_id = ?", tc.uid).Delete(&Checkin{}).Error })
+
+			checkin := &Checkin{
+				UserId:       tc.uid,
+				CheckinDate:  "2099-01-01",
+				QuotaAwarded: tc.award,
+			}
+			got, err := userCheckinWithTransaction(checkin, tc.uid, tc.award)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.NotZero(t, got.Id, "phải tạo được bản ghi checkin")
+
+			u := reloadDebtUser(t, tc.uid)
+			assert.Equal(t, tc.wantQuota, u.Quota, "quota không khớp")
+			assert.Equal(t, tc.wantDebt, u.Debt, "debt không khớp")
+		})
+	}
+}

--- a/model/debt_test.go
+++ b/model/debt_test.go
@@ -1,0 +1,111 @@
+package model
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedDebtUser(t *testing.T, id, quota, debt int) {
+	t.Helper()
+	require.NoError(t, DB.Unscoped().Where("id = ?", id).Delete(&User{}).Error)
+	require.NoError(t, DB.Create(&User{
+		Id:       id,
+		Username: "debt_user_" + strconv.Itoa(id),
+		AffCode:  "aff_" + strconv.Itoa(id),
+		Quota:    quota,
+		Debt:     debt,
+	}).Error)
+}
+
+func reloadDebtUser(t *testing.T, id int) User {
+	t.Helper()
+	var u User
+	require.NoError(t, DB.Where("id = ?", id).First(&u).Error)
+	return u
+}
+
+// FR-015：结算扣费时余额不足，余额清零，不足部分记入 debt，余额永不为负。
+func TestSettleWalletChargeWithDebt(t *testing.T) {
+	cases := []struct {
+		name          string
+		quota         int
+		charge        int
+		wantShortfall int
+		wantQuota     int
+		wantDebt      int
+	}{
+		{name: "余额充足", quota: 100, charge: 30, wantShortfall: 0, wantQuota: 70, wantDebt: 0},
+		{name: "余额恰好", quota: 50, charge: 50, wantShortfall: 0, wantQuota: 0, wantDebt: 0},
+		{name: "余额不足记欠额", quota: 2, charge: 10, wantShortfall: 8, wantQuota: 0, wantDebt: 8},
+		{name: "零余额全额欠", quota: 0, charge: 5, wantShortfall: 5, wantQuota: 0, wantDebt: 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			seedDebtUser(t, 7001, tc.quota, 0)
+			shortfall, err := SettleWalletChargeWithDebt(7001, tc.charge)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantShortfall, shortfall)
+			u := reloadDebtUser(t, 7001)
+			assert.Equal(t, tc.wantQuota, u.Quota)
+			assert.Equal(t, tc.wantDebt, u.Debt)
+			assert.GreaterOrEqual(t, u.Quota, 0, "余额不能为负")
+		})
+	}
+}
+
+func TestSettleWalletChargeWithDebtRejectsNegative(t *testing.T) {
+	seedDebtUser(t, 7002, 100, 0)
+	_, err := SettleWalletChargeWithDebt(7002, -1)
+	require.Error(t, err)
+	u := reloadDebtUser(t, 7002)
+	assert.Equal(t, 100, u.Quota)
+}
+
+// FR-017：充值入账时优先抵扣 debt，剩余部分才进入 quota。
+func TestOffsetUserDebtOnTopUp(t *testing.T) {
+	cases := []struct {
+		name       string
+		quota      int
+		debt       int
+		amount     int
+		wantNet    int
+		wantRepaid int
+		wantQuota  int
+		wantDebt   int
+	}{
+		{name: "无欠额全额入账", quota: 10, debt: 0, amount: 100, wantNet: 100, wantRepaid: 0, wantQuota: 110, wantDebt: 0},
+		{name: "充值大于欠额", quota: 0, debt: 30, amount: 100, wantNet: 70, wantRepaid: 30, wantQuota: 70, wantDebt: 0},
+		{name: "充值恰好抵欠额", quota: 5, debt: 40, amount: 40, wantNet: 0, wantRepaid: 40, wantQuota: 5, wantDebt: 0},
+		{name: "充值小于欠额", quota: 5, debt: 100, amount: 40, wantNet: 0, wantRepaid: 40, wantQuota: 5, wantDebt: 60},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			seedDebtUser(t, 7003, tc.quota, tc.debt)
+			net, repaid, err := OffsetUserDebtOnTopUp(7003, tc.amount)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantNet, net)
+			assert.Equal(t, tc.wantRepaid, repaid)
+			u := reloadDebtUser(t, 7003)
+			assert.Equal(t, tc.wantQuota, u.Quota)
+			assert.Equal(t, tc.wantDebt, u.Debt)
+		})
+	}
+}
+
+func TestOffsetUserDebtOnTopUpRejectsNonPositive(t *testing.T) {
+	seedDebtUser(t, 7004, 0, 50)
+	_, _, err := OffsetUserDebtOnTopUp(7004, 0)
+	require.Error(t, err)
+	u := reloadDebtUser(t, 7004)
+	assert.Equal(t, 50, u.Debt, "非法入账不得改变 debt")
+}
+
+func TestGetUserDebt(t *testing.T) {
+	seedDebtUser(t, 7005, 0, 123)
+	debt, err := GetUserDebt(7005)
+	require.NoError(t, err)
+	assert.Equal(t, 123, debt)
+}

--- a/model/redemption.go
+++ b/model/redemption.go
@@ -142,6 +142,7 @@ func Redeem(key string, userId int) (quota int, err error) {
 		return 0, errors.New("无效的 user id")
 	}
 	redemption := &Redemption{}
+	var redeemNet int
 
 	keyCol := "`key`"
 	if common.UsingMainDatabase(common.DatabaseTypePostgreSQL) {
@@ -175,12 +176,19 @@ func Redeem(key string, userId int) (quota int, err error) {
 		if result.RowsAffected == 0 {
 			return errors.New("该兑换码已被使用")
 		}
-		return tx.Model(&User{}).Where("id = ?", userId).Update("quota", gorm.Expr("quota + ?", redemption.Quota)).Error
+		// FR-017：兑换入账时优先抵扣 debt，剩余部分才进入 quota。
+		net, _, err := applyTopUpWithDebtTx(tx, userId, redemption.Quota)
+		if err != nil {
+			return err
+		}
+		redeemNet = net
+		return nil
 	})
 	if err != nil {
 		common.SysError("redemption failed: " + err.Error())
 		return 0, ErrRedeemFailed
 	}
+	syncTopUpQuotaCache(userId, redeemNet)
 	RecordLog(userId, LogTypeTopup, fmt.Sprintf("通过兑换码充值 %s，兑换码ID %d", logger.LogQuota(redemption.Quota), redemption.Id))
 	return redemption.Quota, nil
 }

--- a/model/topup.go
+++ b/model/topup.go
@@ -113,6 +113,7 @@ func Recharge(referenceId string, customerId string, callerIp string) (err error
 
 	var quota float64
 	topUp := &TopUp{}
+	var stripeNet int
 
 	refCol := "`trade_no`"
 	if common.UsingMainDatabase(common.DatabaseTypePostgreSQL) {
@@ -141,10 +142,16 @@ func Recharge(referenceId string, customerId string, callerIp string) (err error
 		}
 
 		quota = topUp.Money * common.QuotaPerUnit
-		err = tx.Model(&User{}).Where("id = ?", topUp.UserId).Updates(map[string]interface{}{"stripe_customer": customerId, "quota": gorm.Expr("quota + ?", quota)}).Error
+		// 先更新 stripe_customer，再单独入账（FR-017：优先抵扣 debt）。
+		if err := tx.Model(&User{}).Where("id = ?", topUp.UserId).
+			Update("stripe_customer", customerId).Error; err != nil {
+			return err
+		}
+		net, _, err := applyTopUpWithDebtTx(tx, topUp.UserId, int(quota))
 		if err != nil {
 			return err
 		}
+		stripeNet = net
 
 		return nil
 	})
@@ -153,6 +160,7 @@ func Recharge(referenceId string, customerId string, callerIp string) (err error
 		common.SysError("topup failed: " + err.Error())
 		return errors.New("充值失败，请稍后重试")
 	}
+	syncTopUpQuotaCache(topUp.UserId, stripeNet)
 
 	RecordTopupLog(topUp.UserId, fmt.Sprintf("使用在线充值成功，充值金额: %v，支付金额：%d", logger.FormatQuota(int(quota)), topUp.Amount), callerIp, topUp.PaymentMethod, PaymentMethodStripe)
 
@@ -331,6 +339,7 @@ func ManualCompleteTopUp(tradeNo string, callerIp string) error {
 	var quotaToAdd int
 	var payMoney float64
 	var paymentMethod string
+	var manualNet int
 
 	err := DB.Transaction(func(tx *gorm.DB) error {
 		topUp := &TopUp{}
@@ -370,10 +379,12 @@ func ManualCompleteTopUp(tradeNo string, callerIp string) error {
 			return err
 		}
 
-		// 增加用户额度（立即写库，保持一致性）
-		if err := tx.Model(&User{}).Where("id = ?", topUp.UserId).Update("quota", gorm.Expr("quota + ?", quotaToAdd)).Error; err != nil {
+		// 增加用户额度（立即写库，保持一致性）；FR-017：优先抵扣 debt。
+		net, _, err := applyTopUpWithDebtTx(tx, topUp.UserId, quotaToAdd)
+		if err != nil {
 			return err
 		}
+		manualNet = net
 
 		userId = topUp.UserId
 		payMoney = topUp.Money
@@ -384,6 +395,7 @@ func ManualCompleteTopUp(tradeNo string, callerIp string) error {
 	if err != nil {
 		return err
 	}
+	syncTopUpQuotaCache(userId, manualNet)
 
 	// 事务外记录日志，避免阻塞
 	RecordTopupLog(userId, fmt.Sprintf("管理员补单成功，充值金额: %v，支付金额：%f", logger.FormatQuota(quotaToAdd), payMoney), callerIp, paymentMethod, "admin")
@@ -396,6 +408,7 @@ func RechargeCreem(referenceId string, customerEmail string, customerName string
 
 	var quota int64
 	topUp := &TopUp{}
+	var creemNet int
 
 	refCol := "`trade_no`"
 	if common.UsingMainDatabase(common.DatabaseTypePostgreSQL) {
@@ -426,10 +439,12 @@ func RechargeCreem(referenceId string, customerEmail string, customerName string
 		// Creem 直接使用 Amount 作为充值额度（整数）
 		quota = topUp.Amount
 
-		// 构建更新字段，优先使用邮箱，如果邮箱为空则使用用户名
-		updateFields := map[string]interface{}{
-			"quota": gorm.Expr("quota + ?", quota),
+		// FR-017：充值入账优先抵扣 debt，剩余进入 quota。
+		net, _, err := applyTopUpWithDebtTx(tx, topUp.UserId, int(quota))
+		if err != nil {
+			return err
 		}
+		creemNet = net
 
 		// 如果有客户邮箱，尝试更新用户邮箱（仅当用户邮箱为空时）
 		if customerEmail != "" {
@@ -442,13 +457,11 @@ func RechargeCreem(referenceId string, customerEmail string, customerName string
 
 			// 如果用户邮箱为空，则更新为支付时使用的邮箱
 			if user.Email == "" {
-				updateFields["email"] = customerEmail
+				if err := tx.Model(&User{}).Where("id = ?", topUp.UserId).
+					Update("email", customerEmail).Error; err != nil {
+					return err
+				}
 			}
-		}
-
-		err = tx.Model(&User{}).Where("id = ?", topUp.UserId).Updates(updateFields).Error
-		if err != nil {
-			return err
 		}
 
 		return nil
@@ -458,6 +471,7 @@ func RechargeCreem(referenceId string, customerEmail string, customerName string
 		common.SysError("creem topup failed: " + err.Error())
 		return errors.New("充值失败，请稍后重试")
 	}
+	syncTopUpQuotaCache(topUp.UserId, creemNet)
 
 	RecordTopupLog(topUp.UserId, fmt.Sprintf("使用Creem充值成功，充值额度: %v，支付金额：%.2f", quota, topUp.Money), callerIp, topUp.PaymentMethod, PaymentMethodCreem)
 
@@ -471,6 +485,7 @@ func RechargeWaffo(tradeNo string, callerIp string) (err error) {
 
 	var quotaToAdd int
 	topUp := &TopUp{}
+	var waffoNet int
 
 	refCol := "`trade_no`"
 	if common.UsingMainDatabase(common.DatabaseTypePostgreSQL) {
@@ -508,9 +523,12 @@ func RechargeWaffo(tradeNo string, callerIp string) (err error) {
 			return err
 		}
 
-		if err := tx.Model(&User{}).Where("id = ?", topUp.UserId).Update("quota", gorm.Expr("quota + ?", quotaToAdd)).Error; err != nil {
+		// FR-017：充值入账优先抵扣 debt。
+		net, _, err := applyTopUpWithDebtTx(tx, topUp.UserId, quotaToAdd)
+		if err != nil {
 			return err
 		}
+		waffoNet = net
 
 		return nil
 	})
@@ -519,6 +537,7 @@ func RechargeWaffo(tradeNo string, callerIp string) (err error) {
 		common.SysError("waffo topup failed: " + err.Error())
 		return errors.New("充值失败，请稍后重试")
 	}
+	syncTopUpQuotaCache(topUp.UserId, waffoNet)
 
 	if quotaToAdd > 0 {
 		RecordTopupLog(topUp.UserId, fmt.Sprintf("Waffo充值成功，充值额度: %v，支付金额: %.2f", logger.FormatQuota(quotaToAdd), topUp.Money), callerIp, topUp.PaymentMethod, PaymentMethodWaffo)
@@ -534,6 +553,7 @@ func RechargeWaffoPancake(tradeNo string) (err error) {
 
 	var quotaToAdd int
 	topUp := &TopUp{}
+	var pancakeNet int
 
 	refCol := "`trade_no`"
 	if common.UsingMainDatabase(common.DatabaseTypePostgreSQL) {
@@ -569,9 +589,12 @@ func RechargeWaffoPancake(tradeNo string) (err error) {
 			return err
 		}
 
-		if err := tx.Model(&User{}).Where("id = ?", topUp.UserId).Update("quota", gorm.Expr("quota + ?", quotaToAdd)).Error; err != nil {
+		// FR-017：充值入账优先抵扣 debt。
+		net, _, err := applyTopUpWithDebtTx(tx, topUp.UserId, quotaToAdd)
+		if err != nil {
 			return err
 		}
+		pancakeNet = net
 
 		return nil
 	})
@@ -580,6 +603,7 @@ func RechargeWaffoPancake(tradeNo string) (err error) {
 		common.SysError("waffo pancake topup failed: " + err.Error())
 		return errors.New("充值失败，请稍后重试")
 	}
+	syncTopUpQuotaCache(topUp.UserId, pancakeNet)
 
 	if quotaToAdd > 0 {
 		RecordLog(topUp.UserId, LogTypeTopup, fmt.Sprintf("Waffo Pancake充值成功，充值额度: %v，支付金额: %.2f", logger.FormatQuota(quotaToAdd), topUp.Money))

--- a/model/user.go
+++ b/model/user.go
@@ -37,6 +37,7 @@ type User struct {
 	VerificationCode string                     `json:"verification_code" gorm:"-:all"`                         // this field is only for Email verification, don't save it to database!
 	AccessToken      *string                    `json:"-" gorm:"type:char(32);column:access_token;uniqueIndex"` // this token is for system management
 	Quota            int                        `json:"quota" gorm:"type:int;default:0"`
+	Debt             int                        `json:"debt" gorm:"type:int;default:0;column:debt"` // 结算欠额：实际消耗超过余额时的欠款，>0 时阻止后续计费请求
 	UsedQuota        int                        `json:"used_quota" gorm:"type:int;default:0;column:used_quota"` // used quota
 	RequestCount     int                        `json:"request_count" gorm:"type:int;default:0;"`               // request number
 	Group            string                     `json:"group" gorm:"type:varchar(64);default:'default'"`

--- a/service/billing_session.go
+++ b/service/billing_session.go
@@ -344,6 +344,16 @@ func NewBillingSession(c *gin.Context, relayInfo *relaycommon.RelayInfo, preCons
 		return nil, types.NewError(fmt.Errorf("relayInfo is nil"), types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
 	}
 
+	// FR-016：用户存在未偿还的欠额（debt）时，阻止后续计费请求，直至充值抵扣清零。
+	if debt, err := model.GetUserDebt(relayInfo.UserId); err != nil {
+		return nil, types.NewError(err, types.ErrorCodeQueryDataError, types.ErrOptionWithSkipRetry())
+	} else if debt > 0 {
+		return nil, types.NewErrorWithStatusCode(
+			fmt.Errorf("账户存在欠额 %s，请充值后再使用", logger.FormatQuota(debt)),
+			types.ErrorCodeInsufficientUserQuota, http.StatusForbidden,
+			types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
+	}
+
 	pref := common.NormalizeBillingPreference(relayInfo.UserSetting.BillingPreference)
 
 	// 钱包路径需要先检查用户额度

--- a/service/debt_test.go
+++ b/service/debt_test.go
@@ -1,9 +1,16 @@
 package service
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/model"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/types"
+
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -100,4 +107,52 @@ func TestWalletFundingSettleNegativeDeltaIsRefund(t *testing.T) {
 	require.NoError(t, model.DB.Where("id = ?", 8004).First(&u).Error)
 	assert.Equal(t, 15, u.Quota, "负 delta 是退款，应增加 quota")
 	assert.Equal(t, 0, u.Debt, "退款不得影响 debt")
+}
+
+// FR-016 end-to-end: NewBillingSession 必须在选出任何资金来源之前，因用户存在
+// 未偿还 Debt 而拒绝请求，返回 ErrorCodeInsufficientUserQuota (403) 且标记不可重试。
+// 与 TestWalletFundingSettleThenDebtBlocksCondition 互补：前者只断言 settle 后 Debt>0
+// 信号被置位，这里驱动完整的工厂闸门（真实 gin.Context + RelayInfo），并验证
+// 充值抵扣清零后闸门重新打开。
+func TestNewBillingSessionBlocksOnOutstandingDebt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// 用户同时拥有充足 quota 与未偿还 debt：证明阻塞来自 debt 信号而非额度不足。
+	const uid = 8010
+	seedServiceDebtUser(t, uid, 1_000_000, 50)
+
+	relayInfo := &relaycommon.RelayInfo{
+		UserId:          uid,
+		OriginModelName: "gpt-test",
+		// wallet_only 规避订阅查询路径，让断言聚焦在 debt 闸门本身。
+		UserSetting: dto.UserSetting{BillingPreference: "wallet_only"},
+	}
+
+	t.Run("debt>0 blocks before funding selection", func(t *testing.T) {
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		session, apiErr := NewBillingSession(ctx, relayInfo, 100)
+		require.Nil(t, session, "debt>0 时不得创建计费会话")
+		require.NotNil(t, apiErr)
+		assert.Equal(t, types.ErrorCodeInsufficientUserQuota, apiErr.GetErrorCode())
+		assert.Equal(t, http.StatusForbidden, apiErr.StatusCode)
+		assert.True(t, types.IsSkipRetryError(apiErr), "debt 阻塞应标记不可重试")
+	})
+
+	t.Run("debt cleared reopens gate", func(t *testing.T) {
+		net, repaid, err := model.OffsetUserDebtOnTopUp(uid, 200)
+		require.NoError(t, err)
+		assert.Equal(t, 50, repaid, "充值应先偿还 debt 50")
+		assert.Equal(t, 150, net, "偿还后净入 quota 150")
+		debt, _ := model.GetUserDebt(uid)
+		require.Zero(t, debt, "充值后 debt 应清零")
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		// preConsumedQuota=0：跳过令牌与资金预扣，仅证明 debt 闸门不再阻塞，
+		// 会话正常创建并落到钱包资金来源。
+		session, apiErr := NewBillingSession(ctx, relayInfo, 0)
+		require.Nil(t, apiErr)
+		require.NotNil(t, session)
+		assert.Equal(t, 0, session.GetPreConsumedQuota())
+		assert.Equal(t, BillingSourceWallet, relayInfo.BillingSource)
+	})
 }

--- a/service/debt_test.go
+++ b/service/debt_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedServiceDebtUser(t *testing.T, id, quota, debt int) {
+	t.Helper()
+	require.NoError(t, model.DB.Unscoped().Where("id = ?", id).Delete(&model.User{}).Error)
+	require.NoError(t, model.DB.Create(&model.User{
+		Id:       id,
+		Username: "svc_debt_" + itoa(id),
+		AffCode:  "svc_aff_" + itoa(id),
+		Quota:    quota,
+		Debt:     debt,
+	}).Error)
+	t.Cleanup(func() {
+		_ = model.DB.Unscoped().Where("id = ?", id).Delete(&model.User{}).Error
+	})
+}
+
+func itoa(i int) string {
+	return string(rune('0' + i%10))
+}
+
+// FR-015（service 层链路）：WalletFunding.Settle 在余额不足时清零余额并把不足部分
+// 记入 user.Debt。这条路径正是 BillingSession 结算时实际触发 debt 的入口。
+func TestWalletFundingSettleCreatesDebtWhenInsufficient(t *testing.T) {
+	cases := []struct {
+		name        string
+		quota       int
+		delta       int
+		wantQuota   int
+		wantDebt    int
+		wantShort   bool
+	}{
+		{name: "余额充足仅扣 quota", quota: 100, delta: 30, wantQuota: 70, wantDebt: 0, wantShort: false},
+		{name: "余额不足清零并记 debt", quota: 2, delta: 10, wantQuota: 0, wantDebt: 8, wantShort: true},
+		{name: "零余额全额 debt", quota: 0, delta: 5, wantQuota: 0, wantDebt: 5, wantShort: true},
+		{name: "余额恰好不生 debt", quota: 50, delta: 50, wantQuota: 0, wantDebt: 0, wantShort: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			seedServiceDebtUser(t, 8001, tc.quota, 0)
+			funding := &WalletFunding{userId: 8001}
+			err := funding.Settle(tc.delta)
+			require.NoError(t, err)
+			var u model.User
+			require.NoError(t, model.DB.Where("id = ?", 8001).First(&u).Error)
+			assert.Equal(t, tc.wantQuota, u.Quota, "余额不匹配")
+			assert.Equal(t, tc.wantDebt, u.Debt, "debt 不匹配")
+			assert.GreaterOrEqual(t, u.Quota, 0, "余额不得为负")
+		})
+	}
+}
+
+// FR-016 的前提条件：debt > 0 时，NewBillingSession 在选源之前会基于
+// GetUserDebt 拒绝请求。这里验证该判定信号在 service 层 settle 后被正确置位。
+func TestWalletFundingSettleThenDebtBlocksCondition(t *testing.T) {
+	seedServiceDebtUser(t, 8002, 2, 0)
+	funding := &WalletFunding{userId: 8002}
+	require.NoError(t, funding.Settle(10))
+
+	debt, err := model.GetUserDebt(8002)
+	require.NoError(t, err)
+	assert.Equal(t, 8, debt, "debt>0 应触发 NewBillingSession 的阻塞分支")
+
+	// FR-017：后续充值应优先抵扣该 debt
+	net, repaid, err := model.OffsetUserDebtOnTopUp(8002, 100)
+	require.NoError(t, err)
+	assert.Equal(t, 92, net, "充值应先还 debt 8 再入 quota 92")
+	assert.Equal(t, 8, repaid)
+
+	debtAfter, err := model.GetUserDebt(8002)
+	require.NoError(t, err)
+	assert.Equal(t, 0, debtAfter, "充值后 debt 应清零，解除阻塞")
+}
+
+// delta=0 是 no-op，不触碰 quota 也不产生 debt。
+func TestWalletFundingSettleNoOpOnZeroDelta(t *testing.T) {
+	seedServiceDebtUser(t, 8003, 100, 0)
+	funding := &WalletFunding{userId: 8003}
+	require.NoError(t, funding.Settle(0))
+	var u model.User
+	require.NoError(t, model.DB.Where("id = ?", 8003).First(&u).Error)
+	assert.Equal(t, 100, u.Quota)
+	assert.Equal(t, 0, u.Debt)
+}
+
+// 退款路径（delta<0）不应被 debt 吞掉：必须增加 quota。
+func TestWalletFundingSettleNegativeDeltaIsRefund(t *testing.T) {
+	seedServiceDebtUser(t, 8004, 10, 0)
+	funding := &WalletFunding{userId: 8004}
+	require.NoError(t, funding.Settle(-5))
+	var u model.User
+	require.NoError(t, model.DB.Where("id = ?", 8004).First(&u).Error)
+	assert.Equal(t, 15, u.Quota, "负 delta 是退款，应增加 quota")
+	assert.Equal(t, 0, u.Debt, "退款不得影响 debt")
+}

--- a/service/funding_source.go
+++ b/service/funding_source.go
@@ -1,8 +1,10 @@
 package service
 
 import (
+	"fmt"
 	"time"
 
+	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/model"
 )
 
@@ -49,7 +51,15 @@ func (w *WalletFunding) Settle(delta int) error {
 		return nil
 	}
 	if delta > 0 {
-		return model.DecreaseUserQuota(w.userId, delta, false)
+		// FR-015：补扣时余额不足则清零余额并把不足部分记入 debt，余额永不为负。
+		shortfall, err := model.SettleWalletChargeWithDebt(w.userId, delta)
+		if err != nil {
+			return err
+		}
+		if shortfall > 0 {
+			common.SysLog(fmt.Sprintf("用户 %d 结算余额不足，欠额 %d 记入 debt", w.userId, shortfall))
+		}
+		return nil
 	}
 	return model.IncreaseUserQuota(w.userId, -delta, false)
 }


### PR DESCRIPTION
## ⚠️ AI-Assisted Notice / AI 协助声明

> 本 PR 代码由 AI 工具协助生成（git author `chillguyk5` 非项目核心维护者 CaIon / Calcium-Ion / JustSong / t0ng7u / Seefs）。描述已按 `.github/PULL_REQUEST_TEMPLATE.md` 人工整理并完成本地验证。请维护者重点复核**计费不变量**与**跨数据库兼容性**。

## 📝 变更描述 / Description

引入**结算欠额 (debt)** 机制，消除钱包结算时余额不足导致额度为负的隐患，并把充值入账改为「优先抵扣欠额」。

- **FR-015 负结算 → debt**：`WalletFunding.Settle` 补扣时余额不足，改调 `model.SettleWalletChargeWithDebt`：原子事务 + `lockForUpdate` 行锁，余额清零，不足部分累加到新列 `user.Debt`，**余额永不为负**。`charge<0` 直接拒绝（FR-008）。
- **FR-016 debt 阻塞**：`NewBillingSession` 在选择资金来源**之前**先 `GetUserDebt`；`debt>0` 立即返回 `ErrorCodeInsufficientUserQuota`(403, skip-retry, no-record-log)，直至充值清零。
- **FR-017 充值优先抵扣**：新增 `applyTopUpWithDebtTx`（事务内 `lockForUpdate`，先还 debt 剩余入 quota）+ `OffsetUserDebtOnTopUp`（封装事务+缓存同步）。所有入账路径改走该函数：易支付 / Stripe / Creem / Waffo / WaffoPancake / 管理员补单 / 兑换码 / 签到 / 管理员加额。退款路径（`delta<0`）**不**经过 debt 抵扣，避免退款被 debt 吞掉。
- **缓存同步**：settle 只扣减真正从 quota 扣掉的部分（`charge-shortfall`）；topup 只增加净入 quota 的 `net`，均在事务提交后同步 Redis。
- **跨数据库**：全程 GORM 方法 + `lockForUpdate(tx)` 助手（MySQL/PG 发 `FOR UPDATE`，SQLite 跳过），无 raw SQL；`Debt` 列 `gorm:"type:int;default:0"` 与 `Quota`/`UsedQuota` 一致。

## 🚀 变更类型 / Type of change
- [x] ✨ 新功能 (New feature)

## 🔗 关联任务 / Related Issue
- 无对应 Issue（特性规格见内部 `specs/001-billing-engine`）。如需开 Issue 关联请告知。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述已人工整理，未直接粘贴未处理 AI 输出。
- [x] **非重复提交:** 已检索 Issues/PRs，未见 debt accounting 重复提交。
- [ ] ~~Bug fix 说明~~（本 PR 非 bug fix）。
- [x] **变更理解:** 已理解 debt 在 settle → block → topup-repay 全链路的作用及对缓存/事务的影响。
- [x] **范围聚焦:** 仅 debt 相关改动 + 对应测试，无无关改动。
- [x] **本地验证:** `go test ./model/ ./service/ -run "Debt|Billing|Funding|Settle"` 全绿（见下方运行证明）。
- [x] **安全合规:** 无敏感凭据；遵循 `lockForUpdate` / quota-math 等项目规范。

## 📸 运行证明 / Proof of Work

```
$ go test ./model/ ./service/ -run "Debt|Billing|Funding|Settle" -count=1
ok  github.com/QuantumNous/new-api/model    4.9s
ok  github.com/QuantumNous/new-api/service  5.0s

# 新增 FR-016 端到端用例
=== RUN   TestNewBillingSessionBlocksOnOutstandingDebt
=== RUN   TestNewBillingSessionBlocksOnOutstandingDebt/debt>0_blocks_before_funding_selection
=== RUN   TestNewBillingSessionBlocksOnOutstandingDebt/debt_cleared_reopens_gate
--- PASS: TestNewBillingSessionBlocksOnOutstandingDebt (0.00s)
    --- PASS .../debt>0_blocks_before_funding_selection (0.00s)
    --- PASS .../debt_cleared_reopens_gate (0.00s)
PASS
```

## 🔍 待复核 / 已知限制 (Review Notes)

1. **`model/topup.go` `Recharge` 的 `int(quota)` 裸转换**：`quota=topUp.Money*common.QuotaPerUnit`，原代码把 float `quota` 直接交给 `gorm.Expr` 由 DB 截断；本 PR 改为 Go 端 `int(quota)` 截断后传入 `applyTopUpWithDebtTx`，**行为不变**（均为截断）。按项目规范宜走 `common.QuotaFromFloat`，留作 follow-up，不阻塞本 PR。
2. **FR-017 覆盖范围 — referral bonus**：本 PR 覆盖 recharge/redemption/admin-add/checkin 等入账路径。但 `model/user.go:577/634` 的**邀请人/被邀请人 referral bonus**（`common.QuotaForInvitee`）仍走 `IncreaseUserQuota`，**未**经过 debt 抵扣——即有欠额的用户收到 referral bonus 会进入 quota 但 debt 不减，`NewBillingSession` 仍会阻塞（bonus 被「卡住」）。spec FR-017 未把 referral 列入范围，**请确认是预期还是需补齐**。
3. **SC-008 性能基准未含**：未包含 `SettleWalletChargeWithDebt` / `PreConsumeBilling` 在真实 MySQL（row-lock）下的 p95<50ms 基准。SQLite in-memory 不符合该基准前置条件，待有 MySQL 实例后补。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent “outstanding debt” tracking for user accounts.
  * Added debt-first accounting for credits from top-ups, redemptions, check-ins, and manual quota adds (debt is repaid before usable quota increases).
  * Billing-session creation is now blocked when outstanding debt is positive.
* **Bug Fixes**
  * Improved quota/cache synchronization to reflect the net usable quota after debt repayment.
  * Prevents negative quota and correctly handles insufficient-funds settlement behavior.
* **Tests**
  * Expanded coverage for debt settlement, debt-first repayment, and billing-session gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->