### PR TITLE
test(channel-affinity): stabilize usage-cache stats tests (flaky on Windows)

### DIFF
--- a/service/channel_affinity_usage_cache_test.go
+++ b/service/channel_affinity_usage_cache_test.go
@@ -3,14 +3,28 @@ package service
 import (
 	"fmt"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/types"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
+
+var channelAffinityTestSeq atomic.Int64
+
+// affinityTestKeys trả về cặp (ruleName, keyFingerprint) duy nhất cho một lần chạy
+// test. Dùng atomic counter thay cho time.Now().UnixNano() để tránh collision key
+// cross-test trên nền tảng có độ phân giải wall-clock thô (Windows) — nguyên nhân
+// khiến các test usage-cache stats bị flaky (cache global TTL 600s tích lũy chéo).
+func affinityTestKeys(t *testing.T) (ruleName, keyFP string) {
+	t.Helper()
+	seq := channelAffinityTestSeq.Add(1)
+	ruleName = fmt.Sprintf("rule_%s_%d", t.Name(), seq)
+	keyFP = fmt.Sprintf("fp_%d", seq)
+	return ruleName, keyFP
+}
 
 func buildChannelAffinityStatsContextForTest(ruleName, usingGroup, keyFP string) *gin.Context {
 	rec := httptest.NewRecorder()
@@ -26,9 +40,8 @@ func buildChannelAffinityStatsContextForTest(ruleName, usingGroup, keyFP string)
 }
 
 func TestObserveChannelAffinityUsageCacheByRelayFormat_ClaudeMode(t *testing.T) {
-	ruleName := fmt.Sprintf("rule_%d", time.Now().UnixNano())
+	ruleName, keyFP := affinityTestKeys(t)
 	usingGroup := "default"
-	keyFP := fmt.Sprintf("fp_%d", time.Now().UnixNano())
 	ctx := buildChannelAffinityStatsContextForTest(ruleName, usingGroup, keyFP)
 
 	usage := &dto.Usage{
@@ -53,9 +66,8 @@ func TestObserveChannelAffinityUsageCacheByRelayFormat_ClaudeMode(t *testing.T) 
 }
 
 func TestObserveChannelAffinityUsageCacheByRelayFormat_MixedMode(t *testing.T) {
-	ruleName := fmt.Sprintf("rule_%d", time.Now().UnixNano())
+	ruleName, keyFP := affinityTestKeys(t)
 	usingGroup := "default"
-	keyFP := fmt.Sprintf("fp_%d", time.Now().UnixNano())
 	ctx := buildChannelAffinityStatsContextForTest(ruleName, usingGroup, keyFP)
 
 	openAIUsage := &dto.Usage{
@@ -83,9 +95,8 @@ func TestObserveChannelAffinityUsageCacheByRelayFormat_MixedMode(t *testing.T) {
 }
 
 func TestObserveChannelAffinityUsageCacheByRelayFormat_UnsupportedModeKeepsEmpty(t *testing.T) {
-	ruleName := fmt.Sprintf("rule_%d", time.Now().UnixNano())
+	ruleName, keyFP := affinityTestKeys(t)
 	usingGroup := "default"
-	keyFP := fmt.Sprintf("fp_%d", time.Now().UnixNano())
 	ctx := buildChannelAffinityStatsContextForTest(ruleName, usingGroup, keyFP)
 
 	usage := &dto.Usage{


### PR DESCRIPTION
## ⚠️ AI-Assisted Notice / AI 协助声明

> 本 PR 代码由 AI 工具协助生成（git author `chillguyk5` 非项目核心维护者 CaIon/Calcium-Ion/JustSong/t0ng7u/Seefs）。描述已人工整理并完成本地验证。

## 📝 变更描述 / Description

稳定 `service/channel_affinity_usage_cache_test.go` 中 2 个 flaky 测试（及同文件的 `_ClaudeMode`，同模式）：
- `TestObserveChannelAffinityUsageCacheByRelayFormat_MixedMode`
- `TestObserveChannelAffinityUsageCacheByRelayFormat_UnsupportedModeKeepsEmpty`

**Root cause:** 3 个测试用 `time.Now().UnixNano()` 生成 cache key。在 wall-clock 粒度较粗的平台（典型为 Windows），两个在同一 tick 启动的测试得到**相同纳秒** → 相同 `(ruleName, keyFingerprint)` → 全局 usage-cache-stats 缓存（TTL 600s）里**相同 entryKey** → 计数跨测试累加：`_ClaudeMode`(Total=1) + `_MixedMode`(2 次 observe) → `_MixedMode` 读到 `Total=3` 而非 2 → `require.EqualValues(2, stats.Total)` 失败。

**Fix:** 用包级 `atomic.Int64` 计数器（`channelAffinityTestSeq`）+ `t.Name()` 替换 `time.Now().UnixNano()`，生成「按测试 + 按调用」唯一的 key，不依赖时钟。新增 helper `affinityTestKeys(t)`。**仅测试改动，不触碰生产代码。**

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (flaky test) — test-only，无产品行为变更

## 🔗 关联任务 / Related Issue
- 无对应 Issue（测试稳定化，自包含）。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述已人工整理。
- [x] **非重复提交:** 已检索，未见 channel-affinity flaky 修复。
- [x] **Bug fix 说明:** 本 PR 为测试稳定化（非产品 bug），无对应产品 Issue。
- [x] **变更理解 / 范围聚焦 / 本地验证 / 安全合规.**

## 📸 运行证明 / Proof of Work

```
$ go test ./service/ -run "ChannelAffinity" -count=10 -timeout 180s
ok  github.com/QuantumNous/new-api/service  4.2s   # 10×, 无 flake

$ go test ./service/ -count=1 -timeout 300s   # clean main 全量
ok  github.com/QuantumNous/new-api/service  4.8s
```

## 🔍 Note

`service/channel_affinity_template_test.go` 仍用 `time.Now().UnixNano()`（lines 207/242/282）作 `affinityValue`/`cacheKeySuffix`。未被报告 flaky，本 PR 不动以避免范围蔓延；如后续 flake 可另开 follow-up 加固。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved channel-affinity usage-cache test reliability by replacing time-based test identifiers with deterministic, concurrency-safe identifiers.
  * Preserved existing cache statistics assertions while reducing potential test flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->