### PR TITLE
fix(channel): case-insensitive model identity and keep mapping sources routable

### DIFF
--- a/controller/channel_upstream_update.go
+++ b/controller/channel_upstream_update.go
@@ -97,6 +97,25 @@ func normalizeModelNames(models []string) []string {
 	}))
 }
 
+// modelIdentityKey folds model IDs for equality checks so casing-only drift
+// (DeepSeek-V3.1 vs deepseek-v3.1) is not treated as remove+add churn.
+func modelIdentityKey(model string) string {
+	return strings.ToLower(strings.TrimSpace(model))
+}
+
+func modelIdentitySet(models []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(models))
+	for _, modelName := range normalizeModelNames(models) {
+		set[modelIdentityKey(modelName)] = struct{}{}
+	}
+	return set
+}
+
+func modelIdentityInSet(model string, set map[string]struct{}) bool {
+	_, ok := set[modelIdentityKey(model)]
+	return ok
+}
+
 func mergeModelNames(base []string, appended []string) []string {
 	merged := normalizeModelNames(base)
 	seen := make(map[string]struct{}, len(merged))
@@ -175,59 +194,135 @@ func collectPendingUpstreamModelChangesFromModels(
 	ignoredModels []string,
 	modelMapping map[string]string,
 ) (pendingAddModels []string, pendingRemoveModels []string) {
-	localSet := make(map[string]struct{})
 	localModels = normalizeModelNames(localModels)
 	upstreamModels = normalizeModelNames(upstreamModels)
-	for _, modelName := range localModels {
-		localSet[modelName] = struct{}{}
-	}
-	upstreamSet := make(map[string]struct{}, len(upstreamModels))
-	for _, modelName := range upstreamModels {
-		upstreamSet[modelName] = struct{}{}
-	}
-
 	normalizedIgnoredModels := normalizeModelNames(ignoredModels)
 
-	redirectSourceSet := make(map[string]struct{}, len(modelMapping))
-	redirectTargetSet := make(map[string]struct{}, len(modelMapping))
+	// Identity sets use case-folded keys so provider casing churn is not
+	// reported as simultaneous remove + add of "the same" model.
+	localIdentitySet := modelIdentitySet(localModels)
+	upstreamIdentitySet := modelIdentitySet(upstreamModels)
+
+	redirectSourceIdentitySet := make(map[string]struct{}, len(modelMapping))
+	redirectTargetIdentitySet := make(map[string]struct{}, len(modelMapping))
 	for source, target := range modelMapping {
-		redirectSourceSet[source] = struct{}{}
-		redirectTargetSet[target] = struct{}{}
+		redirectSourceIdentitySet[modelIdentityKey(source)] = struct{}{}
+		redirectTargetIdentitySet[modelIdentityKey(target)] = struct{}{}
 	}
 
-	coveredUpstreamSet := make(map[string]struct{}, len(localSet)+len(redirectTargetSet))
-	for modelName := range localSet {
-		coveredUpstreamSet[modelName] = struct{}{}
+	// Upstream IDs already represented locally (exact local name or mapping target).
+	coveredUpstreamIdentitySet := make(map[string]struct{}, len(localIdentitySet)+len(redirectTargetIdentitySet))
+	for key := range localIdentitySet {
+		coveredUpstreamIdentitySet[key] = struct{}{}
 	}
-	for modelName := range redirectTargetSet {
-		coveredUpstreamSet[modelName] = struct{}{}
+	for key := range redirectTargetIdentitySet {
+		coveredUpstreamIdentitySet[key] = struct{}{}
 	}
 
-	pendingAdd := lo.Filter(upstreamModels, func(modelName string, _ int) bool {
-		if _, ok := coveredUpstreamSet[modelName]; ok {
-			return false
-		}
-		if lo.ContainsBy(normalizedIgnoredModels, func(ignoredModel string) bool {
+	isIgnored := func(modelName string) bool {
+		return lo.ContainsBy(normalizedIgnoredModels, func(ignoredModel string) bool {
 			if regexBody, ok := strings.CutPrefix(ignoredModel, "regex:"); ok {
 				matched, err := regexp.MatchString(strings.TrimSpace(regexBody), modelName)
 				return err == nil && matched
 			}
-			return ignoredModel == modelName
-		}) {
+			// Exact match keeps existing ignore semantics; identity match
+			// also suppresses case-only variants of an ignored name.
+			return ignoredModel == modelName || modelIdentityKey(ignoredModel) == modelIdentityKey(modelName)
+		})
+	}
+
+	pendingAdd := lo.Filter(upstreamModels, func(modelName string, _ int) bool {
+		if modelIdentityInSet(modelName, coveredUpstreamIdentitySet) {
+			return false
+		}
+		if isIgnored(modelName) {
 			return false
 		}
 		return true
 	})
 	pendingRemove := lo.Filter(localModels, func(modelName string, _ int) bool {
-		// Redirect source models are virtual aliases and should not be removed
-		// only because they are absent from upstream model list.
-		if _, ok := redirectSourceSet[modelName]; ok {
+		// Redirect source models are virtual aliases (client-facing standard
+		// names) and must not be flagged for removal solely because the
+		// upstream catalog never lists them.
+		if modelIdentityInSet(modelName, redirectSourceIdentitySet) {
 			return false
 		}
-		_, ok := upstreamSet[modelName]
-		return !ok
+		if modelIdentityInSet(modelName, upstreamIdentitySet) {
+			return false
+		}
+		return true
 	})
 	return normalizeModelNames(pendingAdd), normalizeModelNames(pendingRemove)
+}
+
+// ensureModelsIncludeMappingSources appends model_mapping keys that are missing
+// from the models CSV so client-facing standard names stay routable.
+func ensureModelsIncludeMappingSources(models []string, modelMapping map[string]string) []string {
+	if len(modelMapping) == 0 {
+		return normalizeModelNames(models)
+	}
+	sources := make([]string, 0, len(modelMapping))
+	for source := range modelMapping {
+		sources = append(sources, source)
+	}
+	return mergeModelNames(models, sources)
+}
+
+// rewriteMappingTargetsForCaseDrift updates mapping targets when apply removes
+// an old casing and adds the case-equivalent upstream ID in the same operation.
+func rewriteMappingTargetsForCaseDrift(
+	modelMapping map[string]string,
+	removedModels []string,
+	addedModels []string,
+) (map[string]string, bool) {
+	if len(modelMapping) == 0 || len(removedModels) == 0 {
+		return modelMapping, false
+	}
+	// Prefer the newly added spelling when identities collide.
+	addByIdentity := make(map[string]string, len(addedModels))
+	for _, added := range normalizeModelNames(addedModels) {
+		addByIdentity[modelIdentityKey(added)] = added
+	}
+	removedIdentity := modelIdentitySet(removedModels)
+
+	changed := false
+	next := make(map[string]string, len(modelMapping))
+	for source, target := range modelMapping {
+		targetKey := modelIdentityKey(target)
+		if _, removed := removedIdentity[targetKey]; removed {
+			if replacement, ok := addByIdentity[targetKey]; ok && replacement != target {
+				next[source] = replacement
+				changed = true
+				continue
+			}
+		}
+		next[source] = target
+	}
+	if !changed {
+		return modelMapping, false
+	}
+	return next, true
+}
+
+func serializeChannelModelMapping(modelMapping map[string]string) string {
+	if len(modelMapping) == 0 {
+		return ""
+	}
+	// Stable key order keeps Updates diffs deterministic in tests/logs.
+	keys := make([]string, 0, len(modelMapping))
+	for source := range modelMapping {
+		keys = append(keys, source)
+	}
+	slices.Sort(keys)
+	ordered := make(map[string]string, len(modelMapping))
+	for _, source := range keys {
+		ordered[source] = modelMapping[source]
+	}
+	raw, err := common.Marshal(ordered)
+	if err != nil {
+		return ""
+	}
+	return string(raw)
 }
 
 func collectPendingUpstreamModelChanges(channel *model.Channel, settings dto.ChannelOtherSettings) (pendingAddModels []string, pendingRemoveModels []string, err error) {
@@ -342,13 +437,20 @@ func fetchChannelUpstreamModelIDs(channel *model.Channel) ([]string, error) {
 	return normalizeModelNames(ids), nil
 }
 
-func updateChannelUpstreamModelSettings(channel *model.Channel, settings dto.ChannelOtherSettings, updateModels bool) error {
+func updateChannelUpstreamModelSettings(channel *model.Channel, settings dto.ChannelOtherSettings, updateModels bool, updateModelMapping bool) error {
 	channel.SetOtherSettings(settings)
 	updates := map[string]interface{}{
 		"settings": channel.OtherSettings,
 	}
 	if updateModels {
 		updates["models"] = channel.Models
+	}
+	if updateModelMapping {
+		if channel.ModelMapping == nil {
+			updates["model_mapping"] = ""
+		} else {
+			updates["model_mapping"] = *channel.ModelMapping
+		}
 	}
 	return model.DB.Model(&model.Channel{}).Where("id = ?", channel.Id).Updates(updates).Error
 }
@@ -371,7 +473,7 @@ func checkAndPersistChannelUpstreamModelUpdates(
 	pendingAddModels, pendingRemoveModels, fetchErr := collectPendingUpstreamModelChanges(channel, *settings)
 	settings.UpstreamModelUpdateLastCheckTime = now
 	if fetchErr != nil {
-		if err = updateChannelUpstreamModelSettings(channel, *settings, false); err != nil {
+		if err = updateChannelUpstreamModelSettings(channel, *settings, false, false); err != nil {
 			return false, 0, err
 		}
 		return false, 0, fetchErr
@@ -380,9 +482,11 @@ func checkAndPersistChannelUpstreamModelUpdates(
 	if allowAutoApply && settings.UpstreamModelUpdateAutoSyncEnabled && len(pendingAddModels) > 0 {
 		originModels := normalizeModelNames(channel.GetModels())
 		mergedModels := mergeModelNames(originModels, pendingAddModels)
-		if len(mergedModels) > len(originModels) {
+		// Keep client-facing mapping keys present after auto-add so abilities stay routable.
+		mergedModels = ensureModelsIncludeMappingSources(mergedModels, normalizeChannelModelMapping(channel))
+		if !slices.Equal(originModels, mergedModels) {
 			channel.Models = strings.Join(mergedModels, ",")
-			autoAdded = len(mergedModels) - len(originModels)
+			autoAdded = len(subtractModelNames(mergedModels, originModels))
 			modelsChanged = true
 		}
 		settings.UpstreamModelUpdateLastDetectedModels = []string{}
@@ -391,7 +495,7 @@ func checkAndPersistChannelUpstreamModelUpdates(
 	}
 	settings.UpstreamModelUpdateLastRemovedModels = pendingRemoveModels
 
-	if err = updateChannelUpstreamModelSettings(channel, *settings, modelsChanged); err != nil {
+	if err = updateChannelUpstreamModelSettings(channel, *settings, modelsChanged, false); err != nil {
 		return false, autoAdded, err
 	}
 	if modelsChanged {
@@ -820,8 +924,34 @@ func applyChannelUpstreamModelUpdates(
 	removeModels := intersectModelNames(removeModelsInput, pendingRemoveModels)
 	removeModels = subtractModelNames(removeModels, addModels)
 
+	modelMapping := normalizeChannelModelMapping(channel)
+	// Never drop client-facing standard names (mapping sources) via upstream apply.
+	// Identity match (case-insensitive) so a source like "DeepSeek-V3.1" still
+	// protects "deepseek-v3.1" if they ever land in the remove list together.
+	if len(modelMapping) > 0 {
+		sourceIdentity := make(map[string]struct{}, len(modelMapping))
+		for source := range modelMapping {
+			sourceIdentity[modelIdentityKey(source)] = struct{}{}
+		}
+		removeModels = lo.Filter(normalizeModelNames(removeModels), func(modelName string, _ int) bool {
+			return !modelIdentityInSet(modelName, sourceIdentity)
+		})
+	}
+
+	// Case-only renames: rewrite mapping targets before models change so
+	// request-time redirects keep pointing at a live upstream ID.
+	mappingChanged := false
+	if rewritten, ok := rewriteMappingTargetsForCaseDrift(modelMapping, removeModels, addModels); ok {
+		modelMapping = rewritten
+		serialized := serializeChannelModelMapping(modelMapping)
+		channel.ModelMapping = &serialized
+		mappingChanged = true
+	}
+
 	originModels := normalizeModelNames(channel.GetModels())
 	nextModels := applySelectedModelChanges(originModels, addModels, removeModels)
+	// Always keep mapping sources in models so abilities stay routable.
+	nextModels = ensureModelsIncludeMappingSources(nextModels, modelMapping)
 	modelsChanged = !slices.Equal(originModels, nextModels)
 	if modelsChanged {
 		channel.Models = strings.Join(nextModels, ",")
@@ -837,7 +967,7 @@ func applyChannelUpstreamModelUpdates(
 	settings.UpstreamModelUpdateLastRemovedModels = remainingRemoveModels
 	settings.UpstreamModelUpdateLastCheckTime = common.GetTimestamp()
 
-	if err := updateChannelUpstreamModelSettings(channel, settings, modelsChanged); err != nil {
+	if err := updateChannelUpstreamModelSettings(channel, settings, modelsChanged, mappingChanged); err != nil {
 		return nil, nil, nil, nil, false, err
 	}
 

--- a/controller/channel_upstream_update_test.go
+++ b/controller/channel_upstream_update_test.go
@@ -198,3 +198,83 @@ func TestDetectAllChannelUpstreamModelUpdatesRejectsExistingActiveTask(t *testin
 	require.Contains(t, recorder.Body.String(), existing.TaskID)
 	require.Contains(t, recorder.Body.String(), "已有模型更新任务正在运行或等待中")
 }
+
+func TestCollectPendingUpstreamModelChangesFromModels_CaseInsensitiveIdentity(t *testing.T) {
+	// Local uses mixed-case provider IDs; upstream returns lowercased same IDs.
+	// Must not report remove+add churn for the same logical models.
+	pendingAdd, pendingRemove := collectPendingUpstreamModelChangesFromModels(
+		[]string{"DeepSeek-V3.1", "Meta-Llama-3.3-70B-Instruct", "gemma-4-31B-it"},
+		[]string{"deepseek-v3.1", "meta-llama-3.3-70b-instruct", "gemma-4-31b-it"},
+		nil,
+		map[string]string{
+			"deepseek-v3.1": "DeepSeek-V3.1",
+			"llama-3.3-70b":  "Meta-Llama-3.3-70B-Instruct",
+			"gemma-4-31b":    "gemma-4-31B-it",
+		},
+	)
+
+	require.Empty(t, pendingAdd)
+	require.Empty(t, pendingRemove)
+}
+
+func TestCollectPendingUpstreamModelChangesFromModels_MappingSourceNotRemoved(t *testing.T) {
+	// Standard client names live only via mapping; upstream never lists them.
+	pendingAdd, pendingRemove := collectPendingUpstreamModelChangesFromModels(
+		[]string{"deepseek-v3.1", "DeepSeek-V3.1", "stale-gone"},
+		[]string{"DeepSeek-V3.1", "new-upstream"},
+		nil,
+		map[string]string{
+			"deepseek-v3.1": "DeepSeek-V3.1",
+		},
+	)
+
+	require.Equal(t, []string{"new-upstream"}, pendingAdd)
+	require.Equal(t, []string{"stale-gone"}, pendingRemove)
+}
+
+func TestCollectPendingUpstreamModelChangesFromModels_MappingTargetCoversUpstream(t *testing.T) {
+	// models list only has standard names; mapping targets cover upstream IDs.
+	pendingAdd, pendingRemove := collectPendingUpstreamModelChangesFromModels(
+		[]string{"llama-3.3-70b", "gemma-4-31b"},
+		[]string{"Meta-Llama-3.3-70B-Instruct", "gemma-4-31B-it"},
+		nil,
+		map[string]string{
+			"llama-3.3-70b": "Meta-Llama-3.3-70B-Instruct",
+			"gemma-4-31b":   "gemma-4-31B-it",
+		},
+	)
+
+	require.Empty(t, pendingAdd)
+	require.Empty(t, pendingRemove)
+}
+
+func TestEnsureModelsIncludeMappingSources(t *testing.T) {
+	result := ensureModelsIncludeMappingSources(
+		[]string{"DeepSeek-V3.1"},
+		map[string]string{
+			"deepseek-v3.1": "DeepSeek-V3.1",
+			"llama-3.3-70b":  "Meta-Llama-3.3-70B-Instruct",
+		},
+	)
+	require.ElementsMatch(t, []string{"DeepSeek-V3.1", "deepseek-v3.1", "llama-3.3-70b"}, result)
+}
+
+func TestRewriteMappingTargetsForCaseDrift(t *testing.T) {
+	mapping := map[string]string{
+		"deepseek-v3.1": "DeepSeek-V3.1",
+		"gemma-4-31b":   "gemma-4-31B-it",
+	}
+	next, changed := rewriteMappingTargetsForCaseDrift(
+		mapping,
+		[]string{"DeepSeek-V3.1", "gemma-4-31B-it"},
+		[]string{"deepseek-v3.1", "gemma-4-31b-it"},
+	)
+	require.True(t, changed)
+	require.Equal(t, "deepseek-v3.1", next["deepseek-v3.1"])
+	require.Equal(t, "gemma-4-31b-it", next["gemma-4-31b"])
+}
+
+func TestModelIdentityKey(t *testing.T) {
+	require.Equal(t, "deepseek-v3.1", modelIdentityKey(" DeepSeek-V3.1 "))
+	require.Equal(t, modelIdentityKey("GPT-OSS-120B"), modelIdentityKey("gpt-oss-120b"))
+}

--- a/model/ability.go
+++ b/model/ability.go
@@ -193,8 +193,36 @@ func filterAbilitiesByRequestPathAndModel(abilities []Ability, requestPath strin
 	return filtered
 }
 
+
+// ModelNamesForAbilities returns the model names that should create ability
+// rows: channel.Models plus every model_mapping source key. Mapping sources are
+// the client-facing standard names; without them, requests that use those names
+// cannot select this channel even though ModelMappedHelper would rewrite them.
+func (channel *Channel) ModelNamesForAbilities() []string {
+	models := make([]string, 0)
+	seen := make(map[string]struct{})
+	add := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		models = append(models, name)
+	}
+	for _, modelName := range strings.Split(channel.Models, ",") {
+		add(modelName)
+	}
+	for source := range channel.GetModelMappingMap() {
+		add(source)
+	}
+	return models
+}
+
 func (channel *Channel) AddAbilities(tx *gorm.DB) error {
-	models_ := strings.Split(channel.Models, ",")
+	models_ := channel.ModelNamesForAbilities()
 	groups_ := strings.Split(channel.Group, ",")
 	abilitySet := make(map[string]struct{})
 	abilities := make([]Ability, 0, len(models_))
@@ -266,7 +294,7 @@ func (channel *Channel) UpdateAbilities(tx *gorm.DB) error {
 	}
 
 	// Then add new abilities
-	models_ := strings.Split(channel.Models, ",")
+	models_ := channel.ModelNamesForAbilities()
 	groups_ := strings.Split(channel.Group, ",")
 	abilitySet := make(map[string]struct{})
 	abilities := make([]Ability, 0, len(models_))

--- a/model/channel.go
+++ b/model/channel.go
@@ -437,6 +437,10 @@ func BatchInsertChannels(channels []Channel) error {
 		}
 	}()
 
+	for i := range channels {
+		// Ensure client-facing mapping sources are stored before batch create/abilities.
+		_ = channels[i].EnsureModelsIncludeMappingSources()
+	}
 	for _, chunk := range lo.Chunk(channels, 50) {
 		if err := tx.Create(&chunk).Error; err != nil {
 			tx.Rollback()
@@ -506,6 +510,68 @@ func (channel *Channel) GetModelMapping() string {
 	return *channel.ModelMapping
 }
 
+
+// GetModelMappingMap parses model_mapping JSON into source -> target.
+// Invalid or empty mappings yield an empty map (never nil for range safety of callers that check len).
+func (channel *Channel) GetModelMappingMap() map[string]string {
+	result := make(map[string]string)
+	raw := strings.TrimSpace(channel.GetModelMapping())
+	if raw == "" || raw == "{}" {
+		return result
+	}
+	parsed := make(map[string]string)
+	if err := common.UnmarshalJsonStr(raw, &parsed); err != nil {
+		return result
+	}
+	for source, target := range parsed {
+		source = strings.TrimSpace(source)
+		target = strings.TrimSpace(target)
+		if source == "" || target == "" {
+			continue
+		}
+		result[source] = target
+	}
+	return result
+}
+
+// EnsureModelsIncludeMappingSources merges model_mapping source keys into
+// channel.Models so client-facing standard names stay present for abilities
+// and /v1/models. Returns true when Models changed.
+func (channel *Channel) EnsureModelsIncludeMappingSources() bool {
+	mapping := channel.GetModelMappingMap()
+	if len(mapping) == 0 {
+		return false
+	}
+	existing := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, modelName := range strings.Split(channel.Models, ",") {
+		modelName = strings.TrimSpace(modelName)
+		if modelName == "" {
+			continue
+		}
+		if _, ok := seen[modelName]; ok {
+			continue
+		}
+		seen[modelName] = struct{}{}
+		existing = append(existing, modelName)
+	}
+	changed := false
+	for source := range mapping {
+		if _, ok := seen[source]; ok {
+			continue
+		}
+		seen[source] = struct{}{}
+		existing = append(existing, source)
+		changed = true
+	}
+	if !changed {
+		return false
+	}
+	channel.Models = strings.Join(existing, ",")
+	return true
+}
+
+
 func (channel *Channel) GetStatusCodeMapping() string {
 	if channel.StatusCodeMapping == nil {
 		return ""
@@ -515,6 +581,8 @@ func (channel *Channel) GetStatusCodeMapping() string {
 
 func (channel *Channel) Insert() error {
 	var err error
+	// Ensure client-facing mapping sources are stored in models before abilities are built.
+	_ = channel.EnsureModelsIncludeMappingSources()
 	err = DB.Create(channel).Error
 	if err != nil {
 		return err
@@ -563,6 +631,8 @@ func (channel *Channel) Update() error {
 		}
 	}
 	var err error
+	// Ensure client-facing mapping sources are stored in models before abilities are rebuilt.
+	_ = channel.EnsureModelsIncludeMappingSources()
 	err = DB.Model(channel).Updates(channel).Error
 	if err != nil {
 		return err
@@ -806,7 +876,9 @@ func EditChannelByTag(tag string, newTag *string, modelMapping *string, models *
 		updatedTag = *newTag
 	}
 	if modelMapping != nil {
+		// Mapping source keys become ability rows; rebuild abilities when mapping changes.
 		updateData.ModelMapping = modelMapping
+		shouldReCreateAbilities = true
 	}
 	if models != nil && *models != "" {
 		shouldReCreateAbilities = true
@@ -837,6 +909,11 @@ func EditChannelByTag(tag string, newTag *string, modelMapping *string, models *
 		channels, err := GetChannelsByTag(updatedTag, false, false)
 		if err == nil {
 			for _, channel := range channels {
+				if channel.EnsureModelsIncludeMappingSources() {
+					if saveErr := DB.Model(&Channel{}).Where("id = ?", channel.Id).Update("models", channel.Models).Error; saveErr != nil {
+						common.SysLog(fmt.Sprintf("failed to persist mapping sources into models: channel_id=%d, tag=%s, error=%v", channel.Id, channel.GetTag(), saveErr))
+					}
+				}
 				err = channel.UpdateAbilities(nil)
 				if err != nil {
 					common.SysLog(fmt.Sprintf("failed to update abilities: channel_id=%d, tag=%s, error=%v", channel.Id, channel.GetTag(), err))

--- a/model/channel_mapping_test.go
+++ b/model/channel_mapping_test.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureModelsIncludeMappingSources(t *testing.T) {
+	mapping := `{"deepseek-v3.1":"DeepSeek-V3.1","llama-3.3-70b":"Meta-Llama-3.3-70B-Instruct"}`
+	ch := &Channel{
+		Models:       "DeepSeek-V3.1",
+		ModelMapping: &mapping,
+	}
+	require.True(t, ch.EnsureModelsIncludeMappingSources())
+	require.Contains(t, ch.Models, "deepseek-v3.1")
+	require.Contains(t, ch.Models, "llama-3.3-70b")
+	require.Contains(t, ch.Models, "DeepSeek-V3.1")
+	// second call is idempotent
+	require.False(t, ch.EnsureModelsIncludeMappingSources())
+}
+
+func TestModelNamesForAbilitiesIncludesMappingSources(t *testing.T) {
+	mapping := `{"glm-4.7":"zai-glm-4.7","gemma-4-31b":"gemma-4-31b"}`
+	ch := &Channel{
+		Models:       "zai-glm-4.7,gemma-4-31b,gpt-oss-120b",
+		ModelMapping: &mapping,
+	}
+	names := ch.ModelNamesForAbilities()
+	require.Contains(t, names, "zai-glm-4.7")
+	require.Contains(t, names, "gemma-4-31b")
+	require.Contains(t, names, "gpt-oss-120b")
+	require.Contains(t, names, "glm-4.7") // mapping source missing from models
+}
+
+func TestGetModelMappingMap(t *testing.T) {
+	mapping := `{ " alias ": " target ", "": "x", "y": "" }`
+	ch := &Channel{ModelMapping: &mapping}
+	m := ch.GetModelMappingMap()
+	require.Equal(t, map[string]string{"alias": "target"}, m)
+}

--- a/web/default/src/features/channels/components/channels-dialogs.tsx
+++ b/web/default/src/features/channels/components/channels-dialogs.tsx
@@ -16,6 +16,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
+import {
+  extractMappingSourceModels,
+  extractRedirectModels,
+} from '../lib'
 import { useChannels } from './channels-provider'
 import { BalanceQueryDialog } from './dialogs/balance-query-dialog'
 import { ChannelTestDialog } from './dialogs/channel-test-dialog'
@@ -52,10 +56,15 @@ export function ChannelsDialogs() {
         onOpenChange={(v) => !v && setOpen(null)}
       />
 
-      {/* Fetch Models Dialog */}
+      {/* Fetch Models Dialog — pass mapping so Removed/Existing tabs
+          protect client-facing aliases the same way as the edit drawer. */}
       <FetchModelsDialog
         open={open === 'fetch-models'}
         onOpenChange={(v) => !v && setOpen(null)}
+        redirectSourceModels={extractMappingSourceModels(
+          currentRow?.model_mapping || ''
+        )}
+        redirectModels={extractRedirectModels(currentRow?.model_mapping || '')}
       />
 
       {/* Ollama Models Dialog */}

--- a/web/default/src/features/channels/components/dialogs/fetch-models-dialog.tsx
+++ b/web/default/src/features/channels/components/dialogs/fetch-models-dialog.tsx
@@ -54,6 +54,17 @@ function normalizeModelNameList(models: readonly string[]): string[] {
   )
 }
 
+/** Case-folded identity for model IDs (matches backend modelIdentityKey). */
+function modelIdentityKey(model: string): string {
+  return normalizeModelName(model).toLowerCase()
+}
+
+function modelIdentitySet(models: readonly string[]): Set<string> {
+  return new Set(
+    models.map((m) => modelIdentityKey(m)).filter(Boolean)
+  )
+}
+
 type FetchModelsDialogProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -100,28 +111,33 @@ export function FetchModelsDialog({
 
   const { classificationSet, redirectOnlySet } = modelCategories
 
-  const fetchedModelSet = useMemo(
-    () => new Set(normalizeModelNameList(fetchedModels)),
+  const fetchedIdentitySet = useMemo(
+    () => modelIdentitySet(fetchedModels),
     [fetchedModels]
   )
 
   // Source keys in model_mapping are aliases, not real upstream IDs, so we
   // must skip them when computing "removed upstream" entries to avoid false
-  // positives.
-  const redirectSourceKeysSet = useMemo(
-    () => new Set(normalizeModelNameList(redirectSourceModels)),
+  // positives. Match case-insensitively to stay aligned with backend.
+  const redirectSourceIdentitySet = useMemo(
+    () => modelIdentitySet(redirectSourceModels),
     [redirectSourceModels]
   )
 
   const removedModels = useMemo(() => {
     const kw = searchKeyword.toLowerCase().trim()
     return normalizeModelNameList(selectedModels).filter((model) => {
-      if (fetchedModelSet.has(model)) return false
-      if (redirectSourceKeysSet.has(model)) return false
+      if (fetchedIdentitySet.has(modelIdentityKey(model))) return false
+      if (redirectSourceIdentitySet.has(modelIdentityKey(model))) return false
       if (!kw) return true
       return model.toLowerCase().includes(kw)
     })
-  }, [fetchedModelSet, redirectSourceKeysSet, searchKeyword, selectedModels])
+  }, [
+    fetchedIdentitySet,
+    redirectSourceIdentitySet,
+    searchKeyword,
+    selectedModels,
+  ])
 
   useEffect(() => {
     if (open && (activeChannel || customFetcher)) {
@@ -175,7 +191,12 @@ export function FetchModelsDialog({
     if (!activeChannel) return
     setIsSaving(true)
     try {
-      const modelsString = selectedModels.join(',')
+      // Keep mapping source aliases in models so abilities stay routable after save.
+      const modelsToSave = normalizeModelNameList([
+        ...selectedModels,
+        ...redirectSourceModels,
+      ])
+      const modelsString = modelsToSave.join(',')
       const response = await updateChannel(activeChannel.id, {
         models: modelsString,
       })
@@ -249,9 +270,18 @@ export function FetchModelsDialog({
     )
   }, [fetchedModels, searchKeyword])
 
-  // Helper to check if a model is considered "existing" (in selected or redirect)
+  // Existing = already in models list or covered by mapping target, compared
+  // with case-insensitive identity so casing-only upstream drift is not "new".
+  const existingIdentitySet = useMemo(() => {
+    const set = modelIdentitySet([
+      ...Array.from(classificationSet),
+      ...redirectSourceModels,
+    ])
+    return set
+  }, [classificationSet, redirectSourceModels])
+
   const isExistingModel = (model: string) =>
-    classificationSet.has(normalizeModelName(model))
+    existingIdentitySet.has(modelIdentityKey(model))
 
   // Separate new and existing models
   const newModels = filteredModels.filter((m) => !isExistingModel(m))


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

**背景**：渠道上游模型同步用精确字符串比对本地 `models` 与上游 ID。上游仅改大小写（如 `DeepSeek-V3.1` → `deepseek-v3.1`）时，会误报「删除 + 新增」；同时 `model_mapping` 的客户端标准名（source key）不参与 `abilities` 生成，用标准名请求时选不中渠道。standalone「获取模型」弹窗也未带上 mapping，与编辑抽屉行为不一致。

**改动**：

1. **差分身份**：`modelIdentityKey`（trim + lower）用于 pending add/remove；mapping target 覆盖上游 ID；mapping source 不因上游列表无此名而被标 removed。
2. **apply**：用身份集合保护 mapping source 不被移除；同一操作中 casing-only 的 remove+add 会改写 mapping target；合并 source 进 models 再落库。
3. **abilities / models 生命周期**：`ModelNamesForAbilities` = models ∪ mapping sources；`Insert` / `Update` / `BatchInsertChannels` / `EditChannelByTag` 在写 abilities 前 `EnsureModelsIncludeMappingSources`。
4. **前端**：standalone `FetchModelsDialog` 从当前渠道 mapping 传入 `redirectSourceModels` / `redirectModels`；Removed/Existing 大小写不敏感；保存时把 source 合并进 models。

**说明（按 AGENTS.md）**：提交者不是本仓库历史核心开发者；实现过程有 AI 辅助，PR 描述与测试结果已经人工核对整理。

关联：#6345（#4437 只解决了同步时未加载 mapping 字段，本 PR 补身份比对与 abilities 覆盖。）

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6345

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```text
$ go test ./controller/ -count=1 -run 'TestNormalize|TestCollectPending|TestEnsureModels|TestRewriteMapping|TestModelIdentity|TestDetectAll|TestApplySelected|TestMergeModel|TestSubtract|TestIntersect|TestSerialize'
ok  	github.com/QuantumNous/new-api/controller

$ go test ./model/ -count=1 -run 'TestEnsureModels|TestModelNames|TestGetModelMapping'
ok  	github.com/QuantumNous/new-api/model
```

新增/覆盖用例包括：大小写身份无 remove+add、mapping source 不被标 removed、mapping target 覆盖上游、ensure sources、rewrite mapping targets on case drift、abilities 含缺失 source。

未改 `docker-compose.yml` 与任何密钥配置；未对第三方付费模型做探测。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model matching is now case-insensitive, preventing unnecessary remove-and-add changes when capitalization differs.
  * Model mappings and their source models are preserved during channel updates and automatic synchronization.
  * Mapping targets are updated correctly when model capitalization changes.
  * Ability configuration now includes models referenced through mappings.

* **Improvements**
  * Fetch Models now preserves mapping-source aliases when saving selections.
  * Removed and existing model detection is more consistent across channel management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->