### PR TITLE
fix(profile): include Turnstile token for email binding

### DIFF
--- a/web/src/features/profile/__tests__/email-verification.test.ts
+++ b/web/src/features/profile/__tests__/email-verification.test.ts
@@ -1,0 +1,36 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import { buildEmailVerificationPath } from '../api'
+
+describe('profile email verification request', () => {
+  test('includes the Turnstile token when requesting an email bind code', () => {
+    const path = buildEmailVerificationPath(
+      'user+alias@example.com',
+      'turnstile-token'
+    )
+    const url = new URL(path, 'https://example.test')
+
+    assert.equal(url.pathname, '/api/verification')
+    assert.equal(url.searchParams.get('email'), 'user+alias@example.com')
+    assert.equal(url.searchParams.get('turnstile'), 'turnstile-token')
+  })
+})

--- a/web/src/features/profile/api.ts
+++ b/web/src/features/profile/api.ts
@@ -98,15 +98,19 @@ export async function generateAccessToken(): Promise<ApiResponse<string>> {
 /**
  * Send email verification code
  */
+export function buildEmailVerificationPath(
+  email: string,
+  turnstileToken: string
+) {
+  const params = new URLSearchParams({ email, turnstile: turnstileToken })
+  return `/api/verification?${params}`
+}
+
 export async function sendEmailVerification(
   email: string,
-  turnstileToken?: string
+  turnstileToken: string
 ): Promise<ApiResponse> {
-  const params = new URLSearchParams({ email })
-  if (turnstileToken) {
-    params.append('turnstile', turnstileToken)
-  }
-  const res = await api.get(`/api/verification?${params}`)
+  const res = await api.get(buildEmailVerificationPath(email, turnstileToken))
   return res.data
 }
 

--- a/web/src/features/profile/components/dialogs/email-bind-dialog.tsx
+++ b/web/src/features/profile/components/dialogs/email-bind-dialog.tsx
@@ -17,14 +17,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import { Loader2 } from 'lucide-react'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
 import { Dialog } from '@/components/dialog'
+import { Turnstile } from '@/components/turnstile'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { useTurnstile } from '@/features/auth/hooks/use-turnstile'
 import { useCountdown } from '@/hooks/use-countdown'
 
 import { sendEmailVerification, bindEmail } from '../../api'
@@ -51,6 +53,14 @@ export function EmailBindDialog({
   const [sendingCode, setSendingCode] = useState(false)
   const [email, setEmail] = useState('')
   const [code, setCode] = useState('')
+  const [turnstileWidgetKey, setTurnstileWidgetKey] = useState(0)
+  const {
+    isTurnstileEnabled,
+    turnstileSiteKey,
+    turnstileToken,
+    setTurnstileToken,
+    validateTurnstile,
+  } = useTurnstile()
   const {
     secondsLeft,
     isActive,
@@ -59,6 +69,15 @@ export function EmailBindDialog({
   } = useCountdown({
     initialSeconds: 60,
   })
+  const handleTurnstileExpire = useCallback(() => {
+    setTurnstileToken('')
+  }, [setTurnstileToken])
+  let sendButtonLabel = t('Send')
+  if (isActive) {
+    sendButtonLabel = `${secondsLeft}s`
+  } else if (sendingCode) {
+    sendButtonLabel = t('Sending...')
+  }
 
   const handleSendCode = async () => {
     if (!email || !email.includes('@')) {
@@ -66,9 +85,11 @@ export function EmailBindDialog({
       return
     }
 
+    if (!validateTurnstile()) return
+
     try {
       setSendingCode(true)
-      const response = await sendEmailVerification(email)
+      const response = await sendEmailVerification(email, turnstileToken)
 
       if (response.success) {
         toast.success(t('Verification code sent! Please check your email.'))
@@ -76,10 +97,14 @@ export function EmailBindDialog({
       } else {
         toast.error(response.message || t('Failed to send verification code'))
       }
-    } catch (_error) {
+    } catch {
       toast.error(t('Failed to send verification code'))
     } finally {
       setSendingCode(false)
+      if (isTurnstileEnabled) {
+        setTurnstileToken('')
+        setTurnstileWidgetKey((current) => current + 1)
+      }
     }
   }
 
@@ -104,7 +129,7 @@ export function EmailBindDialog({
       } else {
         toast.error(response.message || t('Failed to bind email'))
       }
-    } catch (_error) {
+    } catch {
       toast.error(t('Failed to bind email'))
     } finally {
       setLoading(false)
@@ -172,6 +197,17 @@ export function EmailBindDialog({
           />
         </div>
 
+        {isTurnstileEnabled && (
+          <div className='flex justify-center'>
+            <Turnstile
+              key={turnstileWidgetKey}
+              siteKey={turnstileSiteKey}
+              onVerify={setTurnstileToken}
+              onExpire={handleTurnstileExpire}
+            />
+          </div>
+        )}
+
         <div className='space-y-2'>
           <Label htmlFor='code'>{t('Verification Code')}</Label>
           <div className='flex gap-2'>
@@ -187,13 +223,9 @@ export function EmailBindDialog({
               type='button'
               variant='outline'
               onClick={handleSendCode}
-              disabled={sendingCode || isActive || !email}
+              disabled={sendingCode || isActive || !email || loading}
             >
-              {isActive
-                ? `${secondsLeft}s`
-                : sendingCode
-                  ? t('Sending...')
-                  : t('Send')}
+              {sendButtonLabel}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
修复新版前端个人资料页“绑定邮箱”弹窗在开启 Turnstile 时发送验证码未携带 token 的问题。

具体做法：
- 在绑定邮箱弹窗中接入现有 Turnstile 组件与校验状态。
- 发送邮箱验证码时显式传入 `turnstile` 参数。
- 验证码发送成功后重置 token 并重建组件，避免复用过期 token。
- 补充回归测试，覆盖邮箱验证码请求路径会携带 Turnstile token。

本 PR 由 AI 辅助整理，已由人工复核后提交。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6344

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- `bun test src/features/profile/__tests__/email-verification.test.ts`
- `oxfmt --check src/features/profile/components/dialogs/email-bind-dialog.tsx src/features/profile/api.ts src/features/profile/__tests__/email-verification.test.ts`
- `tsgo -b`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Turnstile verification to the email verification-code request flow, including verification tokens in outgoing requests.
  - The verification widget now reliably resets after each request attempt and when the challenge expires.
  - Send-button text and disabled state now reflect countdown and sending/loading status.

- **Bug Fixes**
  - Ensured Turnstile validation is completed before sending the verification code.

- **Tests**
  - Added coverage to confirm outgoing email verification URLs include both the email address and Turnstile token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->