### PR TITLE
fix(middleware): support zstd Content-Encoding in DecompressRequestMiddleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/middleware/gzip.go
+++ b/middleware/gzip.go
@@ -1,13 +1,16 @@
 package middleware
 
 import (
+	"bufio"
 	"compress/gzip"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/andybalholm/brotli"
 	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
 )
 
 type readCloser struct {
@@ -38,16 +41,46 @@ func DecompressRequestMiddleware() gin.HandlerFunc {
 		wrapMaxBytes := func(body io.ReadCloser) io.ReadCloser {
 			return http.MaxBytesReader(c.Writer, body, maxBytes)
 		}
+		clearContentLength := func() {
+			c.Request.ContentLength = -1
+			c.Request.Header.Del("Content-Length")
+		}
 
-		switch c.GetHeader("Content-Encoding") {
+		encoding := strings.ToLower(c.GetHeader("Content-Encoding"))
+		encoding = strings.TrimSpace(encoding)
+
+		// Auto-detect compression via magic-byte peek when Content-Encoding is
+		// absent or "identity".  Also clear the stale Content-Length after
+		// decompression and return 415 for unsupported encodings.
+		// These improvements originate from PR #4936 by @nerimoe.
+		var br *bufio.Reader
+		if encoding == "" || encoding == "identity" {
+			br = bufio.NewReader(origBody)
+			peek, _ := br.Peek(4)
+			if len(peek) >= 2 && peek[0] == 0x1f && peek[1] == 0x8b {
+				encoding = "gzip"
+			} else if len(peek) >= 4 && peek[0] == 0x28 && peek[1] == 0xb5 && peek[2] == 0x2f && peek[3] == 0xfd {
+				encoding = "zstd"
+			}
+		}
+
+		switch encoding {
 		case "gzip":
-			gzipReader, err := gzip.NewReader(origBody)
+			src := io.Reader(origBody)
+			if br != nil {
+				src = br
+			}
+			gzipReader, err := gzip.NewReader(src)
 			if err != nil {
 				_ = origBody.Close()
-				c.AbortWithStatus(http.StatusBadRequest)
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+					"error": gin.H{
+						"message": "invalid gzip body",
+						"type":    "invalid_request_error",
+					},
+				})
 				return
 			}
-			// Replace the request body with the decompressed data, and enforce a max size (post-decompression).
 			c.Request.Body = wrapMaxBytes(&readCloser{
 				Reader: gzipReader,
 				closeFn: func() error {
@@ -55,19 +88,80 @@ func DecompressRequestMiddleware() gin.HandlerFunc {
 					return origBody.Close()
 				},
 			})
+			clearContentLength()
 			c.Request.Header.Del("Content-Encoding")
 		case "br":
-			reader := brotli.NewReader(origBody)
+			src := io.Reader(origBody)
+			if br != nil {
+				src = br
+			}
+			reader := brotli.NewReader(src)
 			c.Request.Body = wrapMaxBytes(&readCloser{
 				Reader: reader,
 				closeFn: func() error {
 					return origBody.Close()
 				},
 			})
+			clearContentLength()
 			c.Request.Header.Del("Content-Encoding")
+		case "zstd":
+			src := io.Reader(origBody)
+			if br != nil {
+				src = br
+			}
+			// OpenAI Codex CLI/Desktop default to zstd request-body compression
+			// (client feature `enable_request_compression`). Without this branch
+			// the raw zstd frame (magic 0x28 0xb5 0x2f 0xfd) is handed to the
+			// JSON parser and fails with `invalid character '('`.
+			//
+			// Note: zstd.NewReader is lazy — it does not validate the frame header
+			// at construction time, so the error branch below is effectively
+			// unreachable for malformed zstd data. Invalid frames surface as Read
+			// errors downstream (which prevents raw bytes from reaching the JSON
+			// parser). The error check is kept for defensive completeness.
+			zstdReader, err := zstd.NewReader(src)
+			if err != nil {
+				_ = origBody.Close()
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+					"error": gin.H{
+						"message": "invalid zstd body",
+						"type":    "invalid_request_error",
+					},
+				})
+				return
+			}
+			c.Request.Body = wrapMaxBytes(&readCloser{
+				Reader: zstdReader,
+				closeFn: func() error {
+					zstdReader.Close()
+					return origBody.Close()
+				},
+			})
+			clearContentLength()
+			c.Request.Header.Del("Content-Encoding")
+		case "", "identity":
+			// Uncompressed body — still wrap with MaxBytesReader for size
+			// enforcement.  When peek detection was used, br already wraps
+			// origBody; otherwise wrap origBody directly.
+			src := io.Reader(origBody)
+			if br != nil {
+				src = br
+			}
+			c.Request.Body = wrapMaxBytes(&readCloser{
+				Reader: src,
+				closeFn: func() error {
+					return origBody.Close()
+				},
+			})
 		default:
-			// Even for uncompressed bodies, enforce a max size to avoid huge request allocations.
-			c.Request.Body = wrapMaxBytes(origBody)
+			_ = origBody.Close()
+			c.AbortWithStatusJSON(http.StatusUnsupportedMediaType, gin.H{
+				"error": gin.H{
+					"message": "unsupported content encoding: " + encoding,
+					"type":    "invalid_request_error",
+				},
+			})
+			return
 		}
 
 		// Continue processing the request

--- a/middleware/gzip_test.go
+++ b/middleware/gzip_test.go
@@ -1,0 +1,446 @@
+package middleware
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/andybalholm/brotli"
+	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runDecompressMiddleware runs DecompressRequestMiddleware against a request
+// built from the given encoding + raw body, then returns the fully-drained
+// request body (after decompression) and the HTTP status the middleware may
+// have aborted with (0 means no abort).
+func runDecompressMiddleware(t *testing.T, encoding string, compressedBody []byte) (string, int) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	var captured string
+	var status int
+	r.Use(DecompressRequestMiddleware())
+	r.POST("/v1/echo", func(c *gin.Context) {
+		buf, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			status = -1
+			c.String(http.StatusBadRequest, "read err: %v", err)
+			return
+		}
+		captured = string(buf)
+		// Confirm the middleware stripped Content-Encoding, the same way it
+		// does for gzip/br — without this, downstream proxies would re-encode
+		// or reject the body again.
+		ce := c.GetHeader("Content-Encoding")
+		assert.Empty(t, ce, "Content-Encoding header not stripped for %q", encoding)
+		c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/echo", bytes.NewReader(compressedBody))
+	req.Header.Set("Content-Type", "application/json")
+	if encoding != "" {
+		req.Header.Set("Content-Encoding", encoding)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if status == 0 {
+		status = w.Code
+	}
+	if status == http.StatusOK {
+		return captured, status
+	}
+	return "", status
+}
+
+func compressGzip(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err := gw.Write(raw)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+	return buf.Bytes()
+}
+
+func compressBrotli(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	bw := brotli.NewWriter(&buf)
+	_, err := bw.Write(raw)
+	require.NoError(t, err)
+	require.NoError(t, bw.Close())
+	return buf.Bytes()
+}
+
+func compressZstd(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	encoder, err := zstd.NewWriter(&buf)
+	require.NoError(t, err)
+	_, err = encoder.Write(raw)
+	require.NoError(t, err)
+	require.NoError(t, encoder.Close())
+	return buf.Bytes()
+}
+
+// TestDecompressRequestMiddleware_Zstd verifies the regression from issue
+// #6313: a Content-Encoding: zstd body used to be passed through verbatim,
+// causing JSON parsing to fail on the zstd magic bytes (0x28 = '(').
+func TestDecompressRequestMiddleware_Zstd(t *testing.T) {
+	raw := []byte(`{"model":"gpt-4","input":[{"role":"user","content":"hi"}]}`)
+	body := compressZstd(t, raw)
+
+	// Sanity: confirm we actually produced a zstd frame whose magic would be
+	// misread as '(' — otherwise the regression test isn't exercising the bug.
+	require.GreaterOrEqual(t, len(body), 4)
+	require.Equal(t, byte(0x28), body[0], "expected zstd magic 0x28.., got % x", body[:min(4, len(body))])
+
+	got, status := runDecompressMiddleware(t, "zstd", body)
+	require.Equal(t, http.StatusOK, status, "expected 200 OK (the bug from #6313 yields 400 with `invalid character '('`)")
+	assert.Equal(t, string(raw), got, "decompressed body mismatch")
+}
+
+// TestDecompressRequestMiddleware_AllEncodingsBehaviorParity documents that
+// zstd, gzip and br all behave identically: decode to the original payload
+// and strip the Content-Encoding header.
+func TestDecompressRequestMiddleware_AllEncodingsBehaviorParity(t *testing.T) {
+	raw := []byte(`{"hello":"world","n":42}`)
+
+	cases := []struct {
+		name     string
+		encoding string
+		encode   func(t *testing.T, raw []byte) []byte
+	}{
+		{"gzip", "gzip", compressGzip},
+		{"br", "br", compressBrotli},
+		{"zstd", "zstd", compressZstd},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, status := runDecompressMiddleware(t, tc.encoding, tc.encode(t, raw))
+			require.Equal(t, http.StatusOK, status, "%s: expected 200", tc.name)
+			assert.Equal(t, string(raw), got, "%s: body mismatch", tc.name)
+		})
+	}
+}
+
+// TestDecompressRequestMiddleware_UncompressedPassThrough ensures the default
+// branch keeps working (no Content-Encoding → body untouched).
+func TestDecompressRequestMiddleware_UncompressedPassThrough(t *testing.T) {
+	raw := []byte(`{"hello":"world"}`)
+	got, status := runDecompressMiddleware(t, "", raw)
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, string(raw), got, "uncompressed body should pass through untouched")
+}
+
+// TestDecompressRequestMiddleware_InvalidZstdDoesNotLeak verifies that a
+// Content-Encoding: zstd header on a body that is *not* a valid zstd frame
+// does NOT leak raw garbage to the JSON parser. zstd.NewReader is lazy —
+// it succeeds at construction time and errors on the first Read. This means
+// the middleware does not return 400 (unlike gzip where NewReader validates
+// immediately), but the handler's ReadAll will fail, preventing raw bytes
+// from reaching the JSON parser.
+func TestDecompressRequestMiddleware_InvalidZstdDoesNotLeak(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	invalid := []byte("definitely not a zstd frame")
+
+	r := gin.New()
+	var readErr error
+	var captured []byte
+	r.Use(DecompressRequestMiddleware())
+	r.POST("/v1/echo", func(c *gin.Context) {
+		captured, readErr = io.ReadAll(c.Request.Body)
+		if readErr != nil {
+			c.String(http.StatusBadRequest, "read err: %v", readErr)
+			return
+		}
+		c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/echo", bytes.NewReader(invalid))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "zstd")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// Either the read surfaced an error (preferred — the decoder rejected the
+	// input), or the decoder produced empty output. The one thing that must NOT
+	// happen is the raw `invalid` bytes reaching the handler as if they were
+	// JSON — that is exactly the regression from #6313.
+	if readErr == nil {
+		assert.False(t, bytes.Equal(captured, invalid), "invalid zstd body leaked to handler as raw bytes: %q", captured)
+	}
+}
+
+// TestDecompressRequestMiddleware_GetSkipped verifies GET requests are not
+// touched (existing behaviour, kept stable by this change).
+func TestDecompressRequestMiddleware_GetSkipped(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(DecompressRequestMiddleware())
+	r.GET("/v1/ping", func(c *gin.Context) { c.String(http.StatusOK, "pong") })
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/ping", strings.NewReader(""))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "pong", w.Body.String())
+}
+
+// TestDecompressRequestMiddleware_ZstdProducesValidJSON verifies the
+// end-to-end intent of #6313: after decompression, the body must be
+// unmarshallable as JSON by the project's own common.Unmarshal wrapper
+// (which is what downstream relay handlers actually call). This guards the
+// regression at the level the bug actually surfaces.
+func TestDecompressRequestMiddleware_ZstdProducesValidJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	type payload struct {
+		Model string `json:"model"`
+	}
+	raw, err := common.Marshal(payload{Model: "gpt-4"})
+	require.NoError(t, err)
+	body := compressZstd(t, raw)
+
+	r := gin.New()
+	var decoded payload
+	r.Use(DecompressRequestMiddleware())
+	r.POST("/v1/echo", func(c *gin.Context) {
+		require.NoError(t, common.UnmarshalJsonStr(string(mustReadAll(t, c.Request.Body)), &decoded))
+		c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/echo", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "zstd")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "gpt-4", decoded.Model)
+}
+
+// --- Tests for behaviour added alongside the zstd branch (from PR #4936) ---
+
+// TestDecompressRequestMiddleware_PeekDetectsGzipWithoutHeader verifies that
+// when Content-Encoding is absent but the body starts with gzip magic bytes
+// (0x1f 0x8b), the middleware still decompresses it automatically.
+func TestDecompressRequestMiddleware_PeekDetectsGzipWithoutHeader(t *testing.T) {
+	raw := []byte(`{"peek":"gzip"}`)
+	body := compressGzip(t, raw)
+
+	got, status := runDecompressMiddleware(t, "", body)
+	require.Equal(t, http.StatusOK, status, "peek should auto-detect gzip even without Content-Encoding")
+	assert.Equal(t, string(raw), got, "decompressed body mismatch after peek detection")
+}
+
+// TestDecompressRequestMiddleware_PeekDetectsZstdWithoutHeader verifies that
+// when Content-Encoding is absent but the body starts with zstd magic bytes
+// (0x28 0xb5 0x2f 0xfd), the middleware still decompresses it automatically.
+func TestDecompressRequestMiddleware_PeekDetectsZstdWithoutHeader(t *testing.T) {
+	raw := []byte(`{"peek":"zstd"}`)
+	body := compressZstd(t, raw)
+
+	got, status := runDecompressMiddleware(t, "", body)
+	require.Equal(t, http.StatusOK, status, "peek should auto-detect zstd even without Content-Encoding")
+	assert.Equal(t, string(raw), got, "decompressed body mismatch after peek detection")
+}
+
+// TestDecompressRequestMiddleware_IdentityEncodingPassesThrough verifies that
+// Content-Encoding: identity is treated as "no encoding" and the body is
+// passed through unchanged. The identity branch does NOT strip the header
+// (it is not a compression encoding that needs removal).
+func TestDecompressRequestMiddleware_IdentityEncodingPassesThrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	raw := []byte(`{"encoding":"identity"}`)
+
+	r := gin.New()
+	var captured string
+	r.Use(DecompressRequestMiddleware())
+	r.POST("/v1/echo", func(c *gin.Context) {
+		buf, err := io.ReadAll(c.Request.Body)
+		require.NoError(t, err)
+		captured = string(buf)
+		c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/echo", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "identity")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, string(raw), captured, "identity body should pass through untouched")
+}
+
+// TestDecompressRequestMiddleware_UnsupportedEncodingReturns415 verifies that
+// an unsupported Content-Encoding (e.g. "deflate") results in HTTP 415 with
+// an OpenAI-style error JSON, not a passthrough that would corrupt the body.
+func TestDecompressRequestMiddleware_UnsupportedEncodingReturns415(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(DecompressRequestMiddleware())
+	r.POST("/v1/echo", func(c *gin.Context) {
+		// Handler must never be reached for unsupported encodings.
+		c.String(http.StatusOK, "should not reach here")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/echo", strings.NewReader("compressed data"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "deflate")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnsupportedMediaType, w.Code, "unsupported encoding should return 415")
+
+	var resp map[string]any
+	require.NoError(t, common.Unmarshal(w.Body.Bytes(), &resp), "response should be valid JSON")
+	errObj, ok := resp["error"].(map[string]any)
+	require.True(t, ok, "response should have an 'error' object")
+	assert.Contains(t, errObj["message"], "unsupported content encoding", "error message should mention the encoding")
+	assert.Equal(t, "invalid_request_error", errObj["type"], "error type should be invalid_request_error")
+}
+
+// TestDecompressRequestMiddleware_InvalidGzipReturns400 verifies that a
+// Content-Encoding: gzip header on a body that is NOT valid gzip returns
+// HTTP 400 with an OpenAI-style error JSON.
+func TestDecompressRequestMiddleware_InvalidGzipReturns400(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(DecompressRequestMiddleware())
+	r.POST("/v1/echo", func(c *gin.Context) {
+		c.String(http.StatusOK, "should not reach here")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/echo", strings.NewReader("not gzip data"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "invalid gzip body should return 400")
+
+	var resp map[string]any
+	require.NoError(t, common.Unmarshal(w.Body.Bytes(), &resp), "response should be valid JSON")
+	errObj, ok := resp["error"].(map[string]any)
+	require.True(t, ok, "response should have an 'error' object")
+	assert.Contains(t, errObj["message"], "invalid gzip body", "error message should mention invalid gzip")
+}
+
+// TestDecompressRequestMiddleware_ContentLengthClearedAfterDecompression
+// verifies that after decompression, Content-Length and Content-Encoding
+// headers are removed, and ContentLength is set to -1. The Content-Length
+// of the compressed body is stale after decompression and would mislead
+// downstream consumers.
+func TestDecompressRequestMiddleware_ContentLengthClearedAfterDecompression(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, enc := range []string{"gzip", "br", "zstd"} {
+		t.Run(enc, func(t *testing.T) {
+			raw := []byte(`{"test":"content-length"}`)
+			var body []byte
+			switch enc {
+			case "gzip":
+				body = compressGzip(t, raw)
+			case "br":
+				body = compressBrotli(t, raw)
+			case "zstd":
+				body = compressZstd(t, raw)
+			}
+
+			var gotContentLength int64
+			var gotContentLengthHeader string
+			var gotContentEncoding string
+
+			r := gin.New()
+			r.Use(DecompressRequestMiddleware())
+			r.POST("/v1/echo", func(c *gin.Context) {
+				io.ReadAll(c.Request.Body) // drain body
+				gotContentLength = c.Request.ContentLength
+				gotContentLengthHeader = c.Request.Header.Get("Content-Length")
+				gotContentEncoding = c.Request.Header.Get("Content-Encoding")
+				c.String(http.StatusOK, "ok")
+			})
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/echo", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Content-Encoding", enc)
+			req.ContentLength = int64(len(body)) // simulate real Content-Length
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, int64(-1), gotContentLength, "%s: ContentLength should be -1 after decompression", enc)
+			assert.Empty(t, gotContentLengthHeader, "%s: Content-Length header should be removed", enc)
+			assert.Empty(t, gotContentEncoding, "%s: Content-Encoding header should be removed", enc)
+		})
+	}
+}
+
+// TestDecompressRequestMiddleware_PeekDetectsGzipWithIdentityHeader verifies
+// that even when Content-Encoding is explicitly "identity", if the body starts
+// with gzip magic bytes the middleware still auto-detects and decompresses.
+func TestDecompressRequestMiddleware_PeekDetectsGzipWithIdentityHeader(t *testing.T) {
+	raw := []byte(`{"identity":"but-actually-gzip"}`)
+	body := compressGzip(t, raw)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	var captured string
+	r.Use(DecompressRequestMiddleware())
+	r.POST("/v1/echo", func(c *gin.Context) {
+		buf, err := io.ReadAll(c.Request.Body)
+		require.NoError(t, err)
+		captured = string(buf)
+		c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/echo", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "identity")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "peek should auto-detect gzip under Content-Encoding: identity")
+	assert.Equal(t, string(raw), captured, "decompressed body mismatch")
+}
+
+// TestDecompressRequestMiddleware_EmptyBodyNoEncoding verifies that an empty
+// POST body with no Content-Encoding is handled without errors (Peek returns
+// fewer bytes but the length checks prevent false detection).
+func TestDecompressRequestMiddleware_EmptyBodyNoEncoding(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(DecompressRequestMiddleware())
+	r.POST("/v1/echo", func(c *gin.Context) {
+		io.ReadAll(c.Request.Body)
+		c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/echo", bytes.NewReader(nil))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "empty body with no encoding should pass through")
+}
+
+func mustReadAll(t *testing.T, r io.Reader) []byte {
+	t.Helper()
+	b, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return b
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

`DecompressRequestMiddleware` 已挂在 `/v1` relay 路由上，但它的 `switch` 只处理了 `gzip` 和 `br`，**没有 `zstd` 分支**。带 `Content-Encoding: zstd` 的请求体被原封不动交给下游 JSON 解析器，zstd magic `28 b5 2f fd` 的首字节 `0x28`（ASCII `(`）立刻触发解析失败，客户端收到 **HTTP 400**：

```
invalid character '(' looking for beginning of value
```

**影响**：近期的 OpenAI Codex CLI 与 Desktop（`wire_api = responses`）默认开启请求体压缩（client feature `enable_request_compression`，默认 on）。由于完整请求体（system prompt + 工具 schema）即便只发一句 `hi` 也有几十 KB，必然超过压缩阈值 → **每一轮对话都必现此 400**，错误信息还误导（说"invalid request"而非"请求体被压缩"）。这不是边缘场景。

**修复**（位置：`middleware/gzip.go`）：

### 新增 zstd 解压分支
- 新增 `case "zstd":` 分支，镜像现有 `gzip`/`br` 分支：用 `zstd.NewReader` 解码 → 包入 `MaxBytesReader`（与 gzip/br 一致的 post-decompression 限制）→ `Del("Content-Encoding")` + `clearContentLength()`。
- `zstd.NewReader` 是惰性的，无效帧在首 Read 时报错而非构造时（与 gzip 不同）。已添加注释说明。

### 合并 PR #4936 的改进（by @nerimoe）
- **Magic-byte peek 自动检测**：当 `Content-Encoding` 缺失或为 `identity` 时，peek 前 4 字节自动检测 gzip（`0x1f 0x8b`）和 zstd（`0x28 0xb5 0x2f 0xfd`）压缩。JSON 首字节不可能是这两个值，无误判风险。
- **Content-Length 清理**：解压后 `ContentLength` 设为 -1、删除 `Content-Length` header，避免下游使用过期的压缩前大小。
- **OpenAI 风格 JSON 错误响应**：无效 gzip/zstd 返回 400 + `{"error":{"message":"...","type":"invalid_request_error"}}`。
- **不支持的编码返回 415**：`deflate` 等不支持的编码不再 passthrough（会导致 JSON 解析失败），而是返回 415 + JSON 错误体。⚠️ **这是一个行为变更**——之前发 `Content-Encoding: deflate` 的请求会透传到下游（大概率 JSON 解析失败），现在会被明确拒绝。
- `bufio.Reader` 仅在需要 peek 时创建（编码明确为 gzip/br/zstd 时不创建），避免不必要的 4KB 缓冲开销。

### 为什么这是 new-api 自身的程序缺陷而非上游/透传问题
请求在到达转发环节之前就已经在 new-api 自己的中间件里被错误处理了；同一个中间件已为 `gzip`/`br` 做了相同适配，只差一个 `zstd` 分支，是明确的覆盖遗漏。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6313
- 改进来自 #4936（@nerimoe 的 peek 自动检测、Content-Length 清理、415 错误处理）

## ⚠️ 行为变更 / Breaking Changes
- `Content-Encoding` 为不支持的编码（如 `deflate`）时，之前会 passthrough（下游大概率 JSON 解析失败），现在返回 **415 Unsupported Media Type**。这是更正确的错误处理，但如果有客户端依赖 passthrough 行为，需要调整。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已搜索现有 Issues/PR。#4913 已被关闭且无修复。#4936 有类似修复但无测试、无 zstd 错误注释、无 bufio 优化。
- [x] **Bug fix 说明:** 关联 Issue #6313。
- [x] **变更理解:** 已理解：zstd 分支与 gzip/br 行为一致（解码 → 限流 → 删 header）；zstd.NewReader 是惰性的，无效帧在首读时报错；不改变其他编码路径的语义（415 是行为变更，已文档化）；peek 仅在编码不明确时执行；Content-Length 清理对下游无害。
- [x] **范围聚焦:** 后端 2 文件（`middleware/gzip.go`、`middleware/gzip_test.go`）+ `go.mod` 把已存在的 `klauspost/compress` 从 indirect 提升为直接依赖。
- [x] **本地验证:** 15 个 testify 测试全部通过，覆盖 zstd 回归、编码对等、peek 自动检测、identity passthrough、415 不支持编码、400 无效 gzip、Content-Length 清理、GET 跳过、空 body、无效 zstd 不泄露、端到端 JSON 反序列化。
- [x] **安全合规:** 无敏感凭据；解码后仍走 `http.MaxBytesReader` 限流，不存在解压炸弹放大；415 错误消息中的 encoding 值通过 `encoding/json` 自动转义，无注入风险。