### PR TITLE
fix(middleware): bind model rate limits to user group, not token group

### DIFF
--- a/middleware/model-rate-limit.go
+++ b/middleware/model-rate-limit.go
@@ -178,11 +178,12 @@ func ModelRequestRateLimit() func(c *gin.Context) {
 		totalMaxCount := setting.ModelRequestRateLimitCount
 		successMaxCount := setting.ModelRequestRateLimitSuccessCount
 
-		// 获取分组
-		group := common.GetContextKeyString(c, constant.ContextKeyTokenGroup)
-		if group == "" {
-			group = common.GetContextKeyString(c, constant.ContextKeyUserGroup)
-		}
+		// Rate limits are bound to the authenticated user group, not the
+		// token's routing group. Token group is a channel-selection
+		// preference; allowing it to pick the limit table lets a user in a
+		// restricted group (e.g. "paid") create a key with group "default"
+		// and fall through to the more lenient global limits.
+		group := common.GetContextKeyString(c, constant.ContextKeyUserGroup)
 
 		//获取分组的限流配置
 		groupTotalCount, groupSuccessCount, found := setting.GetGroupRateLimit(group)

--- a/middleware/model_rate_limit_test.go
+++ b/middleware/model_rate_limit_test.go
@@ -2,12 +2,122 @@ package middleware
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/setting"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func useModelRequestRateLimitSettings(t *testing.T, groupLimits map[string][2]int, globalTotal, globalSuccess int) {
+	t.Helper()
+
+	setting.ModelRequestRateLimitMutex.Lock()
+	prevEnabled := setting.ModelRequestRateLimitEnabled
+	prevDuration := setting.ModelRequestRateLimitDurationMinutes
+	prevTotal := setting.ModelRequestRateLimitCount
+	prevSuccess := setting.ModelRequestRateLimitSuccessCount
+	prevGroup := setting.ModelRequestRateLimitGroup
+
+	setting.ModelRequestRateLimitEnabled = true
+	setting.ModelRequestRateLimitDurationMinutes = 1
+	setting.ModelRequestRateLimitCount = globalTotal
+	setting.ModelRequestRateLimitSuccessCount = globalSuccess
+	setting.ModelRequestRateLimitGroup = groupLimits
+	setting.ModelRequestRateLimitMutex.Unlock()
+
+	t.Cleanup(func() {
+		setting.ModelRequestRateLimitMutex.Lock()
+		setting.ModelRequestRateLimitEnabled = prevEnabled
+		setting.ModelRequestRateLimitDurationMinutes = prevDuration
+		setting.ModelRequestRateLimitCount = prevTotal
+		setting.ModelRequestRateLimitSuccessCount = prevSuccess
+		setting.ModelRequestRateLimitGroup = prevGroup
+		setting.ModelRequestRateLimitMutex.Unlock()
+	})
+}
+
+func newModelRateLimitRouter(userID int, userGroup, tokenGroup string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/relay",
+		func(c *gin.Context) {
+			c.Set("id", userID)
+			common.SetContextKey(c, constant.ContextKeyUserGroup, userGroup)
+			common.SetContextKey(c, constant.ContextKeyTokenGroup, tokenGroup)
+		},
+		ModelRequestRateLimit(),
+		func(c *gin.Context) {
+			c.Status(http.StatusNoContent)
+		},
+	)
+	return router
+}
+
+func requestModelRateLimit(router http.Handler) *httptest.ResponseRecorder {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/relay", nil)
+	router.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func TestModelRequestRateLimitUsesUserGroupNotTokenGroup(t *testing.T) {
+	// paid users get a tight success limit; global (and any default token-group
+	// config) stays much looser. A key whose token.Group is "default" must
+	// still be constrained by the authenticated user's "paid" group.
+	useModelRequestRateLimitSettings(t, map[string][2]int{
+		"paid":    {0, 1},
+		"default": {0, 100},
+	}, 0, 100)
+	useRateLimitMiniRedis(t)
+
+	router := newModelRateLimitRouter(7, "paid", "default")
+
+	assert.Equal(t, http.StatusNoContent, requestModelRateLimit(router).Code)
+	assert.Equal(t, http.StatusTooManyRequests, requestModelRateLimit(router).Code,
+		"token group \"default\" must not bypass the user's \"paid\" rate limit")
+}
+
+func TestModelRequestRateLimitFallsBackToGlobalWhenUserGroupHasNoOverride(t *testing.T) {
+	useModelRequestRateLimitSettings(t, map[string][2]int{
+		"paid": {0, 1},
+	}, 0, 2)
+	useRateLimitMiniRedis(t)
+
+	// User is in "default"; only "paid" has an override, so global success=2 applies
+	// even if the token is labeled "paid".
+	router := newModelRateLimitRouter(8, "default", "paid")
+
+	assert.Equal(t, http.StatusNoContent, requestModelRateLimit(router).Code)
+	assert.Equal(t, http.StatusNoContent, requestModelRateLimit(router).Code)
+	assert.Equal(t, http.StatusTooManyRequests, requestModelRateLimit(router).Code,
+		"token group must not pull in another group's rate-limit override")
+}
+
+func TestModelRequestRateLimitUsesUserGroupInMemoryBackend(t *testing.T) {
+	// Group selection happens before the redis/memory branch; cover the memory
+	// path so a backend switch cannot reintroduce the token-group bypass.
+	useModelRequestRateLimitSettings(t, map[string][2]int{
+		"paid":    {0, 1},
+		"default": {0, 100},
+	}, 0, 100)
+
+	prevRedisEnabled := common.RedisEnabled
+	common.RedisEnabled = false
+	t.Cleanup(func() { common.RedisEnabled = prevRedisEnabled })
+
+	router := newModelRateLimitRouter(9, "paid", "default")
+
+	assert.Equal(t, http.StatusNoContent, requestModelRateLimit(router).Code)
+	assert.Equal(t, http.StatusTooManyRequests, requestModelRateLimit(router).Code,
+		"memory backend must also bind limits to the user group")
+}
 
 func TestModelRedisRateLimitUsesUTCRegardlessOfLocalTimezone(t *testing.T) {
 	redisServer, redisClient := useRateLimitMiniRedis(t)


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

`ModelRequestRateLimit` previously selected the group rate-limit table from `token.Group` first, falling back to the authenticated user group only when the token had no group.

Token group is a **channel-routing preference**, not an identity attribute. A user whose account is in a restricted group (e.g. `paid`) could create an API key with group `default` and be rate-limited by the looser global / default table instead of the `paid` limits.

This PR always binds model request rate limits to `ContextKeyUserGroup` (set from the user cache in `TokenAuth`). Token group continues to control channel selection via `ContextKeyUsingGroup` / distributor, unchanged.

Code was AI-assisted; the fix and tests were locally reviewed against AGENTS.md and the issue repro before opening.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6333

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```text
$ gofmt -l middleware/model-rate-limit.go middleware/model_rate_limit_test.go
# (empty)

$ go vet ./middleware/...
# (ok)

$ go test ./middleware/ -count=1 -run 'TestModelRequestRateLimit' -v
--- PASS: TestModelRequestRateLimitUsesUserGroupNotTokenGroup
--- PASS: TestModelRequestRateLimitFallsBackToGlobalWhenUserGroupHasNoOverride
--- PASS: TestModelRequestRateLimitUsesUserGroupInMemoryBackend
PASS

# Regression: restore pre-fix file, tests must fail
$ git checkout origin/main -- middleware/model-rate-limit.go
$ go test ./middleware/ -count=1 -run 'TestModelRequestRateLimit' -v
--- FAIL: TestModelRequestRateLimitUsesUserGroupNotTokenGroup
    expected 429, got 204  # token group "default" bypassed paid limit
--- FAIL: TestModelRequestRateLimitFallsBackToGlobalWhenUserGroupHasNoOverride
--- FAIL: TestModelRequestRateLimitUsesUserGroupInMemoryBackend
FAIL

# Restore fix → PASS again
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model request rate limits are now consistently applied based on the authenticated user’s group.
  * Prevents token routing groups from bypassing or incorrectly receiving another group’s rate-limit settings.
  * Requests correctly fall back to global limits when no override exists for the user’s group.
  * Behavior is consistent across supported rate-limit backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->