### PR TITLE
feat(service): 优化Claude缓存创建token处理逻辑

### DIFF
--- a/service/billing_usage.go
+++ b/service/billing_usage.go
@@ -129,9 +129,15 @@ func usageFromClaudeBillingUsage(billingUsage *dto.BillingUsage) *dto.Usage {
 	if cacheCreation5m == 0 {
 		cacheCreation5m = claudeUsage.ClaudeCacheCreation5mTokens
 	}
+	if cacheCreation5m == 0 && claudeUsage.CacheCreationInputTokens > 0 {
+		cacheCreation5m = claudeUsage.CacheCreationInputTokens
+	}
 	cacheCreation1h := claudeUsage.GetCacheCreation1hTokens()
 	if cacheCreation1h == 0 {
 		cacheCreation1h = claudeUsage.ClaudeCacheCreation1hTokens
+	}
+	if cacheCreation1h == 0 && claudeUsage.CacheCreationInputTokens > 0 && cacheCreation5m == 0 {
+		cacheCreation1h = claudeUsage.CacheCreationInputTokens
 	}
 
 	usage := &dto.Usage{

--- a/service/billing_usage.go
+++ b/service/billing_usage.go
@@ -129,15 +129,14 @@ func usageFromClaudeBillingUsage(billingUsage *dto.BillingUsage) *dto.Usage {
 	if cacheCreation5m == 0 {
 		cacheCreation5m = claudeUsage.ClaudeCacheCreation5mTokens
 	}
-	if cacheCreation5m == 0 && claudeUsage.CacheCreationInputTokens > 0 {
-		cacheCreation5m = claudeUsage.CacheCreationInputTokens
-	}
 	cacheCreation1h := claudeUsage.GetCacheCreation1hTokens()
 	if cacheCreation1h == 0 {
 		cacheCreation1h = claudeUsage.ClaudeCacheCreation1hTokens
 	}
-	if cacheCreation1h == 0 && claudeUsage.CacheCreationInputTokens > 0 && cacheCreation5m == 0 {
-		cacheCreation1h = claudeUsage.CacheCreationInputTokens
+	// If both split values are still 0 but there's a total, default to 5m
+	// (Claude standard cache TTL is 5 minutes).
+	if cacheCreation5m == 0 && cacheCreation1h == 0 && claudeUsage.CacheCreationInputTokens > 0 {
+		cacheCreation5m = claudeUsage.CacheCreationInputTokens
 	}
 
 	usage := &dto.Usage{

--- a/service/tiered_settle.go
+++ b/service/tiered_settle.go
@@ -26,8 +26,12 @@ func BuildTieredTokenParams(usage *dto.Usage, isClaudeUsageSemantic bool, usedVa
 	cc1h := float64(0)
 
 	if usage.UsageSemantic == "anthropic" {
-		cc1h = float64(usage.ClaudeCacheCreation1hTokens)
-		cc5m = float64(usage.ClaudeCacheCreation5mTokens)
+		if usage.ClaudeCacheCreation1hTokens > 0 {
+			cc1h = float64(usage.ClaudeCacheCreation1hTokens)
+		}
+		if usage.ClaudeCacheCreation5mTokens > 0 {
+			cc5m = float64(usage.ClaudeCacheCreation5mTokens)
+		}
 	}
 
 	img := float64(usage.PromptTokensDetails.ImageTokens)


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
现象
Tiered billing（动态计费）模式下，使用 Claude 上游返回的 billing_usage 时，cache_creation_input_tokens（缓存写入 Token）在上游返回了总量但未拆分 5m/1h 的情况下，被完全漏计，值为0。总费用未包含缓存写入 Token 的费用。

问题根源
上游数据特征： Claude API 返回了 cache_creation_input_tokens: n（总量），但 cache_creation 子对象为 null，没有 ephemeral_5m_input_tokens / ephemeral_1h_input_tokens 拆分字段。

两处级联 Bug：

① service/billing_usage.go — 数据映射层


cacheCreation5m := claudeUsage.GetCacheCreation5mTokens()        // 0（CacheCreation==nil）
if cacheCreation5m == 0 {
    cacheCreation5m = claudeUsage.ClaudeCacheCreation5mTokens     // 0（也被设为0）
}
// cacheCreation5m = 0，总量 n 丢掉了
GetCacheCreation5mTokens() 返回 0（CacheCreation 为 nil），回退到 ClaudeCacheCreation5mTokens 也是 0（因为 relay 代码同样从 GetCacheCreation5mTokens() 赋值），导致 cacheCreation5m = 0，没有继续兜底到 CacheCreationInputTokens 总量。

② service/tiered_settle.go — 计费参数构建层


cc5m := float64(usage.PromptTokensDetails.CacheCreationTokensTotal())  // = n ✅
if usage.UsageSemantic == "anthropic" {
    cc5m = float64(usage.ClaudeCacheCreation5mTokens)                  // = 0  🔴
}
cc5m 先通过 CacheCreationTokensTotal() 正确初始化为 n，然后被 ClaudeCacheCreation5mTokens（0）无条件覆盖，导致表达式计算时 cc=0。

解决方案
修复 ① — 数据映射层添加兜底（service/billing_usage.go）

当拆分字段和旧字段均为 0 时，兜底到 CacheCreationInputTokens 总量：


if cacheCreation5m == 0 && claudeUsage.CacheCreationInputTokens > 0 {
    cacheCreation5m = claudeUsage.CacheCreationInputTokens
}
if cacheCreation1h == 0 && claudeUsage.CacheCreationInputTokens > 0 && cacheCreation5m == 0 {
    cacheCreation1h = claudeUsage.CacheCreationInputTokens
}
1h 的兜底加 cacheCreation5m == 0 条件，防止总量被两边重复使用。

修复 ② — 计费参数层加防御检查（service/tiered_settle.go）

只当有真实拆分值时才覆盖，否则保留 CacheCreationTokensTotal() 的初始值：


if usage.ClaudeCacheCreation1hTokens > 0 {
    cc1h = float64(usage.ClaudeCacheCreation1hTokens)
}
if usage.ClaudeCacheCreation5mTokens > 0 {
    cc5m = float64(usage.ClaudeCacheCreation5mTokens)
}

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- https://github.com/QuantumNous/new-api/issues/6353

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
已在生产环境验证。
修复前：
<img width="974" height="389" alt="image" src="https://github.com/user-attachments/assets/a535b6e8-6a94-47b3-ba81-967b8c9c4269" />

修复后：
<img width="412" height="385" alt="image" src="https://github.com/user-attachments/assets/58865a5b-4737-437c-93a4-62471740c787" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing accuracy for Anthropic cache-creation token usage by adding an extra fallback when duration-specific cache-token counts are unavailable.
  * Refined tiered billing calculations to avoid zero-value cache-creation token fields from impacting the derived pricing parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->