### PR TITLE
fix: count invites when inviter reward is zero

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -489,15 +489,22 @@ func HardDeleteUserById(id int) error {
 	return user.HardDelete()
 }
 
-func inviteUser(inviterId int) (err error) {
-	user, err := GetUserById(inviterId, true)
-	if err != nil {
-		return err
+func recordUserInvite(inviterId int, rewardQuota int) error {
+	updates := map[string]interface{}{
+		"aff_count": gorm.Expr("aff_count + ?", 1),
 	}
-	user.AffCount++
-	user.AffQuota += common.QuotaForInviter
-	user.AffHistoryQuota += common.QuotaForInviter
-	return DB.Save(user).Error
+	if rewardQuota > 0 {
+		updates["aff_quota"] = gorm.Expr("aff_quota + ?", rewardQuota)
+		updates["aff_history"] = gorm.Expr("aff_history + ?", rewardQuota)
+	}
+	result := DB.Model(&User{}).Where("id = ?", inviterId).Updates(updates)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("inviter %d not found", inviterId)
+	}
+	return nil
 }
 
 func (user *User) TransferAffQuotaToQuota(quota int) error {
@@ -633,17 +640,7 @@ func (user *User) finishInsert(inviterId int) {
 	if common.QuotaForNewUser > 0 {
 		RecordLog(user.Id, LogTypeSystem, fmt.Sprintf("新用户注册赠送 %s", logger.LogQuota(common.QuotaForNewUser)))
 	}
-	if inviterId != 0 && operation_setting.IsPaymentComplianceConfirmed() {
-		if common.QuotaForInvitee > 0 {
-			_ = IncreaseUserQuota(user.Id, common.QuotaForInvitee, true)
-			RecordLog(user.Id, LogTypeSystem, fmt.Sprintf("使用邀请码赠送 %s", logger.LogQuota(common.QuotaForInvitee)))
-		}
-		if common.QuotaForInviter > 0 {
-			//_ = IncreaseUserQuota(inviterId, common.QuotaForInviter)
-			RecordLog(inviterId, LogTypeSystem, fmt.Sprintf("邀请用户赠送 %s", logger.LogQuota(common.QuotaForInviter)))
-			_ = inviteUser(inviterId)
-		}
-	}
+	user.finalizeInvitation(inviterId)
 }
 
 func (user *User) FinishInsert(inviterId int) {
@@ -690,15 +687,32 @@ func (user *User) FinalizeOAuthUserCreation(inviterId int) {
 	if common.QuotaForNewUser > 0 {
 		RecordLog(user.Id, LogTypeSystem, fmt.Sprintf("新用户注册赠送 %s", logger.LogQuota(common.QuotaForNewUser)))
 	}
-	if inviterId != 0 && operation_setting.IsPaymentComplianceConfirmed() {
-		if common.QuotaForInvitee > 0 {
-			_ = IncreaseUserQuota(user.Id, common.QuotaForInvitee, true)
-			RecordLog(user.Id, LogTypeSystem, fmt.Sprintf("使用邀请码赠送 %s", logger.LogQuota(common.QuotaForInvitee)))
-		}
-		if common.QuotaForInviter > 0 {
-			RecordLog(inviterId, LogTypeSystem, fmt.Sprintf("邀请用户赠送 %s", logger.LogQuota(common.QuotaForInviter)))
-			_ = inviteUser(inviterId)
-		}
+	user.finalizeInvitation(inviterId)
+}
+
+func (user *User) finalizeInvitation(inviterId int) {
+	if inviterId == 0 {
+		return
+	}
+
+	rewardQuota := 0
+	complianceConfirmed := operation_setting.IsPaymentComplianceConfirmed()
+	if complianceConfirmed {
+		rewardQuota = common.QuotaForInviter
+	}
+	if err := recordUserInvite(inviterId, rewardQuota); err != nil {
+		common.SysError(fmt.Sprintf("failed to record invite for inviter %d: %v", inviterId, err))
+	}
+
+	if !complianceConfirmed {
+		return
+	}
+	if common.QuotaForInvitee > 0 {
+		_ = IncreaseUserQuota(user.Id, common.QuotaForInvitee, true)
+		RecordLog(user.Id, LogTypeSystem, fmt.Sprintf("使用邀请码赠送 %s", logger.LogQuota(common.QuotaForInvitee)))
+	}
+	if common.QuotaForInviter > 0 {
+		RecordLog(inviterId, LogTypeSystem, fmt.Sprintf("邀请用户赠送 %s", logger.LogQuota(common.QuotaForInviter)))
 	}
 }
 

--- a/model/user_invite_test.go
+++ b/model/user_invite_test.go
@@ -1,0 +1,98 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/setting/operation_setting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistrationTracksInvitesIndependentlyFromRewards(t *testing.T) {
+	originalQuotaForNewUser := common.QuotaForNewUser
+	originalQuotaForInviter := common.QuotaForInviter
+	originalQuotaForInvitee := common.QuotaForInvitee
+	originalPaymentSetting := *operation_setting.GetPaymentSetting()
+	t.Cleanup(func() {
+		common.QuotaForNewUser = originalQuotaForNewUser
+		common.QuotaForInviter = originalQuotaForInviter
+		common.QuotaForInvitee = originalQuotaForInvitee
+		*operation_setting.GetPaymentSetting() = originalPaymentSetting
+	})
+
+	tests := []struct {
+		name                string
+		oauth               bool
+		complianceConfirmed bool
+		inviterReward       int
+		inviteeReward       int
+		wantInviterReward   int
+		wantInviteeReward   int
+	}{
+		{
+			name:                "password registration counts invite when rewards are zero",
+			complianceConfirmed: true,
+		},
+		{
+			name:          "oauth registration counts invite without compliance rewards",
+			oauth:         true,
+			inviterReward: 100,
+			inviteeReward: 50,
+		},
+		{
+			name:                "password registration still grants configured rewards",
+			complianceConfirmed: true,
+			inviterReward:       100,
+			inviteeReward:       50,
+			wantInviterReward:   100,
+			wantInviteeReward:   50,
+		},
+	}
+
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			truncateTables(t)
+			common.QuotaForNewUser = 0
+			common.QuotaForInviter = test.inviterReward
+			common.QuotaForInvitee = test.inviteeReward
+			paymentSetting := operation_setting.GetPaymentSetting()
+			paymentSetting.ComplianceConfirmed = test.complianceConfirmed
+			paymentSetting.ComplianceTermsVersion = operation_setting.CurrentComplianceTermsVersion
+
+			inviter := User{
+				Username: fmt.Sprintf("inviter-%d", index),
+				AffCode:  fmt.Sprintf("inviter-code-%d", index),
+				Status:   common.UserStatusEnabled,
+			}
+			require.NoError(t, DB.Create(&inviter).Error)
+
+			invitee := User{
+				Username:  fmt.Sprintf("invitee-%d", index),
+				Password:  "password123",
+				Status:    common.UserStatusEnabled,
+				InviterId: inviter.Id,
+			}
+			if test.oauth {
+				invitee.Password = ""
+				invitee.AffCode = fmt.Sprintf("invitee-code-%d", index)
+				require.NoError(t, DB.Create(&invitee).Error)
+				invitee.FinalizeOAuthUserCreation(inviter.Id)
+			} else {
+				require.NoError(t, invitee.Insert(inviter.Id))
+			}
+
+			var storedInviter User
+			require.NoError(t, DB.First(&storedInviter, inviter.Id).Error)
+			assert.Equal(t, 1, storedInviter.AffCount)
+			assert.Equal(t, test.wantInviterReward, storedInviter.AffQuota)
+			assert.Equal(t, test.wantInviterReward, storedInviter.AffHistoryQuota)
+
+			var storedInvitee User
+			require.NoError(t, DB.First(&storedInvitee, invitee.Id).Error)
+			assert.Equal(t, inviter.Id, storedInvitee.InviterId)
+			assert.Equal(t, test.wantInviteeReward, storedInvitee.Quota)
+		})
+	}
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

将邀请关系计数与邀请奖励发放解耦。有效邀请现在始终原子增加邀请人的 aff_count；只有奖励额度大于 0 时才增加 aff_quota 和 aff_history。密码注册与 OAuth 注册共用同一收尾逻辑，避免两个入口再次出现行为差异。

新增表驱动回归测试，覆盖邀请人奖励为 0、未确认支付合规时不发奖励，以及奖励正常发放三种场景。

> AI-assisted disclosure: 本 PR 由 AI 辅助从本地开发分支提取、验证并整理提交；原始修复由 JamesHu 编写。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6362

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 Bug fix，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```text
go test ./model -run TestRegistrationTracksInvitesIndependentlyFromRewards -count=1
ok   github.com/QuantumNous/new-api/model

go test ./model -count=1
ok   github.com/QuantumNous/new-api/model
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invitation tracking now records successful invitations independently of reward configuration.
  * Reward quotas and invitation history are applied only when payment compliance requirements are met.
  * Password and OAuth registrations now follow consistent invitation and reward behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->