### PR TITLE
fix: prevent model create from wiping existing pricing for same name

### DIFF
--- a/web/src/features/models/components/drawers/model-mutate-drawer.tsx
+++ b/web/src/features/models/components/drawers/model-mutate-drawer.tsx
@@ -409,6 +409,50 @@ export function ModelMutateDrawer({
         audioRatio: '',
         audioCompletionRatio: '',
       })
+
+      // Prefill pricing already configured for this name: submit rebuilds the
+      // pricing maps delete-then-readd, so empty fields would wipe the entries
+      const modelName = currentRow?.model_name || ''
+      if (modelSettings && modelName) {
+        const lookup = (raw: string) =>
+          safeJsonParse<Record<string, number>>(raw, {
+            fallback: {},
+            silent: true,
+          })[modelName]
+
+        const price = lookup(modelSettings.ModelPrice)
+        const ratio = lookup(modelSettings.ModelRatio)
+        const cacheRatio = lookup(modelSettings.CacheRatio)
+        const completionRatio = lookup(modelSettings.CompletionRatio)
+        const imageRatio = lookup(modelSettings.ImageRatio)
+        const audioRatio = lookup(modelSettings.AudioRatio)
+        const audioCompletionRatio = lookup(modelSettings.AudioCompletionRatio)
+
+        if (price !== undefined && price !== null) {
+          setPricingMode('per-request')
+          form.setValue('price', price.toString())
+        } else {
+          if (ratio !== undefined && ratio !== null) {
+            const tokenPrice = ratio * 2
+            setPromptPrice(tokenPrice.toString())
+            if (completionRatio !== undefined && completionRatio !== null) {
+              setCompletionPrice((tokenPrice * completionRatio).toString())
+            }
+          }
+          form.setValue('ratio', ratio?.toString() || '')
+          form.setValue('cacheRatio', cacheRatio?.toString() || '')
+          form.setValue('completionRatio', completionRatio?.toString() || '')
+          form.setValue('imageRatio', imageRatio?.toString() || '')
+          form.setValue('audioRatio', audioRatio?.toString() || '')
+          form.setValue(
+            'audioCompletionRatio',
+            audioCompletionRatio?.toString() || ''
+          )
+          setAdvancedOpen(
+            !!(cacheRatio || imageRatio || audioRatio || audioCompletionRatio)
+          )
+        }
+      }
     }
   }, [open, isEditing, modelData, currentRow, form, modelSettings])
 

--- a/web/src/features/models/components/drawers/model-mutate-drawer.tsx
+++ b/web/src/features/models/components/drawers/model-mutate-drawer.tsx
@@ -112,6 +112,120 @@ type ExtendedModelFormValues = z.infer<typeof extendedModelFormSchema>
 type PricingMode = 'per-token' | 'per-request'
 type PricingSubMode = 'ratio' | 'price'
 
+type PricingFields = Pick<
+  ExtendedModelFormValues,
+  | 'price'
+  | 'ratio'
+  | 'cacheRatio'
+  | 'completionRatio'
+  | 'imageRatio'
+  | 'audioRatio'
+  | 'audioCompletionRatio'
+>
+
+// Form state describing the pricing currently configured for one model name.
+type PricingConfig = {
+  mode: PricingMode
+  fields: PricingFields
+  promptPrice: string
+  completionPrice: string
+  advancedOpen: boolean
+}
+
+const EMPTY_PRICING_FIELDS: PricingFields = {
+  price: '',
+  ratio: '',
+  cacheRatio: '',
+  completionRatio: '',
+  imageRatio: '',
+  audioRatio: '',
+  audioCompletionRatio: '',
+}
+
+const EMPTY_PRICING_CONFIG: PricingConfig = {
+  mode: 'per-token',
+  fields: EMPTY_PRICING_FIELDS,
+  promptPrice: '',
+  completionPrice: '',
+  advancedOpen: false,
+}
+
+function lookupModelRatio(
+  rawMap: string,
+  modelName: string
+): number | undefined {
+  return safeJsonParse<Record<string, number>>(rawMap, {
+    fallback: {},
+    silent: true,
+  })[modelName]
+}
+
+// Pricing is not stored on the model row: it lives in system options as
+// model-name keyed JSON maps, so it has to be read back out of those maps to
+// populate the form. Both create and edit rely on this, because submit rebuilds
+// the maps from the form and would otherwise drop pricing it never loaded.
+function readPricingConfig(
+  settings: ModelSettings | null,
+  modelName: string
+): PricingConfig {
+  if (!settings || !modelName) return EMPTY_PRICING_CONFIG
+
+  const price = lookupModelRatio(settings.ModelPrice, modelName)
+  const ratio = lookupModelRatio(settings.ModelRatio, modelName)
+  const cacheRatio = lookupModelRatio(settings.CacheRatio, modelName)
+  const completionRatio = lookupModelRatio(settings.CompletionRatio, modelName)
+  const imageRatio = lookupModelRatio(settings.ImageRatio, modelName)
+  const audioRatio = lookupModelRatio(settings.AudioRatio, modelName)
+  const audioCompletionRatio = lookupModelRatio(
+    settings.AudioCompletionRatio,
+    modelName
+  )
+
+  // A fixed per-request price wins outright at billing time (see
+  // GetModelRatioOrPrice), so a name that has one is shown, and saved back, as
+  // price-only: the ratios alongside it are dead weight.
+  if (price !== undefined && price !== null) {
+    return {
+      ...EMPTY_PRICING_CONFIG,
+      mode: 'per-request',
+      fields: { ...EMPTY_PRICING_FIELDS, price: price.toString() },
+    }
+  }
+
+  let promptPrice = ''
+  let completionPrice = ''
+  if (ratio !== undefined && ratio !== null) {
+    const tokenPrice = ratio * 2
+    promptPrice = tokenPrice.toString()
+    if (completionRatio !== undefined && completionRatio !== null) {
+      completionPrice = (tokenPrice * completionRatio).toString()
+    }
+  }
+
+  return {
+    mode: 'per-token',
+    fields: {
+      price: '',
+      ratio: ratio?.toString() || '',
+      cacheRatio: cacheRatio?.toString() || '',
+      completionRatio: completionRatio?.toString() || '',
+      imageRatio: imageRatio?.toString() || '',
+      audioRatio: audioRatio?.toString() || '',
+      audioCompletionRatio: audioCompletionRatio?.toString() || '',
+    },
+    promptPrice,
+    completionPrice,
+    // Configured is not the same as non-zero: a 0 ratio (free cache reads, for
+    // instance) still has to be visible rather than hidden behind the collapse.
+    advancedOpen: [
+      cacheRatio,
+      imageRatio,
+      audioRatio,
+      audioCompletionRatio,
+    ].some((value) => value !== undefined && value !== null),
+  }
+}
+
 type ModelMutateDrawerProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -134,6 +248,10 @@ export function ModelMutateDrawer({
   const [promptPrice, setPromptPrice] = useState('')
   const [completionPrice, setCompletionPrice] = useState('')
   const [oldModelName, setOldModelName] = useState<string>('')
+  // Model name whose pricing was read into the form when the drawer opened.
+  // Submit may only rewrite pricing for this name, or for a name the user
+  // explicitly priced; anything else it never saw and must leave alone.
+  const [loadedPricingName, setLoadedPricingName] = useState<string>('')
 
   // Fetch vendors for dropdown
   const { data: vendorsData } = useQuery({
@@ -285,8 +403,13 @@ export function ModelMutateDrawer({
       const model = modelData.data
       setOldModelName(model.model_name)
 
-      // Base model data reset
-      const baseModelData = {
+      const pricing = readPricingConfig(modelSettings, model.model_name)
+      setLoadedPricingName(model.model_name)
+      setPricingMode(pricing.mode)
+      setPromptPrice(pricing.promptPrice)
+      setCompletionPrice(pricing.completionPrice)
+      setAdvancedOpen(pricing.advancedOpen)
+      form.reset({
         id: model.id,
         model_name: model.model_name,
         description: model.description || '',
@@ -297,102 +420,23 @@ export function ModelMutateDrawer({
         name_rule: model.name_rule || 0,
         status: model.status === 1,
         sync_official: model.sync_official === 1,
-        price: '',
-        ratio: '',
-        cacheRatio: '',
-        completionRatio: '',
-        imageRatio: '',
-        audioRatio: '',
-        audioCompletionRatio: '',
-      }
-
-      // Parse ratio configurations from system settings if available
-      if (modelSettings) {
-        const priceMap = safeJsonParse<Record<string, number>>(
-          modelSettings.ModelPrice,
-          { fallback: {}, silent: true }
-        )
-        const ratioMap = safeJsonParse<Record<string, number>>(
-          modelSettings.ModelRatio,
-          { fallback: {}, silent: true }
-        )
-        const cacheMap = safeJsonParse<Record<string, number>>(
-          modelSettings.CacheRatio,
-          { fallback: {}, silent: true }
-        )
-        const completionMap = safeJsonParse<Record<string, number>>(
-          modelSettings.CompletionRatio,
-          { fallback: {}, silent: true }
-        )
-        const imageMap = safeJsonParse<Record<string, number>>(
-          modelSettings.ImageRatio,
-          { fallback: {}, silent: true }
-        )
-        const audioMap = safeJsonParse<Record<string, number>>(
-          modelSettings.AudioRatio,
-          { fallback: {}, silent: true }
-        )
-        const audioCompletionMap = safeJsonParse<Record<string, number>>(
-          modelSettings.AudioCompletionRatio,
-          { fallback: {}, silent: true }
-        )
-
-        // Extract ratio config for this model
-        const modelName = model.model_name
-        const price = priceMap[modelName]
-        const ratio = ratioMap[modelName]
-        const cacheRatio = cacheMap[modelName]
-        const completionRatio = completionMap[modelName]
-        const imageRatio = imageMap[modelName]
-        const audioRatio = audioMap[modelName]
-        const audioCompletionRatio = audioCompletionMap[modelName]
-
-        // Determine pricing mode
-        if (price !== undefined && price !== null) {
-          setPricingMode('per-request')
-          form.reset({
-            ...baseModelData,
-            price: price.toString(),
-          })
-        } else {
-          setPricingMode('per-token')
-          if (ratio !== undefined && ratio !== null) {
-            const tokenPrice = ratio * 2
-            setPromptPrice(tokenPrice.toString())
-            if (completionRatio !== undefined && completionRatio !== null) {
-              const compPrice = tokenPrice * completionRatio
-              setCompletionPrice(compPrice.toString())
-            }
-          }
-          form.reset({
-            ...baseModelData,
-            ratio: ratio?.toString() || '',
-            cacheRatio: cacheRatio?.toString() || '',
-            completionRatio: completionRatio?.toString() || '',
-            imageRatio: imageRatio?.toString() || '',
-            audioRatio: audioRatio?.toString() || '',
-            audioCompletionRatio: audioCompletionRatio?.toString() || '',
-          })
-          setAdvancedOpen(
-            !!(cacheRatio || imageRatio || audioRatio || audioCompletionRatio)
-          )
-        }
-      } else {
-        // If system settings not loaded yet, just load base model data
-        setPricingMode('per-token')
-        form.reset(baseModelData)
-        setAdvancedOpen(false)
-      }
+        ...pricing.fields,
+      })
     } else if (open && !isEditing) {
-      // Pre-fill model name if passed from missing models
+      // Pre-fill model name if passed from missing models, along with any
+      // pricing that name already has, so the user edits it instead of being
+      // shown an empty form that hides existing configuration.
+      const modelName = currentRow?.model_name || ''
+      const pricing = readPricingConfig(modelSettings, modelName)
       setOldModelName('')
-      setPricingMode('per-token')
+      setLoadedPricingName(modelName)
       setPricingSubMode('ratio')
-      setPromptPrice('')
-      setCompletionPrice('')
-      setAdvancedOpen(false)
+      setPricingMode(pricing.mode)
+      setPromptPrice(pricing.promptPrice)
+      setCompletionPrice(pricing.completionPrice)
+      setAdvancedOpen(pricing.advancedOpen)
       form.reset({
-        model_name: currentRow?.model_name || '',
+        model_name: modelName,
         description: '',
         icon: '',
         tags: [],
@@ -401,58 +445,8 @@ export function ModelMutateDrawer({
         name_rule: 0,
         status: true,
         sync_official: true,
-        price: '',
-        ratio: '',
-        cacheRatio: '',
-        completionRatio: '',
-        imageRatio: '',
-        audioRatio: '',
-        audioCompletionRatio: '',
+        ...pricing.fields,
       })
-
-      // Prefill pricing already configured for this name: submit rebuilds the
-      // pricing maps delete-then-readd, so empty fields would wipe the entries
-      const modelName = currentRow?.model_name || ''
-      if (modelSettings && modelName) {
-        const lookup = (raw: string) =>
-          safeJsonParse<Record<string, number>>(raw, {
-            fallback: {},
-            silent: true,
-          })[modelName]
-
-        const price = lookup(modelSettings.ModelPrice)
-        const ratio = lookup(modelSettings.ModelRatio)
-        const cacheRatio = lookup(modelSettings.CacheRatio)
-        const completionRatio = lookup(modelSettings.CompletionRatio)
-        const imageRatio = lookup(modelSettings.ImageRatio)
-        const audioRatio = lookup(modelSettings.AudioRatio)
-        const audioCompletionRatio = lookup(modelSettings.AudioCompletionRatio)
-
-        if (price !== undefined && price !== null) {
-          setPricingMode('per-request')
-          form.setValue('price', price.toString())
-        } else {
-          if (ratio !== undefined && ratio !== null) {
-            const tokenPrice = ratio * 2
-            setPromptPrice(tokenPrice.toString())
-            if (completionRatio !== undefined && completionRatio !== null) {
-              setCompletionPrice((tokenPrice * completionRatio).toString())
-            }
-          }
-          form.setValue('ratio', ratio?.toString() || '')
-          form.setValue('cacheRatio', cacheRatio?.toString() || '')
-          form.setValue('completionRatio', completionRatio?.toString() || '')
-          form.setValue('imageRatio', imageRatio?.toString() || '')
-          form.setValue('audioRatio', audioRatio?.toString() || '')
-          form.setValue(
-            'audioCompletionRatio',
-            audioCompletionRatio?.toString() || ''
-          )
-          setAdvancedOpen(
-            !!(cacheRatio || imageRatio || audioRatio || audioCompletionRatio)
-          )
-        }
-      }
     }
   }, [open, isEditing, modelData, currentRow, form, modelSettings])
 
@@ -544,15 +538,24 @@ export function ModelMutateDrawer({
               delete audioCompletionMap[oldModelName]
             }
 
-            // Remove current model name from all maps first (always, to handle mode switches or clearing)
-            // This ensures stale entries are removed even when user clears all fields
-            delete priceMap[finalModelName]
-            delete ratioMap[finalModelName]
-            delete cacheMap[finalModelName]
-            delete completionMap[finalModelName]
-            delete imageMap[finalModelName]
-            delete audioMap[finalModelName]
-            delete audioCompletionMap[finalModelName]
+            // Rebuild this model name's entries from the form, but only when
+            // the form speaks for that name: it loaded the name's pricing when
+            // the drawer opened, so clearing every field means "remove
+            // pricing", or the user typed pricing in, which then wins outright
+            // (this is also what replaces the old entries across a mode
+            // switch). A name the form never loaded may still have pricing
+            // configured elsewhere, and an untouched pricing section must not
+            // wipe it -- that covers creating a model over an existing name,
+            // and renaming onto one.
+            if (hasRatioConfig || finalModelName === loadedPricingName) {
+              delete priceMap[finalModelName]
+              delete ratioMap[finalModelName]
+              delete cacheMap[finalModelName]
+              delete completionMap[finalModelName]
+              delete imageMap[finalModelName]
+              delete audioMap[finalModelName]
+              delete audioCompletionMap[finalModelName]
+            }
 
             // Only add new entries if user provided new configuration
             if (hasRatioConfig) {
@@ -691,6 +694,7 @@ export function ModelMutateDrawer({
       onOpenChange,
       pricingMode,
       oldModelName,
+      loadedPricingName,
       modelSettings,
       updateOption,
     ]


### PR DESCRIPTION
## 📝 变更描述 / Description

新建模型时,不会继承已有的模型价格, 价格会按空表单设置就等于把已有配置清空了。

改法:新建抽屉打开时,如果传入的模型名已有定价配置,把原值预填进表单。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无对应 issue,复现步骤见下方运行证明。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述,没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls),确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`,我已提交或关联对应 Issue,且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证,维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据,且符合项目代码规范。

## 📸 运行证明 / Proof of Work

- 复现路径(可据此复核):
  1. 给新模型 A 配置好倍率/价格
  2. 从"缺失模型"入口重新添加 A:
     - 修复前:定价区为空,直接保存后 ModelRatio 等配置里 A 的条目被清掉    
<img width="1344" height="1078" alt="image" src="https://github.com/user-attachments/assets/6ee2af74-1d80-4d59-9cc1-52bfe7cc6905" />

     - 修复后:打开抽屉即预填原有定价,保存后配置保留
<img width="1310" height="1120" alt="image" src="https://github.com/user-attachments/assets/f3d50b4e-97c8-4a65-9b35-fce159a388b2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * New model forms can automatically prefill pricing settings from existing system configuration when creating a model.
  * Supports fixed per-request pricing, per-token pricing, completion ratios, and optional advanced ratios for cache, image, and audio usage.
  * Advanced pricing fields open automatically when applicable settings are detected.

* **Bug Fixes**
  * Pricing is now initialized consistently for both create and edit flows.
  * Submitting updates no longer unintentionally clears pricing entries when the form didn’t load existing data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->