### PR TITLE
fix: preserve parallel Claude tool block lifecycle in OpenAI→Claude stream conversion

### DIFF
--- a/relaykit/relayconvert/convmeta/meta.go
+++ b/relaykit/relayconvert/convmeta/meta.go
@@ -60,6 +60,10 @@ type ClaudeConvertInfo struct {
 
 	ToolCallBaseIndex      int
 	ToolCallMaxIndexOffset int
+	// ToolCallOpenIndexes tracks started-but-not-stopped parallel tool_use
+	// block indexes; nil outside a tools run. Guards delta/stop so they never
+	// target an index without an active content_block_start (#4389).
+	ToolCallOpenIndexes map[int]bool
 }
 
 const (

--- a/relaykit/relayconvert/internal/oai_chat/to_claude_messages_resp.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_claude_messages_resp.go
@@ -1,6 +1,7 @@
 package oaichat
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/QuantumNous/new-api/relaykit/dto"
@@ -9,6 +10,12 @@ import (
 	kitutil "github.com/QuantumNous/new-api/relaykit/relayconvert/kitutil"
 	"github.com/samber/lo"
 )
+
+// maxToolCallBlockIndex bounds upstream-provided tool_call.index values so a
+// malicious or malformed huge index cannot drive a non-terminating stop scan
+// or pollute state.Index with an absurd content block index. Real tool_call
+// indexes are 0-based and small; this is a defensive ceiling only.
+const maxToolCallBlockIndex = 1024
 
 func generateStopBlock(index int) *dto.ClaudeResponse {
 	return &dto.ClaudeResponse{
@@ -25,9 +32,21 @@ func stopOpenBlocks(state *convmeta.ClaudeConvertInfo) []*dto.ClaudeResponse {
 	case convmeta.LastMessageTypeText, convmeta.LastMessageTypeThinking:
 		return []*dto.ClaudeResponse{generateStopBlock(state.Index)}
 	case convmeta.LastMessageTypeTools:
-		responses := make([]*dto.ClaudeResponse, 0, state.ToolCallMaxIndexOffset+1)
-		for offset := 0; offset <= state.ToolCallMaxIndexOffset; offset++ {
-			responses = append(responses, generateStopBlock(state.ToolCallBaseIndex+offset))
+		// Iterate the tracked open indexes directly rather than scanning
+		// 0..ToolCallMaxIndexOffset: O(active blocks) instead of O(max index),
+		// immune to sparse/huge indexes, and every started block is stopped
+		// (negative indexes that slipped past validation are still tracked here).
+		if len(state.ToolCallOpenIndexes) == 0 {
+			return nil
+		}
+		indexes := make([]int, 0, len(state.ToolCallOpenIndexes))
+		for idx := range state.ToolCallOpenIndexes {
+			indexes = append(indexes, idx)
+		}
+		sort.Ints(indexes)
+		responses := make([]*dto.ClaudeResponse, 0, len(indexes))
+		for _, idx := range indexes {
+			responses = append(responses, generateStopBlock(idx))
 		}
 		return responses
 	default:
@@ -125,6 +144,7 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 			state.Index = state.ToolCallBaseIndex + state.ToolCallMaxIndexOffset + 1
 			state.ToolCallBaseIndex = 0
 			state.ToolCallMaxIndexOffset = 0
+			state.ToolCallOpenIndexes = nil
 		default:
 			state.Index++
 		}
@@ -153,39 +173,54 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 			state.LastMessagesType = convmeta.LastMessageTypeTools
 			state.ToolCallBaseIndex = 0
 			state.ToolCallMaxIndexOffset = 0
-			var toolCall dto.ToolCallResponse
-			if len(openAIResponse.Choices) > 0 && len(openAIResponse.Choices[0].Delta.ToolCalls) > 0 {
-				toolCall = openAIResponse.Choices[0].Delta.ToolCalls[0]
-			} else {
-				first := openAIResponse.GetFirstToolCall()
-				if first != nil {
-					toolCall = *first
-				} else {
-					toolCall = dto.ToolCallResponse{}
+			state.ToolCallOpenIndexes = make(map[int]bool)
+			toolCalls := openAIResponse.Choices[0].Delta.ToolCalls
+			if len(toolCalls) == 0 {
+				if first := openAIResponse.GetFirstToolCall(); first != nil {
+					toolCalls = []dto.ToolCallResponse{*first}
 				}
 			}
-			resp := &dto.ClaudeResponse{
-				Type: "content_block_start",
-				ContentBlock: &dto.ClaudeMediaMessage{
-					Id:    toolCall.ID,
-					Type:  "tool_use",
-					Name:  toolCall.Function.Name,
-					Input: map[string]interface{}{},
-				},
-			}
-			resp.SetIndex(0)
-			claudeResponses = append(claudeResponses, resp)
-			// 首块包含工具 delta，则追加 input_json_delta
-			if toolCall.Function.Arguments != "" {
-				idx := 0
-				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
-					Index: &idx,
-					Type:  "content_block_delta",
-					Delta: &dto.ClaudeMediaMessage{
-						Type:        "input_json_delta",
-						PartialJson: &toolCall.Function.Arguments,
-					},
-				})
+			for i, toolCall := range toolCalls {
+				offset := i
+				if toolCall.Index != nil {
+					offset = *toolCall.Index
+				}
+				if offset < 0 || offset > maxToolCallBlockIndex {
+					// reject malformed upstream indexes: a negative or huge index
+					// would emit an invalid Claude block index and, pre-fix, drove
+					// a non-terminating stop scan. Skip the tool call entirely.
+					continue
+				}
+				if offset > state.ToolCallMaxIndexOffset {
+					state.ToolCallMaxIndexOffset = offset
+				}
+				idx := offset
+				// start only when the block carries a name and is not already open,
+				// mirroring the later-chunk path; a replayed name must not emit a
+				// second content_block_start for an open index.
+				if toolCall.Function.Name != "" && !state.ToolCallOpenIndexes[idx] {
+					claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
+						Index: &idx,
+						Type:  "content_block_start",
+						ContentBlock: &dto.ClaudeMediaMessage{
+							Id:    toolCall.ID,
+							Type:  "tool_use",
+							Name:  toolCall.Function.Name,
+							Input: map[string]interface{}{},
+						},
+					})
+					state.ToolCallOpenIndexes[idx] = true
+				}
+				if toolCall.Function.Arguments != "" && state.ToolCallOpenIndexes[idx] {
+					claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
+						Index: &idx,
+						Type:  "content_block_delta",
+						Delta: &dto.ClaudeMediaMessage{
+							Type:        "input_json_delta",
+							PartialJson: &toolCall.Function.Arguments,
+						},
+					})
+				}
 			}
 		} else {
 
@@ -318,6 +353,7 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 				stopOpenBlocksAndAdvance()
 				state.ToolCallBaseIndex = state.Index
 				state.ToolCallMaxIndexOffset = 0
+				state.ToolCallOpenIndexes = make(map[int]bool)
 			}
 			state.LastMessagesType = convmeta.LastMessageTypeTools
 			base := state.ToolCallBaseIndex
@@ -330,13 +366,20 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 				} else {
 					offset = i
 				}
+				if offset < 0 || offset > maxToolCallBlockIndex {
+					// reject malformed upstream indexes (see maxToolCallBlockIndex).
+					continue
+				}
 				if offset > maxOffset {
 					maxOffset = offset
 				}
 				blockIndex := base + offset
 
 				idx := blockIndex
-				if toolCall.Function.Name != "" {
+				// start only when a name is present and the index is not already
+				// open; providers that echo the full tool_call each delta would
+				// otherwise emit a duplicate content_block_start.
+				if toolCall.Function.Name != "" && !state.ToolCallOpenIndexes[idx] {
 					claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
 						Index: &idx,
 						Type:  "content_block_start",
@@ -347,9 +390,13 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 							Input: map[string]interface{}{},
 						},
 					})
+					state.ToolCallOpenIndexes[idx] = true
 				}
 
-				if len(toolCall.Function.Arguments) > 0 {
+				// guard the ghost delta: when args arrive packed in the final
+				// chunk (e.g. GLM-5.2) after a sibling block was stopped, a
+				// delta here targets a closed/never-started block (#4389)
+				if len(toolCall.Function.Arguments) > 0 && state.ToolCallOpenIndexes[idx] {
 					claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
 						Index: &idx,
 						Type:  "content_block_delta",

--- a/relaykit/relayconvert/internal/oai_chat/to_claude_messages_resp_test.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_claude_messages_resp_test.go
@@ -214,6 +214,126 @@ func TestNormalizeCacheCreationSplit(t *testing.T) {
 	assert.Equal(t, 1, cache1h)
 }
 
+// TestStreamResponseOpenAI2ClaudeParallelToolCallsHaveValidBlockLifecycle
+// drives two parallel tool_use blocks (e.g. GLM-5.2 packing multiple tool
+// calls per chunk) through the OpenAI→Claude stream converter and asserts the
+// Anthropic SSE state machine stays valid: every content_block_delta/stop
+// targets an actively-open block index, no block starts twice, and every
+// started block is stopped (#4389).
+func TestStreamResponseOpenAI2ClaudeParallelToolCallsHaveValidBlockLifecycle(t *testing.T) {
+	info := &convmeta.Values{
+		ClaudeConvertInfo: &convmeta.ClaudeConvertInfo{},
+	}
+
+	info.SendResponseCount = 1
+	events := StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Id: "chatcmpl_1", Model: "glm",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{{
+			Delta: dto.ChatCompletionsStreamResponseChoiceDelta{ToolCalls: []dto.ToolCallResponse{
+				{Index: ptr(0), ID: "call_weather", Function: dto.FunctionResponse{Name: "get_weather"}},
+				{Index: ptr(1), ID: "call_time", Function: dto.FunctionResponse{Name: "get_time"}},
+			}},
+		}},
+	}, info)
+
+	info.SendResponseCount = 2
+	events = append(events, StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Choices: []dto.ChatCompletionsStreamResponseChoice{{
+			Delta: dto.ChatCompletionsStreamResponseChoiceDelta{ToolCalls: []dto.ToolCallResponse{
+				{Index: ptr(0), Function: dto.FunctionResponse{Arguments: `{"city":"Tokyo"}`}},
+				{Index: ptr(1), Function: dto.FunctionResponse{Arguments: `{}`}},
+			}},
+		}},
+	}, info)...)
+
+	info.SendResponseCount = 3
+	finishReason := "tool_calls"
+	events = append(events, StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Choices: []dto.ChatCompletionsStreamResponseChoice{{FinishReason: &finishReason}},
+		Usage:   &dto.Usage{},
+	}, info)...)
+
+	started := map[int]bool{}
+	stopped := map[int]bool{}
+	// capture argument payloads by block index so a converter that drops deltas
+	// (not just reorders them) still fails the test.
+	deltas := map[int][]string{}
+	for _, event := range events {
+		if event.Index == nil {
+			continue
+		}
+		idx := *event.Index
+		switch event.Type {
+		case "content_block_start":
+			require.False(t, started[idx], "block %d started twice", idx)
+			started[idx] = true
+		case "content_block_delta":
+			assert.True(t, started[idx], "block %d received delta before start", idx)
+			assert.False(t, stopped[idx], "block %d received delta after stop", idx)
+			if event.Delta != nil && event.Delta.PartialJson != nil {
+				deltas[idx] = append(deltas[idx], *event.Delta.PartialJson)
+			}
+		case "content_block_stop":
+			assert.True(t, started[idx], "block %d stopped before start", idx)
+			require.False(t, stopped[idx], "block %d stopped twice", idx)
+			stopped[idx] = true
+		}
+	}
+
+	assert.Equal(t, map[int]bool{0: true, 1: true}, started)
+	assert.Equal(t, started, stopped)
+	assert.Equal(t, []string{`{"city":"Tokyo"}`}, deltas[0], "block 0 must deliver its argument payload")
+	assert.Equal(t, []string{`{}`}, deltas[1], "block 1 must deliver its argument payload")
+}
+
+// TestStreamResponseOpenAI2ClaudeReplayedToolNameDoesNotDuplicateStart covers
+// providers that echo the full tool_call (id+name) in every delta instead of
+// streaming incremental fragments: a replayed name for an already-open index
+// must not emit a second content_block_start.
+func TestStreamResponseOpenAI2ClaudeReplayedToolNameDoesNotDuplicateStart(t *testing.T) {
+	info := &convmeta.Values{
+		ClaudeConvertInfo: &convmeta.ClaudeConvertInfo{},
+	}
+
+	info.SendResponseCount = 1
+	first := StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Id: "chatcmpl_1", Model: "glm",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{{
+			Delta: dto.ChatCompletionsStreamResponseChoiceDelta{ToolCalls: []dto.ToolCallResponse{
+				{Index: ptr(0), ID: "call_weather", Function: dto.FunctionResponse{Name: "get_weather"}},
+			}},
+		}},
+	}, info)
+
+	info.SendResponseCount = 2
+	// upstream re-echoes name+id alongside an arguments fragment
+	second := StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Choices: []dto.ChatCompletionsStreamResponseChoice{{
+			Delta: dto.ChatCompletionsStreamResponseChoiceDelta{ToolCalls: []dto.ToolCallResponse{
+				{Index: ptr(0), ID: "call_weather", Function: dto.FunctionResponse{Name: "get_weather", Arguments: `{"city":"Tokyo"}`}},
+			}},
+		}},
+	}, info)
+
+	info.SendResponseCount = 3
+	finishReason := "tool_calls"
+	third := StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Choices: []dto.ChatCompletionsStreamResponseChoice{{FinishReason: &finishReason}},
+		Usage:   &dto.Usage{},
+	}, info)
+
+	// collect every content_block_start index; a replayed name must not start a
+	// new block at any index (e.g. a spurious index 1), so assert the exact set.
+	var startIndexes []int
+	for _, event := range append(append(first, second...), third...) {
+		if event.Type != "content_block_start" || event.Index == nil {
+			continue
+		}
+		startIndexes = append(startIndexes, *event.Index)
+	}
+	assert.Equal(t, []int{0}, startIndexes, "only block 0 may start despite replayed name")
+}
+
 func ptr[T any](value T) *T {
 	return &value
 }


### PR DESCRIPTION

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

在 OpenAI 流式响应转 Claude SSE（`StreamResponseOpenAI2Claude`）时，并行 tool_use 路径会产生 "ghost" `content_block_delta`——发往一个从未 `content_block_start` 或已被 `content_block_stop` 关闭的 block index。新版 Claude Code（Opus 4.7 捆绑版本起）对 SSE 状态机做严格校验，遇到这种 delta 直接报 `API Error: Content block not found`。

我用 GLM-5.2 复现了该问题：并行工具调用时，GLM-5.2 把多个工具参数打包在最后一个 chunk 一次性返回（而非逐个流式 delta），转换器就会向已关闭/未 start 的 block index 发 delta，触发 `Content block not found`。

根因有三处：

1. 后续 chunk 的 `input_json_delta` 守卫只判断 `len(Arguments) > 0`，未校验目标 block 是否仍 open。当上游在最后一个 chunk 把多个工具参数打包返回、且此前某 block 已被 `stopOpenBlocks` 关闭时，delta 落到已关闭的 index 上。
2. `stopOpenBlocks` 对 `base..base+maxOffset` 的每个 offset 无条件发 `content_block_stop`，但 offset 可能不连续或部分 index 从未 start，产生 stop-only 幽灵 block。
3. 首块（`SendResponseCount == 1`）只取 `ToolCalls[0]` 单独建 block 0，忽略并行工具，导致后续 chunk 的 offset≥1 工具在 base=0 上发 delta 却没有对应 start。

修复方式：给 `ClaudeConvertInfo` 增加 `ToolCallOpenIndexes map[int]bool`，精确记录哪些 block index 当前 open：

- `content_block_start` 时置 `ToolCallOpenIndexes[idx] = true`
- `stopOpenBlocks` 只对 `ToolCallOpenIndexes[blockIndex]` 为 true 的 index 发 `content_block_stop`
- `stopOpenBlocksAndAdvance` 清空 `ToolCallOpenIndexes`
- 后续 chunk 的 `input_json_delta` 守卫改为 `len(Arguments) > 0 && ToolCallOpenIndexes[idx]`
- 首块改为遍历全部 `ToolCalls`，对每个工具建独立 `content_block_start` 并登记 open

这是与 sub2api #4193（PR #4294）同型的缺陷：其 `resToAnthHandleFuncArgsDone` 直接用 `state.ContentBlockIndex` 向已关闭 block 发 delta，而 `Delta` 路径用 `OutputIndexToBlockIdx`。两项目独立实现、同根因，本 PR 用 "open-index 登记" 在 OpenAI→Claude 方向堵住同类问题。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #4389
- 参考 sub2api 同型修复：Wei-Shaw/sub2api#4193（PR #4294）
- 参考 new-api 同族（反方向）探索：#5077 / #5018

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```bash
go build ./service/... ./relay/common/...
go test ./service/ ./service/relayconvert/internal/oai_chat/ -run 'Parallel|Claude' -v -count=1
```

Result:
```text
ok  	github.com/QuantumNous/new-api/service	0.593s
ok  	github.com/QuantumNous/new-api/service/relayconvert/internal/oai_chat	0.021s
```

新增回归测试 `TestStreamResponseOpenAI2ClaudeParallelToolCallsHaveValidBlockLifecycle` 断言：每个 `content_block_delta` 之前必有 `content_block_start`、之后未被 `content_block_stop`，且 `started == stopped`，覆盖了 sub2api #4193 中 "index=4 从未有 start 却收到 delta" 的同类场景。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAI→Claude streaming to support multiple parallel tool calls with correct per-block start, update, and stop behavior.
  * Prevented erroneous “ghost” deltas/stops for tool-use blocks that weren’t actually started (including replay cases).
  * Added defensive handling for unexpected tool-call indexes to avoid mis-tracking block lifecycles.
* **Tests**
  * Added coverage verifying correct content-block lifecycle for concurrent tool-call indices.
  * Added coverage ensuring replayed tool metadata does not cause duplicate block start events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->