### PR TITLE
fix: preserve reasoning in Responses tool history

### DIFF
--- a/service/relayconvert/internal/oai_responses/to_oai_chat_req.go
+++ b/service/relayconvert/internal/oai_responses/to_oai_chat_req.go
@@ -15,6 +15,7 @@ const (
 	responsesInputTypeFunctionCallOutput = "function_call_output"
 	responsesInputTypeCustomToolCall     = "custom_tool_call"
 	responsesInputTypeCustomToolOutput   = "custom_tool_call_output"
+	responsesInputTypeReasoning          = "reasoning"
 )
 
 const (
@@ -150,35 +151,47 @@ func responsesRequestMessagesToChat(req *dto.OpenAIResponsesRequest) ([]dto.Mess
 		if err := common.Unmarshal(req.Input, &items); err != nil {
 			return nil, fmt.Errorf("invalid input array: %w", err)
 		}
+		pendingReasoning := ""
 		for _, item := range items {
-			nextMessages, err := responsesInputItemToChatMessages(item, messages)
+			nextMessages, err := responsesInputItemToChatMessages(item, messages, &pendingReasoning)
 			if err != nil {
 				return nil, err
 			}
 			messages = nextMessages
 		}
+		attachPendingReasoningToLastAssistant(messages, &pendingReasoning)
 		return messages, nil
 	default:
 		return nil, fmt.Errorf("unsupported responses input type %q", common.GetJsonType(req.Input))
 	}
 }
 
-func responsesInputItemToChatMessages(item map[string]any, messages []dto.Message) ([]dto.Message, error) {
+func responsesInputItemToChatMessages(item map[string]any, messages []dto.Message, pendingReasoning *string) ([]dto.Message, error) {
 	itemType := strings.TrimSpace(common.Interface2String(item["type"]))
 	switch itemType {
+	case responsesInputTypeReasoning:
+		appendPendingReasoning(pendingReasoning, responsesItemReasoningText(item))
+		return messages, nil
 	case responsesInputTypeFunctionCall:
 		toolCall, err := responsesFunctionCallItemToChatToolCall(item)
 		if err != nil {
 			return nil, err
 		}
-		return appendToolCallToLastAssistant(messages, toolCall), nil
+		appendPendingReasoning(pendingReasoning, responsesItemReasoningText(item))
+		messages = appendToolCallToLastAssistant(messages, toolCall)
+		attachPendingReasoningToLastAssistant(messages, pendingReasoning)
+		return messages, nil
 	case responsesInputTypeCustomToolCall:
 		toolCall, err := responsesCustomToolCallItemToChatToolCall(item)
 		if err != nil {
 			return nil, err
 		}
-		return appendToolCallToLastAssistant(messages, toolCall), nil
+		appendPendingReasoning(pendingReasoning, responsesItemReasoningText(item))
+		messages = appendToolCallToLastAssistant(messages, toolCall)
+		attachPendingReasoningToLastAssistant(messages, pendingReasoning)
+		return messages, nil
 	case responsesInputTypeFunctionCallOutput:
+		attachPendingReasoningToLastAssistant(messages, pendingReasoning)
 		callID := strings.TrimSpace(common.Interface2String(item["call_id"]))
 		content := responseToolOutputToChatContent(item["output"])
 		return append(messages, dto.Message{Role: "tool", ToolCallId: callID, Content: content}), nil
@@ -192,7 +205,66 @@ func responsesInputItemToChatMessages(item map[string]any, messages []dto.Messag
 	if err != nil {
 		return nil, err
 	}
-	return append(messages, dto.Message{Role: role, Content: content}), nil
+
+	message := dto.Message{Role: role, Content: content}
+	if role == "assistant" {
+		appendReasoningContent(&message, responsesItemReasoningText(item))
+		messages = append(messages, message)
+		attachPendingReasoningToLastAssistant(messages, pendingReasoning)
+		return messages, nil
+	}
+
+	attachPendingReasoningToLastAssistant(messages, pendingReasoning)
+	return append(messages, message), nil
+}
+
+func responsesItemReasoningText(item map[string]any) string {
+	for _, key := range []string{"reasoning_content", "reasoning"} {
+		if text, ok := item[key].(string); ok && text != "" {
+			return text
+		}
+	}
+	if strings.TrimSpace(common.Interface2String(item["type"])) != responsesInputTypeReasoning {
+		return ""
+	}
+	for _, key := range []string{"summary", "content"} {
+		content, err := responsesInputContentToChatContent(item[key])
+		if text, ok := content.(string); err == nil && ok && text != "" {
+			return text
+		}
+	}
+	return common.Interface2String(item["text"])
+}
+
+func appendPendingReasoning(pending *string, reasoning string) {
+	if pending == nil || reasoning == "" || *pending == reasoning {
+		return
+	}
+	*pending += reasoning
+}
+
+func attachPendingReasoningToLastAssistant(messages []dto.Message, pending *string) {
+	if pending == nil || *pending == "" {
+		return
+	}
+	reasoning := *pending
+	*pending = ""
+	if len(messages) == 0 || messages[len(messages)-1].Role != "assistant" {
+		return
+	}
+	appendReasoningContent(&messages[len(messages)-1], reasoning)
+}
+
+func appendReasoningContent(message *dto.Message, reasoning string) {
+	if message == nil || reasoning == "" {
+		return
+	}
+	current := message.GetReasoningContent()
+	if current == reasoning {
+		return
+	}
+	message.ReasoningContent = new(string)
+	*message.ReasoningContent = current + reasoning
 }
 
 func responsesInputContentToChatContent(content any) (any, error) {
@@ -231,7 +303,7 @@ func responsesContentPartsToChatContent(parts []any) (any, error) {
 
 		partType := strings.TrimSpace(common.Interface2String(part["type"]))
 		switch partType {
-		case "input_text", "output_text", "text":
+		case "input_text", "output_text", "summary_text", "reasoning_text", "text":
 			text := common.Interface2String(part["text"])
 			textOnly.WriteString(text)
 			chatParts = append(chatParts, map[string]any{

--- a/service/relayconvert/internal/oai_responses/to_oai_chat_req_test.go
+++ b/service/relayconvert/internal/oai_responses/to_oai_chat_req_test.go
@@ -128,6 +128,85 @@ func TestResponsesRequestToChatCompletionsRequestAssistantTextAndFunctionCallCoe
 	assert.JSONEq(t, `{"ok":true}`, got.Messages[1].StringContent())
 }
 
+func TestResponsesRequestToChatCompletionsRequestPreservesToolCallReasoning(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         []map[string]any
+		wantContent   string
+		wantReasoning string
+		wantCalls     int
+	}{
+		{
+			name: "reasoning before parallel function calls",
+			input: []map[string]any{
+				{
+					"type": "reasoning",
+					"summary": []map[string]any{
+						{"type": "summary_text", "text": "Need both "},
+						{"type": "summary_text", "text": "tool results."},
+					},
+				},
+				{"type": "function_call", "call_id": "call_1", "name": "first", "arguments": `{}`},
+				{"type": "function_call", "call_id": "call_2", "name": "second", "arguments": `{}`},
+				{"type": "function_call_output", "call_id": "call_1", "output": "one"},
+				{"type": "function_call_output", "call_id": "call_2", "output": "two"},
+			},
+			wantReasoning: "Need both tool results.",
+			wantCalls:     2,
+		},
+		{
+			name: "reasoning between assistant text and function call",
+			input: []map[string]any{
+				{
+					"role":    "assistant",
+					"content": []map[string]any{{"type": "output_text", "text": "Checking now."}},
+				},
+				{
+					"type":    "reasoning",
+					"content": []map[string]any{{"type": "summary_text", "text": "Need the lookup."}},
+				},
+				{"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": `{}`},
+				{"type": "function_call_output", "call_id": "call_1", "output": "done"},
+			},
+			wantContent:   "Checking now.",
+			wantReasoning: "Need the lookup.",
+			wantCalls:     1,
+		},
+		{
+			name: "reasoning embedded in function call",
+			input: []map[string]any{
+				{
+					"type":              "function_call",
+					"call_id":           "call_1",
+					"name":              "lookup",
+					"arguments":         `{}`,
+					"reasoning_content": "Need the lookup.",
+				},
+				{"type": "function_call_output", "call_id": "call_1", "output": "done"},
+			},
+			wantReasoning: "Need the lookup.",
+			wantCalls:     1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResponsesRequestToChatCompletionsRequest(&dto.OpenAIResponsesRequest{
+				Model: "gpt-test",
+				Input: mustRawMessage(t, tt.input),
+			})
+			require.NoError(t, err)
+
+			require.Len(t, got.Messages, tt.wantCalls+1)
+			assistant := got.Messages[0]
+			assert.Equal(t, "assistant", assistant.Role)
+			assert.Equal(t, tt.wantContent, assistant.StringContent())
+			assert.Equal(t, tt.wantReasoning, assistant.GetReasoningContent())
+			assert.Len(t, assistant.ParseToolCalls(), tt.wantCalls)
+		})
+	}
+}
+
 func TestResponsesRequestToChatCompletionsRequestOnlyFunctionCallCreatesAssistant(t *testing.T) {
 	got, err := ResponsesRequestToChatCompletionsRequest(&dto.OpenAIResponsesRequest{
 		Model: "gpt-test",


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

> [!NOTE]
>
> 实现、最小复现和描述初稿由 OpenAI Codex 协助完成；我已经确认了问题、修复和测试

## 📝 变更描述 / Description

Responses→Chat 请求转换此前未识别 standalone `reasoning` input item，也没有保留 function/custom tool call 上内联的 `reasoning_content`。在 Agent 多轮工具调用历史中，这会让转换后的 assistant `tool_calls` 缺少 reasoning；严格要求完整回传 reasoning 的 Chat Completions 上游会在下一轮返回 HTTP 400。这个bug会影响到小米mimo在Codex中的调用，会出现只输出一句话就完成的问题，小米文档：Agent 多轮会话开启深度思考且历史存在工具调用时，后续请求必须完整回传带工具调用 assistant 的 reasoning_content，没回传的话就会 400 文档：https://mimo.mi.com/docs/zh-CN/usage-guide/passing-back-reasoning_content。


本改动仅修改 Responses 请求转换层：

- 收集 `reasoning` item，并绑定到拥有工具调用的 assistant message；
- 支持标准 `summary`、New API 生成的 `content`，以及内联 `reasoning_content` / `reasoning`；
- 支持并行 function calls 和 custom tool calls；
- 仅对完全相同的 reasoning 去重，不生成占位内容；
- 不增加供应商特判、共享 DTO、全局缓存或 `previous_response_id` 状态管理。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #6396
- Related: farion1231/cc-switch#3561

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，未发现同一 Responses→Chat reasoning 历史丢失修复。
- [x] **Bug fix 说明:** 已关联可独立复现转换层数据丢失的 #6396。
- [x] **变更理解:** 已确认 reasoning item、assistant tool calls 和 Chat `reasoning_content` 的映射关系。
- [x] **范围聚焦:** 本 PR 仅修改请求转换实现及其回归测试。
- [x] **本地验证:** 已运行修复前/后对照测试、转换层测试和静态检查。
- [x] **安全合规:** 代码中无凭据、供应商密钥、日志隐私数据或新的持久化状态。

## 📸 运行证明 / Proof of Work

同一个回归测试仅应用到未修复的 `main @ 1721144` 时：

```text
--- FAIL: TestResponsesRequestToChatCompletionsRequestPreservesToolCallReasoning
    --- FAIL: reasoning_before_parallel_function_calls
        expected 3 messages, got 4
        standalone reasoning was converted into a user message
    --- FAIL: reasoning_between_assistant_text_and_function_call
        expected 2 messages, got 4
    --- FAIL: reasoning_embedded_in_function_call
        expected reasoning_content: "Need the lookup."
        actual: ""
FAIL
```

应用本 PR 后，同一测试通过：

```text
ok github.com/QuantumNous/new-api/service/relayconvert/internal/oai_responses
```

完整验证：

```text
go test ./service/relayconvert/internal/oai_responses -count=1
go test ./service/relayconvert/... -count=1
go vet ./service/relayconvert/...
git diff --check
```
