### PR TITLE
fix(relay): honor Responses policy for Claude passthrough

### DIFF
--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -133,7 +133,6 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 	}
 
 	if !model_setting.GetGlobalSettings().PassThroughRequestEnabled &&
-		!info.ChannelSetting.PassThroughBodyEnabled &&
 		service.ShouldChatCompletionsUseResponsesGlobal(info.ChannelId, info.ChannelType, info.OriginModelName) {
 		result, convErr := service.ConvertRequest(c, info, types.RelayFormatOpenAI, request)
 		if convErr != nil {

--- a/relay/claude_handler_test.go
+++ b/relay/claude_handler_test.go
@@ -1,0 +1,114 @@
+package relay
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/setting/model_setting"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestClaudeResponsesPolicyOverridesChannelBodyPassthrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	service.InitHttpClient()
+
+	const testChannelID = 42
+	const testModel = "policy-matched-model"
+
+	var upstreamPath string
+	var upstreamBody []byte
+	var upstreamReadErr error
+	var upstreamWriteErr error
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamPath = r.URL.Path
+		upstreamBody, upstreamReadErr = io.ReadAll(r.Body)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, upstreamWriteErr = w.Write([]byte(`{"error":{"message":"stop after capturing request","type":"invalid_request_error","code":"test"}}`))
+	}))
+	defer upstream.Close()
+
+	globalSettings := model_setting.GetGlobalSettings()
+	originalGlobalSettings := *globalSettings
+	t.Cleanup(func() {
+		*globalSettings = originalGlobalSettings
+	})
+	globalSettings.PassThroughRequestEnabled = false
+	globalSettings.ChatCompletionsToResponsesPolicy = model_setting.ChatCompletionsToResponsesPolicy{
+		Enabled:       true,
+		ChannelIDs:    []int{testChannelID},
+		ModelPatterns: []string{`^policy-matched-model$`},
+	}
+
+	imageData := "iVBORw0KGgo="
+	text := "Read the image."
+	maxTokens := uint(64)
+	request := &dto.ClaudeRequest{
+		Model:     testModel,
+		MaxTokens: &maxTokens,
+		Messages: []dto.ClaudeMessage{
+			{
+				Role: "user",
+				Content: []dto.ClaudeMediaMessage{
+					{
+						Type: "image",
+						Source: &dto.ClaudeMessageSource{
+							Type:      "base64",
+							MediaType: "image/png",
+							Data:      imageData,
+						},
+					},
+					{
+						Type: dto.ContentTypeText,
+						Text: &text,
+					},
+				},
+			},
+		},
+	}
+	requestBody, err := common.Marshal(request)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(requestBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+	common.SetContextKey(c, constant.ContextKeyChannelType, constant.ChannelTypeOpenAI)
+	common.SetContextKey(c, constant.ContextKeyChannelId, testChannelID)
+	common.SetContextKey(c, constant.ContextKeyChannelBaseUrl, upstream.URL)
+	common.SetContextKey(c, constant.ContextKeyChannelKey, "test-key")
+	common.SetContextKey(c, constant.ContextKeyChannelSetting, dto.ChannelSettings{PassThroughBodyEnabled: true})
+	common.SetContextKey(c, constant.ContextKeyOriginalModel, request.Model)
+
+	info, err := relaycommon.GenRelayInfo(c, types.RelayFormatClaude, request, nil)
+	require.NoError(t, err)
+
+	newAPIError := ClaudeHelper(c, info)
+
+	require.NotNil(t, newAPIError)
+	require.NoError(t, upstreamReadErr)
+	require.NoError(t, upstreamWriteErr)
+	assert.Equal(t, "/v1/responses", upstreamPath)
+	assert.Equal(t, "input_image", gjson.GetBytes(upstreamBody, "input.0.content.0.type").String())
+	assert.Equal(t, "data:image/png;base64,"+imageData, gjson.GetBytes(upstreamBody, "input.0.content.0.image_url").String())
+	assert.Equal(t, "input_text", gjson.GetBytes(upstreamBody, "input.0.content.1.type").String())
+	assert.Equal(t, text, gjson.GetBytes(upstreamBody, "input.0.content.1.text").String())
+	assert.Equal(t, []types.RelayFormat{
+		types.RelayFormatClaude,
+		types.RelayFormatOpenAI,
+		types.RelayFormatOpenAIResponses,
+	}, info.RequestConversionChain)
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
当渠道启用了请求体透传时，Claude Messages 请求目前会跳过已经明确匹配的 Chat Completions → Responses 转换策略。原始 Claude 请求体会在未转换媒体内容的情况下直接发送到 OpenAI 兼容上游，导致图片内容可能被忽略。

本次修改让明确匹配的 Responses 转换策略优先于渠道级请求体透传。未匹配该策略的请求仍保持原有透传行为。回归测试验证：匹配策略的 Claude 图片请求会发送到 `/v1/responses`，并将图片转换为 `input_image` 内容项。

本次代码贡献和 PR 文案使用了 AI 辅助。

### 部署与配置

仅部署本次代码修改不足以启用修复。只有全局 Chat Completions → Responses 策略同时匹配所选渠道和模型时，转换链路才会生效。

所需运行时配置：

- 保持 `global.pass_through_request_enabled` 关闭。
- 启用 `global.chat_completions_to_responses_policy`。
- 保持 `all_channels` 关闭，只明确添加需要将 Claude Messages 请求转换为 Responses 请求的 OpenAI 兼容渠道 ID。
- 只为上游支持 `/v1/responses` 的模型添加模型正则表达式。
- 将所需渠道和模型条目合并到现有策略中，不要覆盖现有条目。
- `channel.setting.pass_through_body_enabled` 可以继续保持开启。本次修改后，只有明确匹配 Responses 策略的请求会覆盖渠道请求体透传；未匹配请求仍保持原有透传行为。

预期请求链路：

```text
Claude Messages → OpenAI Chat → OpenAI Responses
```

图片块会转换为 `input_image` 内容项并发送到 `/v1/responses`。

部署后验证：

1. 通过匹配策略的渠道和模型发送一个包含固定 base64 图片的 Claude Messages 请求。
2. 确认转换链路为 `Claude Messages → OpenAI Compatible → OpenAI Responses`。
3. 确认上游路径为 `/v1/responses`、媒体内容类型为 `input_image`，并确认响应实际使用了图片内容，而不是报告缺少图片。
4. 发送一个不匹配策略的请求，确认其原有透传行为不变。

回滚：

- 从 Responses 策略中移除受影响的渠道和模型条目，即可立即停用该转换链路。
- 只有在策略回滚不足以恢复时，才需要回滚本次代码提交。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无（未创建 Issue）

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```text
go test ./relay ./service/relayconvert/...

ok github.com/QuantumNous/new-api/relay
ok github.com/QuantumNous/new-api/service/relayconvert
ok github.com/QuantumNous/new-api/service/relayconvert/internal/oai_chat
ok github.com/QuantumNous/new-api/service/relayconvert/internal/oai_responses
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Claude requests may now be converted and routed through the OpenAI Responses API when global pass-through is disabled, even if channel-level body pass-through is enabled.
  - Improved handling of image and text content during Claude-to-OpenAI request conversion.

- **Tests**
  - Added coverage verifying request routing, payload conversion, and upstream error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->