### PR TITLE
fix(web/channel): stabilize inline priority updates

### DIFF
--- a/web/src/features/channels/components/channels-columns.tsx
+++ b/web/src/features/channels/components/channels-columns.tsx
@@ -27,7 +27,7 @@ import {
   Shuffle,
   SlidersHorizontal,
 } from 'lucide-react'
-import { useState, useMemo, useContext } from 'react'
+import { useState, useMemo, useContext, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -71,6 +71,7 @@ import {
   handleUpdateChannelField,
   handleUpdateTagField,
   handleUpdateChannelBalance,
+  createChannelPriorityUpdateScheduler,
   isTagAggregateRow,
   type TagRow,
 } from '../lib'
@@ -172,55 +173,77 @@ function UpstreamUpdateTags({ channel }: { channel: Channel }) {
  * Priority cell component with inline editing
  */
 function PriorityCell({ channel }: { channel: Channel }) {
+  if (isTagAggregateRow(channel)) {
+    return <TagPriorityCell channel={channel} />
+  }
+
+  return <ChannelPriorityCell channel={channel} />
+}
+
+function TagPriorityCell({ channel }: { channel: TagRow }) {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
-  const isTagRow = isTagAggregateRow(channel)
   const priority = channel.priority
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [pendingValue, setPendingValue] = useState<number | null>(null)
+  const tag = channel.tag || ''
+  const channelCount = channel.children?.length || 0
 
-  // Tag row - editable with confirmation for all tag channels
-  if (isTagRow) {
-    const tag = channel.tag || ''
-    const channelCount = channel.children?.length || 0
+  return (
+    <>
+      <NumericSpinnerInput
+        value={priority ?? 0}
+        onChange={(value) => {
+          setPendingValue(value)
+          setConfirmOpen(true)
+        }}
+        min={-999}
+      />
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title={t('Confirm Batch Update')}
+        desc={t(
+          'This will update the priority to {{value}} for all {{count}} channel(s) with tag "{{tag}}". Continue?',
+          { value: pendingValue, count: channelCount, tag }
+        )}
+        confirmText={t('Update')}
+        handleConfirm={() => {
+          if (pendingValue !== null) {
+            handleUpdateTagField(tag, 'priority', pendingValue, queryClient)
+          }
+          setConfirmOpen(false)
+        }}
+      />
+    </>
+  )
+}
 
-    return (
-      <>
-        <NumericSpinnerInput
-          value={priority ?? 0}
-          onChange={(value) => {
-            setPendingValue(value)
-            setConfirmOpen(true)
-          }}
-          min={-999}
-        />
-        <ConfirmDialog
-          open={confirmOpen}
-          onOpenChange={setConfirmOpen}
-          title={t('Confirm Batch Update')}
-          desc={t(
-            'This will update the priority to {{value}} for all {{count}} channel(s) with tag "{{tag}}". Continue?',
-            { value: pendingValue, count: channelCount, tag }
-          )}
-          confirmText={t('Update')}
-          handleConfirm={() => {
-            if (pendingValue !== null) {
-              handleUpdateTagField(tag, 'priority', pendingValue, queryClient)
-            }
-            setConfirmOpen(false)
-          }}
-        />
-      </>
-    )
-  }
+function ChannelPriorityCell({ channel }: { channel: Channel }) {
+  const queryClient = useQueryClient()
+  const priorityUpdateScheduler = useMemo(
+    () =>
+      createChannelPriorityUpdateScheduler((value) => {
+        void handleUpdateChannelField(
+          channel.id,
+          'priority',
+          value,
+          queryClient
+        )
+      }),
+    [channel.id, queryClient]
+  )
 
-  // Regular channel row - editable
+  useEffect(
+    () => () => priorityUpdateScheduler.flush(),
+    [priorityUpdateScheduler]
+  )
+
   return (
     <NumericSpinnerInput
-      value={priority ?? 0}
-      onChange={(value) => {
-        handleUpdateChannelField(channel.id, 'priority', value, queryClient)
-      }}
+      value={channel.priority ?? 0}
+      onChange={priorityUpdateScheduler.schedule}
+      onCommit={priorityUpdateScheduler.flush}
       min={-999}
     />
   )

--- a/web/src/features/channels/components/channels-table.tsx
+++ b/web/src/features/channels/components/channels-table.tsx
@@ -55,6 +55,7 @@ import {
 import {
   channelsQueryKeys,
   aggregateChannelsByTag,
+  getChannelTableRowId,
   isTagAggregateRow,
   getChannelTypeIcon,
   getChannelTypeLabel,
@@ -330,6 +331,7 @@ export function ChannelsTable() {
     onColumnFiltersChange: handleColumnFiltersChange,
     onPaginationChange,
     onGlobalFilterChange,
+    getRowId: getChannelTableRowId,
     getSubRows: (row: Channel & { children?: Channel[] }) => row.children,
     manualPagination: true,
     manualSorting: true,

--- a/web/src/features/channels/components/numeric-spinner-input.tsx
+++ b/web/src/features/channels/components/numeric-spinner-input.tsx
@@ -107,7 +107,6 @@ export function NumericSpinnerInput({
     if (clamped !== (value ?? 0)) {
       onChange(clamped)
     }
-    onCommit?.()
   }
 
   const handleControlBlur = (e: React.FocusEvent<HTMLDivElement>) => {
@@ -124,6 +123,7 @@ export function NumericSpinnerInput({
     if (e.key === 'Enter') {
       e.preventDefault()
       commitValue()
+      onCommit?.()
     } else if (e.key === 'Escape') {
       setEditing(false)
       setLocalValue(String(value ?? 0))

--- a/web/src/features/channels/components/numeric-spinner-input.tsx
+++ b/web/src/features/channels/components/numeric-spinner-input.tsx
@@ -25,6 +25,7 @@ import { cn } from '@/lib/utils'
 interface NumericSpinnerInputProps {
   value: number | null | undefined
   onChange: (value: number) => void
+  onCommit?: () => void
   min?: number
   max?: number
   step?: number
@@ -36,6 +37,7 @@ interface NumericSpinnerInputProps {
 export function NumericSpinnerInput({
   value,
   onChange,
+  onCommit,
   min = 0,
   max,
   step = 1,
@@ -96,7 +98,7 @@ export function NumericSpinnerInput({
   const commitValue = () => {
     setEditing(false)
     const num = Number(localValue)
-    if (isNaN(num) || localValue === '' || localValue === '-') {
+    if (Number.isNaN(num) || localValue === '' || localValue === '-') {
       setLocalValue(String(value ?? 0))
       return
     }
@@ -105,6 +107,17 @@ export function NumericSpinnerInput({
     if (clamped !== (value ?? 0)) {
       onChange(clamped)
     }
+    onCommit?.()
+  }
+
+  const handleControlBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+    if (
+      e.relatedTarget instanceof Node &&
+      e.currentTarget.contains(e.relatedTarget)
+    ) {
+      return
+    }
+    onCommit?.()
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -126,6 +139,7 @@ export function NumericSpinnerInput({
         <Label className='text-muted-foreground mr-1.5 text-xs'>{label}</Label>
       )}
       <div
+        onBlur={handleControlBlur}
         className={cn(
           'group/spinner border-input inline-flex h-7 items-center gap-0 rounded-md border transition-colors',
           !disabled && 'hover:bg-muted/60',

--- a/web/src/features/channels/lib/__tests__/channel-table-row-id.test.ts
+++ b/web/src/features/channels/lib/__tests__/channel-table-row-id.test.ts
@@ -1,0 +1,56 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import type { Channel } from '../../types'
+import { getChannelTableRowId, type TagRow } from '../channel-utils'
+
+function channel(id: number): Channel {
+  return { id } as Channel
+}
+
+describe('channel table row identity', () => {
+  test('keeps each channel identity when priority updates reorder the rows', () => {
+    const first = channel(101)
+    const updated = channel(202)
+    const third = channel(303)
+
+    const beforeUpdate = [first, updated, third].map(getChannelTableRowId)
+    const afterUpdate = [updated, first, third].map(getChannelTableRowId)
+
+    assert.deepEqual(beforeUpdate, [
+      'channel:101',
+      'channel:202',
+      'channel:303',
+    ])
+    assert.deepEqual(afterUpdate, ['channel:202', 'channel:101', 'channel:303'])
+  })
+
+  test('uses separate namespaces for tag and channel rows', () => {
+    const tagRow = {
+      id: '202' as unknown as number,
+      tag: '202',
+      children: [channel(202)],
+    } as TagRow
+
+    assert.equal(getChannelTableRowId(tagRow), 'tag:202')
+    assert.equal(getChannelTableRowId(channel(202)), 'channel:202')
+  })
+})

--- a/web/src/features/channels/lib/channel-priority-update.test.ts
+++ b/web/src/features/channels/lib/channel-priority-update.test.ts
@@ -1,0 +1,117 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import {
+  CHANNEL_PRIORITY_UPDATE_DELAY_MS,
+  createChannelPriorityUpdateScheduler,
+} from './channel-priority-update'
+
+function createFakeTimers() {
+  const pending = new Map<number, () => void>()
+  let nextId = 1
+
+  return {
+    timers: {
+      setTimeout: (callback: () => void, delay: number) => {
+        assert.equal(delay, CHANNEL_PRIORITY_UPDATE_DELAY_MS)
+        const id = nextId++
+        pending.set(id, callback)
+        return id
+      },
+      clearTimeout: (id: number) => {
+        pending.delete(id)
+      },
+    },
+    fireAll() {
+      const callbacks = [...pending.values()]
+      pending.clear()
+      for (const callback of callbacks) callback()
+    },
+    get pendingCount() {
+      return pending.size
+    },
+  }
+}
+
+describe('channel priority update scheduler', () => {
+  test('coalesces rapid schedules into one update with the latest value', () => {
+    const fake = createFakeTimers()
+    const updates: number[] = []
+    const scheduler = createChannelPriorityUpdateScheduler(
+      (value) => updates.push(value),
+      fake.timers
+    )
+
+    scheduler.schedule(1)
+    scheduler.schedule(2)
+    scheduler.schedule(3)
+    assert.deepEqual(updates, [])
+    assert.equal(fake.pendingCount, 1)
+
+    fake.fireAll()
+    assert.deepEqual(updates, [3])
+  })
+
+  test('flush commits the pending value immediately and cancels the timer', () => {
+    const fake = createFakeTimers()
+    const updates: number[] = []
+    const scheduler = createChannelPriorityUpdateScheduler(
+      (value) => updates.push(value),
+      fake.timers
+    )
+
+    scheduler.schedule(7)
+    scheduler.flush()
+    assert.deepEqual(updates, [7])
+    assert.equal(fake.pendingCount, 0)
+
+    fake.fireAll()
+    assert.deepEqual(updates, [7])
+  })
+
+  test('flush without a pending value does nothing', () => {
+    const fake = createFakeTimers()
+    const updates: number[] = []
+    const scheduler = createChannelPriorityUpdateScheduler(
+      (value) => updates.push(value),
+      fake.timers
+    )
+
+    scheduler.flush()
+    scheduler.schedule(5)
+    scheduler.flush()
+    scheduler.flush()
+    assert.deepEqual(updates, [5])
+  })
+
+  test('preserves a pending value of 0', () => {
+    const fake = createFakeTimers()
+    const updates: number[] = []
+    const scheduler = createChannelPriorityUpdateScheduler(
+      (value) => updates.push(value),
+      fake.timers
+    )
+
+    scheduler.schedule(0)
+    scheduler.flush()
+    assert.deepEqual(updates, [0])
+  })
+})

--- a/web/src/features/channels/lib/channel-priority-update.ts
+++ b/web/src/features/channels/lib/channel-priority-update.ts
@@ -1,0 +1,65 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+
+export const CHANNEL_PRIORITY_UPDATE_DELAY_MS = 800
+
+interface ChannelPriorityUpdateTimers {
+  setTimeout: (callback: () => void, delay: number) => number
+  clearTimeout: (id: number) => void
+}
+
+const browserTimers: ChannelPriorityUpdateTimers = {
+  setTimeout: (callback, delay) => window.setTimeout(callback, delay),
+  clearTimeout: (id) => window.clearTimeout(id),
+}
+
+export function createChannelPriorityUpdateScheduler(
+  onUpdate: (value: number) => void,
+  timers: ChannelPriorityUpdateTimers = browserTimers
+) {
+  let timeoutId: number | undefined
+  let pendingValue: number | undefined
+
+  const clearPendingTimer = () => {
+    if (timeoutId === undefined) return
+    timers.clearTimeout(timeoutId)
+    timeoutId = undefined
+  }
+
+  const commitPendingValue = () => {
+    clearPendingTimer()
+    if (pendingValue === undefined) return
+
+    const value = pendingValue
+    pendingValue = undefined
+    onUpdate(value)
+  }
+
+  return {
+    schedule(value: number) {
+      clearPendingTimer()
+      pendingValue = value
+      timeoutId = timers.setTimeout(
+        commitPendingValue,
+        CHANNEL_PRIORITY_UPDATE_DELAY_MS
+      )
+    },
+    flush: commitPendingValue,
+  }
+}

--- a/web/src/features/channels/lib/channel-utils.ts
+++ b/web/src/features/channels/lib/channel-utils.ts
@@ -616,6 +616,14 @@ export function isTagAggregateRow(row: Channel | TagRow): row is TagRow {
   return Array.isArray((row as TagRow).children)
 }
 
+export function getChannelTableRowId(row: Channel | TagRow): string {
+  if (isTagAggregateRow(row)) {
+    return `tag:${row.tag || ''}`
+  }
+
+  return `channel:${row.id}`
+}
+
 /**
  * Aggregate channels by tag for tag mode display
  * Converts flat array into tree structure grouped by tag

--- a/web/src/features/channels/lib/index.ts
+++ b/web/src/features/channels/lib/index.ts
@@ -18,6 +18,7 @@ For commercial licensing, please contact support@quantumnous.com
 */
 // Re-export all library functions
 export * from './channel-actions'
+export * from './channel-priority-update'
 export * from './advanced-custom'
 export * from './channel-form-errors'
 export * from './channel-form'


### PR DESCRIPTION
## 📝 变更描述 / Description

优化渠道列表中普通渠道优先级的连续调整体验，并修复优先级更新后列表重新排序导致其他渠道显示相同数值的问题。

**具体变更：**

- 连续点击加减按钮时合并更新，停止操作 800ms 后只提交最终优先级，减少重复请求和列表频繁排序。
- 按 Enter、焦点离开整个优先级控件或组件卸载时立即提交待更新值。
- 输入框与加减按钮之间切换焦点时不会提前提交。
- 渠道表格使用稳定的行标识：普通渠道使用渠道 ID，标签聚合行使用标签值。
- 优先级更新导致渠道位置变化时，输入状态和待提交任务会跟随对应渠道移动，不再被复用到原位置的新渠道。
- 标签聚合行原有的二次确认和批量更新行为保持不变。

#6406 的问题是列表默认按优先级排序，但表格此前使用数组下标标识行。渠道更新后移动到新位置时，React 会把原位置数值控件的本地状态复用给另一条渠道，因此界面上会短暂出现两个相同优先级；稳定行标识可以确保状态始终属于真实渠道。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [x] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #6406

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work


手动验证了 #6406 的行为不再发生：修改中间渠道优先级并触发重新排序后，仅目标渠道显示新值，原位置渠道保持原值



https://github.com/user-attachments/assets/766eda21-5322-4914-a9ce-a0c221048afe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Channel priority edits now use a delayed, coalesced update to reduce frequent saves while editing.
  * Channel tables now use stable row identifiers for both channels and tag aggregates.

* **Bug Fixes**
  * Numeric priority inputs now commit reliably on blur and Enter.
  * Improved invalid-number detection and ensured pending priority updates (including zero) apply correctly.

* **Tests**
  * Added unit tests for the priority update scheduler (coalescing, flush behavior, and timing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->