### PR TITLE
feat(relay): support Responses retrieve, delete, and input-items routes

### DIFF
--- a/controller/responses_resource.go
+++ b/controller/responses_resource.go
@@ -1,0 +1,152 @@
+package controller
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/logger"
+	"github.com/QuantumNous/new-api/middleware"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/relay"
+	"github.com/QuantumNous/new-api/relay/channel"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/types"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RelayResponsesResource(c *gin.Context) {
+	responseID := strings.TrimSpace(c.Param("response_id"))
+	if responseID == "" {
+		responsesResourceError(c, http.StatusBadRequest, "response_id is required")
+		return
+	}
+
+	resourceRoute, found, err := service.GetResponsesResourceRoute(c, responseID)
+	if err != nil {
+		responsesResourceError(c, http.StatusInternalServerError, "failed to resolve response route")
+		return
+	}
+	if !found {
+		responsesResourceError(c, http.StatusNotFound, "response not found")
+		return
+	}
+
+	selectedChannel, err := model.CacheGetChannel(resourceRoute.ChannelID)
+	if err != nil || selectedChannel == nil {
+		responsesResourceError(c, http.StatusBadGateway, "response channel is unavailable")
+		return
+	}
+	if setupErr := middleware.SetupContextForSelectedChannel(c, selectedChannel, resourceRoute.OriginModelName); setupErr != nil {
+		responsesResourceError(c, setupErr.StatusCode, setupErr.Error())
+		return
+	}
+	if resourceRoute.ChannelIsMultiKey {
+		keys := selectedChannel.GetKeys()
+		if resourceRoute.ChannelMultiKeyIndex < 0 || resourceRoute.ChannelMultiKeyIndex >= len(keys) {
+			responsesResourceError(c, http.StatusBadGateway, "response channel key is unavailable")
+			return
+		}
+		common.SetContextKey(c, constant.ContextKeyChannelIsMultiKey, true)
+		common.SetContextKey(c, constant.ContextKeyChannelMultiKeyIndex, resourceRoute.ChannelMultiKeyIndex)
+		common.SetContextKey(c, constant.ContextKeyChannelKey, keys[resourceRoute.ChannelMultiKeyIndex])
+	}
+
+	upstreamURL, err := service.BuildResponsesResourceURL(
+		resourceRoute.UpstreamResponsesURL,
+		responseID,
+		strings.HasSuffix(c.Request.URL.Path, "/input_items"),
+		c.Request.URL.Query(),
+	)
+	if err != nil {
+		responsesResourceError(c, http.StatusInternalServerError, "failed to build upstream response URL")
+		return
+	}
+
+	info := &relaycommon.RelayInfo{
+		UserId:          common.GetContextKeyInt(c, constant.ContextKeyUserId),
+		TokenId:         common.GetContextKeyInt(c, constant.ContextKeyTokenId),
+		RelayMode:       relayconstant.RelayModeResponses,
+		RelayFormat:     types.RelayFormatOpenAIResponses,
+		OriginModelName: resourceRoute.OriginModelName,
+		RequestURLPath:  c.Request.URL.RequestURI(),
+		IsStream:        strings.EqualFold(c.Query("stream"), "true"),
+	}
+	info.InitChannelMeta(c)
+
+	adaptor := relay.GetAdaptor(info.ApiType)
+	if adaptor == nil {
+		responsesResourceError(c, http.StatusBadGateway, fmt.Sprintf("unsupported response channel type: %d", info.ApiType))
+		return
+	}
+	adaptor.Init(info)
+
+	upstreamResponse, err := channel.DoApiRequestWithURL(adaptor, c, info, nil, upstreamURL)
+	if err != nil {
+		responsesResourceError(c, http.StatusBadGateway, "failed to query upstream response")
+		return
+	}
+	defer service.CloseResponseBodyGracefully(upstreamResponse)
+
+	copyResponsesResourceHeaders(c, upstreamResponse)
+	c.Status(upstreamResponse.StatusCode)
+	c.Writer.WriteHeaderNow()
+	if _, err = copyResponsesResourceBody(c, upstreamResponse.Body); err != nil {
+		logger.LogError(c, "failed to copy responses resource body: "+err.Error())
+		return
+	}
+
+	if c.Request.Method == http.MethodDelete && upstreamResponse.StatusCode >= 200 && upstreamResponse.StatusCode < 300 {
+		if err := service.DeleteResponsesResourceRoute(c, responseID); err != nil {
+			logger.LogWarn(c, "failed to delete responses resource route: "+err.Error())
+		}
+	}
+}
+
+func copyResponsesResourceHeaders(c *gin.Context, response *http.Response) {
+	for key, values := range response.Header {
+		if !service.ShouldCopyUpstreamHeader(c, key, values) {
+			continue
+		}
+		for _, value := range values {
+			c.Writer.Header().Add(key, value)
+		}
+	}
+}
+
+func copyResponsesResourceBody(c *gin.Context, body io.Reader) (int64, error) {
+	buffer := make([]byte, 32*1024)
+	var total int64
+	for {
+		readCount, readErr := body.Read(buffer)
+		if readCount > 0 {
+			written, writeErr := c.Writer.Write(buffer[:readCount])
+			total += int64(written)
+			c.Writer.Flush()
+			if writeErr != nil {
+				return total, writeErr
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				return total, nil
+			}
+			return total, readErr
+		}
+	}
+}
+
+func responsesResourceError(c *gin.Context, statusCode int, message string) {
+	c.AbortWithStatusJSON(statusCode, gin.H{
+		"error": gin.H{
+			"message": message,
+			"type":    "invalid_request_error",
+		},
+	})
+}

--- a/controller/responses_resource_test.go
+++ b/controller/responses_resource_test.go
@@ -1,0 +1,115 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelayResponsesResourceProxiesRetrieveInputItemsAndDelete(t *testing.T) {
+	db := setupModelListControllerTestDB(t)
+	service.InitHttpClient()
+	originalMemoryCacheEnabled := common.MemoryCacheEnabled
+	common.MemoryCacheEnabled = false
+	t.Cleanup(func() {
+		common.MemoryCacheEnabled = originalMemoryCacheEnabled
+	})
+
+	var (
+		requestsMu sync.Mutex
+		requests   []string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer upstream-secret", r.Header.Get("Authorization"))
+		requestsMu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		requestsMu.Unlock()
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/responses/resp_retrieve":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp_retrieve","status":"completed"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/responses/resp_items/input_items":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/responses/resp_delete":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	baseURL := upstream.URL
+	upstreamChannel := &model.Channel{
+		Type:    constant.ChannelTypeOpenAI,
+		Key:     "upstream-secret",
+		Status:  common.ChannelStatusEnabled,
+		Name:    "responses-resource-test",
+		BaseURL: &baseURL,
+	}
+	require.NoError(t, db.Create(upstreamChannel).Error)
+
+	recordRoute := func(responseID string) {
+		t.Helper()
+		context := &gin.Context{}
+		common.SetContextKey(context, constant.ContextKeyUserId, 301)
+		common.SetContextKey(context, constant.ContextKeyChannelId, upstreamChannel.Id)
+		common.SetContextKey(context, constant.ContextKeyOriginalModel, "gpt-test")
+		require.NoError(t, service.RecordResponsesResourceRoute(
+			context,
+			responseID,
+			0,
+			upstream.URL+"/v1/responses?api-version=preview",
+		))
+	}
+	recordRoute("resp_retrieve")
+	recordRoute("resp_items")
+	recordRoute("resp_delete")
+
+	invoke := func(method string, path string, responseID string) *httptest.ResponseRecorder {
+		t.Helper()
+		recorder := httptest.NewRecorder()
+		context, _ := gin.CreateTestContext(recorder)
+		context.Request = httptest.NewRequest(method, path, nil)
+		context.Params = gin.Params{{Key: "response_id", Value: responseID}}
+		common.SetContextKey(context, constant.ContextKeyUserId, 301)
+		common.SetContextKey(context, constant.ContextKeyTokenId, 401)
+		RelayResponsesResource(context)
+		return recorder
+	}
+
+	retrieve := invoke(http.MethodGet, "/v1/responses/resp_retrieve?stream=true&starting_after=7", "resp_retrieve")
+	require.Equal(t, http.StatusOK, retrieve.Code)
+	assert.JSONEq(t, `{"id":"resp_retrieve","status":"completed"}`, retrieve.Body.String())
+
+	inputItems := invoke(http.MethodGet, "/v1/responses/resp_items/input_items?after=item_1&limit=20", "resp_items")
+	require.Equal(t, http.StatusOK, inputItems.Code)
+	assert.JSONEq(t, `{"object":"list","data":[]}`, inputItems.Body.String())
+
+	deleted := invoke(http.MethodDelete, "/v1/responses/resp_delete", "resp_delete")
+	require.Equal(t, http.StatusNoContent, deleted.Code)
+	lookupContext := &gin.Context{}
+	common.SetContextKey(lookupContext, constant.ContextKeyUserId, 301)
+	_, found, err := service.GetResponsesResourceRoute(lookupContext, "resp_delete")
+	require.NoError(t, err)
+	assert.False(t, found)
+
+	requestsMu.Lock()
+	defer requestsMu.Unlock()
+	assert.Equal(t, []string{
+		"GET /v1/responses/resp_retrieve?api-version=preview&starting_after=7&stream=true",
+		"GET /v1/responses/resp_items/input_items?after=item_1&api-version=preview&limit=20",
+		"DELETE /v1/responses/resp_delete?api-version=preview",
+	}, requests)
+}

--- a/controller/responses_resource_test.go
+++ b/controller/responses_resource_test.go
@@ -113,3 +113,56 @@ func TestRelayResponsesResourceProxiesRetrieveInputItemsAndDelete(t *testing.T) 
 		"DELETE /v1/responses/resp_delete?api-version=preview",
 	}, requests)
 }
+
+func TestRelayResponsesResourceRejectsInvalidOrUnavailableRoutes(t *testing.T) {
+	db := setupModelListControllerTestDB(t)
+	originalMemoryCacheEnabled := common.MemoryCacheEnabled
+	common.MemoryCacheEnabled = false
+	t.Cleanup(func() {
+		common.MemoryCacheEnabled = originalMemoryCacheEnabled
+	})
+
+	invoke := func(responseID string) *httptest.ResponseRecorder {
+		t.Helper()
+		recorder := httptest.NewRecorder()
+		context, _ := gin.CreateTestContext(recorder)
+		context.Request = httptest.NewRequest(http.MethodGet, "/v1/responses/"+responseID, nil)
+		context.Params = gin.Params{{Key: "response_id", Value: responseID}}
+		common.SetContextKey(context, constant.ContextKeyUserId, 302)
+		RelayResponsesResource(context)
+		return recorder
+	}
+
+	assert.Equal(t, http.StatusBadRequest, invoke("").Code)
+	assert.Equal(t, http.StatusNotFound, invoke("resp_missing").Code)
+
+	recordRoute := func(responseID string, channelID int, multiKeyIndex int) {
+		t.Helper()
+		context := &gin.Context{}
+		common.SetContextKey(context, constant.ContextKeyUserId, 302)
+		common.SetContextKey(context, constant.ContextKeyChannelId, channelID)
+		common.SetContextKey(context, constant.ContextKeyChannelIsMultiKey, multiKeyIndex >= 0)
+		common.SetContextKey(context, constant.ContextKeyChannelMultiKeyIndex, multiKeyIndex)
+		require.NoError(t, service.RecordResponsesResourceRoute(
+			context,
+			responseID,
+			0,
+			"https://example.com/v1/responses",
+		))
+	}
+
+	recordRoute("resp_unavailable", 999999, -1)
+	assert.Equal(t, http.StatusBadGateway, invoke("resp_unavailable").Code)
+
+	baseURL := "https://example.com"
+	channel := &model.Channel{
+		Type:    constant.ChannelTypeOpenAI,
+		Key:     "only-key",
+		Status:  common.ChannelStatusEnabled,
+		Name:    "responses-resource-multi-key-test",
+		BaseURL: &baseURL,
+	}
+	require.NoError(t, db.Create(channel).Error)
+	recordRoute("resp_bad_key_index", channel.Id, 2)
+	assert.Equal(t, http.StatusBadGateway, invoke("resp_bad_key_index").Code)
+}

--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -294,6 +294,7 @@ type OpenAIResponsesResponse struct {
 	ID                 string             `json:"id"`
 	Object             string             `json:"object"`
 	CreatedAt          int                `json:"created_at"`
+	ExpiresAt          int                `json:"expires_at,omitempty"`
 	Status             json.RawMessage    `json:"status"`
 	Error              any                `json:"error,omitempty"`
 	IncompleteDetails  *IncompleteDetails `json:"incomplete_details,omitempty"`

--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -309,6 +309,10 @@ func DoApiRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody
 	if err != nil {
 		return nil, fmt.Errorf("get request url failed: %w", err)
 	}
+	return DoApiRequestWithURL(a, c, info, requestBody, fullRequestURL)
+}
+
+func DoApiRequestWithURL(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody io.Reader, fullRequestURL string) (*http.Response, error) {
 	logger.LogDebug(c, "fullRequestURL: %s", common.SanitizeURLForLog(fullRequestURL))
 	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
@@ -519,8 +523,12 @@ func doRequest(c *gin.Context, req *http.Request, info *common.RelayInfo) (*http
 		c.Set(common2.UpstreamRequestIdKey, upID)
 	}
 
-	_ = req.Body.Close()
-	_ = c.Request.Body.Close()
+	if req.Body != nil {
+		_ = req.Body.Close()
+	}
+	if c.Request.Body != nil {
+		_ = c.Request.Body.Close()
+	}
 	return resp, nil
 }
 

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -33,6 +33,11 @@ func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 	if oaiError := responsesResponse.GetOpenAIError(); oaiError != nil && oaiError.Type != "" {
 		return nil, types.WithOpenAIError(*oaiError, resp.StatusCode)
 	}
+	if resp.Request != nil && resp.Request.URL != nil {
+		if err := service.RecordResponsesResourceRoute(c, responsesResponse.ID, int64(responsesResponse.ExpiresAt), resp.Request.URL.String()); err != nil {
+			logger.LogWarn(c, "failed to record responses resource route: "+err.Error())
+		}
+	}
 
 	if responsesResponse.HasImageGenerationCall() {
 		c.Set("image_generation_call", true)
@@ -90,6 +95,11 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 			return
 		}
 		sendResponsesStreamData(c, streamResponse, data)
+		if streamResponse.Response != nil && resp.Request != nil && resp.Request.URL != nil {
+			if err := service.RecordResponsesResourceRoute(c, streamResponse.Response.ID, int64(streamResponse.Response.ExpiresAt), resp.Request.URL.String()); err != nil {
+				logger.LogWarn(c, "failed to record responses resource route: "+err.Error())
+			}
+		}
 		switch streamResponse.Type {
 		case "response.completed":
 			if streamResponse.Response != nil {

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -35,7 +35,7 @@ func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 	}
 	if resp.Request != nil && resp.Request.URL != nil {
 		if err := service.RecordResponsesResourceRoute(c, responsesResponse.ID, int64(responsesResponse.ExpiresAt), resp.Request.URL.String()); err != nil {
-			logger.LogWarn(c, "failed to record responses resource route: "+err.Error())
+			logger.LogWarn(c, "failed to record responses resource route")
 		}
 	}
 
@@ -97,7 +97,7 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 		sendResponsesStreamData(c, streamResponse, data)
 		if streamResponse.Response != nil && resp.Request != nil && resp.Request.URL != nil {
 			if err := service.RecordResponsesResourceRoute(c, streamResponse.Response.ID, int64(streamResponse.Response.ExpiresAt), resp.Request.URL.String()); err != nil {
-				logger.LogWarn(c, "failed to record responses resource route: "+err.Error())
+				logger.LogWarn(c, "failed to record responses resource route")
 			}
 		}
 		switch streamResponse.Type {

--- a/relay/channel/openai/relay_responses_resource_test.go
+++ b/relay/channel/openai/relay_responses_resource_test.go
@@ -1,0 +1,49 @@
+package openai
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOaiResponsesHandlerRecordsResourceRoute(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	context.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	common.SetContextKey(context, constant.ContextKeyUserId, 201)
+	common.SetContextKey(context, constant.ContextKeyChannelId, 11)
+	common.SetContextKey(context, constant.ContextKeyOriginalModel, "doubao-seed-test")
+
+	upstreamRequest := httptest.NewRequest(http.MethodPost, "https://ark.example.com/api/v3/responses", nil)
+	upstreamResponse := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body: io.NopCloser(strings.NewReader(
+			`{"id":"resp_recorded","object":"response","status":"completed","model":"doubao-seed-test","output":[],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`,
+		)),
+		Request: upstreamRequest,
+	}
+
+	usage, newAPIError := OaiResponsesHandler(context, &relaycommon.RelayInfo{}, upstreamResponse)
+	require.Nil(t, newAPIError)
+	require.NotNil(t, usage)
+	assert.Equal(t, 3, usage.TotalTokens)
+
+	route, found, err := service.GetResponsesResourceRoute(context, "resp_recorded")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, 11, route.ChannelID)
+	assert.Equal(t, "https://ark.example.com/api/v3/responses", route.UpstreamResponsesURL)
+}

--- a/router/relay-router.go
+++ b/router/relay-router.go
@@ -80,6 +80,12 @@ func SetRelayRouter(router *gin.Engine) {
 		})
 	}
 	{
+		responsesResourceRouter := relayV1Router.Group("")
+		responsesResourceRouter.GET("/responses/:response_id", controller.RelayResponsesResource)
+		responsesResourceRouter.DELETE("/responses/:response_id", controller.RelayResponsesResource)
+		responsesResourceRouter.GET("/responses/:response_id/input_items", controller.RelayResponsesResource)
+	}
+	{
 		//http router
 		httpRouter := relayV1Router.Group("")
 		httpRouter.Use(middleware.Distribute())

--- a/service/responses_resource.go
+++ b/service/responses_resource.go
@@ -1,0 +1,149 @@
+package service
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/pkg/cachex"
+
+	"github.com/gin-gonic/gin"
+	"github.com/samber/hot"
+)
+
+const (
+	responsesResourceCacheNamespace = "new-api:responses_resource:v1"
+	responsesResourceDefaultTTL     = 30 * 24 * time.Hour
+	responsesResourceCacheCapacity  = 100_000
+)
+
+type ResponsesResourceRoute struct {
+	ChannelID            int    `json:"channel_id"`
+	ChannelIsMultiKey    bool   `json:"channel_is_multi_key"`
+	ChannelMultiKeyIndex int    `json:"channel_multi_key_index"`
+	OriginModelName      string `json:"origin_model_name"`
+	UpstreamResponsesURL string `json:"upstream_responses_url"`
+}
+
+var (
+	responsesResourceCacheOnce sync.Once
+	responsesResourceCache     *cachex.HybridCache[ResponsesResourceRoute]
+)
+
+func getResponsesResourceCache() *cachex.HybridCache[ResponsesResourceRoute] {
+	responsesResourceCacheOnce.Do(func() {
+		responsesResourceCache = cachex.NewHybridCache[ResponsesResourceRoute](cachex.HybridCacheConfig[ResponsesResourceRoute]{
+			Namespace: cachex.Namespace(responsesResourceCacheNamespace),
+			Redis:     common.RDB,
+			RedisEnabled: func() bool {
+				return common.RedisEnabled && common.RDB != nil
+			},
+			RedisCodec: cachex.JSONCodec[ResponsesResourceRoute]{},
+			Memory: func() *hot.HotCache[string, ResponsesResourceRoute] {
+				return hot.NewHotCache[string, ResponsesResourceRoute](hot.LRU, responsesResourceCacheCapacity).
+					WithTTL(responsesResourceDefaultTTL).
+					WithJanitor().
+					Build()
+			},
+		})
+	})
+	return responsesResourceCache
+}
+
+func responsesResourceCacheKey(userID int, responseID string) string {
+	return strconv.Itoa(userID) + ":" + strings.TrimSpace(responseID)
+}
+
+func RecordResponsesResourceRoute(c *gin.Context, responseID string, expiresAt int64, upstreamResponsesURL string) error {
+	responseID = strings.TrimSpace(responseID)
+	if c == nil || responseID == "" || strings.TrimSpace(upstreamResponsesURL) == "" {
+		return nil
+	}
+
+	parsedURL, err := url.Parse(upstreamResponsesURL)
+	if err != nil {
+		return fmt.Errorf("parse upstream responses URL: %w", err)
+	}
+	parsedURL.RawQuery = removeSensitiveQueryValues(parsedURL.Query()).Encode()
+
+	ttl := responsesResourceDefaultTTL
+	if expiresAt > 0 {
+		untilExpiry := time.Until(time.Unix(expiresAt, 0))
+		if untilExpiry > 0 {
+			ttl = untilExpiry
+		}
+	}
+
+	route := ResponsesResourceRoute{
+		ChannelID:            common.GetContextKeyInt(c, constant.ContextKeyChannelId),
+		ChannelIsMultiKey:    common.GetContextKeyBool(c, constant.ContextKeyChannelIsMultiKey),
+		ChannelMultiKeyIndex: common.GetContextKeyInt(c, constant.ContextKeyChannelMultiKeyIndex),
+		OriginModelName:      common.GetContextKeyString(c, constant.ContextKeyOriginalModel),
+		UpstreamResponsesURL: parsedURL.String(),
+	}
+	return getResponsesResourceCache().SetWithTTL(
+		responsesResourceCacheKey(common.GetContextKeyInt(c, constant.ContextKeyUserId), responseID),
+		route,
+		ttl,
+	)
+}
+
+func GetResponsesResourceRoute(c *gin.Context, responseID string) (ResponsesResourceRoute, bool, error) {
+	if c == nil {
+		return ResponsesResourceRoute{}, false, nil
+	}
+	return getResponsesResourceCache().Get(
+		responsesResourceCacheKey(common.GetContextKeyInt(c, constant.ContextKeyUserId), responseID),
+	)
+}
+
+func DeleteResponsesResourceRoute(c *gin.Context, responseID string) error {
+	if c == nil {
+		return nil
+	}
+	key := responsesResourceCacheKey(common.GetContextKeyInt(c, constant.ContextKeyUserId), responseID)
+	_, err := getResponsesResourceCache().DeleteMany([]string{key})
+	return err
+}
+
+func BuildResponsesResourceURL(upstreamResponsesURL string, responseID string, inputItems bool, query url.Values) (string, error) {
+	parsedURL, err := url.Parse(upstreamResponsesURL)
+	if err != nil {
+		return "", fmt.Errorf("parse upstream responses URL: %w", err)
+	}
+
+	parsedURL.Path = strings.TrimSuffix(parsedURL.Path, "/") + "/" + url.PathEscape(strings.TrimSpace(responseID))
+	if inputItems {
+		parsedURL.Path += "/input_items"
+	}
+
+	mergedQuery := parsedURL.Query()
+	for key, values := range query {
+		mergedQuery.Del(key)
+		for _, value := range values {
+			mergedQuery.Add(key, value)
+		}
+	}
+	parsedURL.RawQuery = removeSensitiveQueryValues(mergedQuery).Encode()
+	return parsedURL.String(), nil
+}
+
+func removeSensitiveQueryValues(query url.Values) url.Values {
+	for key := range query {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if strings.Contains(normalized, "key") ||
+			strings.Contains(normalized, "token") ||
+			strings.Contains(normalized, "secret") ||
+			strings.Contains(normalized, "signature") ||
+			normalized == "authorization" ||
+			normalized == "auth" {
+			query.Del(key)
+		}
+	}
+	return query
+}

--- a/service/responses_resource.go
+++ b/service/responses_resource.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"fmt"
+	"errors"
 	"net/url"
 	"strconv"
 	"strings"
@@ -67,7 +67,7 @@ func RecordResponsesResourceRoute(c *gin.Context, responseID string, expiresAt i
 
 	parsedURL, err := url.Parse(upstreamResponsesURL)
 	if err != nil {
-		return fmt.Errorf("parse upstream responses URL: %w", err)
+		return errors.New("parse upstream responses URL: invalid")
 	}
 	parsedURL.RawQuery = removeSensitiveQueryValues(parsedURL.Query()).Encode()
 
@@ -114,7 +114,7 @@ func DeleteResponsesResourceRoute(c *gin.Context, responseID string) error {
 func BuildResponsesResourceURL(upstreamResponsesURL string, responseID string, inputItems bool, query url.Values) (string, error) {
 	parsedURL, err := url.Parse(upstreamResponsesURL)
 	if err != nil {
-		return "", fmt.Errorf("parse upstream responses URL: %w", err)
+		return "", errors.New("parse upstream responses URL: invalid")
 	}
 
 	parsedURL.Path = strings.TrimSuffix(parsedURL.Path, "/") + "/" + url.PathEscape(strings.TrimSpace(responseID))
@@ -136,12 +136,28 @@ func BuildResponsesResourceURL(upstreamResponsesURL string, responseID string, i
 func removeSensitiveQueryValues(query url.Values) url.Values {
 	for key := range query {
 		normalized := strings.ToLower(strings.TrimSpace(key))
-		if strings.Contains(normalized, "key") ||
-			strings.Contains(normalized, "token") ||
-			strings.Contains(normalized, "secret") ||
-			strings.Contains(normalized, "signature") ||
-			normalized == "authorization" ||
-			normalized == "auth" {
+		switch normalized {
+		case "key",
+			"api_key",
+			"api-key",
+			"apikey",
+			"x-api-key",
+			"access_token",
+			"refresh_token",
+			"id_token",
+			"token",
+			"authorization",
+			"auth",
+			"client_secret",
+			"secret",
+			"password",
+			"passwd",
+			"signature",
+			"sig",
+			"awsaccesskeyid",
+			"x-amz-credential",
+			"x-amz-security-token",
+			"x-amz-signature":
 			query.Del(key)
 		}
 	}

--- a/service/responses_resource_test.go
+++ b/service/responses_resource_test.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponsesResourceRouteLifecycleIsScopedToUser(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	responseID := fmt.Sprintf("resp_route_%s", t.Name())
+	owner := &gin.Context{}
+	common.SetContextKey(owner, constant.ContextKeyUserId, 101)
+	common.SetContextKey(owner, constant.ContextKeyChannelId, 17)
+	common.SetContextKey(owner, constant.ContextKeyChannelIsMultiKey, true)
+	common.SetContextKey(owner, constant.ContextKeyChannelMultiKeyIndex, 2)
+	common.SetContextKey(owner, constant.ContextKeyOriginalModel, "doubao-seed-test")
+
+	require.NoError(t, RecordResponsesResourceRoute(
+		owner,
+		responseID,
+		0,
+		"https://ark.example.com/api/v3/responses?api-version=preview&api_key=secret",
+	))
+
+	route, found, err := GetResponsesResourceRoute(owner, responseID)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, 17, route.ChannelID)
+	assert.True(t, route.ChannelIsMultiKey)
+	assert.Equal(t, 2, route.ChannelMultiKeyIndex)
+	assert.Equal(t, "doubao-seed-test", route.OriginModelName)
+	assert.Equal(t, "https://ark.example.com/api/v3/responses?api-version=preview", route.UpstreamResponsesURL)
+
+	otherUser := &gin.Context{}
+	common.SetContextKey(otherUser, constant.ContextKeyUserId, 102)
+	_, found, err = GetResponsesResourceRoute(otherUser, responseID)
+	require.NoError(t, err)
+	assert.False(t, found)
+
+	require.NoError(t, DeleteResponsesResourceRoute(owner, responseID))
+	_, found, err = GetResponsesResourceRoute(owner, responseID)
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestBuildResponsesResourceURLPreservesProviderQueryAndForwardsPagination(t *testing.T) {
+	query := url.Values{
+		"after":          []string{"item_123"},
+		"limit":          []string{"50"},
+		"starting_after": []string{"42"},
+		"api_key":        []string{"must-not-forward"},
+	}
+
+	got, err := BuildResponsesResourceURL(
+		"https://example.com/openai/v1/responses?api-version=preview",
+		"resp_123",
+		true,
+		query,
+	)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"https://example.com/openai/v1/responses/resp_123/input_items?after=item_123&api-version=preview&limit=50&starting_after=42",
+		got,
+	)
+}

--- a/service/responses_resource_test.go
+++ b/service/responses_resource_test.go
@@ -57,6 +57,8 @@ func TestBuildResponsesResourceURLPreservesProviderQueryAndForwardsPagination(t 
 		"limit":          []string{"50"},
 		"starting_after": []string{"42"},
 		"api_key":        []string{"must-not-forward"},
+		"sort_key":       []string{"created_at"},
+		"cache_token":    []string{"cache_123"},
 	}
 
 	got, err := BuildResponsesResourceURL(
@@ -68,7 +70,23 @@ func TestBuildResponsesResourceURLPreservesProviderQueryAndForwardsPagination(t 
 	require.NoError(t, err)
 	assert.Equal(
 		t,
-		"https://example.com/openai/v1/responses/resp_123/input_items?after=item_123&api-version=preview&limit=50&starting_after=42",
+		"https://example.com/openai/v1/responses/resp_123/input_items?after=item_123&api-version=preview&cache_token=cache_123&limit=50&sort_key=created_at&starting_after=42",
 		got,
 	)
+}
+
+func TestResponsesResourceURLParseErrorsDoNotExposeSecrets(t *testing.T) {
+	const invalidURL = "https://example.com/%zz?api_key=must-not-leak"
+
+	context := &gin.Context{}
+	common.SetContextKey(context, constant.ContextKeyUserId, 103)
+	err := RecordResponsesResourceRoute(context, "resp_invalid", 0, invalidURL)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "must-not-leak")
+	assert.NotContains(t, err.Error(), invalidURL)
+
+	_, err = BuildResponsesResourceURL(invalidURL, "resp_invalid", false, nil)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "must-not-leak")
+	assert.NotContains(t, err.Error(), invalidURL)
 }


### PR DESCRIPTION
## 📝 变更描述 / Description
补齐 Responses API 的资源操作路由：

- `GET /v1/responses/:response_id`
- `DELETE /v1/responses/:response_id`
- `GET /v1/responses/:response_id/input_items`

网关在 POST Responses 收到 `response_id` 后，记录创建资源时使用的用户、渠道、多 Key 索引、模型和实际上游 Responses URL。映射优先存储在 Redis；未配置 Redis 时降级为带 TTL 的本地 LRU。后续资源请求按 `user_id` 隔离，并复用原渠道和原多 Key，避免被重新分发到无法访问该 response 的其他上游账号。

查询参数会透传，支持 `stream=true`、`starting_after`、`after` 和 `limit`。删除成功后同步清理路由映射；上游状态码、响应头和流式 Body 原样返回。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5036

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认没有实现这些资源路由的重复 PR。
- [x] **Bug fix 说明:** 本 PR 为新功能，不标记为 Bug fix。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试及端到端代理验证。
- [x] **安全合规:** 不含敏感凭据；路由映射按用户隔离，并移除 URL 中的敏感查询参数。

## 📸 运行证明 / Proof of Work

```text
go test ./controller ./service ./relay/channel/openai ./router
ok github.com/QuantumNous/new-api/controller
ok github.com/QuantumNous/new-api/service
ok github.com/QuantumNous/new-api/relay/channel/openai
ok github.com/QuantumNous/new-api/router

go vet ./controller ./service ./relay/channel/openai ./router
passed
```

端到端测试通过真实 HTTP fake upstream 验证：GET retrieve、GET input_items、DELETE 204、Bearer Key、查询参数透传、API version 保留、用户隔离、敏感 query 清理和删除后的映射清理。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dedicated endpoints to retrieve, list `input_items` for, and delete OpenAI response resources.
  - Responses resource routing is now recorded and reused across requests, with generated `input_items` links that preserve provider query context while forwarding pagination.
- **Bug Fixes**
  - `expires_at` is omitted from response JSON when empty.
  - Improved safety when proxying requests that may not include a request body.
- **Tests**
  - Added controller and service test coverage for proxy behavior, route caching, URL building, and secret-safe error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->