### PR TITLE
fix: preserve Responses SSE framing on chat stream errors

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -99,9 +99,11 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 					"error": newAPIError.ToClaudeError(),
 				})
 			default:
-				c.JSON(newAPIError.StatusCode, gin.H{
-					"error": newAPIError.ToOpenAIError(),
-				})
+				if !c.Writer.Written() {
+					c.JSON(newAPIError.StatusCode, gin.H{
+						"error": newAPIError.ToOpenAIError(),
+					})
+				}
 			}
 		}
 	}()

--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -413,10 +413,11 @@ const (
 
 // ResponsesStreamResponse 用于处理 /v1/responses 流式响应
 type ResponsesStreamResponse struct {
-	Type     string                   `json:"type"`
-	Response *OpenAIResponsesResponse `json:"response,omitempty"`
-	Delta    string                   `json:"delta,omitempty"`
-	Item     *ResponsesOutput         `json:"item,omitempty"`
+	Type           string                   `json:"type"`
+	SequenceNumber int64                    `json:"sequence_number"`
+	Response       *OpenAIResponsesResponse `json:"response,omitempty"`
+	Delta          string                   `json:"delta,omitempty"`
+	Item           *ResponsesOutput         `json:"item,omitempty"`
 	// - response.function_call_arguments.delta
 	// - response.function_call_arguments.done
 	OutputIndex  *int                           `json:"output_index,omitempty"`

--- a/relay/channel/openai/chat_via_responses_test.go
+++ b/relay/channel/openai/chat_via_responses_test.go
@@ -168,6 +168,58 @@ func TestOaiChatToResponsesStreamHandlerConvertsSSEOrderAndUsage(t *testing.T) {
 	)
 }
 
+func TestOaiChatToResponsesStreamHandlerReturnsErrorBeforeOutput(t *testing.T) {
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	body := strings.Join([]string{
+		`data: {"error":{"type":"server_error","code":"upstream_failure","message":"upstream failed"}}`,
+		``,
+	}, "\n")
+
+	c, recorder, resp, info := newResponsesChatTestContext(t, body, true)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	usage, err := OaiChatToResponsesStreamHandler(c, info, resp)
+	require.Nil(t, usage)
+	require.NotNil(t, err)
+	require.False(t, c.Writer.Written())
+	require.Empty(t, recorder.Body.String())
+}
+
+func TestOaiChatToResponsesStreamHandlerEmitsFailureAfterOutput(t *testing.T) {
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1710000000,"model":"gpt-test","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		`data: {"error":{"type":"server_error","code":"upstream_failure","message":"upstream failed"}}`,
+		``,
+	}, "\n")
+
+	c, recorder, resp, info := newResponsesChatTestContext(t, body, true)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	usage, err := OaiChatToResponsesStreamHandler(c, info, resp)
+	require.Nil(t, usage)
+	require.NotNil(t, err)
+	require.True(t, c.Writer.Written())
+
+	got := recorder.Body.String()
+	require.Contains(t, got, `event: response.created`)
+	require.Contains(t, got, `event: response.failed`)
+	require.Contains(t, got, `"status":"failed"`)
+	require.Contains(t, got, `"code":"upstream_failure"`)
+	require.Contains(t, got, `"message":"upstream failed"`)
+	require.NotContains(t, got, `event: response.completed`)
+	requireOrderedSubstrings(t, got,
+		`event: response.created`,
+		`event: response.failed`,
+	)
+}
+
 func requireOrderedSubstrings(t *testing.T, s string, parts ...string) {
 	t.Helper()
 

--- a/relay/channel/openai/chat_via_responses_test.go
+++ b/relay/channel/openai/chat_via_responses_test.go
@@ -230,3 +230,131 @@ func requireOrderedSubstrings(t *testing.T, s string, parts ...string) {
 		offset += idx + len(part)
 	}
 }
+
+type decodedResponsesStreamEvent struct {
+	Type           string `json:"type"`
+	SequenceNumber *int64 `json:"sequence_number"`
+	Payload        map[string]any
+}
+
+func TestOaiChatToResponsesStreamHandlerRequiresSequenceNumbers(t *testing.T) {
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1710000000,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1710000000,"model":"test-model","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1710000000,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	c, recorder, resp, info := newResponsesChatTestContext(t, body, true)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	usage, err := OaiChatToResponsesStreamHandler(c, info, resp)
+	require.Nil(t, err)
+	require.NotNil(t, usage)
+
+	events := decodeResponsesStreamEvents(t, recorder.Body.String())
+	require.NotEmpty(t, events)
+	for i, event := range events {
+		require.NotNilf(t, event.SequenceNumber, "%s is missing sequence_number", event.Type)
+		require.Equalf(t, int64(i), *event.SequenceNumber, "%s has a non-monotonic sequence_number", event.Type)
+	}
+}
+
+func decodeResponsesStreamEvents(t *testing.T, body string) []decodedResponsesStreamEvent {
+	t.Helper()
+
+	events := make([]decodedResponsesStreamEvent, 0)
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
+		if data == "" || data == "[DONE]" {
+			continue
+		}
+
+		var event decodedResponsesStreamEvent
+		require.NoError(t, common.Unmarshal([]byte(data), &event), "invalid Responses SSE data: %s", data)
+		require.NotEmpty(t, event.Type, "Responses SSE event is missing type: %s", data)
+		require.NoError(t, common.Unmarshal([]byte(data), &event.Payload), "invalid Responses SSE payload: %s", data)
+		events = append(events, event)
+	}
+	return events
+}
+
+func TestOaiChatToResponsesStreamHandlerEmitsSequencedFailureAfterPayload(t *testing.T) {
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	tests := []struct {
+		name  string
+		chunk string
+	}{
+		{
+			name:  "text delta",
+			chunk: `data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1710000000,"model":"gpt-test","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}`,
+		},
+		{
+			name:  "tool delta",
+			chunk: `data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1710000000,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"q\":\"x\"}"}}]},"finish_reason":null}]}`,
+		},
+		{
+			name:  "reasoning delta",
+			chunk: `data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1710000000,"model":"gpt-test","choices":[{"index":0,"delta":{"reasoning_content":"thinking"},"finish_reason":null}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := strings.Join([]string{
+				`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1710000000,"model":"gpt-test","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+				tt.chunk,
+				`data: {"error":{"type":"server_error","code":"upstream_failure","message":"upstream failed"}}`,
+				``,
+			}, "\n")
+
+			c, recorder, resp, info := newResponsesChatTestContext(t, body, true)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+			usage, err := OaiChatToResponsesStreamHandler(c, info, resp)
+			require.Nil(t, usage)
+			require.NotNil(t, err)
+			require.True(t, c.Writer.Written())
+
+			got := recorder.Body.String()
+			requireValidSSEFraming(t, got)
+			events := decodeResponsesStreamEvents(t, got)
+			require.NotEmpty(t, events)
+			for i, event := range events {
+				require.NotNilf(t, event.SequenceNumber, "%s is missing sequence_number", event.Type)
+				require.Equalf(t, int64(i), *event.SequenceNumber, "%s has a non-monotonic sequence_number", event.Type)
+			}
+
+			failed := events[len(events)-1]
+			require.Equal(t, "response.failed", failed.Type)
+			response, ok := failed.Payload["response"].(map[string]any)
+			require.True(t, ok)
+			errorObject, ok := response["error"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "upstream_failure", errorObject["code"])
+			require.Equal(t, "upstream failed", errorObject["message"])
+			require.NotContains(t, got, "event: response.completed")
+		})
+	}
+}
+
+func requireValidSSEFraming(t *testing.T, body string) {
+	t.Helper()
+	for _, line := range strings.Split(body, "\n") {
+		if line == "" {
+			continue
+		}
+		require.Truef(t, strings.HasPrefix(line, "event: ") || strings.HasPrefix(line, "data: ") || strings.HasPrefix(line, ":"), "non-SSE line after stream start: %q", line)
+	}
+}

--- a/relay/channel/openai/responses_via_chat.go
+++ b/relay/channel/openai/responses_via_chat.go
@@ -155,17 +155,11 @@ func OaiChatToResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 			message = streamErr.Error()
 		}
 
-		sendEvent(relayconvert.ChatToResponsesStreamEvent{
-			Type: "response.failed",
-			Payload: dto.ResponsesStreamResponse{
-				Type: "response.failed",
-				Response: &dto.OpenAIResponsesResponse{
-					ID: responseID, Object: "response", CreatedAt: int(created),
-					Status: []byte(`"failed"`), Error: map[string]any{"code": code, "message": message},
-					Model: info.UpstreamModelName, Output: []dto.ResponsesOutput{},
-				},
-			},
-		})
+		failureEvent, failureErr := state.FailureEvent(code, message)
+		if failureErr != nil {
+			return nil, types.NewOpenAIError(failureErr, types.ErrorCodeBadResponse, http.StatusInternalServerError)
+		}
+		sendEvent(failureEvent)
 		return nil, streamErr
 	}
 

--- a/relay/channel/openai/responses_via_chat.go
+++ b/relay/channel/openai/responses_via_chat.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
@@ -69,9 +71,11 @@ func OaiChatToResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 	defer service.CloseResponseBodyGracefully(resp)
 
 	responseID := helper.GetResponseID(c)
+	created := time.Now().Unix()
 	state, err := relayconvert.NewResponseStreamState(types.RelayFormatOpenAI, types.RelayFormatOpenAIResponses, relayconvert.ResponseStreamOptions{
-		ID:    responseID,
-		Model: info.UpstreamModelName,
+		ID:      responseID,
+		Model:   info.UpstreamModelName,
+		Created: created,
 	})
 	if err != nil {
 		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponse, http.StatusInternalServerError)
@@ -84,7 +88,10 @@ func OaiChatToResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 			streamErr = types.NewOpenAIError(err, types.ErrorCodeJsonMarshalFailed, http.StatusInternalServerError)
 			return false
 		}
-		helper.ResponseChunkData(c, dto.ResponsesStreamResponse{Type: event.Type}, string(data))
+		if err := helper.ResponseChunkData(c, dto.ResponsesStreamResponse{Type: event.Type}, string(data)); err != nil {
+			streamErr = types.NewOpenAIError(err, types.ErrorCodeBadResponse, http.StatusInternalServerError)
+			return false
+		}
 		return true
 	}
 
@@ -131,6 +138,34 @@ func OaiChatToResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 	})
 
 	if streamErr != nil {
+		if !c.Writer.Written() {
+			return nil, streamErr
+		}
+
+		oaiError := streamErr.ToOpenAIError()
+		code := strings.TrimSpace(fmt.Sprintf("%v", oaiError.Code))
+		if code == "" || code == "<nil>" {
+			code = strings.TrimSpace(oaiError.Type)
+		}
+		if code == "" {
+			code = "server_error"
+		}
+		message := strings.TrimSpace(oaiError.Message)
+		if message == "" {
+			message = streamErr.Error()
+		}
+
+		sendEvent(relayconvert.ChatToResponsesStreamEvent{
+			Type: "response.failed",
+			Payload: dto.ResponsesStreamResponse{
+				Type: "response.failed",
+				Response: &dto.OpenAIResponsesResponse{
+					ID: responseID, Object: "response", CreatedAt: int(created),
+					Status: []byte(`"failed"`), Error: map[string]any{"code": code, "message": message},
+					Model: info.UpstreamModelName, Output: []dto.ResponsesOutput{},
+				},
+			},
+		})
 		return nil, streamErr
 	}
 

--- a/service/relayconvert/internal/oai_chat/to_oai_responses_resp.go
+++ b/service/relayconvert/internal/oai_chat/to_oai_responses_resp.go
@@ -219,14 +219,6 @@ func chatCreatedAt(created any) int {
 	return int(time.Now().Unix())
 }
 
-func responsesStreamEvent(eventType string, payload dto.ResponsesStreamResponse) ChatToResponsesStreamEvent {
-	payload.Type = eventType
-	return ChatToResponsesStreamEvent{
-		Type:    eventType,
-		Payload: payload,
-	}
-}
-
 func intPtr(v int) *int {
 	return &v
 }

--- a/service/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
+++ b/service/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
@@ -20,21 +20,22 @@ type ChatToResponsesStreamState struct {
 	Created int64
 	Usage   *dto.Usage
 
-	status            string
-	incompleteDetails *dto.IncompleteDetails
-	sentCreated       bool
-	textOutputIndex   int
-	textStarted       bool
-	textDone          bool
-	reasoningIndex    int
-	reasoningStarted  bool
-	reasoningDone     bool
-	finalized         bool
-	nextOutputIndex   int
-	toolsByIndex      map[int]*chatToResponsesStreamTool
-	outputOrder       []chatToResponsesOutputRef
-	text              strings.Builder
-	reasoning         strings.Builder
+	status             string
+	incompleteDetails  *dto.IncompleteDetails
+	sentCreated        bool
+	textOutputIndex    int
+	textStarted        bool
+	textDone           bool
+	reasoningIndex     int
+	reasoningStarted   bool
+	reasoningDone      bool
+	finalized          bool
+	nextOutputIndex    int
+	nextSequenceNumber int64
+	toolsByIndex       map[int]*chatToResponsesStreamTool
+	outputOrder        []chatToResponsesOutputRef
+	text               strings.Builder
+	reasoning          strings.Builder
 }
 
 type chatToResponsesStreamTool struct {
@@ -84,7 +85,7 @@ func ChatCompletionsStreamChunkToResponsesEvents(chunk *dto.ChatCompletionsStrea
 	events := make([]ChatToResponsesStreamEvent, 0)
 	if !state.sentCreated {
 		state.sentCreated = true
-		events = append(events, responsesStreamEvent(responsesEventCreated, dto.ResponsesStreamResponse{
+		events = append(events, state.event(responsesEventCreated, dto.ResponsesStreamResponse{
 			Type:     responsesEventCreated,
 			Response: state.createdResponse(),
 		}))
@@ -122,7 +123,7 @@ func FinalizeChatCompletionsStreamToResponses(state *ChatToResponsesStreamState)
 	if state.status == "incomplete" {
 		eventType = responsesEventIncomplete
 	}
-	events = append(events, responsesStreamEvent(eventType, dto.ResponsesStreamResponse{
+	events = append(events, state.event(eventType, dto.ResponsesStreamResponse{
 		Type:     eventType,
 		Response: resp,
 	}))
@@ -141,7 +142,7 @@ func (s *ChatToResponsesStreamState) appendTextDelta(delta string) []ChatToRespo
 	if !s.textStarted {
 		s.textStarted = true
 		s.textOutputIndex = s.nextIndex("message", -1)
-		events = append(events, responsesStreamEvent(responsesEventOutputItemAdded, dto.ResponsesStreamResponse{
+		events = append(events, s.event(responsesEventOutputItemAdded, dto.ResponsesStreamResponse{
 			Type:        responsesEventOutputItemAdded,
 			OutputIndex: intPtr(s.textOutputIndex),
 			Item: &dto.ResponsesOutput{
@@ -154,7 +155,7 @@ func (s *ChatToResponsesStreamState) appendTextDelta(delta string) []ChatToRespo
 		}))
 	}
 	s.text.WriteString(delta)
-	events = append(events, responsesStreamEvent(responsesEventOutputTextDelta, dto.ResponsesStreamResponse{
+	events = append(events, s.event(responsesEventOutputTextDelta, dto.ResponsesStreamResponse{
 		Type:         responsesEventOutputTextDelta,
 		OutputIndex:  intPtr(s.textOutputIndex),
 		ContentIndex: intPtr(0),
@@ -169,7 +170,7 @@ func (s *ChatToResponsesStreamState) appendReasoningDelta(delta string) []ChatTo
 	if !s.reasoningStarted {
 		s.reasoningStarted = true
 		s.reasoningIndex = s.nextIndex("reasoning", -1)
-		events = append(events, responsesStreamEvent(responsesEventOutputItemAdded, dto.ResponsesStreamResponse{
+		events = append(events, s.event(responsesEventOutputItemAdded, dto.ResponsesStreamResponse{
 			Type:        responsesEventOutputItemAdded,
 			OutputIndex: intPtr(s.reasoningIndex),
 			Item: &dto.ResponsesOutput{
@@ -181,7 +182,7 @@ func (s *ChatToResponsesStreamState) appendReasoningDelta(delta string) []ChatTo
 		}))
 	}
 	s.reasoning.WriteString(delta)
-	events = append(events, responsesStreamEvent(responsesEventReasoningSummaryDelta, dto.ResponsesStreamResponse{
+	events = append(events, s.event(responsesEventReasoningSummaryDelta, dto.ResponsesStreamResponse{
 		Type:         responsesEventReasoningSummaryDelta,
 		OutputIndex:  intPtr(s.reasoningIndex),
 		SummaryIndex: intPtr(0),
@@ -209,7 +210,7 @@ func (s *ChatToResponsesStreamState) appendToolCallDelta(toolCall dto.ToolCallRe
 			tool.ID = fmt.Sprintf("%s_call_%d", s.ID, chatIndex)
 		}
 		s.toolsByIndex[chatIndex] = tool
-		events = append(events, responsesStreamEvent(responsesEventOutputItemAdded, dto.ResponsesStreamResponse{
+		events = append(events, s.event(responsesEventOutputItemAdded, dto.ResponsesStreamResponse{
 			Type:        responsesEventOutputItemAdded,
 			OutputIndex: intPtr(tool.OutputIndex),
 			ItemID:      tool.ID,
@@ -231,7 +232,7 @@ func (s *ChatToResponsesStreamState) appendToolCallDelta(toolCall dto.ToolCallRe
 	}
 	if toolCall.Function.Arguments != "" {
 		tool.Arguments.WriteString(toolCall.Function.Arguments)
-		events = append(events, responsesStreamEvent(responsesEventFunctionArgsDelta, dto.ResponsesStreamResponse{
+		events = append(events, s.event(responsesEventFunctionArgsDelta, dto.ResponsesStreamResponse{
 			Type:        responsesEventFunctionArgsDelta,
 			OutputIndex: intPtr(tool.OutputIndex),
 			ItemID:      tool.ID,
@@ -246,13 +247,13 @@ func (s *ChatToResponsesStreamState) doneDeltaEvents() []ChatToResponsesStreamEv
 	status := s.outputStatus()
 	if s.textStarted && !s.textDone {
 		s.textDone = true
-		events = append(events, responsesStreamEvent("response.output_text.done", dto.ResponsesStreamResponse{
+		events = append(events, s.event("response.output_text.done", dto.ResponsesStreamResponse{
 			Type:         "response.output_text.done",
 			OutputIndex:  intPtr(s.textOutputIndex),
 			ContentIndex: intPtr(0),
 			ItemID:       s.messageID(),
 		}))
-		events = append(events, responsesStreamEvent(responsesEventOutputItemDone, dto.ResponsesStreamResponse{
+		events = append(events, s.event(responsesEventOutputItemDone, dto.ResponsesStreamResponse{
 			Type:        responsesEventOutputItemDone,
 			OutputIndex: intPtr(s.textOutputIndex),
 			Item:        s.messageOutput(status),
@@ -260,7 +261,7 @@ func (s *ChatToResponsesStreamState) doneDeltaEvents() []ChatToResponsesStreamEv
 	}
 	if s.reasoningStarted && !s.reasoningDone {
 		s.reasoningDone = true
-		events = append(events, responsesStreamEvent(responsesEventReasoningSummaryDone, dto.ResponsesStreamResponse{
+		events = append(events, s.event(responsesEventReasoningSummaryDone, dto.ResponsesStreamResponse{
 			Type:         responsesEventReasoningSummaryDone,
 			OutputIndex:  intPtr(s.reasoningIndex),
 			SummaryIndex: intPtr(0),
@@ -270,7 +271,7 @@ func (s *ChatToResponsesStreamState) doneDeltaEvents() []ChatToResponsesStreamEv
 				Text: s.reasoning.String(),
 			},
 		}))
-		events = append(events, responsesStreamEvent(responsesEventOutputItemDone, dto.ResponsesStreamResponse{
+		events = append(events, s.event(responsesEventOutputItemDone, dto.ResponsesStreamResponse{
 			Type:        responsesEventOutputItemDone,
 			OutputIndex: intPtr(s.reasoningIndex),
 			Item:        s.reasoningOutput(status),
@@ -281,18 +282,44 @@ func (s *ChatToResponsesStreamState) doneDeltaEvents() []ChatToResponsesStreamEv
 			continue
 		}
 		tool.Done = true
-		events = append(events, responsesStreamEvent(responsesEventFunctionArgsDone, dto.ResponsesStreamResponse{
+		events = append(events, s.event(responsesEventFunctionArgsDone, dto.ResponsesStreamResponse{
 			Type:        responsesEventFunctionArgsDone,
 			OutputIndex: intPtr(tool.OutputIndex),
 			ItemID:      tool.ID,
 		}))
-		events = append(events, responsesStreamEvent(responsesEventOutputItemDone, dto.ResponsesStreamResponse{
+		events = append(events, s.event(responsesEventOutputItemDone, dto.ResponsesStreamResponse{
 			Type:        responsesEventOutputItemDone,
 			OutputIndex: intPtr(tool.OutputIndex),
 			Item:        s.toolOutput(tool, status),
 		}))
 	}
 	return events
+}
+
+func (s *ChatToResponsesStreamState) event(eventType string, payload dto.ResponsesStreamResponse) ChatToResponsesStreamEvent {
+	payload.Type = eventType
+	payload.SequenceNumber = s.nextSequenceNumber
+	s.nextSequenceNumber++
+	return ChatToResponsesStreamEvent{
+		Type:    eventType,
+		Payload: payload,
+	}
+}
+
+func (s *ChatToResponsesStreamState) FailureEvent(code string, message string) ChatToResponsesStreamEvent {
+	s.status = "failed"
+	s.finalized = true
+	return s.event("response.failed", dto.ResponsesStreamResponse{
+		Response: &dto.OpenAIResponsesResponse{
+			ID:        s.ID,
+			Object:    "response",
+			CreatedAt: int(s.Created),
+			Status:    []byte(`"failed"`),
+			Error:     map[string]any{"code": code, "message": message},
+			Model:     s.Model,
+			Output:    []dto.ResponsesOutput{},
+		},
+	})
 }
 
 func (s *ChatToResponsesStreamState) applyFinishReason(finishReason string) {

--- a/service/relayconvert/response_registry.go
+++ b/service/relayconvert/response_registry.go
@@ -408,6 +408,18 @@ func (s *ResponseStreamState) UsageText() string {
 	return ""
 }
 
+func (s *ResponseStreamState) FailureEvent(code string, message string) (ChatToResponsesStreamEvent, error) {
+	if s == nil {
+		return ChatToResponsesStreamEvent{}, fmt.Errorf("response stream state is nil")
+	}
+	for _, state := range s.stepStates {
+		if typed, ok := state.(*ChatToResponsesStreamState); ok {
+			return typed.FailureEvent(code, message), nil
+		}
+	}
+	return ChatToResponsesStreamEvent{}, fmt.Errorf("response stream has no chat-to-responses state")
+}
+
 func executeResponseSpec(c *gin.Context, info *relaycommon.RelayInfo, from types.RelayFormat, target types.RelayFormat, response any, spec ResponseConverterSpec) (*ResponseResult, error) {
 	steps, err := expandResponseConverterSteps(spec)
 	if err != nil {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

这个 PR 修的是 `/v1/responses` 转发到 Chat Completions 时，流式请求中途报错会把 SSE 和普通 JSON 混在一起的问题。

目前 Chat SSE 可能已经转换并输出了 `response.created` 或其他 Responses 事件，后面上游才返回错误。之前 `OaiChatToResponsesStreamHandler` 检测到错误以后，会直接把错误返回给上层控制器；控制器发现有错误后，又会在已经开始输出的 SSE 后面继续写一段普通 JSON，最后响应会变成这样：

```text
event: response.created
data: {...}

event: response.output_text.delta
data: {...}

{"error": {...}}
```

这里主要有两个问题：

1. 同一个 HTTP 响应里同时出现 SSE 和普通 JSON；
2. Responses 流已经开始了，但最后没有输出合法的 `response.failed`。

这个 PR 把首包前和首包后的错误分开处理：

- 如果上游在第一个 Responses 事件输出前就返回错误，继续走原来的错误处理逻辑；
- 如果 Responses SSE 已经实际开始输出，后面再报错，就发送 `response.failed` 结束；
- `response.failed.response.error` 会保留原来的 `code` 和 `message`；
- 失败事件复用当前响应的 ID、创建时间和模型信息；
- 控制器发现响应已经写出后，不再往 SSE 末尾继续追加普通 JSON；
- 同时检查 SSE 写入结果，避免写入失败了还被当成已经成功发送。

新增回归测试：

- Chat SSE 在任何 Responses 事件输出前就返回错误；
- Chat SSE 已经输出 `response.created`，之后才返回错误。

说明：本次修改由 AI 辅助完成，代码和测试结果已经人工检查。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

目前没有精确对应的 Issue。

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已搜索现有 Issues 和 PRs，没有发现完整处理 `responses_via_chat.go` 首包前、首包后错误边界以及 SSE / JSON 混流的提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试，维护者可以按下方命令复核。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

运行：

```text
go test ./relay/channel/openai ./relay/helper ./service/relayconvert/... ./controller
```

结果：

```text
ok github.com/QuantumNous/new-api/relay/channel/openai
ok github.com/QuantumNous/new-api/relay/helper
ok github.com/QuantumNous/new-api/service/relayconvert
ok github.com/QuantumNous/new-api/service/relayconvert/internal/oai_chat
ok github.com/QuantumNous/new-api/service/relayconvert/internal/oai_responses
ok github.com/QuantumNous/new-api/controller
```

另外运行：

```text
git diff --check
```

未发现空白符或补丁格式问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming error handling for Responses-based chat requests.
  * Errors before any output now return cleanly without producing an invalid response/body.
  * Errors after streaming begins now emit a clear `response.failed` event (with status plus `code`/`message`) and omit `response.completed`.
  * Prevented duplicate JSON error responses when a response has already started sending.
* **New Features**
  * Added `sequence_number` to streamed responses events for stable event ordering.
* **Tests**
  * Expanded coverage for failure timing (before/after output) and SSE framing/ordering, including monotonic `sequence_number` validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->