### PR TITLE
fix(xai): preserve token details in stream usage conversion

### DIFF
--- a/relay/channel/xai/text.go
+++ b/relay/channel/xai/text.go
@@ -57,6 +57,8 @@ func xAIStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Re
 			usage.PromptTokens = xAIResp.Usage.PromptTokens
 			usage.TotalTokens = xAIResp.Usage.TotalTokens
 			usage.CompletionTokens = usage.TotalTokens - usage.PromptTokens
+			usage.PromptTokensDetails = xAIResp.Usage.PromptTokensDetails
+			usage.CompletionTokenDetails = xAIResp.Usage.CompletionTokenDetails
 		}
 
 		openaiResponse := streamResponseXAI2OpenAI(xAIResp, usage)


### PR DESCRIPTION
Fixes #6419

## 问题

`xAIStreamHandler` 转换流式 usage 时只拷贝 prompt/total/completion 三个总数，丢掉了 `prompt_tokens_details`（含 `cached_tokens`）和 `completion_tokens_details`。导致流式 grok 请求的缓存命中 token 全部丢失，缓存价格比率永不生效，缓存命中按全价 input 计费。非流式路径（`xAIHandler`）保留完整 usage，行为正常——同渠道流式/非流式计费不一致。

生产数据佐证：grok-4.5 渠道 17,471 条流式日志 `cache_tokens` 全为 0，同渠道 23 条非流式日志全部有值；同环境 gemini/gpt 流式渠道 cache 记录正常。

## 修改

流式 usage 转换处补拷两个 details 字段（+2 行）：

```go
usage.PromptTokensDetails = xAIResp.Usage.PromptTokensDetails
usage.CompletionTokenDetails = xAIResp.Usage.CompletionTokenDetails
```

`go build ./relay/channel/xai/` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Preserved detailed prompt and completion token usage information in streaming responses.
  * Usage data now provides more complete token breakdowns for improved reporting and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->