### PR TITLE
fix: log response body when parsed upstream error message is empty

### DIFF
--- a/service/error.go
+++ b/service/error.go
@@ -123,7 +123,13 @@ func RelayErrorHandler(ctx context.Context, resp *http.Response, showBodyWhenFai
 			return
 		}
 	}
-	newApiErr = types.NewOpenAIError(errors.New(errResponse.ToMessage()), types.ErrorCodeBadResponseStatusCode, resp.StatusCode)
+	message := errResponse.ToMessage()
+	if message == "" {
+		// The body parsed as JSON but carried no usable error message; log the
+		// raw body so the upstream failure remains diagnosable.
+		logger.LogError(ctx, fmt.Sprintf("bad response status code %d with empty error message, body: %s", resp.StatusCode, responseBodyPreview))
+	}
+	newApiErr = types.NewOpenAIError(errors.New(message), types.ErrorCodeBadResponseStatusCode, resp.StatusCode)
 	if showBodyWhenFail {
 		newApiErr.Err = buildErrWithBody(newApiErr.Error())
 	}


### PR DESCRIPTION
## 📝 变更描述 / Description

`RelayErrorHandler` 中，上游错误响应体解析为合法 JSON 但 `ToMessage()` 为空时，生成的错误只有 `bad response status code N`，原始响应体被丢弃，日志无任何排查线索。本 PR 在该路径补一条 `logger.LogError`，记录 body 预览（复用现有 `responseBodyPreview`，与「body 无法解析为 JSON」分支的现有行为保持一致，同样受 `LocalLogPreview` 截断保护）。

变更仅新增一条日志，不改变返回给客户端的错误内容和状态码。

> 说明：本 PR 由 AI（Claude Code）辅助完成，提交者已审阅变更内容。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6432

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述为本次提交整理撰写（AI 辅助，非未经处理的粘贴，见上方说明）。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 已关联 Issue #6432。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已构建镜像并用 mock 上游复现验证（见下方运行证明）。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

mock 上游对任意请求返回 `400` + `{"error":{"type":"","message":""},"type":"error"}`，配置渠道指向后发起 relay 请求。

修复前：日志只有 `channel error (channel #1, status code: 400)`，响应体无踪。

修复后：

```
[ERR] 2026/07/23 - 16:14:38 | 2026...eL5aRuul | bad response status code 400 with empty error message, body: {"error":{"type":"","message":""},"type":"error"}
[ERR] 2026/07/23 - 16:14:38 | 2026...eL5aRuul | channel error (channel #1, status code: 400):
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when an upstream response contains an error object without a message.
  * Added diagnostic logging with a preview of the raw response to help identify otherwise unclear failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
