### PR TITLE
perf(relay): 修复图片 token 估算导致内存飙升的问题

### DIFF
--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -83,6 +83,10 @@ type ChannelMeta struct {
 type TokenCountMeta struct {
 	//promptTokens int
 	estimatePromptTokens int
+	// estimateImageTokens 是请求中图片/媒体的 token 估算值。
+	// 仅在估算阶段计算（使用固定值，不下载完整文件），
+	// 当上游 usage 中未返回 ImageTokens 时作为 fallback 用于计费。
+	estimateImageTokens int
 }
 
 type RelayInfo struct {
@@ -659,6 +663,17 @@ func (info *RelayInfo) SetEstimatePromptTokens(promptTokens int) {
 
 func (info *RelayInfo) GetEstimatePromptTokens() int {
 	return info.estimatePromptTokens
+}
+
+// SetEstimateImageTokens 记录估算阶段计算的图片/媒体 token 数。
+// 当上游 usage 未返回 ImageTokens 时，计费逻辑会以此值作为 fallback。
+func (info *RelayInfo) SetEstimateImageTokens(tokens int) {
+	info.estimateImageTokens = tokens
+}
+
+// GetEstimateImageTokens 返回估算的图片 token 数。
+func (info *RelayInfo) GetEstimateImageTokens() int {
+	return info.estimateImageTokens
 }
 
 func (info *RelayInfo) SetFirstResponseTime() {

--- a/service/file_decoder.go
+++ b/service/file_decoder.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"image"
 	_ "image/gif"
@@ -17,6 +18,160 @@ import (
 
 	"github.com/gin-gonic/gin"
 )
+
+// maxLightweightSniffBytes 是估算阶段 MIME 嗅探的最大读取字节数。
+// 512 字节对 http.DetectContentType 足够识别绝大多数常见格式
+// （图片/音频/视频/PDF/EXE 等都有显著 magic bytes）。
+const maxLightweightSniffBytes = 512
+
+// DetectMimeTypeLightweight 轻量级 MIME 类型检测，用于估算阶段。
+// URL 来源最多读取 maxLightweightSniffBytes 字节用于嗅探，不下载完整文件，不缓存数据。
+// 优先级：已缓存 > 来源携带的 MimeType > HTTP 响应头 > URL 扩展名 > 内容嗅探(512B)。
+func DetectMimeTypeLightweight(c *gin.Context, source types.FileSource) (string, error) {
+	if source == nil {
+		return "application/octet-stream", nil
+	}
+
+	// 优先复用中继阶段已加载的缓存（不重复下载）
+	if source.HasCache() {
+		return source.GetCache().MimeType, nil
+	}
+
+	switch s := source.(type) {
+	case *types.URLSource:
+		return sniffMimeTypeFromURL(c, s.URL)
+	case *types.Base64Source:
+		if s.MimeType != "" {
+			return s.MimeType, nil
+		}
+		return sniffMimeTypeFromBase64(s.Base64Data)
+	}
+
+	return "application/octet-stream", nil
+}
+
+// sniffMimeTypeFromURL 通过 HTTP 请求获取 MIME 类型，最多读取 512 字节用于内容嗅探。
+func sniffMimeTypeFromURL(c *gin.Context, url string) (string, error) {
+	response, err := DoDownloadRequest(url, "sniff_mime_type_lightweight")
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != 200 {
+		return "", fmt.Errorf("failed to download file, status code: %d", response.StatusCode)
+	}
+
+	// 1. Content-Type header
+	if mt := mimeTypeFromHeaders(response); mt != "" {
+		return mt, nil
+	}
+
+	// 2. URL 扩展名
+	if mt := guessMimeTypeFromURL(url); mt != "application/octet-stream" {
+		return mt, nil
+	}
+
+	// 3. 读取前 512 字节做内容嗅探
+	sniffBuf := make([]byte, maxLightweightSniffBytes)
+	n, _ := io.ReadFull(response.Body, sniffBuf)
+	if n > 0 {
+		if mt := sniffBytes(sniffBuf[:n]); mt != "" {
+			return mt, nil
+		}
+	}
+
+	return "application/octet-stream", nil
+}
+
+// sniffMimeTypeFromBase64 从 base64 数据中解码前 512 字节做内容嗅探。
+// 数据本身已在内存中（请求体携带），仅做最小解码用于类型识别。
+func sniffMimeTypeFromBase64(base64String string) (string, error) {
+	cleaned := base64String
+	if strings.HasPrefix(cleaned, "data:") {
+		if idx := strings.Index(cleaned, ","); idx != -1 {
+			cleaned = cleaned[idx+1:]
+		}
+	}
+
+	// base64 编码每 4 字符对应 3 字节，684 字符即可解码出 512 字节
+	maxChars := (maxLightweightSniffBytes*4 + 2) / 3
+	if len(cleaned) > maxChars {
+		// 截取到 4 字符对齐边界，避免解码失败
+		aligned := maxChars - (maxChars % 4)
+		if aligned < 4 {
+			aligned = 4
+		}
+		cleaned = cleaned[:aligned]
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(cleaned)
+	if err != nil || len(decoded) == 0 {
+		return "application/octet-stream", nil
+	}
+
+	if mt := sniffBytes(decoded); mt != "" {
+		return mt, nil
+	}
+	return "application/octet-stream", nil
+}
+
+// mimeTypeFromHeaders 从 HTTP 响应头（Content-Type / Content-Disposition）推断 MIME 类型。
+func mimeTypeFromHeaders(resp *http.Response) string {
+	if headerType := strings.TrimSpace(resp.Header.Get("Content-Type")); headerType != "" {
+		if i := strings.Index(headerType, ";"); i != -1 {
+			headerType = strings.TrimSpace(headerType[:i])
+		}
+		if headerType != "" && headerType != "application/octet-stream" {
+			return headerType
+		}
+	}
+
+	if cd := resp.Header.Get("Content-Disposition"); cd != "" {
+		for _, part := range strings.Split(cd, ";") {
+			part = strings.TrimSpace(part)
+			if !strings.HasPrefix(strings.ToLower(part), "filename=") {
+				continue
+			}
+			name := strings.TrimSpace(strings.TrimPrefix(part, "filename="))
+			if len(name) > 2 && name[0] == '"' && name[len(name)-1] == '"' {
+				name = name[1 : len(name)-1]
+			}
+			if dot := strings.LastIndex(name, "."); dot != -1 && dot+1 < len(name) {
+				if mt := GetMimeTypeByExtension(strings.ToLower(name[dot+1:])); mt != "application/octet-stream" {
+					return mt
+				}
+			}
+			break
+		}
+	}
+
+	return ""
+}
+
+// sniffBytes 使用 http.DetectContentType + HEIF/HEIC 检测 + 图片解码配置识别 MIME 类型。
+func sniffBytes(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+
+	if sniffed := http.DetectContentType(data); sniffed != "" && sniffed != "application/octet-stream" {
+		if i := strings.Index(sniffed, ";"); i != -1 {
+			sniffed = strings.TrimSpace(sniffed[:i])
+		}
+		return sniffed
+	}
+
+	if heifMime := detectHEIF(data); heifMime != "" {
+		return heifMime
+	}
+
+	if _, format, err := image.DecodeConfig(bytes.NewReader(data)); err == nil && format != "" {
+		return "image/" + strings.ToLower(format)
+	}
+
+	return ""
+}
 
 // GetFileTypeFromUrl 获取文件类型，返回 mime type， 例如 image/jpeg, image/png, image/gif, image/bmp, image/tiff, application/pdf
 // 如果获取失败，返回 application/octet-stream

--- a/service/relayconvert/internal/oai_chat/to_claude_messages_req.go
+++ b/service/relayconvert/internal/oai_chat/to_claude_messages_req.go
@@ -11,6 +11,7 @@ import (
 	sharedclaude "github.com/QuantumNous/new-api/service/relayconvert/internal/shared/claude"
 	"github.com/QuantumNous/new-api/setting/model_setting"
 	"github.com/QuantumNous/new-api/setting/reasoning"
+	"github.com/QuantumNous/new-api/types"
 	"github.com/gin-gonic/gin"
 )
 
@@ -348,6 +349,26 @@ func OpenAIChatRequestToClaudeMessages(c *gin.Context, textRequest dto.GeneralOp
 					if source == nil {
 						continue
 					}
+					// URL 来源直传给 Claude，避免下载图片造成内存飙升。
+					// Claude 的 source.type="url" 支持直接传入 URL，由 Claude 侧获取文件。
+					if urlSource, isURL := source.(*types.URLSource); isURL {
+						claudeMediaMessage := dto.ClaudeMediaMessage{
+							Source: &dto.ClaudeMessageSource{
+								Type: "url",
+								Url:  urlSource.URL,
+							},
+						}
+						// 根据 OpenAI 请求中的 content type 推断 Claude 媒体类型
+						// image_url -> image, file/video_url/input_audio -> document
+						if mediaMessage.Type == dto.ContentTypeImageURL {
+							claudeMediaMessage.Type = "image"
+						} else {
+							claudeMediaMessage.Type = "document"
+						}
+						claudeMediaMessages = append(claudeMediaMessages, claudeMediaMessage)
+						continue
+					}
+					// Base64 来源：解析数据并转为 base64（保留原有行为）
 					base64Data, mimeType, err := relaymedia.ResolveBase64Data(c, source, "formatting image for Claude")
 					if err != nil {
 						return nil, fmt.Errorf("get file data failed: %s", err.Error())

--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -212,6 +212,13 @@ func calculateTextQuotaSummary(ctx *gin.Context, relayInfo *relaycommon.RelayInf
 	summary.CacheCreationTokens5m = usage.ClaudeCacheCreation5mTokens
 	summary.CacheCreationTokens1h = usage.ClaudeCacheCreation1hTokens
 	summary.ImageTokens = usage.PromptTokensDetails.ImageTokens
+	// 上游未返回 ImageTokens 时，使用估算阶段记录的固定值作为 fallback。
+	// 估算阶段不下载完整文件，仅用固定值估算（见 token_counter.go）。
+	// 此 fallback 假定上游 PromptTokens 已包含图片 token（多数上游如此），
+	// 因此从 baseTokens 中减去 ImageTokens 避免按文本重复计费。
+	if summary.ImageTokens == 0 && relayInfo.GetEstimateImageTokens() > 0 {
+		summary.ImageTokens = relayInfo.GetEstimateImageTokens()
+	}
 	summary.AudioTokens = usage.PromptTokensDetails.AudioTokens
 	legacyClaudeDerived := isLegacyClaudeDerivedOpenAIUsage(relayInfo, usage)
 	isOpenRouterClaudeBilling := relayInfo.ChannelMeta != nil &&

--- a/service/token_counter.go
+++ b/service/token_counter.go
@@ -19,6 +19,9 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// getImageToken 返回图片的固定估算 token 数（不再下载文件解码尺寸）。
+// 估算阶段不下载完整文件，避免内存飙升；实际计费时优先使用上游返回的 ImageTokens，
+// 若上游未返回，则使用此处估算的固定值（见 text_quota.go 的 fallback 逻辑）。
 func getImageToken(c *gin.Context, fileMeta *types.FileMeta, model string, stream bool) (int, error) {
 	if fileMeta == nil || fileMeta.Source == nil {
 		return 0, fmt.Errorf("image_url_is_nil")
@@ -26,7 +29,6 @@ func getImageToken(c *gin.Context, fileMeta *types.FileMeta, model string, strea
 
 	// Defaults for 4o/4.1/4.5 family unless overridden below
 	baseTokens := 85
-	tileTokens := 170
 
 	// Model classification
 	lowerModel := strings.ToLower(model)
@@ -38,142 +40,38 @@ func getImageToken(c *gin.Context, fileMeta *types.FileMeta, model string, strea
 
 	// Patch-based models (32x32 patches, capped at 1536, with multiplier)
 	isPatchBased := false
-	multiplier := 1.0
 	switch {
-	case strings.Contains(lowerModel, "gpt-4.1-mini"):
+	case strings.Contains(lowerModel, "gpt-4.1-mini"),
+		strings.Contains(lowerModel, "gpt-4.1-nano"),
+		strings.HasPrefix(lowerModel, "o4-mini"),
+		strings.HasPrefix(lowerModel, "gpt-5-mini"),
+		strings.HasPrefix(lowerModel, "gpt-5-nano"):
 		isPatchBased = true
-		multiplier = 1.62
-	case strings.Contains(lowerModel, "gpt-4.1-nano"):
-		isPatchBased = true
-		multiplier = 2.46
-	case strings.HasPrefix(lowerModel, "o4-mini"):
-		isPatchBased = true
-		multiplier = 1.72
-	case strings.HasPrefix(lowerModel, "gpt-5-mini"):
-		isPatchBased = true
-		multiplier = 1.62
-	case strings.HasPrefix(lowerModel, "gpt-5-nano"):
-		isPatchBased = true
-		multiplier = 2.46
 	}
 
-	// Tile-based model tokens and bases per doc
+	// Tile-based model bases per doc
 	if !isPatchBased {
 		if strings.HasPrefix(lowerModel, "gpt-4o-mini") {
 			baseTokens = 2833
-			tileTokens = 5667
 		} else if strings.HasPrefix(lowerModel, "gpt-5-chat-latest") || (strings.HasPrefix(lowerModel, "gpt-5") && !strings.Contains(lowerModel, "mini") && !strings.Contains(lowerModel, "nano")) {
 			baseTokens = 70
-			tileTokens = 140
 		} else if strings.HasPrefix(lowerModel, "o1") || strings.HasPrefix(lowerModel, "o3") || strings.HasPrefix(lowerModel, "o1-pro") {
 			baseTokens = 75
-			tileTokens = 150
 		} else if strings.Contains(lowerModel, "computer-use-preview") {
 			baseTokens = 65
-			tileTokens = 129
 		} else if strings.Contains(lowerModel, "4.1") || strings.Contains(lowerModel, "4o") || strings.Contains(lowerModel, "4.5") {
 			baseTokens = 85
-			tileTokens = 170
 		}
 	}
 
-	// Respect existing feature flags/short-circuits
+	// low detail 直接返回 baseTokens
 	if fileMeta.Detail == "low" && !isPatchBased {
 		return baseTokens, nil
 	}
 
-	// Whether to count image tokens at all
-	if !constant.GetMediaToken {
-		return 3 * baseTokens, nil
-	}
-
-	if !constant.GetMediaTokenNotStream && !stream {
-		return 3 * baseTokens, nil
-	}
-	// Normalize detail
-	if fileMeta.Detail == "auto" || fileMeta.Detail == "" {
-		fileMeta.Detail = "high"
-	}
-
-	// 使用统一的文件服务获取图片配置
-	config, format, err := GetImageConfig(c, fileMeta.Source)
-	if err != nil {
-		return 0, err
-	}
-	if config.Width == 0 || config.Height == 0 {
-		// not an image, but might be a valid file
-		if format != "" {
-			// file type
-			return 3 * baseTokens, nil
-		}
-		return 0, errors.New(fmt.Sprintf("fail to decode image config: %s", fileMeta.GetIdentifier()))
-	}
-
-	width := config.Width
-	height := config.Height
-	logger.LogDebug(c, "image token input: format=%s, width=%d, height=%d", format, width, height)
-
-	if isPatchBased {
-		// 32x32 patch-based calculation with 1536 cap and model multiplier
-		ceilDiv := func(a, b int) int { return (a + b - 1) / b }
-		rawPatchesW := ceilDiv(width, 32)
-		rawPatchesH := ceilDiv(height, 32)
-		rawPatches := rawPatchesW * rawPatchesH
-		if rawPatches > 1536 {
-			// scale down
-			area := float64(width * height)
-			r := math.Sqrt(float64(32*32*1536) / area)
-			wScaled := float64(width) * r
-			hScaled := float64(height) * r
-			// adjust to fit whole number of patches after scaling
-			adjW := math.Floor(wScaled/32.0) / (wScaled / 32.0)
-			adjH := math.Floor(hScaled/32.0) / (hScaled / 32.0)
-			adj := math.Min(adjW, adjH)
-			if !math.IsNaN(adj) && adj > 0 {
-				r = r * adj
-			}
-			wScaled = float64(width) * r
-			hScaled = float64(height) * r
-			patchesW := math.Ceil(wScaled / 32.0)
-			patchesH := math.Ceil(hScaled / 32.0)
-			imageTokens := int(patchesW * patchesH)
-			if imageTokens > 1536 {
-				imageTokens = 1536
-			}
-			return int(math.Round(float64(imageTokens) * multiplier)), nil
-		}
-		// below cap
-		imageTokens := rawPatches
-		return int(math.Round(float64(imageTokens) * multiplier)), nil
-	}
-
-	// Tile-based calculation for 4o/4.1/4.5/o1/o3/etc.
-	// Step 1: fit within 2048x2048 square
-	maxSide := math.Max(float64(width), float64(height))
-	fitScale := 1.0
-	if maxSide > 2048 {
-		fitScale = maxSide / 2048.0
-	}
-	fitW := int(math.Round(float64(width) / fitScale))
-	fitH := int(math.Round(float64(height) / fitScale))
-
-	// Step 2: scale so that shortest side is exactly 768
-	minSide := math.Min(float64(fitW), float64(fitH))
-	if minSide == 0 {
-		return baseTokens, nil
-	}
-	shortScale := 768.0 / minSide
-	finalW := int(math.Round(float64(fitW) * shortScale))
-	finalH := int(math.Round(float64(fitH) * shortScale))
-
-	// Count 512px tiles
-	tilesW := (finalW + 512 - 1) / 512
-	tilesH := (finalH + 512 - 1) / 512
-	tiles := tilesW * tilesH
-
-	logger.LogDebug(c, "image token scaled size: width=%d, height=%d, tiles=%d", finalW, finalH, tiles)
-
-	return tiles*tileTokens + baseTokens, nil
+	// 估算阶段固定使用 3*baseTokens 作为高细节图片的 token 估算值，
+	// 不再下载图片解码尺寸。实际计费优先使用上游返回的 ImageTokens。
+	return 3 * baseTokens, nil
 }
 
 func EstimateRequestToken(c *gin.Context, meta *types.TokenCountMeta, info *relaycommon.RelayInfo) (int, error) {
@@ -235,45 +133,26 @@ func EstimateRequestToken(c *gin.Context, meta *types.TokenCountMeta, info *rela
 		tkm += 3
 	}
 
-	shouldFetchFiles := true
-
-	if info.RelayFormat == types.RelayFormatGemini {
-		shouldFetchFiles = false
-	}
-
-	// 是否本地计算媒体token数量
-	if !constant.GetMediaToken {
-		shouldFetchFiles = false
-	}
-
-	// 是否在非流模式下本地计算媒体token数量
-	if !constant.GetMediaTokenNotStream && !info.IsStream {
-		shouldFetchFiles = false
-	}
-
-	// 使用统一的文件服务获取文件类型
-	for _, file := range meta.Files {
+	// 估算阶段不再下载完整文件计算媒体 token。
+	// 仅当 FileType 未知时，做轻量级 MIME 检测（最多读取 512 字节）判断类型，
+	// 之后使用固定估算值计算 token。实际计费优先使用上游返回的 ImageTokens。
+	estimateImageTokens := 0
+	for i, file := range meta.Files {
 		if file.Source == nil {
 			continue
 		}
 
-		// 如果文件类型未知且需要获取，通过 MIME 类型检测
-		if file.FileType == "" || (file.Source.IsURL() && shouldFetchFiles) {
-			// 注意：这里我们直接调用 LoadFileSource 而不是 GetMimeType
-			// 因为 GetMimeType 内部可能会调用 GetFileTypeFromUrl (HEAD 请求)
-			// 而我们这里既然要计算 token，通常需要完整数据
-			cachedData, err := LoadFileSource(c, file.Source, "token_counter")
+		// 仅当 FileType 未知时，做轻量级 MIME 检测（不缓存数据）
+		if file.FileType == "" {
+			mimeType, err := DetectMimeTypeLightweight(c, file.Source)
 			if err != nil {
-				if shouldFetchFiles {
-					return 0, fmt.Errorf("error getting file type: %v", err)
-				}
-				continue
+				// 检测失败按未知文件处理，避免阻断估算
+				logger.LogWarn(c, fmt.Sprintf("lightweight mime detect failed, identifier[%s], err: %v", file.GetIdentifier(), err))
+			} else if mimeType != "" {
+				file.FileType = DetectFileType(mimeType)
 			}
-			file.FileType = DetectFileType(cachedData.MimeType)
 		}
-	}
 
-	for i, file := range meta.Files {
 		switch file.FileType {
 		case types.FileTypeImage:
 			if common.IsOpenAITextModel(model) {
@@ -282,8 +161,10 @@ func EstimateRequestToken(c *gin.Context, meta *types.TokenCountMeta, info *rela
 					return 0, fmt.Errorf("error counting image token, media index[%d], identifier[%s], err: %v", i, file.GetIdentifier(), err)
 				}
 				tkm += token
+				estimateImageTokens += token
 			} else {
 				tkm += 520
+				estimateImageTokens += 520
 			}
 		case types.FileTypeAudio:
 			tkm += 256
@@ -295,6 +176,9 @@ func EstimateRequestToken(c *gin.Context, meta *types.TokenCountMeta, info *rela
 			tkm += 4096 // Default case for unknown file types
 		}
 	}
+
+	// 记录图片 token 估算值，供计费阶段在上游未返回 ImageTokens 时 fallback 使用
+	info.SetEstimateImageTokens(estimateImageTokens)
 
 	common.SetContextKey(c, constant.ContextKeyPromptTokens, tkm)
 	return tkm, nil


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本 PR 的代码由 AI（GLM-5.2 模型）辅助生成，已由人工审查并整理提交说明。

## 📝 变更描述 / Description

### 问题背景
当处理大量带图片的请求时，系统会在 token 估算阶段下载完整图片文件并 base64 编码缓存，导致内存持续飙升。在高并发场景（如 4000 请求/分钟）下，内存占用会急剧增长，严重影响服务稳定性。

### 根本原因
`EstimateRequestToken` 函数通过 `LoadFileSource` 下载完整图片文件（最大可达几十 MB），解码图片尺寸用于精确计算 tile-based token 数。下载的数据会缓存到请求 context 中直到请求结束，造成内存常驻。

### 解决方案
估算阶段不再下载完整文件，改用以下策略：
1. **固定估算值**：图片 token 使用固定值（OpenAI 模型 `3*baseTokens`，非 OpenAI 模型 `520`），不再按尺寸精确计算
2. **轻量 MIME 检测**：仅当文件类型未知时，做最多 512 字节的 HTTP 内容嗅探判断类型（图片/音频/视频/文件），不缓存数据
3. **Claude URL 直传**：Claude 中继不再下载图片转 base64，直接传 URL 给上游（`source.type="url"`）
4. **计费 fallback**：实际计费优先使用上游返回的 `ImageTokens`；若上游未返回，则使用估算阶段记录的固定值

### 变更详情
- **relay/common/relay_info.go**：`TokenCountMeta` 新增 `estimateImageTokens` 字段及 Set/Get 方法，用于计费阶段 fallback
- **service/token_counter.go**：`getImageToken` 移除 `GetImageConfig` 下载调用，固定返回 `3*baseTokens`；`EstimateRequestToken` 用 `DetectMimeTypeLightweight` 替代 `LoadFileSource`
- **service/file_decoder.go**：新增 `DetectMimeTypeLightweight` 及辅助函数（`sniffMimeTypeFromURL`/`sniffMimeTypeFromBase64`/`mimeTypeFromHeaders`/`sniffBytes`），URL 最多读 512 字节，base64 仅解码前 512 字节，不缓存数据
- **service/text_quota.go**：上游未返回 `ImageTokens` 时 fallback 到 `RelayInfo.GetEstimateImageTokens()`
- **service/relayconvert/internal/oai_chat/to_claude_messages_req.go**：URL 来源直传 Claude（`source.type="url"`），不再下载转 base64

## 🚀 变更类型 / Type of change
- [x] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] 📝 文档更新 (Documentation)

> 注：本变更主要解决性能问题（内存飙升），归类为性能优化。虽然内存飙升可视为 bug，但根因是设计取舍（精确估算 vs 资源占用），故选择 Refactor。

## 🔗 关联任务 / Related Issue
- 暂无关联 Issue

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 本 PR 未标记为 Bug fix。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行 `go build` 和 `go vet` 通过，相关测试全部通过。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

### 编译验证
```
$ go build ./service/... ./relay/common/... ./service/relayconvert/...
（成功，无错误）

$ go vet ./service/... ./relay/common/... ./service/relayconvert/...
（成功，无警告）
```

### 测试结果
```
$ go test ./service/ -run "TestCalculateTextQuota|TestBuildTieredTokenParams" -v
--- PASS: TestCalculateTextQuotaSummaryFixedPriceAppliesImageCountOnceAndAllowsOverride (0.00s)
--- PASS: TestBuildTieredTokenParams_GPT_WithImage (0.00s)
--- PASS: TestBuildTieredTokenParams_Claude_WithCache (0.00s)
--- PASS: TestBuildTieredTokenParams_ParityWithRatio_Image (0.00s)
...（全部通过）
PASS
ok  github.com/QuantumNous/new-api/service  2.039s
```

### 内存优化效果
- **优化前**：估算阶段下载完整图片（可达几十 MB）并 base64 缓存至请求结束
- **优化后**：估算阶段最多读取 512 字节做 MIME 嗅探，无数据常驻内存；Claude 中继直接传 URL，不下载图片

### 潜在影响审计

#### 不会有问题的部分
- **内存飙升已解决**：估算阶段不再调用 `LoadFileSource`（完整下载+缓存），改为最多 512 字节嗅探，无数据常驻内存
- **计费准确性**：优先使用上游返回的 `ImageTokens`，仅在上游未返回时才 fallback 到固定估算值
- **文件类型识别**：OpenAI/Claude/Gemini 格式在请求解析时已设置 `FileType`，轻量检测仅在 `FileType==""` 时触发（罕见）
- **base64 来源**：`Base64Source.MimeType` 通常在解析时已设置，无需额外检测
- **Claude URL 直传**：ClaudeMessageSource 结构体已支持 `Url` 字段，API 兼容

#### 需要注意的潜在影响
1. **估算精度降低**：所有图片固定用 `3*baseTokens`（OpenAI）或 `520`（非 OpenAI）估算，不再按尺寸精确计算。这是**有意为之** — 实际计费以上游返回值为准
2. **Claude 内网 URL 场景**：之前 Claude 转换会下载内网 URL 转 base64 再发送，现在直接传 URL 给 Claude。若 URL 是内网地址（如 `http://localhost/...`），Claude 服务器无法访问。**这与 OpenAI/Gemini 行为一致**，符合设计预期
3. **`constant.GetMediaToken` / `GetMediaTokenNotStream` 环境变量变为无效**：这两个 env var 不再影响估算行为（之前控制是否下载完整文件计算精确 token）。env var 定义保留（不破坏现有配置），但实际效果变为 no-op
4. **Gemini 仍下载 base64**：Gemini API 的 `inlineData` 要求 base64，不支持任意 URL 直传（需先上传到 Gemini File API）。本次未修改 Gemini 转换，仍走 `ResolveBase64Data`
5. **`GetImageConfig` 函数变为 dead code**：仅定义未被调用。保留不删，属工具函数

---

> ⚠️ **AI 辅助声明**：本 PR 的代码由 AI（GLM-5.2 模型）辅助生成，提交者（ROYWANG）已人工审查代码逻辑、验证编译与测试，并整理撰写此 PR 描述。代码修改涉及计费逻辑，建议维护者重点审查 `text_quota.go` 的 fallback 逻辑和 `token_counter.go` 的估算策略。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved media handling by forwarding URL-based images and documents directly when supported.
  - Added lightweight file-type detection without downloading full file contents.
  - Added fallback image-token estimation for more consistent usage and billing when upstream data is incomplete.

- **Bug Fixes**
  - Reduced unnecessary media downloads during token estimation.
  - Improved recognition of image formats and URL-provided media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->