### PR TITLE
fix: complete Responses stream done events

### DIFF
--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -413,10 +413,13 @@ const (
 
 // ResponsesStreamResponse 用于处理 /v1/responses 流式响应
 type ResponsesStreamResponse struct {
-	Type     string                   `json:"type"`
-	Response *OpenAIResponsesResponse `json:"response,omitempty"`
-	Delta    string                   `json:"delta,omitempty"`
-	Item     *ResponsesOutput         `json:"item,omitempty"`
+	Type      string                   `json:"type"`
+	Response  *OpenAIResponsesResponse `json:"response,omitempty"`
+	Delta     string                   `json:"delta,omitempty"`
+	Text      *string                  `json:"text,omitempty"`
+	Name      *string                  `json:"name,omitempty"`
+	Arguments *string                  `json:"arguments,omitempty"`
+	Item      *ResponsesOutput         `json:"item,omitempty"`
 	// - response.function_call_arguments.delta
 	// - response.function_call_arguments.done
 	OutputIndex  *int                           `json:"output_index,omitempty"`

--- a/relay/channel/openai/chat_via_responses_test.go
+++ b/relay/channel/openai/chat_via_responses_test.go
@@ -178,3 +178,98 @@ func requireOrderedSubstrings(t *testing.T, s string, parts ...string) {
 		offset += idx + len(part)
 	}
 }
+
+type decodedResponsesStreamEvent struct {
+	Type           string `json:"type"`
+	SequenceNumber *int64 `json:"sequence_number"`
+	Payload        map[string]any
+}
+
+func TestOaiChatToResponsesStreamHandlerRequiresDoneEventFields(t *testing.T) {
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1710000000,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1710000000,"model":"test-model","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1710000000,"model":"test-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"q\":"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1710000000,"model":"test-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"x\"}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1710000000,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	c, recorder, resp, info := newResponsesChatTestContext(t, body, true)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	usage, err := OaiChatToResponsesStreamHandler(c, info, resp)
+	require.Nil(t, err)
+	require.NotNil(t, usage)
+
+	events := decodeResponsesStreamEvents(t, recorder.Body.String())
+	textDone := requireResponsesStreamEvent(t, events, "response.output_text.done")
+	require.Equal(t, "hello", textDone.Payload["text"])
+
+	argumentsDone := requireResponsesStreamEvent(t, events, "response.function_call_arguments.done")
+	require.Equal(t, "lookup", argumentsDone.Payload["name"])
+	require.Equal(t, `{"q":"x"}`, argumentsDone.Payload["arguments"])
+}
+
+func TestOaiChatToResponsesStreamHandlerRequiresReasoningDoneText(t *testing.T) {
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1710000000,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1710000000,"model":"test-model","choices":[{"index":0,"delta":{"reasoning_content":"thinking"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1710000000,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	c, recorder, resp, info := newResponsesChatTestContext(t, body, true)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	usage, err := OaiChatToResponsesStreamHandler(c, info, resp)
+	require.Nil(t, err)
+	require.NotNil(t, usage)
+
+	events := decodeResponsesStreamEvents(t, recorder.Body.String())
+	reasoningDone := requireResponsesStreamEvent(t, events, "response.reasoning_summary_text.done")
+	require.Equal(t, "thinking", reasoningDone.Payload["text"])
+}
+
+func decodeResponsesStreamEvents(t *testing.T, body string) []decodedResponsesStreamEvent {
+	t.Helper()
+
+	events := make([]decodedResponsesStreamEvent, 0)
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
+		if data == "" || data == "[DONE]" {
+			continue
+		}
+
+		var event decodedResponsesStreamEvent
+		require.NoError(t, common.Unmarshal([]byte(data), &event), "invalid Responses SSE data: %s", data)
+		require.NotEmpty(t, event.Type, "Responses SSE event is missing type: %s", data)
+		require.NoError(t, common.Unmarshal([]byte(data), &event.Payload), "invalid Responses SSE payload: %s", data)
+		events = append(events, event)
+	}
+	return events
+}
+
+func requireResponsesStreamEvent(t *testing.T, events []decodedResponsesStreamEvent, eventType string) decodedResponsesStreamEvent {
+	t.Helper()
+	for _, event := range events {
+		if event.Type == eventType {
+			return event
+		}
+	}
+	require.FailNowf(t, "missing Responses SSE event", "event type %s was not emitted", eventType)
+	return decodedResponsesStreamEvent{}
+}

--- a/service/relayconvert/internal/oai_chat/to_oai_responses_resp.go
+++ b/service/relayconvert/internal/oai_chat/to_oai_responses_resp.go
@@ -230,3 +230,7 @@ func responsesStreamEvent(eventType string, payload dto.ResponsesStreamResponse)
 func intPtr(v int) *int {
 	return &v
 }
+
+func stringPtr(v string) *string {
+	return &v
+}

--- a/service/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
+++ b/service/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
@@ -251,6 +251,7 @@ func (s *ChatToResponsesStreamState) doneDeltaEvents() []ChatToResponsesStreamEv
 			OutputIndex:  intPtr(s.textOutputIndex),
 			ContentIndex: intPtr(0),
 			ItemID:       s.messageID(),
+			Text:         stringPtr(s.text.String()),
 		}))
 		events = append(events, responsesStreamEvent(responsesEventOutputItemDone, dto.ResponsesStreamResponse{
 			Type:        responsesEventOutputItemDone,
@@ -265,10 +266,7 @@ func (s *ChatToResponsesStreamState) doneDeltaEvents() []ChatToResponsesStreamEv
 			OutputIndex:  intPtr(s.reasoningIndex),
 			SummaryIndex: intPtr(0),
 			ItemID:       s.reasoningID(),
-			Part: &dto.ResponsesReasoningSummaryPart{
-				Type: "summary_text",
-				Text: s.reasoning.String(),
-			},
+			Text:         stringPtr(s.reasoning.String()),
 		}))
 		events = append(events, responsesStreamEvent(responsesEventOutputItemDone, dto.ResponsesStreamResponse{
 			Type:        responsesEventOutputItemDone,
@@ -285,6 +283,8 @@ func (s *ChatToResponsesStreamState) doneDeltaEvents() []ChatToResponsesStreamEv
 			Type:        responsesEventFunctionArgsDone,
 			OutputIndex: intPtr(tool.OutputIndex),
 			ItemID:      tool.ID,
+			Name:        stringPtr(tool.Name),
+			Arguments:   stringPtr(tool.Arguments.String()),
 		}))
 		events = append(events, responsesStreamEvent(responsesEventOutputItemDone, dto.ResponsesStreamResponse{
 			Type:        responsesEventOutputItemDone,


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

> [!NOTE]
>
> 实现、最小复现和描述初稿由 OpenAI Codex 协助完成；我已检查代码范围和测试结果。

## 📝 变更描述 / Description

Chat Completions 流转换为 Responses SSE 时，三个结束事件没有按照 Responses 事件结构携带最终聚合值：

- `response.output_text.done` 缢少顶层 `text`；
- `response.function_call_arguments.done` 缺少顶层 `name` 和 `arguments`；
- `response.reasoning_summary_text.done` 把内容写入了 `part`，而不是顶层 `text`。

这会导致严格反序列化 Responses 事件的客户端拒绝对应 done 事件，或者无法从 done 事件取得最终文本与工具参数。

本改动只补齐上述事件字段：

- 文本 done 使用已聚合的完整文本；
- 工具参数 done 使用已聚合的函数名和完整参数；
- reasoning text done 使用顶层完整文本；
- 新字段使用指针，确保需要时可以显式序列化空字符串。

本 PR 不包含 `sequence_number`、错误流 framing、请求历史 reasoning 映射或 lifecycle 扩展。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

目前没有精确对应的 Issue。

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并检查此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，未发现针对当前 `relayconvert/internal/oai_chat` 转换路径补齐这三个 done 事件字段的提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 已确认各 done 事件应携带的最终聚合值及当前状态机的数据来源。
- [x] **范围聚焦:** 本 PR 仅修改 done 事件 DTO、构造逻辑和回归测试。
- [x] **本地验证:** 已运行专项测试和相关包测试。
- [x] **安全合规:** 代码中无敏感凭据或新的持久化状态。

## 📸 运行证明 / Proof of Work

仅应用测试到未修复的 `main @ 1721144` 时：

```text
response.output_text.done:
expected: "hello"
actual: nil

response.function_call_arguments.done:
expected name: "lookup"
actual: nil

response.reasoning_summary_text.done:
expected: "thinking"
actual: nil
```

应用本 PR 后：

```text
PASS TestOaiChatToResponsesStreamHandlerRequiresDoneEventFields
PASS TestOaiChatToResponsesStreamHandlerRequiresReasoningDoneText

ok github.com/QuantumNous/new-api/relay/channel/openai
ok github.com/QuantumNous/new-api/service/relayconvert/internal/oai_chat
```

另外运行：

```text
git diff --check
```

未发现补丁格式问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed response events to include completed text and reasoning content.
  * Completed function-call events now include the function name and arguments.
  * Enhanced compatibility with clients consuming streamed response data.

* **Tests**
  * Added coverage validating text, reasoning, function names, and arguments in completed streaming events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->