### PR TITLE
fix: retry pre-stream rate limit SSE errors

### DIFF
--- a/controller/responses_via_chat_retry_test.go
+++ b/controller/responses_via_chat_retry_test.go
@@ -1,0 +1,81 @@
+package controller
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	relayopenai "github.com/QuantumNous/new-api/relay/channel/openai"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/setting/operation_setting"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponsesViaChatRetriesRateLimitErrorBeforeOutput(t *testing.T) {
+	oldTimeout := constant.StreamingTimeout
+	oldRanges := operation_setting.AutomaticRetryStatusCodeRanges
+	constant.StreamingTimeout = 30
+	operation_setting.AutomaticRetryStatusCodeRanges = []operation_setting.StatusCodeRange{{Start: 429, End: 429}}
+	t.Cleanup(func() {
+		constant.StreamingTimeout = oldTimeout
+		operation_setting.AutomaticRetryStatusCodeRanges = oldRanges
+	})
+
+	body := "data: {\"error\":{\"message\":\"rate limited\",\"type\":\"rate_limit_error\",\"code\":\"rate_limit_exceeded\"}}\n\n"
+	c, recorder, resp, info := newResponsesViaChatRetryContext(body)
+
+	usage, relayErr := relayopenai.OaiChatToResponsesStreamHandler(c, info, resp)
+	require.Nil(t, usage)
+	require.NotNil(t, relayErr)
+	require.Equal(t, http.StatusTooManyRequests, relayErr.StatusCode)
+	require.Zero(t, recorder.Body.Len())
+	require.True(t, shouldRetry(c, relayErr, 1))
+}
+
+func TestResponsesViaChatDoesNotRetryRateLimitAfterOutput(t *testing.T) {
+	oldTimeout := constant.StreamingTimeout
+	oldRanges := operation_setting.AutomaticRetryStatusCodeRanges
+	constant.StreamingTimeout = 30
+	operation_setting.AutomaticRetryStatusCodeRanges = []operation_setting.StatusCodeRange{{Start: 429, End: 429}}
+	t.Cleanup(func() {
+		constant.StreamingTimeout = oldTimeout
+		operation_setting.AutomaticRetryStatusCodeRanges = oldRanges
+	})
+
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1710000000,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		`data: {"error":{"message":"rate limited","type":"rate_limit_error","code":"rate_limit_exceeded"}}`,
+		``,
+	}, "\n")
+	c, recorder, resp, info := newResponsesViaChatRetryContext(body)
+
+	usage, relayErr := relayopenai.OaiChatToResponsesStreamHandler(c, info, resp)
+	require.Nil(t, usage)
+	require.NotNil(t, relayErr)
+	require.Equal(t, http.StatusOK, relayErr.StatusCode)
+	require.NotZero(t, recorder.Body.Len())
+	require.False(t, shouldRetry(c, relayErr, 1))
+}
+
+func newResponsesViaChatRetryContext(body string) (*gin.Context, *httptest.ResponseRecorder, *http.Response, *relaycommon.RelayInfo) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "test-model"},
+		IsStream:    true,
+		RelayFormat: types.RelayFormatOpenAI,
+		DisablePing: true,
+	}
+	return c, recorder, resp, info
+}

--- a/controller/responses_via_chat_retry_test.go
+++ b/controller/responses_via_chat_retry_test.go
@@ -37,6 +37,29 @@ func TestResponsesViaChatRetriesRateLimitErrorBeforeOutput(t *testing.T) {
 	require.True(t, shouldRetry(c, relayErr, 1))
 }
 
+func TestResponsesViaChatRetriesCodeOnlyRateLimitBeforeOutput(t *testing.T) {
+	oldTimeout := constant.StreamingTimeout
+	oldRanges := operation_setting.AutomaticRetryStatusCodeRanges
+	constant.StreamingTimeout = 30
+	operation_setting.AutomaticRetryStatusCodeRanges = []operation_setting.StatusCodeRange{
+		{Start: 429, End: 429},
+	}
+	t.Cleanup(func() {
+		constant.StreamingTimeout = oldTimeout
+		operation_setting.AutomaticRetryStatusCodeRanges = oldRanges
+	})
+
+	body := "data: {\"error\":{\"message\":\"rate limited\",\"code\":\"rate_limit_exceeded\"}}\n\n"
+	c, recorder, resp, info := newResponsesViaChatRetryContext(body)
+
+	usage, relayErr := relayopenai.OaiChatToResponsesStreamHandler(c, info, resp)
+	require.Nil(t, usage)
+	require.NotNil(t, relayErr)
+	require.Equal(t, http.StatusTooManyRequests, relayErr.StatusCode)
+	require.Zero(t, recorder.Body.Len())
+	require.True(t, shouldRetry(c, relayErr, 1))
+}
+
 func TestResponsesViaChatDoesNotRetryRateLimitAfterOutput(t *testing.T) {
 	oldTimeout := constant.StreamingTimeout
 	oldRanges := operation_setting.AutomaticRetryStatusCodeRanges

--- a/relay/channel/openai/responses_via_chat.go
+++ b/relay/channel/openai/responses_via_chat.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
@@ -97,7 +98,8 @@ func OaiChatToResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 		var errorResp dto.OpenAITextResponse
 		if err := common.UnmarshalJsonStr(data, &errorResp); err == nil {
 			if oaiError := errorResp.GetOpenAIError(); oaiError != nil && oaiError.Type != "" {
-				streamErr = types.WithOpenAIError(*oaiError, resp.StatusCode)
+				statusCode := responsesViaChatStreamErrorStatus(resp.StatusCode, oaiError, c.Writer.Written())
+				streamErr = types.WithOpenAIError(*oaiError, statusCode)
 				sr.Stop(streamErr)
 				return
 			}
@@ -155,4 +157,17 @@ func OaiChatToResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 	}
 
 	return usage, nil
+}
+
+func responsesViaChatStreamErrorStatus(upstreamStatus int, oaiError *types.OpenAIError, downstreamStarted bool) int {
+	if downstreamStarted || oaiError == nil || upstreamStatus < http.StatusOK || upstreamStatus >= http.StatusMultipleChoices {
+		return upstreamStatus
+	}
+
+	errorType := strings.ToLower(strings.TrimSpace(oaiError.Type))
+	errorCode := strings.ToLower(strings.TrimSpace(fmt.Sprint(oaiError.Code)))
+	if errorType == "rate_limit_error" || errorCode == "rate_limit_exceeded" || errorCode == "rate_limit_error" || errorCode == "429" {
+		return http.StatusTooManyRequests
+	}
+	return upstreamStatus
 }

--- a/relay/channel/openai/responses_via_chat.go
+++ b/relay/channel/openai/responses_via_chat.go
@@ -97,7 +97,7 @@ func OaiChatToResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 
 		var errorResp dto.OpenAITextResponse
 		if err := common.UnmarshalJsonStr(data, &errorResp); err == nil {
-			if oaiError := errorResp.GetOpenAIError(); oaiError != nil && oaiError.Type != "" {
+			if oaiError := errorResp.GetOpenAIError(); oaiError != nil {
 				statusCode := responsesViaChatStreamErrorStatus(resp.StatusCode, oaiError, c.Writer.Written())
 				streamErr = types.WithOpenAIError(*oaiError, statusCode)
 				sr.Stop(streamErr)


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

> [!IMPORTANT]
>
> - 这份说明已按实际代码和测试结果整理；实现与测试过程使用了 Codex 辅助。

## 📝 变更描述 / Description

这个 PR 修复 `/v1/responses` 通过 Chat Completions 上游转发时，HTTP 200 SSE 在首个有效响应事件前返回限流错误却不会进入现有 429 重试逻辑的问题。

部分 Chat-compatible 上游会保持 HTTP 200，然后在 SSE data 中返回：

```json
{"error":{"type":"rate_limit_error","code":"rate_limit_exceeded","message":"rate limited"}}
```

此前转换 handler 直接沿用上游 HTTP 200 构造内部错误，`shouldRetry` 因状态码为 2xx 跳过重试。

本次只在以下条件同时满足时把内部状态恢复为 429：

- 上游 HTTP 状态为 2xx；
- 下游尚未输出任何 Responses SSE 事件；
- SSE 错误的 type/code 明确表示 rate limit。

这样可以复用现有重试配置和渠道选择逻辑。只要下游已经开始输出，就保持原状态且不做透明重试，避免重复或混合流内容。真实 HTTP 429 的处理逻辑没有改动。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #6643

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已检查并整理此描述，没有直接粘贴未经处理的输出。
- [x] **非重复提交:** 已搜索现有 Issues 和 PRs，没有发现完整处理该边界的提交。
- [ ] **Bug fix 说明:** 当前没有可关联的精确 Issue。
- [x] **变更理解:** 已确认只在下游未开始时恢复限流状态，已开始的流不会透明重试。
- [x] **范围聚焦:** 本 PR 未包含无关改动。
- [x] **本地验证:** 已运行相关测试。
- [x] **安全合规:** 代码中无敏感凭据，并符合现有代码规范。

## 📸 运行证明 / Proof of Work

```text
go test ./controller -run 'TestResponsesViaChat' -count=1 -v
PASS TestResponsesViaChatRetriesRateLimitErrorBeforeOutput
PASS TestResponsesViaChatRetriesCodeOnlyRateLimitBeforeOutput
PASS TestResponsesViaChatDoesNotRetryRateLimitAfterOutput

 go test ./relay/channel/openai ./controller -count=1
ok github.com/QuantumNous/new-api/relay/channel/openai
ok github.com/QuantumNous/new-api/controller

 git diff --check
(no output)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rate-limit errors during streaming responses.
  * Returns HTTP 429 when a rate-limit error occurs before output begins.
  * Preserves successful response behavior when output has already started.

* **Tests**
  * Added coverage for retry decisions and status codes across streaming rate-limit scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->