### PR TITLE
fix: preserve Responses reasoning summary fields

### DIFF
--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -361,16 +361,17 @@ type IncompleteDetails struct {
 }
 
 type ResponsesOutput struct {
-	Type      string                   `json:"type"`
-	ID        string                   `json:"id"`
-	Status    string                   `json:"status"`
-	Role      string                   `json:"role"`
-	Content   []ResponsesOutputContent `json:"content"`
-	Quality   string                   `json:"quality"`
-	Size      string                   `json:"size"`
-	CallId    string                   `json:"call_id,omitempty"`
-	Name      string                   `json:"name,omitempty"`
-	Arguments json.RawMessage          `json:"arguments,omitempty"`
+	Type      string                           `json:"type"`
+	ID        string                           `json:"id"`
+	Status    string                           `json:"status"`
+	Role      string                           `json:"role"`
+	Content   []ResponsesOutputContent         `json:"content"`
+	Quality   string                           `json:"quality"`
+	Size      string                           `json:"size"`
+	CallId    string                           `json:"call_id,omitempty"`
+	Name      string                           `json:"name,omitempty"`
+	Arguments json.RawMessage                  `json:"arguments,omitempty"`
+	Summary   *[]ResponsesReasoningSummaryPart `json:"summary,omitempty"`
 }
 
 // ArgumentsString returns function call arguments in the string form expected by Chat Completions.

--- a/service/relayconvert/internal/oai_chat/to_oai_responses_resp.go
+++ b/service/relayconvert/internal/oai_chat/to_oai_responses_resp.go
@@ -74,10 +74,11 @@ func ChatCompletionsResponseToResponsesResponse(resp *dto.OpenAITextResponse, id
 	}
 	if reasoning := choice.Message.GetReasoningContent(); reasoning != "" {
 		out.Output = append(out.Output, dto.ResponsesOutput{
-			Type:   responsesOutputTypeReasoning,
-			ID:     fmt.Sprintf("%s_reasoning_0", id),
-			Status: responseOutputStatus(out),
-			Content: []dto.ResponsesOutputContent{
+			Type:    responsesOutputTypeReasoning,
+			ID:      fmt.Sprintf("%s_reasoning_0", id),
+			Status:  responseOutputStatus(out),
+			Content: []dto.ResponsesOutputContent{},
+			Summary: &[]dto.ResponsesReasoningSummaryPart{
 				{
 					Type: "summary_text",
 					Text: reasoning,

--- a/service/relayconvert/internal/oai_chat/to_oai_responses_resp_test.go
+++ b/service/relayconvert/internal/oai_chat/to_oai_responses_resp_test.go
@@ -1,6 +1,7 @@
 package oaichat
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/QuantumNous/new-api/dto"
@@ -9,6 +10,88 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestChatCompletionsResponseToResponsesUsesReasoningSummaryField(t *testing.T) {
+	reasoning := "thinking"
+	resp, _, err := ChatCompletionsResponseToResponsesResponse(&dto.OpenAITextResponse{
+		Id:    "chatcmpl_1",
+		Model: "gpt-test",
+		Choices: []dto.OpenAITextResponseChoice{
+			{
+				Message: dto.Message{
+					Role:             "assistant",
+					ReasoningContent: &reasoning,
+				},
+				FinishReason: "stop",
+			},
+		},
+	}, "resp_1")
+	require.NoError(t, err)
+	require.Len(t, resp.Output, 1)
+
+	assertReasoningSummaryJSON(t, resp.Output[0], "thinking")
+}
+
+func TestChatCompletionsStreamToResponsesUsesReasoningSummaryField(t *testing.T) {
+	state := NewChatToResponsesStreamState("resp_1", "gpt-test")
+	reasoning := "thinking"
+
+	events := mustResponsesEventsFromChatChunk(t, state, &dto.ChatCompletionsStreamResponse{
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{Index: 0, Delta: dto.ChatCompletionsStreamResponseChoiceDelta{ReasoningContent: &reasoning}},
+		},
+	})
+
+	var added *dto.ResponsesOutput
+	for _, event := range events {
+		if event.Type == responsesEventOutputItemAdded {
+			added = event.Payload.Item
+		}
+	}
+	require.NotNil(t, added)
+	assertReasoningSummaryJSON(t, *added, "")
+
+	finishReason := "stop"
+	events = mustResponsesEventsFromChatChunk(t, state, &dto.ChatCompletionsStreamResponse{
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{Index: 0, FinishReason: &finishReason},
+		},
+	})
+
+	var done *dto.ResponsesOutput
+	for _, event := range events {
+		if event.Type == responsesEventOutputItemDone {
+			done = event.Payload.Item
+		}
+	}
+	require.NotNil(t, done)
+	assertReasoningSummaryJSON(t, *done, "thinking")
+
+	finalEvents := FinalizeChatCompletionsStreamToResponses(state)
+	require.Len(t, finalEvents, 1)
+	require.NotNil(t, finalEvents[0].Payload.Response)
+	require.Len(t, finalEvents[0].Payload.Response.Output, 1)
+	assertReasoningSummaryJSON(t, finalEvents[0].Payload.Response.Output[0], "thinking")
+}
+
+func assertReasoningSummaryJSON(t *testing.T, output dto.ResponsesOutput, wantText string) {
+	t.Helper()
+	require.Equal(t, responsesOutputTypeReasoning, output.Type)
+
+	encoded, err := json.Marshal(output)
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(encoded, &raw))
+	summaryJSON, ok := raw["summary"]
+	require.True(t, ok, "reasoning output must include summary: %s", encoded)
+
+	var summary []dto.ResponsesReasoningSummaryPart
+	require.NoError(t, json.Unmarshal(summaryJSON, &summary))
+	if wantText == "" {
+		require.Empty(t, summary)
+		return
+	}
+	require.Equal(t, []dto.ResponsesReasoningSummaryPart{{Type: "summary_text", Text: wantText}}, summary)
+}
 func TestChatCompletionsResponseToResponsesPreservesTextToolCallsAndUsage(t *testing.T) {
 	chat := &dto.OpenAITextResponse{
 		Id:      "chatcmpl_1",

--- a/service/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
+++ b/service/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
@@ -177,6 +177,7 @@ func (s *ChatToResponsesStreamState) appendReasoningDelta(delta string) []ChatTo
 				ID:      s.reasoningID(),
 				Status:  "in_progress",
 				Content: []dto.ResponsesOutputContent{},
+				Summary: &[]dto.ResponsesReasoningSummaryPart{},
 			},
 		}))
 	}
@@ -393,10 +394,11 @@ func (s *ChatToResponsesStreamState) messageOutput(status string) *dto.Responses
 
 func (s *ChatToResponsesStreamState) reasoningOutput(status string) *dto.ResponsesOutput {
 	return &dto.ResponsesOutput{
-		Type:   responsesOutputTypeReasoning,
-		ID:     s.reasoningID(),
-		Status: status,
-		Content: []dto.ResponsesOutputContent{
+		Type:    responsesOutputTypeReasoning,
+		ID:      s.reasoningID(),
+		Status:  status,
+		Content: []dto.ResponsesOutputContent{},
+		Summary: &[]dto.ResponsesReasoningSummaryPart{
 			{
 				Type: "summary_text",
 				Text: s.reasoning.String(),


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

> [!IMPORTANT]
>
> - 请提供**人工整理后的简洁摘要**，避免直接粘贴未经处理的 AI 输出。

## 📝 变更描述 / Description

Chat Completions → Responses 转换目前会把 reasoning summary 放到 reasoning item 的 `content` 里，但 `ResponsesOutput` 没有 `summary` 字段。

当 Chat 上游返回 `reasoning_content` 时，转换后的 reasoning item 类似：

```json
{
  "type": "reasoning",
  "content": [
    {
      "type": "summary_text",
      "text": "thinking"
    }
  ]
}
```

严格解析 Responses 事件的客户端会因此直接报错：

```text
serialization error: missing field `summary`
```

这个 PR 只修 reasoning output item 的结构：

- `response.output_item.added` 中显式输出空的 `summary: []`；
- `response.output_item.done` 中输出聚合后的 `summary_text`；
- 最终 `response.completed.response.output` 中保留完整 summary；
- 非流式 Chat → Responses 转换使用相同的顶层 `summary`；
- reasoning item 的 `content` 保持为空数组；
- message 和 function_call 等其他 output item 不输出无关的 `summary` 字段。

这里使用可选的 slice 指针，而不是带 `omitempty` 的普通 slice，是为了确保 reasoning 开始事件中的空数组不会再次被序列化器省略。

这个修改只处理 Chat → Responses 响应转换中的 reasoning item 结构，不修改 Responses → Chat 请求历史，也不改变 SSE 错误处理、sequence number 或 done 事件逻辑。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

目前没有精确对应的 Issue。

相关但不重复：

- #6395：Responses → Chat 请求转换中的 reasoning/tool history
- #6417：Chat → Responses 流式错误结束和 SSE framing
- #6445：Responses done 事件字段完整性

## ✅ 提交前检查项 / Checklist

- [x] **人工确认：** 我已亲自检查并整理 PR 描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交：** 已搜索现有 Issues 和 PRs，没有发现相同的 reasoning `summary` 修复。
- [ ] **Bug fix 说明：** 如果此 PR 标记为 Bug fix，我已提交或关联对应 Issue。
- [x] **变更理解：** 已确认流式和非流式 reasoning item 的序列化结果。
- [x] **范围聚焦：** 本 PR 没有包含其他 Responses 兼容性修改。
- [x] **本地验证：** 已运行相关转换层、流处理和控制器测试。
- [x] **安全合规：** 代码中没有敏感凭据，并符合项目现有代码规范。

## 📸 运行证明 / Proof of Work

修复前，新增的严格序列化测试可以稳定复现：

```text
--- FAIL: TestChatCompletionsResponseToResponsesUsesReasoningSummaryField
    reasoning output must include summary:
    {"type":"reasoning","id":"resp_1_reasoning_0","status":"completed",
     "content":[{"type":"summary_text","text":"thinking"}]}

--- FAIL: TestChatCompletionsStreamToResponsesUsesReasoningSummaryField
    reasoning output must include summary:
    {"type":"reasoning","id":"resp_1_reasoning_0","status":"in_progress",
     "content":[]}
```

修复后运行：

```text
go test ./service/relayconvert/internal/oai_chat \
  ./service/relayconvert/... \
  ./relay/channel/openai \
  ./relay/helper \
  ./controller \
  -count=1
```

结果：

```text
ok github.com/QuantumNous/new-api/service/relayconvert/internal/oai_chat
ok github.com/QuantumNous/new-api/service/relayconvert
ok github.com/QuantumNous/new-api/service/relayconvert/internal/oai_responses
ok github.com/QuantumNous/new-api/relay/channel/openai
ok github.com/QuantumNous/new-api/relay/helper
ok github.com/QuantumNous/new-api/controller
```

另外运行：

```text
git diff --check
```

未发现空白符或补丁格式问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reasoning summaries in Responses API output are now provided through the standard `summary` field.
  * Improved compatibility when converting chat responses and streaming responses, including correct handling of partial and finalized reasoning summaries.

* **Tests**
  * Added coverage for reasoning summaries in regular and streaming response conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->