### PR TITLE
fix: 移除 responses/compact 端点的 API type 白名单限制

### DIFF
--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
-	appconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/logger"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
@@ -22,18 +21,6 @@ import (
 
 func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
 	info.InitChannelMeta(c)
-	if info.RelayMode == relayconstant.RelayModeResponsesCompact {
-		switch info.ApiType {
-		case appconstant.APITypeOpenAI, appconstant.APITypeCodex:
-		default:
-			return types.NewErrorWithStatusCode(
-				fmt.Errorf("unsupported endpoint %q for api type %d", "/v1/responses/compact", info.ApiType),
-				types.ErrorCodeInvalidRequest,
-				http.StatusBadRequest,
-				types.ErrOptionWithSkipRetry(),
-			)
-		}
-	}
 
 	var responsesReq *dto.OpenAIResponsesRequest
 	switch req := info.Request.(type) {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

移除 [`relay/responses_handler.go`](https://github.com/QuantumNous/new-api/blob/main/relay/responses_handler.go) 中 `/v1/responses/compact` 端点的 API type 白名单（仅允许 OpenAI/Codex 通过）。

该白名单与适配器层校验完全重叠——不支持 Responses 的适配器会在 `ConvertOpenAIResponsesRequest` 中自行报错，
白名单只是把更精准的适配器错误替换成了笼统的 `"unsupported endpoint for api type X"`。

AdvancedCustom 适配器已完整实现 Responses 处理链，却被白名单拦截在适配器之前，属于遗漏。
删除后，AdvancedCustom 渠道在 `converter=none` 模式下可正常使用 compact 端点，其他不支持的适配器仍会自然报错，行为不变。

下游 compact 逻辑（后缀处理、定价 fallback、计费）本身不区分 API type，无需联动修改。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6461

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compact relay mode requests are no longer rejected upfront based solely on their API type.
  * These requests now follow the same standard request parsing, model mapping, upstream handling, and response processing flow as other supported variants, improving reliability for compact request payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->