### PR TITLE
fix: Responses→Chat 转换正确处理非 function 类型 tools（namespace 展开 + 非法类型丢弃）

### DIFF
--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -370,6 +370,7 @@ type ResponsesOutput struct {
 	Size      string                   `json:"size"`
 	CallId    string                   `json:"call_id,omitempty"`
 	Name      string                   `json:"name,omitempty"`
+	Namespace string                   `json:"namespace,omitempty"`
 	Arguments json.RawMessage          `json:"arguments,omitempty"`
 }
 

--- a/service/relayconvert/internal/oai_chat/to_oai_responses_resp.go
+++ b/service/relayconvert/internal/oai_chat/to_oai_responses_resp.go
@@ -175,12 +175,14 @@ func chatToolCallToResponsesOutput(toolCall dto.ToolCallRequest, responseID stri
 		callID = fmt.Sprintf("%s_call_%d", responseID, index)
 	}
 	if toolCall.Type == "" || toolCall.Type == "function" {
+		ns, name := splitNamespaceName(toolCall.Function.Name)
 		return dto.ResponsesOutput{
 			Type:      responsesOutputTypeFunctionCall,
 			ID:        callID,
 			Status:    status,
 			CallId:    callID,
-			Name:      toolCall.Function.Name,
+			Name:      name,
+			Namespace: ns,
 			Arguments: chatArgumentsRawMessage(toolCall.Function.Arguments),
 		}, nil
 	}

--- a/service/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
+++ b/service/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
@@ -209,6 +209,7 @@ func (s *ChatToResponsesStreamState) appendToolCallDelta(toolCall dto.ToolCallRe
 			tool.ID = fmt.Sprintf("%s_call_%d", s.ID, chatIndex)
 		}
 		s.toolsByIndex[chatIndex] = tool
+		addedNs, addedName := splitNamespaceName(tool.Name)
 		events = append(events, responsesStreamEvent(responsesEventOutputItemAdded, dto.ResponsesStreamResponse{
 			Type:        responsesEventOutputItemAdded,
 			OutputIndex: intPtr(tool.OutputIndex),
@@ -218,7 +219,8 @@ func (s *ChatToResponsesStreamState) appendToolCallDelta(toolCall dto.ToolCallRe
 				ID:        tool.ID,
 				Status:    "in_progress",
 				CallId:    tool.ID,
-				Name:      tool.Name,
+				Name:      addedName,
+				Namespace: addedNs,
 				Arguments: []byte(`""`),
 			},
 		}))
@@ -406,12 +408,25 @@ func (s *ChatToResponsesStreamState) reasoningOutput(status string) *dto.Respons
 }
 
 func (s *ChatToResponsesStreamState) toolOutput(tool *chatToResponsesStreamTool, status string) *dto.ResponsesOutput {
+	ns, name := splitNamespaceName(tool.Name)
 	return &dto.ResponsesOutput{
 		Type:      responsesOutputTypeFunctionCall,
 		ID:        tool.ID,
 		Status:    status,
 		CallId:    tool.ID,
-		Name:      tool.Name,
+		Name:      name,
+		Namespace: ns,
 		Arguments: chatArgumentsRawMessage(tool.Arguments.String()),
 	}
+}
+
+
+// splitNamespaceName splits a flattened "ns__name" tool name back into
+// (namespace, name).  Returns ("", fullName) when no "__" separator is
+// present or the prefix is empty.
+func splitNamespaceName(fullName string) (namespace, name string) {
+	if idx := strings.LastIndex(fullName, "__"); idx > 0 {
+		return fullName[:idx], fullName[idx+2:]
+	}
+	return "", fullName
 }

--- a/service/relayconvert/internal/oai_responses/to_oai_chat_req.go
+++ b/service/relayconvert/internal/oai_responses/to_oai_chat_req.go
@@ -279,6 +279,10 @@ func responsesFunctionCallItemToChatToolCall(item map[string]any) (dto.ToolCallR
 	if name == "" {
 		return dto.ToolCallRequest{}, errors.New("function_call item is missing name")
 	}
+	// Reconstruct flattened name when namespace is present (roundtrip).
+	if ns := strings.TrimSpace(common.Interface2String(item["namespace"])); ns != "" {
+		name = ns + "__" + name
+	}
 	return dto.ToolCallRequest{
 		ID:   responsesCallID(item),
 		Type: "function",
@@ -331,7 +335,8 @@ func responsesRequestToolsToChat(raw json.RawMessage) ([]dto.ToolCallRequest, er
 	out := make([]dto.ToolCallRequest, 0, len(tools))
 	for _, tool := range tools {
 		toolType := strings.TrimSpace(common.Interface2String(tool["type"]))
-		if toolType == "function" {
+		switch toolType {
+		case "function":
 			out = append(out, dto.ToolCallRequest{
 				Type: "function",
 				Function: dto.FunctionRequest{
@@ -340,17 +345,37 @@ func responsesRequestToolsToChat(raw json.RawMessage) ([]dto.ToolCallRequest, er
 					Parameters:  tool["parameters"],
 				},
 			})
-			continue
+		case "namespace", "mcp_server":
+			// Flatten inner tools into individual function entries
+			nsName := strings.TrimSpace(common.Interface2String(tool["name"]))
+			innerTools, _ := tool["tools"].([]any)
+			for _, rawInner := range innerTools {
+				inner, ok := rawInner.(map[string]any)
+				if !ok {
+					continue
+				}
+				innerName := strings.TrimSpace(common.Interface2String(inner["name"]))
+				if innerName == "" {
+					continue
+				}
+				fullName := innerName
+				if nsName != "" {
+					fullName = nsName + "__" + innerName
+				}
+				out = append(out, dto.ToolCallRequest{
+					Type: "function",
+					Function: dto.FunctionRequest{
+						Name:        fullName,
+						Description: common.Interface2String(inner["description"]),
+						Parameters:  inner["parameters"],
+					},
+				})
+			}
+		case "custom", "web_search", "tool_search", "file_search", "code_interpreter":
+			// No Chat Completions equivalent; drop to avoid upstream 400.
+		default:
+			// Unknown tool types: drop to avoid upstream 400.
 		}
-
-		rawTool, err := common.Marshal(tool)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, dto.ToolCallRequest{
-			Type:   toolType,
-			Custom: rawTool,
-		})
 	}
 	return out, nil
 }
@@ -424,8 +449,18 @@ func RequestTextToChatResponseFormat(raw json.RawMessage) (*dto.ResponseFormat, 
 }
 
 func responsesImagePartToChatImageURL(part map[string]any) any {
+	// If image_url is already an object (map), pass through.
 	if imageURL, ok := part["image_url"]; ok {
-		return imageURL
+		if m, isMap := imageURL.(map[string]any); isMap {
+			return m
+		}
+		// image_url is a string (e.g. data URI) — wrap into the
+		// {"url": ..., "detail": ...} object that Chat Completions expects.
+		wrapped := map[string]any{"url": imageURL}
+		if detail, ok := part["detail"]; ok {
+			wrapped["detail"] = detail
+		}
+		return wrapped
 	}
 	imageURL := map[string]any{}
 	for _, key := range []string{"url", "file_id", "detail"} {


### PR DESCRIPTION
## 变更描述 / Description

修复 Responses↔Chat Completions 协议转换中四个相关问题，使 Codex Desktop 通过 new-api 使用 GLM 等仅支持 function tools 的上游时，MCP 工具调用、subagent 调度、图片传递、多轮对话均正常工作。

### Fix 1: 请求方向 — 非 function 类型 tools 导致上游 400

**问题**：Codex 等 Responses API 客户端发送包含 `custom`、`namespace`、`mcp_server`、`web_search` 等类型 tools 的请求时，转换器将这些类型原样透传给上游 Chat Completions API。智谱 GLM 等只接受 `type: "function"` 的上游直接返回 `400: tools[N].type:type is illegal`。

**修复**（`responsesRequestToolsToChat`）：
- `namespace` / `mcp_server`：展开内部 `tools[]` 为独立 `type: "function"` 条目，name 加 `ns__` 前缀（如 `mcp__zai_vision__analyze_image`）避免冲突
- `custom` / `web_search` / `tool_search` / `file_search` / `code_interpreter`：丢弃（Chat Completions 无对应物）
- 未知类型：丢弃，避免上游 400

### Fix 2: 请求方向 — 图片 image_url 格式错误

**问题**：Codex 发送 `input_image` 时 `image_url` 是字符串（data URI），但 Chat Completions 要求 `image_url` 是 `{"url": ..., "detail": ...}` 对象。转换后上游报 `image_url格式错误`。

**修复**（`responsesImagePartToChatImageURL`）：当 `image_url` 是字符串时，包装为 `{"url": ..., "detail": ...}` 对象；已经是 map 的透传不变。

### Fix 3: 响应方向 — namespace 拆分错误导致 MCP/subagent 全部 unsupported call

**问题**：响应转换中需要将上游返回的扁平 function name（如 `mcp__zai_vision__analyze_image`）拆回 `namespace` + `name`，以便 Codex 路由到正确的 MCP server 或内置工具。原代码使用 `strings.Index`（第一个 `__`）拆分，导致 `mcp__zai_vision__analyze_image` 被错误拆成 namespace=`mcp` + name=`zai_vision__analyze_image`。Codex 重组时丢失分隔符，变成 `mcpzai_vision__analyze_image`，触发 `unsupported call`。同样的问题影响 `multi_agent_v1__spawn_agent` 等所有带 namespace 的工具。

**修复**：使用 `strings.LastIndex(name, "__")` 拆分。因为 namespace 段本身包含 `__`（如 `mcp__zai_vision`），而工具名（最后一段）只使用单下划线，所以最后一个 `__` 才是 namespace 与 name 的分界。同时恢复 `ResponsesOutput.Namespace` 字段，确保 Codex 能正确路由。

拆分示例：
- `mcp__zai_vision__analyze_image` → namespace=`mcp__zai_vision`, name=`analyze_image`
- `multi_agent_v1__spawn_agent` → namespace=`multi_agent_v1`, name=`spawn_agent`
- `web_search`（无 `__`）→ namespace=``, name=`web_search`

### Fix 4: 请求方向 — 多轮对话 function_call 历史消息丢失 namespace（roundtrip 断裂）

**问题**：当客户端回传带 `namespace` 的 `function_call` 历史消息时（如 Codex 在第二轮对话中回传上一轮的 tool call 结果），`responsesFunctionCallItemToChatToolCall` 只读取 `item["name"]`，忽略 `item["namespace"]`，导致发给上游的 function name 缺少 namespace 前缀。上游找不到对应的 tool 定义，返回错误或幻觉。

**修复**：在 `responsesFunctionCallItemToChatToolCall` 中读取 `item["namespace"]`，非空时拼接为 `ns + "__" + name`，与请求方向 tools 展开时的命名规则一致。

## 变更类型 / Type of change
- [x] Bug 修复 (Bug fix)
- [ ] 新功能 (New feature)
- [ ] 性能优化 / 重构 (Refactor)
- [ ] 文档更新 (Documentation)

## 关联任务 / Related Issue
- Closes #5938
- Closes #5936

## 已知限制 / Known Limitations

- 如果用户通过 Responses API 定义的普通 `function` tool 名字本身包含 `__`（如 `my__custom__tool`），响应方向会误拆出 namespace。这是 Responses↔Chat Completions 协议转换的固有限制：`__` 在展开时被用作 namespace 分隔符，无法与用户自定义名字中的 `__` 区分。实践中 OpenAI 规范中 `__` 就是 namespace 分隔符，正常 function 命名不应使用双下划线。

## 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 已关联 #5938 / #5936。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 仅涉及 Responses↔Chat 转换层的 tools/image/namespace 处理。
- [x] **本地验证:** 已在生产环境副本上通过完整自测（见下方）。
- [x] **回归审查:** 已通过 subagent 逐改动点审查回归风险，修复了 roundtrip 断裂和 Index→LastIndex 两个问题。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 运行证明 / Proof of Work

环境：new-api + 本 patch，Docker 容器独立部署于 `0.0.0.0:3005`，上游为智谱 GLM Coding Plan（`/coding/paas/v4/chat/completions`）。原始生产容器（`:3000`）未受影响。数据通过 bind mount 持久化到宿主机 `/opt/new-api-test/data/`。

**测试 A：无 tools 基线** → 200
```
POST /v1/responses {"model":"glm-5.2","input":"说一个字：好","stream":false}
→ 200, output_text: "好"
```

**测试 B：带 custom + namespace + web_search tools** → 200（修复前 400）
```
tools: [function exec_command, custom apply_patch, namespace multi_agent_v1, web_search]
→ 200, custom/web_search 被丢弃，namespace 展开为 function
```

**测试 C：流式 + tool call** → SSE 正常
```
→ response.function_call_arguments.delta {"cmd":"echo hello"} → response.completed
```

**测试 D：图片 image_url 格式** → 不再报格式错误
```
input_image with string image_url → 正确包装为 {"url": ..., "detail": ...}
```

**测试 E：MCP 工具 namespace 还原** → Codex 正确路由
```
GLM 返回 tool_call name="mcp__zai_vision__analyze_image"
→ 转换后 namespace="mcp__zai_vision", name="analyze_image"
→ Codex 成功调用 zai-vision MCP server（修复前报 unsupported call）
```

**测试 F：subagent namespace 还原** → Codex 正确路由
```
GLM 返回 tool_call name="multi_agent_v1__spawn_agent"
→ 转换后 namespace="multi_agent_v1", name="spawn_agent"
→ Codex 成功调度 subagent（修复前报 unsupported call）
```

**测试 G：多轮对话 roundtrip** → namespace 正确拼接
```
第一轮：Codex 发 namespace tool → 展开为 ns__name → GLM 调用 → 响应拆回 namespace+name
第二轮：Codex 回传 function_call with namespace="ns", name="tool"
→ 转换为 function name="ns__tool" 发给上游（修复前只发 "tool"，上游找不到）
```

## 变更文件

```
dto/openai_response.go                                                       |  1 +
service/relayconvert/internal/oai_chat/to_oai_responses_resp.go              | 14 +++++++++++++-
service/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go       |  9 +++++++--
service/relayconvert/internal/oai_responses/to_oai_chat_req.go               | 58 ++++++++++++++++++++++++++++++++++++++++++++--------------
4 files changed, 68 insertions(+), 15 deletions(-)
```
