### PR TITLE
fix(billing): make Responses image generation prices configurable

### DIFF
--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -46,9 +46,18 @@ type RerankerInfo struct {
 }
 
 type BuildInToolInfo struct {
-	ToolName          string
-	CallCount         int
-	SearchContextSize string
+	ToolName               string
+	CallCount              int
+	SearchContextSize      string
+	ImageGenerationQuality string
+	ImageGenerationSize    string
+	ImageGenerationTiers   map[ImageGenerationTier]int
+}
+
+// ImageGenerationTier identifies one billable image quality and size combination.
+type ImageGenerationTier struct {
+	Quality string
+	Size    string
 }
 
 type ResponsesUsageInfo struct {
@@ -414,6 +423,11 @@ func GenRelayInfoResponses(c *gin.Context, request *dto.OpenAIResponsesRequest) 
 					searchContextSize = "medium"
 				}
 				info.ResponsesUsageInfo.BuiltInTools[toolType].SearchContextSize = searchContextSize
+			case dto.BuildInToolImageGeneration:
+				info.ResponsesUsageInfo.BuiltInTools[toolType].ImageGenerationQuality =
+					common.Interface2String(tool["quality"])
+				info.ResponsesUsageInfo.BuiltInTools[toolType].ImageGenerationSize =
+					common.Interface2String(tool["size"])
 			}
 		}
 	}

--- a/relay/common/relay_info_test.go
+++ b/relay/common/relay_info_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"encoding/json"
 	"net/http/httptest"
 	"testing"
@@ -43,6 +44,26 @@ func TestRelayInfoGetFinalRequestRelayFormatFallsBackToRelayFormat(t *testing.T)
 func TestRelayInfoGetFinalRequestRelayFormatNilReceiver(t *testing.T) {
 	var info *RelayInfo
 	require.Equal(t, types.RelayFormat(""), info.GetFinalRequestRelayFormat())
+}
+
+func TestGenRelayInfoResponsesCapturesImageGenerationOptions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequestWithContext(context.Background(), "POST", "/v1/responses", nil)
+
+	request := &dto.OpenAIResponsesRequest{
+		Model: "gpt-5.5",
+		Tools: json.RawMessage(`[
+			{"type":"image_generation","quality":"medium","size":"1024x1536"}
+		]`),
+	}
+
+	info := GenRelayInfoResponses(ctx, request)
+	tool := info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolImageGeneration]
+
+	require.NotNil(t, tool)
+	assert.Equal(t, "medium", tool.ImageGenerationQuality)
+	assert.Equal(t, "1024x1536", tool.ImageGenerationSize)
 }
 
 func TestRelayInfoMetaTypedNilReceiver(t *testing.T) {

--- a/relay/common/tool_usage.go
+++ b/relay/common/tool_usage.go
@@ -77,8 +77,9 @@ func (info *RelayInfo) incrementBillableToolCall(name string) {
 // ImageGenerationCallCounter counts completed Responses image_generation_call
 // outputs with stream-safe identity deduplication.
 type ImageGenerationCallCounter struct {
-	seen  map[string]struct{}
+	seen  map[string]int
 	count int
+	tiers []ImageGenerationTier
 }
 
 // Observe records one completed final image output when billable.
@@ -97,6 +98,14 @@ func (c *ImageGenerationCallCounter) Observe(item *dto.ResponsesOutput, outputIn
 	case "failed", "cancelled", "canceled", "incomplete", "partial":
 		return
 	}
+	quality := strings.ToLower(strings.TrimSpace(item.Quality))
+	if quality == "auto" {
+		quality = ""
+	}
+	size := strings.ToLower(strings.TrimSpace(item.Size))
+	if size == "auto" {
+		size = ""
+	}
 
 	aliases := make([]string, 0, 4)
 	if item.ID != "" {
@@ -112,16 +121,33 @@ func (c *ImageGenerationCallCounter) Observe(item *dto.ResponsesOutput, outputIn
 	aliases = append(aliases, "result:"+hex.EncodeToString(sum[:]))
 
 	if c.seen == nil {
-		c.seen = make(map[string]struct{})
+		c.seen = make(map[string]int)
 	}
+	observedIndex := -1
 	for _, alias := range aliases {
-		if _, ok := c.seen[alias]; ok {
-			return
+		if index, ok := c.seen[alias]; ok {
+			observedIndex = index
+			break
 		}
 	}
-	for _, alias := range aliases {
-		c.seen[alias] = struct{}{}
+	if observedIndex >= 0 {
+		for _, alias := range aliases {
+			c.seen[alias] = observedIndex
+		}
+		if quality != "" {
+			c.tiers[observedIndex].Quality = quality
+		}
+		if size != "" {
+			c.tiers[observedIndex].Size = size
+		}
+		return
 	}
+
+	observedIndex = len(c.tiers)
+	for _, alias := range aliases {
+		c.seen[alias] = observedIndex
+	}
+	c.tiers = append(c.tiers, ImageGenerationTier{Quality: quality, Size: size})
 	c.count++
 }
 
@@ -132,6 +158,7 @@ func (c *ImageGenerationCallCounter) Reset() {
 	}
 	c.seen = nil
 	c.count = 0
+	c.tiers = nil
 }
 
 // Count returns the deduplicated completed image output count before commit capping.
@@ -165,13 +192,40 @@ func (c *ImageGenerationCallCounter) Commit(info *RelayInfo) {
 		count = dto.MaxImageN
 	}
 
+	requestQuality, requestSize := "", ""
+	if existing, ok := info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolImageGeneration]; ok && existing != nil {
+		requestQuality = strings.ToLower(strings.TrimSpace(existing.ImageGenerationQuality))
+		requestSize = strings.ToLower(strings.TrimSpace(existing.ImageGenerationSize))
+	}
+	if requestQuality == "auto" {
+		requestQuality = ""
+	}
+	if requestSize == "auto" {
+		requestSize = ""
+	}
+
+	tierCounts := make(map[ImageGenerationTier]int)
+	if c != nil {
+		for _, tier := range c.tiers[:count] {
+			if tier.Quality == "" {
+				tier.Quality = requestQuality
+			}
+			if tier.Size == "" {
+				tier.Size = requestSize
+			}
+			tierCounts[tier]++
+		}
+	}
+
 	if existing, ok := info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolImageGeneration]; ok && existing != nil {
 		existing.CallCount = count
+		existing.ImageGenerationTiers = tierCounts
 		return
 	}
 	info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolImageGeneration] = &BuildInToolInfo{
-		ToolName:  dto.BuildInToolImageGeneration,
-		CallCount: count,
+		ToolName:             dto.BuildInToolImageGeneration,
+		CallCount:            count,
+		ImageGenerationTiers: tierCounts,
 	}
 }
 

--- a/relay/common/tool_usage_test.go
+++ b/relay/common/tool_usage_test.go
@@ -316,7 +316,13 @@ func TestImageGenerationCallCounterCommitCapsAtMaxImageN(t *testing.T) {
 	info := &RelayInfo{}
 	counter.Commit(info)
 	require.Contains(t, info.ResponsesUsageInfo.BuiltInTools, dto.BuildInToolImageGeneration)
-	assert.Equal(t, dto.MaxImageN, info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolImageGeneration].CallCount)
+	tool := info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolImageGeneration]
+	assert.Equal(t, dto.MaxImageN, tool.CallCount)
+	tierTotal := 0
+	for _, count := range tool.ImageGenerationTiers {
+		tierTotal += count
+	}
+	assert.Equal(t, dto.MaxImageN, tierTotal)
 }
 
 func TestImageGenerationCallCounterCommitDoesNotBillDeclarationsAlone(t *testing.T) {
@@ -334,6 +340,116 @@ func TestImageGenerationCallCounterCommitDoesNotBillDeclarationsAlone(t *testing
 	}
 	(&ImageGenerationCallCounter{}).Commit(info)
 	assert.Equal(t, 0, info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolImageGeneration].CallCount)
+}
+
+func TestImageGenerationCallCounterCommitPrefersResponseOptions(t *testing.T) {
+	t.Parallel()
+
+	info := &RelayInfo{
+		ResponsesUsageInfo: &ResponsesUsageInfo{
+			BuiltInTools: map[string]*BuildInToolInfo{
+				dto.BuildInToolImageGeneration: {
+					ToolName:               dto.BuildInToolImageGeneration,
+					ImageGenerationQuality: "medium",
+					ImageGenerationSize:    "1024x1536",
+				},
+			},
+		},
+	}
+	counter := &ImageGenerationCallCounter{}
+	counter.Observe(&dto.ResponsesOutput{
+		Type:   dto.ResponsesOutputTypeImageGenerationCall,
+		ID:     "img_1",
+		Status: "completed",
+		Result: "base64-a",
+	}, nil)
+	counter.Observe(&dto.ResponsesOutput{
+		Type:    dto.ResponsesOutputTypeImageGenerationCall,
+		ID:      "img_1",
+		Status:  "completed",
+		Result:  "base64-a",
+		Quality: "high",
+		Size:    "1536x1024",
+	}, nil)
+	counter.Commit(info)
+
+	tool := info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolImageGeneration]
+	require.NotNil(t, tool)
+	assert.Equal(t, 1, tool.CallCount)
+	assert.Equal(t, 1, tool.ImageGenerationTiers[ImageGenerationTier{
+		Quality: "high",
+		Size:    "1536x1024",
+	}])
+}
+
+func TestImageGenerationCallCounterCommitKeepsRequestOptionsWhenResponseOmitsThem(t *testing.T) {
+	t.Parallel()
+
+	info := &RelayInfo{
+		ResponsesUsageInfo: &ResponsesUsageInfo{
+			BuiltInTools: map[string]*BuildInToolInfo{
+				dto.BuildInToolImageGeneration: {
+					ToolName:               dto.BuildInToolImageGeneration,
+					ImageGenerationQuality: "medium",
+					ImageGenerationSize:    "1024x1536",
+				},
+			},
+		},
+	}
+	counter := &ImageGenerationCallCounter{}
+	counter.Observe(&dto.ResponsesOutput{
+		Type:    dto.ResponsesOutputTypeImageGenerationCall,
+		Status:  "completed",
+		Result:  "base64-a",
+		Quality: "auto",
+		Size:    "",
+	}, nil)
+	counter.Commit(info)
+
+	tool := info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolImageGeneration]
+	require.NotNil(t, tool)
+	assert.Equal(t, 1, tool.CallCount)
+	assert.Equal(t, 1, tool.ImageGenerationTiers[ImageGenerationTier{
+		Quality: "medium",
+		Size:    "1024x1536",
+	}])
+}
+
+func TestImageGenerationCallCounterCommitKeepsDistinctResponseTiers(t *testing.T) {
+	t.Parallel()
+
+	counter := &ImageGenerationCallCounter{}
+	counter.Observe(&dto.ResponsesOutput{
+		Type:    dto.ResponsesOutputTypeImageGenerationCall,
+		ID:      "img_1",
+		Status:  "completed",
+		Result:  "base64-a",
+		Quality: "high",
+		Size:    "1024x1024",
+	}, nil)
+	counter.Observe(&dto.ResponsesOutput{
+		Type:    dto.ResponsesOutputTypeImageGenerationCall,
+		ID:      "img_2",
+		Status:  "completed",
+		Result:  "base64-b",
+		Quality: "high",
+		Size:    "1024x1536",
+	}, nil)
+
+	info := &RelayInfo{}
+	counter.Commit(info)
+	tool := info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolImageGeneration]
+
+	require.NotNil(t, tool)
+	assert.Equal(t, 2, tool.CallCount)
+	assert.Equal(t, 1, tool.ImageGenerationTiers[ImageGenerationTier{
+		Quality: "high",
+		Size:    "1024x1024",
+	}])
+	assert.Equal(t, 1, tool.ImageGenerationTiers[ImageGenerationTier{
+		Quality: "high",
+		Size:    "1024x1536",
+	}])
 }
 
 func TestIsNonBillableResponsesStatus(t *testing.T) {

--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -100,11 +100,17 @@ func isLegacyClaudeDerivedOpenAIUsage(relayInfo *relaycommon.RelayInfo, usage *d
 	return usage.ClaudeCacheCreation5mTokens > 0 || usage.ClaudeCacheCreation1hTokens > 0
 }
 
+// collectToolSurchargeItem resolves a model-aware tool price before appending it.
 func collectToolSurchargeItem(items []ToolSurchargeItem, name string, count int, modelName string) []ToolSurchargeItem {
+	price := operation_setting.GetToolPriceForModel(name, modelName)
+	return collectToolSurchargeItemWithPrice(items, name, count, price)
+}
+
+// collectToolSurchargeItemWithPrice appends one validated, explicitly priced tool charge.
+func collectToolSurchargeItemWithPrice(items []ToolSurchargeItem, name string, count int, price float64) []ToolSurchargeItem {
 	if count <= 0 {
 		return items
 	}
-	price := operation_setting.GetToolPriceForModel(name, modelName)
 	if price <= 0 || math.IsNaN(price) || math.IsInf(price, 0) {
 		return items
 	}
@@ -154,6 +160,26 @@ func calculateTextToolCallSurcharge(ctx *gin.Context, relayInfo *relaycommon.Rel
 	if relayInfo.ResponsesUsageInfo != nil {
 		for name, tool := range relayInfo.ResponsesUsageInfo.BuiltInTools {
 			if tool == nil {
+				continue
+			}
+			if name == dto.BuildInToolImageGeneration {
+				if len(tool.ImageGenerationTiers) == 0 {
+					price := operation_setting.GetImageGenerationToolPriceForModel(
+						summary.ModelName,
+						tool.ImageGenerationQuality,
+						tool.ImageGenerationSize,
+					)
+					items = collectToolSurchargeItemWithPrice(items, name, tool.CallCount, price)
+					continue
+				}
+				for tier, count := range tool.ImageGenerationTiers {
+					price := operation_setting.GetImageGenerationToolPriceForModel(
+						summary.ModelName,
+						tier.Quality,
+						tier.Size,
+					)
+					items = collectToolSurchargeItemWithPrice(items, name, count, price)
+				}
 				continue
 			}
 			items = collectToolSurchargeItem(items, name, tool.CallCount, summary.ModelName)

--- a/service/text_quota_test.go
+++ b/service/text_quota_test.go
@@ -1074,6 +1074,43 @@ func TestCalculateTextToolCallSurchargeImageGenerationDefaultPrice(t *testing.T)
 	assert.Equal(t, 150.0, summary.ToolSurchargeItems[0].Price)
 }
 
+func TestCalculateTextToolCallSurchargeImageGenerationUsesTierAndModelOverrides(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	const squareTierKey = "image_generation/high/1024x1024:gpt-5.5*"
+	const portraitTierKey = "image_generation/high/1024x1536:gpt-5.5*"
+	operation_setting.SetToolPriceForTest(squareTierKey, 211)
+	operation_setting.SetToolPriceForTest(portraitTierKey, 165)
+	t.Cleanup(func() {
+		operation_setting.DeleteToolPriceForTest(squareTierKey)
+		operation_setting.DeleteToolPriceForTest(portraitTierKey)
+	})
+
+	relayInfo := &relaycommon.RelayInfo{
+		OriginModelName: "gpt-5.5",
+		ResponsesUsageInfo: &relaycommon.ResponsesUsageInfo{
+			BuiltInTools: map[string]*relaycommon.BuildInToolInfo{
+				dto.BuildInToolImageGeneration: {
+					CallCount: 2,
+					ImageGenerationTiers: map[relaycommon.ImageGenerationTier]int{
+						{Quality: "high", Size: "1024x1024"}: 1,
+						{Quality: "high", Size: "1024x1536"}: 1,
+					},
+				},
+			},
+		},
+	}
+	summary := &textQuotaSummary{ModelName: "gpt-5.5", GroupRatio: 1}
+
+	surcharge := calculateTextToolCallSurcharge(ctx, relayInfo, summary)
+	expected := decimal.NewFromFloat((211.0 + 165.0) / 1000).Mul(decimal.NewFromFloat(common.QuotaPerUnit))
+	assert.True(t, expected.Equal(surcharge), "got %s want %s", surcharge, expected)
+	require.Len(t, summary.ToolSurchargeItems, 2)
+	assert.Equal(t, dto.BuildInToolImageGeneration, summary.ToolSurchargeItems[0].Name)
+	assert.Equal(t, 165.0, summary.ToolSurchargeItems[0].Price)
+	assert.Equal(t, 211.0, summary.ToolSurchargeItems[1].Price)
+}
+
 func TestCalculateTextToolCallSurchargeImageGenerationExplicitZeroDisables(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())

--- a/setting/operation_setting/tools.go
+++ b/setting/operation_setting/tools.go
@@ -190,32 +190,53 @@ func RebuildToolPriceIndex() {
 // GetToolPriceForModel returns the price ($/1K calls) for a tool given a model name.
 // Lookup: longest prefix match → tool default → 0.
 func GetToolPriceForModel(toolName, modelName string) float64 {
+	price, _ := lookupToolPriceForModel(toolName, modelName)
+	return price
+}
+
+// lookupToolPriceForModel resolves a price and reports whether a matching rule exists.
+func lookupToolPriceForModel(toolName, modelName string) (float64, bool) {
 	idx := currentIndex.Load()
 	if idx == nil {
 		RebuildToolPriceIndex()
 		idx = currentIndex.Load()
 		if idx == nil {
-			return 0
+			return 0, false
 		}
 	}
 
 	if entries, ok := idx.prefixes[toolName]; ok && modelName != "" {
 		for _, e := range entries {
 			if strings.HasPrefix(modelName, e.prefix) {
-				return e.price
+				return e.price, true
 			}
 		}
 	}
 
 	if p, ok := idx.defaults[toolName]; ok {
-		return p
+		return p, true
 	}
-	return 0
+	return 0, false
 }
 
 // GetToolPrice is a convenience wrapper when no model name is needed.
 func GetToolPrice(toolName string) float64 {
 	return GetToolPriceForModel(toolName, "")
+}
+
+// GetImageGenerationToolPriceForModel returns the image tool price ($/1K calls).
+// Explicit quality and size select a tier; unknown or auto values use the
+// model-aware image_generation fallback.
+func GetImageGenerationToolPriceForModel(modelName, quality, size string) float64 {
+	quality = strings.ToLower(strings.TrimSpace(quality))
+	size = strings.ToLower(strings.TrimSpace(size))
+	if quality != "" && quality != "auto" && size != "" && size != "auto" {
+		tierName := "image_generation/" + quality + "/" + size
+		if price, ok := lookupToolPriceForModel(tierName, modelName); ok {
+			return price
+		}
+	}
+	return GetToolPriceForModel("image_generation", modelName)
 }
 
 // SetToolPriceForTest injects a tool price and rebuilds the lookup index. Tests only.

--- a/setting/operation_setting/tools_price_test.go
+++ b/setting/operation_setting/tools_price_test.go
@@ -37,6 +37,9 @@ func TestToolPriceHardcodedFallbacksSurviveMissingOperatorConfig(t *testing.T) {
 	}
 	assert.Equal(t, 25.0, GetToolPriceForModel("web_search_preview", "gpt-4o-2024-11-20"))
 	assert.Equal(t, 25.0, GetToolPriceForModel("web_search_preview", "gpt-4.1-mini"))
+	assert.Equal(t, 150.0, GetImageGenerationToolPriceForModel("gpt-5.1", "low", "1024x1024"))
+	assert.Equal(t, 150.0, GetImageGenerationToolPriceForModel("gpt-5.1", "high", "1024x1024"))
+	assert.Equal(t, 150.0, GetImageGenerationToolPriceForModel("gpt-5.1", "auto", "auto"))
 }
 
 func TestToolPriceOperatorOverridePrecedenceAndExplicitZero(t *testing.T) {
@@ -82,6 +85,23 @@ func TestToolPriceCustomFunctionHasNoHardcodedFallback(t *testing.T) {
 	toolPriceSetting.Prices["lookup_customer"] = 0
 	RebuildToolPriceIndex()
 	assert.Equal(t, 0.0, GetToolPrice("lookup_customer"))
+}
+
+func TestImageGenerationToolPriceModelOverrideAndExplicitZero(t *testing.T) {
+	preserveToolPrices(t)
+	toolPriceSetting.Prices = map[string]float64{
+		"image_generation:gpt-5.5*":                  211,
+		"image_generation/high/1024x1024:gpt-5.5*":   205,
+		"image_generation/high/1536x1024:gpt-5.5*":   0,
+		"image_generation/medium/1024x1024:gpt-5.1*": 42,
+	}
+	RebuildToolPriceIndex()
+
+	assert.Equal(t, 205.0, GetImageGenerationToolPriceForModel("gpt-5.5-2026-07-01", "high", "1024x1024"))
+	assert.Equal(t, 0.0, GetImageGenerationToolPriceForModel("gpt-5.5-2026-07-01", "high", "1536x1024"))
+	assert.Equal(t, 211.0, GetImageGenerationToolPriceForModel("gpt-5.5-2026-07-01", "", ""))
+	assert.Equal(t, 42.0, GetImageGenerationToolPriceForModel("gpt-5.1", "medium", "1024x1024"))
+	assert.Equal(t, 150.0, GetImageGenerationToolPriceForModel("gpt-5.1", "high", "1024x1024"))
 }
 
 func TestValidateToolPricesJSON(t *testing.T) {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

> [!IMPORTANT]
> 本 PR 由 chenyoubei 提交；过程中使用 AI 辅助，所有代码、测试和说明均已由提交者人工复核。

## 📝 变更描述 / Description

基于最新 `main` 已引入的统一工具附加费架构，补全 Responses API 图片生成工具按实际请求参数计价的能力。

- 从原始 `image_generation` 工具声明中记录 `quality` 和 `size`。
- 非流式和流式响应通过现有图片调用计数器收集上游返回的实际参数；响应缺失或返回 `auto` 时保留请求参数。
- 同一响应生成多张不同档位图片时，按每个去重后的 `quality` / `size` 组合分别累计和计价，不会把全部图片套用最后一张的价格。
- 新增 `GetImageGenerationToolPriceForModel(modelName, quality, size)`：
  - 优先查找 `image_generation/<quality>/<size>`；
  - 同样支持现有的最长模型前缀匹配；
  - 未配置该档位、参数未知或为 `auto` 时回退到 `image_generation`。
- 保持最新 `main` 的默认行为不变：未配置具体档位时仍使用 `image_generation = 150`（单位为 $/1K calls）。
- 显式配置为 `0` 的具体档位会终止查找并禁用该档位收费，不会错误回退到默认价格。

例如，若某个上游把 `gpt-5.5*` 的托管图片工具路由到 GPT Image 2，可在现有“工具价格”设置中配置：

```json
{
  "image_generation:gpt-5.5*": 211,
  "image_generation/high/1024x1024:gpt-5.5*": 211,
  "image_generation/high/1024x1536:gpt-5.5*": 165,
  "image_generation/high/1536x1024:gpt-5.5*": 165
}
```

代码不猜测 OpenAI 内部最终使用的图片模型；管理员可以按 Responses 模型前缀、质量和尺寸显式配置并审计计费规则。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #6470

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 已人工整理并核对描述，没有直接粘贴未经处理的输出。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs；#4474 和 #6054 的协议路径及计费对象不同。
- [x] **Bug fix 说明:** 已提交并关联对应 Issue。
- [x] **变更理解:** 已核对 Responses 请求参数、非流式/流式图片调用计数、结构化工具附加费、模型前缀索引及显式零值语义。
- [x] **范围聚焦:** 仅修改 Responses 图片工具参数元数据、价格解析及对应测试。
- [x] **本地验证:** 已运行完整 Go 测试、前端类型检查、相关格式/lint 检查和生产构建。
- [x] **安全合规:** 不包含任何凭据或用户数据，默认价格和未配置档位的行为保持与最新 `main` 一致。

## 📸 运行证明 / Proof of Work

```text
go test ./...                                                        PASS
bun run typecheck                                                    PASS
oxfmt --check src/features/system-settings/models/tool-price-settings.tsx PASS
oxlint -c .oxlintrc.json src/features/system-settings/models/tool-price-settings.tsx PASS
bun run build                                                        PASS
```

新增回归测试覆盖：

- 请求工具声明中的 `quality` / `size` 提取。
- 流式重复事件只计一次，同时允许最终响应补全实际图片参数。
- 同一响应包含多个不同图片档位时分别累计和结算。
- 响应缺失或为 `auto` 时保留请求参数。
- 图片档位按 Responses 模型最长前缀覆盖。
- 未配置档位回退到现有 `image_generation` 默认价格。
- 具体档位显式设为 `0` 时不回退、不收费。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking image-generation quality and size options.
  * Image-generation usage now records separate counts for different quality and size combinations.
  * Added model- and tier-specific pricing for image-generation requests, with fallback pricing when no tier is configured.

* **Bug Fixes**
  * Improved quota and surcharge calculations using the most accurate available image-generation options.
  * Preserved request options when response data does not provide usable values.
  * Added safeguards for invalid or unsupported pricing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->