### PR TITLE
fix: debounce users page search input

### DIFF
--- a/web/src/features/users/components/users-table.tsx
+++ b/web/src/features/users/components/users-table.tsx
@@ -216,6 +216,7 @@ export function UsersTable() {
       applyHeaderSize
       toolbarProps={{
         searchPlaceholder: t('Filter by username, name or email...'),
+        searchDebounceMs: 500,
         filters: [
           {
             columnId: 'status',


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

用户页搜索框每输入一个字符就发一次 `/api/user/search`，每页 100 条时明显卡顿。
参考渠道页的防抖逻辑, 这里给用户表同样加上 `searchDebounceMs: 500`

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6399

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

本地实例浏览器手测：用户页连续输入 `8888` ，全程只发出一次搜索请求（修复前每个字符一次）：

```
[GET] /api/user/search?keyword=rootuser&group=&p=1&page_size=20 => [200] OK
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Improved the users table search experience by applying a brief delay before search results update, reducing unnecessary refreshes while typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->