### PR TITLE
fix(relay): reject image models on chat completions

### DIFF
--- a/common/model.go
+++ b/common/model.go
@@ -12,7 +12,8 @@ var (
 	ImageGenerationModels = []string{
 		"dall-e-3",
 		"dall-e-2",
-		"gpt-image-1",
+		"prefix:gpt-image-",
+		"chatgpt-image-latest",
 		"prefix:imagen-",
 		"flux-",
 		"flux.1-",

--- a/relay/helper/text_endpoint_compatibility_test.go
+++ b/relay/helper/text_endpoint_compatibility_test.go
@@ -1,0 +1,62 @@
+package helper
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatCompletionsRejectsImageGenerationModels(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name  string
+		model string
+	}{
+		{name: "current GPT Image model", model: "gpt-image-2"},
+		{name: "GPT Image snapshot", model: "gpt-image-2-2026-04-21"},
+		{name: "future GPT Image model", model: "gpt-image-3"},
+		{name: "legacy GPT Image model", model: "gpt-image-1.5"},
+		{name: "ChatGPT image model", model: "chatgpt-image-latest"},
+		{name: "DALL-E model", model: "dall-e-3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"model":"` + tt.model + `","messages":[{"role":"user","content":"Generate an image"}]}`
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			_, err := GetAndValidateTextRequest(c, relayconstant.RelayModeChatCompletions)
+
+			require.Error(t, err)
+			assert.Equal(
+				t,
+				`model "`+tt.model+`" is not supported on /v1/chat/completions; use /v1/images/generations instead`,
+				err.Error(),
+			)
+		})
+	}
+}
+
+func TestChatCompletionsAcceptsTextModel(t *testing.T) {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/v1/chat/completions",
+		bytes.NewBufferString(`{"model":"gpt-5","messages":[{"role":"user","content":"Hello"}]}`),
+	)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	request, err := GetAndValidateTextRequest(c, relayconstant.RelayModeChatCompletions)
+
+	require.NoError(t, err)
+	assert.Equal(t, "gpt-5", request.Model)
+}

--- a/relay/helper/valid_request.go
+++ b/relay/helper/valid_request.go
@@ -329,6 +329,12 @@ func GetAndValidateTextRequest(c *gin.Context, relayMode int) (*dto.GeneralOpenA
 	if textRequest.Model == "" {
 		return nil, errors.New("model is required")
 	}
+	if relayMode == relayconstant.RelayModeChatCompletions && common.IsImageGenerationModel(textRequest.Model) {
+		return nil, fmt.Errorf(
+			"model %q is not supported on /v1/chat/completions; use /v1/images/generations instead",
+			textRequest.Model,
+		)
+	}
 	if textRequest.WebSearchOptions != nil {
 		if textRequest.WebSearchOptions.SearchContextSize != "" {
 			validSizes := map[string]bool{


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice


## 📝 变更描述 / Description

修复图片生成模型可通过 `/v1/chat/completions` 被当作文本补全转发和计费的问题。

- 在文本请求校验阶段拒绝图片生成模型访问 Chat Completions，返回明确的 400 错误并提示使用 `/v1/images/generations`。
- 将 `gpt-image-*` 识别改为前缀匹配，覆盖 `gpt-image-2`、模型快照和后续版本；同时覆盖 `chatgpt-image-latest` 与 DALL·E。
- 增加回归测试，验证图片模型被拒绝、普通文本模型仍可通过。

校验发生在 token 估算、预扣费和上游转发之前，避免错误端点请求造成额度消耗。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

Related to #6308.

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 已人工确认
- [x] **非重复提交:** 已检查关联 Issue 与现有实现。
- [x] **Bug fix 说明:** 修复公共 Relay 请求中图片模型与 Chat Completions 端点不兼容的问题。
- [x] **变更理解:** 校验在计费和转发前执行，且仅影响已识别的图片生成模型。
- [x] **范围聚焦:** 仅包含模型分类、入口校验和回归测试。
- [x] **本地验证:** `go test ./relay/helper -run 'TestChatCompletionsRejectsImageGenerationModels|TestChatCompletionsAcceptsTextModel' -count=1` 通过；其余后端包测试也已通过。
- [x] **安全合规:** 未包含凭据或用户数据。

## 📸 运行证明 / Proof of Work

修复后，以下请求会在 Relay 入口返回 400，而不会选择渠道或扣费：

`POST /v1/chat/completions`
`{ "model": "gpt-image-2", "stream": true, "messages": [{"role":"user","content":"Generate an image"}] }`

错误信息：`model "gpt-image-2" is not supported on /v1/chat/completions; use /v1/images/generations instead`

## 📸 运行证明 / Proof of Work

使用 `gpt-image-2` 请求 `/v1/chat/completions`，现在在 Relay 入口返回 400，
未进入上游转发或计费流程。

<img width="1682" height="750" alt="9dec06f3-2c0d-44af-bf8d-9bef5dabecb1" src="https://github.com/user-attachments/assets/9c04eaa0-4f2b-42d5-bad6-052c3eaf082c" />


本地回归测试：

```text
ok github.com/QuantumNous/new-api/relay/helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of “response-only” OpenAI image model identifiers (including a broader image prefix pattern and the latest image model name).
  - Requests to **POST /v1/chat/completions** using image-generation models are now rejected with guidance to use **POST /v1/images/generations** instead.
- **Tests**
  - Added coverage to confirm chat-completions rejects image-generation models and accepts text models as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->