### PR TITLE
feat(openrouter): optional Management Key for balance queries

### DIFF
--- a/controller/channel-billing.go
+++ b/controller/channel-billing.go
@@ -306,9 +306,18 @@ func updateChannelAIGC2DBalance(channel *model.Channel) (float64, error) {
 	return response.TotalAvailable, nil
 }
 
+func openRouterBalanceToken(channel *model.Channel) string {
+	// OpenRouter requires a Management Key for /api/v1/credits. Prefer the
+	// optional settings field; fall back to channel.Key for legacy channels.
+	if token := channel.GetOtherSettings().GetOpenRouterManagementKey(); token != "" {
+		return token
+	}
+	return channel.Key
+}
+
 func updateChannelOpenRouterBalance(channel *model.Channel) (float64, error) {
 	url := "https://openrouter.ai/api/v1/credits"
-	body, err := GetResponseBody("GET", url, channel, GetAuthHeader(channel.Key))
+	body, err := GetResponseBody("GET", url, channel, GetAuthHeader(openRouterBalanceToken(channel)))
 	if err != nil {
 		return 0, err
 	}

--- a/controller/channel.go
+++ b/controller/channel.go
@@ -69,6 +69,36 @@ func clearChannelInfo(channel *model.Channel) {
 		channel.ChannelInfo.MultiKeyDisabledReason = nil
 		channel.ChannelInfo.MultiKeyDisabledTime = nil
 	}
+	maskOpenRouterManagementKeyInChannel(channel)
+}
+
+// maskOpenRouterManagementKeyInChannel redacts the OpenRouter management key from
+// API responses. List/get must never return the plaintext value.
+func maskOpenRouterManagementKeyInChannel(channel *model.Channel) {
+	if channel == nil || channel.OtherSettings == "" {
+		return
+	}
+	settings := channel.GetOtherSettings()
+	if strings.TrimSpace(settings.OpenRouterManagementKey) == "" {
+		return
+	}
+	settings.OpenRouterManagementKey = dto.OpenRouterManagementKeyMasked
+	channel.SetOtherSettings(settings)
+}
+
+// preserveOpenRouterManagementKey keeps the stored management key when the client
+// omits it or sends the masked placeholder (same UX as leaving channel.key empty).
+func preserveOpenRouterManagementKey(channel *model.Channel, origin *model.Channel) {
+	if channel == nil || origin == nil {
+		return
+	}
+	incoming := channel.GetOtherSettings()
+	if !dto.IsOpenRouterManagementKeyMasked(incoming.OpenRouterManagementKey) {
+		return
+	}
+	originKey := origin.GetOtherSettings().GetOpenRouterManagementKey()
+	incoming.OpenRouterManagementKey = originKey
+	channel.SetOtherSettings(incoming)
 }
 
 func applyChannelStatusFilter(query *gorm.DB, statusFilter int) *gorm.DB {
@@ -443,13 +473,19 @@ func GetChannelKey(c *gin.Context) {
 		"name": channel.Name,
 	})
 
-	// 返回渠道密钥
+	data := map[string]interface{}{
+		"key": channel.Key,
+	}
+	// OpenRouter Management Key is a sensitive credential; return it together
+	// with the channel key after the same security verification.
+	if mgmt := channel.GetOtherSettings().GetOpenRouterManagementKey(); mgmt != "" {
+		data["openrouter_management_key"] = mgmt
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "获取成功",
-		"data": map[string]interface{}{
-			"key": channel.Key,
-		},
+		"data":    data,
 	})
 }
 
@@ -987,6 +1023,10 @@ func UpdateChannel(c *gin.Context) {
 
 	// Always copy the original ChannelInfo so that fields like IsMultiKey and MultiKeySize are retained.
 	channel.ChannelInfo = originChannel.ChannelInfo
+
+	// Keep existing OpenRouter management key unless the client sent a new value.
+	// Empty / masked values must not wipe the stored secret (same as channel.Key).
+	preserveOpenRouterManagementKey(&channel.Channel, originChannel)
 
 	if channelHasSensitiveChanges(&channel, originChannel, requestData) &&
 		!authz.Can(c.GetInt("id"), c.GetInt("role"), authz.ChannelSensitiveWrite) {

--- a/controller/channel_openrouter_management_key_test.go
+++ b/controller/channel_openrouter_management_key_test.go
@@ -1,0 +1,68 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenRouterBalanceTokenPrefersManagementKey(t *testing.T) {
+	channel := &model.Channel{Key: "sk-or-api"}
+	channel.SetOtherSettings(dto.ChannelOtherSettings{
+		OpenRouterManagementKey: " sk-or-mgmt ",
+	})
+	require.Equal(t, "sk-or-mgmt", openRouterBalanceToken(channel))
+}
+
+func TestOpenRouterBalanceTokenFallsBackToChannelKey(t *testing.T) {
+	channel := &model.Channel{Key: "sk-or-api"}
+	channel.SetOtherSettings(dto.ChannelOtherSettings{})
+	require.Equal(t, "sk-or-api", openRouterBalanceToken(channel))
+}
+
+func TestPreserveOpenRouterManagementKeyKeepsOriginWhenMasked(t *testing.T) {
+	origin := &model.Channel{}
+	origin.SetOtherSettings(dto.ChannelOtherSettings{
+		OpenRouterManagementKey: "sk-or-mgmt-origin",
+		OpenRouterEnterprise:    boolPtr(false),
+	})
+	incoming := &model.Channel{}
+	incoming.SetOtherSettings(dto.ChannelOtherSettings{
+		OpenRouterManagementKey: dto.OpenRouterManagementKeyMasked,
+		OpenRouterEnterprise:    boolPtr(true),
+	})
+
+	preserveOpenRouterManagementKey(incoming, origin)
+	settings := incoming.GetOtherSettings()
+	require.Equal(t, "sk-or-mgmt-origin", settings.OpenRouterManagementKey)
+	require.True(t, settings.IsOpenRouterEnterprise())
+}
+
+func TestPreserveOpenRouterManagementKeyAllowsReplacement(t *testing.T) {
+	origin := &model.Channel{}
+	origin.SetOtherSettings(dto.ChannelOtherSettings{
+		OpenRouterManagementKey: "sk-or-old",
+	})
+	incoming := &model.Channel{}
+	incoming.SetOtherSettings(dto.ChannelOtherSettings{
+		OpenRouterManagementKey: "sk-or-new",
+	})
+
+	preserveOpenRouterManagementKey(incoming, origin)
+	require.Equal(t, "sk-or-new", incoming.GetOtherSettings().OpenRouterManagementKey)
+}
+
+func TestMaskOpenRouterManagementKeyInChannel(t *testing.T) {
+	channel := &model.Channel{}
+	channel.SetOtherSettings(dto.ChannelOtherSettings{
+		OpenRouterManagementKey: "sk-or-secret",
+	})
+	maskOpenRouterManagementKeyInChannel(channel)
+	require.Equal(t, dto.OpenRouterManagementKeyMasked, channel.GetOtherSettings().OpenRouterManagementKey)
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/dto/channel_settings.go
+++ b/dto/channel_settings.go
@@ -37,6 +37,7 @@ type ChannelOtherSettings struct {
 	AzureResponsesVersion                 string                `json:"azure_responses_version,omitempty"`
 	VertexKeyType                         VertexKeyType         `json:"vertex_key_type,omitempty"` // "json" or "api_key"
 	OpenRouterEnterprise                  *bool                 `json:"openrouter_enterprise,omitempty"`
+	OpenRouterManagementKey               string                `json:"openrouter_management_key,omitempty"` // OpenRouter Management Key，仅用于余额查询（/credits）
 	ClaudeBetaQuery                       bool                  `json:"claude_beta_query,omitempty"`          // Claude 渠道是否强制追加 ?beta=true
 	AllowServiceTier                      bool                  `json:"allow_service_tier,omitempty"`         // 是否允许 service_tier 透传（默认过滤以避免额外计费）
 	AllowInferenceGeo                     bool                  `json:"allow_inference_geo,omitempty"`        // 是否允许 inference_geo 透传（仅 Claude，默认过滤以满足数据驻留合规
@@ -60,6 +61,20 @@ func (s *ChannelOtherSettings) IsOpenRouterEnterprise() bool {
 		return false
 	}
 	return *s.OpenRouterEnterprise
+}
+
+// GetOpenRouterManagementKey returns the trimmed management key used only for
+// OpenRouter account credit queries. Empty means fall back to channel.Key.
+func (s ChannelOtherSettings) GetOpenRouterManagementKey() string {
+	return strings.TrimSpace(s.OpenRouterManagementKey)
+}
+
+// OpenRouterManagementKeyMasked is the placeholder returned by list/get APIs.
+const OpenRouterManagementKeyMasked = "********"
+
+func IsOpenRouterManagementKeyMasked(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	return trimmed == "" || trimmed == OpenRouterManagementKeyMasked
 }
 
 const (

--- a/web/src/features/channels/api.ts
+++ b/web/src/features/channels/api.ts
@@ -296,7 +296,11 @@ export async function deleteDisabledChannels(): Promise<{
 export async function getChannelKey(
   id: number,
   proofToken?: string
-): Promise<{ success: boolean; message?: string; data?: { key: string } }> {
+): Promise<{
+  success: boolean
+  message?: string
+  data?: { key: string; openrouter_management_key?: string }
+}> {
   const res = await api.post(
     `/api/channel/${id}/key`,
     undefined,

--- a/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
+++ b/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
@@ -278,6 +278,8 @@ const SENSITIVE_FORM_FIELDS = [
   'setting',
   'advanced_custom',
   'is_enterprise_account',
+  'openrouter_management_key',
+  'openrouter_management_key_configured',
   'vertex_key_type',
   'aws_key_type',
   'azure_responses_version',
@@ -615,6 +617,9 @@ export function ChannelMutateDrawer({
   const canRevealChannelKey = currentUser?.role === ROLE.SUPER_ADMIN
   const [fetchModelsDialogOpen, setFetchModelsDialogOpen] = useState(false)
   const [channelKey, setChannelKey] = useState<string | null>(null)
+  const [openrouterManagementKey, setOpenrouterManagementKey] = useState<
+    string | null
+  >(null)
   const [isChannelKeyLoading, setIsChannelKeyLoading] = useState(false)
   const [isCodexCredentialRefreshing, setIsCodexCredentialRefreshing] =
     useState(false)
@@ -693,9 +698,11 @@ export function ChannelMutateDrawer({
   useEffect(() => {
     if (!open) {
       setChannelKey(null)
+      setOpenrouterManagementKey(null)
       setIsChannelKeyLoading(false)
     } else if (channelId) {
       setChannelKey(null)
+      setOpenrouterManagementKey(null)
     }
   }, [open, channelId])
 
@@ -1357,6 +1364,12 @@ export function ChannelMutateDrawer({
 
         const keyValue = res.data?.key ?? ''
         setChannelKey(keyValue)
+        const managementKeyValue = res.data?.openrouter_management_key
+        if (typeof managementKeyValue === 'string' && managementKeyValue) {
+          setOpenrouterManagementKey(managementKeyValue)
+        } else {
+          setOpenrouterManagementKey(null)
+        }
         toast.success(t('Channel key unlocked'))
         return res
       } finally {
@@ -3067,6 +3080,152 @@ export function ChannelMutateDrawer({
                                   )
                                 }}
                               />
+
+                              {/* OpenRouter Management Key — peer to API Key under Authentication */}
+                              {currentType === 20 && (
+                                <div className='border-border/60 flex flex-col gap-3 border-t pt-4'>
+                                  <div className='flex items-center gap-2'>
+                                    <KeyRound
+                                      className='text-muted-foreground h-3.5 w-3.5'
+                                      aria-hidden='true'
+                                    />
+                                    <h4 className='text-muted-foreground text-xs font-medium tracking-wide uppercase'>
+                                      {t('Management')}
+                                    </h4>
+                                  </div>
+                                  <FormField
+                                    control={form.control}
+                                    name='openrouter_management_key'
+                                    render={({ field }) => {
+                                      const managementKeyConfigured = Boolean(
+                                        form.watch(
+                                          'openrouter_management_key_configured'
+                                        )
+                                      )
+                                      let managementKeyPlaceholder = t(
+                                        'Optional — used only for balance / credits queries'
+                                      )
+                                      if (
+                                        isEditing &&
+                                        managementKeyConfigured
+                                      ) {
+                                        managementKeyPlaceholder = t(
+                                          'Leave empty to keep existing key'
+                                        )
+                                      }
+                                      return (
+                                        <FormItem>
+                                          <FormLabel>
+                                            {t('OpenRouter Management Key')}
+                                          </FormLabel>
+                                          <FormControl>
+                                            <Input
+                                              type='password'
+                                              autoComplete='new-password'
+                                              placeholder={
+                                                managementKeyPlaceholder
+                                              }
+                                              {...field}
+                                            />
+                                          </FormControl>
+                                          <FormDescription>
+                                            {isEditing
+                                              ? t(
+                                                  'Enter new key to update, or leave empty to keep current key'
+                                                )
+                                              : t(
+                                                  'OpenRouter requires a Management Key for account balance. Inference still uses the channel API Key. Do not put the Management Key in the channel key field.'
+                                                )}
+                                          </FormDescription>
+                                          {isEditing &&
+                                            canRevealChannelKey && (
+                                              <div className='border-border/60 mt-4 flex flex-col gap-3 border-y border-dashed py-4'>
+                                                <div className='flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
+                                                  <div>
+                                                    <p className='text-sm font-medium'>
+                                                      {t(
+                                                        'Current management key'
+                                                      )}
+                                                    </p>
+                                                    <p className='text-muted-foreground text-xs'>
+                                                      {form.watch(
+                                                        'openrouter_management_key_configured'
+                                                      )
+                                                        ? t(
+                                                            'Verification required to reveal the saved key.'
+                                                          )
+                                                        : t(
+                                                            'No management key configured yet.'
+                                                          )}
+                                                    </p>
+                                                  </div>
+                                                  <div className='flex items-center gap-2'>
+                                                    <Button
+                                                      type='button'
+                                                      variant='outline'
+                                                      size='sm'
+                                                      onClick={handleRevealKey}
+                                                      disabled={
+                                                        isChannelKeyLoading ||
+                                                        verificationState.loading ||
+                                                        !form.watch(
+                                                          'openrouter_management_key_configured'
+                                                        )
+                                                      }
+                                                    >
+                                                      {isChannelKeyLoading ||
+                                                      verificationState.loading ? (
+                                                        <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                                                      ) : (
+                                                        <Eye className='mr-2 h-4 w-4' />
+                                                      )}
+                                                      {t('Reveal key')}
+                                                    </Button>
+                                                    <Button
+                                                      type='button'
+                                                      variant='ghost'
+                                                      size='sm'
+                                                      onClick={async () => {
+                                                        if (
+                                                          openrouterManagementKey
+                                                        ) {
+                                                          await copyToClipboard(
+                                                            openrouterManagementKey
+                                                          )
+                                                        }
+                                                      }}
+                                                      disabled={
+                                                        !openrouterManagementKey
+                                                      }
+                                                    >
+                                                      <Copy className='mr-2 h-4 w-4' />
+                                                      {t('Copy')}
+                                                    </Button>
+                                                  </div>
+                                                </div>
+                                                <Input
+                                                  readOnly
+                                                  aria-label={t(
+                                                    'Current management key'
+                                                  )}
+                                                  value={
+                                                    openrouterManagementKey ??
+                                                    ''
+                                                  }
+                                                  placeholder={t(
+                                                    'Hidden — verify to reveal'
+                                                  )}
+                                                  className='font-mono'
+                                                />
+                                              </div>
+                                            )}
+                                          <FormMessage />
+                                        </FormItem>
+                                      )
+                                    }}
+                                  />
+                                </div>
+                              )}
 
                               {currentType === 57 && (
                                 <div className='border-border/60 flex flex-col gap-3 border-y py-4'>

--- a/web/src/features/channels/lib/channel-form.ts
+++ b/web/src/features/channels/lib/channel-form.ts
@@ -229,6 +229,8 @@ export const channelFormSchema = z
     system_prompt_override: z.boolean().optional(),
     // Type-specific settings (stored in settings JSON)
     is_enterprise_account: z.boolean().optional(), // OpenRouter specific
+    openrouter_management_key: z.string().optional(), // OpenRouter management key (balance only)
+    openrouter_management_key_configured: z.boolean().optional(), // existing key present (masked)
     vertex_key_type: z.enum(['json', 'api_key']).optional(), // Vertex AI specific
     aws_key_type: z.enum(['ak_sk', 'api_key']).optional(), // AWS specific
     azure_responses_version: z.string().optional(), // Azure specific
@@ -379,6 +381,8 @@ export const CHANNEL_FORM_DEFAULT_VALUES: ChannelFormValues = {
   system_prompt_override: false,
   // Type-specific settings
   is_enterprise_account: false,
+  openrouter_management_key: '',
+  openrouter_management_key_configured: false,
   vertex_key_type: 'json',
   aws_key_type: 'ak_sk',
   azure_responses_version: '',
@@ -451,6 +455,7 @@ export function transformChannelToFormDefaults(
   let upstreamModelUpdateAutoSyncEnabled = false
   let upstreamModelUpdateIgnoredModels = ''
   let advancedCustom = ''
+  let openrouterManagementKeyConfigured = false
 
   if (channel.settings) {
     try {
@@ -458,6 +463,10 @@ export function transformChannelToFormDefaults(
       vertexKeyType = parsed.vertex_key_type || 'json'
       azureResponsesVersion = parsed.azure_responses_version || ''
       isEnterpriseAccount = parsed.openrouter_enterprise === true
+      openrouterManagementKeyConfigured = Boolean(
+        parsed.openrouter_management_key &&
+          String(parsed.openrouter_management_key).trim() !== ''
+      )
       awsKeyType = parsed.aws_key_type || 'ak_sk'
       allowServiceTier = parsed.allow_service_tier === true
       disableStore = parsed.disable_store === true
@@ -515,6 +524,8 @@ export function transformChannelToFormDefaults(
     ...extraSettings,
     // Type-specific settings
     is_enterprise_account: isEnterpriseAccount,
+    openrouter_management_key: '', // Never prefill plaintext; leave empty to keep existing
+    openrouter_management_key_configured: openrouterManagementKeyConfigured,
     vertex_key_type: vertexKeyType,
     azure_responses_version: azureResponsesVersion,
     aws_key_type: awsKeyType,
@@ -581,8 +592,16 @@ function buildSettingsJSON(formData: ChannelFormValues): string {
   // Add enterprise account setting for OpenRouter (type 20)
   if (formData.type === 20) {
     settingsObj.openrouter_enterprise = formData.is_enterprise_account === true
+    const managementKey = (formData.openrouter_management_key || '').trim()
+    if (managementKey) {
+      // Only send a new value; empty means backend preserves the stored key.
+      settingsObj.openrouter_management_key = managementKey
+    } else {
+      delete settingsObj.openrouter_management_key
+    }
   } else if ('openrouter_enterprise' in settingsObj) {
     delete settingsObj.openrouter_enterprise
+    delete settingsObj.openrouter_management_key
   }
 
   // Add aws_key_type for AWS channels (type 33)

--- a/web/src/features/channels/types.ts
+++ b/web/src/features/channels/types.ts
@@ -92,6 +92,8 @@ export interface ChannelOtherSettings {
   azure_responses_version?: string
   vertex_key_type?: 'json' | 'api_key'
   openrouter_enterprise?: boolean
+  /** Masked on list/get; plaintext only when user submits a new value. */
+  openrouter_management_key?: string
   aws_key_type?: 'ak_sk' | 'api_key'
   allow_service_tier?: boolean
   disable_store?: boolean

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2029,7 +2029,7 @@
     "footer.columns.related.links.oneApi": "One API",
     "footer.columns.related.title": "Related Projects",
     "footer.defaultCopyright": "All rights reserved.",
-    "footer.new\u0061pi.projectAttributionSuffix": "All rights reserved. Designed and developed by the project contributors.",
+    "footer.newapi.projectAttributionSuffix": "All rights reserved. Designed and developed by the project contributors.",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment",
     "For private deployments, format: https://fastgpt.run/api/openapi": "For private deployments, format: https://fastgpt.run/api/openapi",
     "Force a syntactically valid JSON response": "Force a syntactically valid JSON response",
@@ -5215,6 +5215,12 @@
     "Zero retention": "Zero retention",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Management": "Management",
+    "OpenRouter Management Key": "OpenRouter Management Key",
+    "Optional — used only for balance / credits queries": "Optional — used only for balance / credits queries",
+    "OpenRouter requires a Management Key for account balance. Inference still uses the channel API Key. Do not put the Management Key in the channel key field.": "OpenRouter requires a Management Key for account balance. Inference still uses the channel API Key. Do not put the Management Key in the channel key field.",
+    "Current management key": "Current management key",
+    "No management key configured yet.": "No management key configured yet."
   }
 }

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -2029,7 +2029,7 @@
     "footer.columns.related.links.oneApi": "One API",
     "footer.columns.related.title": "Projets liés",
     "footer.defaultCopyright": "Tous droits réservés.",
-    "footer.new\u0061pi.projectAttributionSuffix": "Tous droits réservés. Conçu et développé par les contributeurs du projet.",
+    "footer.newapi.projectAttributionSuffix": "Tous droits réservés. Conçu et développé par les contributeurs du projet.",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "Pour les canaux ajoutés après le 10 mai 2025, pas besoin de supprimer \".\" des noms de modèles lors du déploiement",
     "For private deployments, format: https://fastgpt.run/api/openapi": "Pour les déploiements privés, format : https://fastgpt.run/api/openapi",
     "Force a syntactically valid JSON response": "Imposer une réponse JSON syntaxiquement valide",
@@ -5215,6 +5215,12 @@
     "Zero retention": "Aucune rétention",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Management": "Management",
+    "OpenRouter Management Key": "OpenRouter Management Key",
+    "Optional — used only for balance / credits queries": "Optional — used only for balance / credits queries",
+    "OpenRouter requires a Management Key for account balance. Inference still uses the channel API Key. Do not put the Management Key in the channel key field.": "OpenRouter requires a Management Key for account balance. Inference still uses the channel API Key. Do not put the Management Key in the channel key field.",
+    "Current management key": "Current management key",
+    "No management key configured yet.": "No management key configured yet."
   }
 }

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -2029,7 +2029,7 @@
     "footer.columns.related.links.oneApi": "1つのAPI",
     "footer.columns.related.title": "関連プロジェクト",
     "footer.defaultCopyright": "すべての権利を留保します。",
-    "footer.new\u0061pi.projectAttributionSuffix": "すべての権利を留保します。プロジェクトコントリビューターにより設計・開発されています。",
+    "footer.newapi.projectAttributionSuffix": "すべての権利を留保します。プロジェクトコントリビューターにより設計・開発されています。",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "2025 年 5 月 10 日以降に追加されたチャネルの場合、デプロイ時にモデル名から「.」を削除する必要はありません",
     "For private deployments, format: https://fastgpt.run/api/openapi": "プライベートデプロイメントの場合、形式: https://fastgpt.run/api/openapi",
     "Force a syntactically valid JSON response": "構文的に有効な JSON 応答を強制",
@@ -5215,6 +5215,12 @@
     "Zero retention": "データ保持なし",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V 4",
-    "Zoom": "ズーム"
+    "Zoom": "ズーム",
+    "Management": "Management",
+    "OpenRouter Management Key": "OpenRouter Management Key",
+    "Optional — used only for balance / credits queries": "Optional — used only for balance / credits queries",
+    "OpenRouter requires a Management Key for account balance. Inference still uses the channel API Key. Do not put the Management Key in the channel key field.": "OpenRouter requires a Management Key for account balance. Inference still uses the channel API Key. Do not put the Management Key in the channel key field.",
+    "Current management key": "Current management key",
+    "No management key configured yet.": "No management key configured yet."
   }
 }

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -2029,7 +2029,7 @@
     "footer.columns.related.links.oneApi": "Один API",
     "footer.columns.related.title": "Связанные проекты",
     "footer.defaultCopyright": "Все права защищены.",
-    "footer.new\u0061pi.projectAttributionSuffix": "Все права защищены. Разработано участниками проекта.",
+    "footer.newapi.projectAttributionSuffix": "Все права защищены. Разработано участниками проекта.",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "Для каналов, добавленных после 10 мая 2025 г., не нужно удалять \".\" из имён моделей при развёртывании",
     "For private deployments, format: https://fastgpt.run/api/openapi": "Для частных развертываний, формат: https://fastgpt.run/api/openapi",
     "Force a syntactically valid JSON response": "Принудительно возвращать синтаксически корректный JSON",
@@ -5215,6 +5215,12 @@
     "Zero retention": "Без хранения данных",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Management": "Management",
+    "OpenRouter Management Key": "OpenRouter Management Key",
+    "Optional — used only for balance / credits queries": "Optional — used only for balance / credits queries",
+    "OpenRouter requires a Management Key for account balance. Inference still uses the channel API Key. Do not put the Management Key in the channel key field.": "OpenRouter requires a Management Key for account balance. Inference still uses the channel API Key. Do not put the Management Key in the channel key field.",
+    "Current management key": "Current management key",
+    "No management key configured yet.": "No management key configured yet."
   }
 }

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -2029,7 +2029,7 @@
     "footer.columns.related.links.oneApi": "One API",
     "footer.columns.related.title": "Các Dự Án Liên Quan",
     "footer.defaultCopyright": "Bản quyền được bảo lưu.",
-    "footer.new\u0061pi.projectAttributionSuffix": "Bản quyền được bảo lưu. Được thiết kế và phát triển bởi các cộng tác viên dự án.",
+    "footer.newapi.projectAttributionSuffix": "Bản quyền được bảo lưu. Được thiết kế và phát triển bởi các cộng tác viên dự án.",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "Đối với các kênh được thêm sau ngày 10 tháng 5 năm 2025, không cần loại bỏ \".\" khỏi tên mô hình trong quá trình triển khai",
     "For private deployments, format: https://fastgpt.run/api/openapi": "Đối với các triển khai riêng tư, định dạng: https://fastgpt.run/api/openapi",
     "Force a syntactically valid JSON response": "Buộc phản hồi JSON hợp lệ về cú pháp",
@@ -5215,6 +5215,12 @@
     "Zero retention": "Không lưu dữ liệu",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Management": "Management",
+    "OpenRouter Management Key": "OpenRouter Management Key",
+    "Optional — used only for balance / credits queries": "Optional — used only for balance / credits queries",
+    "OpenRouter requires a Management Key for account balance. Inference still uses the channel API Key. Do not put the Management Key in the channel key field.": "OpenRouter requires a Management Key for account balance. Inference still uses the channel API Key. Do not put the Management Key in the channel key field.",
+    "Current management key": "Current management key",
+    "No management key configured yet.": "No management key configured yet."
   }
 }

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -2029,7 +2029,7 @@
     "footer.columns.related.links.oneApi": "One API",
     "footer.columns.related.title": "相關項目",
     "footer.defaultCopyright": "版權所有。",
-    "footer.new\u0061pi.projectAttributionSuffix": "版權所有，由項目貢獻者設計與開發。",
+    "footer.newapi.projectAttributionSuffix": "版權所有，由項目貢獻者設計與開發。",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "對於 2025 年 5 月 10 日之後新增的渠道，在部署時無需從模型名稱中移除 \".\"",
     "For private deployments, format: https://fastgpt.run/api/openapi": "對於私有部署，格式為：https://fastgpt.run/api/openapi",
     "Force a syntactically valid JSON response": "強制返回語法合法的 JSON",
@@ -5215,6 +5215,12 @@
     "Zero retention": "零數據保留",
     "Zhipu": "智譜",
     "Zhipu V4": "智譜 V4",
-    "Zoom": "縮放"
+    "Zoom": "縮放",
+    "Management": "管理",
+    "OpenRouter Management Key": "OpenRouter 管理金鑰",
+    "Optional — used only for balance / credits queries": "可選 — 僅用於餘額 / credits 查詢",
+    "OpenRouter requires a Management Key for account balance. Inference still uses the channel API Key. Do not put the Management Key in the channel key field.": "OpenRouter 查詢帳戶餘額需要 Management Key；推理仍使用管道 API Key。請勿把 Management Key 填進管道金鑰欄位。",
+    "Current management key": "目前管理金鑰",
+    "No management key configured yet.": "尚未設定管理金鑰。"
   }
 }

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -2029,7 +2029,7 @@
     "footer.columns.related.links.oneApi": "One API",
     "footer.columns.related.title": "相关项目",
     "footer.defaultCopyright": "版权所有。",
-    "footer.new\u0061pi.projectAttributionSuffix": "版权所有，由项目贡献者设计与开发。",
+    "footer.newapi.projectAttributionSuffix": "版权所有，由项目贡献者设计与开发。",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "对于 2025 年 5 月 10 日之后添加的渠道，在部署时无需从模型名称中移除 \".\"",
     "For private deployments, format: https://fastgpt.run/api/openapi": "对于私有部署，格式为：https://fastgpt.run/api/openapi",
     "Force a syntactically valid JSON response": "强制返回语法合法的 JSON",
@@ -5215,6 +5215,12 @@
     "Zero retention": "零数据保留",
     "Zhipu": "智谱",
     "Zhipu V4": "智谱 V4",
-    "Zoom": "缩放"
+    "Zoom": "缩放",
+    "Management": "管理",
+    "OpenRouter Management Key": "OpenRouter 管理密钥",
+    "Optional — used only for balance / credits queries": "可选 — 仅用于余额 / credits 查询",
+    "OpenRouter requires a Management Key for account balance. Inference still uses the channel API Key. Do not put the Management Key in the channel key field.": "OpenRouter 查询账户余额需要 Management Key；推理仍使用渠道 API Key。请勿把 Management Key 填进渠道密钥字段。",
+    "Current management key": "当前管理密钥",
+    "No management key configured yet.": "尚未配置管理密钥。"
   }
 }


### PR DESCRIPTION
## Summary

OpenRouter now requires a **Management Key** for `GET /api/v1/credits`. Using a normal inference API key returns:

> `403 Only management keys can fetch credits for an account`

This PR adds an optional channel setting `openrouter_management_key` that is used **only** for balance / credits queries. Inference / relay continues to use `channel.Key` unchanged.

### Behavior
- Prefer `settings.openrouter_management_key` for OpenRouter balance updates
- Fall back to `channel.Key` when unset (backward compatible)
- Mask the management key on list/get responses
- Empty / masked value on update preserves the stored secret (same UX as channel key)
- After security verification, `GET channel key` can also return the management key for the edit UI
- Channel form (type OpenRouter) exposes an optional Management Key field under Authentication

### Non-goals
- No change to chat / relay authentication
- No migration required; existing channels keep working with the fallback

## Test plan
- [x] `go test ./controller/ -run 'OpenRouter|PreserveOpenRouter|MaskOpenRouter'`
- [ ] Create/edit an OpenRouter channel with only inference key → balance behavior unchanged (may 403 if OpenRouter rejects inference keys)
- [ ] Set Management Key → 「更新余额」 / balance update succeeds
- [ ] Edit channel, leave Management Key empty → stored key preserved
- [ ] list/get responses show masked management key, not plaintext


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional OpenRouter Management Key configuration for balance and credits queries.
  - Added UI controls to enter, reveal, copy, and manage the credential.
  - Added localized labels, guidance, and status messages.

- **Security**
  - Management keys are masked in channel listings and details.
  - Existing credentials are preserved when masked or empty values are submitted.
  - Secure key retrieval now supports revealing the management key when authorized.

- **Bug Fixes**
  - OpenRouter balance checks now use the configured Management Key when available, with fallback support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->