### PR TITLE
fix(limiter): recover redis script after flush(#6412)

### DIFF
--- a/common/limiter/limiter.go
+++ b/common/limiter/limiter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/QuantumNous/new-api/common"
@@ -63,6 +64,20 @@ func (rl *RedisLimiter) Allow(ctx context.Context, key string, opts ...Option) (
 	).Int()
 
 	if err != nil {
+		if strings.HasPrefix(err.Error(), "NOSCRIPT ") {
+			result, err := rl.client.Eval(
+				ctx,
+				rateLimitScript,
+				[]string{key},
+				config.Requested,
+				config.Rate,
+				config.Capacity,
+			).Int()
+			if err != nil {
+				return false, fmt.Errorf("rate limit failed: %w", err)
+			}
+			return result == 1, nil
+		}
 		return false, fmt.Errorf("rate limit failed: %w", err)
 	}
 	return result == 1, nil

--- a/common/limiter/limiter_test.go
+++ b/common/limiter/limiter_test.go
@@ -1,0 +1,80 @@
+package limiter
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func useLimiterMiniRedis(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
+	t.Helper()
+
+	previousInstance := instance
+
+	redisServer := miniredis.RunT(t)
+	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	require.NoError(t, redisClient.Ping(context.Background()).Err())
+
+	instance = nil
+	once = sync.Once{}
+
+	t.Cleanup(func() {
+		_ = redisClient.Close()
+		instance = previousInstance
+		once = sync.Once{}
+		if previousInstance != nil {
+			once.Do(func() {})
+		}
+	})
+
+	return redisServer, redisClient
+}
+
+func TestAllowFallsBackToEvalAfterScriptFlush(t *testing.T) {
+	ctx := context.Background()
+	_, redisClient := useLimiterMiniRedis(t)
+
+	redisLimiter := New(ctx, redisClient)
+
+	allowed, err := redisLimiter.Allow(
+		ctx,
+		"rateLimit:test-before-flush",
+		WithCapacity(60),
+		WithRate(60),
+		WithRequested(60),
+	)
+	require.NoError(t, err)
+	assert.True(t, allowed)
+
+	exists, err := redisClient.ScriptExists(ctx, redisLimiter.limitScriptSHA).Result()
+	require.NoError(t, err)
+	require.Len(t, exists, 1)
+	assert.True(t, exists[0])
+
+	require.NoError(t, redisClient.ScriptFlush(ctx).Err())
+
+	exists, err = redisClient.ScriptExists(ctx, redisLimiter.limitScriptSHA).Result()
+	require.NoError(t, err)
+	require.Len(t, exists, 1)
+	assert.False(t, exists[0])
+
+	allowed, err = redisLimiter.Allow(
+		ctx,
+		"rateLimit:test-after-flush",
+		WithCapacity(60),
+		WithRate(60),
+		WithRequested(60),
+	)
+	require.NoError(t, err)
+	assert.True(t, allowed)
+
+	exists, err = redisClient.ScriptExists(ctx, redisLimiter.limitScriptSHA).Result()
+	require.NoError(t, err)
+	require.Len(t, exists, 1)
+	assert.True(t, exists[0])
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

在 `EvalSha` 因 `NOSCRIPT` 失败后调用 `Eval`  重试（与 go-redis Script.Run 的降级策略一致;
添加回归测试

因为调用`Eval`后,Redis 服务端会缓存脚本，脚本对应SHA由脚本内容确定，之后 EvalSha 就可以找到对应脚本，所以生效

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6412 

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 关联 Issue #6412 
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 后端 limiter/limiter.go  、新增对应回归测试
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

### fix 前

Redis 脚本缓存被清空后限流请求持续返回 500
```bash
redis-cli SCRIPT FLUSH
# OK

curl -X POST "http://localhost:3003/v1/chat/completions" \
  -H "Authorization: Bearer sk-***" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "deepseek-v4-flash",
    "messages": [
      {
        "role": "system",
        "content": "hi"
      }
    ]
  }'
```

```json
{
  "error": {
    "code": "",
    "message": "rate_limit_check_failed (request id: ***)",
    "type": "new_api_error"
  }
}
```

### fix 后

在 `SCRIPT FLUSH` 后，同样的请求成功

```bash
redis-cli SCRIPT FLUSH
# OK

curl -X POST "http://localhost:3003/v1/chat/completions" \
  -H "Authorization: Bearer sk-***" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "deepseek-v4-flash",
    "messages": [
      {
        "role": "system",
        "content": "hi"
      }
    ]
  }'
```

```json
{
  "object": "chat.completion",
  "model": "deepseek-v4-flash",
  "choices": [
    {
      "message": {
        "role": "assistant",
        "content": "Hi there! How can I help you today?"
      },
      "finish_reason": "stop"
    }
  ]
}
```

### Automated tests

```bash
$ go test ./common/limiter
ok      github.com/QuantumNous/new-api/common/limiter   ...

$ go test -race ./common/limiter
ok      github.com/QuantumNous/new-api/common/limiter   ...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate limiting reliability when the Redis rate-limiting script is missing or flushed.
  * Rate-limit checks now automatically recover by reloading and retrying script execution as needed.
* **Tests**
  * Added Redis-backed limiter coverage using an in-memory Redis setup to verify recovery behavior after script flushes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->