### PR TITLE
feat: add batch delete for redemption codes (#6481)

### DIFF
--- a/controller/redemption.go
+++ b/controller/redemption.go
@@ -188,6 +188,10 @@ func DeleteRedemptionBatch(c *gin.Context) {
 		common.ApiErrorI18n(c, i18n.MsgInvalidParams)
 		return
 	}
+	if len(redemptionBatch.Ids) > 100 {
+		common.ApiErrorI18n(c, i18n.MsgBatchTooMany, map[string]any{"Max": 100})
+		return
+	}
 	count, err := model.BatchDeleteRedemptions(redemptionBatch.Ids)
 	if err != nil {
 		common.ApiError(c, err)

--- a/controller/redemption.go
+++ b/controller/redemption.go
@@ -178,6 +178,28 @@ func UpdateRedemption(c *gin.Context) {
 	return
 }
 
+type RedemptionBatch struct {
+	Ids []int `json:"ids"`
+}
+
+func DeleteRedemptionBatch(c *gin.Context) {
+	redemptionBatch := RedemptionBatch{}
+	if err := c.ShouldBindJSON(&redemptionBatch); err != nil || len(redemptionBatch.Ids) == 0 {
+		common.ApiErrorI18n(c, i18n.MsgInvalidParams)
+		return
+	}
+	count, err := model.BatchDeleteRedemptions(redemptionBatch.Ids)
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "",
+		"data":    count,
+	})
+}
+
 func DeleteInvalidRedemption(c *gin.Context) {
 	rows, err := model.DeleteInvalidRedemptions()
 	if err != nil {

--- a/model/redemption.go
+++ b/model/redemption.go
@@ -9,6 +9,8 @@ import (
 	"github.com/QuantumNous/new-api/logger"
 
 	"gorm.io/gorm"
+
+	"github.com/samber/lo"
 )
 
 type Redemption struct {
@@ -225,4 +227,28 @@ func DeleteInvalidRedemptions() (int64, error) {
 	now := common.GetTimestamp()
 	result := DB.Where("status IN ? OR (status = ? AND expired_time != 0 AND expired_time < ?)", []int{common.RedemptionCodeStatusUsed, common.RedemptionCodeStatusDisabled}, common.RedemptionCodeStatusEnabled, now).Delete(&Redemption{})
 	return result.RowsAffected, result.Error
+}
+
+
+func BatchDeleteRedemptions(ids []int) (int64, error) {
+	if len(ids) == 0 {
+		return 0, errors.New("ids 不能为空！")
+	}
+	tx := DB.Begin()
+	if tx.Error != nil {
+		return 0, tx.Error
+	}
+	var deletedCount int64
+	for _, chunk := range lo.Chunk(ids, 200) {
+		result := tx.Where("id in (?)", chunk).Delete(&Redemption{})
+		if result.Error != nil {
+			tx.Rollback()
+			return 0, result.Error
+		}
+		deletedCount += result.RowsAffected
+	}
+	if err := tx.Commit().Error; err != nil {
+		return 0, err
+	}
+	return deletedCount, nil
 }

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -265,6 +265,7 @@ func SetApiRouter(router *gin.Engine) {
 			redemptionRoute.GET("/:id", controller.GetRedemption)
 			redemptionRoute.POST("/", controller.AddRedemption)
 			redemptionRoute.PUT("/", controller.UpdateRedemption)
+			redemptionRoute.POST("/batch", controller.DeleteRedemptionBatch)
 			redemptionRoute.DELETE("/invalid", controller.DeleteInvalidRedemption)
 			redemptionRoute.DELETE("/:id", controller.DeleteRedemption)
 		}

--- a/web/src/features/redemption-codes/api.ts
+++ b/web/src/features/redemption-codes/api.ts
@@ -94,6 +94,14 @@ export async function deleteRedemption(id: number): Promise<ApiResponse> {
 }
 
 // Delete invalid redemption codes (used, disabled, expired)
+// Batch delete redemption codes
+export async function deleteRedemptionBatch(
+  ids: number[]
+): Promise<ApiResponse<number>> {
+  const res = await api.post('/api/redemption/batch', { ids })
+  return res.data
+}
+
 export async function deleteInvalidRedemptions(): Promise<ApiResponse<number>> {
   const res = await api.delete('/api/redemption/invalid')
   return res.data

--- a/web/src/features/redemption-codes/components/data-table-bulk-actions.tsx
+++ b/web/src/features/redemption-codes/components/data-table-bulk-actions.tsx
@@ -16,13 +16,25 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
+import { useQueryClient } from '@tanstack/react-query'
 import type { Table } from '@tanstack/react-table'
-import { useMemo } from 'react'
+import { Trash2 } from 'lucide-react'
+import { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
 
 import { CopyButton } from '@/components/copy-button'
 import { DataTableBulkActions as BulkActionsToolbar } from '@/components/data-table'
+import { Dialog } from '@/components/dialog'
+import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
+import { deleteRedemptionBatch } from '../api'
+import { SUCCESS_MESSAGES } from '../constants'
 import type { Redemption } from '../types'
 
 type DataTableBulkActionsProps<TData> = {
@@ -33,7 +45,17 @@ export function DataTableBulkActions<TData>({
   table,
 }: DataTableBulkActionsProps<TData>) {
   const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const selectedRows = table.getSelectedRowModel().rows
+
+  const selectedIds = selectedRows.reduce<number[]>((ids, row) => {
+    const id = (row.original as Redemption).id
+    if (typeof id === 'number') {
+      ids.push(id)
+    }
+    return ids
+  }, [])
 
   const contentToCopy = useMemo(() => {
     const selectedCodes = selectedRows.map((row) => {
@@ -43,17 +65,88 @@ export function DataTableBulkActions<TData>({
     return selectedCodes.join('\n')
   }, [selectedRows])
 
+  const handleClearSelection = () => {
+    table.resetRowSelection()
+  }
+
+  const handleDeleteAll = async () => {
+    try {
+      const result = await deleteRedemptionBatch(selectedIds)
+      if (result.success) {
+        toast.success(t(SUCCESS_MESSAGES.REDEMPTION_DELETED))
+        setShowDeleteConfirm(false)
+        handleClearSelection()
+        queryClient.invalidateQueries({ queryKey: ['redemptions'] })
+      }
+    } catch {
+      toast.error(t('Failed to delete redemption codes'))
+    }
+  }
+
   return (
-    <BulkActionsToolbar table={table} entityName={t('redemption code')}>
-      <CopyButton
-        value={contentToCopy}
-        variant='outline'
-        size='icon'
-        className='size-8'
-        tooltip={t('Copy selected codes')}
-        successTooltip={t('Codes copied!')}
-        aria-label={t('Copy selected codes')}
-      />
-    </BulkActionsToolbar>
+    <>
+      <BulkActionsToolbar table={table} entityName={t('redemption code')}>
+        <CopyButton
+          value={contentToCopy}
+          variant='outline'
+          size='icon'
+          className='size-8'
+          tooltip={t('Copy selected codes')}
+          successTooltip={t('Codes copied!')}
+          aria-label={t('Copy selected codes')}
+        />
+
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant='destructive'
+                size='icon'
+                onClick={() => setShowDeleteConfirm(true)}
+                className='size-8'
+                aria-label={t('Delete selected codes')}
+                title={t('Delete selected codes')}
+              />
+            }
+          >
+            <Trash2 />
+            <span className='sr-only'>{t('Delete selected codes')}</span>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{t('Delete selected codes')}</p>
+          </TooltipContent>
+        </Tooltip>
+      </BulkActionsToolbar>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog
+        open={showDeleteConfirm}
+        onOpenChange={setShowDeleteConfirm}
+        title={t('Delete redemption codes?')}
+        description={
+          <>
+            {t('Are you sure you want to delete')}
+            {selectedIds.length}{' '}
+            {t('redemption code(s)? This action cannot be undone.')}
+          </>
+        }
+        contentHeight='auto'
+        footer={
+          <>
+            <Button
+              variant='outline'
+              onClick={() => setShowDeleteConfirm(false)}
+            >
+              {t('Cancel')}
+            </Button>
+            <Button variant='destructive' onClick={handleDeleteAll}>
+              {t('Delete')}
+            </Button>
+          </>
+        }
+      >
+        {' '}
+      </Dialog>
+    </>
   )
 }

--- a/web/src/features/redemption-codes/components/data-table-bulk-actions.tsx
+++ b/web/src/features/redemption-codes/components/data-table-bulk-actions.tsx
@@ -49,13 +49,17 @@ export function DataTableBulkActions<TData>({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const selectedRows = table.getSelectedRowModel().rows
 
-  const selectedIds = selectedRows.reduce<number[]>((ids, row) => {
-    const id = (row.original as Redemption).id
-    if (typeof id === 'number') {
-      ids.push(id)
-    }
-    return ids
-  }, [])
+  const selectedIds = useMemo(
+    () =>
+      selectedRows.reduce<number[]>((ids, row) => {
+        const id = (row.original as Redemption).id
+        if (typeof id === 'number') {
+          ids.push(id)
+        }
+        return ids
+      }, []),
+    [selectedRows]
+  )
 
   const contentToCopy = useMemo(() => {
     const selectedCodes = selectedRows.map((row) => {


### PR DESCRIPTION
## 改动说明

为兑换码管理界面添加多选批量删除功能。

### 背景

Issue #6481：兑换码界面多选后只能复制，无法批量删除，只能一个一个删。

### 改动

**后端（3 个文件）：**
- `model/redemption.go` — 新增 `BatchDeleteRedemptions(ids []int)` 函数，支持事务内分批批量删除
- `controller/redemption.go` — 新增 `DeleteRedemptionBatch` handler，接收 `{ ids: [...] }` JSON
- `router/api-router.go` — 新增 `POST /api/redemption/batch` 路由

**前端（2 个文件）：**
- `web/src/features/redemption-codes/api.ts` — 新增 `deleteRedemptionBatch(ids)` API 函数
- `web/src/features/redemption-codes/components/data-table-bulk-actions.tsx` — 在批量操作工具栏新增删除按钮（红色 Trash2 图标），点击弹出确认对话框，确认后执行批量删除并刷新表格

### 实现参考

与渠道、令牌的批量删除模式一致：使用 `POST /batch` 而非 `DELETE`，后端事务分批删除（每批 200 个），前端使用确认对话框防止误操作。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch deletion for redemption codes from the data table bulk actions menu.
  * Select multiple codes and delete them in one request.
  * Added a “Delete redemption codes?” confirmation dialog showing the number selected.
  * Displays success and error notifications after deletion.
  * Automatically refreshes the redemption list after a successful batch deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->