### PR TITLE
fix: add group filter to user management page (#6398)

### DIFF
--- a/web/src/features/users/components/users-columns.tsx
+++ b/web/src/features/users/components/users-columns.tsx
@@ -184,9 +184,7 @@ export function useUsersColumns(): ColumnDef<User>[] {
         )
       },
       filterFn: (row, id, value) => {
-        const group = String(row.getValue(id) || t('User Group')).toLowerCase()
-        const searchValue = String(value).toLowerCase()
-        return group.includes(searchValue)
+        return value.includes(String(row.getValue(id)))
       },
       size: 140,
       meta: { mobileOrder: 30 },

--- a/web/src/features/users/components/users-table.tsx
+++ b/web/src/features/users/components/users-table.tsx
@@ -32,7 +32,7 @@ import {
 import { useMediaQuery } from '@/hooks'
 import { useTableUrlState } from '@/hooks/use-table-url-state'
 
-import { getUsers, searchUsers } from '../api'
+import { getUsers, searchUsers, getGroups } from '../api'
 import {
   USER_STATUS,
   getUserStatusOptions,
@@ -82,7 +82,7 @@ export function UsersTable() {
     columnFilters: [
       { columnId: 'status', searchKey: 'status', type: 'array' },
       { columnId: 'role', searchKey: 'role', type: 'array' },
-      { columnId: 'group', searchKey: 'group', type: 'string' },
+      { columnId: 'group', searchKey: 'group', type: 'array' },
     ],
   })
   const statusFilter =
@@ -94,8 +94,9 @@ export function UsersTable() {
       | string[]
       | undefined) ?? []
   const groupFilter =
-    (columnFilters.find((filter) => filter.id === 'group')?.value as string) ??
-    ''
+    (columnFilters.find((filter) => filter.id === 'group')?.value as
+      | string[]
+      | undefined) ?? []
 
   const sortParams = useMemo(() => {
     const activeSort = sorting[0]
@@ -119,6 +120,21 @@ export function UsersTable() {
     }
   }
 
+  // Fetch groups for filter
+  const { data: groupsData } = useQuery({
+    queryKey: ['groups'],
+    queryFn: getGroups,
+  })
+
+  const groupOptions = useMemo(
+    () =>
+      (groupsData?.data || []).map((g) => ({
+        label: g,
+        value: g,
+      })),
+    [groupsData]
+  )
+
   // Fetch data with React Query
   const { data, isLoading, isFetching } = useQuery({
     queryKey: [
@@ -135,7 +151,7 @@ export function UsersTable() {
     queryFn: async () => {
       const hasFilter = globalFilter?.trim()
       const hasColumnFilter =
-        statusFilter.length > 0 || roleFilter.length > 0 || Boolean(groupFilter)
+        statusFilter.length > 0 || roleFilter.length > 0 || groupFilter.length > 0
       const params = {
         p: pagination.pageIndex + 1,
         page_size: pagination.pageSize,
@@ -149,7 +165,7 @@ export function UsersTable() {
               keyword: globalFilter,
               status: statusFilter[0] ?? '',
               role: roleFilter[0] ?? '',
-              group: groupFilter,
+              group: groupFilter[0] ?? '',
             })
           : await getUsers(params)
 
@@ -228,6 +244,12 @@ export function UsersTable() {
             columnId: 'role',
             title: t('Role'),
             options: getUserRoleOptions(t),
+            singleSelect: true,
+          },
+          {
+            columnId: 'group',
+            title: t('Group'),
+            options: groupOptions,
             singleSelect: true,
           },
         ],

--- a/web/src/features/users/components/users-table.tsx
+++ b/web/src/features/users/components/users-table.tsx
@@ -123,7 +123,14 @@ export function UsersTable() {
   // Fetch groups for filter
   const { data: groupsData } = useQuery({
     queryKey: ['groups'],
-    queryFn: getGroups,
+    queryFn: async () => {
+      const result = await getGroups()
+      if (!result.success) {
+        toast.error(result.message || t('Failed to load groups'))
+        return { data: [] }
+      }
+      return result
+    },
   })
 
   const groupOptions = useMemo(


### PR DESCRIPTION
## 改动说明

### 背景

Issue #6398：新版本 UI 用户页面无法筛选分组查看用户列表，旧版本可以。

### 原因

后端 `/api/user/search` 接口已经支持 `group` 参数，前端 `searchUsers` API 也支持 `group` 参数，URL 状态中也配置了 `group` 列筛选器，但**工具栏（toolbar）中缺少分组筛选的 UI 组件**，导致用户无法通过界面选择分组进行筛选。

### 改动

**`web/src/features/users/components/users-table.tsx`：**
- 导入 `getGroups` API，用于获取可用分组列表
- 新增 `useQuery` 查询获取分组数据
- 将 `group` 列筛选类型从 `string` 改为 `array`（与 `status`、`role` 保持一致）
- 在工具栏的 `filters` 数组中新增 `group` 筛选器，支持单选分组筛选

**`web/src/features/users/components/users-columns.tsx`：**
- 更新 `group` 列的 `filterFn`，从字符串匹配改为数组匹配（与 `status`、`role` 列一致）

### 实现参考

与渠道管理页面的分组筛选模式一致：使用 `DataTableFacetedFilter` 组件，从 `getGroups` API 获取分组列表，支持单选筛选。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added group-based filtering to the users table.
  * Group filter options are loaded dynamically and shown in the filter UI.
  * Group selections are preserved using URL-backed table filters.
* **Bug Fixes**
  * Updated group filter matching logic for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->