### PR TITLE
fix(sidebar): separate drawing and task logs

### DIFF
--- a/web/src/features/usage-logs/index.tsx
+++ b/web/src/features/usage-logs/index.tsx
@@ -117,8 +117,7 @@ function UsageLogsContent() {
     [setViewScope]
   )
 
-  const pageMeta =
-    activeCategory === 'common' ? SECTION_META.common : SECTION_META.task
+  const pageMeta = SECTION_META[activeCategory]
   const showTaskSwitcher =
     activeCategory !== 'common' && visibleSections.length > 1
 

--- a/web/src/hooks/use-sidebar-data.ts
+++ b/web/src/hooks/use-sidebar-data.ts
@@ -22,6 +22,7 @@ import {
   CreditCard,
   FileText,
   FlaskConical,
+  ImageIcon,
   Key,
   LayoutDashboard,
   ListTodo,
@@ -36,7 +37,7 @@ import {
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { type SidebarData } from '@/components/layout/types'
+import type { SidebarData } from '@/components/layout/types'
 import { ROLE } from '@/lib/roles'
 
 /**
@@ -91,10 +92,13 @@ export function useSidebarData(): SidebarData {
             icon: FileText,
           },
           {
+            title: t('Drawing Logs'),
+            url: '/usage-logs/drawing',
+            icon: ImageIcon,
+          },
+          {
             title: t('Task Logs'),
             url: '/usage-logs/task',
-            activeUrls: ['/usage-logs/drawing'],
-            configUrls: ['/usage-logs/drawing', '/usage-logs/task'],
             icon: ListTodo,
           },
         ],


### PR DESCRIPTION
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

> [!NOTE]
>
> 实现、问题定位和描述初稿由 OpenAI Codex 协助完成；我已检查代码范围并完成本地验证。

## 📝 变更描述 / Description

### 问题背景
系统设置 - 侧边栏模块 - 控制台区域 - 绘制日志开关错误控制了任务日志功能的显示与隐藏。

### 根本原因
侧边栏原本将绘画日志和任务日志合并在同一个菜单配置中，导致任一开关开启都会显示“任务日志”。同时，日志页面统一使用任务日志的元信息，导致绘画日志页面标题显示错误。

### 解决方案
将绘画日志和任务日志拆分为独立菜单项，并根据当前日志类型显示对应标题，使两个开关能够分别控制各自入口。

### 变更详情
- 在 `web/src/hooks/use-sidebar-data.ts` 中：
    - 新增独立的“绘画日志”菜单项。
    - 使用 `ImageIcon` 作为绘画日志图标。
    - 保留独立的“任务日志”菜单项。
    - 移除两个日志路由之间共享的 `activeUrls` 和 `configUrls`。
- 在 `web/src/features/usage-logs/index.tsx` 中：
    - 将页面元信息改为通过 `SECTION_META[activeCategory]` 获取。
    - 修复绘画日志页面错误显示“任务日志”标题的问题。


## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6296

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [[Issues](https://github.com/QuantumNous/new-api/issues)](https://github.com/QuantumNous/new-api/issues) 与 [[PRs](https://github.com/QuantumNous/new-api/pulls)](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

### 手动验证
已验证以下配置组合：
|绘画日志|任务日志|验证结果|
|---|---|---|
|关闭|关闭|两个菜单均不显示|
|开启|关闭|仅显示“绘画日志”，页面标题正确|
|关闭|开启|仅显示“任务日志”，页面标题正确|
|开启|开启|两个菜单独立显示，页面标题均正确|

#### 仅开启绘画日志
<img width="1882" height="568" alt="Pasted image 20260727232318" src="https://github.com/user-attachments/assets/54e67c79-d7f3-4076-809d-c9e4bd0914e6" />
<img width="1910" height="410" alt="Pasted image 20260727232415" src="https://github.com/user-attachments/assets/cff11599-d3b9-4338-840f-9d8134f72ec9" />


#### 仅开启任务日志
<img width="1894" height="573" alt="Pasted image 20260727232342" src="https://github.com/user-attachments/assets/ed55277c-6d17-435a-bfce-ed4225a70156" />
<img width="1901" height="537" alt="Pasted image 20260727232357" src="https://github.com/user-attachments/assets/475f82fc-ed7d-49a0-a2ce-129daebd698f" />


#### 同时开启任务日志与绘画日志
<img width="1895" height="564" alt="Pasted image 20260727232452" src="https://github.com/user-attachments/assets/8330715b-60d8-45b7-8c4b-f33e42ba40cf" />
<img width="1905" height="452" alt="Pasted image 20260727232503" src="https://github.com/user-attachments/assets/244feeae-6c59-4d83-b851-20e290505fb1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Drawing Logs** entry under **General → Usage Logs** for direct access to drawing activity.
  * Updated the sidebar navigation to distinguish Drawing Logs from Task Logs.

* **Bug Fixes**
  * Improved usage-log page title selection so titles correctly reflect the currently selected log category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->