### PR TITLE
fix(ability): report an emptied group as no channel, not DB corruption

### DIFF
--- a/model/ability.go
+++ b/model/ability.go
@@ -60,7 +60,9 @@ func GetAllEnableAbilities() []Ability {
 	return abilities
 }
 
-func getPriority(group string, model string, retry int) (int, error) {
+// getPriority reports the priority to use for this retry step, and whether the
+// group still serves the model.
+func getPriority(group string, model string, retry int) (int, bool, error) {
 
 	var priorities []int
 	err := DB.Model(&Ability{}).
@@ -71,12 +73,13 @@ func getPriority(group string, model string, retry int) (int, error) {
 
 	if err != nil {
 		// 处理错误
-		return 0, err
+		return 0, false, err
 	}
 
 	if len(priorities) == 0 {
-		// 如果没有查询到优先级，则返回错误
-		return 0, errors.New("数据库一致性被破坏")
+		// 分组内已无该模型的启用渠道，属于正常的无可用渠道。
+		// 重试期间可达：自动禁用会把刚失败的渠道置为禁用。
+		return 0, false, nil
 	}
 
 	// 确定要使用的优先级
@@ -87,19 +90,21 @@ func getPriority(group string, model string, retry int) (int, error) {
 	} else {
 		priorityToUse = priorities[retry]
 	}
-	return priorityToUse, nil
+	return priorityToUse, true, nil
 }
 
 func getChannelQuery(group string, model string, retry int) (*gorm.DB, error) {
 	maxPrioritySubQuery := DB.Model(&Ability{}).Select("MAX(priority)").Where(commonGroupCol+" = ? and model = ? and enabled = ?", group, model, true)
 	channelQuery := DB.Where(commonGroupCol+" = ? and model = ? and enabled = ? and priority = (?)", group, model, true, maxPrioritySubQuery)
 	if retry != 0 {
-		priority, err := getPriority(group, model, retry)
+		priority, found, err := getPriority(group, model, retry)
 		if err != nil {
 			return nil, err
-		} else {
-			channelQuery = DB.Where(commonGroupCol+" = ? and model = ? and enabled = ? and priority = ?", group, model, true, priority)
 		}
+		if !found {
+			return nil, nil
+		}
+		channelQuery = DB.Where(commonGroupCol+" = ? and model = ? and enabled = ? and priority = ?", group, model, true, priority)
 	}
 
 	return channelQuery, nil
@@ -112,6 +117,9 @@ func GetChannel(group string, model string, retry int, requestPath string) (*Cha
 	channelQuery, err := getChannelQuery(group, model, retry)
 	if err != nil {
 		return nil, err
+	}
+	if channelQuery == nil {
+		return nil, nil
 	}
 	if common.UsingMainDatabase(common.DatabaseTypeSQLite) || common.UsingMainDatabase(common.DatabaseTypePostgreSQL) {
 		err = channelQuery.Order("weight DESC").Find(&abilities).Error

--- a/model/ability.go
+++ b/model/ability.go
@@ -60,9 +60,7 @@ func GetAllEnableAbilities() []Ability {
 	return abilities
 }
 
-// getPriority reports the priority to use for this retry step, and whether the
-// group still serves the model.
-func getPriority(group string, model string, retry int) (int, bool, error) {
+func getPriority(group string, model string, retry int) (int, error) {
 
 	var priorities []int
 	err := DB.Model(&Ability{}).
@@ -73,13 +71,12 @@ func getPriority(group string, model string, retry int) (int, bool, error) {
 
 	if err != nil {
 		// 处理错误
-		return 0, false, err
+		return 0, err
 	}
 
 	if len(priorities) == 0 {
-		// 分组内已无该模型的启用渠道，属于正常的无可用渠道。
-		// 重试期间可达：自动禁用会把刚失败的渠道置为禁用。
-		return 0, false, nil
+		// 如果没有查询到优先级，则返回错误
+		return 0, errors.New("数据库一致性被破坏")
 	}
 
 	// 确定要使用的优先级
@@ -90,21 +87,19 @@ func getPriority(group string, model string, retry int) (int, bool, error) {
 	} else {
 		priorityToUse = priorities[retry]
 	}
-	return priorityToUse, true, nil
+	return priorityToUse, nil
 }
 
 func getChannelQuery(group string, model string, retry int) (*gorm.DB, error) {
 	maxPrioritySubQuery := DB.Model(&Ability{}).Select("MAX(priority)").Where(commonGroupCol+" = ? and model = ? and enabled = ?", group, model, true)
 	channelQuery := DB.Where(commonGroupCol+" = ? and model = ? and enabled = ? and priority = (?)", group, model, true, maxPrioritySubQuery)
 	if retry != 0 {
-		priority, found, err := getPriority(group, model, retry)
+		priority, err := getPriority(group, model, retry)
 		if err != nil {
 			return nil, err
+		} else {
+			channelQuery = DB.Where(commonGroupCol+" = ? and model = ? and enabled = ? and priority = ?", group, model, true, priority)
 		}
-		if !found {
-			return nil, nil
-		}
-		channelQuery = DB.Where(commonGroupCol+" = ? and model = ? and enabled = ? and priority = ?", group, model, true, priority)
 	}
 
 	return channelQuery, nil
@@ -117,9 +112,6 @@ func GetChannel(group string, model string, retry int, requestPath string) (*Cha
 	channelQuery, err := getChannelQuery(group, model, retry)
 	if err != nil {
 		return nil, err
-	}
-	if channelQuery == nil {
-		return nil, nil
 	}
 	if common.UsingMainDatabase(common.DatabaseTypeSQLite) || common.UsingMainDatabase(common.DatabaseTypePostgreSQL) {
 		err = channelQuery.Order("weight DESC").Find(&abilities).Error

--- a/model/ability_no_channel_test.go
+++ b/model/ability_no_channel_test.go
@@ -26,32 +26,32 @@ func TestGetChannelReportsNoChannelAfterLastAbilityDisabled(t *testing.T) {
 	})
 
 	priority := int64(100)
-	require.NoError(t, DB.Create(&Channel{
-		Id:       1,
+	channel := &Channel{
 		Status:   common.ChannelStatusEnabled,
 		Name:     "only-channel",
 		Group:    "chat",
 		Models:   "gpt-test",
 		Priority: &priority,
-	}).Error)
+	}
+	require.NoError(t, DB.Create(channel).Error)
 	require.NoError(t, DB.Create(&Ability{
 		Group:     "chat",
 		Model:     "gpt-test",
-		ChannelId: 1,
+		ChannelId: channel.Id,
 		Enabled:   true,
 		Priority:  &priority,
 	}).Error)
 
-	channel, err := GetChannel("chat", "gpt-test", 0, "")
+	selected, err := GetChannel("chat", "gpt-test", 0, "")
 	require.NoError(t, err)
-	require.NotNil(t, channel, "the first attempt must find the only channel")
+	require.NotNil(t, selected, "the first attempt must find the only channel")
 
 	// The channel fails and auto-ban disables it, exactly as UpdateAbilityStatus
 	// does when a relay error trips the disable threshold.
-	require.NoError(t, UpdateAbilityStatus(1, false))
+	require.NoError(t, UpdateAbilityStatus(channel.Id, false))
 
 	// The in-flight request now retries against a group that has become empty.
-	channel, err = GetChannel("chat", "gpt-test", 1, "")
+	selected, err = GetChannel("chat", "gpt-test", 1, "")
 	assert.NoError(t, err, "an emptied group is an ordinary no-channel result, not a database consistency failure")
-	assert.Nil(t, channel)
+	assert.Nil(t, selected)
 }

--- a/model/ability_no_channel_test.go
+++ b/model/ability_no_channel_test.go
@@ -1,0 +1,57 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetChannelReportsNoChannelAfterLastAbilityDisabled reproduces what a client
+// sees when auto-ban disables the last channel serving a model in its group while
+// a request is still retrying: the retry re-queries the group, finds nothing, and
+// must report "no available channel" rather than a database consistency failure.
+func TestGetChannelReportsNoChannelAfterLastAbilityDisabled(t *testing.T) {
+	prevMemoryCache := common.MemoryCacheEnabled
+	common.MemoryCacheEnabled = false
+	t.Cleanup(func() { common.MemoryCacheEnabled = prevMemoryCache })
+
+	require.NoError(t, DB.AutoMigrate(&Channel{}, &Ability{}))
+	require.NoError(t, DB.Exec("DELETE FROM abilities").Error)
+	require.NoError(t, DB.Exec("DELETE FROM channels").Error)
+	t.Cleanup(func() {
+		require.NoError(t, DB.Exec("DELETE FROM abilities").Error)
+		require.NoError(t, DB.Exec("DELETE FROM channels").Error)
+	})
+
+	priority := int64(100)
+	require.NoError(t, DB.Create(&Channel{
+		Id:       1,
+		Status:   common.ChannelStatusEnabled,
+		Name:     "only-channel",
+		Group:    "chat",
+		Models:   "gpt-test",
+		Priority: &priority,
+	}).Error)
+	require.NoError(t, DB.Create(&Ability{
+		Group:     "chat",
+		Model:     "gpt-test",
+		ChannelId: 1,
+		Enabled:   true,
+		Priority:  &priority,
+	}).Error)
+
+	channel, err := GetChannel("chat", "gpt-test", 0, "")
+	require.NoError(t, err)
+	require.NotNil(t, channel, "the first attempt must find the only channel")
+
+	// The channel fails and auto-ban disables it, exactly as UpdateAbilityStatus
+	// does when a relay error trips the disable threshold.
+	require.NoError(t, UpdateAbilityStatus(1, false))
+
+	// The in-flight request now retries against a group that has become empty.
+	channel, err = GetChannel("chat", "gpt-test", 1, "")
+	assert.NoError(t, err, "an emptied group is an ordinary no-channel result, not a database consistency failure")
+	assert.Nil(t, channel)
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

## 📝 变更描述 / Description

`getPriority` 在查不到优先级时返回 `errors.New("数据库一致性被破坏")`。但这个空结果在重试路径上是可以正常出现的：自动禁用会通过 `UpdateAbilityStatus` 把刚失败的渠道的 ability 置为禁用，因此一个只剩最后一个渠道的分组会在请求进行中合法地变空。于是一个正常的“没有可用渠道了”被报成了数据损坏，并一路冒到客户端。

改法：`getPriority` 额外返回一个 `found` 标志；`getChannelQuery` 在未找到时返回 nil query；`GetChannel` 据此返回 `(nil, nil)`，交由调用方走既有的无可用渠道处理逻辑。

只影响 `retry != 0`：`retry = 0` 用的是 `MAX(priority)` 子查询，从不经过这个检查，行为不变。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6503

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

新增 `model/ability_no_channel_test.go`，复刻“自动禁用后重试”的场景，不依赖真实上游、不依赖网络：先取一次渠道，再 `UpdateAbilityStatus(1, false)` 模拟自动禁用，然后以 `retry = 1` 再次 `GetChannel`。

当前 main（`afe16c64`）：

```
--- FAIL: TestGetChannelReportsNoChannelAfterLastAbilityDisabled (0.00s)
        Error Trace: model/ability_no_channel_test.go:55
        Error:       Received unexpected error:
                     数据库一致性被破坏
FAIL    github.com/QuantumNous/new-api/model
```

本 PR 之后：

```
--- PASS: TestGetChannelReportsNoChannelAfterLastAbilityDisabled (0.00s)
PASS
ok      github.com/QuantumNous/new-api/model     0.021s
```

`gofmt -l model/`、`go vet ./model/`、`go build ./model/` 均通过。

## 说明

本 PR 的代码为 AI 辅助编写。问题定位、改法取舍与最终代码由我逐行复核；测试是不依赖网络的确定性用例，上面的红/绿输出可由维护者直接复跑验证。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel selection when the last available channel is automatically disabled.
  * Subsequent retries now correctly report no available channel without producing an error.

* **Tests**
  * Added coverage for this channel availability scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->