### PR TITLE
fix(codex): inline remote Responses input files

### DIFF
--- a/relay/channel/codex/adaptor.go
+++ b/relay/channel/codex/adaptor.go
@@ -3,6 +3,7 @@ package codex
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/QuantumNous/new-api/relay/channel/openai"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/types"
 
 	"github.com/gin-gonic/gin"
@@ -54,6 +56,26 @@ func (a *Adaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.Rela
 
 func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {
 	isCompact := info != nil && info.RelayMode == relayconstant.RelayModeResponsesCompact
+
+	rewrittenInput, err := rewriteRemoteInputFiles(request.Input, func(fileURL string) (string, error) {
+		cachedData, err := service.LoadFileSource(c, types.NewURLFileSource(fileURL), "codex_input_file")
+		if err != nil {
+			return "", err
+		}
+		base64Data, err := cachedData.GetBase64Data()
+		if err != nil {
+			return "", err
+		}
+		mimeType := strings.TrimSpace(cachedData.MimeType)
+		if mimeType == "" {
+			mimeType = "application/octet-stream"
+		}
+		return fmt.Sprintf("data:%s;base64,%s", mimeType, base64Data), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	request.Input = rewrittenInput
 
 	if info != nil && info.ChannelSetting.SystemPrompt != "" {
 		systemPrompt := info.ChannelSetting.SystemPrompt

--- a/relay/channel/codex/input_file.go
+++ b/relay/channel/codex/input_file.go
@@ -1,0 +1,93 @@
+package codex
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+)
+
+type remoteInputFileLoader func(fileURL string) (dataURL string, err error)
+
+func rewriteRemoteInputFiles(input json.RawMessage, load remoteInputFileLoader) (json.RawMessage, error) {
+	if len(input) == 0 {
+		return input, nil
+	}
+
+	var value any
+	if err := json.Unmarshal(input, &value); err != nil {
+		return nil, fmt.Errorf("decode responses input: %w", err)
+	}
+	changed, err := rewriteRemoteInputFileValue(value, load)
+	if err != nil {
+		return nil, err
+	}
+	if !changed {
+		return input, nil
+	}
+
+	rewritten, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode responses input: %w", err)
+	}
+	return rewritten, nil
+}
+
+func rewriteRemoteInputFileValue(value any, load remoteInputFileLoader) (bool, error) {
+	switch node := value.(type) {
+	case []any:
+		changed := false
+		for _, item := range node {
+			itemChanged, err := rewriteRemoteInputFileValue(item, load)
+			if err != nil {
+				return false, err
+			}
+			changed = changed || itemChanged
+		}
+		return changed, nil
+	case map[string]any:
+		changed := false
+		if node["type"] == "input_file" {
+			fileURL, _ := node["file_url"].(string)
+			fileURL = strings.TrimSpace(fileURL)
+			if fileURL != "" {
+				if load == nil {
+					return false, fmt.Errorf("load remote input file: loader is nil")
+				}
+				dataURL, err := load(fileURL)
+				if err != nil {
+					return false, fmt.Errorf("load remote input file: %w", err)
+				}
+				node["file_data"] = dataURL
+				delete(node, "file_url")
+				if filename, _ := node["filename"].(string); strings.TrimSpace(filename) == "" {
+					node["filename"] = filenameFromRemoteInputFileURL(fileURL)
+				}
+				changed = true
+			}
+		}
+		for _, item := range node {
+			itemChanged, err := rewriteRemoteInputFileValue(item, load)
+			if err != nil {
+				return false, err
+			}
+			changed = changed || itemChanged
+		}
+		return changed, nil
+	default:
+		return false, nil
+	}
+}
+
+func filenameFromRemoteInputFileURL(fileURL string) string {
+	parsed, err := url.Parse(fileURL)
+	if err != nil {
+		return "file"
+	}
+	filename, err := url.PathUnescape(path.Base(parsed.Path))
+	if err != nil || filename == "" || filename == "." || filename == "/" {
+		return "file"
+	}
+	return filename
+}

--- a/relay/channel/codex/input_file_test.go
+++ b/relay/channel/codex/input_file_test.go
@@ -1,0 +1,59 @@
+package codex
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestRewriteRemoteInputFiles(t *testing.T) {
+	input := json.RawMessage(`[{"role":"user","content":[{"type":"input_text","text":"summarize"},{"type":"input_file","file_url":"https://files.example.com/attachments/47/file.pdf?verify=secret"}]}]`)
+
+	rewritten, err := rewriteRemoteInputFiles(input, func(fileURL string) (string, error) {
+		if fileURL != "https://files.example.com/attachments/47/file.pdf?verify=secret" {
+			t.Fatalf("loader URL = %q", fileURL)
+		}
+		return "data:application/pdf;base64,JVBERi0=", nil
+	})
+	if err != nil {
+		t.Fatalf("rewriteRemoteInputFiles() error = %v", err)
+	}
+
+	var decoded []map[string]any
+	if err := json.Unmarshal(rewritten, &decoded); err != nil {
+		t.Fatalf("unmarshal rewritten input: %v", err)
+	}
+	content := decoded[0]["content"].([]any)
+	file := content[1].(map[string]any)
+	if _, exists := file["file_url"]; exists {
+		t.Fatalf("rewritten input still contains file_url: %#v", file)
+	}
+	if file["file_data"] != "data:application/pdf;base64,JVBERi0=" {
+		t.Fatalf("file_data = %#v", file["file_data"])
+	}
+	if file["filename"] != "file.pdf" {
+		t.Fatalf("filename = %#v, want URL basename", file["filename"])
+	}
+}
+
+func TestRewriteRemoteInputFilesPreservesInlineAndPropagatesLoadErrors(t *testing.T) {
+	inline := json.RawMessage(`[{"role":"user","content":[{"type":"input_file","filename":"report.pdf","file_data":"data:application/pdf;base64,JVBERi0="}]}]`)
+	rewritten, err := rewriteRemoteInputFiles(inline, func(string) (string, error) {
+		t.Fatal("inline file must not invoke loader")
+		return "", nil
+	})
+	if err != nil {
+		t.Fatalf("inline rewrite error = %v", err)
+	}
+	if string(rewritten) != string(inline) {
+		t.Fatalf("inline input changed: %s", rewritten)
+	}
+
+	wantErr := errors.New("download failed")
+	_, err = rewriteRemoteInputFiles(json.RawMessage(`[{"type":"input_file","file_url":"https://files.example.com/report.pdf"}]`), func(string) (string, error) {
+		return "", wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("rewrite error = %v, want %v", err, wantErr)
+	}
+}


### PR DESCRIPTION
## 📝 变更描述 / Description
Codex Responses can reject remote `input_file.file_url` values when the URL requires signed access or cannot be fetched by the upstream. The Codex adaptor now loads remote input files through the existing file-source cache and sends them as `file_data` data URIs. Inline files and image inputs are unchanged.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- Internal tracking: LM-2750

## ✅ 提交前检查项 / Checklist
- [x] 人工确认
- [x] 深度理解
- [x] 范围聚焦
- [x] 本地验证
- [x] 安全合规

## 📸 运行证明 / Proof of Work
- `go test ./relay/channel/codex` passes.
- A Responses request containing a PDF `file_data` completes successfully through the Codex channel.
- Tests cover remote URL rewriting, filename preservation, inline-file passthrough, and loader errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote input files are now embedded directly into requests as base64 data, enabling more reliable file processing.
  * File names are automatically preserved or derived when remote file references are converted.
  * Existing inline file data remains unchanged.

* **Bug Fixes**
  * File loading and conversion errors are now surfaced instead of silently ignored.

* **Tests**
  * Added coverage for remote file conversion, inline file preservation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->