### PR TITLE
fix: exclude failed requests from memory rate limit success count

### DIFF
--- a/common/rate-limit.go
+++ b/common/rate-limit.go
@@ -41,6 +41,18 @@ func (l *InMemoryRateLimiter) clearExpiredItems() {
 	}
 }
 
+// CanRequest reports whether Request would allow key right now, without
+// recording anything. Parameter duration's unit is seconds.
+func (l *InMemoryRateLimiter) CanRequest(key string, maxRequestNum int, duration int64) bool {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	queue, ok := l.store[key]
+	if !ok || len(*queue) < maxRequestNum {
+		return true
+	}
+	return time.Now().Unix()-(*queue)[0] >= duration
+}
+
 // Request parameter duration's unit is seconds
 func (l *InMemoryRateLimiter) Request(key string, maxRequestNum int, duration int64) bool {
 	l.mutex.Lock()

--- a/middleware/model-rate-limit.go
+++ b/middleware/model-rate-limit.go
@@ -140,24 +140,20 @@ func memoryRateLimitHandler(duration int64, totalMaxCount, successMaxCount int) 
 
 		// 1. 检查总请求数限制（当totalMaxCount为0时跳过）
 		if totalMaxCount > 0 && !inMemoryRateLimiter.Request(totalKey, totalMaxCount, duration) {
-			c.Status(http.StatusTooManyRequests)
-			c.Abort()
+			abortWithOpenAiMessage(c, http.StatusTooManyRequests, fmt.Sprintf("您已达到总请求数限制：%d分钟内最多请求%d次，包括失败次数，请检查您的请求是否正确", setting.ModelRequestRateLimitDurationMinutes, totalMaxCount))
 			return
 		}
 
-		// 2. 检查成功请求数限制
-		// 使用一个临时key来检查限制，这样可以避免实际记录
-		checkKey := successKey + "_check"
-		if !inMemoryRateLimiter.Request(checkKey, successMaxCount, duration) {
-			c.Status(http.StatusTooManyRequests)
-			c.Abort()
+		// 2. 检查成功请求数限制：只检查不计数，成功后才在步骤4计入
+		if !inMemoryRateLimiter.CanRequest(successKey, successMaxCount, duration) {
+			abortWithOpenAiMessage(c, http.StatusTooManyRequests, fmt.Sprintf("您已达到请求数限制：%d分钟内最多请求%d次", setting.ModelRequestRateLimitDurationMinutes, successMaxCount))
 			return
 		}
 
 		// 3. 处理请求
 		c.Next()
 
-		// 4. 如果请求成功，记录到实际的成功请求计数中
+		// 4. 如果请求成功，记录到成功请求计数中
 		if c.Writer.Status() < 400 {
 			inMemoryRateLimiter.Request(successKey, successMaxCount, duration)
 		}

--- a/middleware/model_rate_limit_test.go
+++ b/middleware/model_rate_limit_test.go
@@ -2,9 +2,12 @@ package middleware
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,4 +34,35 @@ func TestModelRedisRateLimitUsesUTCRegardlessOfLocalTimezone(t *testing.T) {
 	allowed, err := checkRedisRateLimit(ctx, redisClient, checkKey, 2, 60)
 	require.NoError(t, err)
 	assert.False(t, allowed, "an existing UTC timestamp inside the window must remain limited on a non-UTC host")
+}
+
+// 成功数限制只统计成功请求，失败请求不占配额；拒绝时返回 JSON 错误体而非空 429。
+func TestModelMemoryRateLimitSuccessCountIgnoresFailedRequests(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// 限流器是进程级全局且无重置接口，user id 每次唯一才能保证 -count=2 复跑
+	userID := int(time.Now().UnixNano() % 1_000_000_000)
+	downstreamStatus := http.StatusOK
+	router := gin.New()
+	router.GET("/limited", func(c *gin.Context) {
+		c.Set("id", userID)
+	}, memoryRateLimitHandler(60, 0, 2), func(c *gin.Context) {
+		c.Status(downstreamStatus)
+	})
+
+	do := func(status int) *httptest.ResponseRecorder {
+		downstreamStatus = status
+		return performRateLimitRequest(router, "/limited", "192.0.2.70:12345")
+	}
+
+	for range 5 {
+		assert.Equal(t, http.StatusInternalServerError, do(http.StatusInternalServerError).Code, "failed requests must not consume the success quota")
+	}
+
+	require.Equal(t, http.StatusOK, do(http.StatusOK).Code)
+	require.Equal(t, http.StatusOK, do(http.StatusOK).Code)
+
+	limited := do(http.StatusOK)
+	require.Equal(t, http.StatusTooManyRequests, limited.Code)
+	assert.Contains(t, limited.Body.String(), "您已达到请求数限制", "429 must carry the same error message as the Redis path")
 }


### PR DESCRIPTION
## 📝 变更描述 / Description

1. 内存限流的版`最大成功请求数`将失败也计入了总数
2. 客户端实际成功数远没到配置值就开始收 429，且响应是空 body（429），不好排查问题

修法：

- 失败的请求不再计入`成功请求数`
- 两处空 body 429 换成 `abortWithOpenAiMessage`，文案与 Redis 一致。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无独立 Issue，现象与根因见上面描述

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
设置:
<img width="1698" height="478" alt="image" src="https://github.com/user-attachments/assets/af5348f5-70ba-47b7-be23-05ab84d96aae" />

成功数限制(不含失败):
<img width="2820" height="1214" alt="image" src="https://github.com/user-attachments/assets/32a066cb-e489-4e4d-bf9b-73e24c7f9b2b" />

总请求数限制:
<img width="2834" height="1048" alt="image" src="https://github.com/user-attachments/assets/edb9694a-f4cf-4246-839f-7abade869172" />

