### PR TITLE
fix: disable playground request parameters by default

### DIFF
--- a/web/src/features/playground/constants.ts
+++ b/web/src/features/playground/constants.ts
@@ -57,11 +57,11 @@ export const DEFAULT_CONFIG: PlaygroundConfig = {
 }
 
 export const DEFAULT_PARAMETER_ENABLED: ParameterEnabled = {
-  temperature: true,
-  top_p: true,
+  temperature: false,
+  top_p: false,
   max_tokens: false,
-  frequency_penalty: true,
-  presence_penalty: true,
+  frequency_penalty: false,
+  presence_penalty: false,
   seed: false,
 }
 


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

Playground 的参数面板目前默认启用 temperature、top_p、frequency_penalty、presence_penalty 四个参数。但现在很多新模型不支持这些参数，收到会直接返回 400，新用户选中这类模型发第一条消息就报错，参数面板又比较隐蔽
<img width="858" height="420" alt="image" src="https://github.com/user-attachments/assets/86158ad3-2626-4f7e-9eb8-0a146f5e259c" />


这个 PR 把 `DEFAULT_PARAMETER_ENABLED` 全部改为默认关闭, 想调参的用户可以手动开

老用户不受影响：开关状态已持久化在 localStorage，初始化时会覆盖默认值。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified the playground’s default settings by disabling advanced generation parameters initially.
  * Parameters such as temperature, top-p, frequency penalty, and presence penalty can still be enabled when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->