### PR TITLE
fix: ignore self window.opener when detecting oauth bind mode

### DIFF
--- a/web/src/routes/oauth/$provider.tsx
+++ b/web/src/routes/oauth/$provider.tsx
@@ -68,8 +68,12 @@ function OAuthCallback() {
     flow_token?: string
     error_code?: string
   }
+  // Firefox sets opener to the window itself after window.open(url, '_self')
+  // and it survives the IdP roundtrip, so exclude it from bind detection.
   const mode: 'login' | 'bind' =
-    typeof window !== 'undefined' && window.opener ? 'bind' : 'login'
+    typeof window !== 'undefined' && window.opener && window.opener !== window
+      ? 'bind'
+      : 'login'
 
   useEffect(() => {
     if (typeof window === 'undefined') return


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

Firefox 的 `window.open(url, '_self')` 会把 `window.opener` 置为窗口自身,且跨域 IdP 往返后仍保留(Chromium 为 null)。`/oauth/$provider` 回调仅凭 `window.opener` 非空判定 bind/login,导致 Firefox 上所有 OAuth 登录必然误入绑定分支:postMessage 发给自己无人应答,30 秒后报「OAuth 绑定超时」,登录请求不会发往后端。

修复:判定 bind 时排除 `opener === window`。真正的绑定弹窗由个人资料页 `window.open('', '_blank')` 打开,opener 是另一个窗口,不受影响。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6542

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

修复前: firefox使用oidc登录必现
<img width="1946" height="1426" alt="image" src="https://github.com/user-attachments/assets/b82a0828-6ab4-4a22-9b2f-d35e6b534aa9" />

修复后: chrome 和 firebox都成功登录
<img width="1410" height="392" alt="image" src="https://github.com/user-attachments/assets/f3523224-6bbf-443a-94e0-80c35480bde3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth callback handling in Firefox.
  * Prevented login flows from being incorrectly treated as account-binding flows when opened in the same window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->