### PR TITLE
fix(ui/sidebar):correct-sidebar-position

### DIFF
--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -42,6 +42,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { useDirection } from '@/context/direction-provider'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { cn } from '@/lib/utils'
 
@@ -170,20 +171,19 @@ function SidebarProvider({
 }
 
 function Sidebar({
-  side = 'left',
   variant = 'sidebar',
   collapsible = 'offcanvas',
   className,
   children,
-  dir,
+
   ...props
 }: React.ComponentProps<'div'> & {
-  side?: 'left' | 'right'
   variant?: 'sidebar' | 'floating' | 'inset'
   collapsible?: 'offcanvas' | 'icon' | 'none'
 }) {
   const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
-
+  const { dir } = useDirection()
+  const side = dir === 'ltr' ? 'left' : 'right'
   if (collapsible === 'none') {
     return (
       <div


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>

## 📝 变更描述 / Description
移除 Sidebar 未实际使用的 side/dir props，改为从 DirectionContext 读取 dir 并推导 side

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6544 

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
修复前
<img width="1440" height="818" alt="截屏2026-07-30 16 13 01" src="https://github.com/user-attachments/assets/7a1d93f8-1535-45c9-8d14-10cccaa7512a" />

修复后
<img width="1440" height="817" alt="截屏2026-07-30 16 13 46" src="https://github.com/user-attachments/assets/141dc461-1de3-4f7a-a86e-b3c52677d625" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The sidebar now automatically positions itself on the correct side based on the application’s reading direction, including right-to-left layouts.

* **Improvements**
  * Simplified sidebar usage by removing the need to manually specify its side or direction (the component derives this automatically).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->