### PR TITLE
fix(channel): unify weighted selection across cache modes

### DIFF
--- a/model/ability.go
+++ b/model/ability.go
@@ -122,26 +122,20 @@ func GetChannel(group string, model string, retry int, requestPath string) (*Cha
 		return nil, err
 	}
 	abilities = filterAbilitiesByRequestPathAndModel(abilities, requestPath, model)
-	channel := Channel{}
-	if len(abilities) > 0 {
-		// Randomly choose one
-		weightSum := uint(0)
-		for _, ability_ := range abilities {
-			weightSum += ability_.Weight + 10
-		}
-		// Randomly choose one
-		weight := common.GetRandomInt(int(weightSum))
-		for _, ability_ := range abilities {
-			weight -= int(ability_.Weight) + 10
-			//log.Printf("weight: %d, ability weight: %d", weight, *ability_.Weight)
-			if weight <= 0 {
-				channel.Id = ability_.ChannelId
-				break
-			}
-		}
-	} else {
+	if len(abilities) == 0 {
 		return nil, nil
 	}
+
+	weights := make([]uint, len(abilities))
+	for index, ability := range abilities {
+		weights[index] = ability.Weight
+	}
+	selectedIndex, err := selectWeightedIndex(weights)
+	if err != nil {
+		return nil, err
+	}
+
+	channel := Channel{Id: abilities[selectedIndex].ChannelId}
 	err = DB.First(&channel, "id = ?", channel.Id).Error
 	return &channel, err
 }

--- a/model/channel_cache.go
+++ b/model/channel_cache.go
@@ -3,7 +3,6 @@ package model
 import (
 	"errors"
 	"fmt"
-	"math/rand"
 	"sort"
 	"strings"
 	"sync"
@@ -160,13 +159,17 @@ func GetRandomSatisfiedChannel(group string, model string, retry int, requestPat
 	targetPriority := int64(sortedUniquePriorities[retry])
 
 	// get the priority for the given retry number
-	var sumWeight = 0
-	var targetChannels []*Channel
+	targetChannels := make([]*Channel, 0, len(channels))
+	targetWeights := make([]uint, 0, len(channels))
 	for _, channelId := range channels {
 		if channel, ok := channelsIDM[channelId]; ok {
 			if channel.GetPriority() == targetPriority {
-				sumWeight += channel.GetWeight()
+				weight := uint(0)
+				if channel.Weight != nil {
+					weight = *channel.Weight
+				}
 				targetChannels = append(targetChannels, channel)
+				targetWeights = append(targetWeights, weight)
 			}
 		} else {
 			return nil, fmt.Errorf("数据库一致性错误，渠道# %d 不存在，请联系管理员修复", channelId)
@@ -177,35 +180,11 @@ func GetRandomSatisfiedChannel(group string, model string, retry int, requestPat
 		return nil, errors.New(fmt.Sprintf("no channel found, group: %s, model: %s, priority: %d", group, model, targetPriority))
 	}
 
-	// smoothing factor and adjustment
-	smoothingFactor := 1
-	smoothingAdjustment := 0
-
-	if sumWeight == 0 {
-		// when all channels have weight 0, set sumWeight to the number of channels and set smoothing adjustment to 100
-		// each channel's effective weight = 100
-		sumWeight = len(targetChannels) * 100
-		smoothingAdjustment = 100
-	} else if sumWeight/len(targetChannels) < 10 {
-		// when the average weight is less than 10, set smoothing factor to 100
-		smoothingFactor = 100
+	selectedIndex, err := selectWeightedIndex(targetWeights)
+	if err != nil {
+		return nil, err
 	}
-
-	// Calculate the total weight of all channels up to endIdx
-	totalWeight := sumWeight * smoothingFactor
-
-	// Generate a random value in the range [0, totalWeight)
-	randomWeight := rand.Intn(totalWeight)
-
-	// Find a channel based on its weight
-	for _, channel := range targetChannels {
-		randomWeight -= channel.GetWeight()*smoothingFactor + smoothingAdjustment
-		if randomWeight < 0 {
-			return channel, nil
-		}
-	}
-	// return null if no channel is not found
-	return nil, errors.New("channel not found")
+	return targetChannels[selectedIndex], nil
 }
 
 // filterChannelsByRequestPathAndModel restricts candidates by request path and

--- a/model/channel_weight.go
+++ b/model/channel_weight.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/rand/v2"
+)
+
+func selectWeightedIndex(weights []uint) (int, error) {
+	return selectWeightedIndexWithDraw(weights, rand.Uint64N)
+}
+
+func selectWeightedIndexWithDraw(weights []uint, draw func(uint64) uint64) (int, error) {
+	if len(weights) == 0 {
+		return -1, errors.New("cannot select a channel from an empty weight list")
+	}
+
+	var totalWeight uint64
+	for _, weight := range weights {
+		if uint64(weight) > math.MaxUint64-totalWeight {
+			return -1, errors.New("channel weight sum overflows uint64")
+		}
+		totalWeight += uint64(weight)
+	}
+
+	useEqualWeights := totalWeight == 0
+	if useEqualWeights {
+		totalWeight = uint64(len(weights))
+	}
+
+	randomWeight := draw(totalWeight)
+	if randomWeight >= totalWeight {
+		return -1, fmt.Errorf("random channel weight %d is outside [0, %d)", randomWeight, totalWeight)
+	}
+
+	for index, weight := range weights {
+		effectiveWeight := uint64(weight)
+		if useEqualWeights {
+			effectiveWeight = 1
+		}
+		if randomWeight < effectiveWeight {
+			return index, nil
+		}
+		randomWeight -= effectiveWeight
+	}
+
+	return -1, errors.New("channel not found in weighted selection")
+}

--- a/model/channel_weight_test.go
+++ b/model/channel_weight_test.go
@@ -1,0 +1,140 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectWeightedIndexUsesRawWeightIntervals(t *testing.T) {
+	type selection struct {
+		randomWeight  uint64
+		expectedIndex int
+	}
+	testCases := []struct {
+		name       string
+		weights    []uint
+		total      uint64
+		selections []selection
+	}{
+		{
+			name:    "two to one remains two to one",
+			weights: []uint{2, 1},
+			total:   3,
+			selections: []selection{
+				{randomWeight: 0, expectedIndex: 0},
+				{randomWeight: 1, expectedIndex: 0},
+				{randomWeight: 2, expectedIndex: 1},
+			},
+		},
+		{
+			name:    "all zero weights are equal",
+			weights: []uint{0, 0, 0},
+			total:   3,
+			selections: []selection{
+				{randomWeight: 0, expectedIndex: 0},
+				{randomWeight: 1, expectedIndex: 1},
+				{randomWeight: 2, expectedIndex: 2},
+			},
+		},
+		{
+			name:    "zero weights get no interval when another weight is positive",
+			weights: []uint{0, 1, 0},
+			total:   1,
+			selections: []selection{
+				{randomWeight: 0, expectedIndex: 1},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			for _, selection := range testCase.selections {
+				index, err := selectWeightedIndexWithDraw(testCase.weights, func(total uint64) uint64 {
+					assert.Equal(t, testCase.total, total)
+					return selection.randomWeight
+				})
+				require.NoError(t, err)
+				assert.Equal(t, selection.expectedIndex, index, "random weight %d", selection.randomWeight)
+			}
+		})
+	}
+}
+
+func TestSelectWeightedIndexRejectsEmptyWeights(t *testing.T) {
+	_, err := selectWeightedIndexWithDraw(nil, func(uint64) uint64 {
+		t.Fatal("draw must not be called for an empty weight list")
+		return 0
+	})
+
+	require.ErrorContains(t, err, "empty weight list")
+}
+
+func TestGetRandomSatisfiedChannelExcludesZeroWeightAcrossCacheModes(t *testing.T) {
+	const (
+		groupName = "weight-selection-test"
+		modelName = "weight-selection-model"
+	)
+	originalMemoryCacheEnabled := common.MemoryCacheEnabled
+	positiveWeight := uint(1)
+	zeroWeight := uint(0)
+	priority := int64(0)
+	channels := []*Channel{
+		{
+			Name:     "positive-weight",
+			Key:      "test-key-positive",
+			Status:   common.ChannelStatusEnabled,
+			Weight:   &positiveWeight,
+			Priority: &priority,
+			Group:    groupName,
+			Models:   modelName,
+		},
+		{
+			Name:     "zero-weight",
+			Key:      "test-key-zero",
+			Status:   common.ChannelStatusEnabled,
+			Weight:   &zeroWeight,
+			Priority: &priority,
+			Group:    groupName,
+			Models:   modelName,
+		},
+	}
+	t.Cleanup(func() {
+		defer func() {
+			common.MemoryCacheEnabled = originalMemoryCacheEnabled
+		}()
+		channelIDs := []int{channels[0].Id, channels[1].Id}
+		require.NoError(t, DB.Where("channel_id IN ?", channelIDs).Delete(&Ability{}).Error)
+		require.NoError(t, DB.Where("id IN ?", channelIDs).Delete(&Channel{}).Error)
+		common.MemoryCacheEnabled = true
+		InitChannelCache()
+	})
+
+	for _, channel := range channels {
+		require.NoError(t, DB.Create(channel).Error)
+		require.NoError(t, channel.AddAbilities(nil))
+	}
+
+	testCases := []struct {
+		name               string
+		memoryCacheEnabled bool
+	}{
+		{name: "database", memoryCacheEnabled: false},
+		{name: "memory cache", memoryCacheEnabled: true},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			common.MemoryCacheEnabled = testCase.memoryCacheEnabled
+			if testCase.memoryCacheEnabled {
+				InitChannelCache()
+			}
+
+			selected, err := GetRandomSatisfiedChannel(groupName, modelName, 0, "")
+			require.NoError(t, err)
+			require.NotNil(t, selected)
+			assert.Equal(t, channels[0].Id, selected.Id)
+		})
+	}
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

> [!NOTE]
>
> AI 辅助说明：本 PR 的代码与说明由 AI 编程助手协助生成，并由提交者授权提交，请按常规标准审阅。

## 📝 变更描述 / Description
数据库选路当前使用 `weight + 10` 和闭区间边界，而内存缓存选路使用原始 `weight` 和半开区间，导致相同渠道配置因缓存开关不同而产生不同流量比例。

本 PR 将两条路径收敛到同一个加权选择 helper：

- 候选总权重大于 0 时，直接按原始权重构造 `[0, totalWeight)` 区间。
- 所有权重为 0 时，每个候选获得一个等长区间。
- 部分权重为 0 时，零权重候选不获得选择区间。
- 使用同一半开区间判断，消除数据库路径原有的首项多一个随机值、末项少一个随机值的问题。

该变更只调整渠道选择算法，不修改现有渠道配置、优先级、分组或缓存设置。

> [!WARNING]
>
> 升级提示：如果某个同优先级渠道池同时包含正权重与零权重渠道，修复后零权重渠道将不再接收新流量。过去依赖零权重渠道仍获得少量流量的部署，应在升级前显式调整对应权重。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6510
- Nexus 跟踪项：https://github.com/NexusAgentX/new-api/issues/34

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
以下检查均在最新 `main@66ee6b8f` 的 PR 分支上通过：

```text
go test ./model
go test -race ./model
go test ./...
cd web && DISABLE_ESLINT_PLUGIN=true VITE_REACT_APP_VERSION=$(cat ../VERSION) bun run build
```

确定性测试直接验证选择区间：

```text
weights [2, 1]    -> draws 0,1 select index 0; draw 2 selects index 1
weights [0, 0, 0] -> draws 0,1,2 分别选择三个候选
weights [0, 1, 0] -> 唯一 draw 0 只选择正权重候选
```

另有集成测试分别关闭和开启 `MemoryCacheEnabled`，确认 `1:0` 候选集在数据库与内存缓存路径下都只选择权重为 1 的渠道。
