### PR TITLE
fix(rate-limit): return structured JSON for 429 responses

### DIFF
--- a/i18n/keys.go
+++ b/i18n/keys.go
@@ -234,6 +234,7 @@ const (
 
 // Rate limit related messages
 const (
+	MsgRateLimitExceeded     = "rate_limit.exceeded"
 	MsgRateLimitReached      = "rate_limit.reached"
 	MsgRateLimitTotalReached = "rate_limit.total_reached"
 )

--- a/i18n/locales/en.yaml
+++ b/i18n/locales/en.yaml
@@ -198,6 +198,7 @@ twofa.record_id_empty: "2FA record ID cannot be empty"
 twofa.code_invalid: "Verification code or backup code is incorrect"
 
 # Rate limit messages
+rate_limit.exceeded: "Too many requests. Please try again later."
 rate_limit.reached: "You have reached the request limit: maximum {{.Max}} requests in {{.Minutes}} minutes"
 rate_limit.total_reached: "You have reached the total request limit: maximum {{.Max}} requests in {{.Minutes}} minutes, including failed attempts"
 

--- a/i18n/locales/zh-CN.yaml
+++ b/i18n/locales/zh-CN.yaml
@@ -199,6 +199,7 @@ twofa.record_id_empty: "2FA记录ID不能为空"
 twofa.code_invalid: "验证码或备用码不正确"
 
 # Rate limit messages
+rate_limit.exceeded: "请求过于频繁，请稍后再试"
 rate_limit.reached: "您已达到请求数限制：{{.Minutes}}分钟内最多请求{{.Max}}次"
 rate_limit.total_reached: "您已达到总请求数限制：{{.Minutes}}分钟内最多请求{{.Max}}次，包括失败次数"
 

--- a/i18n/locales/zh-TW.yaml
+++ b/i18n/locales/zh-TW.yaml
@@ -199,6 +199,7 @@ twofa.record_id_empty: "2FA記錄ID不能為空"
 twofa.code_invalid: "驗證碼或備用碼不正確"
 
 # Rate limit messages
+rate_limit.exceeded: "請求過於頻繁，請稍後再試"
 rate_limit.reached: "您已達到請求數限制：{{.Minutes}}分鐘內最多請求{{.Max}}次"
 rate_limit.total_reached: "您已達到總請求數限制：{{.Minutes}}分鐘內最多請求{{.Max}}次，包括失敗次數"
 

--- a/middleware/rate-limit.go
+++ b/middleware/rate-limit.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/logger"
 	"github.com/gin-gonic/gin"
 )
@@ -132,16 +133,18 @@ func memoryRateLimiter(c *gin.Context, maxRequestNum int, duration int64, mark s
 	}
 }
 
-// writeRateLimited rejects the request with 429 and a Retry-After hint so
-// clients can back off instead of treating the rejection as a fatal error.
+// writeRateLimited rejects the request with a structured 429 response and a
+// Retry-After hint so clients can report the error and back off safely.
 // The in-memory limiter cannot report the remaining window, so callers
 // without a TTL pass the full window duration as a conservative upper bound.
 func writeRateLimited(c *gin.Context, retryAfterSeconds int64) {
 	if retryAfterSeconds > 0 {
 		c.Header("Retry-After", strconv.FormatInt(retryAfterSeconds, 10))
 	}
-	c.Status(http.StatusTooManyRequests)
-	c.Abort()
+	c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+		"success": false,
+		"message": common.TranslateMessage(c, i18n.MsgRateLimitExceeded),
+	})
 }
 
 func rateLimitFactory(maxRequestNum int, duration int64, mark string) func(c *gin.Context) {

--- a/middleware/rate-limit.go
+++ b/middleware/rate-limit.go
@@ -125,6 +125,7 @@ func redisRateLimiter(c *gin.Context, maxRequestNum int, duration int64, mark st
 	}
 }
 
+// memoryRateLimiter enforces an IP-based limit using process-local state.
 func memoryRateLimiter(c *gin.Context, maxRequestNum int, duration int64, mark string) {
 	key := mark + c.ClientIP()
 	if !inMemoryRateLimiter.Request(key, maxRequestNum, duration) {
@@ -147,6 +148,7 @@ func writeRateLimited(c *gin.Context, retryAfterSeconds int64) {
 	})
 }
 
+// rateLimitFactory selects the configured backend for an IP-based rate limiter.
 func rateLimitFactory(maxRequestNum int, duration int64, mark string) func(c *gin.Context) {
 	if common.RedisEnabled {
 		return func(c *gin.Context) {

--- a/middleware/rate_limit_test.go
+++ b/middleware/rate_limit_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
 	"github.com/alicebob/miniredis/v2"
 	"github.com/gin-gonic/gin"
 	"github.com/go-redis/redis/v8"
@@ -45,18 +46,31 @@ func performRateLimitRequest(router http.Handler, path string, remoteAddr string
 	return recorder
 }
 
-func TestRedisIPRateLimiterThresholdTTLAndNamespace(t *testing.T) {
+func TestRedisCriticalRateLimiterReturnsJSONWithRetryAfter(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	require.NoError(t, i18n.Init())
 	redisServer, _ := useRateLimitMiniRedis(t)
+
+	previousEnabled := common.CriticalRateLimitEnable
+	previousMaxRequests := common.CriticalRateLimitNum
+	previousDuration := common.CriticalRateLimitDuration
+	common.CriticalRateLimitEnable = true
+	common.CriticalRateLimitNum = 2
+	common.CriticalRateLimitDuration = 37
+	t.Cleanup(func() {
+		common.CriticalRateLimitEnable = previousEnabled
+		common.CriticalRateLimitNum = previousMaxRequests
+		common.CriticalRateLimitDuration = previousDuration
+	})
 
 	router := gin.New()
 	require.NoError(t, router.SetTrustedProxies(nil))
-	router.GET("/limited", rateLimitFactory(2, 37, "TEST"), func(c *gin.Context) {
+	router.GET("/limited", CriticalRateLimit(), func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
 	})
 
 	remoteAddr := "192.0.2.10:12345"
-	legacyKey := "rateLimit:TEST192.0.2.10"
+	legacyKey := "rateLimit:CT192.0.2.10"
 	_, err := redisServer.Push(legacyKey, "legacy-list-entry")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, performRateLimitRequest(router, "/limited", remoteAddr).Code)
@@ -64,8 +78,10 @@ func TestRedisIPRateLimiterThresholdTTLAndNamespace(t *testing.T) {
 	limitedResponse := performRateLimitRequest(router, "/limited", remoteAddr)
 	assert.Equal(t, http.StatusTooManyRequests, limitedResponse.Code)
 	assert.Equal(t, "37", limitedResponse.Header().Get("Retry-After"))
+	assert.Equal(t, "application/json; charset=utf-8", limitedResponse.Header().Get("Content-Type"))
+	assert.JSONEq(t, `{"success":false,"message":"Too many requests. Please try again later."}`, limitedResponse.Body.String())
 
-	key := redisIPRateLimitKey("TEST", "192.0.2.10")
+	key := redisIPRateLimitKey("CT", "192.0.2.10")
 	count, err := redisServer.Get(key)
 	require.NoError(t, err)
 	assert.Equal(t, "3", count)

--- a/middleware/rate_limit_test.go
+++ b/middleware/rate_limit_test.go
@@ -21,6 +21,7 @@ import (
 
 var memoryCriticalRateLimitTestRun atomic.Uint64
 
+// useRateLimitMiniRedis configures an isolated Redis backend for rate-limit tests.
 func useRateLimitMiniRedis(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
 	t.Helper()
 
@@ -41,6 +42,7 @@ func useRateLimitMiniRedis(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
 	return redisServer, redisClient
 }
 
+// performRateLimitRequest records a GET request with a controlled client address.
 func performRateLimitRequest(router http.Handler, path string, remoteAddr string) *httptest.ResponseRecorder {
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodGet, path, nil)
@@ -49,6 +51,7 @@ func performRateLimitRequest(router http.Handler, path string, remoteAddr string
 	return recorder
 }
 
+// TestMemoryCriticalRateLimiterReturnsJSONWithRetryAfter verifies the in-memory 429 response contract.
 func TestMemoryCriticalRateLimiterReturnsJSONWithRetryAfter(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	require.NoError(t, i18n.Init())
@@ -85,6 +88,7 @@ func TestMemoryCriticalRateLimiterReturnsJSONWithRetryAfter(t *testing.T) {
 	assert.JSONEq(t, `{"success":false,"message":"Too many requests. Please try again later."}`, limitedResponse.Body.String())
 }
 
+// TestRedisCriticalRateLimiterReturnsJSONWithRetryAfter verifies the Redis-backed 429 response contract.
 func TestRedisCriticalRateLimiterReturnsJSONWithRetryAfter(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	require.NoError(t, i18n.Init())

--- a/middleware/rate_limit_test.go
+++ b/middleware/rate_limit_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -17,6 +18,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var memoryCriticalRateLimitTestRun atomic.Uint64
 
 func useRateLimitMiniRedis(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
 	t.Helper()
@@ -44,6 +47,42 @@ func performRateLimitRequest(router http.Handler, path string, remoteAddr string
 	request.RemoteAddr = remoteAddr
 	router.ServeHTTP(recorder, request)
 	return recorder
+}
+
+func TestMemoryCriticalRateLimiterReturnsJSONWithRetryAfter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	require.NoError(t, i18n.Init())
+
+	previousRedisEnabled := common.RedisEnabled
+	previousEnabled := common.CriticalRateLimitEnable
+	previousMaxRequests := common.CriticalRateLimitNum
+	previousDuration := common.CriticalRateLimitDuration
+	common.RedisEnabled = false
+	common.CriticalRateLimitEnable = true
+	common.CriticalRateLimitNum = 2
+	common.CriticalRateLimitDuration = 43
+	t.Cleanup(func() {
+		common.RedisEnabled = previousRedisEnabled
+		common.CriticalRateLimitEnable = previousEnabled
+		common.CriticalRateLimitNum = previousMaxRequests
+		common.CriticalRateLimitDuration = previousDuration
+	})
+
+	router := gin.New()
+	require.NoError(t, router.SetTrustedProxies(nil))
+	router.GET("/limited", CriticalRateLimit(), func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	runID := memoryCriticalRateLimitTestRun.Add(1)
+	remoteAddr := fmt.Sprintf("[2001:db8::%x]:12345", runID)
+	assert.Equal(t, http.StatusNoContent, performRateLimitRequest(router, "/limited", remoteAddr).Code)
+	assert.Equal(t, http.StatusNoContent, performRateLimitRequest(router, "/limited", remoteAddr).Code)
+	limitedResponse := performRateLimitRequest(router, "/limited", remoteAddr)
+	assert.Equal(t, http.StatusTooManyRequests, limitedResponse.Code)
+	assert.Equal(t, "43", limitedResponse.Header().Get("Retry-After"))
+	assert.Equal(t, "application/json; charset=utf-8", limitedResponse.Header().Get("Content-Type"))
+	assert.JSONEq(t, `{"success":false,"message":"Too many requests. Please try again later."}`, limitedResponse.Body.String())
 }
 
 func TestRedisCriticalRateLimiterReturnsJSONWithRetryAfter(t *testing.T) {


### PR DESCRIPTION


## 📝 变更描述 / Description

通用限流中间件的 `writeRateLimited` 当前只返回 HTTP 429 和 `Retry-After`，响应体为空。浏览器/API 客户端若按 JSON 解析错误响应，会得到二次解析错误，无法向用户展示真正的限流原因。

本 PR 保留现有状态码和 `Retry-After` 行为，同时返回 dashboard API 已使用的稳定 JSON 结构：

```json
{
  "success": false,
  "message": "Too many requests. Please try again later."
}
```

错误消息通过现有后端 i18n 机制支持英文、简体中文和繁体中文。该修复同时覆盖 Redis 与内存后端，以及共用 `writeRateLimited` 的 Global Web/API、Critical、Download、Upload 和 Search 限流。

This is intentionally separate from #6528: that PR fixes the model-specific in-memory limiter, while this PR fixes the shared IP/user limiter response used by `CriticalRateLimit` and the other generic rate-limit middleware.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Related issue: #6361
- Related PR: #6528

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```text
$ go test ./middleware ./i18n -count=1
ok      github.com/QuantumNous/new-api/middleware
?       github.com/QuantumNous/new-api/i18n    [no test files]

$ go vet ./middleware ./i18n
# passed

$ git diff --check
# passed
```

回归测试验证：

- 第三个 Redis 限流请求返回 HTTP 429；
- 保留精确的 `Retry-After`；
- `Content-Type` 为 JSON；
- 响应体包含 `success: false` 和可读、可本地化的 `message`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate-limit responses now return structured JSON with localized error messages.
  * Added English, Simplified Chinese, and Traditional Chinese translations for rate-limit errors.
  * The existing `Retry-After` header continues to provide retry guidance.

* **Bug Fixes**
  * Improved clarity and consistency when request limits are exceeded.
  * Rate-limit messages now clearly advise trying again later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->