### PR TITLE
fix: sync reasoning effort after parameter overrides

### DIFF
--- a/relay/common/override.go
+++ b/relay/common/override.go
@@ -213,6 +213,7 @@ func syncReasoningEffort(info *RelayInfo, jsonData []byte) {
 	if info == nil {
 		return
 	}
+	info.ReasoningEffort = ""
 
 	for _, path := range []string{"reasoning.effort", "reasoning_effort"} {
 		value := gjson.GetBytes(jsonData, path)
@@ -221,8 +222,6 @@ func syncReasoningEffort(info *RelayInfo, jsonData []byte) {
 		}
 		if value.Type == gjson.String {
 			info.ReasoningEffort = value.String()
-		} else {
-			info.ReasoningEffort = ""
 		}
 		return
 	}

--- a/relay/common/override.go
+++ b/relay/common/override.go
@@ -30,6 +30,8 @@ var paramOverrideSensitivePathPrefixes = []string{
 	"model",
 	"original_model",
 	"upstream_model",
+	"reasoning",
+	"reasoning_effort",
 	"service_tier",
 	"inference_geo",
 	"speed",
@@ -191,6 +193,7 @@ func ApplyParamOverrideWithRelayInfo(jsonData []byte, info *RelayInfo) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
+	syncReasoningEffort(info, result)
 	syncRuntimeHeaderOverrideFromContext(info, overrideCtx)
 	if info != nil {
 		if recorder != nil {
@@ -200,6 +203,29 @@ func ApplyParamOverrideWithRelayInfo(jsonData []byte, info *RelayInfo) ([]byte, 
 		}
 	}
 	return result, nil
+}
+
+// syncReasoningEffort keeps request metadata aligned with the final outbound
+// body after parameter overrides have been applied. Adapters populate this
+// field before overrides run, so reading the final JSON prevents logs from
+// reporting the pre-override effort.
+func syncReasoningEffort(info *RelayInfo, jsonData []byte) {
+	if info == nil {
+		return
+	}
+
+	for _, path := range []string{"reasoning.effort", "reasoning_effort"} {
+		value := gjson.GetBytes(jsonData, path)
+		if !value.Exists() {
+			continue
+		}
+		if value.Type == gjson.String {
+			info.ReasoningEffort = value.String()
+		} else {
+			info.ReasoningEffort = ""
+		}
+		return
+	}
 }
 
 func shouldEnableParamOverrideAudit(paramOverride map[string]interface{}) bool {

--- a/relay/common/override_test.go
+++ b/relay/common/override_test.go
@@ -2153,6 +2153,79 @@ func TestApplyParamOverrideWithRelayInfoRecordsOperationAuditInDebugMode(t *test
 	}
 }
 
+func TestApplyParamOverrideWithRelayInfoSyncsResponsesReasoningEffort(t *testing.T) {
+	originalDebugEnabled := common2.DebugEnabled
+	common2.DebugEnabled = false
+	t.Cleanup(func() {
+		common2.DebugEnabled = originalDebugEnabled
+	})
+
+	info := &RelayInfo{
+		ReasoningEffort: "high",
+		ChannelMeta: &ChannelMeta{
+			ParamOverride: map[string]interface{}{
+				"operations": []interface{}{
+					map[string]interface{}{
+						"mode":  "set",
+						"path":  "reasoning.effort",
+						"value": "max",
+					},
+				},
+			},
+		},
+	}
+
+	out, err := ApplyParamOverrideWithRelayInfo([]byte(`{
+		"model":"gpt-5.6-sol",
+		"reasoning":{"effort":"high"}
+	}`), info)
+	if err != nil {
+		t.Fatalf("ApplyParamOverrideWithRelayInfo returned error: %v", err)
+	}
+	assertJSONEqual(t, `{
+		"model":"gpt-5.6-sol",
+		"reasoning":{"effort":"max"}
+	}`, string(out))
+	if info.ReasoningEffort != "max" {
+		t.Fatalf("expected final reasoning effort max, got %q", info.ReasoningEffort)
+	}
+	if !reflect.DeepEqual(info.ParamOverrideAudit, []string{"set reasoning.effort = max"}) {
+		t.Fatalf("unexpected param override audit, got %#v", info.ParamOverrideAudit)
+	}
+}
+
+func TestApplyParamOverrideWithRelayInfoSyncsChatReasoningEffort(t *testing.T) {
+	info := &RelayInfo{
+		ReasoningEffort: "high",
+		ChannelMeta: &ChannelMeta{
+			ParamOverride: map[string]interface{}{
+				"operations": []interface{}{
+					map[string]interface{}{
+						"mode":  "set",
+						"path":  "reasoning_effort",
+						"value": "xhigh",
+					},
+				},
+			},
+		},
+	}
+
+	out, err := ApplyParamOverrideWithRelayInfo([]byte(`{
+		"model":"gpt-5.6-sol",
+		"reasoning_effort":"high"
+	}`), info)
+	if err != nil {
+		t.Fatalf("ApplyParamOverrideWithRelayInfo returned error: %v", err)
+	}
+	assertJSONEqual(t, `{
+		"model":"gpt-5.6-sol",
+		"reasoning_effort":"xhigh"
+	}`, string(out))
+	if info.ReasoningEffort != "xhigh" {
+		t.Fatalf("expected final reasoning effort xhigh, got %q", info.ReasoningEffort)
+	}
+}
+
 func TestApplyParamOverrideWithRelayInfoRecordsOnlyKeyOperationsWhenDebugDisabled(t *testing.T) {
 	originalDebugEnabled := common2.DebugEnabled
 	common2.DebugEnabled = false

--- a/relay/common/override_test.go
+++ b/relay/common/override_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/QuantumNous/new-api/setting/model_setting"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -2179,22 +2180,49 @@ func TestApplyParamOverrideWithRelayInfoSyncsResponsesReasoningEffort(t *testing
 		"model":"gpt-5.6-sol",
 		"reasoning":{"effort":"high"}
 	}`), info)
-	if err != nil {
-		t.Fatalf("ApplyParamOverrideWithRelayInfo returned error: %v", err)
-	}
+	require.NoError(t, err)
 	assertJSONEqual(t, `{
 		"model":"gpt-5.6-sol",
 		"reasoning":{"effort":"max"}
 	}`, string(out))
-	if info.ReasoningEffort != "max" {
-		t.Fatalf("expected final reasoning effort max, got %q", info.ReasoningEffort)
+	assert.Equal(t, "max", info.ReasoningEffort)
+	assert.Equal(t, []string{"set reasoning.effort = max"}, info.ParamOverrideAudit)
+}
+
+func TestApplyParamOverrideWithRelayInfoClearsRemovedReasoningEffort(t *testing.T) {
+	info := &RelayInfo{
+		ReasoningEffort: "high",
+		ChannelMeta: &ChannelMeta{
+			ParamOverride: map[string]interface{}{
+				"operations": []interface{}{
+					map[string]interface{}{
+						"mode": "delete",
+						"path": "reasoning.effort",
+					},
+				},
+			},
+		},
 	}
-	if !reflect.DeepEqual(info.ParamOverrideAudit, []string{"set reasoning.effort = max"}) {
-		t.Fatalf("unexpected param override audit, got %#v", info.ParamOverrideAudit)
-	}
+
+	out, err := ApplyParamOverrideWithRelayInfo([]byte(`{
+		"model":"gpt-5.6-sol",
+		"reasoning":{"effort":"high"}
+	}`), info)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"model":"gpt-5.6-sol",
+		"reasoning":{}
+	}`, string(out))
+	assert.Empty(t, info.ReasoningEffort)
 }
 
 func TestApplyParamOverrideWithRelayInfoSyncsChatReasoningEffort(t *testing.T) {
+	originalDebugEnabled := common2.DebugEnabled
+	common2.DebugEnabled = false
+	t.Cleanup(func() {
+		common2.DebugEnabled = originalDebugEnabled
+	})
+
 	info := &RelayInfo{
 		ReasoningEffort: "high",
 		ChannelMeta: &ChannelMeta{
@@ -2214,16 +2242,13 @@ func TestApplyParamOverrideWithRelayInfoSyncsChatReasoningEffort(t *testing.T) {
 		"model":"gpt-5.6-sol",
 		"reasoning_effort":"high"
 	}`), info)
-	if err != nil {
-		t.Fatalf("ApplyParamOverrideWithRelayInfo returned error: %v", err)
-	}
+	require.NoError(t, err)
 	assertJSONEqual(t, `{
 		"model":"gpt-5.6-sol",
 		"reasoning_effort":"xhigh"
 	}`, string(out))
-	if info.ReasoningEffort != "xhigh" {
-		t.Fatalf("expected final reasoning effort xhigh, got %q", info.ReasoningEffort)
-	}
+	assert.Equal(t, "xhigh", info.ReasoningEffort)
+	assert.Equal(t, []string{"set reasoning_effort = xhigh"}, info.ParamOverrideAudit)
 }
 
 func TestApplyParamOverrideWithRelayInfoRecordsOnlyKeyOperationsWhenDebugDisabled(t *testing.T) {


### PR DESCRIPTION
## Problem

Parameter overrides can change the outbound reasoning setting after the adapter has populated RelayInfo.ReasoningEffort. Usage logs then report the stale pre-override value, and reasoning override operations are omitted from the parameter-override audit.

## Fix

- Synchronize RelayInfo.ReasoningEffort from the final outbound JSON for both Responses (reasoning.effort) and Chat Completions (reasoning_effort).
- Include reasoning paths in the sensitive audit path list.
- Add regression tests for both request formats and audit output.

This keeps the displayed reasoning effort aligned with the request actually sent upstream without changing routing or persistence behavior.

## Verification

- go test ./relay/common
- go test ./relay/... ./service/...
- go test ./... (with the ignored web/dist/index.html build artifact supplied temporarily for the clone; all packages passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reasoning effort settings now stay synchronized when request parameters are overridden.
  * Supports both nested and top-level reasoning effort fields.
  * Invalid reasoning effort values are cleared to prevent stale settings.
  * Parameter override activity is audited even when debug mode is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->