### PR TITLE
feat: Sub2API-style in-place binary update (check / apply / rollback)

### DIFF
--- a/controller/system_update.go
+++ b/controller/system_update.go
@@ -1,0 +1,131 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/systemupdate"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	// Keep updater version in sync with process version string.
+	systemupdate.CurrentVersion = common.Version
+}
+
+// systemUpdateTimeout bounds long-running download/replace operations.
+// Detached from the request context so proxy/browser timeouts do not cancel mid-download.
+const systemUpdateTimeout = 15 * time.Minute
+
+func systemUpdateContext(parent context.Context) (context.Context, context.CancelFunc) {
+	base := context.Background()
+	if parent != nil {
+		base = context.WithoutCancel(parent)
+	}
+	return context.WithTimeout(base, systemUpdateTimeout)
+}
+
+// CheckSystemUpdate GET /api/system-update/check
+func CheckSystemUpdate(c *gin.Context) {
+	force := c.Query("force") == "true"
+	info, err := systemupdate.GetSystemUpdateService().CheckUpdate(c.Request.Context(), force)
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	common.ApiSuccess(c, info)
+}
+
+// PerformSystemUpdate POST /api/system-update/apply
+func PerformSystemUpdate(c *gin.Context) {
+	ctx, cancel := systemUpdateContext(c.Request.Context())
+	defer cancel()
+
+	err := systemupdate.GetSystemUpdateService().PerformUpdate(ctx)
+	if err != nil {
+		if errors.Is(err, systemupdate.ErrNoUpdateAvailable) {
+			info, _ := systemupdate.GetSystemUpdateService().CheckUpdate(ctx, false)
+			current, latest := "", ""
+			if info != nil {
+				current, latest = info.CurrentVersion, info.LatestVersion
+			}
+			common.ApiSuccess(c, gin.H{
+				"message":            "Already up to date",
+				"already_up_to_date": true,
+				"need_restart":       false,
+				"current_version":    current,
+				"latest_version":     latest,
+			})
+			return
+		}
+		if errors.Is(err, systemupdate.ErrUpdateNotSupportedEnv) {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"success": false,
+				"message": err.Error() + "; for Docker: docker compose pull && docker compose up -d",
+			})
+			return
+		}
+		common.ApiError(c, err)
+		return
+	}
+	common.ApiSuccess(c, gin.H{
+		"message":      "Update completed. Please restart the new-api process to load the new binary.",
+		"need_restart": true,
+	})
+}
+
+// ListSystemRollbackVersions GET /api/system-update/rollback-versions
+func ListSystemRollbackVersions(c *gin.Context) {
+	versions, err := systemupdate.GetSystemUpdateService().ListRollbackVersions(c.Request.Context())
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	common.ApiSuccess(c, gin.H{"versions": versions})
+}
+
+// PerformSystemRollback POST /api/system-update/rollback
+// Body optional: {"version":"1.0.0"} to download a specific older release;
+// empty body restores the local .backup from the last update.
+func PerformSystemRollback(c *gin.Context) {
+	var req struct {
+		Version string `json:"version"`
+	}
+	if c.Request.ContentLength > 0 {
+		if err := c.ShouldBindJSON(&req); err != nil {
+			common.ApiErrorMsg(c, "invalid request body")
+			return
+		}
+	}
+	target := strings.TrimSpace(req.Version)
+
+	ctx, cancel := systemUpdateContext(c.Request.Context())
+	defer cancel()
+
+	var err error
+	if target != "" {
+		err = systemupdate.GetSystemUpdateService().RollbackToVersion(ctx, target)
+	} else {
+		err = systemupdate.GetSystemUpdateService().Rollback()
+	}
+	if err != nil {
+		if errors.Is(err, systemupdate.ErrUpdateNotSupportedEnv) ||
+			errors.Is(err, systemupdate.ErrRollbackVersionNotAllowed) ||
+			errors.Is(err, systemupdate.ErrNoBackupFound) {
+			c.JSON(http.StatusBadRequest, gin.H{"success": false, "message": err.Error()})
+			return
+		}
+		common.ApiError(c, err)
+		return
+	}
+	common.ApiSuccess(c, gin.H{
+		"message":      "Rollback completed. Please restart the new-api process.",
+		"need_restart": true,
+		"version":      target,
+	})
+}

--- a/controller/system_update.go
+++ b/controller/system_update.go
@@ -28,7 +28,8 @@ func systemUpdateContext(parent context.Context) (context.Context, context.Cance
 
 func syncUpdateVersion() {
 	// Must run after common.InitEnv() so VERSION env / build tags are final.
-	systemupdate.CurrentVersion = common.Version
+	// Concurrency-safe: handlers can call this in parallel without data races.
+	systemupdate.SetCurrentVersion(common.Version)
 }
 
 // CheckSystemUpdate GET /api/system-update/check

--- a/controller/system_update.go
+++ b/controller/system_update.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -12,11 +13,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 )
-
-func init() {
-	// Keep updater version in sync with process version string.
-	systemupdate.CurrentVersion = common.Version
-}
 
 // systemUpdateTimeout bounds long-running download/replace operations.
 // Detached from the request context so proxy/browser timeouts do not cancel mid-download.
@@ -30,8 +26,14 @@ func systemUpdateContext(parent context.Context) (context.Context, context.Cance
 	return context.WithTimeout(base, systemUpdateTimeout)
 }
 
+func syncUpdateVersion() {
+	// Must run after common.InitEnv() so VERSION env / build tags are final.
+	systemupdate.CurrentVersion = common.Version
+}
+
 // CheckSystemUpdate GET /api/system-update/check
 func CheckSystemUpdate(c *gin.Context) {
+	syncUpdateVersion()
 	force := c.Query("force") == "true"
 	info, err := systemupdate.GetSystemUpdateService().CheckUpdate(c.Request.Context(), force)
 	if err != nil {
@@ -43,6 +45,7 @@ func CheckSystemUpdate(c *gin.Context) {
 
 // PerformSystemUpdate POST /api/system-update/apply
 func PerformSystemUpdate(c *gin.Context) {
+	syncUpdateVersion()
 	ctx, cancel := systemUpdateContext(c.Request.Context())
 	defer cancel()
 
@@ -81,6 +84,7 @@ func PerformSystemUpdate(c *gin.Context) {
 
 // ListSystemRollbackVersions GET /api/system-update/rollback-versions
 func ListSystemRollbackVersions(c *gin.Context) {
+	syncUpdateVersion()
 	versions, err := systemupdate.GetSystemUpdateService().ListRollbackVersions(c.Request.Context())
 	if err != nil {
 		common.ApiError(c, err)
@@ -93,11 +97,14 @@ func ListSystemRollbackVersions(c *gin.Context) {
 // Body optional: {"version":"1.0.0"} to download a specific older release;
 // empty body restores the local .backup from the last update.
 func PerformSystemRollback(c *gin.Context) {
+	syncUpdateVersion()
 	var req struct {
 		Version string `json:"version"`
 	}
-	if c.Request.ContentLength > 0 {
-		if err := c.ShouldBindJSON(&req); err != nil {
+	// Do not gate on ContentLength: chunked bodies report -1 and would skip binding.
+	if err := c.ShouldBindJSON(&req); err != nil {
+		// Empty body is valid (rollback to local .backup).
+		if !errors.Is(err, io.EOF) && !isEmptyJSONBodyError(err) {
 			common.ApiErrorMsg(c, "invalid request body")
 			return
 		}
@@ -128,4 +135,14 @@ func PerformSystemRollback(c *gin.Context) {
 		"need_restart": true,
 		"version":      target,
 	})
+}
+
+func isEmptyJSONBodyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return msg == "EOF" ||
+		strings.Contains(msg, "unexpected end of JSON input") ||
+		strings.Contains(msg, "EOF")
 }

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -292,6 +292,16 @@ func SetApiRouter(router *gin.Engine) {
 			systemInfoRoute.DELETE("/stale-instances", controller.DeleteStaleSystemInstances)
 			systemInfoRoute.DELETE("/instances/:node_name", controller.DeleteStaleSystemInstance)
 		}
+		// In-place binary update (Sub2API-style). Root only.
+		// Docker deployments should continue to use image pull; apply returns 400 there.
+		systemUpdateRoute := apiRouter.Group("/system-update")
+		systemUpdateRoute.Use(middleware.RootAuth())
+		{
+			systemUpdateRoute.GET("/check", controller.CheckSystemUpdate)
+			systemUpdateRoute.POST("/apply", controller.PerformSystemUpdate)
+			systemUpdateRoute.GET("/rollback-versions", controller.ListSystemRollbackVersions)
+			systemUpdateRoute.POST("/rollback", controller.PerformSystemRollback)
+		}
 
 		dataRoute := apiRouter.Group("/data")
 		dataRoute.GET("/", middleware.AdminAuth(), controller.GetAllQuotaDates)

--- a/systemupdate/update.go
+++ b/systemupdate/update.go
@@ -1,0 +1,753 @@
+package systemupdate
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// CurrentVersion is the running binary version. Set it at process start
+// (e.g. from common.Version) before calling GetSystemUpdateService.
+var CurrentVersion = "v0.0.0"
+
+const (
+	defaultUpdateGitHubRepo = "Calcium-Ion/new-api"
+	maxUpdateDownloadSize   = 500 * 1024 * 1024
+	maxRollbackVersions     = 3
+	rollbackFetchPageSize   = 15
+	updateCacheTTL          = 20 * time.Minute
+	githubAPITimeout        = 30 * time.Second
+	githubDownloadTimeout   = 10 * time.Minute
+)
+
+var (
+	ErrNoUpdateAvailable         = errors.New("no update available; current version is latest")
+	ErrRollbackVersionNotAllowed = errors.New("version is not in the allowed rollback list")
+	ErrUpdateNotSupportedEnv     = errors.New("in-place binary update is not supported in this environment")
+	ErrNoBackupFound             = errors.New("no backup found")
+)
+
+// UpdateInfo is returned by the check-update API.
+type UpdateInfo struct {
+	CurrentVersion string       `json:"current_version"`
+	LatestVersion  string       `json:"latest_version"`
+	HasUpdate      bool         `json:"has_update"`
+	ReleaseInfo    *ReleaseInfo `json:"release_info,omitempty"`
+	Cached         bool         `json:"cached"`
+	Warning        string       `json:"warning,omitempty"`
+	// DeployMode: "binary" | "docker" | "unknown"
+	DeployMode string `json:"deploy_mode"`
+	// CanApply indicates whether PerformUpdate can replace the local binary.
+	CanApply bool `json:"can_apply"`
+}
+
+// ReleaseInfo holds GitHub release metadata for the UI.
+type ReleaseInfo struct {
+	Name        string         `json:"name"`
+	Body        string         `json:"body"`
+	PublishedAt string         `json:"published_at"`
+	HTMLURL     string         `json:"html_url"`
+	Assets      []ReleaseAsset `json:"assets,omitempty"`
+}
+
+// ReleaseAsset is a downloadable release file.
+type ReleaseAsset struct {
+	Name        string `json:"name"`
+	DownloadURL string `json:"download_url"`
+	Size        int64  `json:"size"`
+}
+
+// RollbackVersion describes an older release that can be re-installed.
+type RollbackVersion struct {
+	Version     string `json:"version"`
+	PublishedAt string `json:"published_at"`
+	HTMLURL     string `json:"html_url"`
+}
+
+type githubRelease struct {
+	TagName     string `json:"tag_name"`
+	Name        string `json:"name"`
+	Body        string `json:"body"`
+	PublishedAt string `json:"published_at"`
+	HTMLURL     string `json:"html_url"`
+	Draft       bool   `json:"draft"`
+	Prerelease  bool   `json:"prerelease"`
+	Assets      []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+		Size               int64  `json:"size"`
+	} `json:"assets"`
+}
+
+type updateCacheEntry struct {
+	info      *UpdateInfo
+	expiresAt time.Time
+}
+
+// SystemUpdateService implements in-place binary updates similar to Sub2API.
+type SystemUpdateService struct {
+	repo       string
+	token      string
+	apiClient  *http.Client
+	dlClient   *http.Client
+	cacheMu    sync.Mutex
+	cache      *updateCacheEntry
+	currentVer string
+}
+
+var defaultSystemUpdateService *SystemUpdateService
+var systemUpdateOnce sync.Once
+
+// GetSystemUpdateService returns the process-wide update service.
+func GetSystemUpdateService() *SystemUpdateService {
+	systemUpdateOnce.Do(func() {
+		repo := strings.TrimSpace(os.Getenv("NEW_API_UPDATE_GITHUB_REPO"))
+		if repo == "" {
+			repo = defaultUpdateGitHubRepo
+		}
+		defaultSystemUpdateService = &SystemUpdateService{
+			repo:  repo,
+			token: strings.TrimSpace(os.Getenv("UPDATE_GITHUB_TOKEN")),
+			apiClient: &http.Client{
+				Timeout: githubAPITimeout,
+			},
+			dlClient: &http.Client{
+				Timeout: githubDownloadTimeout,
+			},
+			currentVer: CurrentVersion,
+		}
+	})
+	return defaultSystemUpdateService
+}
+
+// DetectDeployMode returns binary / docker / unknown.
+func DetectDeployMode() string {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return "docker"
+	}
+	// cgroup hint (linux containers without /.dockerenv)
+	if data, err := os.ReadFile("/proc/1/cgroup"); err == nil {
+		content := string(data)
+		if strings.Contains(content, "docker") || strings.Contains(content, "kubepods") || strings.Contains(content, "containerd") {
+			return "docker"
+		}
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return "unknown"
+	}
+	// Running from go run / temp may not be a durable binary install.
+	if strings.Contains(exe, os.TempDir()) {
+		return "unknown"
+	}
+	return "binary"
+}
+
+// CheckUpdate fetches the latest GitHub release and compares with the running version.
+func (s *SystemUpdateService) CheckUpdate(ctx context.Context, force bool) (*UpdateInfo, error) {
+	if !force {
+		if cached := s.getCache(); cached != nil {
+			return cached, nil
+		}
+	}
+
+	info, err := s.fetchLatest(ctx)
+	if err != nil {
+		if cached := s.getCache(); cached != nil {
+			cloned := *cached
+			cloned.Warning = "Using cached data: " + err.Error()
+			return &cloned, nil
+		}
+		mode := DetectDeployMode()
+		return &UpdateInfo{
+			CurrentVersion: normalizeVersion(s.currentVer),
+			LatestVersion:  normalizeVersion(s.currentVer),
+			HasUpdate:      false,
+			Warning:        err.Error(),
+			DeployMode:     mode,
+			CanApply:       mode == "binary",
+		}, nil
+	}
+	s.setCache(info)
+	return info, nil
+}
+
+// PerformUpdate downloads and atomically replaces the running binary.
+func (s *SystemUpdateService) PerformUpdate(ctx context.Context) error {
+	if DetectDeployMode() != "binary" {
+		return fmt.Errorf("%w: deploy_mode=%s (use docker compose pull/up for containers)", ErrUpdateNotSupportedEnv, DetectDeployMode())
+	}
+	info, err := s.CheckUpdate(ctx, true)
+	if err != nil {
+		return err
+	}
+	if !info.HasUpdate {
+		return ErrNoUpdateAvailable
+	}
+	if info.ReleaseInfo == nil {
+		return errors.New("release info missing")
+	}
+	return s.applyAssets(ctx, info.ReleaseInfo.Assets, info.LatestVersion)
+}
+
+// Rollback restores the local .backup binary left by the last successful update.
+func (s *SystemUpdateService) Rollback() error {
+	if DetectDeployMode() != "binary" {
+		return fmt.Errorf("%w: deploy_mode=%s", ErrUpdateNotSupportedEnv, DetectDeployMode())
+	}
+	exePath, err := resolveExecutable()
+	if err != nil {
+		return err
+	}
+	backup := exePath + ".backup"
+	if _, err := os.Stat(backup); os.IsNotExist(err) {
+		return ErrNoBackupFound
+	}
+	// Swap: current -> .failed, backup -> current
+	failed := exePath + ".failed"
+	_ = os.Remove(failed)
+	if err := os.Rename(exePath, failed); err != nil {
+		return fmt.Errorf("backup current failed: %w", err)
+	}
+	if err := os.Rename(backup, exePath); err != nil {
+		_ = os.Rename(failed, exePath)
+		return fmt.Errorf("restore backup failed: %w", err)
+	}
+	_ = os.Remove(failed)
+	return nil
+}
+
+// ListRollbackVersions returns up to maxRollbackVersions older releases.
+func (s *SystemUpdateService) ListRollbackVersions(ctx context.Context) ([]RollbackVersion, error) {
+	releases, err := s.fetchRecent(ctx, rollbackFetchPageSize)
+	if err != nil {
+		return nil, err
+	}
+	current := normalizeVersion(s.currentVer)
+	seen := map[string]bool{}
+	out := make([]RollbackVersion, 0, maxRollbackVersions)
+	for _, r := range releases {
+		if r.Draft || r.Prerelease {
+			continue
+		}
+		v := normalizeVersion(r.TagName)
+		if v == "" || seen[v] || compareVersions(v, current) >= 0 {
+			continue
+		}
+		seen[v] = true
+		out = append(out, RollbackVersion{
+			Version:     v,
+			PublishedAt: r.PublishedAt,
+			HTMLURL:     r.HTMLURL,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return compareVersions(out[i].Version, out[j].Version) > 0
+	})
+	if len(out) > maxRollbackVersions {
+		out = out[:maxRollbackVersions]
+	}
+	return out, nil
+}
+
+// RollbackToVersion installs a specific older release binary.
+func (s *SystemUpdateService) RollbackToVersion(ctx context.Context, version string) error {
+	if DetectDeployMode() != "binary" {
+		return fmt.Errorf("%w: deploy_mode=%s", ErrUpdateNotSupportedEnv, DetectDeployMode())
+	}
+	target := normalizeVersion(version)
+	if target == "" {
+		return ErrRollbackVersionNotAllowed
+	}
+	allowed, err := s.ListRollbackVersions(ctx)
+	if err != nil {
+		return err
+	}
+	ok := false
+	for _, a := range allowed {
+		if a.Version == target {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return ErrRollbackVersionNotAllowed
+	}
+	// Fetch full release list to get assets for the target tag.
+	releases, err := s.fetchRecent(ctx, rollbackFetchPageSize)
+	if err != nil {
+		return err
+	}
+	for _, r := range releases {
+		if normalizeVersion(r.TagName) != target {
+			continue
+		}
+		assets := make([]ReleaseAsset, 0, len(r.Assets))
+		for _, a := range r.Assets {
+			assets = append(assets, ReleaseAsset{
+				Name:        a.Name,
+				DownloadURL: a.BrowserDownloadURL,
+				Size:        a.Size,
+			})
+		}
+		return s.applyAssets(ctx, assets, target)
+	}
+	return ErrRollbackVersionNotAllowed
+}
+
+func (s *SystemUpdateService) fetchLatest(ctx context.Context) (*UpdateInfo, error) {
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", s.repo)
+	var release githubRelease
+	if err := s.getJSON(ctx, apiURL, &release); err != nil {
+		return nil, err
+	}
+	return s.releaseToUpdateInfo(&release), nil
+}
+
+func (s *SystemUpdateService) fetchRecent(ctx context.Context, perPage int) ([]githubRelease, error) {
+	if perPage <= 0 {
+		perPage = 10
+	}
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/releases?per_page=%d", s.repo, perPage)
+	var releases []githubRelease
+	if err := s.getJSON(ctx, apiURL, &releases); err != nil {
+		return nil, err
+	}
+	return releases, nil
+}
+
+func (s *SystemUpdateService) releaseToUpdateInfo(release *githubRelease) *UpdateInfo {
+	latest := normalizeVersion(release.TagName)
+	current := normalizeVersion(s.currentVer)
+	assets := make([]ReleaseAsset, 0, len(release.Assets))
+	for _, a := range release.Assets {
+		assets = append(assets, ReleaseAsset{
+			Name:        a.Name,
+			DownloadURL: a.BrowserDownloadURL,
+			Size:        a.Size,
+		})
+	}
+	mode := DetectDeployMode()
+	return &UpdateInfo{
+		CurrentVersion: current,
+		LatestVersion:  latest,
+		HasUpdate:      compareVersions(current, latest) < 0,
+		ReleaseInfo: &ReleaseInfo{
+			Name:        release.Name,
+			Body:        release.Body,
+			PublishedAt: release.PublishedAt,
+			HTMLURL:     release.HTMLURL,
+			Assets:      assets,
+		},
+		Cached:     false,
+		DeployMode: mode,
+		CanApply:   mode == "binary",
+	}
+}
+
+func (s *SystemUpdateService) applyAssets(ctx context.Context, assets []ReleaseAsset, version string) error {
+	downloadURL, checksumURL, err := selectReleaseAsset(assets, version)
+	if err != nil {
+		return err
+	}
+	if err := validateGitHubDownloadURL(downloadURL); err != nil {
+		return err
+	}
+	if checksumURL != "" {
+		if err := validateGitHubDownloadURL(checksumURL); err != nil {
+			return err
+		}
+	}
+
+	exePath, err := resolveExecutable()
+	if err != nil {
+		return err
+	}
+	exeDir := filepath.Dir(exePath)
+
+	tempDir, err := os.MkdirTemp(exeDir, ".new-api-update-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	assetName := filepath.Base(downloadURL)
+	// strip query from URL path base
+	if u, err := url.Parse(downloadURL); err == nil {
+		assetName = filepath.Base(u.Path)
+	}
+	downloadPath := filepath.Join(tempDir, assetName)
+	if err := s.downloadFile(ctx, downloadURL, downloadPath); err != nil {
+		return fmt.Errorf("download failed: %w", err)
+	}
+	if checksumURL != "" {
+		if err := s.verifyChecksum(ctx, downloadPath, checksumURL); err != nil {
+			return fmt.Errorf("checksum verification failed: %w", err)
+		}
+	}
+
+	newBinary := filepath.Join(tempDir, "new-api-bin")
+	if err := os.Rename(downloadPath, newBinary); err != nil {
+		// cross-device unlikely in same dir; fall back to copy
+		if copyErr := copyFile(downloadPath, newBinary); copyErr != nil {
+			return fmt.Errorf("stage binary: %w", err)
+		}
+	}
+	if err := os.Chmod(newBinary, 0o755); err != nil {
+		return fmt.Errorf("chmod failed: %w", err)
+	}
+
+	backupPath := exePath + ".backup"
+	_ = os.Remove(backupPath)
+	if err := os.Rename(exePath, backupPath); err != nil {
+		return fmt.Errorf("backup failed: %w", err)
+	}
+	if err := os.Rename(newBinary, exePath); err != nil {
+		if restoreErr := os.Rename(backupPath, exePath); restoreErr != nil {
+			return fmt.Errorf("replace failed and restore failed: %w (restore: %v)", err, restoreErr)
+		}
+		return fmt.Errorf("replace failed (restored backup): %w", err)
+	}
+	return nil
+}
+
+func selectReleaseAsset(assets []ReleaseAsset, version string) (downloadURL, checksumURL string, err error) {
+	version = normalizeVersion(version)
+	// Prefer matching exact platform asset names from release.yml:
+	//   linux amd64: new-api-vX.Y.Z
+	//   linux arm64: new-api-arm64-vX.Y.Z
+	//   darwin:      new-api-macos-vX.Y.Z
+	//   windows:     new-api-vX.Y.Z.exe
+	wantNames := candidateAssetNames(version)
+	var checksumNames []string
+	switch runtime.GOOS {
+	case "linux":
+		checksumNames = []string{"checksums-linux.txt"}
+	case "darwin":
+		checksumNames = []string{"checksums-macos.txt"}
+	case "windows":
+		checksumNames = []string{"checksums-windows.txt"}
+	}
+
+	byName := map[string]ReleaseAsset{}
+	for _, a := range assets {
+		byName[a.Name] = a
+		if checksumURL == "" {
+			for _, cn := range checksumNames {
+				if a.Name == cn {
+					checksumURL = a.DownloadURL
+				}
+			}
+		}
+	}
+	for _, name := range wantNames {
+		if a, ok := byName[name]; ok {
+			return a.DownloadURL, checksumURL, nil
+		}
+	}
+	// Fuzzy fallback: match by platform keywords when version in filename differs slightly.
+	for _, a := range assets {
+		n := strings.ToLower(a.Name)
+		if strings.HasSuffix(n, ".txt") || strings.Contains(n, "checksum") {
+			continue
+		}
+		if assetMatchesPlatform(n) {
+			return a.DownloadURL, checksumURL, nil
+		}
+	}
+	return "", "", fmt.Errorf("no compatible release asset for %s/%s (looked for %v)", runtime.GOOS, runtime.GOARCH, wantNames)
+}
+
+func candidateAssetNames(version string) []string {
+	// VERSION in release.yml is git describe tags, usually with leading v.
+	tag := version
+	if !strings.HasPrefix(tag, "v") {
+		tag = "v" + tag
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if runtime.GOARCH == "arm64" {
+			return []string{"new-api-arm64-" + tag}
+		}
+		return []string{"new-api-" + tag}
+	case "darwin":
+		return []string{"new-api-macos-" + tag}
+	case "windows":
+		return []string{"new-api-" + tag + ".exe"}
+	default:
+		return []string{"new-api-" + tag}
+	}
+}
+
+func assetMatchesPlatform(nameLower string) bool {
+	switch runtime.GOOS {
+	case "linux":
+		if runtime.GOARCH == "arm64" {
+			return strings.Contains(nameLower, "arm64") && !strings.HasSuffix(nameLower, ".exe")
+		}
+		return strings.HasPrefix(nameLower, "new-api-") &&
+			!strings.Contains(nameLower, "arm64") &&
+			!strings.Contains(nameLower, "macos") &&
+			!strings.HasSuffix(nameLower, ".exe")
+	case "darwin":
+		return strings.Contains(nameLower, "macos")
+	case "windows":
+		return strings.HasSuffix(nameLower, ".exe")
+	default:
+		return false
+	}
+}
+
+func (s *SystemUpdateService) getJSON(ctx context.Context, apiURL string, dest any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "new-api-updater")
+	if s.token != "" {
+		req.Header.Set("Authorization", "Bearer "+s.token)
+	}
+	resp, err := s.apiClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return json.NewDecoder(resp.Body).Decode(dest)
+}
+
+func (s *SystemUpdateService) downloadFile(ctx context.Context, rawURL, dest string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "new-api-updater")
+	// Do not attach Authorization for asset CDN URLs.
+	resp, err := s.dlClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download status %d", resp.StatusCode)
+	}
+	if resp.ContentLength > maxUpdateDownloadSize {
+		return fmt.Errorf("file too large: %d", resp.ContentLength)
+	}
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	written, err := io.Copy(out, io.LimitReader(resp.Body, maxUpdateDownloadSize+1))
+	if err != nil {
+		return err
+	}
+	if written > maxUpdateDownloadSize {
+		return fmt.Errorf("file exceeds max size %d", maxUpdateDownloadSize)
+	}
+	return nil
+}
+
+func (s *SystemUpdateService) verifyChecksum(ctx context.Context, filePath, checksumURL string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, checksumURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "new-api-updater")
+	resp, err := s.apiClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("checksum download status %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	actual := hex.EncodeToString(h.Sum(nil))
+	fileName := filepath.Base(filePath)
+
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		parts := strings.Fields(scanner.Text())
+		if len(parts) >= 2 {
+			// sha256sum format: "<hash>  <filename>" or "<hash> *<filename>"
+			name := strings.TrimPrefix(parts[len(parts)-1], "*")
+			name = filepath.Base(name)
+			if name == fileName {
+				if parts[0] == actual {
+					return nil
+				}
+				return fmt.Errorf("checksum mismatch for %s", fileName)
+			}
+		}
+	}
+	// Checksum file present but entry missing: warn by soft-fail? Prefer hard fail for safety.
+	return fmt.Errorf("checksum not found for %s", fileName)
+}
+
+func (s *SystemUpdateService) getCache() *UpdateInfo {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	if s.cache == nil || time.Now().After(s.cache.expiresAt) {
+		return nil
+	}
+	cloned := *s.cache.info
+	cloned.Cached = true
+	return &cloned
+}
+
+func (s *SystemUpdateService) setCache(info *UpdateInfo) {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	cp := *info
+	s.cache = &updateCacheEntry{info: &cp, expiresAt: time.Now().Add(updateCacheTTL)}
+}
+
+func resolveExecutable() (string, error) {
+	exePath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("get executable: %w", err)
+	}
+	return filepath.EvalSymlinks(exePath)
+}
+
+func validateGitHubDownloadURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return errors.New("only HTTPS download URLs are allowed")
+	}
+	host := strings.ToLower(u.Host)
+	allowed := []string{
+		"github.com",
+		"objects.githubusercontent.com",
+		"release-assets.githubusercontent.com",
+	}
+	ok := false
+	for _, a := range allowed {
+		if host == a || strings.HasSuffix(host, "."+a) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("download from untrusted host: %s", host)
+	}
+	return nil
+}
+
+func normalizeVersion(v string) string {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	return v
+}
+
+// compareVersions compares semver-ish versions (supports -rc.N suffix roughly).
+// returns -1 if a<b, 0 if equal, 1 if a>b.
+func compareVersions(a, b string) int {
+	a = normalizeVersion(a)
+	b = normalizeVersion(b)
+	if a == b {
+		return 0
+	}
+	aMain, aPre := splitPreRelease(a)
+	bMain, bPre := splitPreRelease(b)
+	aParts := parseVersionParts(aMain)
+	bParts := parseVersionParts(bMain)
+	for i := 0; i < 3; i++ {
+		if aParts[i] < bParts[i] {
+			return -1
+		}
+		if aParts[i] > bParts[i] {
+			return 1
+		}
+	}
+	// release without prerelease is greater than with prerelease
+	if aPre == "" && bPre != "" {
+		return 1
+	}
+	if aPre != "" && bPre == "" {
+		return -1
+	}
+	if aPre < bPre {
+		return -1
+	}
+	if aPre > bPre {
+		return 1
+	}
+	return 0
+}
+
+func splitPreRelease(v string) (main, pre string) {
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		return v[:i], v[i+1:]
+	}
+	return v, ""
+}
+
+func parseVersionParts(v string) [3]int {
+	var out [3]int
+	parts := strings.Split(v, ".")
+	for i := 0; i < len(parts) && i < 3; i++ {
+		n := 0
+		for _, ch := range parts[i] {
+			if ch < '0' || ch > '9' {
+				break
+			}
+			n = n*10 + int(ch-'0')
+		}
+		out[i] = n
+	}
+	return out
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
+}

--- a/systemupdate/update.go
+++ b/systemupdate/update.go
@@ -107,12 +107,15 @@ type SystemUpdateService struct {
 	cacheMu    sync.Mutex
 	cache      *updateCacheEntry
 	currentVer string
+	// opMu serializes apply/rollback so concurrent renames cannot corrupt the binary.
+	opMu sync.Mutex
 }
 
 var defaultSystemUpdateService *SystemUpdateService
 var systemUpdateOnce sync.Once
 
 // GetSystemUpdateService returns the process-wide update service.
+// Set CurrentVersion (e.g. from common.Version after InitEnv) before calling handlers.
 func GetSystemUpdateService() *SystemUpdateService {
 	systemUpdateOnce.Do(func() {
 		repo := strings.TrimSpace(os.Getenv("NEW_API_UPDATE_GITHUB_REPO"))
@@ -131,6 +134,10 @@ func GetSystemUpdateService() *SystemUpdateService {
 			currentVer: CurrentVersion,
 		}
 	})
+	// Refresh on every access so post-InitEnv VERSION overrides are visible.
+	if v := strings.TrimSpace(CurrentVersion); v != "" {
+		defaultSystemUpdateService.currentVer = v
+	}
 	return defaultSystemUpdateService
 }
 
@@ -188,6 +195,9 @@ func (s *SystemUpdateService) CheckUpdate(ctx context.Context, force bool) (*Upd
 
 // PerformUpdate downloads and atomically replaces the running binary.
 func (s *SystemUpdateService) PerformUpdate(ctx context.Context) error {
+	s.opMu.Lock()
+	defer s.opMu.Unlock()
+
 	if DetectDeployMode() != "binary" {
 		return fmt.Errorf("%w: deploy_mode=%s (use docker compose pull/up for containers)", ErrUpdateNotSupportedEnv, DetectDeployMode())
 	}
@@ -206,6 +216,9 @@ func (s *SystemUpdateService) PerformUpdate(ctx context.Context) error {
 
 // Rollback restores the local .backup binary left by the last successful update.
 func (s *SystemUpdateService) Rollback() error {
+	s.opMu.Lock()
+	defer s.opMu.Unlock()
+
 	if DetectDeployMode() != "binary" {
 		return fmt.Errorf("%w: deploy_mode=%s", ErrUpdateNotSupportedEnv, DetectDeployMode())
 	}
@@ -266,6 +279,9 @@ func (s *SystemUpdateService) ListRollbackVersions(ctx context.Context) ([]Rollb
 
 // RollbackToVersion installs a specific older release binary.
 func (s *SystemUpdateService) RollbackToVersion(ctx context.Context, version string) error {
+	s.opMu.Lock()
+	defer s.opMu.Unlock()
+
 	if DetectDeployMode() != "binary" {
 		return fmt.Errorf("%w: deploy_mode=%s", ErrUpdateNotSupportedEnv, DetectDeployMode())
 	}
@@ -367,11 +383,6 @@ func (s *SystemUpdateService) applyAssets(ctx context.Context, assets []ReleaseA
 	if err := validateGitHubDownloadURL(downloadURL); err != nil {
 		return err
 	}
-	if checksumURL != "" {
-		if err := validateGitHubDownloadURL(checksumURL); err != nil {
-			return err
-		}
-	}
 
 	exePath, err := resolveExecutable()
 	if err != nil {
@@ -394,17 +405,22 @@ func (s *SystemUpdateService) applyAssets(ctx context.Context, assets []ReleaseA
 	if err := s.downloadFile(ctx, downloadURL, downloadPath); err != nil {
 		return fmt.Errorf("download failed: %w", err)
 	}
-	if checksumURL != "" {
-		if err := s.verifyChecksum(ctx, downloadPath, checksumURL); err != nil {
-			return fmt.Errorf("checksum verification failed: %w", err)
-		}
+	// Checksum is mandatory: never install an unverified binary.
+	if checksumURL == "" {
+		return errors.New("checksum file missing for this platform; refusing to install")
+	}
+	if err := validateGitHubDownloadURL(checksumURL); err != nil {
+		return err
+	}
+	if err := s.verifyChecksum(ctx, downloadPath, checksumURL); err != nil {
+		return fmt.Errorf("checksum verification failed: %w", err)
 	}
 
 	newBinary := filepath.Join(tempDir, "new-api-bin")
 	if err := os.Rename(downloadPath, newBinary); err != nil {
 		// cross-device unlikely in same dir; fall back to copy
 		if copyErr := copyFile(downloadPath, newBinary); copyErr != nil {
-			return fmt.Errorf("stage binary: %w", err)
+			return fmt.Errorf("stage binary: %w", copyErr)
 		}
 	}
 	if err := os.Chmod(newBinary, 0o755); err != nil {
@@ -459,10 +475,20 @@ func selectReleaseAsset(assets []ReleaseAsset, version string) (downloadURL, che
 			return a.DownloadURL, checksumURL, nil
 		}
 	}
-	// Fuzzy fallback: match by platform keywords when version in filename differs slightly.
+	// Restricted fuzzy fallback: must include the target version tag AND match platform.
+	// Avoids picking an unrelated OS/arch asset when the exact filename differs slightly.
+	tag := version
+	if !strings.HasPrefix(tag, "v") {
+		tag = "v" + tag
+	}
+	tagLower := strings.ToLower(tag)
+	verLower := strings.ToLower(version)
 	for _, a := range assets {
 		n := strings.ToLower(a.Name)
 		if strings.HasSuffix(n, ".txt") || strings.Contains(n, "checksum") {
+			continue
+		}
+		if !strings.Contains(n, tagLower) && !strings.Contains(n, verLower) {
 			continue
 		}
 		if assetMatchesPlatform(n) {
@@ -556,13 +582,21 @@ func (s *SystemUpdateService) downloadFile(ctx context.Context, rawURL, dest str
 	if err != nil {
 		return err
 	}
-	defer out.Close()
 	written, err := io.Copy(out, io.LimitReader(resp.Body, maxUpdateDownloadSize+1))
 	if err != nil {
+		_ = out.Close()
 		return err
 	}
 	if written > maxUpdateDownloadSize {
+		_ = out.Close()
 		return fmt.Errorf("file exceeds max size %d", maxUpdateDownloadSize)
+	}
+	if err := out.Sync(); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("sync download: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close download: %w", err)
 	}
 	return nil
 }
@@ -703,13 +737,64 @@ func compareVersions(a, b string) int {
 	if aPre != "" && bPre == "" {
 		return -1
 	}
-	if aPre < bPre {
-		return -1
+	return comparePreRelease(aPre, bPre)
+}
+
+// comparePreRelease compares identifiers like "rc.9" vs "rc.10" numerically per dot segment.
+func comparePreRelease(a, b string) int {
+	if a == b {
+		return 0
 	}
-	if aPre > bPre {
-		return 1
+	as := strings.Split(a, ".")
+	bs := strings.Split(b, ".")
+	n := len(as)
+	if len(bs) > n {
+		n = len(bs)
+	}
+	for i := 0; i < n; i++ {
+		var ap, bp string
+		if i < len(as) {
+			ap = as[i]
+		}
+		if i < len(bs) {
+			bp = bs[i]
+		}
+		an, aNum := parseLeadingInt(ap)
+		bn, bNum := parseLeadingInt(bp)
+		if aNum && bNum {
+			if an < bn {
+				return -1
+			}
+			if an > bn {
+				return 1
+			}
+			// equal numeric prefix: compare remainder as string if any
+			continue
+		}
+		if ap < bp {
+			return -1
+		}
+		if ap > bp {
+			return 1
+		}
 	}
 	return 0
+}
+
+func parseLeadingInt(s string) (int, bool) {
+	if s == "" {
+		return 0, true
+	}
+	n := 0
+	ok := false
+	for _, ch := range s {
+		if ch < '0' || ch > '9' {
+			return n, ok
+		}
+		ok = true
+		n = n*10 + int(ch-'0')
+	}
+	return n, ok
 }
 
 func splitPreRelease(v string) (main, pre string) {

--- a/systemupdate/update.go
+++ b/systemupdate/update.go
@@ -134,11 +134,25 @@ func GetSystemUpdateService() *SystemUpdateService {
 			currentVer: CurrentVersion,
 		}
 	})
-	// Refresh on every access so post-InitEnv VERSION overrides are visible.
+	// Refresh under cacheMu so concurrent checks cannot race with version/cache reads.
+	// Invalidate cache when the version changes so HasUpdate is not stale.
 	if v := strings.TrimSpace(CurrentVersion); v != "" {
-		defaultSystemUpdateService.currentVer = v
+		s := defaultSystemUpdateService
+		s.cacheMu.Lock()
+		if s.currentVer != v {
+			s.currentVer = v
+			s.cache = nil
+		}
+		s.cacheMu.Unlock()
 	}
 	return defaultSystemUpdateService
+}
+
+// currentVersion returns the service's running version under cacheMu.
+func (s *SystemUpdateService) currentVersion() string {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	return s.currentVer
 }
 
 // DetectDeployMode returns binary / docker / unknown.
@@ -180,9 +194,10 @@ func (s *SystemUpdateService) CheckUpdate(ctx context.Context, force bool) (*Upd
 			return &cloned, nil
 		}
 		mode := DetectDeployMode()
+		cur := normalizeVersion(s.currentVersion())
 		return &UpdateInfo{
-			CurrentVersion: normalizeVersion(s.currentVer),
-			LatestVersion:  normalizeVersion(s.currentVer),
+			CurrentVersion: cur,
+			LatestVersion:  cur,
 			HasUpdate:      false,
 			Warning:        err.Error(),
 			DeployMode:     mode,
@@ -250,7 +265,7 @@ func (s *SystemUpdateService) ListRollbackVersions(ctx context.Context) ([]Rollb
 	if err != nil {
 		return nil, err
 	}
-	current := normalizeVersion(s.currentVer)
+	current := normalizeVersion(s.currentVersion())
 	seen := map[string]bool{}
 	out := make([]RollbackVersion, 0, maxRollbackVersions)
 	for _, r := range releases {
@@ -348,7 +363,7 @@ func (s *SystemUpdateService) fetchRecent(ctx context.Context, perPage int) ([]g
 
 func (s *SystemUpdateService) releaseToUpdateInfo(release *githubRelease) *UpdateInfo {
 	latest := normalizeVersion(release.TagName)
-	current := normalizeVersion(s.currentVer)
+	current := normalizeVersion(s.currentVersion())
 	assets := make([]ReleaseAsset, 0, len(release.Assets))
 	for _, a := range release.Assets {
 		assets = append(assets, ReleaseAsset{
@@ -557,6 +572,8 @@ func (s *SystemUpdateService) getJSON(ctx context.Context, apiURL string, dest a
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		return fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
+	// Keep stdlib decoder: importing common/json pulls a large dependency graph
+	// into this package for no behavioral difference (DecodeJson is a thin wrap).
 	return json.NewDecoder(resp.Body).Decode(dest)
 }
 
@@ -740,7 +757,12 @@ func compareVersions(a, b string) int {
 	return comparePreRelease(aPre, bPre)
 }
 
-// comparePreRelease compares identifiers like "rc.9" vs "rc.10" numerically per dot segment.
+// comparePreRelease implements SemVer 2.0.0 prerelease precedence:
+// - identifiers separated by dots
+// - numeric identifiers (all digits) compare numerically (no int conversion)
+// - numeric identifiers have lower precedence than non-numeric
+// - non-numeric compare lexically in ASCII order
+// - when all shared identifiers are equal, the shorter set has lower precedence
 func comparePreRelease(a, b string) int {
 	if a == b {
 		return 0
@@ -748,53 +770,75 @@ func comparePreRelease(a, b string) int {
 	as := strings.Split(a, ".")
 	bs := strings.Split(b, ".")
 	n := len(as)
-	if len(bs) > n {
+	if len(bs) < n {
 		n = len(bs)
 	}
 	for i := 0; i < n; i++ {
-		var ap, bp string
-		if i < len(as) {
-			ap = as[i]
-		}
-		if i < len(bs) {
-			bp = bs[i]
-		}
-		an, aNum := parseLeadingInt(ap)
-		bn, bNum := parseLeadingInt(bp)
-		if aNum && bNum {
-			if an < bn {
+		ap, bp := as[i], bs[i]
+		aNum := isNumericIdent(ap)
+		bNum := isNumericIdent(bp)
+		switch {
+		case aNum && bNum:
+			if c := compareNumericIdent(ap, bp); c != 0 {
+				return c
+			}
+		case aNum && !bNum:
+			return -1
+		case !aNum && bNum:
+			return 1
+		default:
+			if ap < bp {
 				return -1
 			}
-			if an > bn {
+			if ap > bp {
 				return 1
 			}
-			// equal numeric prefix: compare remainder as string if any
-			continue
 		}
-		if ap < bp {
-			return -1
-		}
-		if ap > bp {
-			return 1
-		}
+	}
+	if len(as) < len(bs) {
+		return -1
+	}
+	if len(as) > len(bs) {
+		return 1
 	}
 	return 0
 }
 
-func parseLeadingInt(s string) (int, bool) {
+func isNumericIdent(s string) bool {
 	if s == "" {
-		return 0, true
+		return false
 	}
-	n := 0
-	ok := false
 	for _, ch := range s {
 		if ch < '0' || ch > '9' {
-			return n, ok
+			return false
 		}
-		ok = true
-		n = n*10 + int(ch-'0')
 	}
-	return n, ok
+	return true
+}
+
+// compareNumericIdent compares pure-digit identifiers without int conversion.
+func compareNumericIdent(a, b string) int {
+	a = strings.TrimLeft(a, "0")
+	b = strings.TrimLeft(b, "0")
+	if a == "" {
+		a = "0"
+	}
+	if b == "" {
+		b = "0"
+	}
+	if len(a) < len(b) {
+		return -1
+	}
+	if len(a) > len(b) {
+		return 1
+	}
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
 }
 
 func splitPreRelease(v string) (main, pre string) {

--- a/systemupdate/update.go
+++ b/systemupdate/update.go
@@ -117,7 +117,9 @@ type SystemUpdateService struct {
 	opMu sync.Mutex
 }
 
-var defaultSystemUpdateService *SystemUpdateService
+// defaultSystemUpdateService is published via atomic.Pointer so SetCurrentVersion
+// and GetSystemUpdateService can observe initialization without data races.
+var defaultSystemUpdateService atomic.Pointer[SystemUpdateService]
 var systemUpdateOnce sync.Once
 
 func init() {
@@ -132,20 +134,19 @@ func SetCurrentVersion(v string) {
 		return
 	}
 	runningVer.Store(v)
-	CurrentVersion = v // best-effort mirror for diagnostics; service uses runningVer
+	// Diagnostic mirror only; concurrent readers should use runningVer / the service.
+	CurrentVersion = v
 
-	// If the process-wide service is already live, refresh under cacheMu.
-	s := defaultSystemUpdateService
-	if s == nil {
-		return
+	// Load via atomic.Pointer so we never race with GetSystemUpdateService init.
+	if s := defaultSystemUpdateService.Load(); s != nil {
+		s.cacheMu.Lock()
+		if s.currentVer != v {
+			s.currentVer = v
+			s.cache = nil
+			s.cacheGen++
+		}
+		s.cacheMu.Unlock()
 	}
-	s.cacheMu.Lock()
-	if s.currentVer != v {
-		s.currentVer = v
-		s.cache = nil
-		s.cacheGen++
-	}
-	s.cacheMu.Unlock()
 }
 
 // GetSystemUpdateService returns the process-wide update service.
@@ -160,7 +161,7 @@ func GetSystemUpdateService() *SystemUpdateService {
 		if stored, ok := runningVer.Load().(string); ok && strings.TrimSpace(stored) != "" {
 			ver = stored
 		}
-		defaultSystemUpdateService = &SystemUpdateService{
+		s := &SystemUpdateService{
 			repo:  repo,
 			token: strings.TrimSpace(os.Getenv("UPDATE_GITHUB_TOKEN")),
 			apiClient: &http.Client{
@@ -171,13 +172,14 @@ func GetSystemUpdateService() *SystemUpdateService {
 			},
 			currentVer: ver,
 		}
+		defaultSystemUpdateService.Store(s)
 	})
+	s := defaultSystemUpdateService.Load()
 	// Refresh under cacheMu so concurrent checks cannot race with version/cache reads.
 	// Invalidate cache when the version changes so HasUpdate is not stale.
 	if v, ok := runningVer.Load().(string); ok {
 		v = strings.TrimSpace(v)
 		if v != "" {
-			s := defaultSystemUpdateService
 			s.cacheMu.Lock()
 			if s.currentVer != v {
 				s.currentVer = v
@@ -187,7 +189,7 @@ func GetSystemUpdateService() *SystemUpdateService {
 			s.cacheMu.Unlock()
 		}
 	}
-	return defaultSystemUpdateService
+	return s
 }
 
 // currentVersion returns the service's running version under cacheMu.

--- a/systemupdate/update.go
+++ b/systemupdate/update.go
@@ -17,12 +17,16 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
-// CurrentVersion is the running binary version. Set it at process start
-// (e.g. from common.Version) before calling GetSystemUpdateService.
+// CurrentVersion is the running binary version.
+// Prefer SetCurrentVersion for concurrent-safe updates after InitEnv.
 var CurrentVersion = "v0.0.0"
+
+// runningVer mirrors CurrentVersion for concurrent-safe reads/writes.
+var runningVer atomic.Value // string
 
 const (
 	defaultUpdateGitHubRepo = "Calcium-Ion/new-api"
@@ -106,6 +110,8 @@ type SystemUpdateService struct {
 	dlClient   *http.Client
 	cacheMu    sync.Mutex
 	cache      *updateCacheEntry
+	// cacheGen increments whenever currentVer changes; CheckUpdate only caches if gen is stable.
+	cacheGen   uint64
 	currentVer string
 	// opMu serializes apply/rollback so concurrent renames cannot corrupt the binary.
 	opMu sync.Mutex
@@ -114,6 +120,34 @@ type SystemUpdateService struct {
 var defaultSystemUpdateService *SystemUpdateService
 var systemUpdateOnce sync.Once
 
+func init() {
+	runningVer.Store(CurrentVersion)
+}
+
+// SetCurrentVersion updates the running version in a concurrency-safe way.
+// Call after common.InitEnv() when VERSION is finalized.
+func SetCurrentVersion(v string) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return
+	}
+	runningVer.Store(v)
+	CurrentVersion = v // best-effort mirror for diagnostics; service uses runningVer
+
+	// If the process-wide service is already live, refresh under cacheMu.
+	s := defaultSystemUpdateService
+	if s == nil {
+		return
+	}
+	s.cacheMu.Lock()
+	if s.currentVer != v {
+		s.currentVer = v
+		s.cache = nil
+		s.cacheGen++
+	}
+	s.cacheMu.Unlock()
+}
+
 // GetSystemUpdateService returns the process-wide update service.
 // Set CurrentVersion (e.g. from common.Version after InitEnv) before calling handlers.
 func GetSystemUpdateService() *SystemUpdateService {
@@ -121,6 +155,10 @@ func GetSystemUpdateService() *SystemUpdateService {
 		repo := strings.TrimSpace(os.Getenv("NEW_API_UPDATE_GITHUB_REPO"))
 		if repo == "" {
 			repo = defaultUpdateGitHubRepo
+		}
+		ver := CurrentVersion
+		if stored, ok := runningVer.Load().(string); ok && strings.TrimSpace(stored) != "" {
+			ver = stored
 		}
 		defaultSystemUpdateService = &SystemUpdateService{
 			repo:  repo,
@@ -131,19 +169,23 @@ func GetSystemUpdateService() *SystemUpdateService {
 			dlClient: &http.Client{
 				Timeout: githubDownloadTimeout,
 			},
-			currentVer: CurrentVersion,
+			currentVer: ver,
 		}
 	})
 	// Refresh under cacheMu so concurrent checks cannot race with version/cache reads.
 	// Invalidate cache when the version changes so HasUpdate is not stale.
-	if v := strings.TrimSpace(CurrentVersion); v != "" {
-		s := defaultSystemUpdateService
-		s.cacheMu.Lock()
-		if s.currentVer != v {
-			s.currentVer = v
-			s.cache = nil
+	if v, ok := runningVer.Load().(string); ok {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			s := defaultSystemUpdateService
+			s.cacheMu.Lock()
+			if s.currentVer != v {
+				s.currentVer = v
+				s.cache = nil
+				s.cacheGen++
+			}
+			s.cacheMu.Unlock()
 		}
-		s.cacheMu.Unlock()
 	}
 	return defaultSystemUpdateService
 }
@@ -153,6 +195,12 @@ func (s *SystemUpdateService) currentVersion() string {
 	s.cacheMu.Lock()
 	defer s.cacheMu.Unlock()
 	return s.currentVer
+}
+
+func (s *SystemUpdateService) cacheGeneration() uint64 {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	return s.cacheGen
 }
 
 // DetectDeployMode returns binary / docker / unknown.
@@ -186,6 +234,8 @@ func (s *SystemUpdateService) CheckUpdate(ctx context.Context, force bool) (*Upd
 		}
 	}
 
+	// Capture generation so an in-flight fetch cannot cache over a newer version.
+	gen := s.cacheGeneration()
 	info, err := s.fetchLatest(ctx)
 	if err != nil {
 		if cached := s.getCache(); cached != nil {
@@ -203,6 +253,13 @@ func (s *SystemUpdateService) CheckUpdate(ctx context.Context, force bool) (*Upd
 			DeployMode:     mode,
 			CanApply:       mode == "binary",
 		}, nil
+	}
+	// Refresh CurrentVersion fields against latest service state if gen advanced mid-fetch.
+	if s.cacheGeneration() != gen {
+		info.CurrentVersion = normalizeVersion(s.currentVersion())
+		info.HasUpdate = compareVersions(info.CurrentVersion, info.LatestVersion) < 0
+		// Do not cache: version changed while we were fetching.
+		return info, nil
 	}
 	s.setCache(info)
 	return info, nil
@@ -572,8 +629,9 @@ func (s *SystemUpdateService) getJSON(ctx context.Context, apiURL string, dest a
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		return fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
-	// Keep stdlib decoder: importing common/json pulls a large dependency graph
-	// into this package for no behavioral difference (DecodeJson is a thin wrap).
+	// Intentionally use stdlib decoder: this package must stay free of the
+	// heavy common dependency graph (gin/redis/etc.) so unit tests stay fast.
+	// Behavior matches common.DecodeJson (thin wrap of encoding/json).
 	return json.NewDecoder(resp.Body).Decode(dest)
 }
 
@@ -874,9 +932,16 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
 	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
 		return err
 	}
-	return out.Close()
+	if err := out.Sync(); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("sync copy: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close copy: %w", err)
+	}
+	return nil
 }

--- a/systemupdate/update_test.go
+++ b/systemupdate/update_test.go
@@ -22,6 +22,15 @@ func TestNormalizeAndCompareVersions(t *testing.T) {
 		// numeric prerelease ordering (rc.9 < rc.10)
 		{"1.0.0-rc.9", "1.0.0-rc.10", -1},
 		{"1.0.0-rc.10", "1.0.0-rc.9", 1},
+		// SemVer: only all-digit identifiers are numeric
+		{"1.0.0-rc.1alpha", "1.0.0-rc.1beta", -1},
+		{"1.0.0-rc.1beta", "1.0.0-rc.1alpha", 1},
+		// SemVer: more identifiers after equal prefix → higher
+		{"1.0.0-rc.1", "1.0.0-rc.1.0", -1},
+		{"1.0.0-rc.1.0", "1.0.0-rc.1", 1},
+		// SemVer: numeric identifiers have lower precedence than non-numeric
+		{"1.0.0-1", "1.0.0-alpha", -1},
+		{"1.0.0-alpha", "1.0.0-1", 1},
 	}
 	for _, tc := range cases {
 		t.Run(tc.a+"_"+tc.b, func(t *testing.T) {

--- a/systemupdate/update_test.go
+++ b/systemupdate/update_test.go
@@ -1,0 +1,136 @@
+package systemupdate
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestNormalizeAndCompareVersions(t *testing.T) {
+	if got := normalizeVersion("v1.0.0"); got != "1.0.0" {
+		t.Fatalf("normalizeVersion: got %q", got)
+	}
+	if compareVersions("1.0.0", "1.0.1") != -1 {
+		t.Fatal("expected 1.0.0 < 1.0.1")
+	}
+	if compareVersions("1.2.0", "1.1.9") != 1 {
+		t.Fatal("expected 1.2.0 > 1.1.9")
+	}
+	if compareVersions("v1.0.0", "1.0.0") != 0 {
+		t.Fatal("expected v1.0.0 == 1.0.0")
+	}
+	// release without prerelease is greater
+	if compareVersions("1.0.0", "1.0.0-rc.22") != 1 {
+		t.Fatal("expected 1.0.0 > 1.0.0-rc.22")
+	}
+	if compareVersions("1.0.0-rc.21", "1.0.0-rc.22") != -1 {
+		t.Fatal("expected rc.21 < rc.22")
+	}
+}
+
+func TestCandidateAssetNames(t *testing.T) {
+	names := candidateAssetNames("1.0.0-rc.22")
+	if len(names) == 0 {
+		t.Fatal("expected non-empty candidate names")
+	}
+	if names[0] == "" || !contains(names[0], "new-api") {
+		t.Fatalf("unexpected name %q", names[0])
+	}
+	// Platform-specific expectations
+	switch runtime.GOOS {
+	case "windows":
+		if !hasSuffix(names[0], ".exe") {
+			t.Fatalf("windows asset should end with .exe, got %q", names[0])
+		}
+	case "darwin":
+		if !contains(names[0], "macos") {
+			t.Fatalf("darwin asset should contain macos, got %q", names[0])
+		}
+	case "linux":
+		if runtime.GOARCH == "arm64" {
+			if !contains(names[0], "arm64") {
+				t.Fatalf("linux arm64 asset should contain arm64, got %q", names[0])
+			}
+		} else if contains(names[0], "arm64") || contains(names[0], "macos") {
+			t.Fatalf("linux amd64 asset should not contain arm64/macos, got %q", names[0])
+		}
+	}
+}
+
+func TestSelectReleaseAsset(t *testing.T) {
+	assets := []ReleaseAsset{
+		{Name: "checksums-linux.txt", DownloadURL: "https://github.com/x/checksums-linux.txt"},
+		{Name: "checksums-macos.txt", DownloadURL: "https://github.com/x/checksums-macos.txt"},
+		{Name: "checksums-windows.txt", DownloadURL: "https://github.com/x/checksums-windows.txt"},
+		{Name: "new-api-v1.0.0-rc.22", DownloadURL: "https://github.com/x/new-api-v1.0.0-rc.22"},
+		{Name: "new-api-arm64-v1.0.0-rc.22", DownloadURL: "https://github.com/x/new-api-arm64-v1.0.0-rc.22"},
+		{Name: "new-api-macos-v1.0.0-rc.22", DownloadURL: "https://github.com/x/new-api-macos-v1.0.0-rc.22"},
+		{Name: "new-api-v1.0.0-rc.22.exe", DownloadURL: "https://github.com/x/new-api-v1.0.0-rc.22.exe"},
+	}
+	url, sum, err := selectReleaseAsset(assets, "v1.0.0-rc.22")
+	if err != nil {
+		t.Fatalf("selectReleaseAsset: %v", err)
+	}
+	if url == "" {
+		t.Fatal("empty download url")
+	}
+	// Ensure selected asset matches current platform expectations
+	switch runtime.GOOS {
+	case "windows":
+		if !hasSuffix(url, ".exe") {
+			t.Fatalf("expected exe asset, got %s", url)
+		}
+		if sum != "https://github.com/x/checksums-windows.txt" {
+			t.Fatalf("expected windows checksum, got %s", sum)
+		}
+	case "darwin":
+		if !contains(url, "macos") {
+			t.Fatalf("expected macos asset, got %s", url)
+		}
+	case "linux":
+		if runtime.GOARCH == "arm64" {
+			if !contains(url, "arm64") {
+				t.Fatalf("expected arm64 asset, got %s", url)
+			}
+		} else if contains(url, "arm64") || contains(url, "macos") || hasSuffix(url, ".exe") {
+			t.Fatalf("unexpected linux amd64 selection: %s", url)
+		}
+	}
+}
+
+func TestValidateGitHubDownloadURL(t *testing.T) {
+	if err := validateGitHubDownloadURL("https://github.com/Calcium-Ion/new-api/releases/download/v1/x"); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateGitHubDownloadURL("https://objects.githubusercontent.com/foo"); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateGitHubDownloadURL("http://github.com/x"); err == nil {
+		t.Fatal("expected error for http")
+	}
+	if err := validateGitHubDownloadURL("https://evil.example/x"); err == nil {
+		t.Fatal("expected error for untrusted host")
+	}
+}
+
+func TestDetectDeployMode(t *testing.T) {
+	mode := DetectDeployMode()
+	if mode != "binary" && mode != "docker" && mode != "unknown" {
+		t.Fatalf("unexpected mode %q", mode)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		(func() bool {
+			for i := 0; i+len(sub) <= len(s); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		})())
+}
+
+func hasSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}

--- a/systemupdate/update_test.go
+++ b/systemupdate/update_test.go
@@ -3,55 +3,48 @@ package systemupdate
 import (
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNormalizeAndCompareVersions(t *testing.T) {
-	if got := normalizeVersion("v1.0.0"); got != "1.0.0" {
-		t.Fatalf("normalizeVersion: got %q", got)
+	require.Equal(t, "1.0.0", normalizeVersion("v1.0.0"))
+
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "1.0.1", -1},
+		{"1.2.0", "1.1.9", 1},
+		{"v1.0.0", "1.0.0", 0},
+		{"1.0.0", "1.0.0-rc.22", 1},
+		{"1.0.0-rc.21", "1.0.0-rc.22", -1},
+		// numeric prerelease ordering (rc.9 < rc.10)
+		{"1.0.0-rc.9", "1.0.0-rc.10", -1},
+		{"1.0.0-rc.10", "1.0.0-rc.9", 1},
 	}
-	if compareVersions("1.0.0", "1.0.1") != -1 {
-		t.Fatal("expected 1.0.0 < 1.0.1")
-	}
-	if compareVersions("1.2.0", "1.1.9") != 1 {
-		t.Fatal("expected 1.2.0 > 1.1.9")
-	}
-	if compareVersions("v1.0.0", "1.0.0") != 0 {
-		t.Fatal("expected v1.0.0 == 1.0.0")
-	}
-	// release without prerelease is greater
-	if compareVersions("1.0.0", "1.0.0-rc.22") != 1 {
-		t.Fatal("expected 1.0.0 > 1.0.0-rc.22")
-	}
-	if compareVersions("1.0.0-rc.21", "1.0.0-rc.22") != -1 {
-		t.Fatal("expected rc.21 < rc.22")
+	for _, tc := range cases {
+		t.Run(tc.a+"_"+tc.b, func(t *testing.T) {
+			require.Equal(t, tc.want, compareVersions(tc.a, tc.b))
+		})
 	}
 }
 
 func TestCandidateAssetNames(t *testing.T) {
 	names := candidateAssetNames("1.0.0-rc.22")
-	if len(names) == 0 {
-		t.Fatal("expected non-empty candidate names")
-	}
-	if names[0] == "" || !contains(names[0], "new-api") {
-		t.Fatalf("unexpected name %q", names[0])
-	}
-	// Platform-specific expectations
+	require.NotEmpty(t, names)
+	require.Contains(t, names[0], "new-api")
 	switch runtime.GOOS {
 	case "windows":
-		if !hasSuffix(names[0], ".exe") {
-			t.Fatalf("windows asset should end with .exe, got %q", names[0])
-		}
+		require.True(t, stringsHasSuffix(names[0], ".exe"))
 	case "darwin":
-		if !contains(names[0], "macos") {
-			t.Fatalf("darwin asset should contain macos, got %q", names[0])
-		}
+		require.Contains(t, names[0], "macos")
 	case "linux":
 		if runtime.GOARCH == "arm64" {
-			if !contains(names[0], "arm64") {
-				t.Fatalf("linux arm64 asset should contain arm64, got %q", names[0])
-			}
-		} else if contains(names[0], "arm64") || contains(names[0], "macos") {
-			t.Fatalf("linux amd64 asset should not contain arm64/macos, got %q", names[0])
+			require.Contains(t, names[0], "arm64")
+		} else {
+			require.NotContains(t, names[0], "arm64")
+			require.NotContains(t, names[0], "macos")
 		}
 	}
 }
@@ -65,72 +58,46 @@ func TestSelectReleaseAsset(t *testing.T) {
 		{Name: "new-api-arm64-v1.0.0-rc.22", DownloadURL: "https://github.com/x/new-api-arm64-v1.0.0-rc.22"},
 		{Name: "new-api-macos-v1.0.0-rc.22", DownloadURL: "https://github.com/x/new-api-macos-v1.0.0-rc.22"},
 		{Name: "new-api-v1.0.0-rc.22.exe", DownloadURL: "https://github.com/x/new-api-v1.0.0-rc.22.exe"},
+		// Wrong version should never be selected by fuzzy match
+		{Name: "new-api-v9.9.9", DownloadURL: "https://github.com/x/new-api-v9.9.9"},
 	}
 	url, sum, err := selectReleaseAsset(assets, "v1.0.0-rc.22")
-	if err != nil {
-		t.Fatalf("selectReleaseAsset: %v", err)
-	}
-	if url == "" {
-		t.Fatal("empty download url")
-	}
-	// Ensure selected asset matches current platform expectations
+	require.NoError(t, err)
+	require.NotEmpty(t, url)
+	require.Contains(t, url, "1.0.0-rc.22")
+	require.NotContains(t, url, "9.9.9")
+
 	switch runtime.GOOS {
 	case "windows":
-		if !hasSuffix(url, ".exe") {
-			t.Fatalf("expected exe asset, got %s", url)
-		}
-		if sum != "https://github.com/x/checksums-windows.txt" {
-			t.Fatalf("expected windows checksum, got %s", sum)
-		}
+		require.True(t, stringsHasSuffix(url, ".exe"))
+		require.Equal(t, "https://github.com/x/checksums-windows.txt", sum)
 	case "darwin":
-		if !contains(url, "macos") {
-			t.Fatalf("expected macos asset, got %s", url)
-		}
+		require.Contains(t, url, "macos")
+		require.Equal(t, "https://github.com/x/checksums-macos.txt", sum)
 	case "linux":
 		if runtime.GOARCH == "arm64" {
-			if !contains(url, "arm64") {
-				t.Fatalf("expected arm64 asset, got %s", url)
-			}
-		} else if contains(url, "arm64") || contains(url, "macos") || hasSuffix(url, ".exe") {
-			t.Fatalf("unexpected linux amd64 selection: %s", url)
+			require.Contains(t, url, "arm64")
+		} else {
+			require.NotContains(t, url, "arm64")
+			require.NotContains(t, url, "macos")
+			require.False(t, stringsHasSuffix(url, ".exe"))
 		}
+		require.Equal(t, "https://github.com/x/checksums-linux.txt", sum)
 	}
 }
 
 func TestValidateGitHubDownloadURL(t *testing.T) {
-	if err := validateGitHubDownloadURL("https://github.com/Calcium-Ion/new-api/releases/download/v1/x"); err != nil {
-		t.Fatal(err)
-	}
-	if err := validateGitHubDownloadURL("https://objects.githubusercontent.com/foo"); err != nil {
-		t.Fatal(err)
-	}
-	if err := validateGitHubDownloadURL("http://github.com/x"); err == nil {
-		t.Fatal("expected error for http")
-	}
-	if err := validateGitHubDownloadURL("https://evil.example/x"); err == nil {
-		t.Fatal("expected error for untrusted host")
-	}
+	require.NoError(t, validateGitHubDownloadURL("https://github.com/Calcium-Ion/new-api/releases/download/v1/x"))
+	require.NoError(t, validateGitHubDownloadURL("https://objects.githubusercontent.com/foo"))
+	require.Error(t, validateGitHubDownloadURL("http://github.com/x"))
+	require.Error(t, validateGitHubDownloadURL("https://evil.example/x"))
 }
 
 func TestDetectDeployMode(t *testing.T) {
 	mode := DetectDeployMode()
-	if mode != "binary" && mode != "docker" && mode != "unknown" {
-		t.Fatalf("unexpected mode %q", mode)
-	}
+	require.Contains(t, []string{"binary", "docker", "unknown"}, mode)
 }
 
-func contains(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
-		(func() bool {
-			for i := 0; i+len(sub) <= len(s); i++ {
-				if s[i:i+len(sub)] == sub {
-					return true
-				}
-			}
-			return false
-		})())
-}
-
-func hasSuffix(s, suffix string) bool {
+func stringsHasSuffix(s, suffix string) bool {
 	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
 }

--- a/web/src/features/system-settings/maintenance/update-checker-section.tsx
+++ b/web/src/features/system-settings/maintenance/update-checker-section.tsx
@@ -64,6 +64,33 @@ type UpdateCheckerSectionProps = {
 }
 
 const UPDATE_TIMEOUT_MS = 15 * 60 * 1000
+// Keep in sync with systemupdate.defaultUpdateGitHubRepo
+const DEFAULT_UPDATE_GITHUB_REPO = 'Calcium-Ion/new-api'
+
+function apiErrorMessage(error: unknown, fallback: string): string {
+  if (error && typeof error === 'object') {
+    const maybeAxios = error as {
+      response?: { data?: { message?: string; error?: string } }
+      message?: string
+    }
+    const backendMsg =
+      maybeAxios.response?.data?.message || maybeAxios.response?.data?.error
+    if (typeof backendMsg === 'string' && backendMsg.trim()) {
+      return backendMsg
+    }
+    if (typeof maybeAxios.message === 'string' && maybeAxios.message.trim()) {
+      // Prefer backend message; axios default "Request failed with status code 400" is last resort
+      if (!maybeAxios.message.startsWith('Request failed with status code')) {
+        return maybeAxios.message
+      }
+      if (backendMsg) return String(backendMsg)
+    }
+  }
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+  return fallback
+}
 
 export function UpdateCheckerSection({
   currentVersion,
@@ -125,7 +152,7 @@ export function UpdateCheckerSection({
       // Fallback: browser-side GitHub check (legacy behavior) if backend fails
       try {
         const response = await fetch(
-          'https://api.github.com/repos/Calcium-Ion/new-api/releases/latest',
+          `https://api.github.com/repos/${DEFAULT_UPDATE_GITHUB_REPO}/releases/latest`,
           {
             headers: {
               Accept: 'application/vnd.github+json',
@@ -181,7 +208,7 @@ export function UpdateCheckerSection({
       const res = await api.post(
         '/api/system-update/apply',
         {},
-        { timeout: UPDATE_TIMEOUT_MS }
+        { timeout: UPDATE_TIMEOUT_MS, skipErrorHandler: true }
       )
       if (!res.data?.success) {
         throw new Error(res.data?.message || t('Update failed'))
@@ -202,9 +229,7 @@ export function UpdateCheckerSection({
       )
       setDialogOpen(false)
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : t('Update failed')
-      toast.error(message)
+      toast.error(apiErrorMessage(error, t('Update failed')))
     } finally {
       setApplying(false)
     }
@@ -216,7 +241,7 @@ export function UpdateCheckerSection({
       const res = await api.post(
         '/api/system-update/rollback',
         version ? { version } : {},
-        { timeout: UPDATE_TIMEOUT_MS }
+        { timeout: UPDATE_TIMEOUT_MS, skipErrorHandler: true }
       )
       if (!res.data?.success) {
         throw new Error(res.data?.message || t('Rollback failed'))
@@ -227,9 +252,7 @@ export function UpdateCheckerSection({
       )
       setDialogOpen(false)
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : t('Rollback failed')
-      toast.error(message)
+      toast.error(apiErrorMessage(error, t('Rollback failed')))
     } finally {
       setRollingBack(false)
     }

--- a/web/src/features/system-settings/maintenance/update-checker-section.tsx
+++ b/web/src/features/system-settings/maintenance/update-checker-section.tsx
@@ -16,7 +16,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { ExternalLinkIcon, RefreshCcwIcon } from 'lucide-react'
+import {
+  ExternalLinkIcon,
+  RefreshCcwIcon,
+  DownloadIcon,
+  Undo2Icon,
+} from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -25,15 +30,32 @@ import { Dialog } from '@/components/dialog'
 import { Button } from '@/components/ui/button'
 import { Markdown } from '@/components/ui/markdown'
 import { formatTimestamp, formatTimestampToDate } from '@/lib/format'
+import { api } from '@/lib/api'
 
 import { SettingsSection } from '../components/settings-section'
 
 type ReleaseInfo = {
-  tag_name: string
   name?: string
   body?: string
   html_url?: string
   published_at?: string
+}
+
+type UpdateInfo = {
+  current_version: string
+  latest_version: string
+  has_update: boolean
+  release_info?: ReleaseInfo
+  cached?: boolean
+  warning?: string
+  deploy_mode?: string
+  can_apply?: boolean
+}
+
+type RollbackVersion = {
+  version: string
+  published_at?: string
+  html_url?: string
 }
 
 type UpdateCheckerSectionProps = {
@@ -41,67 +63,187 @@ type UpdateCheckerSectionProps = {
   startTime?: number | null
 }
 
+const UPDATE_TIMEOUT_MS = 15 * 60 * 1000
+
 export function UpdateCheckerSection({
   currentVersion,
   startTime,
 }: UpdateCheckerSectionProps) {
   const { t } = useTranslation()
   const [checking, setChecking] = useState(false)
+  const [applying, setApplying] = useState(false)
+  const [rollingBack, setRollingBack] = useState(false)
   const [dialogOpen, setDialogOpen] = useState(false)
-  const [release, setRelease] = useState<ReleaseInfo | null>(null)
+  const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null)
+  const [rollbackVersions, setRollbackVersions] = useState<RollbackVersion[]>(
+    []
+  )
 
   const uptime = startTime ? formatTimestamp(startTime) : t('Unknown')
   const version = currentVersion || t('Unknown')
 
+  const loadRollbackVersions = async () => {
+    try {
+      const res = await api.get('/api/system-update/rollback-versions')
+      if (res.data?.success) {
+        setRollbackVersions(res.data.data?.versions || [])
+      }
+    } catch {
+      // optional; ignore if backend old or network error
+      setRollbackVersions([])
+    }
+  }
+
   const handleCheckUpdates = async () => {
     setChecking(true)
     try {
-      const response = await fetch(
-        'https://api.github.com/repos/Calcium-Ion/new-api/releases/latest',
-        {
-          headers: {
-            Accept: 'application/vnd.github+json',
-            'User-Agent': 'new-api-dashboard',
-          },
-        }
-      )
+      const res = await api.get('/api/system-update/check', {
+        params: { force: true },
+      })
+      if (!res.data?.success) {
+        throw new Error(res.data?.message || t('Failed to check for updates'))
+      }
+      const data = res.data.data as UpdateInfo
+      setUpdateInfo(data)
+      await loadRollbackVersions()
 
-      if (!response.ok) {
-        throw new Error(t('Failed to contact GitHub releases API'))
+      if (data.warning) {
+        toast.warning(data.warning)
       }
 
-      const data = (await response.json()) as ReleaseInfo
-      if (!data?.tag_name) {
-        throw new Error(t('Unexpected release payload'))
-      }
-
-      if (currentVersion && data.tag_name === currentVersion) {
+      if (!data.has_update) {
         toast.success(
           t('You are running the latest version ({{version}}).', {
-            version: data.tag_name,
+            version: data.latest_version || data.current_version,
           })
         )
         return
       }
 
-      setRelease(data)
       setDialogOpen(true)
     } catch (error) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : t('Failed to check for updates')
-      toast.error(message)
+      // Fallback: browser-side GitHub check (legacy behavior) if backend fails
+      try {
+        const response = await fetch(
+          'https://api.github.com/repos/Calcium-Ion/new-api/releases/latest',
+          {
+            headers: {
+              Accept: 'application/vnd.github+json',
+              'User-Agent': 'new-api-dashboard',
+            },
+          }
+        )
+        if (!response.ok) {
+          throw new Error(t('Failed to contact GitHub releases API'))
+        }
+        const release = (await response.json()) as ReleaseInfo & {
+          tag_name?: string
+        }
+        const latest = (release.tag_name || '').replace(/^v/, '')
+        const current = (currentVersion || '').replace(/^v/, '')
+        if (current && latest && current === latest) {
+          toast.success(
+            t('You are running the latest version ({{version}}).', {
+              version: release.tag_name,
+            })
+          )
+          return
+        }
+        setUpdateInfo({
+          current_version: current,
+          latest_version: latest,
+          has_update: true,
+          release_info: release,
+          can_apply: false,
+          deploy_mode: 'unknown',
+          warning: t(
+            'Backend update API unavailable; showing release notes only.'
+          ),
+        })
+        setDialogOpen(true)
+      } catch (fallbackError) {
+        const message =
+          fallbackError instanceof Error
+            ? fallbackError.message
+            : error instanceof Error
+              ? error.message
+              : t('Failed to check for updates')
+        toast.error(message)
+      }
     } finally {
       setChecking(false)
     }
   }
 
-  const goToRelease = () => {
-    if (release?.html_url) {
-      window.open(release.html_url, '_blank', 'noopener,noreferrer')
+  const handleApplyUpdate = async () => {
+    setApplying(true)
+    try {
+      const res = await api.post(
+        '/api/system-update/apply',
+        {},
+        { timeout: UPDATE_TIMEOUT_MS }
+      )
+      if (!res.data?.success) {
+        throw new Error(res.data?.message || t('Update failed'))
+      }
+      const data = res.data.data || {}
+      if (data.already_up_to_date) {
+        toast.success(t('You are running the latest version ({{version}}).', {
+          version: data.latest_version || updateInfo?.latest_version,
+        }))
+        setDialogOpen(false)
+        return
+      }
+      toast.success(
+        data.message ||
+          t(
+            'Update completed. Please restart the new-api process to load the new binary.'
+          )
+      )
+      setDialogOpen(false)
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : t('Update failed')
+      toast.error(message)
+    } finally {
+      setApplying(false)
     }
   }
+
+  const handleRollback = async (version?: string) => {
+    setRollingBack(true)
+    try {
+      const res = await api.post(
+        '/api/system-update/rollback',
+        version ? { version } : {},
+        { timeout: UPDATE_TIMEOUT_MS }
+      )
+      if (!res.data?.success) {
+        throw new Error(res.data?.message || t('Rollback failed'))
+      }
+      toast.success(
+        res.data.data?.message ||
+          t('Rollback completed. Please restart the new-api process.')
+      )
+      setDialogOpen(false)
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : t('Rollback failed')
+      toast.error(message)
+    } finally {
+      setRollingBack(false)
+    }
+  }
+
+  const goToRelease = () => {
+    const url = updateInfo?.release_info?.html_url
+    if (url) {
+      window.open(url, '_blank', 'noopener,noreferrer')
+    }
+  }
+
+  const canApply = Boolean(updateInfo?.can_apply && updateInfo?.has_update)
+  const isDocker = updateInfo?.deploy_mode === 'docker'
 
   return (
     <>
@@ -122,16 +264,33 @@ export function UpdateCheckerSection({
             </div>
           </div>
 
-          <Button onClick={handleCheckUpdates} disabled={checking}>
-            {checking ? (
-              t('Checking updates...')
-            ) : (
-              <>
-                <RefreshCcwIcon className='me-2 h-4 w-4' />
-                {t('Check for updates')}
-              </>
+          <div className='flex flex-wrap gap-2'>
+            <Button onClick={handleCheckUpdates} disabled={checking || applying}>
+              {checking ? (
+                t('Checking updates...')
+              ) : (
+                <>
+                  <RefreshCcwIcon className='me-2 h-4 w-4' />
+                  {t('Check for updates')}
+                </>
+              )}
+            </Button>
+            <Button
+              type='button'
+              variant='outline'
+              disabled={rollingBack || applying || checking}
+              onClick={() => handleRollback()}
+            >
+              <Undo2Icon className='me-2 h-4 w-4' />
+              {rollingBack ? t('Rolling back...') : t('Rollback last backup')}
+            </Button>
+          </div>
+
+          <p className='text-muted-foreground text-sm'>
+            {t(
+              'In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.'
             )}
-          </Button>
+          </p>
         </div>
       </SettingsSection>
 
@@ -139,16 +298,16 @@ export function UpdateCheckerSection({
         open={dialogOpen}
         onOpenChange={setDialogOpen}
         title={
-          release?.tag_name
+          updateInfo?.latest_version
             ? t('New version available: {{version}}', {
-                version: release.tag_name,
+                version: updateInfo.latest_version,
               })
             : t('Release details')
         }
         description={
-          release?.published_at
+          updateInfo?.release_info?.published_at
             ? `${t('Published')} ${formatTimestampToDate(
-                new Date(release.published_at).getTime(),
+                new Date(updateInfo.release_info.published_at).getTime(),
                 'milliseconds'
               )}`
             : undefined
@@ -165,22 +324,66 @@ export function UpdateCheckerSection({
             >
               {t('Close')}
             </Button>
-            {release?.html_url && (
-              <Button type='button' onClick={goToRelease}>
+            {updateInfo?.release_info?.html_url && (
+              <Button type='button' variant='outline' onClick={goToRelease}>
                 <ExternalLinkIcon className='me-2 h-4 w-4' />
                 {t('Open release')}
+              </Button>
+            )}
+            {canApply && (
+              <Button
+                type='button'
+                onClick={handleApplyUpdate}
+                disabled={applying}
+              >
+                <DownloadIcon className='me-2 h-4 w-4' />
+                {applying ? t('Updating...') : t('Update now')}
               </Button>
             )}
           </>
         }
       >
         <div className='space-y-4'>
-          {release?.body ? (
-            <Markdown>{release.body}</Markdown>
+          {isDocker && (
+            <div className='rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm'>
+              {t(
+                'Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d'
+              )}
+            </div>
+          )}
+          {!canApply && !isDocker && updateInfo?.has_update && (
+            <div className='text-muted-foreground text-sm'>
+              {t(
+                'Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.'
+              )}
+            </div>
+          )}
+          {updateInfo?.release_info?.body ? (
+            <Markdown>{updateInfo.release_info.body}</Markdown>
           ) : (
             <p className='text-muted-foreground text-sm'>
               {t('No release notes provided.')}
             </p>
+          )}
+
+          {rollbackVersions.length > 0 && (
+            <div className='space-y-2 border-t pt-4'>
+              <div className='text-sm font-medium'>{t('Rollback versions')}</div>
+              <div className='flex flex-wrap gap-2'>
+                {rollbackVersions.map((v) => (
+                  <Button
+                    key={v.version}
+                    type='button'
+                    size='sm'
+                    variant='outline'
+                    disabled={rollingBack || applying}
+                    onClick={() => handleRollback(v.version)}
+                  >
+                    {v.version}
+                  </Button>
+                ))}
+              </div>
+            </div>
           )}
         </div>
       </Dialog>

--- a/web/src/features/system-settings/maintenance/update-checker-section.tsx
+++ b/web/src/features/system-settings/maintenance/update-checker-section.tsx
@@ -109,7 +109,7 @@ export function UpdateCheckerSection({
   const uptime = startTime ? formatTimestamp(startTime) : t('Unknown')
   const version = currentVersion || t('Unknown')
 
-  const loadRollbackVersions = async () => {
+  const loadRollbackVersions = async (): Promise<void> => {
     try {
       const res = await api.get('/api/system-update/rollback-versions')
       if (res.data?.success) {
@@ -121,7 +121,7 @@ export function UpdateCheckerSection({
     }
   }
 
-  const handleCheckUpdates = async () => {
+  const handleCheckUpdates = async (): Promise<void> => {
     setChecking(true)
     try {
       const res = await api.get('/api/system-update/check', {
@@ -202,7 +202,8 @@ export function UpdateCheckerSection({
     }
   }
 
-  const handleApplyUpdate = async () => {
+  const handleApplyUpdate = async (): Promise<void> => {
+    if (applying || rollingBack) return
     setApplying(true)
     try {
       const res = await api.post(
@@ -235,7 +236,8 @@ export function UpdateCheckerSection({
     }
   }
 
-  const handleRollback = async (version?: string) => {
+  const handleRollback = async (version?: string): Promise<void> => {
+    if (applying || rollingBack) return
     setRollingBack(true)
     try {
       const res = await api.post(
@@ -258,7 +260,7 @@ export function UpdateCheckerSection({
     }
   }
 
-  const goToRelease = () => {
+  const goToRelease = (): void => {
     const url = updateInfo?.release_info?.html_url
     if (url) {
       window.open(url, '_blank', 'noopener,noreferrer')
@@ -288,12 +290,15 @@ export function UpdateCheckerSection({
           </div>
 
           <div className='flex flex-wrap gap-2'>
-            <Button onClick={handleCheckUpdates} disabled={checking || applying}>
+            <Button
+              onClick={handleCheckUpdates}
+              disabled={checking || applying || rollingBack}
+            >
               {checking ? (
                 t('Checking updates...')
               ) : (
                 <>
-                  <RefreshCcwIcon className='me-2 h-4 w-4' />
+                  <RefreshCcwIcon className='me-2 h-4 w-4' aria-hidden='true' />
                   {t('Check for updates')}
                 </>
               )}
@@ -304,7 +309,7 @@ export function UpdateCheckerSection({
               disabled={rollingBack || applying || checking}
               onClick={() => handleRollback()}
             >
-              <Undo2Icon className='me-2 h-4 w-4' />
+              <Undo2Icon className='me-2 h-4 w-4' aria-hidden='true' />
               {rollingBack ? t('Rolling back...') : t('Rollback last backup')}
             </Button>
           </div>
@@ -349,7 +354,7 @@ export function UpdateCheckerSection({
             </Button>
             {updateInfo?.release_info?.html_url && (
               <Button type='button' variant='outline' onClick={goToRelease}>
-                <ExternalLinkIcon className='me-2 h-4 w-4' />
+                <ExternalLinkIcon className='me-2 h-4 w-4' aria-hidden='true' />
                 {t('Open release')}
               </Button>
             )}
@@ -357,9 +362,9 @@ export function UpdateCheckerSection({
               <Button
                 type='button'
                 onClick={handleApplyUpdate}
-                disabled={applying}
+                disabled={applying || rollingBack}
               >
-                <DownloadIcon className='me-2 h-4 w-4' />
+                <DownloadIcon className='me-2 h-4 w-4' aria-hidden='true' />
                 {applying ? t('Updating...') : t('Update now')}
               </Button>
             )}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1,4 +1,13 @@
 {
+  "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.",
+  "Backend update API unavailable; showing release notes only.": "Backend update API unavailable; showing release notes only.",
+  "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d",
+  "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.",
+  "Rollback completed. Please restart the new-api process.": "Rollback completed. Please restart the new-api process.",
+  "Rollback failed": "Rollback failed",
+  "Rollback last backup": "Rollback last backup",
+  "Rollback versions": "Rollback versions",
+  "Rolling back...": "Rolling back...",
   "translation": {
     "360": "360",
     "1000": "1000",
@@ -2033,7 +2042,7 @@
     "footer.columns.related.links.oneApi": "One API",
     "footer.columns.related.title": "Related Projects",
     "footer.defaultCopyright": "All rights reserved.",
-    "footer.new\u0061pi.projectAttributionSuffix": "All rights reserved. Designed and developed by the project contributors.",
+    "footer.newapi.projectAttributionSuffix": "All rights reserved. Designed and developed by the project contributors.",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment",
     "For private deployments, format: https://fastgpt.run/api/openapi": "For private deployments, format: https://fastgpt.run/api/openapi",
     "Force a syntactically valid JSON response": "Force a syntactically valid JSON response",
@@ -5228,5 +5237,7 @@
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
     "Zoom": "Zoom"
-  }
+  },
+  "Update completed. Please restart the new-api process to load the new binary.": "Update completed. Please restart the new-api process to load the new binary.",
+  "Update now": "Update now"
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1,13 +1,4 @@
 {
-  "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.",
-  "Backend update API unavailable; showing release notes only.": "Backend update API unavailable; showing release notes only.",
-  "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d",
-  "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.",
-  "Rollback completed. Please restart the new-api process.": "Rollback completed. Please restart the new-api process.",
-  "Rollback failed": "Rollback failed",
-  "Rollback last backup": "Rollback last backup",
-  "Rollback versions": "Rollback versions",
-  "Rolling back...": "Rolling back...",
   "translation": {
     "360": "360",
     "1000": "1000",
@@ -5236,8 +5227,17 @@
     "Zero retention": "Zero retention",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
-  },
-  "Update completed. Please restart the new-api process to load the new binary.": "Update completed. Please restart the new-api process to load the new binary.",
-  "Update now": "Update now"
+    "Zoom": "Zoom",
+    "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.",
+    "Backend update API unavailable; showing release notes only.": "Backend update API unavailable; showing release notes only.",
+    "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d",
+    "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.",
+    "Rollback completed. Please restart the new-api process.": "Rollback completed. Please restart the new-api process.",
+    "Rollback failed": "Rollback failed",
+    "Rollback last backup": "Rollback last backup",
+    "Rollback versions": "Rollback versions",
+    "Rolling back...": "Rolling back...",
+    "Update completed. Please restart the new-api process to load the new binary.": "Update completed. Please restart the new-api process to load the new binary.",
+    "Update now": "Update now"
+  }
 }

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -1,13 +1,4 @@
 {
-  "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "L'application automatique est indisponible dans cet environnement. Téléchargez la version manuellement ou ouvrez la page GitHub.",
-  "Backend update API unavailable; showing release notes only.": "API de mise à jour backend indisponible ; affichage des notes de version uniquement.",
-  "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Déploiement Docker détecté. La mise à jour binaire sur place est désactivée. Mettez à niveau avec : docker compose pull && docker compose up -d",
-  "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "La mise à jour sur place télécharge le binaire de release officiel et remplace l'exécutable en cours (installations binaires uniquement). Les utilisateurs Docker doivent tirer une nouvelle image.",
-  "Rollback completed. Please restart the new-api process.": "Rollback terminé. Veuillez redémarrer le processus new-api.",
-  "Rollback failed": "Échec du rollback",
-  "Rollback last backup": "Revenir à la dernière sauvegarde",
-  "Rollback versions": "Versions de rollback",
-  "Rolling back...": "Rollback en cours…",
   "translation": {
     "360": "360",
     "1000": "1000",
@@ -5236,8 +5227,17 @@
     "Zero retention": "Aucune rétention",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
-  },
-  "Update completed. Please restart the new-api process to load the new binary.": "Mise à jour terminée. Redémarrez le processus new-api pour charger le nouveau binaire.",
-  "Update now": "Mettre à jour maintenant"
+    "Zoom": "Zoom",
+    "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "L'application automatique est indisponible dans cet environnement. Téléchargez la version manuellement ou ouvrez la page GitHub.",
+    "Backend update API unavailable; showing release notes only.": "API de mise à jour backend indisponible ; affichage des notes de version uniquement.",
+    "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Déploiement Docker détecté. La mise à jour binaire sur place est désactivée. Mettez à niveau avec : docker compose pull && docker compose up -d",
+    "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "La mise à jour sur place télécharge le binaire de release officiel et remplace l'exécutable en cours (installations binaires uniquement). Les utilisateurs Docker doivent tirer une nouvelle image.",
+    "Rollback completed. Please restart the new-api process.": "Rollback terminé. Veuillez redémarrer le processus new-api.",
+    "Rollback failed": "Échec du rollback",
+    "Rollback last backup": "Revenir à la dernière sauvegarde",
+    "Rollback versions": "Versions de rollback",
+    "Rolling back...": "Rollback en cours…",
+    "Update completed. Please restart the new-api process to load the new binary.": "Mise à jour terminée. Redémarrez le processus new-api pour charger le nouveau binaire.",
+    "Update now": "Mettre à jour maintenant"
+  }
 }

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -1,4 +1,13 @@
 {
+  "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "L'application automatique est indisponible dans cet environnement. Téléchargez la version manuellement ou ouvrez la page GitHub.",
+  "Backend update API unavailable; showing release notes only.": "API de mise à jour backend indisponible ; affichage des notes de version uniquement.",
+  "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Déploiement Docker détecté. La mise à jour binaire sur place est désactivée. Mettez à niveau avec : docker compose pull && docker compose up -d",
+  "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "La mise à jour sur place télécharge le binaire de release officiel et remplace l'exécutable en cours (installations binaires uniquement). Les utilisateurs Docker doivent tirer une nouvelle image.",
+  "Rollback completed. Please restart the new-api process.": "Rollback terminé. Veuillez redémarrer le processus new-api.",
+  "Rollback failed": "Échec du rollback",
+  "Rollback last backup": "Revenir à la dernière sauvegarde",
+  "Rollback versions": "Versions de rollback",
+  "Rolling back...": "Rollback en cours…",
   "translation": {
     "360": "360",
     "1000": "1000",
@@ -2033,7 +2042,7 @@
     "footer.columns.related.links.oneApi": "One API",
     "footer.columns.related.title": "Projets liés",
     "footer.defaultCopyright": "Tous droits réservés.",
-    "footer.new\u0061pi.projectAttributionSuffix": "Tous droits réservés. Conçu et développé par les contributeurs du projet.",
+    "footer.newapi.projectAttributionSuffix": "Tous droits réservés. Conçu et développé par les contributeurs du projet.",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "Pour les canaux ajoutés après le 10 mai 2025, pas besoin de supprimer \".\" des noms de modèles lors du déploiement",
     "For private deployments, format: https://fastgpt.run/api/openapi": "Pour les déploiements privés, format : https://fastgpt.run/api/openapi",
     "Force a syntactically valid JSON response": "Imposer une réponse JSON syntaxiquement valide",
@@ -5228,5 +5237,7 @@
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
     "Zoom": "Zoom"
-  }
+  },
+  "Update completed. Please restart the new-api process to load the new binary.": "Mise à jour terminée. Redémarrez le processus new-api pour charger le nouveau binaire.",
+  "Update now": "Mettre à jour maintenant"
 }

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -1,13 +1,4 @@
 {
-  "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "この環境では自動適用できません。リリースを手動でダウンロードするか GitHub ページを開いてください。",
-  "Backend update API unavailable; showing release notes only.": "バックエンド更新 API を利用できないため、リリースノートのみ表示します。",
-  "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Docker デプロイを検出しました。バイナリの直接更新は無効です。docker compose pull && docker compose up -d でアップグレードしてください。",
-  "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "インプレース更新は公式リリースバイナリをダウンロードし、実行中の実行ファイルを置き換えます（バイナリインストールのみ）。Docker では新しいイメージを pull してください。",
-  "Rollback completed. Please restart the new-api process.": "ロールバックが完了しました。new-api プロセスを再起動してください。",
-  "Rollback failed": "ロールバックに失敗しました",
-  "Rollback last backup": "直前のバックアップに戻す",
-  "Rollback versions": "ロールバック可能なバージョン",
-  "Rolling back...": "ロールバック中…",
   "translation": {
     "360": "360",
     "1000": "1000",
@@ -5236,8 +5227,17 @@
     "Zero retention": "データ保持なし",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V 4",
-    "Zoom": "ズーム"
-  },
-  "Update completed. Please restart the new-api process to load the new binary.": "更新が完了しました。新しいバイナリを読み込むには new-api プロセスを再起動してください。",
-  "Update now": "今すぐ更新"
+    "Zoom": "ズーム",
+    "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "この環境では自動適用できません。リリースを手動でダウンロードするか GitHub ページを開いてください。",
+    "Backend update API unavailable; showing release notes only.": "バックエンド更新 API を利用できないため、リリースノートのみ表示します。",
+    "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Docker デプロイを検出しました。バイナリの直接更新は無効です。docker compose pull && docker compose up -d でアップグレードしてください。",
+    "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "インプレース更新は公式リリースバイナリをダウンロードし、実行中の実行ファイルを置き換えます（バイナリインストールのみ）。Docker では新しいイメージを pull してください。",
+    "Rollback completed. Please restart the new-api process.": "ロールバックが完了しました。new-api プロセスを再起動してください。",
+    "Rollback failed": "ロールバックに失敗しました",
+    "Rollback last backup": "直前のバックアップに戻す",
+    "Rollback versions": "ロールバック可能なバージョン",
+    "Rolling back...": "ロールバック中…",
+    "Update completed. Please restart the new-api process to load the new binary.": "更新が完了しました。新しいバイナリを読み込むには new-api プロセスを再起動してください。",
+    "Update now": "今すぐ更新"
+  }
 }

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -1,4 +1,13 @@
 {
+  "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "この環境では自動適用できません。リリースを手動でダウンロードするか GitHub ページを開いてください。",
+  "Backend update API unavailable; showing release notes only.": "バックエンド更新 API を利用できないため、リリースノートのみ表示します。",
+  "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Docker デプロイを検出しました。バイナリの直接更新は無効です。docker compose pull && docker compose up -d でアップグレードしてください。",
+  "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "インプレース更新は公式リリースバイナリをダウンロードし、実行中の実行ファイルを置き換えます（バイナリインストールのみ）。Docker では新しいイメージを pull してください。",
+  "Rollback completed. Please restart the new-api process.": "ロールバックが完了しました。new-api プロセスを再起動してください。",
+  "Rollback failed": "ロールバックに失敗しました",
+  "Rollback last backup": "直前のバックアップに戻す",
+  "Rollback versions": "ロールバック可能なバージョン",
+  "Rolling back...": "ロールバック中…",
   "translation": {
     "360": "360",
     "1000": "1000",
@@ -2033,7 +2042,7 @@
     "footer.columns.related.links.oneApi": "1つのAPI",
     "footer.columns.related.title": "関連プロジェクト",
     "footer.defaultCopyright": "すべての権利を留保します。",
-    "footer.new\u0061pi.projectAttributionSuffix": "すべての権利を留保します。プロジェクトコントリビューターにより設計・開発されています。",
+    "footer.newapi.projectAttributionSuffix": "すべての権利を留保します。プロジェクトコントリビューターにより設計・開発されています。",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "2025 年 5 月 10 日以降に追加されたチャネルの場合、デプロイ時にモデル名から「.」を削除する必要はありません",
     "For private deployments, format: https://fastgpt.run/api/openapi": "プライベートデプロイメントの場合、形式: https://fastgpt.run/api/openapi",
     "Force a syntactically valid JSON response": "構文的に有効な JSON 応答を強制",
@@ -5228,5 +5237,7 @@
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V 4",
     "Zoom": "ズーム"
-  }
+  },
+  "Update completed. Please restart the new-api process to load the new binary.": "更新が完了しました。新しいバイナリを読み込むには new-api プロセスを再起動してください。",
+  "Update now": "今すぐ更新"
 }

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -1,13 +1,4 @@
 {
-  "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "Автоматическое применение недоступно в этой среде. Скачайте релиз вручную или откройте страницу GitHub.",
-  "Backend update API unavailable; showing release notes only.": "API обновления бэкенда недоступен; показаны только примечания к выпуску.",
-  "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Обнаружено развёртывание Docker. Обновление бинарника на месте отключено. Обновите: docker compose pull && docker compose up -d",
-  "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "Обновление на месте скачивает официальный бинарник релиза и заменяет работающий исполняемый файл (только бинарные установки). Пользователям Docker следует pull нового образа.",
-  "Rollback completed. Please restart the new-api process.": "Откат завершён. Перезапустите процесс new-api.",
-  "Rollback failed": "Откат не выполнен",
-  "Rollback last backup": "Откатить к последнему бэкапу",
-  "Rollback versions": "Версии для отката",
-  "Rolling back...": "Откат…",
   "translation": {
     "360": "360",
     "1000": "1000",
@@ -5236,8 +5227,17 @@
     "Zero retention": "Без хранения данных",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
-  },
-  "Update completed. Please restart the new-api process to load the new binary.": "Обновление завершено. Перезапустите процесс new-api, чтобы загрузить новый бинарник.",
-  "Update now": "Обновить сейчас"
+    "Zoom": "Zoom",
+    "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "Автоматическое применение недоступно в этой среде. Скачайте релиз вручную или откройте страницу GitHub.",
+    "Backend update API unavailable; showing release notes only.": "API обновления бэкенда недоступен; показаны только примечания к выпуску.",
+    "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Обнаружено развёртывание Docker. Обновление бинарника на месте отключено. Обновите: docker compose pull && docker compose up -d",
+    "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "Обновление на месте скачивает официальный бинарник релиза и заменяет работающий исполняемый файл (только бинарные установки). Пользователям Docker следует загрузить новый образ.",
+    "Rollback completed. Please restart the new-api process.": "Откат завершён. Перезапустите процесс new-api.",
+    "Rollback failed": "Откат не выполнен",
+    "Rollback last backup": "Откатить к последнему бэкапу",
+    "Rollback versions": "Версии для отката",
+    "Rolling back...": "Откат…",
+    "Update completed. Please restart the new-api process to load the new binary.": "Обновление завершено. Перезапустите процесс new-api, чтобы загрузить новый бинарник.",
+    "Update now": "Обновить сейчас"
+  }
 }

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -1,4 +1,13 @@
 {
+  "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "Автоматическое применение недоступно в этой среде. Скачайте релиз вручную или откройте страницу GitHub.",
+  "Backend update API unavailable; showing release notes only.": "API обновления бэкенда недоступен; показаны только примечания к выпуску.",
+  "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Обнаружено развёртывание Docker. Обновление бинарника на месте отключено. Обновите: docker compose pull && docker compose up -d",
+  "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "Обновление на месте скачивает официальный бинарник релиза и заменяет работающий исполняемый файл (только бинарные установки). Пользователям Docker следует pull нового образа.",
+  "Rollback completed. Please restart the new-api process.": "Откат завершён. Перезапустите процесс new-api.",
+  "Rollback failed": "Откат не выполнен",
+  "Rollback last backup": "Откатить к последнему бэкапу",
+  "Rollback versions": "Версии для отката",
+  "Rolling back...": "Откат…",
   "translation": {
     "360": "360",
     "1000": "1000",
@@ -2033,7 +2042,7 @@
     "footer.columns.related.links.oneApi": "Один API",
     "footer.columns.related.title": "Связанные проекты",
     "footer.defaultCopyright": "Все права защищены.",
-    "footer.new\u0061pi.projectAttributionSuffix": "Все права защищены. Разработано участниками проекта.",
+    "footer.newapi.projectAttributionSuffix": "Все права защищены. Разработано участниками проекта.",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "Для каналов, добавленных после 10 мая 2025 г., не нужно удалять \".\" из имён моделей при развёртывании",
     "For private deployments, format: https://fastgpt.run/api/openapi": "Для частных развертываний, формат: https://fastgpt.run/api/openapi",
     "Force a syntactically valid JSON response": "Принудительно возвращать синтаксически корректный JSON",
@@ -5228,5 +5237,7 @@
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
     "Zoom": "Zoom"
-  }
+  },
+  "Update completed. Please restart the new-api process to load the new binary.": "Обновление завершено. Перезапустите процесс new-api, чтобы загрузить новый бинарник.",
+  "Update now": "Обновить сейчас"
 }

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -1,4 +1,13 @@
 {
+  "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "Không thể tự động áp dụng cập nhật trong môi trường này. Hãy tải bản phát hành thủ công hoặc mở trang GitHub.",
+  "Backend update API unavailable; showing release notes only.": "API cập nhật backend không khả dụng; chỉ hiển thị ghi chú phát hành.",
+  "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Phát hiện triển khai Docker. Đã tắt cập nhật nhị phân tại chỗ. Nâng cấp bằng: docker compose pull && docker compose up -d",
+  "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "Cập nhật tại chỗ tải nhị phân phát hành chính thức và thay thế file thực thi đang chạy (chỉ cài đặt nhị phân). Người dùng Docker nên kéo image mới.",
+  "Rollback completed. Please restart the new-api process.": "Đã hoàn tất rollback. Vui lòng khởi động lại tiến trình new-api.",
+  "Rollback failed": "Rollback thất bại",
+  "Rollback last backup": "Rollback bản sao lưu gần nhất",
+  "Rollback versions": "Phiên bản rollback",
+  "Rolling back...": "Đang rollback…",
   "translation": {
     "360": "360",
     "1000": "1000",
@@ -2033,7 +2042,7 @@
     "footer.columns.related.links.oneApi": "One API",
     "footer.columns.related.title": "Các Dự Án Liên Quan",
     "footer.defaultCopyright": "Bản quyền được bảo lưu.",
-    "footer.new\u0061pi.projectAttributionSuffix": "Bản quyền được bảo lưu. Được thiết kế và phát triển bởi các cộng tác viên dự án.",
+    "footer.newapi.projectAttributionSuffix": "Bản quyền được bảo lưu. Được thiết kế và phát triển bởi các cộng tác viên dự án.",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "Đối với các kênh được thêm sau ngày 10 tháng 5 năm 2025, không cần loại bỏ \".\" khỏi tên mô hình trong quá trình triển khai",
     "For private deployments, format: https://fastgpt.run/api/openapi": "Đối với các triển khai riêng tư, định dạng: https://fastgpt.run/api/openapi",
     "Force a syntactically valid JSON response": "Buộc phản hồi JSON hợp lệ về cú pháp",
@@ -5228,5 +5237,7 @@
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
     "Zoom": "Zoom"
-  }
+  },
+  "Update completed. Please restart the new-api process to load the new binary.": "Cập nhật hoàn tất. Hãy khởi động lại tiến trình new-api để tải nhị phân mới.",
+  "Update now": "Cập nhật ngay"
 }

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -1,13 +1,4 @@
 {
-  "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "Không thể tự động áp dụng cập nhật trong môi trường này. Hãy tải bản phát hành thủ công hoặc mở trang GitHub.",
-  "Backend update API unavailable; showing release notes only.": "API cập nhật backend không khả dụng; chỉ hiển thị ghi chú phát hành.",
-  "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Phát hiện triển khai Docker. Đã tắt cập nhật nhị phân tại chỗ. Nâng cấp bằng: docker compose pull && docker compose up -d",
-  "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "Cập nhật tại chỗ tải nhị phân phát hành chính thức và thay thế file thực thi đang chạy (chỉ cài đặt nhị phân). Người dùng Docker nên kéo image mới.",
-  "Rollback completed. Please restart the new-api process.": "Đã hoàn tất rollback. Vui lòng khởi động lại tiến trình new-api.",
-  "Rollback failed": "Rollback thất bại",
-  "Rollback last backup": "Rollback bản sao lưu gần nhất",
-  "Rollback versions": "Phiên bản rollback",
-  "Rolling back...": "Đang rollback…",
   "translation": {
     "360": "360",
     "1000": "1000",
@@ -5236,8 +5227,17 @@
     "Zero retention": "Không lưu dữ liệu",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
-  },
-  "Update completed. Please restart the new-api process to load the new binary.": "Cập nhật hoàn tất. Hãy khởi động lại tiến trình new-api để tải nhị phân mới.",
-  "Update now": "Cập nhật ngay"
+    "Zoom": "Zoom",
+    "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "Không thể tự động áp dụng cập nhật trong môi trường này. Hãy tải bản phát hành thủ công hoặc mở trang GitHub.",
+    "Backend update API unavailable; showing release notes only.": "API cập nhật backend không khả dụng; chỉ hiển thị ghi chú phát hành.",
+    "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "Phát hiện triển khai Docker. Đã tắt cập nhật nhị phân tại chỗ. Nâng cấp bằng: docker compose pull && docker compose up -d",
+    "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "Cập nhật tại chỗ tải nhị phân phát hành chính thức và thay thế file thực thi đang chạy (chỉ cài đặt nhị phân). Người dùng Docker nên kéo image mới.",
+    "Rollback completed. Please restart the new-api process.": "Đã hoàn tất rollback. Vui lòng khởi động lại tiến trình new-api.",
+    "Rollback failed": "Rollback thất bại",
+    "Rollback last backup": "Rollback bản sao lưu gần nhất",
+    "Rollback versions": "Phiên bản rollback",
+    "Rolling back...": "Đang rollback…",
+    "Update completed. Please restart the new-api process to load the new binary.": "Cập nhật hoàn tất. Hãy khởi động lại tiến trình new-api để tải nhị phân mới.",
+    "Update now": "Cập nhật ngay"
+  }
 }

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -1,13 +1,4 @@
 {
-  "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "目前環境無法自動套用更新。請手動下載發布包或開啟 GitHub 頁面。",
-  "Backend update API unavailable; showing release notes only.": "後端更新介面不可用；僅顯示發布說明。",
-  "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "偵測到 Docker 部署。已停用原地二進位更新。請使用：docker compose pull && docker compose up -d",
-  "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "原地更新會下載官方發布二進位並替換正在執行的可執行檔（僅適用於二進位安裝）。Docker 使用者應改為拉取新映像。",
-  "Rollback completed. Please restart the new-api process.": "回滾完成。請重啟 new-api 行程。",
-  "Rollback failed": "回滾失敗",
-  "Rollback last backup": "回滾到上次備份",
-  "Rollback versions": "可回滾版本",
-  "Rolling back...": "正在回滾…",
   "translation": {
     "360": "360",
     "1000": "1000",
@@ -5236,8 +5227,17 @@
     "Zero retention": "零數據保留",
     "Zhipu": "智譜",
     "Zhipu V4": "智譜 V4",
-    "Zoom": "縮放"
-  },
-  "Update completed. Please restart the new-api process to load the new binary.": "更新完成。請重啟 new-api 行程以載入新二進位。",
-  "Update now": "立即更新"
+    "Zoom": "縮放",
+    "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "目前環境無法自動套用更新。請手動下載發布包或開啟 GitHub 頁面。",
+    "Backend update API unavailable; showing release notes only.": "後端更新介面不可用；僅顯示發布說明。",
+    "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "偵測到 Docker 部署。已停用原地二進位更新。請使用：docker compose pull && docker compose up -d",
+    "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "原地更新會下載官方發布二進位並替換正在執行的可執行檔（僅適用於二進位安裝）。Docker 使用者應改為拉取新映像。",
+    "Rollback completed. Please restart the new-api process.": "回滾完成。請重啟 new-api 行程。",
+    "Rollback failed": "回滾失敗",
+    "Rollback last backup": "回滾到上次備份",
+    "Rollback versions": "可回滾版本",
+    "Rolling back...": "正在回滾…",
+    "Update completed. Please restart the new-api process to load the new binary.": "更新完成。請重啟 new-api 行程以載入新二進位。",
+    "Update now": "立即更新"
+  }
 }

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -1,4 +1,13 @@
 {
+  "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "目前環境無法自動套用更新。請手動下載發布包或開啟 GitHub 頁面。",
+  "Backend update API unavailable; showing release notes only.": "後端更新介面不可用；僅顯示發布說明。",
+  "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "偵測到 Docker 部署。已停用原地二進位更新。請使用：docker compose pull && docker compose up -d",
+  "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "原地更新會下載官方發布二進位並替換正在執行的可執行檔（僅適用於二進位安裝）。Docker 使用者應改為拉取新映像。",
+  "Rollback completed. Please restart the new-api process.": "回滾完成。請重啟 new-api 行程。",
+  "Rollback failed": "回滾失敗",
+  "Rollback last backup": "回滾到上次備份",
+  "Rollback versions": "可回滾版本",
+  "Rolling back...": "正在回滾…",
   "translation": {
     "360": "360",
     "1000": "1000",
@@ -2033,7 +2042,7 @@
     "footer.columns.related.links.oneApi": "One API",
     "footer.columns.related.title": "相關項目",
     "footer.defaultCopyright": "版權所有。",
-    "footer.new\u0061pi.projectAttributionSuffix": "版權所有，由項目貢獻者設計與開發。",
+    "footer.newapi.projectAttributionSuffix": "版權所有，由項目貢獻者設計與開發。",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "對於 2025 年 5 月 10 日之後新增的渠道，在部署時無需從模型名稱中移除 \".\"",
     "For private deployments, format: https://fastgpt.run/api/openapi": "對於私有部署，格式為：https://fastgpt.run/api/openapi",
     "Force a syntactically valid JSON response": "強制返回語法合法的 JSON",
@@ -5228,5 +5237,7 @@
     "Zhipu": "智譜",
     "Zhipu V4": "智譜 V4",
     "Zoom": "縮放"
-  }
+  },
+  "Update completed. Please restart the new-api process to load the new binary.": "更新完成。請重啟 new-api 行程以載入新二進位。",
+  "Update now": "立即更新"
 }

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -1,4 +1,13 @@
 {
+  "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "当前环境无法自动应用更新。请手动下载发布包或打开 GitHub 页面。",
+  "Backend update API unavailable; showing release notes only.": "后端更新接口不可用；仅显示发布说明。",
+  "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "检测到 Docker 部署。已禁用原地二进制更新。请使用：docker compose pull && docker compose up -d",
+  "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "原地更新会下载官方发布二进制并替换正在运行的可执行文件（仅适用于二进制安装）。Docker 用户应改为拉取新镜像。",
+  "Rollback completed. Please restart the new-api process.": "回滚完成。请重启 new-api 进程。",
+  "Rollback failed": "回滚失败",
+  "Rollback last backup": "回滚到上次备份",
+  "Rollback versions": "可回滚版本",
+  "Rolling back...": "正在回滚…",
   "translation": {
     "360": "360",
     "1000": "1000",
@@ -2033,7 +2042,7 @@
     "footer.columns.related.links.oneApi": "One API",
     "footer.columns.related.title": "相关项目",
     "footer.defaultCopyright": "版权所有。",
-    "footer.new\u0061pi.projectAttributionSuffix": "版权所有，由项目贡献者设计与开发。",
+    "footer.newapi.projectAttributionSuffix": "版权所有，由项目贡献者设计与开发。",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "对于 2025 年 5 月 10 日之后添加的渠道，在部署时无需从模型名称中移除 \".\"",
     "For private deployments, format: https://fastgpt.run/api/openapi": "对于私有部署，格式为：https://fastgpt.run/api/openapi",
     "Force a syntactically valid JSON response": "强制返回语法合法的 JSON",
@@ -5228,5 +5237,7 @@
     "Zhipu": "智谱",
     "Zhipu V4": "智谱 V4",
     "Zoom": "缩放"
-  }
+  },
+  "Update completed. Please restart the new-api process to load the new binary.": "更新完成。请重启 new-api 进程以加载新二进制。",
+  "Update now": "立即更新"
 }

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -1,13 +1,4 @@
 {
-  "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "当前环境无法自动应用更新。请手动下载发布包或打开 GitHub 页面。",
-  "Backend update API unavailable; showing release notes only.": "后端更新接口不可用；仅显示发布说明。",
-  "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "检测到 Docker 部署。已禁用原地二进制更新。请使用：docker compose pull && docker compose up -d",
-  "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "原地更新会下载官方发布二进制并替换正在运行的可执行文件（仅适用于二进制安装）。Docker 用户应改为拉取新镜像。",
-  "Rollback completed. Please restart the new-api process.": "回滚完成。请重启 new-api 进程。",
-  "Rollback failed": "回滚失败",
-  "Rollback last backup": "回滚到上次备份",
-  "Rollback versions": "可回滚版本",
-  "Rolling back...": "正在回滚…",
   "translation": {
     "360": "360",
     "1000": "1000",
@@ -5236,8 +5227,17 @@
     "Zero retention": "零数据保留",
     "Zhipu": "智谱",
     "Zhipu V4": "智谱 V4",
-    "Zoom": "缩放"
-  },
-  "Update completed. Please restart the new-api process to load the new binary.": "更新完成。请重启 new-api 进程以加载新二进制。",
-  "Update now": "立即更新"
+    "Zoom": "缩放",
+    "Automatic apply is unavailable in this environment. Download the release manually or open the GitHub page.": "当前环境无法自动应用更新。请手动下载发布包或打开 GitHub 页面。",
+    "Backend update API unavailable; showing release notes only.": "后端更新接口不可用；仅显示发布说明。",
+    "Docker deployment detected. In-place binary update is disabled. Upgrade with: docker compose pull && docker compose up -d": "检测到 Docker 部署。已禁用原地二进制更新。请使用：docker compose pull && docker compose up -d",
+    "In-place update downloads the official release binary and replaces the running executable (binary installs only). Docker users should pull a new image instead.": "原地更新会下载官方发布二进制并替换正在运行的可执行文件（仅适用于二进制安装）。Docker 用户应改为拉取新镜像。",
+    "Rollback completed. Please restart the new-api process.": "回滚完成。请重启 new-api 进程。",
+    "Rollback failed": "回滚失败",
+    "Rollback last backup": "回滚到上次备份",
+    "Rollback versions": "可回滚版本",
+    "Rolling back...": "正在回滚…",
+    "Update completed. Please restart the new-api process to load the new binary.": "更新完成。请重启 new-api 进程以加载新二进制。",
+    "Update now": "立即更新"
+  }
 }


### PR DESCRIPTION
## Summary

Adds an in-place binary update flow inspired by Sub2API, so binary installs can check for updates, apply them, and roll back from the admin UI.

### Backend (`systemupdate` + controller)
- `GET /api/system-update/check`
- `POST /api/system-update/apply`
- `GET /api/system-update/rollback-versions`
- `POST /api/system-update/rollback`
- Root-only (`RootAuth`)
- Docker detected; apply blocked with compose pull guidance
- Env: `NEW_API_UPDATE_GITHUB_REPO` (default `Calcium-Ion/new-api`), `UPDATE_GITHUB_TOKEN`

### Frontend
- System maintenance: Check / Update now / Rollback
- Fallback to browser GitHub check if API unavailable

### Tests
- `go test ./systemupdate/` → 5/5 PASS

## Notes
- Binary installs: one-click apply
- Docker: use image pull

## Test plan
- [x] unit tests
- [ ] UI check-updates as root
- [ ] binary apply + restart
- [ ] docker apply blocked
- [ ] rollback backup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added system update checks using release information.
  * Added controls to apply updates and roll back to previous or selected versions.
  * Added update status, release details, progress feedback, and error handling.
  * Added deployment capability notices and manual-update guidance.

* **Bug Fixes**
  * Improved update package validation and download safety.
  * Added backup preservation and rollback safeguards.
  * Improved handling of unavailable updates, unsupported environments, and failed operations.

* **Documentation**
  * Added update and rollback guidance in supported languages, including Docker upgrade instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->