### PR TITLE
fix(billing): harden tiered retry group-switch billing (follow-up to #6518)

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -199,12 +199,12 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 			newAPIError = channelErr
 			break
 		}
+		addUsedChannel(c, channel.Id)
 		if billingErr := service.PrepareTieredBillingForSelectedGroup(c, relayInfo); billingErr != nil {
 			newAPIError = billingErr
 			break
 		}
 
-		addUsedChannel(c, channel.Id)
 		bodyStorage, bodyErr := common.GetBodyStorage(c)
 		if bodyErr != nil {
 			// Ensure consistent 413 for oversized bodies even when error occurs later (e.g., retry path)
@@ -312,15 +312,14 @@ func getChannel(c *gin.Context, info *relaycommon.RelayInfo, retryParam *service
 		}, nil
 	}
 	channel, selectGroup, err := service.CacheGetRandomSatisfiedChannel(retryParam)
-
-	info.PriceData.GroupRatioInfo = helper.HandleGroupRatio(c, info)
-
 	if err != nil {
 		return nil, types.NewError(fmt.Errorf("获取分组 %s 下模型 %s 的可用渠道失败（retry）: %s", selectGroup, info.OriginModelName, err.Error()), types.ErrorCodeGetChannelFailed, types.ErrOptionWithSkipRetry())
 	}
 	if channel == nil {
 		return nil, types.NewError(fmt.Errorf("分组 %s 下模型 %s 的可用渠道不存在（retry）", selectGroup, info.OriginModelName), types.ErrorCodeGetChannelFailed, types.ErrOptionWithSkipRetry())
 	}
+
+	info.PriceData.GroupRatioInfo = helper.HandleGroupRatio(c, info)
 
 	newAPIError := middleware.SetupContextForSelectedChannel(c, channel, info.OriginModelName)
 	if newAPIError != nil {

--- a/service/billing_session.go
+++ b/service/billing_session.go
@@ -232,6 +232,10 @@ func (s *BillingSession) preConsume(c *gin.Context, quota int) *types.NewAPIErro
 func (s *BillingSession) reserveFunding(delta int) error {
 	switch funding := s.funding.(type) {
 	case *WalletFunding:
+		// 与结算补扣（SettleBilling 正差额 → WalletFunding.Settle）语义一致：
+		// 全额无条件扣减，余额不足的部分记为欠费（余额可为负），不中断请求，
+		// 保证日志记录的预扣额度与用户余额的实际变动始终对账一致。
+		// DecreaseUserQuota 仅在数据库错误时失败。
 		if err := model.DecreaseUserQuota(funding.userId, delta, false); err != nil {
 			return types.NewError(err, types.ErrorCodeUpdateDataError, types.ErrOptionWithSkipRetry())
 		}

--- a/service/tiered_settle.go
+++ b/service/tiered_settle.go
@@ -132,9 +132,19 @@ func PrepareTieredBillingForSelectedGroup(c *gin.Context, relayInfo *relaycommon
 			types.ErrOptionWithSkipRetry(),
 		)
 	}
-	if snap == nil || snap.GroupRatio == 0 {
+	if snap == nil {
 		return nil
 	}
+	if snap.GroupRatio == 0 {
+		// Paid-to-free keeps FreeModel as-is: FreeModel means "pre-consume was
+		// skipped", which is not true once a session exists, and settlement
+		// already yields 0 for a zero group ratio.
+		return nil
+	}
+
+	// The selected group is paid; clear a FreeModel flag frozen when the
+	// initial group was free so downstream state stays consistent.
+	relayInfo.PriceData.FreeModel = false
 
 	if relayInfo.Billing == nil {
 		return PreConsumeBilling(c, snap.EstimatedQuotaAfterGroup, relayInfo)

--- a/service/tiered_settle_test.go
+++ b/service/tiered_settle_test.go
@@ -389,6 +389,7 @@ func TestPrepareTieredBillingForSelectedGroupStartsBillingAfterFreeGroup(t *test
 			QuotaPerUnit:              testQuotaPerUnit,
 		},
 		PriceData: types.PriceData{
+			FreeModel:      true,
 			GroupRatioInfo: types.GroupRatioInfo{GroupRatio: 0.20},
 		},
 	}
@@ -396,6 +397,7 @@ func TestPrepareTieredBillingForSelectedGroupStartsBillingAfterFreeGroup(t *test
 
 	require.Nil(t, PrepareTieredBillingForSelectedGroup(ctx, relayInfo))
 	require.NotNil(t, relayInfo.Billing)
+	assert.False(t, relayInfo.PriceData.FreeModel, "FreeModel must be cleared after switching to a paid group")
 	assert.Equal(t, 100_000, relayInfo.FinalPreConsumedQuota)
 	assert.Equal(t, 0.20, relayInfo.TieredBillingSnapshot.GroupRatio)
 	assert.Equal(t, 100_000, relayInfo.TieredBillingSnapshot.EstimatedQuotaAfterGroup)
@@ -403,6 +405,113 @@ func TestPrepareTieredBillingForSelectedGroupStartsBillingAfterFreeGroup(t *test
 	userQuota, err := model.GetUserQuota(userID, false)
 	require.NoError(t, err)
 	assert.Equal(t, 400_000, userQuota)
+}
+
+func TestPrepareTieredBillingForSelectedGroupPaidToFreeKeepsFreeModelFalse(t *testing.T) {
+	const expr = `tier("base", p)`
+	billing := &recordingBillingSettler{preConsumedQuota: 50_000}
+	relayInfo := &relaycommon.RelayInfo{
+		Billing:               billing,
+		FinalPreConsumedQuota: 50_000,
+		TieredBillingSnapshot: &billingexpr.BillingSnapshot{
+			BillingMode:               "tiered_expr",
+			ExprString:                expr,
+			ExprHash:                  billingexpr.ExprHashString(expr),
+			GroupRatio:                0.10,
+			EstimatedQuotaBeforeGroup: 500_000,
+			EstimatedQuotaAfterGroup:  50_000,
+			QuotaPerUnit:              testQuotaPerUnit,
+		},
+		PriceData: types.PriceData{
+			GroupRatioInfo: types.GroupRatioInfo{GroupRatio: 0},
+		},
+	}
+
+	require.Nil(t, PrepareTieredBillingForSelectedGroup(nil, relayInfo))
+
+	// Pre-consume did happen under the paid group, so FreeModel stays false;
+	// settlement already yields 0 for GroupRatio == 0 and the session refunds.
+	assert.False(t, relayInfo.PriceData.FreeModel)
+	assert.Empty(t, billing.reserveTargets)
+	assert.Equal(t, 50_000, relayInfo.FinalPreConsumedQuota)
+}
+
+func TestPrepareTieredBillingForSelectedGroupTopUpArrearsAllowsNegativeBalance(t *testing.T) {
+	truncate(t)
+
+	const userID = 701
+	// Balance covers the initial 50k pre-consume (already deducted before this
+	// test's seed) but not the 50k top-up to the more expensive retry group.
+	// The top-up must NOT abort the request: the full delta is deducted, the
+	// uncovered 30k becomes arrears (negative balance), mirroring how
+	// settlement charges a positive delta unconditionally.
+	seedUser(t, userID, 20_000)
+
+	relayInfo := &relaycommon.RelayInfo{
+		UserId:                userID,
+		IsPlayground:          true,
+		FinalPreConsumedQuota: 50_000,
+		TieredBillingSnapshot: &billingexpr.BillingSnapshot{
+			BillingMode:               "tiered_expr",
+			ExprString:                `tier("base", p)`,
+			ExprHash:                  billingexpr.ExprHashString(`tier("base", p)`),
+			GroupRatio:                0.10,
+			EstimatedQuotaBeforeGroup: 500_000,
+			EstimatedQuotaAfterGroup:  50_000,
+			QuotaPerUnit:              testQuotaPerUnit,
+		},
+		PriceData: types.PriceData{
+			GroupRatioInfo: types.GroupRatioInfo{GroupRatio: 0.20},
+		},
+	}
+	session := &BillingSession{
+		relayInfo:        relayInfo,
+		funding:          &WalletFunding{userId: userID, consumed: 50_000},
+		preConsumedQuota: 50_000,
+	}
+	relayInfo.Billing = session
+
+	require.Nil(t, PrepareTieredBillingForSelectedGroup(nil, relayInfo))
+
+	// Full reservation recorded; wallet charged the full delta into arrears.
+	assert.Equal(t, 100_000, session.GetPreConsumedQuota())
+	assert.Equal(t, 100_000, relayInfo.FinalPreConsumedQuota)
+	assert.Equal(t, 100_000, relayInfo.TieredBillingSnapshot.EstimatedQuotaAfterGroup)
+	userQuota, err := model.GetUserQuota(userID, false)
+	require.NoError(t, err)
+	assert.Equal(t, -30_000, userQuota)
+
+	// Settlement still reconciles against the full reservation: actual 80k
+	// refunds the 20k over-reserve, landing at seed - (actual - initial) = -10k.
+	require.NoError(t, session.Settle(80_000))
+	userQuota, err = model.GetUserQuota(userID, false)
+	require.NoError(t, err)
+	assert.Equal(t, -10_000, userQuota)
+}
+
+func TestBillingSessionReserveWalletTopUpDecrementsBalance(t *testing.T) {
+	truncate(t)
+
+	const userID = 702
+	seedUser(t, userID, 500_000)
+
+	relayInfo := &relaycommon.RelayInfo{
+		UserId:       userID,
+		IsPlayground: true,
+	}
+	session := &BillingSession{
+		relayInfo:        relayInfo,
+		funding:          &WalletFunding{userId: userID, consumed: 50_000},
+		preConsumedQuota: 50_000,
+	}
+
+	require.NoError(t, session.Reserve(100_000))
+
+	assert.Equal(t, 100_000, session.GetPreConsumedQuota())
+	assert.Equal(t, 100_000, relayInfo.FinalPreConsumedQuota)
+	userQuota, err := model.GetUserQuota(userID, false)
+	require.NoError(t, err)
+	assert.Equal(t, 450_000, userQuota)
 }
 
 func TestTryTieredSettleUsesFinalGroupAfterRetry(t *testing.T) {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
Follow-up to #6518 (fix for #6480), addressing three non-blocking review findings on the tiered-billing retry path. This PR was developed with AI assistance (reviewed before submission).

1. **钱包 Reserve 补扣的欠费（arrears）语义** — 重试落到更贵的分组时，预扣目标的补扣差额必须**全额无条件扣减**：`model.DecreaseUserQuota` 是无条件 `quota - ?` 递减，余额不足的部分记为用户欠费（余额可为负），与结算路径（`SettleBilling` 正差额 → `WalletFunding.Settle`）语义完全一致，请求不因补扣不足而中断。这是对账要求：日志记录的预扣/结算额度必须与用户余额的实际变动一致。本 PR 为该分支补充了明确的语义注释，并新增回归测试锁定该行为（此前无任何测试覆盖，未来改动若引入余额检查会立即破坏对账一致性）。真正的数据库错误仍返回 `update_data_error` 并使本次尝试失败，绝不静默少预扣。**订阅资金来源不变**：`PostConsumeUserSubscriptionDelta` 强制 `used <= total` 硬上限（model/subscription.go），订阅不支持欠费，因此保留其 `insufficient_user_quota`（403）行为。
2. **免费转付费分组后 `PriceData.FreeModel` 未同步** — 初始分组 ratio 为 0（跳过预扣费）而重试落到付费分组时，`PrepareTieredBillingForSelectedGroup` 会创建计费会话，但 `FreeModel` 仍为 `true`。现在在付费分组分支将其清为 `false`。付费转免费方向保持不变：会话已存在时 "跳过预扣费" 不再成立，且结算对 ratio 0 本就产出 0。
3. **`controller/relay.go` 顺序问题** — (a) `getChannel` 中 `HandleGroupRatio` 原先在 `CacheGetRandomSatisfiedChannel` 的错误检查之前执行，选路失败也会改写定价状态，现移到错误处理之后；(b) 重试循环中 `PrepareTieredBillingForSelectedGroup` 原先在 `addUsedChannel` 之前，Prepare 失败时选中的渠道不会出现在 `use_channel` 重试日志里，现先记录渠道再执行 Prepare。

计费不变量保持：扣费金额永不为负（欠费指余额可为负，而非扣费额为负）；`FinalPreConsumedQuota` 与会话预扣量始终反映完整的补扣后预扣目标，保证预扣与结算差额正确对账；补扣遇数据库错误即失败整个尝试。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Follow-up to #6518, context: #6480

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述基于对代码逻辑的实际理解撰写并经过整理；本 PR 为 AI 辅助开发（AI-assisted），特此说明。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```
$ go build ./...   # ok

$ go test ./service/... ./pkg/billingexpr/... ./controller/...
ok  	github.com/QuantumNous/new-api/service	0.419s
ok  	github.com/QuantumNous/new-api/service/authz	0.021s
ok  	github.com/QuantumNous/new-api/pkg/billingexpr	0.012s
ok  	github.com/QuantumNous/new-api/controller	0.311s

$ go test ./service/ -run 'TestPrepareTieredBilling|TestBillingSessionReserve' -v
--- PASS: TestPrepareTieredBillingForSelectedGroupUpdatesReservation (0.00s)
--- PASS: TestPrepareTieredBillingForSelectedGroupStartsBillingAfterFreeGroup (0.00s)
--- PASS: TestPrepareTieredBillingForSelectedGroupPaidToFreeKeepsFreeModelFalse (0.00s)
--- PASS: TestPrepareTieredBillingForSelectedGroupTopUpArrearsAllowsNegativeBalance (0.00s)
--- PASS: TestBillingSessionReserveWalletTopUpDecrementsBalance (0.00s)
PASS
```
新增测试覆盖：余额不足时补扣不中断请求（Prepare 返回 nil）、全额扣减使余额进入欠费（-30k）、`FinalPreConsumedQuota` 等于完整新预扣目标（100k）、后续结算按完整预扣正确对账（80k 实耗 → 退 20k → 余额 -10k）；余额充足的补扣正确扣减并同步 `FinalPreConsumedQuota`；免费转付费清除 `FreeModel`；付费转免费保持 `FreeModel=false` 且不触发 Reserve。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay channel selection and pricing preparation when selection fails or no channel is available.
  * Updated wallet funding to allow temporary negative balances when usage exceeds available funds, with subsequent settlement adjustments.
  * Corrected free and paid model status transitions when switching billing groups.
  * Improved consistency for paid-group billing reservations and pre-consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->