### PR TITLE
fix: custom oauth binding status never shown due to id type mismatch

### DIFF
--- a/web/src/features/profile/api.ts
+++ b/web/src/features/profile/api.ts
@@ -173,9 +173,9 @@ export async function revokeOtherLoginSessions(): Promise<ApiResponse> {
 // ============================================================================
 
 export interface CustomOAuthBinding {
-  provider_id: string
+  provider_id: number
   provider_name: string
-  external_id?: string
+  provider_user_id?: string
 }
 
 /**
@@ -192,7 +192,7 @@ export async function getSelfOAuthBindings(): Promise<
  * Unbind a custom OAuth provider for current user
  */
 export async function unbindCustomOAuth(
-  providerId: string
+  providerId: number
 ): Promise<ApiResponse> {
   const res = await api.delete(`/api/user/oauth/bindings/${providerId}`)
   return res.data

--- a/web/src/features/profile/components/tabs/account-bindings-tab.tsx
+++ b/web/src/features/profile/components/tabs/account-bindings-tab.tsx
@@ -475,7 +475,7 @@ export function AccountBindingsTab({
           <div className='grid grid-cols-1 gap-2.5 sm:grid-cols-2 sm:gap-3'>
             {customProviders.map((provider) => {
               const binding = customBindings.find(
-                (b) => b.provider_id === String(provider.id)
+                (b) => b.provider_id === provider.id
               )
               const isBound = !!binding
               return (
@@ -500,7 +500,7 @@ export function AccountBindingsTab({
                       </div>
                       <p className='text-muted-foreground truncate text-xs'>
                         {isBound
-                          ? binding?.external_id || t('Bound')
+                          ? binding?.provider_user_id || t('Bound')
                           : t('Not bound')}
                       </p>
                     </div>


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
个人资料页「账户绑定」里，自定义 OAuth 提供商永远显示「未绑定」，即使 user_oauth_bindings 表里有绑定记录。

原因：后端 `/api/user/oauth/bindings` 返回的 `provider_id` 是 JSON 数字（Go int），前端却用 `b.provider_id === String(provider.id)` 严格比较，数字和字符串永远不相等，所以 isBound 恒为 false。另外前端接口声明的 `external_id` 字段后端并不返回（实际字段叫 `provider_user_id`），绑定卡片上也一直显示不出第三方身份 ID。

改法：前端类型声明对齐后端响应（`provider_id: number`、`provider_user_id`），按数字直接比较，卡片显示改用 `provider_user_id`。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无（自测发现，前端显示层类型比较错误，非设计取舍）

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
修复前:
<img width="1688" height="1304" alt="image" src="https://github.com/user-attachments/assets/7cc77136-13a8-4b3a-99ea-95ba545b75bb" />

修复后:
<img width="1708" height="1350" alt="image" src="https://github.com/user-attachments/assets/c0313344-2e55-4fa0-a2f0-7dcbe368890b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom OAuth account binding compatibility by using numeric provider identifiers.
  * Updated bound account details to display the correct provider user identifier.
  * Improved unbinding behavior for custom OAuth providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->