### PR TITLE
fix(video): avoid duplicate CORS headers in content proxy

### DIFF
--- a/controller/video_proxy.go
+++ b/controller/video_proxy.go
@@ -169,16 +169,25 @@ func VideoProxy(c *gin.Context) {
 		return
 	}
 
-	for key, values := range resp.Header {
-		for _, value := range values {
-			c.Writer.Header().Add(key, value)
-		}
-	}
+	copyVideoProxyResponseHeaders(c.Writer.Header(), resp.Header)
 
 	c.Writer.Header().Set("Cache-Control", "public, max-age=86400")
 	c.Writer.WriteHeader(resp.StatusCode)
 	if _, err = io.Copy(c.Writer, resp.Body); err != nil {
 		logger.LogError(c.Request.Context(), fmt.Sprintf("Failed to stream video content: %s", err.Error()))
+	}
+}
+
+func copyVideoProxyResponseHeaders(dst, src http.Header) {
+	for key, values := range src {
+		// CORS headers are managed by the current NewAPI instance. Copying them
+		// from an upstream proxy can produce duplicate headers rejected by browsers.
+		if strings.HasPrefix(strings.ToLower(key), "access-control-") {
+			continue
+		}
+		for _, value := range values {
+			dst.Add(key, value)
+		}
 	}
 }
 

--- a/controller/video_proxy_test.go
+++ b/controller/video_proxy_test.go
@@ -2,15 +2,16 @@ package controller
 
 import (
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCopyVideoProxyResponseHeadersSkipsUpstreamCORS(t *testing.T) {
 	dst := make(http.Header)
 	dst.Set("Access-Control-Allow-Origin", "*")
 	src := http.Header{
-		"Access-Control-Allow-Origin":  {"https://upstream.example"},
+		"aCcEsS-cOnTrOl-AlLoW-OrIgIn":  {"https://upstream.example"},
 		"Access-Control-Allow-Headers": {"Authorization"},
 		"Content-Type":                 {"video/mp4"},
 		"X-Upstream-Value":             {"first", "second"},
@@ -18,16 +19,8 @@ func TestCopyVideoProxyResponseHeadersSkipsUpstreamCORS(t *testing.T) {
 
 	copyVideoProxyResponseHeaders(dst, src)
 
-	if got := dst.Values("Access-Control-Allow-Origin"); !reflect.DeepEqual(got, []string{"*"}) {
-		t.Fatalf("Access-Control-Allow-Origin = %v, want existing middleware value", got)
-	}
-	if got := dst.Values("Access-Control-Allow-Headers"); len(got) != 0 {
-		t.Fatalf("Access-Control-Allow-Headers = %v, want no copied upstream values", got)
-	}
-	if got := dst.Get("Content-Type"); got != "video/mp4" {
-		t.Fatalf("Content-Type = %q, want video/mp4", got)
-	}
-	if got := dst.Values("X-Upstream-Value"); !reflect.DeepEqual(got, []string{"first", "second"}) {
-		t.Fatalf("X-Upstream-Value = %v, want both upstream values", got)
-	}
+	assert.Equal(t, []string{"*"}, dst.Values("Access-Control-Allow-Origin"))
+	assert.Empty(t, dst.Values("Access-Control-Allow-Headers"))
+	assert.Equal(t, "video/mp4", dst.Get("Content-Type"))
+	assert.Equal(t, []string{"first", "second"}, dst.Values("X-Upstream-Value"))
 }

--- a/controller/video_proxy_test.go
+++ b/controller/video_proxy_test.go
@@ -1,0 +1,33 @@
+package controller
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestCopyVideoProxyResponseHeadersSkipsUpstreamCORS(t *testing.T) {
+	dst := make(http.Header)
+	dst.Set("Access-Control-Allow-Origin", "*")
+	src := http.Header{
+		"Access-Control-Allow-Origin":  {"https://upstream.example"},
+		"Access-Control-Allow-Headers": {"Authorization"},
+		"Content-Type":                 {"video/mp4"},
+		"X-Upstream-Value":             {"first", "second"},
+	}
+
+	copyVideoProxyResponseHeaders(dst, src)
+
+	if got := dst.Values("Access-Control-Allow-Origin"); !reflect.DeepEqual(got, []string{"*"}) {
+		t.Fatalf("Access-Control-Allow-Origin = %v, want existing middleware value", got)
+	}
+	if got := dst.Values("Access-Control-Allow-Headers"); len(got) != 0 {
+		t.Fatalf("Access-Control-Allow-Headers = %v, want no copied upstream values", got)
+	}
+	if got := dst.Get("Content-Type"); got != "video/mp4" {
+		t.Fatalf("Content-Type = %q, want video/mp4", got)
+	}
+	if got := dst.Values("X-Upstream-Value"); !reflect.DeepEqual(got, []string{"first", "second"}) {
+		t.Fatalf("X-Upstream-Value = %v, want both upstream values", got)
+	}
+}


### PR DESCRIPTION
## 📝 变更描述 / Description

视频内容代理目前会使用 `Header().Add()` 复制上游的所有响应头。当上游也返回 CORS 响应头时，它们会与当前实例 CORS 中间件已经设置的响应头叠加，导致浏览器因多个 `Access-Control-Allow-Origin` 值而拒绝读取视频响应。

本次修改在复制视频响应头时跳过上游的所有 `Access-Control-*` 头，继续由当前实例的 CORS 中间件统一管理；其他响应头（包括普通多值头）保持原有透传行为。新增单元测试覆盖上述行为。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #6574

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 已结合实际响应头、现有 CORS 中间件和视频代理代码整理此描述。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，未发现相同问题。
- [x] **Bug fix 说明:** 已提交并关联 Issue #6574。
- [x] **变更理解:** 已确认重复响应头来自视频代理对上游 CORS 头的追加。
- [x] **范围聚焦:** 仅修改视频代理响应头复制逻辑并新增对应测试。
- [x] **本地验证:** 已运行并通过 controller 包测试。
- [x] **安全合规:** 代码和测试不包含敏感凭据。

## 📸 运行证明 / Proof of Work

```text
$ go test ./controller -count=1
ok  github.com/QuantumNous/new-api/controller  0.744s
```

新增测试验证：

- 保留当前实例已经设置的 `Access-Control-Allow-Origin`
- 不复制上游 `Access-Control-*` 响应头
- 正常复制 `Content-Type`
- 保留普通响应头的多个值


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video proxy responses by preventing upstream CORS headers from overriding the application’s CORS settings.
  * Preserved other upstream response headers, including headers with multiple values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->