### PR TITLE
fix(responses): accept scientific created_at timestamps

### DIFF
--- a/relay/channel/openai/chat_via_responses.go
+++ b/relay/channel/openai/chat_via_responses.go
@@ -143,7 +143,7 @@ func OaiResponsesToChatBufferedStreamHandler(c *gin.Context, info *relaycommon.R
 	if finalResponse == nil {
 		finalResponse = &dto.OpenAIResponsesResponse{
 			ID:        helper.GetResponseID(c),
-			CreatedAt: int(time.Now().Unix()),
+			CreatedAt: dto.UnixTimestamp(time.Now().Unix()),
 			Model:     info.UpstreamModelName,
 			Status:    []byte(`"completed"`),
 		}

--- a/relay/channel/openai/relay_responses_scientific_test.go
+++ b/relay/channel/openai/relay_responses_scientific_test.go
@@ -15,10 +15,14 @@ import (
 )
 
 func TestOaiResponsesStreamHandlerForwardsScientificCreatedAtCompletion(t *testing.T) {
+	oldMode := gin.Mode()
 	gin.SetMode(gin.TestMode)
 	oldTimeout := constant.StreamingTimeout
 	constant.StreamingTimeout = 30
-	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+	t.Cleanup(func() {
+		gin.SetMode(oldMode)
+		constant.StreamingTimeout = oldTimeout
+	})
 
 	event := `{"type":"response.completed","response":{"id":"resp_test","created_at":1.76848816E9,"status":"completed","output":[]}}`
 	body := "event: response.completed\n" + "data: " + event + "\n\ndata: [DONE]\n\n"

--- a/relay/channel/openai/relay_responses_scientific_test.go
+++ b/relay/channel/openai/relay_responses_scientific_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/QuantumNous/new-api/constant"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,7 +43,7 @@ func TestOaiResponsesStreamHandlerForwardsScientificCreatedAtCompletion(t *testi
 
 	_, apiErr := OaiResponsesStreamHandler(c, info, resp)
 	require.Nil(t, apiErr)
-	require.Contains(t, recorder.Body.String(), "event: response.completed\n")
-	require.Contains(t, recorder.Body.String(), "data: "+event)
-	require.Zero(t, info.StreamStatus.TotalErrorCount())
+	assert.Contains(t, recorder.Body.String(), "event: response.completed\n")
+	assert.Contains(t, recorder.Body.String(), "data: "+event)
+	assert.Zero(t, info.StreamStatus.TotalErrorCount())
 }

--- a/relay/channel/openai/relay_responses_scientific_test.go
+++ b/relay/channel/openai/relay_responses_scientific_test.go
@@ -1,0 +1,44 @@
+package openai
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOaiResponsesStreamHandlerForwardsScientificCreatedAtCompletion(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	event := `{"type":"response.completed","response":{"id":"resp_test","created_at":1.76848816E9,"status":"completed","output":[]}}`
+	body := "event: response.completed\n" + "data: " + event + "\n\ndata: [DONE]\n\n"
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Set(common.RequestIdKey, "scientific-created-at-test")
+	info := &relaycommon.RelayInfo{
+		DisablePing: true,
+		ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "grok-test"},
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+
+	_, apiErr := OaiResponsesStreamHandler(c, info, resp)
+	require.Nil(t, apiErr)
+	require.Contains(t, recorder.Body.String(), "event: response.completed\n")
+	require.Contains(t, recorder.Body.String(), "data: "+event)
+	require.Zero(t, info.StreamStatus.TotalErrorCount())
+}

--- a/relaykit/dto/openai_compaction.go
+++ b/relaykit/dto/openai_compaction.go
@@ -9,7 +9,7 @@ import (
 type OpenAIResponsesCompactionResponse struct {
 	ID        string          `json:"id"`
 	Object    string          `json:"object"`
-	CreatedAt int             `json:"created_at"`
+	CreatedAt UnixTimestamp   `json:"created_at"`
 	Output    json.RawMessage `json:"output"`
 	Usage     *Usage          `json:"usage"`
 	Error     any             `json:"error,omitempty"`

--- a/relaykit/dto/openai_response.go
+++ b/relaykit/dto/openai_response.go
@@ -293,7 +293,7 @@ type OutputTokenDetails struct {
 type OpenAIResponsesResponse struct {
 	ID                 string             `json:"id"`
 	Object             string             `json:"object"`
-	CreatedAt          int                `json:"created_at"`
+	CreatedAt          UnixTimestamp      `json:"created_at"`
 	Status             json.RawMessage    `json:"status"`
 	Error              any                `json:"error,omitempty"`
 	IncompleteDetails  *IncompleteDetails `json:"incomplete_details,omitempty"`

--- a/relaykit/dto/values.go
+++ b/relaykit/dto/values.go
@@ -1,7 +1,9 @@
 package dto
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"strconv"
 )
 
@@ -49,6 +51,41 @@ func (i *IntValue) UnmarshalJSON(b []byte) error {
 
 func (i IntValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(int(i))
+}
+
+type UnixTimestamp int64
+
+func (t *UnixTimestamp) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+	if trimmed[0] == '"' {
+		return fmt.Errorf("timestamp must be json number, got string")
+	}
+
+	var n json.Number
+	if err := json.Unmarshal(trimmed, &n); err != nil {
+		return err
+	}
+	if i, err := n.Int64(); err == nil {
+		*t = UnixTimestamp(i)
+		return nil
+	}
+	f, err := n.Float64()
+	if err != nil {
+		return err
+	}
+	*t = UnixTimestamp(int64(f))
+	return nil
+}
+
+func (t UnixTimestamp) MarshalJSON() ([]byte, error) {
+	return json.Marshal(int64(t))
+}
+
+func (t UnixTimestamp) Int64() int64 {
+	return int64(t)
 }
 
 type BoolValue bool

--- a/relaykit/dto/values.go
+++ b/relaykit/dto/values.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"strconv"
 )
 
@@ -53,6 +54,8 @@ func (i IntValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(int(i))
 }
 
+// UnixTimestamp accepts integer and scientific-notation JSON timestamps while
+// preserving an integer Unix timestamp for downstream consumers.
 type UnixTimestamp int64
 
 func (t *UnixTimestamp) UnmarshalJSON(data []byte) error {
@@ -72,11 +75,15 @@ func (t *UnixTimestamp) UnmarshalJSON(data []byte) error {
 		*t = UnixTimestamp(i)
 		return nil
 	}
-	f, err := n.Float64()
-	if err != nil {
-		return err
+	rational, ok := new(big.Rat).SetString(n.String())
+	if !ok {
+		return fmt.Errorf("invalid timestamp %s", n.String())
 	}
-	*t = UnixTimestamp(int64(f))
+	i := new(big.Int).Quo(rational.Num(), rational.Denom())
+	if !i.IsInt64() {
+		return fmt.Errorf("timestamp %s is out of int64 range", n.String())
+	}
+	*t = UnixTimestamp(i.Int64())
 	return nil
 }
 

--- a/relaykit/dto/values_test.go
+++ b/relaykit/dto/values_test.go
@@ -1,0 +1,31 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnixTimestampUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int64
+	}{
+		{name: "integer", input: `1768488160`, want: 1768488160},
+		{name: "scientific notation", input: `1.76848816E9`, want: 1768488160},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var timestamp UnixTimestamp
+			require.NoError(t, timestamp.UnmarshalJSON([]byte(tt.input)))
+			require.Equal(t, tt.want, timestamp.Int64())
+		})
+	}
+}
+
+func TestUnixTimestampRejectsString(t *testing.T) {
+	var timestamp UnixTimestamp
+	require.Error(t, timestamp.UnmarshalJSON([]byte(`"1768488160"`)))
+}

--- a/relaykit/dto/values_test.go
+++ b/relaykit/dto/values_test.go
@@ -8,21 +8,35 @@ import (
 
 func TestUnixTimestampUnmarshalJSON(t *testing.T) {
 	tests := []struct {
-		name  string
-		input string
-		want  int64
+		name      string
+		input     string
+		want      int64
+		wantError bool
 	}{
 		{name: "integer", input: `1768488160`, want: 1768488160},
 		{name: "scientific notation", input: `1.76848816E9`, want: 1768488160},
+		{name: "max int64", input: `9223372036854775807`, want: 9223372036854775807},
+		{name: "first value above int64", input: `9223372036854775808`, wantError: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var timestamp UnixTimestamp
-			require.NoError(t, timestamp.UnmarshalJSON([]byte(tt.input)))
+			err := timestamp.UnmarshalJSON([]byte(tt.input))
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 			require.Equal(t, tt.want, timestamp.Int64())
 		})
 	}
+}
+
+func TestUnixTimestampMarshalJSONUsesInteger(t *testing.T) {
+	data, err := UnixTimestamp(1768488160).MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, `1768488160`, string(data))
 }
 
 func TestUnixTimestampRejectsString(t *testing.T) {

--- a/relaykit/relayconvert/internal/oai_chat/to_oai_responses_resp.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_oai_responses_resp.go
@@ -40,7 +40,7 @@ func ChatCompletionsResponseToResponsesResponse(resp *dto.OpenAITextResponse, id
 	out := &dto.OpenAIResponsesResponse{
 		ID:        id,
 		Object:    "response",
-		CreatedAt: chatCreatedAt(resp.Created),
+		CreatedAt: dto.UnixTimestamp(chatCreatedAt(resp.Created)),
 		Status:    []byte(`"completed"`),
 		Model:     resp.Model,
 		Output:    make([]dto.ResponsesOutput, 0),

--- a/relaykit/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
@@ -320,7 +320,7 @@ func (s *ChatToResponsesStreamState) finalResponse() *dto.OpenAIResponsesRespons
 	return &dto.OpenAIResponsesResponse{
 		ID:                s.ID,
 		Object:            "response",
-		CreatedAt:         int(s.Created),
+		CreatedAt:         dto.UnixTimestamp(s.Created),
 		Status:            []byte(fmt.Sprintf("%q", s.status)),
 		IncompleteDetails: s.incompleteDetails,
 		Model:             s.Model,
@@ -333,7 +333,7 @@ func (s *ChatToResponsesStreamState) createdResponse() *dto.OpenAIResponsesRespo
 	return &dto.OpenAIResponsesResponse{
 		ID:        s.ID,
 		Object:    "response",
-		CreatedAt: int(s.Created),
+		CreatedAt: dto.UnixTimestamp(s.Created),
 		Status:    []byte(`"in_progress"`),
 		Model:     s.Model,
 		Output:    []dto.ResponsesOutput{},

--- a/relaykit/relayconvert/internal/oai_responses/to_oai_chat_resp.go
+++ b/relaykit/relayconvert/internal/oai_responses/to_oai_chat_resp.go
@@ -65,7 +65,7 @@ func ResponsesResponseToChatCompletionsResponse(resp *dto.OpenAIResponsesRespons
 
 	usage := UsageFromResponsesUsage(resp.Usage)
 
-	created := resp.CreatedAt
+	created := resp.CreatedAt.Int64()
 
 	var toolCalls []dto.ToolCallResponse
 	if len(resp.Output) > 0 {

--- a/relaykit/relayconvert/internal/oai_responses/to_oai_chat_stream_resp.go
+++ b/relaykit/relayconvert/internal/oai_responses/to_oai_chat_stream_resp.go
@@ -129,7 +129,7 @@ func (s *ResponsesToChatStreamState) applyResponseMetadata(response *dto.OpenAIR
 		s.Model = response.Model
 	}
 	if response.CreatedAt != 0 {
-		s.Created = int64(response.CreatedAt)
+		s.Created = response.CreatedAt.Int64()
 	}
 	if response.Usage != nil {
 		s.Usage = UsageFromResponsesUsage(response.Usage)


### PR DESCRIPTION
## 📝 变更描述 / Description

原生 `/v1/responses` SSE handler 会先将每个 `data:` 解析为 `ResponsesStreamResponse`，再转发给客户端。部分 Grok/xAI Responses 上游在 `response.completed.response.created_at` 中返回合法的科学计数法 JSON number，例如 `1.76848816E9`。当前 DTO 使用 `int`，解析失败后该终止事件被跳过，Codex 最终因没有收到 `response.completed` 而报告流提前关闭。

本 PR 将 Responses 和 Responses Compaction 的 `created_at` 改为可同时接受整数及科学计数法数字的 `UnixTimestamp`，并同步当前 `relaykit` 转换层中的类型使用。输出仍序列化为整数 Unix 时间戳。

新增测试覆盖：

- 整数和科学计数法时间戳解析；
- 拒绝字符串时间戳；
- 原生 Responses SSE 能完整转发带科学计数法 `created_at` 的 `response.completed`。

这是已关闭 PR #2946 针对当前 `relaykit/dto` 目录结构的重新适配。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Fixes #2267
- Supersedes #2946

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 已根据最小 SSE 复现、当前 DTO 和 handler 调用链整理描述。
- [x] **非重复提交:** 已搜索开放 Issues/PRs；#2946 已关闭且未合并，当前 main 不含等价修复。
- [x] **Bug fix 说明:** 已关联 Issue #2267。
- [x] **变更理解:** 已验证解析失败会跳过 `response.completed`，但 scanner 继续到 `[DONE]`。
- [x] **范围聚焦:** 仅修改 Responses 时间戳 DTO、必要转换点及回归测试。
- [x] **本地验证:** 已运行原生 handler、controller、DTO 和转换层测试。
- [x] **安全合规:** 不包含凭据或外部服务信息。

## 📸 运行证明 / Proof of Work

修复前的最小事件：

```text
event: response.completed
data: {"type":"response.completed","response":{"id":"resp_test","created_at":1.76848816E9,"status":"completed","output":[]}}
```

稳定产生：

```text
cannot unmarshal number 1.76848816E9 into Go struct field OpenAIResponsesResponse.response.created_at of type int
```

修复后测试：

```text
$ go test ./relay/channel/openai ./controller -count=1
ok github.com/QuantumNous/new-api/relay/channel/openai
ok github.com/QuantumNous/new-api/controller

$ cd relaykit && go test ./dto ./relayconvert/... -count=1
ok github.com/QuantumNous/new-api/relaykit/dto
ok github.com/QuantumNous/new-api/relaykit/relayconvert
ok github.com/QuantumNous/new-api/relaykit/relayconvert/internal/oai_chat
ok github.com/QuantumNous/new-api/relaykit/relayconvert/internal/oai_responses
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of response timestamps, including fractional and scientific-notation values.
  - Preserved accurate creation times across standard and streaming responses.
  - Improved compatibility when converting Responses API data to chat completions.

- **Tests**
  - Added regression coverage for scientific-notation timestamps in completed streaming responses.
  - Added validation for supported timestamp formats, range limits, and rejection of quoted values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->