### PR TITLE
fix: render custom oauth provider icon on login button and provider table

### DIFF
--- a/web/src/features/auth/components/oauth-providers.tsx
+++ b/web/src/features/auth/components/oauth-providers.tsx
@@ -27,6 +27,7 @@ import {
   IconWeChat,
 } from '@/assets/brand-icons'
 import { Button } from '@/components/ui/button'
+import { getLobeIcon } from '@/lib/lobe-icon'
 import { cn } from '@/lib/utils'
 
 import { useOAuthLogin } from '../hooks/use-oauth-login'
@@ -143,6 +144,7 @@ export function OAuthProviders({
         key: `custom-${provider.slug}`,
         label: t('Continue with {{name}}', { name: provider.name }),
         onClick: () => handleCustomOAuthLogin(provider),
+        icon: provider.icon ? getLobeIcon(provider.icon, 16) : undefined,
       })
     }
   }

--- a/web/src/features/system-settings/auth/custom-oauth/components/provider-table.tsx
+++ b/web/src/features/system-settings/auth/custom-oauth/components/provider-table.tsx
@@ -26,6 +26,7 @@ import { StaticDataTable } from '@/components/data-table/static/static-data-tabl
 import { StaticRowActions } from '@/components/data-table/static/static-row-actions'
 import { StatusBadge } from '@/components/status-badge'
 import { Button } from '@/components/ui/button'
+import { getLobeIcon } from '@/lib/lobe-icon'
 
 import { useDeleteProvider } from '../hooks/use-custom-oauth-mutations'
 import type { CustomOAuthProvider } from '../types'
@@ -72,7 +73,7 @@ export function ProviderTable(props: ProviderTableProps) {
             header: t('Icon'),
             cell: (provider) =>
               provider.icon ? (
-                <span className='text-lg'>{provider.icon}</span>
+                getLobeIcon(provider.icon, 20)
               ) : (
                 <span className='text-muted-foreground text-sm'>--</span>
               ),

--- a/web/src/lib/lobe-icon.tsx
+++ b/web/src/lib/lobe-icon.tsx
@@ -34,6 +34,17 @@ const CUSTOM_ICONS: Record<string, React.ComponentType<{ size?: number }>> = {
   Sub2API: IconSub2api,
 }
 
+// Icon names stored in user config are often lowercase (e.g. "github"),
+// while @lobehub/icons exports are PascalCase (e.g. "Github").
+// Null prototype and the /^[A-Z]/ filter keep prototype keys ("constructor")
+// and non-component exports (toc, useFillId, *Mappings) out of resolution.
+const ICON_KEYS_BY_LOWERCASE: Record<string, string> = Object.create(null)
+for (const key of [...Object.keys(CUSTOM_ICONS), ...Object.keys(LobeIcons)]) {
+  if (/^[A-Z]/.test(key)) {
+    ICON_KEYS_BY_LOWERCASE[key.toLowerCase()] ??= key
+  }
+}
+
 /**
  * Parse a property value from string to appropriate type
  * @param raw - Raw string value
@@ -108,7 +119,8 @@ export function getLobeIcon(
 
   // Parse component path and chained properties
   const segments = trimmedName.split('.')
-  const baseKey = segments[0]
+  const baseKey =
+    ICON_KEYS_BY_LOWERCASE[segments[0].toLowerCase()] ?? segments[0]
   const CustomIcon = CUSTOM_ICONS[baseKey]
   if (CustomIcon) {
     return <CustomIcon size={size} />


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

自定义 OAuth 提供商后台设置的icon 字段（预设模板也会自动填 github/gitlab 等），没有生效：登录页按钮不渲染图标，管理端列表只把它当纯文本显示。
<img width="1562" height="488" alt="image" src="https://github.com/user-attachments/assets/8419ecba-f53f-4398-8511-88191c76bb8e" />


改动：

- 登录页自定义提供商按钮：icon 非空时经 `getLobeIcon()` 渲染，和内置提供商按钮外观一致
- 管理端提供商列表图标列：从显示原始字符串改为渲染真实图标
- `getLobeIcon` 增加大小写不敏感解析：配置里常存小写（如 `github`），而 @lobehub/icons 导出是 PascalCase（`Github`）。映射只收组件导出（过滤 `toc`、`useFillId`、`*Mappings` 等非组件导出，避免坏配置字符串导致登录页渲染崩溃），用 null-prototype 字典防 `constructor` 这类原型键穿透。lobehub 没有的名字维持原有首字母占位兜底

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5639

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
修复前:
<img width="1048" height="452" alt="image" src="https://github.com/user-attachments/assets/2d14d99d-11a2-44c9-b845-854a61e28d38" />

修复后:
<img width="950" height="478" alt="image" src="https://github.com/user-attachments/assets/2f1613ca-68d0-4d60-ac8a-4f4f44f08ddc" />

