### PR TITLE
feat: support Claude 5 model family

### DIFF
--- a/relay/channel/aws/constants.go
+++ b/relay/channel/aws/constants.go
@@ -20,6 +20,9 @@ var awsModelIDMap = map[string]string{
 	"claude-opus-4-6":            "anthropic.claude-opus-4-6-v1",
 	"claude-opus-4-7":            "anthropic.claude-opus-4-7",
 	"claude-opus-4-8":            "anthropic.claude-opus-4-8",
+	"claude-fable-5":             "anthropic.claude-fable-5",
+	"claude-sonnet-5":            "anthropic.claude-sonnet-5",
+	"claude-opus-5":              "anthropic.claude-opus-5",
 	// Nova models
 	"nova-micro-v1:0":   "amazon.nova-micro-v1:0",
 	"nova-lite-v1:0":    "amazon.nova-lite-v1:0",
@@ -99,6 +102,21 @@ var awsModelCanCrossRegionMap = map[string]map[string]bool{
 		"eu": true,
 	},
 	"anthropic.claude-opus-4-8": {
+		"us": true,
+		"ap": true,
+		"eu": true,
+	},
+	"anthropic.claude-fable-5": {
+		"us": true,
+		"ap": true,
+		"eu": true,
+	},
+	"anthropic.claude-sonnet-5": {
+		"us": true,
+		"ap": true,
+		"eu": true,
+	},
+	"anthropic.claude-opus-5": {
 		"us": true,
 		"ap": true,
 		"eu": true,

--- a/relay/channel/claude/constants.go
+++ b/relay/channel/claude/constants.go
@@ -40,6 +40,9 @@ var ModelList = []string{
 	"claude-opus-4-8-medium",
 	"claude-opus-4-8-low",
 	"claude-opus-4-8-thinking",
+	"claude-fable-5",
+	"claude-sonnet-5",
+	"claude-opus-5",
 }
 
 var ChannelName = "claude"

--- a/relay/channel/claude/relay_claude_test.go
+++ b/relay/channel/claude/relay_claude_test.go
@@ -374,3 +374,34 @@ func TestOpenAIChatRequestToClaudeMessages_ClaudeOpus48ThinkingUsesAdaptiveHighE
 	require.Nil(t, claudeRequest.TopP)
 	require.Nil(t, claudeRequest.TopK)
 }
+
+func TestOpenAIChatRequestToClaudeMessages_Claude5OmitsSamplingParameters(t *testing.T) {
+	for _, model := range []string{"claude-fable-5", "claude-sonnet-5", "claude-opus-5"} {
+		t.Run(model, func(t *testing.T) {
+			request := dto.GeneralOpenAIRequest{
+				Model:       model,
+				Temperature: commonPointer(0.7),
+				TopP:        commonPointer(0.9),
+				TopK:        commonPointer(40),
+				Messages: []dto.Message{
+					{Role: "user", Content: "hello"},
+				},
+			}
+
+			claudeRequest, err := relayconvert.OpenAIChatRequestToClaudeMessages(nil, &relaycommon.RelayInfo{}, request)
+			require.NoError(t, err)
+			require.Equal(t, model, claudeRequest.Model)
+			require.Nil(t, claudeRequest.Temperature)
+			require.Nil(t, claudeRequest.TopP)
+			require.Nil(t, claudeRequest.TopK)
+		})
+	}
+}
+
+func TestAdaptorGetModelListIncludesClaude5Models(t *testing.T) {
+	models := (&Adaptor{}).GetModelList()
+
+	require.Contains(t, models, "claude-fable-5")
+	require.Contains(t, models, "claude-sonnet-5")
+	require.Contains(t, models, "claude-opus-5")
+}

--- a/relay/channel/vertex/adaptor.go
+++ b/relay/channel/vertex/adaptor.go
@@ -46,6 +46,9 @@ var claudeModelMap = map[string]string{
 	"claude-opus-4-6":            "claude-opus-4-6",
 	"claude-opus-4-7":            "claude-opus-4-7",
 	"claude-opus-4-8":            "claude-opus-4-8",
+	"claude-fable-5":             "claude-fable-5",
+	"claude-sonnet-5":            "claude-sonnet-5",
+	"claude-opus-5":              "claude-opus-5",
 }
 
 const anthropicVersion = "vertex-2023-10-16"

--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -52,6 +52,14 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 		request.MaxTokens = &defaultMaxTokens
 	}
 
+	if strings.HasPrefix(request.Model, "claude-fable-5") ||
+		strings.HasPrefix(request.Model, "claude-sonnet-5") ||
+		strings.HasPrefix(request.Model, "claude-opus-5") {
+		request.Temperature = nil
+		request.TopP = nil
+		request.TopK = nil
+	}
+
 	if baseModel, effortLevel, ok := reasoning.TrimEffortSuffix(request.Model); ok && effortLevel != "" &&
 		(strings.HasPrefix(request.Model, "claude-opus-4-6") ||
 			strings.HasPrefix(request.Model, "claude-opus-4-7") ||

--- a/relaykit/relayconvert/internal/oai_chat/to_claude_messages_req.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_claude_messages_req.go
@@ -130,6 +130,14 @@ func OpenAIChatRequestToClaudeMessages(c context.Context, info convmeta.Meta, te
 		}
 	}
 
+	if strings.HasPrefix(textRequest.Model, "claude-fable-5") ||
+		strings.HasPrefix(textRequest.Model, "claude-sonnet-5") ||
+		strings.HasPrefix(textRequest.Model, "claude-opus-5") {
+		claudeRequest.Temperature = nil
+		claudeRequest.TopP = nil
+		claudeRequest.TopK = nil
+	}
+
 	if baseModel, effortLevel, ok := reasoning.TrimEffortSuffix(textRequest.Model); ok && effortLevel != "" &&
 		(strings.HasPrefix(textRequest.Model, "claude-opus-4-6") ||
 			strings.HasPrefix(textRequest.Model, "claude-opus-4-7") ||

--- a/setting/ratio_setting/cache_ratio.go
+++ b/setting/ratio_setting/cache_ratio.go
@@ -78,6 +78,9 @@ var defaultCacheRatio = map[string]float64{
 	"claude-opus-4-8-high":                0.1,
 	"claude-opus-4-8-medium":              0.1,
 	"claude-opus-4-8-low":                 0.1,
+	"claude-fable-5":                      0.1,
+	"claude-sonnet-5":                     0.1,
+	"claude-opus-5":                       0.1,
 }
 
 var defaultCreateCacheRatio = map[string]float64{
@@ -123,6 +126,9 @@ var defaultCreateCacheRatio = map[string]float64{
 	"claude-opus-4-8-high":                1.25,
 	"claude-opus-4-8-medium":              1.25,
 	"claude-opus-4-8-low":                 1.25,
+	"claude-fable-5":                      1.25,
+	"claude-sonnet-5":                     1.25,
+	"claude-opus-5":                       1.25,
 }
 
 //var defaultCreateCacheRatio = map[string]float64{}

--- a/setting/ratio_setting/claude_5_ratio_test.go
+++ b/setting/ratio_setting/claude_5_ratio_test.go
@@ -1,0 +1,39 @@
+package ratio_setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaude5DefaultRatios(t *testing.T) {
+	InitRatioSettings()
+
+	tests := []struct {
+		model      string
+		modelRatio float64
+	}{
+		{model: "claude-fable-5", modelRatio: 0.5},
+		{model: "claude-sonnet-5", modelRatio: 1.5},
+		{model: "claude-opus-5", modelRatio: 2.5},
+	}
+
+	for _, test := range tests {
+		t.Run(test.model, func(t *testing.T) {
+			modelRatio, found, matchedModel := GetModelRatio(test.model)
+			require.True(t, found)
+			assert.Equal(t, test.model, matchedModel)
+			assert.Equal(t, test.modelRatio, modelRatio)
+			assert.Equal(t, 5.0, GetCompletionRatio(test.model))
+
+			cacheRatio, found := GetCacheRatio(test.model)
+			require.True(t, found)
+			assert.Equal(t, 0.1, cacheRatio)
+
+			createCacheRatio, found := GetCreateCacheRatio(test.model)
+			require.True(t, found)
+			assert.Equal(t, 1.25, createCacheRatio)
+		})
+	}
+}

--- a/setting/ratio_setting/claude_5_ratio_test.go
+++ b/setting/ratio_setting/claude_5_ratio_test.go
@@ -14,7 +14,7 @@ func TestClaude5DefaultRatios(t *testing.T) {
 		model      string
 		modelRatio float64
 	}{
-		{model: "claude-fable-5", modelRatio: 0.5},
+		{model: "claude-fable-5", modelRatio: 5.0},
 		{model: "claude-sonnet-5", modelRatio: 1.5},
 		{model: "claude-opus-5", modelRatio: 2.5},
 	}

--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -153,6 +153,9 @@ var defaultModelRatio = map[string]float64{
 	"claude-opus-4-8-high":                      2.5,
 	"claude-opus-4-8-medium":                    2.5,
 	"claude-opus-4-8-low":                       2.5,
+	"claude-fable-5":                            0.5,
+	"claude-sonnet-5":                           1.5,
+	"claude-opus-5":                             2.5,
 	"claude-3-opus-20240229":                    7.5, // $15 / 1M tokens
 	"claude-opus-4-20250514":                    7.5,
 	"claude-opus-4-1-20250805":                  7.5,
@@ -539,7 +542,8 @@ func getHardcodedCompletionModelRatio(name string) (float64, bool) {
 
 	if strings.Contains(name, "claude-3") {
 		return 5, true
-	} else if strings.Contains(name, "claude-sonnet-4") || strings.Contains(name, "claude-opus-4") || strings.Contains(name, "claude-haiku-4") {
+	} else if strings.Contains(name, "claude-sonnet-4") || strings.Contains(name, "claude-opus-4") || strings.Contains(name, "claude-haiku-4") ||
+		strings.Contains(name, "claude-fable-5") || strings.Contains(name, "claude-sonnet-5") || strings.Contains(name, "claude-opus-5") {
 		return 5, true
 	}
 

--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -153,7 +153,7 @@ var defaultModelRatio = map[string]float64{
 	"claude-opus-4-8-high":                      2.5,
 	"claude-opus-4-8-medium":                    2.5,
 	"claude-opus-4-8-low":                       2.5,
-	"claude-fable-5":                            0.5,
+	"claude-fable-5":                            5.0,
 	"claude-sonnet-5":                           1.5,
 	"claude-opus-5":                             2.5,
 	"claude-3-opus-20240229":                    7.5, // $15 / 1M tokens


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
新增 `claude-fable-5`、`claude-sonnet-5` 和 `claude-opus-5` 三个模型，覆盖 Anthropic Claude、AWS Bedrock 与 Google Vertex AI 渠道的模型发现和上游模型 ID 映射。

Claude 5 默认使用 adaptive thinking，不接受 `temperature`、`top_p` 和 `top_k` 等采样参数，因此原生 Claude 请求和 OpenAI 转 Claude 请求都会在转发前移除这些字段，避免上游参数校验失败。Fable、Sonnet、Opus 输入倍率分别为 `5.0`、`1.5`、`2.5`，其中 Fable 价格是 Opus 的两倍；输出倍率为 `5`，缓存读取/创建倍率为 `0.1`/`1.25`。

本次代码由 Codex AI-assisted 完成，并已在本地审查变更范围和测试结果。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```text
git diff origin/main...HEAD --check
# passed

go test ./relay/channel/claude ./relay/channel/aws ./relay/channel/vertex ./setting/ratio_setting ./relay -count=1
# ok github.com/QuantumNous/new-api/relay/channel/claude
# ok github.com/QuantumNous/new-api/relay/channel/aws
# ?  github.com/QuantumNous/new-api/relay/channel/vertex [no test files]
# ok github.com/QuantumNous/new-api/setting/ratio_setting
# ok github.com/QuantumNous/new-api/relay

cd relaykit && GOWORK=off go test ./...
# passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Fable 5, Sonnet 5, and Opus 5 models across supported AWS, Vertex, and Claude integrations.
  * Added regional availability for the new models in US, AP, and EU regions.
  * Applied model-specific request handling and default usage ratios.

* **Tests**
  * Added coverage verifying model availability, parameter handling, and default ratios for Claude 5 models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->