### PR TITLE
fix(relay): apply channel header override on task API requests

### DIFF
--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -557,6 +557,13 @@ func DoTaskApiRequest(a TaskAdaptor, c *gin.Context, info *common.RelayInfo, req
 	if err != nil {
 		return nil, fmt.Errorf("setup request header failed: %w", err)
 	}
+	// 在 BuildRequestHeader 之后应用 Header Override，确保用户设置优先级最高
+	// 这样可以覆盖默认的 Authorization header 设置
+	headerOverride, err := processHeaderOverride(info, c)
+	if err != nil {
+		return nil, err
+	}
+	applyHeaderOverrideToRequest(req, headerOverride)
 	resp, err := doRequest(c, req, info)
 	if err != nil {
 		return nil, fmt.Errorf("do request failed: %w", err)

--- a/relay/channel/api_request_test.go
+++ b/relay/channel/api_request_test.go
@@ -3,6 +3,7 @@ package channel
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
@@ -190,4 +191,53 @@ func TestProcessHeaderOverride_PassHeadersTemplateSetsRuntimeHeaders(t *testing.
 	require.Equal(t, "Codex CLI", upstreamReq.Header.Get("Originator"))
 	require.Equal(t, "sess-123", upstreamReq.Header.Get("Session_id"))
 	require.Empty(t, upstreamReq.Header.Get("X-Codex-Beta-Features"))
+}
+
+type headerOverrideTaskAdaptor struct {
+	TaskAdaptor
+	upstreamURL string
+}
+
+func (a *headerOverrideTaskAdaptor) BuildRequestURL(info *relaycommon.RelayInfo) (string, error) {
+	return a.upstreamURL, nil
+}
+
+func (a *headerOverrideTaskAdaptor) BuildRequestHeader(c *gin.Context, req *http.Request, info *relaycommon.RelayInfo) error {
+	req.Header.Set("Authorization", "Bearer channel-key")
+	return nil
+}
+
+func TestDoTaskApiRequest_AppliesHeaderOverride(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	received := make(chan http.Header, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received <- r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/video/generations", strings.NewReader("{}"))
+	ctx.Request.Header.Set("Idempotency-Key", "idem-123")
+
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			HeadersOverride: map[string]any{
+				"*":                "",
+				"X-Upstream-Token": "override-token",
+			},
+		},
+	}
+
+	resp, err := DoTaskApiRequest(&headerOverrideTaskAdaptor{upstreamURL: upstream.URL}, ctx, info, strings.NewReader("{}"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	headers := <-received
+	require.Equal(t, "idem-123", headers.Get("Idempotency-Key"))
+	require.Equal(t, "override-token", headers.Get("X-Upstream-Token"))
+	require.Equal(t, "Bearer channel-key", headers.Get("Authorization"))
 }


### PR DESCRIPTION
## 📝 变更描述 / Description

`DoTaskApiRequest`（视频/异步任务转发路径）只调用各 TaskAdaptor 的 `BuildRequestHeader`，没有像 `DoApiRequest`/`DoWssRequest` 等同步路径那样应用渠道「请求头覆盖」。因此任务类渠道（如豆包视频）上 `{"*": true}` 透传模板和显式覆盖均不生效，客户端的 `Idempotency-Key` 等头无法到达上游。

修复方式：在 `BuildRequestHeader` 之后按同文件既有模式调用 `processHeaderOverride` + `applyHeaderOverrideToRequest`，保持「用户设置优先级最高」的一致语义。通配透传仍受既有 skip 名单约束，`Authorization` 等凭据头不会被透传（新增测试覆盖了这一点）。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #6505

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

说明：本修复由 AI 辅助完成，已人工审阅代码与测试结果。

## 📸 运行证明 / Proof of Work

新增测试 `TestDoTaskApiRequest_AppliesHeaderOverride`：httptest 模拟上游 + stub TaskAdaptor，验证 `{"*": ""}` 下客户端 `Idempotency-Key` 透传、显式覆盖生效、且渠道 `Authorization` 不被通配透传覆盖。

```
$ go test ./relay/channel/ -run TestDoTaskApiRequest -v
=== RUN   TestDoTaskApiRequest_AppliesHeaderOverride
=== PAUSE TestDoTaskApiRequest_AppliesHeaderOverride
=== CONT  TestDoTaskApiRequest_AppliesHeaderOverride
--- PASS: TestDoTaskApiRequest_AppliesHeaderOverride (0.00s)
PASS
ok      github.com/QuantumNous/new-api/relay/channel    0.876s

$ go test ./relay/channel/
ok      github.com/QuantumNous/new-api/relay/channel
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configured header overrides are now applied correctly to outgoing API requests.
  * Existing request headers and authorization information are preserved.
  * Errors encountered while resolving header overrides are now surfaced properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->