### PR TITLE
fix(web): register header/param/has and time functions in cost estimator

### DIFF
--- a/web/src/features/pricing/lib/tier-expr.test.ts
+++ b/web/src/features/pricing/lib/tier-expr.test.ts
@@ -1,0 +1,96 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import { evalExprLocally, type ExtraTokenValues } from './tier-expr'
+
+const NO_EXTRAS: ExtraTokenValues = {
+  cacheReadTokens: 0,
+  cacheCreateTokens: 0,
+  cacheCreate1hTokens: 0,
+  imageTokens: 0,
+  imageOutputTokens: 0,
+  audioInputTokens: 0,
+  audioOutputTokens: 0,
+}
+
+describe('evalExprLocally request and time functions', () => {
+  test('header() resolves like an absent request header', () => {
+    const result = evalExprLocally(
+      'header("x-billing-tier") == "pro" ? tier("pro", p * 2) : tier("std", p * 1)',
+      100,
+      0,
+      NO_EXTRAS
+    )
+    assert.equal(result.error, null)
+    assert.equal(result.cost, 100)
+    assert.equal(result.matchedTier, 'std')
+  })
+
+  test('param() resolves like an absent body field', () => {
+    const result = evalExprLocally(
+      'has(param("model"), "mini") ? tier("mini", p * 0.5) : tier("full", p * 1)',
+      100,
+      0,
+      NO_EXTRAS
+    )
+    assert.equal(result.error, null)
+    assert.equal(result.cost, 100)
+    assert.equal(result.matchedTier, 'full')
+  })
+
+  test('has() matches substrings on literal sources', () => {
+    const result = evalExprLocally(
+      'has("gpt-4o-mini", "mini") ? tier("mini", p * 0.5) : tier("full", p * 1)',
+      100,
+      0,
+      NO_EXTRAS
+    )
+    assert.equal(result.error, null)
+    assert.equal(result.cost, 50)
+    assert.equal(result.matchedTier, 'mini')
+  })
+
+  test('time functions evaluate without error', () => {
+    const result = evalExprLocally(
+      'hour("Asia/Shanghai") >= 0 && hour("Asia/Shanghai") <= 23 && ' +
+        'minute("Asia/Shanghai") >= 0 && minute("Asia/Shanghai") <= 59 && ' +
+        'weekday("Asia/Shanghai") >= 0 && weekday("Asia/Shanghai") <= 6 && ' +
+        'month("Asia/Shanghai") >= 1 && month("Asia/Shanghai") <= 12 && ' +
+        'day("Asia/Shanghai") >= 1 && day("Asia/Shanghai") <= 31 ? 1 : 0',
+      0,
+      0,
+      NO_EXTRAS
+    )
+    assert.equal(result.error, null)
+    assert.equal(result.cost, 1)
+  })
+
+  test('time functions fall back to UTC for an invalid timezone', () => {
+    const result = evalExprLocally(
+      'hour("Not/AZone") >= 0 && hour("Not/AZone") <= 23 ? 1 : 0',
+      0,
+      0,
+      NO_EXTRAS
+    )
+    assert.equal(result.error, null)
+    assert.equal(result.cost, 1)
+  })
+})

--- a/web/src/features/pricing/lib/tier-expr.ts
+++ b/web/src/features/pricing/lib/tier-expr.ts
@@ -268,6 +268,38 @@ export type EvalResult = {
   error: string | null
 }
 
+const ZONED_WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+// Mirrors the backend timeInZone helper (pkg/billingexpr/run.go): an empty or
+// invalid timezone falls back to UTC instead of throwing.
+function zonedTimeParts(tz: string): Record<string, string> {
+  const options: Intl.DateTimeFormatOptions = {
+    hourCycle: 'h23',
+    hour: '2-digit',
+    minute: '2-digit',
+    day: '2-digit',
+    month: '2-digit',
+    weekday: 'short',
+  }
+  let formatter: Intl.DateTimeFormat
+  try {
+    formatter = new Intl.DateTimeFormat('en-US', {
+      ...options,
+      timeZone: tz.trim() || 'UTC',
+    })
+  } catch {
+    formatter = new Intl.DateTimeFormat('en-US', {
+      ...options,
+      timeZone: 'UTC',
+    })
+  }
+  const parts: Record<string, string> = {}
+  for (const part of formatter.formatToParts(new Date())) {
+    parts[part.type] = part.value
+  }
+  return parts
+}
+
 export function evalExprLocally(
   exprStr: string,
   promptTokens: number,
@@ -298,6 +330,22 @@ export function evalExprLocally(
       abs: Math.abs,
       ceil: Math.ceil,
       floor: Math.floor,
+      // The estimator runs without a request context, so header()/param()
+      // resolve the same way the backend does for an absent header or body
+      // field (pkg/billingexpr/run.go): empty string / null.
+      header: () => '',
+      param: () => null,
+      has: (source: unknown, substr: string) =>
+        source !== null &&
+        source !== undefined &&
+        substr !== '' &&
+        String(source).includes(substr),
+      hour: (tz: string) => Number(zonedTimeParts(tz).hour),
+      minute: (tz: string) => Number(zonedTimeParts(tz).minute),
+      weekday: (tz: string) =>
+        Math.max(0, ZONED_WEEKDAYS.indexOf(zonedTimeParts(tz).weekday)),
+      month: (tz: string) => Number(zonedTimeParts(tz).month),
+      day: (tz: string) => Number(zonedTimeParts(tz).day),
     }
     for (const field of ESTIMATOR_VARS) {
       env[field.var] = extraTokenValues[field.stateKey] || 0


### PR DESCRIPTION
## 📝 变更描述 / Description

模型定价表达式编辑器的费用预估器（`evalExprLocally`）求值环境缺少后端 `pkg/billingexpr` 已注册的 `header`、`param`、`has` 以及 `hour`/`minute`/`weekday`/`month`/`day` 时间函数，表达式一使用就报 `header is not defined`（时间函数同理，编辑器帮助文档中也声明了这些函数）。

修复方式：在预估器环境中补齐这些函数。预估器没有请求上下文，`header()`/`param()` 返回与后端「头缺失/字段缺失」一致的空值（空字符串 / null）；`has` 复刻后端的子串匹配语义（nil 源或空子串返回 false）；时间函数用 `Intl.DateTimeFormat` 按时区求值，非法或空时区回退 UTC，与后端 `timeInZone` 行为一致。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #6491

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

说明：本修复由 AI 辅助完成，已人工审阅代码与测试结果。

## 📸 运行证明 / Proof of Work

新增 `web/src/features/pricing/lib/tier-expr.test.ts`，覆盖 header/param/has 的缺省语义与时间函数的时区回退：

```
$ bun test src/features/pricing/lib/tier-expr.test.ts   # bun 1.3.14（与 CI 一致）
 5 pass
 0 fail
Ran 5 tests across 1 file. [145.00ms]

$ bun run typecheck
$ tsgo -b
Finished in 431ms on 1059 files using 10 threads.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timezone-aware date and time conditions to local pricing estimates.
  * Added support for evaluating request headers, body parameters, and substring matching.
  * Invalid or missing timezones now fall back to UTC for consistent results.

* **Bug Fixes**
  * Improved local estimate consistency with backend pricing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->