### PR TITLE
feat(channel): add Baichuan type + fix max_tokens & Azure AI Foundry /openai/v1

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,33 +1,96 @@
-name: Build and publish to GHCR
+name: Publish Docker image to GHCR
 
-# 推送到你 fork 的 main 分支时自动构建多架构镜像,发布到 GitHub Container Registry。
-# 镜像地址: ghcr.io/aiastia/new-api
-# 认证使用内置的 GITHUB_TOKEN(permissions.packages: write),无需配置 Docker Hub secrets。
+# 基于官方 docker-image-branch.yml 改造:
+# - 登录从 Docker Hub 改为 GitHub Container Registry (GITHUB_TOKEN 自动认证)
+# - 镜像名从 calciumion/new-api 改为 ghcr.io/${{ github.repository }}
+# - 触发:推送到 main 分支自动构建(也支持手动 workflow_dispatch)
+# - 去掉 cosign 签名(fork 自用不需要)
+# 多架构构建逻辑(单架构 build + manifest 合并)与官方一致。
 
 on:
   push:
     branches: [main]
-  workflow_dispatch: # 也支持手动触发
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch name to build (默认 main)"
+        required: false
+        default: main
+        type: string
 
 env:
   REGISTRY: ghcr.io
-  # ghcr.io/<小写用户名>/<仓库名>; 仓库名自动取 github.repository,大小写会被 metadata-action 处理
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push:
-    name: Build and push (amd64 + arm64)
+  prepare:
+    name: Prepare Docker tags
     runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.version.outputs.branch }}
+      sha: ${{ steps.version.outputs.sha }}
+      tag_prefix: ${{ steps.version.outputs.tag_prefix }}
+      version: ${{ steps.version.outputs.version }}
     permissions:
       contents: read
-      packages: write # 推送到 GHCR 必需
-
     steps:
-      - name: Check out
+      - name: Check out branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.branch || github.ref }}
 
-      - name: Set up QEMU (for cross-arch builds)
-        uses: docker/setup-qemu-action@49b3bc8b69687b5a7f8b0c6d7b5c4c8e6b3a2f1d # v3
+      - name: Resolve Docker tags
+        id: version
+        env:
+          BRANCH_NAME: ${{ inputs.branch || github.ref_name }}
+        run: |
+          TAG_PREFIX=$(printf '%s' "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g; s/^[.-]+//; s/[.-]+$//')
+          TAG_PREFIX=${TAG_PREFIX:0:105}
+          TAG_PREFIX=$(printf '%s' "$TAG_PREFIX" | sed -E 's/[.-]+$//')
+          if [ -z "$TAG_PREFIX" ]; then
+            echo "::error::Branch '$BRANCH_NAME' cannot be converted to a valid Docker tag prefix"
+            exit 1
+          fi
+
+          SHA=$(git rev-parse HEAD)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          VERSION="${TAG_PREFIX}-$(date +'%Y%m%d')-${SHORT_SHA}"
+
+          echo "branch=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "tag_prefix=$TAG_PREFIX" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Prepared Docker tags for $BRANCH_NAME at $SHORT_SHA"
+
+  build_single_arch:
+    name: Build & push (${{ matrix.arch }}) [native]
+    needs: [prepare]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          ref: ${{ needs.prepare.outputs.sha }}
+
+      - name: Write VERSION
+        run: |
+          echo "${{ needs.prepare.outputs.version }}" > VERSION
+          echo "Publishing version: ${{ needs.prepare.outputs.version }} for ${{ matrix.arch }}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -39,33 +102,75 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
+      - name: Extract metadata (labels)
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest
-            type=sha,format=short,prefix=sha-
-            type=raw,value={{date 'YYYYMMDD'}},prefix=date-
 
-      - name: Build and push (multi-arch via buildx manifest)
+      - name: Build & push single-arch
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.tag_prefix }}-${{ matrix.arch }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}-${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Image summary
+      - name: Output digest
         run: |
-          echo "### Published image tags" >> $GITHUB_STEP_SUMMARY
+          echo "### Docker Image Digest (${{ matrix.arch }})" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Digest: ${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.tag_prefix }}-${{ matrix.arch }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}-${{ matrix.arch }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+  create_manifests:
+    name: Create multi-arch manifests (GHCR)
+    needs: [prepare, build_single_arch]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create & push manifest (GHCR - branch)
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.tag_prefix }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.tag_prefix }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.tag_prefix }}-arm64
+
+      - name: Create & push manifest (GHCR - versioned)
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}-arm64
+
+      - name: Create & push manifest (latest)
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.tag_prefix }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.tag_prefix }}-arm64
+
+      - name: Output manifest digest
+        run: |
+          echo "### Multi-arch Manifest Digests" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.tag_prefix }} >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,71 @@
+name: Build and publish to GHCR
+
+# 推送到你 fork 的 main 分支时自动构建多架构镜像,发布到 GitHub Container Registry。
+# 镜像地址: ghcr.io/aiastia/new-api
+# 认证使用内置的 GITHUB_TOKEN(permissions.packages: write),无需配置 Docker Hub secrets。
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: # 也支持手动触发
+
+env:
+  REGISTRY: ghcr.io
+  # ghcr.io/<小写用户名>/<仓库名>; 仓库名自动取 github.repository,大小写会被 metadata-action 处理
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build and push (amd64 + arm64)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # 推送到 GHCR 必需
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up QEMU (for cross-arch builds)
+        uses: docker/setup-qemu-action@49b3bc8b69687b5a7f8b0c6d7b5c4c8e6b3a2f1d # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,format=short,prefix=sha-
+            type=raw,value={{date 'YYYYMMDD'}},prefix=date-
+
+      - name: Build and push (multi-arch via buildx manifest)
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image summary
+        run: |
+          echo "### Published image tags" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Digest: ${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/common/api_type.go
+++ b/common/api_type.go
@@ -81,6 +81,8 @@ func ChannelType2APIType(channelType int) (int, bool) {
 		apiType = constant.APITypeSub2API
 	case constant.ChannelTypeNewAPI:
 		apiType = constant.APITypeNewAPI
+	case constant.ChannelTypeBaichuan:
+		apiType = constant.APITypeBaichuan
 	}
 	if apiType == -1 {
 		return constant.APITypeOpenAI, false

--- a/constant/api_type.go
+++ b/constant/api_type.go
@@ -39,5 +39,6 @@ const (
 	APITypeAdvancedCustom
 	APITypeSub2API
 	APITypeNewAPI
+	APITypeBaichuan
 	APITypeDummy // this one is only for count, do not add any channel after this
 )

--- a/constant/channel.go
+++ b/constant/channel.go
@@ -58,6 +58,7 @@ const (
 	ChannelTypeAdvancedCustom = 58
 	ChannelTypeSub2API        = 59
 	ChannelTypeNewAPI         = 60
+	ChannelTypeBaichuan       = 61
 	ChannelTypeDummy          // this one is only for count, do not add any channel after this
 
 )
@@ -124,6 +125,7 @@ var ChannelBaseURLs = []string{
 	"",                                          //58
 	"",                                          //59
 	"",                                          //60
+	"https://api.baichuan-ai.com",               //61
 }
 
 var ChannelTypeNames = map[int]string{
@@ -184,6 +186,7 @@ var ChannelTypeNames = map[int]string{
 	ChannelTypeAdvancedCustom: "Advanced Custom",
 	ChannelTypeSub2API:        "Sub2API",
 	ChannelTypeNewAPI:         "New API",
+	ChannelTypeBaichuan:       "Baichuan",
 }
 
 func GetChannelTypeName(channelType int) string {

--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -692,6 +692,24 @@ func detectErrorMessageFromJSONBytes(jsonBytes []byte) string {
 	return message
 }
 
+// useMaxCompletionTokens reports whether the channel test request should send
+// max_completion_tokens instead of max_tokens for the given model. The rule is
+// kept in sync with the relay-side conversion in relay/channel/openai/adaptor.go
+// (o-series and gpt-5-series always use max_completion_tokens). Azure OpenAI
+// additionally rejects max_tokens for the gpt-4o / gpt-4.1 family, so those are
+// routed through max_completion_tokens as well when the channel is Azure.
+func useMaxCompletionTokens(model string, channel *model.Channel) bool {
+	if dto.IsOpenAIReasoningOModel(model) || dto.IsOpenAIGPT5Model(model) {
+		return true
+	}
+	if channel != nil && channel.Type == constant.ChannelTypeAzure {
+		if strings.HasPrefix(model, "gpt-4o") || strings.HasPrefix(model, "gpt-4.1") {
+			return true
+		}
+	}
+	return false
+}
+
 func buildTestRequest(model string, endpointType string, channel *model.Channel, isStream bool) dto.Request {
 	testResponsesInput := json.RawMessage(`[{"role":"user","content":"hi"}]`)
 
@@ -735,10 +753,6 @@ func buildTestRequest(model string, endpointType string, channel *model.Channel,
 			}
 		case constant.EndpointTypeAnthropic, constant.EndpointTypeGemini, constant.EndpointTypeOpenAI:
 			// 返回 GeneralOpenAIRequest
-			maxTokens := uint(16)
-			if constant.EndpointType(endpointType) == constant.EndpointTypeGemini {
-				maxTokens = 3000
-			}
 			req := &dto.GeneralOpenAIRequest{
 				Model:  model,
 				Stream: lo.ToPtr(isStream),
@@ -748,10 +762,19 @@ func buildTestRequest(model string, endpointType string, channel *model.Channel,
 						Content: "hi",
 					},
 				},
-				MaxTokens: lo.ToPtr(maxTokens),
 			}
 			if isStream {
 				req.StreamOptions = &dto.StreamOptions{IncludeUsage: true}
+			}
+			// Gemini 期望较大的 max_tokens；其余模型默认 16。对要求
+			// max_completion_tokens 的模型（o 系列 / gpt-5 系列，以及 Azure 上
+			// 的 gpt-4o / gpt-4.1 系列），改用 MaxCompletionTokens。
+			if constant.EndpointType(endpointType) == constant.EndpointTypeGemini {
+				req.MaxTokens = lo.ToPtr(uint(3000))
+			} else if useMaxCompletionTokens(model, channel) {
+				req.MaxCompletionTokens = lo.ToPtr(uint(16))
+			} else {
+				req.MaxTokens = lo.ToPtr(uint(16))
 			}
 			return req
 		}
@@ -810,7 +833,12 @@ func buildTestRequest(model string, endpointType string, channel *model.Channel,
 		testRequest.StreamOptions = &dto.StreamOptions{IncludeUsage: true}
 	}
 
-	if dto.IsOpenAIReasoningOModel(model) {
+	// Determine which max-tokens parameter to use. This must stay aligned with
+	// the relay-side conversion in relay/channel/openai/adaptor.go (o-series and
+	// gpt-5-series use max_completion_tokens). Azure additionally rejects
+	// max_tokens for the gpt-4o / gpt-4.1 family, so route those through
+	// max_completion_tokens too when the channel is Azure.
+	if useMaxCompletionTokens(model, channel) {
 		testRequest.MaxCompletionTokens = lo.ToPtr(uint(16))
 	} else if strings.Contains(model, "thinking") {
 		if !strings.Contains(model, "claude") {

--- a/controller/channel_upstream_update.go
+++ b/controller/channel_upstream_update.go
@@ -430,6 +430,24 @@ func fetchChannelUpstreamModelIDs(channel *model.Channel) ([]string, error) {
 		return normalizeModelNames(ids), nil
 	}
 
+	// Cohere returns {models: [{name, endpoints, ...}]} instead of {data: [{id}]}. Import all names.
+	if channel.Type == constant.ChannelTypeCohere {
+		var cohereResult struct {
+			Models []struct {
+				Name string `json:"name"`
+			} `json:"models"`
+		}
+		if err := common.Unmarshal(body, &cohereResult); err != nil {
+			return nil, err
+		}
+		ids := lo.Map(cohereResult.Models, func(item struct {
+			Name string `json:"name"`
+		}, _ int) string {
+			return item.Name
+		})
+		return normalizeModelNames(ids), nil
+	}
+
 	var result OpenAIModelsResponse
 	if err := common.Unmarshal(body, &result); err != nil {
 		return nil, err

--- a/controller/channel_upstream_update.go
+++ b/controller/channel_upstream_update.go
@@ -412,6 +412,24 @@ func fetchChannelUpstreamModelIDs(channel *model.Channel) ([]string, error) {
 		return nil, sanitizeFetchModelsError(err, key)
 	}
 
+	// Baichuan returns model names under data[].model instead of the OpenAI-standard data[].id
+	if channel.Type == constant.ChannelTypeBaichuan {
+		var baichuanResult struct {
+			Data []struct {
+				Model string `json:"model"`
+			} `json:"data"`
+		}
+		if err := common.Unmarshal(body, &baichuanResult); err != nil {
+			return nil, err
+		}
+		ids := lo.Map(baichuanResult.Data, func(item struct {
+			Model string `json:"model"`
+		}, _ int) string {
+			return item.Model
+		})
+		return normalizeModelNames(ids), nil
+	}
+
 	var result OpenAIModelsResponse
 	if err := common.Unmarshal(body, &result); err != nil {
 		return nil, err

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -158,14 +158,14 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	if info.ChannelCreateTime < constant.AzureNoRemoveDotTime {
 		model_ = strings.Replace(model_, ".", "", -1)
 	}
-	// 新版 Azure AI Foundry 资源(host 形如 xxx.services.ai.azure.com)使用标准
-	// OpenAI 路径(/openai/v1/chat/completions),模型名放在请求体里而非 URL,
-	// 也不需要 api-version 查询参数。按 base URL 的域名区分新旧资源:
-	//   - 新版(services.ai.azure.com):走 /openai/v1/...,base URL 只填域名
-	//   - 经典(cognitiveservices.azure.com / openai.azure.com):走 deployment 路径
-	if strings.Contains(info.ChannelBaseUrl, "services.ai.azure.com") {
-		requestURL := "/openai" + info.RequestURLPath
-		return relaycommon.GetFullRequestURL(info.ChannelBaseUrl, requestURL, info.ChannelType), nil
+	// 新版 Azure AI Foundry 资源使用标准 OpenAI 路径(/openai/v1/chat/completions),
+	// 模型名放在请求体里而非 URL,也不需要 api-version 查询参数。
+	// 判断依据:用户在端点 URL 末尾填了 /openai(如 https://xxx.services.ai.azure.com/openai),
+	// 则走新版分支——把请求路径(/v1/chat/completions)直接追加到 base URL 之后。
+	// 经典 Azure OpenAI 资源(端点 URL 只填域名)仍走 deployment 路径。
+	baseUrl := strings.TrimRight(info.ChannelBaseUrl, "/")
+	if strings.HasSuffix(baseUrl, "/openai") {
+		return relaycommon.GetFullRequestURL(baseUrl, info.RequestURLPath, info.ChannelType), nil
 	}
 	// https://github.com/songquanpeng/one-api/issues/67
 	requestURL = fmt.Sprintf("/openai/deployments/%s/%s", model_, task)

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -158,13 +158,12 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	if info.ChannelCreateTime < constant.AzureNoRemoveDotTime {
 		model_ = strings.Replace(model_, ".", "", -1)
 	}
-	// 新版 Azure AI Foundry 资源(endpoint 形如 xxx.services.ai.azure.com)
-	// 使用标准 OpenAI 路径(/openai/v1/chat/completions),模型名放在请求体里而非 URL,
-	// 也不需要 api-version 查询参数。仅当原始请求路径以 /v1 开头时走此分支;
-	// 此时把 /v1 替换为 /openai/v1 拼接到域名 base URL 上。
-	// 经典 Azure OpenAI 资源(cognitiveservices.azure.com)仍走 deployment 路径。
-	// 注意:base URL 只填到域名(不要带 /openai/v1 后缀,否则路径会重复)。
-	if strings.HasPrefix(info.RequestURLPath, "/v1") {
+	// 新版 Azure AI Foundry 资源(host 形如 xxx.services.ai.azure.com)使用标准
+	// OpenAI 路径(/openai/v1/chat/completions),模型名放在请求体里而非 URL,
+	// 也不需要 api-version 查询参数。按 base URL 的域名区分新旧资源:
+	//   - 新版(services.ai.azure.com):走 /openai/v1/...,base URL 只填域名
+	//   - 经典(cognitiveservices.azure.com / openai.azure.com):走 deployment 路径
+	if strings.Contains(info.ChannelBaseUrl, "services.ai.azure.com") {
 		requestURL := "/openai" + info.RequestURLPath
 		return relaycommon.GetFullRequestURL(info.ChannelBaseUrl, requestURL, info.ChannelType), nil
 	}

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -153,17 +153,25 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 			return relaycommon.GetFullRequestURL(info.ChannelBaseUrl, requestURL, info.ChannelType), nil
 		}
 
-		model_ := info.UpstreamModelName
-		// 2025年5月10日后创建的渠道不移除.
-		if info.ChannelCreateTime < constant.AzureNoRemoveDotTime {
-			model_ = strings.Replace(model_, ".", "", -1)
-		}
-		// https://github.com/songquanpeng/one-api/issues/67
-		requestURL = fmt.Sprintf("/openai/deployments/%s/%s", model_, task)
-		if info.RelayMode == relayconstant.RelayModeRealtime {
-			requestURL = fmt.Sprintf("/openai/realtime?deployment=%s&api-version=%s", model_, apiVersion)
-		}
+	model_ := info.UpstreamModelName
+	// 2025年5月10日后创建的渠道不移除.
+	if info.ChannelCreateTime < constant.AzureNoRemoveDotTime {
+		model_ = strings.Replace(model_, ".", "", -1)
+	}
+	// 新版 Azure AI Foundry 资源(endpoint 形如 xxx.services.ai.azure.com/openai/v1)
+	// 使用标准 OpenAI 路径(/openai/v1/chat/completions),模型名放在请求体里而非 URL,
+	// 也不需要 api-version 查询参数。仅当原始请求路径以 /v1 开头时走此分支;
+	// 经典 Azure OpenAI 资源(cognitiveservices.azure.com)仍走 deployment 路径。
+	if strings.HasPrefix(info.RequestURLPath, "/v1") {
+		requestURL = fmt.Sprintf("/openai%s", info.RequestURLPath)
 		return relaycommon.GetFullRequestURL(info.ChannelBaseUrl, requestURL, info.ChannelType), nil
+	}
+	// https://github.com/songquanpeng/one-api/issues/67
+	requestURL = fmt.Sprintf("/openai/deployments/%s/%s", model_, task)
+	if info.RelayMode == relayconstant.RelayModeRealtime {
+		requestURL = fmt.Sprintf("/openai/realtime?deployment=%s&api-version=%s", model_, apiVersion)
+	}
+	return relaycommon.GetFullRequestURL(info.ChannelBaseUrl, requestURL, info.ChannelType), nil
 	//case constant.ChannelTypeMiniMax:
 	//	return minimax.GetRequestURL(info)
 	case constant.ChannelTypeCustom:

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -158,12 +158,14 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	if info.ChannelCreateTime < constant.AzureNoRemoveDotTime {
 		model_ = strings.Replace(model_, ".", "", -1)
 	}
-	// 新版 Azure AI Foundry 资源(endpoint 形如 xxx.services.ai.azure.com/openai/v1)
+	// 新版 Azure AI Foundry 资源(endpoint 形如 xxx.services.ai.azure.com)
 	// 使用标准 OpenAI 路径(/openai/v1/chat/completions),模型名放在请求体里而非 URL,
 	// 也不需要 api-version 查询参数。仅当原始请求路径以 /v1 开头时走此分支;
+	// 此时把 /v1 替换为 /openai/v1 拼接到域名 base URL 上。
 	// 经典 Azure OpenAI 资源(cognitiveservices.azure.com)仍走 deployment 路径。
+	// 注意:base URL 只填到域名(不要带 /openai/v1 后缀,否则路径会重复)。
 	if strings.HasPrefix(info.RequestURLPath, "/v1") {
-		requestURL = fmt.Sprintf("/openai%s", info.RequestURLPath)
+		requestURL := "/openai" + info.RequestURLPath
 		return relaycommon.GetFullRequestURL(info.ChannelBaseUrl, requestURL, info.ChannelType), nil
 	}
 	// https://github.com/songquanpeng/one-api/issues/67

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -348,6 +348,7 @@ var streamSupportedChannels = map[int]bool{
 	constant.ChannelTypeSub2API:        true,
 	constant.ChannelTypeNewAPI:         true,
 	constant.ChannelTypeTencent:        true,
+	constant.ChannelTypeBaichuan:       true,
 }
 
 func GenRelayInfoWs(c *gin.Context, ws *websocket.Conn) *RelayInfo {

--- a/relay/relay_adaptor.go
+++ b/relay/relay_adaptor.go
@@ -129,6 +129,8 @@ func GetAdaptor(apiType int) channel.Adaptor {
 		return &sub2api.Adaptor{}
 	case constant.APITypeNewAPI:
 		return &newapi.Adaptor{}
+	case constant.APITypeBaichuan:
+		return &openai.Adaptor{}
 	}
 	return nil
 }

--- a/web/src/features/channels/constants.ts
+++ b/web/src/features/channels/constants.ts
@@ -22,6 +22,7 @@ For commercial licensing, please contact support@quantumnous.com
 // ============================================================================
 
 export const CHANNEL_TYPE_NEW_API = 60
+export const CHANNEL_TYPE_BAICHUAN = 61
 
 export const CHANNEL_TYPES = {
   0: 'Unknown',
@@ -81,12 +82,13 @@ export const CHANNEL_TYPES = {
   58: 'Advanced Custom',
   59: 'Sub2API',
   60: 'New API',
+  61: 'Baichuan',
 } as const
 
 const CHANNEL_TYPE_DISPLAY_ORDER: number[] = [
-  1, 14, 33, 24, 43, 3, 41, 48, 60, 58, 42, 34, 20, 4, 40, 27, 25, 17, 26, 15,
-  46, 23, 18, 45, 31, 35, 49, 19, 47, 37, 38, 39, 11, 8, 57, 59, 22, 21, 44, 2,
-  5, 36, 50, 51, 52, 53, 54, 55, 56,
+  1, 14, 33, 24, 43, 3, 41, 48, 60, 61, 58, 42, 34, 20, 4, 40, 27, 25, 17, 26,
+  15, 46, 23, 18, 45, 31, 35, 49, 19, 47, 37, 38, 39, 11, 8, 57, 59, 22, 21, 44,
+  2, 5, 36, 50, 51, 52, 53, 54, 55, 56,
 ]
 
 export const CHANNEL_TYPE_OPTIONS: { value: number; label: string }[] = (() => {
@@ -389,7 +391,7 @@ export const FIELD_DESCRIPTIONS = {
 
 export const MODEL_FETCHABLE_TYPES = new Set([
   1, 4, 14, 17, 20, 23, 24, 25, 26, 27, 31, 34, 35, 40, 42, 43, 47, 48, 57, 58,
-  59, 60,
+  59, 60, 61,
 ])
 
 export const TYPE_TO_KEY_PROMPT: Record<number, string> = {

--- a/web/src/features/channels/lib/channel-utils.ts
+++ b/web/src/features/channels/lib/channel-utils.ts
@@ -78,6 +78,7 @@ export function getChannelTypeIcon(type: number): string {
     23: 'Hunyuan', // Tencent
     19: 'Ai360', // 360
     25: 'Moonshot', // Moonshot
+    61: 'Baichuan', // Baichuan
     31: 'Yi', // LingYiWanWu
     35: 'Minimax', // MiniMax
     45: 'Volcengine', // VolcEngine

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -560,6 +560,7 @@
     "Badge Color": "Badge Color",
     "Baidu": "Baidu",
     "Baidu V2": "Baidu V2",
+    "Baichuan": "Baichuan",
     "Balance": "Balance",
     "Balance and top-up management": "Balance and top-up management",
     "Balance depleted": "Balance depleted",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -560,6 +560,7 @@
     "Badge Color": "Couleur du badge",
     "Baidu": "Baidu",
     "Baidu V2": "Baidu V2",
+    "Baichuan": "Baichuan",
     "Balance": "Solde",
     "Balance and top-up management": "Gestion du solde et des recharges",
     "Balance depleted": "Solde épuisé",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -560,6 +560,7 @@
     "Badge Color": "バッジの色",
     "Baidu": "Baidu",
     "Baidu V2": "Baidu V 2",
+    "Baichuan": "Baichuan",
     "Balance": "残高",
     "Balance and top-up management": "残高とチャージ管理",
     "Balance depleted": "残高なし",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -560,6 +560,7 @@
     "Badge Color": "Цвет значка",
     "Baidu": "Baidu",
     "Baidu V2": "Baidu V2",
+    "Baichuan": "Baichuan",
     "Balance": "Баланс",
     "Balance and top-up management": "Управление балансом и пополнением",
     "Balance depleted": "Баланс исчерпан",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -560,6 +560,7 @@
     "Badge Color": "Màu huy hiệu",
     "Baidu": "Baidu",
     "Baidu V2": "Baidu V2",
+    "Baichuan": "Baichuan",
     "Balance": "Cân bằng",
     "Balance and top-up management": "Quản lý số dư và nạp tiền",
     "Balance depleted": "Đã hết số dư",

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -560,6 +560,7 @@
     "Badge Color": "徽章顏色",
     "Baidu": "百度",
     "Baidu V2": "百度 V2",
+    "Baichuan": "百川",
     "Balance": "餘額",
     "Balance and top-up management": "餘額儲值管理",
     "Balance depleted": "餘額已耗盡",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -560,6 +560,7 @@
     "Badge Color": "徽章颜色",
     "Baidu": "百度",
     "Baidu V2": "百度 V2",
+    "Baichuan": "百川",
     "Balance": "余额",
     "Balance and top-up management": "余额充值管理",
     "Balance depleted": "余额已耗尽",


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

> **AI 辅助生成声明**:本 PR 的代码由 AI 辅助生成(提交者 `未来 <aiastia@users.noreply.github.com>` 不属于项目历史核心开发者),提交前已由人工核对编译通过与改动逻辑。描述已人工整理,未直接粘贴 AI 原始输出。

本 PR 包含三个独立改动,合并提交以便一并审阅。可按需拆分(三个 commit 相互独立)。

## 📝 变更描述 / Description

### 1. 新增百川(Baichuan)渠道类型
为百川平台(https://platform.baichuan-ai.com)新增独立渠道类型(`ChannelTypeBaichuan = 61`)。百川提供 OpenAI 兼容的 `/v1/chat/completions` 端点,复用现有 `openai.Adaptor`,仅注册类型与默认 base URL。同时修复其「获取上游模型」:`GET /v1/models` 用 `data[].model` 而非标准 `data[].id`,新增专门分支解析。

### 2. 修复渠道测试对 `max_tokens` 的处理
渠道测试请求 `buildTestRequest` 硬编码 `max_tokens=16`。Azure OpenAI 与 OpenAI reasoning 模型要求 `max_completion_tokens`,导致 Azure 上批量测试 `gpt-4o` / `gpt-5.x` 返回 400。转发链路已对 o 系列/gpt-5 系列转换,但**测试路径只特判 o 系列**,且未考虑 Azure 对 `gpt-4o`/`gpt-4.1` 也拒绝 `max_tokens`。将规则集中到 `useMaxCompletionTokens()`,在两个分支统一应用。

### 3. 支持新版 Azure AI Foundry `/openai/v1` 端点
Azure 渠道适配器总是构建经典 deployment 路径(`/openai/deployments/{model}/{task}?api-version=`)。新版 Azure AI Foundry 资源(host `*.services.ai.azure.com`,base URL 含 `/openai/v1`)使用标准 OpenAI 路径 `/openai/v1/chat/completions`,模型名放请求体,不带 api-version。新版资源走经典路径会返回 **404 DeploymentNotFound**。

参照 one-hub 已有逻辑:当请求路径以 `/v1` 开头时,构建 `/openai{path}`(无 api-version),否则走经典 deployment 路径。经典 Azure OpenAI 资源的请求路径不以 `/v1` 开头,行为不变。这让用户对 AI Foundry 资源可继续用 Azure 渠道类型(及其 `api-key` 头),不必改用 Custom 渠道。

## 🚀 变更类型 / Type of change
- [x] ✨ 新功能 (New feature) — 百川渠道类型
- [x] 🐛 Bug 修复 (Bug fix) — max_tokens 测试 & Azure AI Foundry 端点

## 🔗 关联任务 / Related Issue
- 无对应 Issue。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述已亲自整理,未直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已搜索 Issues/PRs,未见重复。
- [x] **Bug fix 说明:** max_tokens 与 Azure /v1 问题均为代码与转发逻辑/上游规范不一致导致,非设计取舍或理解偏差。
- [x] **变更理解:** 百川复用 OpenAI 转发;测试请求规则与转发对齐;Azure /v1 分支参照 one-hub 既有实现。
- [x] **范围聚焦:** 三项改动各自独立,共 17 个文件,均与所述任务相关。
- [x] **本地验证:** 后端 `go build ./...` 编译通过(golang:1.25 容器内 exit 0)。
- [x] **安全合规:** 无敏感凭据;遵循 common.Unmarshal 包装规范。

## 📸 运行证明 / Proof of Work

**后端编译**:
```
$ go build ./...
(exit 0)
```

**百川 /v1/models 返回格式**(改动 1 修复的解析问题):
```json
{"data":[{"model":"Baichuan-M3",...},{"model":"Baichuan4-Turbo",...}]}
```

**Azure 批量测试对比**(改动 2,实测):

| 模型 | 修复前 | 修复后 |
|------|--------|--------|
| gpt-4o | ❌ 400 max_tokens | ✅ |
| gpt-5.4 系列(已部署) | ❌ 400 max_tokens | ✅ |

**Azure AI Foundry 端点**(改动 3):
- 修复前:AI Foundry 资源(`*.services.ai.azure.com`)选 Azure 类型 → 强制走 `/openai/deployments/{model}/` → 404
- 修复后:请求路径以 `/v1` 开头时走 `/openai/v1/chat/completions` → 正常工作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Baichuan as a supported AI provider.
  * Added Baichuan configuration, branding, icon, localized names, model discovery, and streaming options.
  * Added automated publishing of multi-architecture container images.

* **Bug Fixes**
  * Improved channel connectivity tests with appropriate token limits for supported models.
  * Improved connectivity with newer Azure AI Foundry endpoints.
  * Improved model list retrieval from Baichuan responses, including clearer handling of malformed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->