### PR TITLE
fix(ollama): preserve reasoning and tool-call context

### DIFF
--- a/relay/channel/ollama/dto.go
+++ b/relay/channel/ollama/dto.go
@@ -5,12 +5,13 @@ import (
 )
 
 type OllamaChatMessage struct {
-	Role      string           `json:"role"`
-	Content   string           `json:"content,omitempty"`
-	Images    []string         `json:"images,omitempty"`
-	ToolCalls []OllamaToolCall `json:"tool_calls,omitempty"`
-	ToolName  string           `json:"tool_name,omitempty"`
-	Thinking  json.RawMessage  `json:"thinking,omitempty"`
+	Role       string           `json:"role"`
+	Content    string           `json:"content,omitempty"`
+	Images     []string         `json:"images,omitempty"`
+	ToolCalls  []OllamaToolCall `json:"tool_calls,omitempty"`
+	ToolName   string           `json:"tool_name,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"`
+	Thinking   json.RawMessage  `json:"thinking,omitempty"`
 }
 
 type OllamaToolFunction struct {
@@ -25,6 +26,7 @@ type OllamaTool struct {
 }
 
 type OllamaToolCall struct {
+	ID       string `json:"id,omitempty"`
 	Function struct {
 		Name      string      `json:"name"`
 		Arguments interface{} `json:"arguments"`
@@ -36,7 +38,7 @@ type OllamaChatRequest struct {
 	Messages  []OllamaChatMessage `json:"messages"`
 	Tools     interface{}         `json:"tools,omitempty"`
 	Format    interface{}         `json:"format,omitempty"`
-	Stream    bool                `json:"stream,omitempty"`
+	Stream    bool                `json:"stream"`
 	Options   map[string]any      `json:"options,omitempty"`
 	KeepAlive interface{}         `json:"keep_alive,omitempty"`
 	Think     json.RawMessage     `json:"think,omitempty"`
@@ -48,7 +50,7 @@ type OllamaGenerateRequest struct {
 	Suffix    string          `json:"suffix,omitempty"`
 	Images    []string        `json:"images,omitempty"`
 	Format    interface{}     `json:"format,omitempty"`
-	Stream    bool            `json:"stream,omitempty"`
+	Stream    bool            `json:"stream"`
 	Options   map[string]any  `json:"options,omitempty"`
 	KeepAlive interface{}     `json:"keep_alive,omitempty"`
 	Think     json.RawMessage `json:"think,omitempty"`

--- a/relay/channel/ollama/relay-ollama.go
+++ b/relay/channel/ollama/relay-ollama.go
@@ -1,7 +1,6 @@
 package ollama
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,24 +18,67 @@ import (
 	"github.com/samber/lo"
 )
 
+func toOllamaResponseFormat(responseFormat *dto.ResponseFormat) (any, error) {
+	if responseFormat == nil {
+		return nil, nil
+	}
+	switch responseFormat.Type {
+	case "json", "json_object":
+		return "json", nil
+	case "json_schema":
+		if len(responseFormat.JsonSchema) == 0 {
+			return nil, nil
+		}
+		var jsonSchema dto.FormatJsonSchema
+		if err := common.Unmarshal(responseFormat.JsonSchema, &jsonSchema); err != nil {
+			return nil, fmt.Errorf("invalid ollama response format: %w", err)
+		}
+		return jsonSchema.Schema, nil
+	default:
+		return nil, nil
+	}
+}
+
 func openAIChatToOllamaChat(c *gin.Context, r *dto.GeneralOpenAIRequest) (*OllamaChatRequest, error) {
+	think := r.Think
+	if len(think) == 0 {
+		effort := r.ReasoningEffort
+		if len(r.Reasoning) > 0 {
+			var reasoning dto.Reasoning
+			if err := common.Unmarshal(r.Reasoning, &reasoning); err != nil {
+				return nil, fmt.Errorf("invalid ollama reasoning: %w", err)
+			}
+			effort = lo.CoalesceOrEmpty(reasoning.Effort, effort)
+		}
+		if effort != "" {
+			var thinkValue any
+			switch effort {
+			case "none":
+				thinkValue = false
+			case "low", "medium", "high", "max":
+				thinkValue = effort
+			default:
+				return nil, fmt.Errorf("unsupported ollama reasoning effort %q", effort)
+			}
+			var err error
+			think, err = common.Marshal(thinkValue)
+			if err != nil {
+				return nil, fmt.Errorf("marshal ollama think: %w", err)
+			}
+		}
+	}
+
 	chatReq := &OllamaChatRequest{
 		Model:   r.Model,
 		Stream:  lo.FromPtrOr(r.Stream, false),
 		Options: map[string]any{},
-		Think:   r.Think,
+		Think:   think,
 	}
-	if r.ResponseFormat != nil {
-		if r.ResponseFormat.Type == "json" {
-			chatReq.Format = "json"
-		} else if r.ResponseFormat.Type == "json_schema" {
-			if len(r.ResponseFormat.JsonSchema) > 0 {
-				var schema any
-				_ = json.Unmarshal(r.ResponseFormat.JsonSchema, &schema)
-				chatReq.Format = schema
-			}
-		}
+	format, err := toOllamaResponseFormat(r.ResponseFormat)
+	if err != nil {
+		return nil, err
 	}
+	chatReq.Format = format
 
 	// options mapping
 	if r.Temperature != nil {
@@ -68,12 +110,10 @@ func openAIChatToOllamaChat(c *gin.Context, r *dto.GeneralOpenAIRequest) (*Ollam
 		case []string:
 			chatReq.Options["stop"] = v
 		case []any:
-			arr := make([]string, 0, len(v))
-			for _, i := range v {
-				if s, ok := i.(string); ok {
-					arr = append(arr, s)
-				}
-			}
+			arr := lo.FilterMap(v, func(item any, _ int) (string, bool) {
+				value, ok := item.(string)
+				return value, ok
+			})
 			if len(arr) > 0 {
 				chatReq.Options["stop"] = arr
 			}
@@ -81,14 +121,20 @@ func openAIChatToOllamaChat(c *gin.Context, r *dto.GeneralOpenAIRequest) (*Ollam
 	}
 
 	if len(r.Tools) > 0 {
-		tools := make([]OllamaTool, 0, len(r.Tools))
-		for _, t := range r.Tools {
-			tools = append(tools, OllamaTool{Type: "function", Function: OllamaToolFunction{Name: t.Function.Name, Description: t.Function.Description, Parameters: t.Function.Parameters}})
-		}
-		chatReq.Tools = tools
+		chatReq.Tools = lo.Map(r.Tools, func(tool dto.ToolCallRequest, _ int) OllamaTool {
+			return OllamaTool{
+				Type: "function",
+				Function: OllamaToolFunction{
+					Name:        tool.Function.Name,
+					Description: tool.Function.Description,
+					Parameters:  tool.Function.Parameters,
+				},
+			}
+		})
 	}
 
 	chatReq.Messages = make([]OllamaChatMessage, 0, len(r.Messages))
+	toolNamesByCallID := make(map[string]string)
 	for _, m := range r.Messages {
 		var textBuilder strings.Builder
 		var images []string
@@ -117,8 +163,18 @@ func openAIChatToOllamaChat(c *gin.Context, r *dto.GeneralOpenAIRequest) (*Ollam
 		if len(images) > 0 {
 			cm.Images = images
 		}
-		if m.Role == "tool" && m.Name != nil {
-			cm.ToolName = *m.Name
+		if m.Role == "assistant" {
+			if reasoning, ok := lo.Coalesce(m.ReasoningContent, m.Reasoning); ok {
+				thinking, err := common.Marshal(*reasoning)
+				if err != nil {
+					return nil, fmt.Errorf("marshal ollama thinking: %w", err)
+				}
+				cm.Thinking = thinking
+			}
+		}
+		if m.Role == "tool" {
+			cm.ToolCallID = m.ToolCallId
+			cm.ToolName = lo.CoalesceOrEmpty(lo.FromPtr(m.Name), toolNamesByCallID[m.ToolCallId])
 		}
 		if m.ToolCalls != nil && len(m.ToolCalls) > 0 {
 			parsed := m.ParseToolCalls()
@@ -127,15 +183,18 @@ func openAIChatToOllamaChat(c *gin.Context, r *dto.GeneralOpenAIRequest) (*Ollam
 				for _, tc := range parsed {
 					var args interface{}
 					if tc.Function.Arguments != "" {
-						_ = json.Unmarshal([]byte(tc.Function.Arguments), &args)
+						_ = common.Unmarshal([]byte(tc.Function.Arguments), &args)
 					}
 					if args == nil {
 						args = map[string]any{}
 					}
-					oc := OllamaToolCall{}
+					oc := OllamaToolCall{ID: tc.ID}
 					oc.Function.Name = tc.Function.Name
 					oc.Function.Arguments = args
 					calls = append(calls, oc)
+					if tc.ID != "" {
+						toolNamesByCallID[tc.ID] = tc.Function.Name
+					}
 				}
 				cm.ToolCalls = calls
 			}
@@ -175,15 +234,11 @@ func openAIToGenerate(c *gin.Context, r *dto.GeneralOpenAIRequest) (*OllamaGener
 			gen.Suffix = s
 		}
 	}
-	if r.ResponseFormat != nil {
-		if r.ResponseFormat.Type == "json" {
-			gen.Format = "json"
-		} else if r.ResponseFormat.Type == "json_schema" {
-			var schema any
-			_ = json.Unmarshal(r.ResponseFormat.JsonSchema, &schema)
-			gen.Format = schema
-		}
+	format, err := toOllamaResponseFormat(r.ResponseFormat)
+	if err != nil {
+		return nil, err
 	}
+	gen.Format = format
 	if r.Temperature != nil {
 		gen.Options["temperature"] = r.Temperature
 	}
@@ -212,12 +267,10 @@ func openAIToGenerate(c *gin.Context, r *dto.GeneralOpenAIRequest) (*OllamaGener
 		case []string:
 			gen.Options["stop"] = v
 		case []any:
-			arr := make([]string, 0, len(v))
-			for _, i := range v {
-				if s, ok := i.(string); ok {
-					arr = append(arr, s)
-				}
-			}
+			arr := lo.FilterMap(v, func(item any, _ int) (string, bool) {
+				value, ok := item.(string)
+				return value, ok
+			})
 			if len(arr) > 0 {
 				gen.Options["stop"] = arr
 			}
@@ -510,7 +563,7 @@ func FetchOllamaVersion(baseURL, apiKey string) (string, error) {
 		Version string `json:"version"`
 	}
 
-	if err := json.Unmarshal(body, &versionResp); err != nil {
+	if err := common.Unmarshal(body, &versionResp); err != nil {
 		return "", fmt.Errorf("解析响应失败: %v", err)
 	}
 

--- a/relay/channel/ollama/stream.go
+++ b/relay/channel/ollama/stream.go
@@ -58,8 +58,12 @@ func ollamaToolCallsToOpenAI(toolCalls []OllamaToolCall, startIndex int, include
 				argBytes = []byte("{}")
 			}
 		}
+		toolCallID := tc.ID
+		if toolCallID == "" {
+			toolCallID = fmt.Sprintf("call_%d", startIndex)
+		}
 		tr := dto.ToolCallResponse{
-			ID:   fmt.Sprintf("call_%d", startIndex),
+			ID:   toolCallID,
 			Type: "function",
 			Function: dto.FunctionResponse{
 				Name:      tc.Function.Name,

--- a/relay/channel/ollama/stream_test.go
+++ b/relay/channel/ollama/stream_test.go
@@ -21,12 +21,14 @@ func TestOllamaChatHandlerNonStreamToolCalls(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
-		name string
-		raw  string
+		name   string
+		raw    string
+		wantID string
 	}{
 		{
-			name: "compact json per-line parse path",
-			raw:  `{"model":"llama3.1","created_at":"2026-05-27T12:00:00Z","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"Paris","days":0}}}]},"done":true,"done_reason":"stop","prompt_eval_count":5,"eval_count":7}`,
+			name:   "compact json per-line parse path",
+			raw:    `{"model":"llama3.1","created_at":"2026-05-27T12:00:00Z","message":{"role":"assistant","content":"","tool_calls":[{"id":"call_upstream","function":{"name":"get_weather","arguments":{"city":"Paris","days":0}}}]},"done":true,"done_reason":"stop","prompt_eval_count":5,"eval_count":7}`,
+			wantID: "call_upstream",
 		},
 		{
 			name: "pretty json fallback parse path",
@@ -53,6 +55,7 @@ func TestOllamaChatHandlerNonStreamToolCalls(t *testing.T) {
   "prompt_eval_count": 5,
   "eval_count": 7
 }`,
+			wantID: "call_0",
 		},
 	}
 
@@ -82,7 +85,7 @@ func TestOllamaChatHandlerNonStreamToolCalls(t *testing.T) {
 			var toolCalls []dto.ToolCallResponse
 			require.NoError(t, common.Unmarshal(out.Choices[0].Message.ToolCalls, &toolCalls))
 			require.Len(t, toolCalls, 1)
-			assert.NotEmpty(t, toolCalls[0].ID)
+			assert.Equal(t, tt.wantID, toolCalls[0].ID)
 			assert.Equal(t, "function", toolCalls[0].Type)
 			assert.Equal(t, "get_weather", toolCalls[0].Function.Name)
 			assert.Nil(t, toolCalls[0].Index)


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

对OpenAI chat completions -> ollama chat 缺失的部分进行补全

reasoning_content/reasoning 转 ollama thinking
reasoning_effort/reasoning.effort -> think( none -> think=none)
json_object -> json
stream 显式处理
tool_call_id 补全

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6603

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility with tool calls by preserving call IDs across requests and streamed responses.
  * Added support for assistant reasoning content and tool names in Ollama interactions.
  * Improved handling of response formats and JSON schemas.

* **Bug Fixes**
  * Ensured chat and generation requests consistently include stream settings.
  * Added clearer errors when response-format schemas cannot be parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->