### PR TITLE
fix(aws): record cancellations and sync partial usage

### DIFF
--- a/relay/channel/aws/relay-aws.go
+++ b/relay/channel/aws/relay-aws.go
@@ -60,6 +60,19 @@ func newAwsInvokeError(requestContext context.Context, err error, operation stri
 	)
 }
 
+func recordAwsStreamContextEnd(info *relaycommon.RelayInfo, requestContext, invokeContext context.Context) {
+	if info == nil || info.StreamStatus == nil {
+		return
+	}
+	if err := requestContext.Err(); err != nil {
+		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, err)
+		return
+	}
+	if err := invokeContext.Err(); err != nil {
+		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonTimeout, err)
+	}
+}
+
 func newAwsClient(c *gin.Context, info *relaycommon.RelayInfo) (*bedrockruntime.Client, error) {
 	httpClient, err := service.GetHttpClientWithProxySettings(info.ChannelSetting.Proxy, info.ChannelSetting)
 	if err != nil {
@@ -261,9 +274,15 @@ func awsStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, a *Adaptor) (
 	requestContext := c.Request.Context()
 	ctx, cancel := newAwsInvokeContext(requestContext)
 	defer cancel()
+	info.StreamStatus = relaycommon.NewStreamStatus()
 
 	awsResp, err := a.AwsClient.InvokeModelWithResponseStream(ctx, a.AwsReq.(*bedrockruntime.InvokeModelWithResponseStreamInput))
 	if err != nil {
+		recordAwsStreamContextEnd(info, requestContext, ctx)
+		if info.StreamStatus.EndReason == relaycommon.StreamEndReasonNone {
+			info.StreamStatus.RecordError(err.Error())
+			info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonHandlerStop, err)
+		}
 		return newAwsInvokeError(requestContext, err, "InvokeModelWithResponseStream"), nil
 	}
 	stream := awsResp.GetStream()
@@ -282,12 +301,19 @@ streamLoop:
 	for {
 		select {
 		case <-ctx.Done():
+			recordAwsStreamContextEnd(info, requestContext, ctx)
 			break streamLoop
 		case event, ok := <-events:
 			if !ok {
+				if claudeInfo.Done {
+					info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonDone, nil)
+				} else {
+					info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonEOF, nil)
+				}
 				break streamLoop
 			}
 			if ctx.Err() != nil {
+				recordAwsStreamContextEnd(info, requestContext, ctx)
 				break streamLoop
 			}
 
@@ -296,15 +322,27 @@ streamLoop:
 				info.SetFirstResponseTime()
 				respErr := claude.HandleStreamResponseData(c, info, claudeInfo, string(v.Value.Bytes))
 				if respErr != nil {
+					info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonHandlerStop, respErr)
 					return respErr, nil
 				}
 			case *bedrockruntimeTypes.UnknownUnionMember:
 				fmt.Println("unknown tag:", v.Tag)
-				return types.NewError(errors.New("unknown response type"), types.ErrorCodeInvalidRequest), nil
+				err := types.NewError(errors.New("unknown response type"), types.ErrorCodeInvalidRequest)
+				info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonHandlerStop, err)
+				return err, nil
 			default:
 				fmt.Println("union is nil or unknown type")
-				return types.NewError(errors.New("nil or unknown response type"), types.ErrorCodeInvalidRequest), nil
+				err := types.NewError(errors.New("nil or unknown response type"), types.ErrorCodeInvalidRequest)
+				info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonHandlerStop, err)
+				return err, nil
 			}
+		}
+	}
+	if info.StreamStatus.EndReason == relaycommon.StreamEndReasonNone {
+		if claudeInfo.Done {
+			info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonDone, nil)
+		} else {
+			info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonEOF, nil)
 		}
 	}
 

--- a/relay/channel/aws/relay_aws_test.go
+++ b/relay/channel/aws/relay_aws_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -377,6 +379,7 @@ func TestAwsStreamHandlerStopsAtClientCancellationAndKeepsPartialBillingUsage(t 
 
 	producerResults := make(chan error, 1)
 	upstreamContexts := make(chan context.Context, 1)
+	partialText := strings.Repeat("partial cancellation output ", 64)
 	client := newAwsTestClient(awsHTTPClientFunc(func(request *http.Request) (*http.Response, error) {
 		upstreamContexts <- request.Context()
 		reader, writer := io.Pipe()
@@ -385,7 +388,7 @@ func TestAwsStreamHandlerStopsAtClientCancellationAndKeepsPartialBillingUsage(t 
 			initialEvents := []string{
 				`{"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","model":"claude-test","content":[],"usage":{"input_tokens":100,"output_tokens":1}}}`,
 				`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
-				`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}`,
+				fmt.Sprintf(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":%q}}`, partialText),
 			}
 			for _, event := range initialEvents {
 				if err := writeAwsStreamEvent(writer, event); err != nil {
@@ -400,9 +403,10 @@ func TestAwsStreamHandlerStopsAtClientCancellationAndKeepsPartialBillingUsage(t 
 		return newAwsStreamResponse(request, reader), nil
 	}))
 
-	responseWriter := newAwsNotifyingResponseWriter("partial")
+	responseWriter := newAwsNotifyingResponseWriter(partialText)
 	c := newAwsTestContext(responseWriter, requestContext)
 	adaptor := &Adaptor{AwsClient: client, AwsReq: newAwsStreamInput()}
+	info := newAwsTestRelayInfo()
 
 	type handlerResult struct {
 		err   *relaytypes.NewAPIError
@@ -410,7 +414,7 @@ func TestAwsStreamHandlerStopsAtClientCancellationAndKeepsPartialBillingUsage(t 
 	}
 	results := make(chan handlerResult, 1)
 	go func() {
-		err, usage := awsStreamHandler(c, newAwsTestRelayInfo(), adaptor)
+		err, usage := awsStreamHandler(c, info, adaptor)
 		results <- handlerResult{err: err, usage: usage}
 	}()
 
@@ -444,8 +448,12 @@ func TestAwsStreamHandlerStopsAtClientCancellationAndKeepsPartialBillingUsage(t 
 	assert.Equal(t, dto.BillingUsageSourceClaudeMessages, result.usage.BillingUsage.Source)
 	assert.Equal(t, dto.BillingUsageSemanticAnthropic, result.usage.BillingUsage.Semantic)
 	assert.Equal(t, 100, result.usage.BillingUsage.ClaudeUsage.InputTokens)
-	assert.Equal(t, 1, result.usage.BillingUsage.ClaudeUsage.OutputTokens)
-	assert.Equal(t, bodyLengthBeforeCancel, responseWriter.Body.Len())
+	assert.Greater(t, result.usage.CompletionTokens, 1)
+	assert.Equal(t, result.usage.CompletionTokens, result.usage.BillingUsage.ClaudeUsage.OutputTokens)
+	require.NotNil(t, info.StreamStatus)
+	assert.Equal(t, relaycommon.StreamEndReasonClientGone, info.StreamStatus.EndReason)
+	require.ErrorIs(t, info.StreamStatus.EndError, context.Canceled)
+	assert.GreaterOrEqual(t, responseWriter.Body.Len(), bodyLengthBeforeCancel)
 	assert.NotContains(t, responseWriter.Body.String(), "[DONE]")
 
 	release()

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -154,7 +154,8 @@ func HandleStreamFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, clau
 	if claudeInfo.Usage.PromptTokens == 0 {
 		//上游出错
 	}
-	if claudeInfo.Usage.CompletionTokens == 0 || !claudeInfo.Done {
+	usageIncomplete := claudeInfo.Usage.CompletionTokens == 0 || !claudeInfo.Done
+	if usageIncomplete {
 		if common.DebugEnabled {
 			common.SysLog("claude response usage is not complete, maybe upstream error")
 		}
@@ -172,7 +173,7 @@ func HandleStreamFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, clau
 	if claudeInfo.Usage != nil {
 		claudeInfo.Usage.UsageSemantic = "anthropic"
 	}
-	if claudeInfo.Usage != nil && claudeInfo.Usage.BillingUsage == nil {
+	if claudeInfo.Usage != nil && (claudeInfo.Usage.BillingUsage == nil || usageIncomplete) {
 		claudeInfo.Usage.BillingUsage = dto.NewClaudeMessagesBillingUsage(buildMessageDeltaPatchUsage(nil, claudeInfo))
 	}
 

--- a/relay/channel/claude/relay_claude_test.go
+++ b/relay/channel/claude/relay_claude_test.go
@@ -1,12 +1,14 @@
 package claude
 
 import (
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/QuantumNous/new-api/relaykit/relayconvert"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -222,6 +224,47 @@ func TestFormatClaudeResponseInfo_ContentBlockDelta(t *testing.T) {
 	if claudeInfo.ResponseText.String() != "hello" {
 		t.Errorf("ResponseText = %q, want %q", claudeInfo.ResponseText.String(), "hello")
 	}
+}
+
+func TestHandleStreamFinalResponseRefreshesIncompleteBillingUsage(t *testing.T) {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "claude-test"},
+	}
+	info.SetEstimatePromptTokens(100)
+
+	partialText := strings.Repeat("partial cancellation output ", 64)
+	var responseText strings.Builder
+	responseText.WriteString(partialText)
+	claudeInfo := &ClaudeResponseInfo{
+		ResponseText: responseText,
+		Usage: &dto.Usage{
+			PromptTokens:     100,
+			CompletionTokens: 1,
+			PromptTokensDetails: dto.InputTokenDetails{
+				CachedTokens:         100_000,
+				CachedCreationTokens: 120_000,
+			},
+			ClaudeCacheCreation5mTokens: 120_000,
+			BillingUsage: dto.NewClaudeMessagesBillingUsage(&dto.ClaudeUsage{
+				InputTokens:              100,
+				OutputTokens:             1,
+				CacheReadInputTokens:     100_000,
+				CacheCreationInputTokens: 120_000,
+			}),
+		},
+		Done: false,
+	}
+
+	HandleStreamFinalResponse(c, info, claudeInfo)
+
+	assert.Greater(t, claudeInfo.Usage.CompletionTokens, 1)
+	require.NotNil(t, claudeInfo.Usage.BillingUsage)
+	require.NotNil(t, claudeInfo.Usage.BillingUsage.ClaudeUsage)
+	assert.Equal(t, claudeInfo.Usage.CompletionTokens, claudeInfo.Usage.BillingUsage.ClaudeUsage.OutputTokens)
+	assert.Equal(t, 100, claudeInfo.Usage.BillingUsage.ClaudeUsage.InputTokens)
+	assert.Equal(t, 100_000, claudeInfo.Usage.BillingUsage.ClaudeUsage.CacheReadInputTokens)
+	assert.Equal(t, 120_000, claudeInfo.Usage.BillingUsage.ClaudeUsage.CacheCreationInputTokens)
 }
 
 func TestBuildOpenAIStyleUsageFromClaudeUsage(t *testing.T) {

--- a/relaykit/relayconvert/internal/claude_messages/to_oai_chat_resp.go
+++ b/relaykit/relayconvert/internal/claude_messages/to_oai_chat_resp.go
@@ -241,6 +241,9 @@ func BuildMessageDeltaPatchUsage(claudeResponse *dto.ClaudeResponse, claudeInfo 
 	if usage.InputTokens == 0 && claudeInfo.Usage.PromptTokens > 0 {
 		usage.InputTokens = claudeInfo.Usage.PromptTokens
 	}
+	if usage.OutputTokens == 0 && claudeInfo.Usage.CompletionTokens > 0 {
+		usage.OutputTokens = claudeInfo.Usage.CompletionTokens
+	}
 	if usage.CacheReadInputTokens == 0 && claudeInfo.Usage.PromptTokensDetails.CachedTokens > 0 {
 		usage.CacheReadInputTokens = claudeInfo.Usage.PromptTokensDetails.CachedTokens
 	}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本 PR 的代码与说明由 AI 协助完成，并由提交者发起，请维护者重点复核取消计费语义。

## 📝 变更描述 / Description
这是 #6589 的后续修复，补齐 AWS Bedrock 流取消后的日志和部分 usage 结算：

- AWS 自定义 EventStream 循环现在写入 `RelayInfo.StreamStatus`，区分 `client_gone`、`timeout`、`done` 和 `eof`，从而与公共 `StreamScannerHandler` 的日志行为一致。
- Claude 流在拿不到最终 `message_delta` 时，会根据已累计文本更新部分 `CompletionTokens`，并重新构建 `BillingUsage`，避免继续采用 `message_start` 中常见的 `output_tokens=1`。
- `BuildMessageDeltaPatchUsage` 会在上游缺失输出 usage 时，从已归一化的语义 usage 补齐 `OutputTokens`；输入与 cache 字段仍保持独立语义。
- 回归测试覆盖客户端取消状态、多 Token 部分输出和高 cache 占比下的 usage 保留。

实际复现中，Claude 原生流在客户端收到约 50 KB 后断开，旧逻辑仍以 `output_tokens=1` 结算；该修改确保部分输出计数同步到最终计费 usage，同时保留 Bedrock 上游取消。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Follow-up to #6589

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 和 PRs，未发现覆盖 AWS `client_gone` 与取消后 stale `BillingUsage` 的重复修改。
- [x] **Bug fix 说明:** 本修改修复 #6589 合入后仍可复现的 AWS 取消日志缺失与部分输出少计费问题。
- [x] **变更理解:** 已追踪 AWS EventStream、Claude finalizer、BillingUsage 选择与日志序列化链路。
- [x] **范围聚焦:** 仅修改 AWS/Claude 流取消状态、usage 映射及对应测试。
- [x] **本地验证:** 已运行并通过下列测试和独立构建。
- [x] **安全合规:** 代码中无敏感凭据。

## 📸 运行证明 / Proof of Work
```text
go test ./relay/channel/aws ./relay/channel/claude ./service
ok github.com/QuantumNous/new-api/relay/channel/aws
ok github.com/QuantumNous/new-api/relay/channel/claude
ok github.com/QuantumNous/new-api/service

cd relaykit && GOWORK=off go build ./...
PASS

cd relaykit && GOWORK=off go test ./...
PASS
```

新增断言确保：

1. 客户端取消后 `StreamStatus.EndReason == client_gone`；
2. 部分输出的 `BillingUsage.ClaudeUsage.OutputTokens` 与本地累计的 `CompletionTokens` 一致且大于 1；
3. 高 cache 样本仍保持净输入、cache read、cache creation 三类字段独立。
