### PR TITLE
fix(relay): handle DeepSeek V4 streaming edge cases in OpenAI→Claude …

### DIFF
--- a/relaykit/relayconvert/convmeta/meta.go
+++ b/relaykit/relayconvert/convmeta/meta.go
@@ -60,6 +60,11 @@ type ClaudeConvertInfo struct {
 
 	ToolCallBaseIndex      int
 	ToolCallMaxIndexOffset int
+
+	// HasContentBlock tracks whether any non-thinking content block (text or
+	// tool_use) has been emitted in the stream. Used to detect thinking-only
+	// streams that need an empty text block fallback before message_stop.
+	HasContentBlock bool
 }
 
 const (

--- a/relaykit/relayconvert/internal/oai_chat/to_claude_messages_resp.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_claude_messages_resp.go
@@ -35,6 +35,41 @@ func stopOpenBlocks(state *convmeta.ClaudeConvertInfo) []*dto.ClaudeResponse {
 	}
 }
 
+// appendEmptyTextFallback adds an empty text content block when the stream
+// has not emitted any non-thinking content block (text or tool_use). This
+// handles the case where a reasoning model (e.g. DeepSeek V4-Flash with max
+// reasoning_effort) consumes the entire max_tokens budget on reasoning,
+// leaving content empty. Anthropic's streaming protocol requires at least one
+// non-thinking content block; without it, Claude Code reports an empty or
+// malformed response.
+//
+// Must be called AFTER stopOpenBlocks has closed any open block.
+func appendEmptyTextFallback(state *convmeta.ClaudeConvertInfo, responses []*dto.ClaudeResponse) []*dto.ClaudeResponse {
+	if state == nil || state.HasContentBlock {
+		return responses
+	}
+	// stopOpenBlocks has already advanced the index for thinking blocks, so
+	// state.Index points to the next free slot. For the empty-stream case
+	// (LastMessagesType == None), state.Index is 0.
+	textIndex := state.Index
+	if state.LastMessagesType != convmeta.LastMessageTypeNone {
+		textIndex = state.Index + 1
+	}
+	responses = append(responses,
+		&dto.ClaudeResponse{
+			Index: kitutil.GetPointer[int](textIndex),
+			Type:  "content_block_start",
+			ContentBlock: &dto.ClaudeMediaMessage{
+				Type: "text",
+				Text: kitutil.GetPointer[string](""),
+			},
+		},
+		generateStopBlock(textIndex),
+	)
+	state.HasContentBlock = true
+	return responses
+}
+
 func buildClaudeUsageFromOpenAIUsage(oaiUsage *dto.Usage) *dto.ClaudeUsage {
 	if oaiUsage == nil {
 		return nil
@@ -153,6 +188,7 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 			state.LastMessagesType = convmeta.LastMessageTypeTools
 			state.ToolCallBaseIndex = 0
 			state.ToolCallMaxIndexOffset = 0
+			state.HasContentBlock = true
 			var toolCall dto.ToolCallResponse
 			if len(openAIResponse.Choices) > 0 && len(openAIResponse.Choices[0].Delta.ToolCalls) > 0 {
 				toolCall = openAIResponse.Choices[0].Delta.ToolCalls[0]
@@ -218,7 +254,10 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 					},
 				})
 				state.LastMessagesType = convmeta.LastMessageTypeThinking
-			} else if content != "" {
+			} else if content != "" && state.LastMessagesType != convmeta.LastMessageTypeTools {
+				// Bug #1: skip text content after tool_use — sglang dsv4 parser
+				// emits trailing content='\n' after tool_use completes, and
+				// Anthropic streaming requires tool_use to be the final block.
 				if state.LastMessagesType != convmeta.LastMessageTypeText {
 					stopOpenBlocksAndAdvance()
 				}
@@ -241,6 +280,7 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 					},
 				})
 				state.LastMessagesType = convmeta.LastMessageTypeText
+				state.HasContentBlock = true
 			}
 		}
 
@@ -255,6 +295,7 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 				return claudeResponses
 			}
 			appendStopOpenBlocks()
+			claudeResponses = appendEmptyTextFallback(state, claudeResponses)
 			claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
 				Type:  "message_delta",
 				Usage: buildClaudeUsageFromOpenAIUsage(oaiUsage),
@@ -278,6 +319,7 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 		}
 		if oaiUsage != nil {
 			appendStopOpenBlocks()
+			claudeResponses = appendEmptyTextFallback(state, claudeResponses)
 			stopReason := stopReasonOpenAI2Claude(state.FinishReason)
 			if stopReason == "" {
 				stopReason = "end_turn"
@@ -320,6 +362,7 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 				state.ToolCallMaxIndexOffset = 0
 			}
 			state.LastMessagesType = convmeta.LastMessageTypeTools
+			state.HasContentBlock = true
 			base := state.ToolCallBaseIndex
 			maxOffset := state.ToolCallMaxIndexOffset
 
@@ -365,6 +408,15 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 		} else {
 			reasoning := chosenChoice.Delta.GetReasoningContent()
 			textContent := chosenChoice.Delta.GetContentString()
+			// Bug #1: Discard trailing text-only chunks emitted after tool_use
+			// by some upstreams (e.g. DeepSeek V4 via sglang dsv4 parser emits
+			// content='\n' after tool_calls). A text block after tool_use
+			// violates Anthropic's streaming content-block lifecycle and
+			// triggers "Content block not found" in Claude Code. Reasoning
+			// content is still allowed since it switches to a thinking block.
+			if reasoning == "" && textContent != "" && state.LastMessagesType == convmeta.LastMessageTypeTools {
+				textContent = ""
+			}
 			if reasoning != "" || textContent != "" {
 				if reasoning != "" {
 					if state.LastMessagesType != convmeta.LastMessageTypeThinking {
@@ -398,6 +450,7 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 						})
 					}
 					state.LastMessagesType = convmeta.LastMessageTypeText
+					state.HasContentBlock = true
 					claudeResponse.Delta = &dto.ClaudeMediaMessage{
 						Type: "text_delta",
 						Text: kitutil.GetPointer[string](textContent),
@@ -415,6 +468,7 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 
 		if doneChunk || state.Done {
 			appendStopOpenBlocks()
+			claudeResponses = appendEmptyTextFallback(state, claudeResponses)
 			oaiUsage := openAIResponse.Usage
 			if oaiUsage == nil {
 				oaiUsage = state.Usage
@@ -453,6 +507,7 @@ func FinalizeStreamResponseOpenAI2Claude(info convmeta.Meta) []*dto.ClaudeRespon
 		stopReason = "end_turn"
 	}
 	responses := stopOpenBlocks(state)
+	responses = appendEmptyTextFallback(state, responses)
 	responses = append(responses,
 		&dto.ClaudeResponse{
 			Type:  "message_delta",

--- a/relaykit/relayconvert/internal/oai_chat/to_claude_messages_resp_test.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_claude_messages_resp_test.go
@@ -217,3 +217,238 @@ func TestNormalizeCacheCreationSplit(t *testing.T) {
 func ptr[T any](value T) *T {
 	return &value
 }
+
+// TestStreamResponseOpenAI2ClaudeDiscardsTrailingTextAfterToolUse verifies
+// Bug #1: sglang dsv4 parser emits trailing content='\n' after tool_use
+// completes. Anthropic streaming requires tool_use to be the final content
+// block, so the trailing text must be discarded, not opened as a new text
+// block. Without this fix Claude Code reports "Content block not found".
+func TestStreamResponseOpenAI2ClaudeDiscardsTrailingTextAfterToolUse(t *testing.T) {
+	info := &convmeta.Values{
+		ClaudeConvertInfo: &convmeta.ClaudeConvertInfo{
+			LastMessagesType: convmeta.LastMessageTypeNone,
+		},
+	}
+
+	// Chunk 1: text content
+	info.SendResponseCount = 1
+	textResponses := StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_1",
+		Model: "deepseek-v4-flash",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{Delta: dto.ChatCompletionsStreamResponseChoiceDelta{Content: ptr("Let me check the weather.")}},
+		},
+	}, info)
+	require.Len(t, textResponses, 3)
+	assert.Equal(t, "message_start", textResponses[0].Type)
+	assert.Equal(t, "content_block_start", textResponses[1].Type)
+	assert.Equal(t, "text", textResponses[1].ContentBlock.Type)
+
+	// Chunk 2: tool_use
+	info.SendResponseCount = 2
+	toolResponses := StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_1",
+		Model: "deepseek-v4-flash",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{Delta: dto.ChatCompletionsStreamResponseChoiceDelta{
+				ToolCalls: []dto.ToolCallResponse{
+					{Index: ptr(0), ID: "call_1", Type: "function",
+						Function: dto.FunctionResponse{Name: "get_weather", Arguments: `{"city":"Shanghai"}`}},
+				},
+			}},
+		},
+	}, info)
+	require.True(t, len(toolResponses) >= 2)
+	assert.Equal(t, "content_block_stop", toolResponses[0].Type)
+	assert.Equal(t, 0, toolResponses[0].GetIndex())
+	assert.Equal(t, "content_block_start", toolResponses[1].Type)
+	assert.Equal(t, "tool_use", toolResponses[1].ContentBlock.Type)
+
+	// Chunk 3: trailing content='\n' from sglang dsv4 — must be DISCARDED
+	info.SendResponseCount = 3
+	trailingResponses := StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_1",
+		Model: "deepseek-v4-flash",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{Delta: dto.ChatCompletionsStreamResponseChoiceDelta{Content: ptr("\n")}},
+		},
+	}, info)
+	assert.Empty(t, trailingResponses, "trailing text after tool_use must be discarded")
+
+	// Chunk 4: finish_reason=tool_calls + usage
+	info.SendResponseCount = 4
+	finishResponses := StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_1",
+		Model: "deepseek-v4-flash",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{FinishReason: ptr("tool_calls")},
+		},
+		Usage: &dto.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+	}, info)
+	require.True(t, len(finishResponses) >= 2)
+	assert.Equal(t, "content_block_stop", finishResponses[0].Type)
+	assert.Equal(t, 1, finishResponses[0].GetIndex(), "should close tool_use at index 1")
+	assert.Equal(t, "message_delta", finishResponses[1].Type)
+	require.NotNil(t, finishResponses[1].Delta.StopReason)
+	assert.Equal(t, "tool_use", *finishResponses[1].Delta.StopReason)
+}
+
+// TestStreamResponseOpenAI2ClaudeAppendsEmptyTextForThinkingOnlyStream
+// verifies Bug #2: DeepSeek V4-Flash with max reasoning_effort can consume
+// the entire max_tokens budget on reasoning (finish_reason=length, content
+// empty). The stream then has only thinking blocks and no text/tool_use
+// block, which Claude Code rejects as empty/malformed. The fix appends an
+// empty text block as fallback.
+func TestStreamResponseOpenAI2ClaudeAppendsEmptyTextForThinkingOnlyStream(t *testing.T) {
+	info := &convmeta.Values{
+		ClaudeConvertInfo: &convmeta.ClaudeConvertInfo{
+			LastMessagesType: convmeta.LastMessageTypeNone,
+		},
+	}
+
+	// Chunk 1: reasoning content (thinking)
+	info.SendResponseCount = 1
+	thinkingResponses := StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_1",
+		Model: "deepseek-v4-flash",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{Delta: dto.ChatCompletionsStreamResponseChoiceDelta{ReasoningContent: ptr("thinking hard...")}},
+		},
+	}, info)
+	require.True(t, len(thinkingResponses) >= 3)
+	assert.Equal(t, "message_start", thinkingResponses[0].Type)
+	assert.Equal(t, "content_block_start", thinkingResponses[1].Type)
+	assert.Equal(t, "thinking", thinkingResponses[1].ContentBlock.Type)
+
+	// Chunk 2: more reasoning
+	info.SendResponseCount = 2
+	moreThinking := StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_1",
+		Model: "deepseek-v4-flash",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{Delta: dto.ChatCompletionsStreamResponseChoiceDelta{ReasoningContent: ptr("still thinking...")}},
+		},
+	}, info)
+	require.Len(t, moreThinking, 1)
+	assert.Equal(t, "content_block_delta", moreThinking[0].Type)
+
+	// Chunk 3: finish_reason=length + usage (all budget consumed by thinking)
+	info.SendResponseCount = 3
+	finishResponses := StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_1",
+		Model: "deepseek-v4-flash",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{FinishReason: ptr("length")},
+		},
+		Usage: &dto.Usage{PromptTokens: 10, CompletionTokens: 2000, TotalTokens: 2010},
+	}, info)
+
+	// Bug #2 fix: empty text block appended after thinking block.
+	// Sequence: content_block_stop(0) → content_block_start(1, text) →
+	//           content_block_stop(1) → message_delta → message_stop
+	require.Len(t, finishResponses, 5)
+	assert.Equal(t, "content_block_stop", finishResponses[0].Type)
+	assert.Equal(t, 0, finishResponses[0].GetIndex(), "close thinking at index 0")
+	assert.Equal(t, "content_block_start", finishResponses[1].Type)
+	assert.Equal(t, 1, finishResponses[1].GetIndex(), "empty text at index 1")
+	require.NotNil(t, finishResponses[1].ContentBlock)
+	assert.Equal(t, "text", finishResponses[1].ContentBlock.Type)
+	assert.Equal(t, "content_block_stop", finishResponses[2].Type)
+	assert.Equal(t, 1, finishResponses[2].GetIndex(), "close empty text at index 1")
+	assert.Equal(t, "message_delta", finishResponses[3].Type)
+	require.NotNil(t, finishResponses[3].Delta.StopReason)
+	assert.Equal(t, "max_tokens", *finishResponses[3].Delta.StopReason)
+	assert.Equal(t, "message_stop", finishResponses[4].Type)
+}
+
+// TestFinalizeStreamResponseOpenAI2ClaudeAppendsEmptyTextForThinkingOnly
+// verifies Bug #2 fix in the Finalize path (stream ended without
+// finish_reason, e.g. upstream connection drop during thinking).
+func TestFinalizeStreamResponseOpenAI2ClaudeAppendsEmptyTextForThinkingOnly(t *testing.T) {
+	info := &convmeta.Values{
+		ClaudeConvertInfo: &convmeta.ClaudeConvertInfo{
+			LastMessagesType: convmeta.LastMessageTypeNone,
+		},
+	}
+
+	// Chunk 1: reasoning only
+	info.SendResponseCount = 1
+	StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_1",
+		Model: "deepseek-v4-flash",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{Delta: dto.ChatCompletionsStreamResponseChoiceDelta{ReasoningContent: ptr("thinking...")}},
+		},
+	}, info)
+
+	// Stream ends without finish_reason — Finalize is called
+	finalResponses := FinalizeStreamResponseOpenAI2Claude(info)
+	// Sequence: content_block_stop(0) → content_block_start(1, text) →
+	//           content_block_stop(1) → message_delta → message_stop
+	require.Len(t, finalResponses, 5)
+	assert.Equal(t, "content_block_stop", finalResponses[0].Type)
+	assert.Equal(t, 0, finalResponses[0].GetIndex())
+	assert.Equal(t, "content_block_start", finalResponses[1].Type)
+	assert.Equal(t, 1, finalResponses[1].GetIndex())
+	assert.Equal(t, "text", finalResponses[1].ContentBlock.Type)
+	assert.Equal(t, "content_block_stop", finalResponses[2].Type)
+	assert.Equal(t, 1, finalResponses[2].GetIndex())
+	assert.Equal(t, "message_delta", finalResponses[3].Type)
+	assert.Equal(t, "message_stop", finalResponses[4].Type)
+}
+
+// TestStreamResponseOpenAI2ClaudeThinkingThenTextDoesNotGetFallback is a
+// negative test for Bug #2: when a stream has thinking followed by actual
+// text content, no empty text fallback should be appended. The HasContentBlock
+// flag prevents false-positive fallback insertion.
+func TestStreamResponseOpenAI2ClaudeThinkingThenTextDoesNotGetFallback(t *testing.T) {
+	info := &convmeta.Values{
+		ClaudeConvertInfo: &convmeta.ClaudeConvertInfo{
+			LastMessagesType: convmeta.LastMessageTypeNone,
+		},
+	}
+
+	// Chunk 1: reasoning
+	info.SendResponseCount = 1
+	StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_1",
+		Model: "deepseek-v4-flash",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{Delta: dto.ChatCompletionsStreamResponseChoiceDelta{ReasoningContent: ptr("Thinking...")}},
+		},
+	}, info)
+	assert.False(t, info.ClaudeConvertInfo.HasContentBlock, "thinking alone should not set HasContentBlock")
+
+	// Chunk 2: text content
+	info.SendResponseCount = 2
+	StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_1",
+		Model: "deepseek-v4-flash",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{Delta: dto.ChatCompletionsStreamResponseChoiceDelta{Content: ptr("Hello!")}},
+		},
+	}, info)
+	assert.True(t, info.ClaudeConvertInfo.HasContentBlock, "text content should set HasContentBlock")
+
+	// Chunk 3: finish
+	info.SendResponseCount = 3
+	finishResponses := StreamResponseOpenAI2Claude(&dto.ChatCompletionsStreamResponse{
+		Id:    "chatcmpl_1",
+		Model: "deepseek-v4-flash",
+		Choices: []dto.ChatCompletionsStreamResponseChoice{
+			{FinishReason: ptr("stop")},
+		},
+		Usage: &dto.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+	}, info)
+	require.NotEmpty(t, finishResponses)
+
+	// Count text blocks — should be 0 in finishResponses (the real text block
+	// was already opened in chunk 2; finish only closes it).
+	textStartCount := 0
+	for _, r := range finishResponses {
+		if r.Type == "content_block_start" && r.ContentBlock != nil && r.ContentBlock.Type == "text" {
+			textStartCount++
+		}
+	}
+	assert.Equal(t, 0, textStartCount, "no fallback text block should be added when content already exists")
+}


### PR DESCRIPTION
> [!IMPORTANT]
> - This PR was AI-assisted. The code was generated with AI tooling and reviewed/curated by a human developer.

## 📝 变更描述 / Description

DeepSeek V4-Flash (released 2026-07-31) introduced two streaming edge cases that break Claude Code when responses are converted from OpenAI format to Anthropic `/v1/messages` format via `StreamResponseOpenAI2Claude`.

### Bug #1: `Content block not found` (tool-call scenario)

**Root cause**: The sglang dsv4 parser emits a trailing `content='\n'` chunk after `tool_use` completes. The converter mechanically created a new text block from this trailing content, violating Anthropic's streaming block lifecycle (tool_use must be the final content block). Claude Code's content-block index tracker rejected the invalid sequence.

**Fix**: Discard text-only chunks when `LastMessagesType == Tools`. Reasoning content is still allowed (switches to thinking block). Applied in both the first-chunk and subsequent-chunk paths.

### Bug #2: `Empty or malformed response (HTTP 200)` (max reasoning effort scenario)

**Root cause**: DeepSeek V4-Flash shares a single `max_tokens` budget between thinking and content (unlike V3's separate CoT budget). With `reasoning_effort=max` (automatically applied to Claude Code by DeepSeek's API), the entire budget can be consumed by thinking, leaving content empty (`finish_reason=length`, content empty). The converted stream had only thinking blocks with no text/tool_use block, which Claude Code rejects as malformed.

**Fix**: Added a `HasContentBlock` flag to `ClaudeConvertInfo` that tracks whether any non-thinking content block (text or tool_use) has been emitted. At all four stream termination paths (first-chunk-done, usage-only, doneChunk, Finalize), if no content block was emitted, an empty text block (`content_block_start` + `content_block_stop`) is appended as fallback.

**Why `HasContentBlock` over `LastMessagesType == Thinking`**: The cumulative flag avoids false positives (e.g. `text → thinking → done` would incorrectly trigger fallback with the state-based check) and false negatives (completely empty streams).

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- No existing issue found.

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** Bug #1 and #2 are real protocol-conversion defects triggered by DeepSeek V4-Flash's new streaming behavior, not design trade-offs.
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

### Tests (all passing)

```
=== RUN   TestStreamResponseOpenAI2ClaudeClosesTextThinkingAndToolBlocks
--- PASS: TestStreamResponseOpenAI2ClaudeClosesTextThinkingAndToolBlocks (0.00s)
=== RUN   TestStreamResponseOpenAI2ClaudeDiscardsTrailingTextAfterToolUse
--- PASS: TestStreamResponseOpenAI2ClaudeDiscardsTrailingTextAfterToolUse (0.00s)
=== RUN   TestStreamResponseOpenAI2ClaudeAppendsEmptyTextForThinkingOnlyStream
--- PASS: TestStreamResponseOpenAI2ClaudeAppendsEmptyTextForThinkingOnlyStream (0.00s)
=== RUN   TestFinalizeStreamResponseOpenAI2ClaudeAppendsEmptyTextForThinkingOnly
--- PASS: TestFinalizeStreamResponseOpenAI2ClaudeAppendsEmptyTextForThinkingOnly (0.00s)
=== RUN   TestStreamResponseOpenAI2ClaudeThinkingThenTextDoesNotGetFallback
--- PASS: TestStreamResponseOpenAI2ClaudeThinkingThenTextDoesNotGetFallback (0.00s)
PASS
ok      github.com/QuantumNous/new-api/relaykit/relayconvert/internal/oai_chat  0.009s
```

### Build verification
- relaykit independent build: `cd relaykit && GOWORK=off go build ./...` OK
- Root module build: `go build ./service/... ./relay/...` OK
- Full test suite: `go test ./relayconvert/... ./service/... ./relay/common/...` OK

### Regression test coverage

| Test | Bug | Scenario |
|------|-----|----------|
| `TestStreamResponseOpenAI2ClaudeDiscardsTrailingTextAfterToolUse` | #1 | text → tool_use → trailing '\n' → finish: trailing text discarded |
| `TestStreamResponseOpenAI2ClaudeAppendsEmptyTextForThinkingOnlyStream` | #2 | thinking → thinking → finish(length): empty text fallback appended |
| `TestFinalizeStreamResponseOpenAI2ClaudeAppendsEmptyTextForThinkingOnly` | #2 | thinking → Finalize (no finish_reason): fallback appended |
| `TestStreamResponseOpenAI2ClaudeThinkingThenTextDoesNotGetFallback` | #2 negative | thinking → text → finish: NO fallback (prevents false positive) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming responses when messages contain only reasoning or tool-use content.
  * Added an empty text block when required for thinking-only responses.
  * Prevented trailing text from appearing after tool-use blocks.
  * Preserved valid text when reasoning is followed by regular content.

* **Tests**
  * Added coverage for streaming and finalization edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->