### PR TITLE
fix(relay): log client reasoning effort

### DIFF
--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -398,6 +398,9 @@ func GenRelayInfoResponses(c *gin.Context, request *dto.OpenAIResponsesRequest) 
 	info := genBaseRelayInfo(c, request)
 	info.RelayMode = relayconstant.RelayModeResponses
 	info.RelayFormat = types.RelayFormatOpenAIResponses
+	if request.Reasoning != nil {
+		info.ReasoningEffort = request.Reasoning.Effort
+	}
 
 	info.ResponsesUsageInfo = &ResponsesUsageInfo{
 		BuiltInTools: make(map[string]*BuildInToolInfo),
@@ -439,6 +442,9 @@ func GenRelayInfoImage(c *gin.Context, request dto.Request) *RelayInfo {
 func GenRelayInfoOpenAI(c *gin.Context, request dto.Request) *RelayInfo {
 	info := genBaseRelayInfo(c, request)
 	info.RelayFormat = types.RelayFormatOpenAI
+	if openAIRequest, ok := request.(*dto.GeneralOpenAIRequest); ok {
+		info.ReasoningEffort = openAIRequest.ReasoningEffort
+	}
 	return info
 }
 

--- a/relay/common/relay_info_test.go
+++ b/relay/common/relay_info_test.go
@@ -1,13 +1,59 @@
 package common
 
 import (
+	"net/http/httptest"
 	"testing"
 
+	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/QuantumNous/new-api/relaykit/relayconvert/convmeta"
 	"github.com/QuantumNous/new-api/relaykit/types"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGenRelayInfoCapturesClientReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		relayFormat types.RelayFormat
+		request     dto.Request
+		wantEffort  string
+	}{
+		{
+			name:        "chat completions",
+			path:        "/v1/chat/completions",
+			relayFormat: types.RelayFormatOpenAI,
+			request: &dto.GeneralOpenAIRequest{
+				Model:           "gpt-5.6",
+				ReasoningEffort: "high",
+			},
+			wantEffort: "high",
+		},
+		{
+			name:        "responses",
+			path:        "/v1/responses",
+			relayFormat: types.RelayFormatOpenAIResponses,
+			request: &dto.OpenAIResponsesRequest{
+				Model:     "gpt-5.6",
+				Reasoning: &dto.Reasoning{Effort: "max"},
+			},
+			wantEffort: "max",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			context, _ := gin.CreateTestContext(httptest.NewRecorder())
+			context.Request = httptest.NewRequest("POST", tt.path, nil)
+
+			info, err := GenRelayInfo(context, tt.relayFormat, tt.request, nil)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEffort, info.ReasoningEffort)
+		})
+	}
+}
 
 func TestRelayInfoGetFinalRequestRelayFormatPrefersExplicitFinal(t *testing.T) {
 	info := &RelayInfo{


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
调用日志中的推理强度此前依赖具体渠道适配器写入，因此 New API、Sub2API、Codex、高级自定义以及请求体透传等路径可能遗漏该字段。

本次改动将推理强度的采集前移到统一请求解析阶段：Chat Completions 从 `reasoning_effort` 读取，Responses API 从 `reasoning.effort` 读取。这样日志元数据不再依赖后续选择的渠道或是否执行请求转换，同时保留渠道适配器根据模型后缀推导推理强度的现有行为。

同时增加表格驱动测试，覆盖 Chat Completions 与 Responses API 两种请求格式。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [x] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6634

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- `go test ./...` 全部通过。
- 手动调用 `/v1/chat/completions`，请求携带 `reasoning_effort: "high"`，响应成功且 UI 日志正确显示推理强度。
- 手动调用 `/v1/responses`，使用 `glm-5.2` 和 `reasoning.effort: "high"`，返回 HTTP 200，消费日志中的 `reasoning_effort` 正确记录为 `high`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Preserves the requested reasoning effort when processing supported OpenAI requests, improving request metadata accuracy.

- **Tests**
  - Added coverage confirming reasoning effort is captured for OpenAI Chat Completions and Responses requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->