### PR TITLE
fix(web): 修复「选择同步渠道」打开弹窗时页面卡死

### DIFF
--- a/web/src/features/system-settings/models/channel-selector-dialog.tsx
+++ b/web/src/features/system-settings/models/channel-selector-dialog.tsx
@@ -31,14 +31,6 @@ import { StatusBadge } from '@/components/status-badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 
 import type { UpstreamChannel } from '../types'
 import {
@@ -235,27 +227,18 @@ export function ChannelSelectorDialog({
 
           return (
             <div className='flex min-w-0 items-center gap-2'>
-              <Select
-                items={ENDPOINT_OPTIONS.map((option) => ({
-                  value: option.value,
-                  label: option.label,
-                }))}
+              <select
+                className='border-input bg-background h-8 w-32 shrink-0 rounded-md border px-2 text-sm'
                 value={endpointType}
-                onValueChange={(v) => v !== null && handleTypeChange(v)}
+                onChange={(e) => handleTypeChange(e.target.value)}
+                aria-label={t('Sync Endpoint')}
               >
-                <SelectTrigger className='h-8 w-32'>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent alignItemWithTrigger={false}>
-                  <SelectGroup>
-                    {ENDPOINT_OPTIONS.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
+                {ENDPOINT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
               {endpointType === 'custom' && (
                 <Input
                   value={currentEndpoint}

--- a/web/src/features/system-settings/models/upstream-ratio-sync.tsx
+++ b/web/src/features/system-settings/models/upstream-ratio-sync.tsx
@@ -509,16 +509,18 @@ export function UpstreamRatioSync({ modelRatios }: UpstreamRatioSyncProps) {
         />
       </div>
 
-      <ChannelSelectorDialog
-        open={channelDialogOpen}
-        onOpenChange={setChannelDialogOpen}
-        channels={channels}
-        selectedChannelIds={selectedChannelIds}
-        onSelectedChannelIdsChange={setSelectedChannelIds}
-        channelEndpoints={channelEndpoints}
-        onChannelEndpointsChange={setChannelEndpoints}
-        onConfirm={handleConfirmChannelSelection}
-      />
+      {channelDialogOpen ? (
+        <ChannelSelectorDialog
+          open
+          onOpenChange={setChannelDialogOpen}
+          channels={channels}
+          selectedChannelIds={selectedChannelIds}
+          onSelectedChannelIdsChange={setSelectedChannelIds}
+          channelEndpoints={channelEndpoints}
+          onChannelEndpointsChange={setChannelEndpoints}
+          onConfirm={handleConfirmChannelSelection}
+        />
+      ) : null}
 
       <ConflictConfirmDialog
         open={conflictDialogOpen}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

## 📝 变更描述 / Description

现象：在「系统设置 → 模型定价 → 上游价格同步」点击选择同步渠道** 时，浏览器主线程卡死，弹窗打不开, 界面无响应。

根因：弹窗表格每行使用 Base UI `Select`，其内容 Portal 到 `body`，与 Dialog 的 modal 焦点陷阱冲突，打开时主线程被拖死。

**修复：**
1. endpoint 列改为原生 `<select>`，不再使用带 Portal 的 Base UI Select
2. 渠道选择 Dialog 仅在打开时挂载

**范围：** 纯前端，2 个文件；无后端改动。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

https://github.com/QuantumNous/new-api/issues/6650

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


## 📸 运行证明 / Proof of Work

**复现（修复前）：**
模型定价 → 上游价格同步 → 点击「选择同步渠道」→ 页面卡死。

**验证（修复后）：**
同上步骤 → 弹窗立即出现；可搜索/分页/勾选/改 Sync Endpoint/确认。

<img width="1444" height="832" alt="image" src="https://github.com/user-attachments/assets/67c29bac-6fe0-4e97-9227-30dd88235321" />
---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the sync endpoint selector by replacing a custom component with a native HTML select element, reducing unnecessary imports and code complexity.
  * Optimized component mounting behavior for improved performance by conditionally mounting the channel selector dialog only when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->