### PR TITLE
feat: add native Claude Messages compatibility

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -97,10 +97,7 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 			case types.RelayFormatOpenAIRealtime:
 				helper.WssError(c, ws, newAPIError.ToOpenAIError())
 			case types.RelayFormatClaude:
-				c.JSON(newAPIError.StatusCode, gin.H{
-					"type":  "error",
-					"error": newAPIError.ToClaudeError(),
-				})
+				c.JSON(newAPIError.StatusCode, newAPIError.ToClaudeErrorResponse(c.GetString(common.RequestIdKey)))
 			default:
 				c.JSON(newAPIError.StatusCode, gin.H{
 					"error": newAPIError.ToOpenAIError(),
@@ -125,9 +122,11 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 		newAPIError = types.NewError(err, types.ErrorCodeGenRelayInfoFailed)
 		return
 	}
+	isClaudeCountTokens := relayFormat == types.RelayFormatClaude &&
+		relayInfo.RelayMode == relayconstant.RelayModeClaudeCountTokens
 
 	needSensitiveCheck := setting.ShouldCheckPromptSensitive()
-	needCountToken := constant.CountToken
+	needCountToken := constant.CountToken && !isClaudeCountTokens
 	// Avoid building huge CombineText (strings.Join) when token counting and sensitive check are both disabled.
 	var meta *types.TokenCountMeta
 	if needSensitiveCheck || needCountToken {
@@ -145,41 +144,43 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 		}
 	}
 
-	tokens, err := service.EstimateRequestToken(c, meta, relayInfo)
-	if err != nil {
-		newAPIError = types.NewError(err, types.ErrorCodeCountTokenFailed)
-		return
-	}
-
-	relayInfo.SetEstimatePromptTokens(tokens)
-
-	priceData, err := helper.ModelPriceHelper(c, relayInfo, tokens, meta)
-	if err != nil {
-		newAPIError = types.NewError(err, types.ErrorCodeModelPriceError, types.ErrOptionWithStatusCode(http.StatusBadRequest))
-		return
-	}
-
-	// common.SetContextKey(c, constant.ContextKeyTokenCountMeta, meta)
-
-	if priceData.FreeModel {
-		logger.LogInfo(c, fmt.Sprintf("模型 %s 免费，跳过预扣费", relayInfo.OriginModelName))
-	} else {
-		newAPIError = service.PreConsumeBilling(c, priceData.QuotaToPreConsume, relayInfo)
-		if newAPIError != nil {
+	if !isClaudeCountTokens {
+		tokens, err := service.EstimateRequestToken(c, meta, relayInfo)
+		if err != nil {
+			newAPIError = types.NewError(err, types.ErrorCodeCountTokenFailed)
 			return
 		}
-	}
 
-	defer func() {
-		// Only return quota if downstream failed and quota was actually pre-consumed
-		if newAPIError != nil {
-			newAPIError = service.NormalizeViolationFeeError(newAPIError)
-			if relayInfo.Billing != nil {
-				relayInfo.Billing.Refund(c)
-			}
-			service.ChargeViolationFeeIfNeeded(c, relayInfo, newAPIError)
+		relayInfo.SetEstimatePromptTokens(tokens)
+
+		priceData, err := helper.ModelPriceHelper(c, relayInfo, tokens, meta)
+		if err != nil {
+			newAPIError = types.NewError(err, types.ErrorCodeModelPriceError, types.ErrOptionWithStatusCode(http.StatusBadRequest))
+			return
 		}
-	}()
+
+		// common.SetContextKey(c, constant.ContextKeyTokenCountMeta, meta)
+
+		if priceData.FreeModel {
+			logger.LogInfo(c, fmt.Sprintf("模型 %s 免费，跳过预扣费", relayInfo.OriginModelName))
+		} else {
+			newAPIError = service.PreConsumeBilling(c, priceData.QuotaToPreConsume, relayInfo)
+			if newAPIError != nil {
+				return
+			}
+		}
+
+		defer func() {
+			// Only return quota if downstream failed and quota was actually pre-consumed
+			if newAPIError != nil {
+				newAPIError = service.NormalizeViolationFeeError(newAPIError)
+				if relayInfo.Billing != nil {
+					relayInfo.Billing.Refund(c)
+				}
+				service.ChargeViolationFeeIfNeeded(c, relayInfo, newAPIError)
+			}
+		}()
+	}
 
 	retryParam := &service.RetryParam{
 		Ctx:         c,
@@ -200,9 +201,11 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 			break
 		}
 		addUsedChannel(c, channel.Id)
-		if billingErr := service.PrepareTieredBillingForSelectedGroup(c, relayInfo); billingErr != nil {
-			newAPIError = billingErr
-			break
+		if !isClaudeCountTokens {
+			if billingErr := service.PrepareTieredBillingForSelectedGroup(c, relayInfo); billingErr != nil {
+				newAPIError = billingErr
+				break
+			}
 		}
 
 		bodyStorage, bodyErr := common.GetBodyStorage(c)
@@ -221,7 +224,11 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 		case types.RelayFormatOpenAIRealtime:
 			newAPIError = relay.WssHelper(c, relayInfo)
 		case types.RelayFormatClaude:
-			newAPIError = relay.ClaudeHelper(c, relayInfo)
+			if isClaudeCountTokens {
+				newAPIError = relay.ClaudeCountTokensHelper(c, relayInfo)
+			} else {
+				newAPIError = relay.ClaudeHelper(c, relayInfo)
+			}
 		case types.RelayFormatGemini:
 			newAPIError = geminiRelayHandler(c, relayInfo)
 		default:

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -415,10 +415,10 @@ func TokenAuth() func(c *gin.Context) {
 		if err != nil {
 			if errors.Is(err, model.ErrDatabase) {
 				common.SysLog("TokenAuth ValidateUserToken database error: " + err.Error())
-				abortWithOpenAiMessage(c, http.StatusInternalServerError,
+				abortWithRelayMessage(c, http.StatusInternalServerError,
 					common.TranslateMessage(c, i18n.MsgDatabaseError))
 			} else {
-				abortWithOpenAiMessage(c, http.StatusUnauthorized,
+				abortWithRelayMessage(c, http.StatusUnauthorized,
 					common.TranslateMessage(c, i18n.MsgTokenInvalid))
 			}
 			return
@@ -430,11 +430,11 @@ func TokenAuth() func(c *gin.Context) {
 			logger.LogDebug(c, "Token has IP restrictions, checking client IP %s", clientIp)
 			ip := net.ParseIP(clientIp)
 			if ip == nil {
-				abortWithOpenAiMessage(c, http.StatusForbidden, "无法解析客户端 IP 地址")
+				abortWithRelayMessage(c, http.StatusForbidden, "无法解析客户端 IP 地址")
 				return
 			}
 			if common.IsIpInCIDRList(ip, allowIps) == false {
-				abortWithOpenAiMessage(c, http.StatusForbidden, "您的 IP 不在令牌允许访问的列表中", types.ErrorCodeAccessDenied)
+				abortWithRelayMessage(c, http.StatusForbidden, "您的 IP 不在令牌允许访问的列表中", types.ErrorCodeAccessDenied)
 				return
 			}
 			logger.LogDebug(c, "Client IP %s passed the token IP restrictions check", clientIp)
@@ -443,13 +443,13 @@ func TokenAuth() func(c *gin.Context) {
 		userCache, err := model.GetUserCache(token.UserId)
 		if err != nil {
 			common.SysLog(fmt.Sprintf("TokenAuth GetUserCache error for user %d: %v", token.UserId, err))
-			abortWithOpenAiMessage(c, http.StatusInternalServerError,
+			abortWithRelayMessage(c, http.StatusInternalServerError,
 				common.TranslateMessage(c, i18n.MsgDatabaseError))
 			return
 		}
 		userEnabled := userCache.Status == common.UserStatusEnabled
 		if !userEnabled {
-			abortWithOpenAiMessage(c, http.StatusForbidden, common.TranslateMessage(c, i18n.MsgAuthUserBanned))
+			abortWithRelayMessage(c, http.StatusForbidden, common.TranslateMessage(c, i18n.MsgAuthUserBanned))
 			return
 		}
 
@@ -460,13 +460,13 @@ func TokenAuth() func(c *gin.Context) {
 		if tokenGroup != "" {
 			// check common.UserUsableGroups[userGroup]
 			if _, ok := service.GetUserUsableGroups(userGroup)[tokenGroup]; !ok {
-				abortWithOpenAiMessage(c, http.StatusForbidden, fmt.Sprintf("无权访问 %s 分组", tokenGroup))
+				abortWithRelayMessage(c, http.StatusForbidden, fmt.Sprintf("无权访问 %s 分组", tokenGroup))
 				return
 			}
 			// check group in common.GroupRatio
 			if !ratio_setting.ContainsGroupRatio(tokenGroup) {
 				if tokenGroup != "auto" {
-					abortWithOpenAiMessage(c, http.StatusForbidden, fmt.Sprintf("分组 %s 已被弃用", tokenGroup))
+					abortWithRelayMessage(c, http.StatusForbidden, fmt.Sprintf("分组 %s 已被弃用", tokenGroup))
 					return
 				}
 			}
@@ -517,7 +517,7 @@ func SetupContextForToken(c *gin.Context, token *model.Token, parts ...string) e
 			c.Set("specific_channel_id", parts[1])
 		} else {
 			c.Header("specific_channel_version", "701e3ae1dc3f7975556d354e0675168d004891c8")
-			abortWithOpenAiMessage(c, http.StatusForbidden, "普通用户不支持指定渠道")
+			abortWithRelayMessage(c, http.StatusForbidden, "普通用户不支持指定渠道")
 			return fmt.Errorf("普通用户不支持指定渠道")
 		}
 	}

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -36,22 +36,26 @@ func Distribute() func(c *gin.Context) {
 		channelId, ok := common.GetContextKey(c, constant.ContextKeyTokenSpecificChannelId)
 		modelRequest, shouldSelectChannel, err := getModelRequest(c)
 		if err != nil {
-			abortWithOpenAiMessage(c, http.StatusBadRequest, i18n.T(c, i18n.MsgDistributorInvalidRequest, map[string]any{"Error": err.Error()}))
+			statusCode := http.StatusBadRequest
+			if common.IsRequestBodyTooLargeError(err) {
+				statusCode = http.StatusRequestEntityTooLarge
+			}
+			abortWithRelayMessage(c, statusCode, i18n.T(c, i18n.MsgDistributorInvalidRequest, map[string]any{"Error": err.Error()}))
 			return
 		}
 		if ok {
 			id, err := strconv.Atoi(channelId.(string))
 			if err != nil {
-				abortWithOpenAiMessage(c, http.StatusBadRequest, i18n.T(c, i18n.MsgDistributorInvalidChannelId))
+				abortWithRelayMessage(c, http.StatusBadRequest, i18n.T(c, i18n.MsgDistributorInvalidChannelId))
 				return
 			}
 			channel, err = model.GetChannelById(id, true)
 			if err != nil {
-				abortWithOpenAiMessage(c, http.StatusBadRequest, i18n.T(c, i18n.MsgDistributorInvalidChannelId))
+				abortWithRelayMessage(c, http.StatusBadRequest, i18n.T(c, i18n.MsgDistributorInvalidChannelId))
 				return
 			}
 			if channel.Status != common.ChannelStatusEnabled {
-				abortWithOpenAiMessage(c, http.StatusForbidden, i18n.T(c, i18n.MsgDistributorChannelDisabled))
+				abortWithRelayMessage(c, http.StatusForbidden, i18n.T(c, i18n.MsgDistributorChannelDisabled))
 				return
 			}
 		} else {
@@ -62,7 +66,7 @@ func Distribute() func(c *gin.Context) {
 				s, ok := common.GetContextKey(c, constant.ContextKeyTokenModelLimit)
 				if !ok {
 					// token model limit is empty, all models are not allowed
-					abortWithOpenAiMessage(c, http.StatusForbidden, i18n.T(c, i18n.MsgDistributorTokenNoModelAccess))
+					abortWithRelayMessage(c, http.StatusForbidden, i18n.T(c, i18n.MsgDistributorTokenNoModelAccess))
 					return
 				}
 				var tokenModelLimit map[string]bool
@@ -72,14 +76,14 @@ func Distribute() func(c *gin.Context) {
 				}
 				matchName := ratio_setting.FormatMatchingModelName(modelRequest.Model) // match gpts & thinking-*
 				if _, ok := tokenModelLimit[matchName]; !ok {
-					abortWithOpenAiMessage(c, http.StatusForbidden, i18n.T(c, i18n.MsgDistributorTokenModelForbidden, map[string]any{"Model": modelRequest.Model}))
+					abortWithRelayMessage(c, http.StatusForbidden, i18n.T(c, i18n.MsgDistributorTokenModelForbidden, map[string]any{"Model": modelRequest.Model}))
 					return
 				}
 			}
 
 			if shouldSelectChannel {
 				if modelRequest.Model == "" {
-					abortWithOpenAiMessage(c, http.StatusBadRequest, i18n.T(c, i18n.MsgDistributorModelNameRequired))
+					abortWithRelayMessage(c, http.StatusBadRequest, i18n.T(c, i18n.MsgDistributorModelNameRequired))
 					return
 				}
 				var selectGroup string
@@ -89,12 +93,12 @@ func Distribute() func(c *gin.Context) {
 					playgroundRequest := &dto.PlayGroundRequest{}
 					err = common.UnmarshalBodyReusable(c, playgroundRequest)
 					if err != nil {
-						abortWithOpenAiMessage(c, http.StatusBadRequest, i18n.T(c, i18n.MsgDistributorInvalidPlayground, map[string]any{"Error": err.Error()}))
+						abortWithRelayMessage(c, http.StatusBadRequest, i18n.T(c, i18n.MsgDistributorInvalidPlayground, map[string]any{"Error": err.Error()}))
 						return
 					}
 					if playgroundRequest.Group != "" {
 						if !service.GroupInUserUsableGroups(usingGroup, playgroundRequest.Group) && playgroundRequest.Group != usingGroup {
-							abortWithOpenAiMessage(c, http.StatusForbidden, i18n.T(c, i18n.MsgDistributorGroupAccessDenied))
+							abortWithRelayMessage(c, http.StatusForbidden, i18n.T(c, i18n.MsgDistributorGroupAccessDenied))
 							return
 						}
 						usingGroup = playgroundRequest.Group
@@ -151,11 +155,11 @@ func Distribute() func(c *gin.Context) {
 						//	common.SysError(fmt.Sprintf("渠道不存在：%d", channel.Id))
 						//	message = "数据库一致性已被破坏，请联系管理员"
 						//}
-						abortWithOpenAiMessage(c, http.StatusServiceUnavailable, message, types.ErrorCodeModelNotFound)
+						abortWithRelayMessage(c, http.StatusServiceUnavailable, message, types.ErrorCodeModelNotFound)
 						return
 					}
 					if channel == nil {
-						abortWithOpenAiMessage(c, http.StatusServiceUnavailable, i18n.T(c, i18n.MsgDistributorNoAvailableChannel, map[string]any{"Group": usingGroup, "Model": modelRequest.Model}), types.ErrorCodeModelNotFound)
+						abortWithRelayMessage(c, http.StatusServiceUnavailable, i18n.T(c, i18n.MsgDistributorNoAvailableChannel, map[string]any{"Group": usingGroup, "Model": modelRequest.Model}), types.ErrorCodeModelNotFound)
 						return
 					}
 				}
@@ -193,7 +197,7 @@ func getModelFromRequest(c *gin.Context) (*ModelRequest, error) {
 	if strings.HasPrefix(c.Request.Header.Get("Content-Type"), "application/json") {
 		modelRequest, err := getModelFromJSONBody(c)
 		if err != nil {
-			return nil, errors.New(i18n.T(c, i18n.MsgDistributorInvalidRequest, map[string]any{"Error": err.Error()}))
+			return nil, fmt.Errorf("%s: %w", i18n.T(c, i18n.MsgDistributorInvalidRequest, map[string]any{"Error": err.Error()}), err)
 		}
 		return modelRequest, nil
 	}
@@ -201,7 +205,7 @@ func getModelFromRequest(c *gin.Context) (*ModelRequest, error) {
 	var modelRequest ModelRequest
 	err := common.UnmarshalBodyReusable(c, &modelRequest)
 	if err != nil {
-		return nil, errors.New(i18n.T(c, i18n.MsgDistributorInvalidRequest, map[string]any{"Error": err.Error()}))
+		return nil, fmt.Errorf("%s: %w", i18n.T(c, i18n.MsgDistributorInvalidRequest, map[string]any{"Error": err.Error()}), err)
 	}
 	return &modelRequest, nil
 }

--- a/middleware/jimeng_adapter.go
+++ b/middleware/jimeng_adapter.go
@@ -16,14 +16,14 @@ func JimengRequestConvert() func(c *gin.Context) {
 	return func(c *gin.Context) {
 		action := c.Query("Action")
 		if action == "" {
-			abortWithOpenAiMessage(c, http.StatusBadRequest, "Action query parameter is required")
+			abortWithRelayMessage(c, http.StatusBadRequest, "Action query parameter is required")
 			return
 		}
 
 		// Handle Jimeng official API request
 		var originalReq map[string]interface{}
 		if err := common.UnmarshalBodyReusable(c, &originalReq); err != nil {
-			abortWithOpenAiMessage(c, http.StatusBadRequest, "Invalid request body")
+			abortWithRelayMessage(c, http.StatusBadRequest, "Invalid request body")
 			return
 		}
 		model, _ := originalReq["req_key"].(string)
@@ -37,7 +37,7 @@ func JimengRequestConvert() func(c *gin.Context) {
 
 		jsonData, err := json.Marshal(unifiedReq)
 		if err != nil {
-			abortWithOpenAiMessage(c, http.StatusInternalServerError, "Failed to marshal request body")
+			abortWithRelayMessage(c, http.StatusInternalServerError, "Failed to marshal request body")
 			return
 		}
 
@@ -54,7 +54,7 @@ func JimengRequestConvert() func(c *gin.Context) {
 		if action == "CVSync2AsyncGetResult" {
 			taskId, ok := originalReq["task_id"].(string)
 			if !ok || taskId == "" {
-				abortWithOpenAiMessage(c, http.StatusBadRequest, "task_id is required for CVSync2AsyncGetResult")
+				abortWithRelayMessage(c, http.StatusBadRequest, "task_id is required for CVSync2AsyncGetResult")
 				return
 			}
 			c.Request.URL.Path = "/v1/video/generations/" + taskId

--- a/middleware/model-rate-limit.go
+++ b/middleware/model-rate-limit.go
@@ -87,11 +87,11 @@ func redisRateLimitHandler(duration int64, totalMaxCount, successMaxCount int) g
 		allowed, err := checkRedisRateLimit(ctx, rdb, successKey, successMaxCount, duration)
 		if err != nil {
 			fmt.Println("检查成功请求数限制失败:", err.Error())
-			abortWithOpenAiMessage(c, http.StatusInternalServerError, "rate_limit_check_failed")
+			abortWithRelayMessage(c, http.StatusInternalServerError, "rate_limit_check_failed")
 			return
 		}
 		if !allowed {
-			abortWithOpenAiMessage(c, http.StatusTooManyRequests, fmt.Sprintf("您已达到请求数限制：%d分钟内最多请求%d次", setting.ModelRequestRateLimitDurationMinutes, successMaxCount))
+			abortWithRelayMessage(c, http.StatusTooManyRequests, fmt.Sprintf("您已达到请求数限制：%d分钟内最多请求%d次", setting.ModelRequestRateLimitDurationMinutes, successMaxCount))
 			return
 		}
 
@@ -110,12 +110,12 @@ func redisRateLimitHandler(duration int64, totalMaxCount, successMaxCount int) g
 
 			if err != nil {
 				fmt.Println("检查总请求数限制失败:", err.Error())
-				abortWithOpenAiMessage(c, http.StatusInternalServerError, "rate_limit_check_failed")
+				abortWithRelayMessage(c, http.StatusInternalServerError, "rate_limit_check_failed")
 				return
 			}
 
 			if !allowed {
-				abortWithOpenAiMessage(c, http.StatusTooManyRequests, fmt.Sprintf("您已达到总请求数限制：%d分钟内最多请求%d次，包括失败次数，请检查您的请求是否正确", setting.ModelRequestRateLimitDurationMinutes, totalMaxCount))
+				abortWithRelayMessage(c, http.StatusTooManyRequests, fmt.Sprintf("您已达到总请求数限制：%d分钟内最多请求%d次，包括失败次数，请检查您的请求是否正确", setting.ModelRequestRateLimitDurationMinutes, totalMaxCount))
 			}
 		}
 

--- a/middleware/performance.go
+++ b/middleware/performance.go
@@ -18,9 +18,7 @@ func SystemPerformanceCheck() gin.HandlerFunc {
 		path := c.Request.URL.Path
 		if strings.HasPrefix(path, "/v1/messages") {
 			if err := checkSystemPerformance(); err != nil {
-				c.JSON(err.StatusCode, gin.H{
-					"error": err.ToClaudeError(),
-				})
+				c.JSON(err.StatusCode, err.ToClaudeErrorResponse(c.GetString(common.RequestIdKey)))
 				c.Abort()
 				return
 			}

--- a/middleware/utils.go
+++ b/middleware/utils.go
@@ -1,7 +1,9 @@
 package middleware
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/logger"
@@ -9,19 +11,30 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func abortWithOpenAiMessage(c *gin.Context, statusCode int, message string, code ...types.ErrorCode) {
-	codeStr := ""
+func abortWithRelayMessage(c *gin.Context, statusCode int, message string, code ...types.ErrorCode) {
+	errorCode := types.ErrorCode("")
 	if len(code) > 0 {
-		codeStr = string(code[0])
+		errorCode = code[0]
 	}
 	userId := c.GetInt("id")
-	c.JSON(statusCode, gin.H{
-		"error": gin.H{
-			"message": common.MessageWithRequestId(message, c.GetString(common.RequestIdKey)),
-			"type":    "new_api_error",
-			"code":    codeStr,
-		},
-	})
+	requestID := c.GetString(common.RequestIdKey)
+	if strings.HasPrefix(c.Request.URL.Path, "/v1/messages") {
+		newAPIError := types.NewClaudeError(
+			errors.New(message),
+			errorCode,
+			statusCode,
+			types.ErrOptionWithClaudeRequestID(requestID),
+		)
+		c.JSON(statusCode, newAPIError.ToClaudeErrorResponse())
+	} else {
+		c.JSON(statusCode, gin.H{
+			"error": gin.H{
+				"message": common.MessageWithRequestId(message, requestID),
+				"type":    "new_api_error",
+				"code":    string(errorCode),
+			},
+		})
+	}
 	c.Abort()
 	logger.LogError(c.Request.Context(), fmt.Sprintf("user %d | %s", userId, message))
 }

--- a/middleware/utils_test.go
+++ b/middleware/utils_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	newapii18n "github.com/QuantumNous/new-api/i18n"
+	"github.com/QuantumNous/new-api/relaykit/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAbortWithRelayMessageUsesClaudeEnvelope(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", nil)
+	c.Set(common.RequestIdKey, "req_gateway")
+
+	abortWithRelayMessage(c, http.StatusTooManyRequests, "slow down")
+
+	require.Equal(t, http.StatusTooManyRequests, recorder.Code)
+	require.JSONEq(t, `{
+		"type":"error",
+		"error":{"type":"rate_limit_error","message":"slow down"},
+		"request_id":"req_gateway"
+	}`, recorder.Body.String())
+	require.True(t, c.IsAborted())
+}
+
+func TestAbortWithRelayMessageKeepsOpenAIEnvelope(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	c.Set(common.RequestIdKey, "req_gateway")
+
+	abortWithRelayMessage(c, http.StatusServiceUnavailable, "no channel", types.ErrorCodeModelNotFound)
+
+	require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	require.JSONEq(t, `{
+		"error":{
+			"type":"new_api_error",
+			"code":"model_not_found",
+			"message":"no channel (request id: req_gateway)"
+		}
+	}`, recorder.Body.String())
+	require.True(t, c.IsAborted())
+}
+
+func TestDistributeUsesClaudeRequestTooLargeEnvelope(t *testing.T) {
+	require.NoError(t, newapii18n.Init())
+
+	oldMaxRequestBodyMB := constant.MaxRequestBodyMB
+	constant.MaxRequestBodyMB = 1
+	t.Cleanup(func() {
+		constant.MaxRequestBodyMB = oldMaxRequestBodyMB
+	})
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/v1/messages",
+		strings.NewReader(`{"model":"claude-test","padding":"`+strings.Repeat("x", 1<<20)+`"}`),
+	)
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set(common.RequestIdKey, "req_too_large")
+
+	Distribute()(c)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, recorder.Code)
+	require.Contains(t, recorder.Body.String(), `"type":"request_too_large"`)
+	require.Contains(t, recorder.Body.String(), `"request_id":"req_too_large"`)
+	require.True(t, c.IsAborted())
+}

--- a/relay/channel/adapter.go
+++ b/relay/channel/adapter.go
@@ -32,6 +32,15 @@ type Adaptor interface {
 	ConvertGeminiRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeminiChatRequest) (any, error)
 }
 
+// ClaudeCountTokensAdaptor is implemented only by channels that provide a
+// model-aware Claude token counting operation. Keeping this capability
+// separate prevents /v1/messages/count_tokens from falling through to a text
+// generation endpoint or an unrelated OpenAI-compatible tokenizer.
+type ClaudeCountTokensAdaptor interface {
+	ConvertClaudeCountTokensRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.ClaudeRequest) (any, error)
+	DoClaudeCountTokensResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) *types.NewAPIError
+}
+
 type TaskAdaptor interface {
 	Init(info *relaycommon.RelayInfo)
 

--- a/relay/channel/claude/adaptor.go
+++ b/relay/channel/claude/adaptor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/QuantumNous/new-api/relay/channel"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/QuantumNous/new-api/relaykit/relayconvert"
 	"github.com/QuantumNous/new-api/relaykit/types"
@@ -29,6 +30,23 @@ func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, info *relaycommon.RelayIn
 	return request, nil
 }
 
+func (a *Adaptor) ConvertClaudeCountTokensRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.ClaudeRequest) (any, error) {
+	return &dto.ClaudeCountTokensRequest{
+		Model:             request.Model,
+		System:            request.System,
+		Messages:          request.Messages,
+		CacheControl:      request.CacheControl,
+		ContextManagement: request.ContextManagement,
+		McpServers:        request.McpServers,
+		OutputConfig:      request.OutputConfig,
+		OutputFormat:      request.OutputFormat,
+		Speed:             request.Speed,
+		Thinking:          request.Thinking,
+		ToolChoice:        request.ToolChoice,
+		Tools:             request.Tools,
+	}, nil
+}
+
 func (a *Adaptor) ConvertAudioRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.AudioRequest) (io.Reader, error) {
 	//TODO implement me
 	return nil, errors.New("not implemented")
@@ -43,7 +61,11 @@ func (a *Adaptor) Init(info *relaycommon.RelayInfo) {
 }
 
 func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
-	requestURL := fmt.Sprintf("%s/v1/messages", info.ChannelBaseUrl)
+	path := "/v1/messages"
+	if info.RelayMode == relayconstant.RelayModeClaudeCountTokens {
+		path = "/v1/messages/count_tokens"
+	}
+	requestURL := fmt.Sprintf("%s%s", info.ChannelBaseUrl, path)
 	if !shouldAppendClaudeBetaQuery(info) {
 		return requestURL, nil
 	}
@@ -124,10 +146,16 @@ func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, request
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
 	info.FinalRequestRelayFormat = types.RelayFormatClaude
 	if info.IsStream {
+		info.StreamTerminalRequired = true
 		return ClaudeStreamHandler(c, resp, info)
 	} else {
 		return ClaudeHandler(c, resp, info)
 	}
+}
+
+func (a *Adaptor) DoClaudeCountTokensResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) *types.NewAPIError {
+	info.FinalRequestRelayFormat = types.RelayFormatClaude
+	return ClaudeCountTokensHandler(c, resp)
 }
 
 func (a *Adaptor) GetModelList() []string {

--- a/relay/channel/claude/count_tokens_test.go
+++ b/relay/channel/claude/count_tokens_test.go
@@ -1,0 +1,128 @@
+package claude
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetRequestURLClaudeCountTokens(t *testing.T) {
+	t.Parallel()
+
+	adaptor := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeClaudeCountTokens,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelBaseUrl: "https://api.anthropic.com",
+		},
+	}
+
+	requestURL, err := adaptor.GetRequestURL(info)
+
+	require.NoError(t, err)
+	require.Equal(t, "https://api.anthropic.com/v1/messages/count_tokens", requestURL)
+}
+
+func TestGetRequestURLClaudeCountTokensWithBetaQuery(t *testing.T) {
+	t.Parallel()
+
+	adaptor := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		RelayMode:         relayconstant.RelayModeClaudeCountTokens,
+		IsClaudeBetaQuery: true,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelBaseUrl: "https://api.anthropic.com",
+		},
+	}
+
+	requestURL, err := adaptor.GetRequestURL(info)
+
+	require.NoError(t, err)
+	require.Equal(t, "https://api.anthropic.com/v1/messages/count_tokens?beta=true", requestURL)
+}
+
+func TestConvertClaudeCountTokensRequestDropsGenerationFields(t *testing.T) {
+	t.Parallel()
+
+	maxTokens := uint(4096)
+	temperature := 0.7
+	stream := true
+	request := &dto.ClaudeRequest{
+		Model:             "claude-test",
+		System:            "system",
+		Messages:          []dto.ClaudeMessage{{Role: "user", Content: "hello"}},
+		MaxTokens:         &maxTokens,
+		Temperature:       &temperature,
+		Stream:            &stream,
+		ContextManagement: []byte(`{"edits":[]}`),
+		McpServers:        []byte(`[{"type":"url","name":"tools","url":"https://example.com"}]`),
+		OutputFormat:      []byte(`{"type":"json_schema","schema":{}}`),
+		Speed:             []byte(`"fast"`),
+		Tools:             []any{map[string]any{"name": "lookup"}},
+	}
+
+	converted, err := (&Adaptor{}).ConvertClaudeCountTokensRequest(nil, nil, request)
+	require.NoError(t, err)
+
+	jsonData, err := common.Marshal(converted)
+	require.NoError(t, err)
+	jsonBody := string(jsonData)
+	assert.Contains(t, jsonBody, `"model":"claude-test"`)
+	assert.Contains(t, jsonBody, `"messages"`)
+	assert.Contains(t, jsonBody, `"tools"`)
+	assert.Contains(t, jsonBody, `"context_management"`)
+	assert.Contains(t, jsonBody, `"mcp_servers"`)
+	assert.Contains(t, jsonBody, `"output_format"`)
+	assert.Contains(t, jsonBody, `"speed":"fast"`)
+	assert.NotContains(t, jsonBody, "max_tokens")
+	assert.NotContains(t, jsonBody, "temperature")
+	assert.NotContains(t, jsonBody, "stream")
+}
+
+func TestClaudeCountTokensHandlerCopiesNativeResponse(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", nil)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{"input_tokens":2095}`)),
+	}
+
+	newAPIError := ClaudeCountTokensHandler(c, resp)
+
+	require.Nil(t, newAPIError)
+	require.JSONEq(t, `{"input_tokens":2095}`, recorder.Body.String())
+}
+
+func TestClaudeCountTokensHandlerRejectsInvalidResponse(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", nil)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{"input_tokens":-1}`)),
+	}
+
+	newAPIError := ClaudeCountTokensHandler(c, resp)
+
+	require.NotNil(t, newAPIError)
+	require.Equal(t, types.ErrorTypeClaudeError, newAPIError.GetErrorType())
+	require.Equal(t, http.StatusBadGateway, newAPIError.StatusCode)
+}

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -1,6 +1,7 @@
 package claude
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -204,6 +205,10 @@ func ClaudeStreamHandler(c *gin.Context, resp *http.Response, info *relaycommon.
 		err = HandleStreamResponseData(c, info, claudeInfo, data)
 		if err != nil {
 			sr.Stop(err)
+			return
+		}
+		if claudeInfo.MessageStopReceived {
+			sr.Done()
 		}
 	})
 	if err != nil {
@@ -285,4 +290,25 @@ func ClaudeHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayI
 		return nil, handleErr
 	}
 	return claudeInfo.Usage, nil
+}
+
+func ClaudeCountTokensHandler(c *gin.Context, resp *http.Response) *types.NewAPIError {
+	if resp == nil || resp.Body == nil {
+		return types.NewClaudeError(errors.New("empty Claude count_tokens response"), types.ErrorCodeEmptyResponse, http.StatusBadGateway)
+	}
+	defer service.CloseResponseBodyGracefully(resp)
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return types.NewClaudeError(err, types.ErrorCodeReadResponseBodyFailed, http.StatusBadGateway)
+	}
+	var response dto.ClaudeCountTokensResponse
+	if err := common.Unmarshal(responseBody, &response); err != nil {
+		return types.NewClaudeError(err, types.ErrorCodeBadResponseBody, http.StatusBadGateway)
+	}
+	if response.InputTokens == nil || *response.InputTokens < 0 {
+		return types.NewClaudeError(errors.New("invalid Claude count_tokens response"), types.ErrorCodeBadResponseBody, http.StatusBadGateway)
+	}
+	service.IOCopyBytesGracefully(c, resp, responseBody)
+	return nil
 }

--- a/relay/channel/claude/relay_claude_test.go
+++ b/relay/channel/claude/relay_claude_test.go
@@ -202,6 +202,15 @@ func TestFormatClaudeResponseInfo_NilClaudeInfo(t *testing.T) {
 	}
 }
 
+func TestFormatClaudeResponseInfo_MessageStop(t *testing.T) {
+	claudeInfo := &ClaudeResponseInfo{Usage: &dto.Usage{}}
+
+	ok := FormatClaudeResponseInfo(&dto.ClaudeResponse{Type: "message_stop"}, nil, claudeInfo)
+
+	assert.False(t, ok)
+	assert.True(t, claudeInfo.MessageStopReceived)
+}
+
 func TestFormatClaudeResponseInfo_ContentBlockDelta(t *testing.T) {
 	text := "hello"
 	claudeInfo := &ClaudeResponseInfo{

--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/logger"
+	"github.com/QuantumNous/new-api/relay/channel"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/relaykit/dto"
@@ -21,32 +22,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
-
-	info.InitChannelMeta(c)
-
-	claudeReq, ok := info.Request.(*dto.ClaudeRequest)
-
-	if !ok {
-		return types.NewErrorWithStatusCode(fmt.Errorf("invalid request type, expected *dto.ClaudeRequest, got %T", info.Request), types.ErrorCodeInvalidRequest, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
-	}
-
-	request, err := common.DeepCopy(claudeReq)
-	if err != nil {
-		return types.NewError(fmt.Errorf("failed to copy request to ClaudeRequest: %w", err), types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
-	}
-
-	err = helper.ModelMappedHelper(c, info, request)
-	if err != nil {
-		return types.NewError(err, types.ErrorCodeChannelModelMappedError, types.ErrOptionWithSkipRetry())
-	}
-
-	adaptor := GetAdaptor(info.ApiType)
-	if adaptor == nil {
-		return types.NewError(fmt.Errorf("invalid api type: %d", info.ApiType), types.ErrorCodeInvalidApiType, types.ErrOptionWithSkipRetry())
-	}
-	adaptor.Init(info)
-
+func prepareClaudeRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.ClaudeRequest) {
 	if request.MaxTokens == nil || *request.MaxTokens == 0 {
 		defaultMaxTokens := uint(model_setting.GetClaudeSettings().GetDefaultMaxTokens(request.Model))
 		request.MaxTokens = &defaultMaxTokens
@@ -86,17 +62,15 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 				request.TopP = nil
 				request.TopK = nil
 			} else {
-				// 因为BudgetTokens 必须大于1024
+				// BudgetTokens must be greater than 1024.
 				if request.MaxTokens == nil || *request.MaxTokens < 1280 {
 					request.MaxTokens = common.GetPointer[uint](1280)
 				}
 
-				// BudgetTokens 为 max_tokens 的 80%
 				request.Thinking = &dto.Thinking{
 					Type:         "enabled",
 					BudgetTokens: common.GetPointer[int](int(float64(*request.MaxTokens) * model_setting.GetClaudeSettings().ThinkingAdapterBudgetTokensPercentage)),
 				}
-				// TODO: 临时处理
 				// https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#important-considerations-when-using-extended-thinking
 				request.Temperature = common.GetPointer[float64](1.0)
 			}
@@ -107,30 +81,61 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 		info.UpstreamModelName = request.Model
 	}
 
-	if info.ChannelSetting.SystemPrompt != "" {
-		if request.System == nil {
-			request.SetStringSystem(info.ChannelSetting.SystemPrompt)
-		} else if info.ChannelSetting.SystemPromptOverride {
-			common.SetContextKey(c, constant.ContextKeySystemPromptOverride, true)
-			if request.IsStringSystem() {
-				existing := strings.TrimSpace(request.GetStringSystem())
-				if existing == "" {
-					request.SetStringSystem(info.ChannelSetting.SystemPrompt)
-				} else {
-					request.SetStringSystem(info.ChannelSetting.SystemPrompt + "\n" + existing)
-				}
-			} else {
-				systemContents := request.ParseSystem()
-				newSystem := dto.ClaudeMediaMessage{Type: dto.ContentTypeText}
-				newSystem.SetText(info.ChannelSetting.SystemPrompt)
-				if len(systemContents) == 0 {
-					request.System = []dto.ClaudeMediaMessage{newSystem}
-				} else {
-					request.System = append([]dto.ClaudeMediaMessage{newSystem}, systemContents...)
-				}
-			}
-		}
+	if info.ChannelSetting.SystemPrompt == "" {
+		return
 	}
+	if request.System == nil {
+		request.SetStringSystem(info.ChannelSetting.SystemPrompt)
+		return
+	}
+	if !info.ChannelSetting.SystemPromptOverride {
+		return
+	}
+
+	common.SetContextKey(c, constant.ContextKeySystemPromptOverride, true)
+	if request.IsStringSystem() {
+		existing := strings.TrimSpace(request.GetStringSystem())
+		if existing == "" {
+			request.SetStringSystem(info.ChannelSetting.SystemPrompt)
+		} else {
+			request.SetStringSystem(info.ChannelSetting.SystemPrompt + "\n" + existing)
+		}
+		return
+	}
+
+	systemContents := request.ParseSystem()
+	newSystem := dto.ClaudeMediaMessage{Type: dto.ContentTypeText}
+	newSystem.SetText(info.ChannelSetting.SystemPrompt)
+	request.System = append([]dto.ClaudeMediaMessage{newSystem}, systemContents...)
+}
+
+func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
+
+	info.InitChannelMeta(c)
+
+	claudeReq, ok := info.Request.(*dto.ClaudeRequest)
+
+	if !ok {
+		return types.NewErrorWithStatusCode(fmt.Errorf("invalid request type, expected *dto.ClaudeRequest, got %T", info.Request), types.ErrorCodeInvalidRequest, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+	}
+
+	request, err := common.DeepCopy(claudeReq)
+	if err != nil {
+		return types.NewError(fmt.Errorf("failed to copy request to ClaudeRequest: %w", err), types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
+	}
+
+	err = helper.ModelMappedHelper(c, info, request)
+	if err != nil {
+		return types.NewError(err, types.ErrorCodeChannelModelMappedError, types.ErrOptionWithSkipRetry())
+	}
+
+	adaptor := GetAdaptor(info.ApiType)
+	if adaptor == nil {
+		return types.NewError(fmt.Errorf("invalid api type: %d", info.ApiType), types.ErrorCodeInvalidApiType, types.ErrOptionWithSkipRetry())
+	}
+	adaptor.Init(info)
+
+	prepareClaudeRequest(c, info, request)
 
 	if !model_setting.GetGlobalSettings().PassThroughRequestEnabled &&
 		!info.ChannelSetting.PassThroughBodyEnabled &&
@@ -201,14 +206,25 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 	var httpResp *http.Response
 	resp, err := adaptor.DoRequest(c, info, requestBody)
 	if err != nil {
-		return types.NewOpenAIError(err, types.ErrorCodeDoRequestFailed, http.StatusInternalServerError)
+		if info.GetFinalRequestRelayFormat() == types.RelayFormatClaude {
+			return types.NewClaudeError(err, types.ErrorCodeDoRequestFailed, http.StatusBadGateway)
+		}
+		return types.NewOpenAIError(err, types.ErrorCodeDoRequestFailed, http.StatusBadGateway)
 	}
 
 	if resp != nil {
-		httpResp = resp.(*http.Response)
+		var ok bool
+		httpResp, ok = resp.(*http.Response)
+		if !ok {
+			return types.NewClaudeError(fmt.Errorf("invalid response type: %T", resp), types.ErrorCodeBadResponse, http.StatusBadGateway)
+		}
 		info.IsStream = info.IsStream || strings.HasPrefix(httpResp.Header.Get("Content-Type"), "text/event-stream")
 		if httpResp.StatusCode != http.StatusOK {
-			newAPIError = service.RelayErrorHandler(c.Request.Context(), httpResp, false)
+			if info.GetFinalRequestRelayFormat() == types.RelayFormatClaude {
+				newAPIError = service.RelayClaudeErrorHandler(c.Request.Context(), httpResp, false)
+			} else {
+				newAPIError = service.RelayErrorHandler(c.Request.Context(), httpResp, false)
+			}
 			// reset status code 重置状态码
 			service.ResetStatusCode(newAPIError, statusCodeMappingStr)
 			return newAPIError
@@ -224,4 +240,117 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 
 	service.PostTextConsumeQuota(c, info, usage.(*dto.Usage), nil)
 	return nil
+}
+
+// ClaudeCountTokensHelper relays Anthropic token-count requests without
+// converting them through an OpenAI request or a local tokenizer. Only
+// adaptors that expose the native capability can serve this endpoint.
+func ClaudeCountTokensHelper(c *gin.Context, info *relaycommon.RelayInfo) *types.NewAPIError {
+	info.InitChannelMeta(c)
+
+	claudeReq, ok := info.Request.(*dto.ClaudeRequest)
+	if !ok {
+		return types.NewClaudeError(
+			fmt.Errorf("invalid request type, expected *dto.ClaudeRequest, got %T", info.Request),
+			types.ErrorCodeInvalidRequest,
+			http.StatusBadRequest,
+			types.ErrOptionWithSkipRetry(),
+		)
+	}
+
+	request, err := common.DeepCopy(claudeReq)
+	if err != nil {
+		return types.NewClaudeError(
+			fmt.Errorf("failed to copy request to ClaudeRequest: %w", err),
+			types.ErrorCodeInvalidRequest,
+			http.StatusBadRequest,
+			types.ErrOptionWithSkipRetry(),
+		)
+	}
+	if err := helper.ModelMappedHelper(c, info, request); err != nil {
+		return types.NewClaudeError(err, types.ErrorCodeChannelModelMappedError, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+	}
+
+	adaptor := GetAdaptor(info.ApiType)
+	if adaptor == nil {
+		return types.NewClaudeError(
+			fmt.Errorf("invalid api type: %d", info.ApiType),
+			types.ErrorCodeInvalidApiType,
+			http.StatusBadRequest,
+			types.ErrOptionWithSkipRetry(),
+		)
+	}
+	adaptor.Init(info)
+
+	countTokensAdaptor, ok := adaptor.(channel.ClaudeCountTokensAdaptor)
+	if !ok {
+		return types.NewClaudeError(
+			fmt.Errorf("channel %s does not support Claude count_tokens", adaptor.GetChannelName()),
+			types.ErrorCodeInvalidApiType,
+			http.StatusBadRequest,
+			types.ErrOptionWithSkipRetry(),
+		)
+	}
+
+	prepareClaudeRequest(c, info, request)
+
+	var requestBody io.Reader
+	if model_setting.GetGlobalSettings().PassThroughRequestEnabled || info.ChannelSetting.PassThroughBodyEnabled {
+		storage, err := common.GetBodyStorage(c)
+		if err != nil {
+			return types.NewClaudeError(err, types.ErrorCodeReadRequestBodyFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+		}
+		info.UpstreamRequestBodySize = storage.Size()
+		requestBody = common.ReaderOnly(storage)
+	} else {
+		convertedRequest, err := countTokensAdaptor.ConvertClaudeCountTokensRequest(c, info, request)
+		if err != nil {
+			return types.NewClaudeError(err, types.ErrorCodeConvertRequestFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+		}
+		relaycommon.AppendRequestConversionFromRequest(info, convertedRequest)
+
+		jsonData, err := common.Marshal(convertedRequest)
+		if err != nil {
+			return types.NewClaudeError(err, types.ErrorCodeConvertRequestFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+		}
+		jsonData, err = relaycommon.RemoveDisabledFields(jsonData, info.ChannelOtherSettings, info.ChannelSetting.PassThroughBodyEnabled)
+		if err != nil {
+			return types.NewClaudeError(err, types.ErrorCodeConvertRequestFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+		}
+		if len(info.ParamOverride) > 0 {
+			jsonData, err = relaycommon.ApplyParamOverrideWithRelayInfo(jsonData, info)
+			if err != nil {
+				return newAPIErrorFromParamOverride(err)
+			}
+		}
+
+		logger.LogDebug(c, "requestBody: %s", jsonData)
+		body, size, closer, err := relaycommon.NewOutboundJSONBody(jsonData)
+		if err != nil {
+			return types.NewClaudeError(err, types.ErrorCodeConvertRequestFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+		}
+		defer closer.Close()
+		info.UpstreamRequestBodySize = size
+		requestBody = body
+	}
+
+	resp, err := adaptor.DoRequest(c, info, requestBody)
+	if err != nil {
+		return types.NewClaudeError(err, types.ErrorCodeDoRequestFailed, http.StatusBadGateway)
+	}
+	httpResp, ok := resp.(*http.Response)
+	if !ok || httpResp == nil {
+		return types.NewClaudeError(fmt.Errorf("invalid response type: %T", resp), types.ErrorCodeBadResponse, http.StatusBadGateway)
+	}
+
+	statusCodeMappingStr := c.GetString("status_code_mapping")
+	if httpResp.StatusCode != http.StatusOK {
+		newAPIError := service.RelayClaudeErrorHandler(c.Request.Context(), httpResp, false)
+		service.ResetStatusCode(newAPIError, statusCodeMappingStr)
+		return newAPIError
+	}
+
+	newAPIError := countTokensAdaptor.DoClaudeCountTokensResponse(c, httpResp, info)
+	service.ResetStatusCode(newAPIError, statusCodeMappingStr)
+	return newAPIError
 }

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -178,7 +178,8 @@ type RelayInfo struct {
 	// 若为空，调用 GetFinalRequestRelayFormat 会回退到 RequestConversionChain 的最后一项或 RelayFormat。
 	FinalRequestRelayFormat types.RelayFormat
 
-	StreamStatus *StreamStatus
+	StreamStatus           *StreamStatus
+	StreamTerminalRequired bool
 
 	// convOptions caches the converter settings snapshot (see ConvOptions).
 	convOptions *convmeta.Options

--- a/relay/common/stream_status.go
+++ b/relay/common/stream_status.go
@@ -17,6 +17,7 @@ const (
 	StreamEndReasonScannerErr  StreamEndReason = "scanner_error"
 	StreamEndReasonHandlerStop StreamEndReason = "handler_stop"
 	StreamEndReasonEOF         StreamEndReason = "eof"
+	StreamEndReasonIncomplete  StreamEndReason = "incomplete"
 	StreamEndReasonPanic       StreamEndReason = "panic"
 	StreamEndReasonPingFail    StreamEndReason = "ping_fail"
 )
@@ -92,6 +93,10 @@ func (s *StreamStatus) IsNormalEnd() bool {
 	return s.EndReason == StreamEndReasonDone ||
 		s.EndReason == StreamEndReasonEOF ||
 		s.EndReason == StreamEndReasonHandlerStop
+}
+
+func (s *StreamStatus) IsSuccessful() bool {
+	return s.IsNormalEnd() && !s.HasErrors()
 }
 
 func (s *StreamStatus) Summary() string {

--- a/relay/common/stream_status_test.go
+++ b/relay/common/stream_status_test.go
@@ -48,6 +48,7 @@ func TestStreamStatus_SetEndReason_Concurrent(t *testing.T) {
 		StreamEndReasonScannerErr,
 		StreamEndReasonHandlerStop,
 		StreamEndReasonEOF,
+		StreamEndReasonIncomplete,
 		StreamEndReasonPanic,
 		StreamEndReasonPingFail,
 	}
@@ -140,6 +141,7 @@ func TestStreamStatus_IsNormalEnd(t *testing.T) {
 		{StreamEndReasonTimeout, false},
 		{StreamEndReasonClientGone, false},
 		{StreamEndReasonScannerErr, false},
+		{StreamEndReasonIncomplete, false},
 		{StreamEndReasonPanic, false},
 		{StreamEndReasonPingFail, false},
 		{StreamEndReasonNone, false},
@@ -155,6 +157,26 @@ func TestStreamStatus_IsNormalEnd_NilSafe(t *testing.T) {
 	t.Parallel()
 	var s *StreamStatus
 	assert.True(t, s.IsNormalEnd())
+}
+
+func TestStreamStatus_IsSuccessful(t *testing.T) {
+	t.Parallel()
+
+	done := NewStreamStatus()
+	done.SetEndReason(StreamEndReasonDone, nil)
+	assert.True(t, done.IsSuccessful())
+
+	doneWithErrors := NewStreamStatus()
+	doneWithErrors.SetEndReason(StreamEndReasonDone, nil)
+	doneWithErrors.RecordError("malformed chunk")
+	assert.False(t, doneWithErrors.IsSuccessful())
+
+	incomplete := NewStreamStatus()
+	incomplete.SetEndReason(StreamEndReasonIncomplete, fmt.Errorf("missing terminal event"))
+	assert.False(t, incomplete.IsSuccessful())
+
+	var absent *StreamStatus
+	assert.True(t, absent.IsSuccessful())
 }
 
 func TestStreamStatus_Summary(t *testing.T) {

--- a/relay/constant/relay_mode.go
+++ b/relay/constant/relay_mode.go
@@ -54,6 +54,8 @@ const (
 	RelayModeResponsesCompact
 
 	RelayModeAlphaSearch
+
+	RelayModeClaudeCountTokens
 )
 
 func Path2RelayMode(path string) int {
@@ -80,6 +82,8 @@ func Path2RelayMode(path string) int {
 		relayMode = RelayModeResponses
 	} else if strings.HasPrefix(path, "/v1/alpha/search") {
 		relayMode = RelayModeAlphaSearch
+	} else if strings.HasPrefix(path, "/v1/messages/count_tokens") {
+		relayMode = RelayModeClaudeCountTokens
 	} else if strings.HasPrefix(path, "/v1/audio/speech") {
 		relayMode = RelayModeAudioSpeech
 	} else if strings.HasPrefix(path, "/v1/audio/transcriptions") {

--- a/relay/constant/relay_mode_test.go
+++ b/relay/constant/relay_mode_test.go
@@ -13,6 +13,8 @@ func TestPath2RelayMode(t *testing.T) {
 	}{
 		{path: "/v1/alpha/search", want: RelayModeAlphaSearch},
 		{path: "/v1/alpha/search?foo=1", want: RelayModeAlphaSearch},
+		{path: "/v1/messages/count_tokens", want: RelayModeClaudeCountTokens},
+		{path: "/v1/messages/count_tokens?beta=true", want: RelayModeClaudeCountTokens},
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -197,6 +197,7 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	}
 
 	dataChan := make(chan string, 10)
+	dataHandlerDone := make(chan struct{})
 
 	wg.Add(1)
 	gopool.Go(func() {
@@ -206,6 +207,7 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 				info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonPanic, fmt.Errorf("handler panic: %v", r))
 			}
 			stop()
+			close(dataHandlerDone)
 			wg.Done()
 		}()
 		sr := newStreamResult(info.StreamStatus)
@@ -226,8 +228,11 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	// Scanner goroutine with improved error handling
 	wg.Add(1)
 	common.RelayCtxGo(ctx, func() {
+		dataChanClosed := false
 		defer func() {
-			close(dataChan)
+			if !dataChanClosed {
+				close(dataChan)
+			}
 			if r := recover(); r != nil {
 				logger.LogError(c, fmt.Sprintf("scanner goroutine panic: %v", r))
 				info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonPanic, fmt.Errorf("scanner panic: %v", r))
@@ -285,6 +290,19 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 				logger.LogError(c, "scanner error: "+err.Error())
 				info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonScannerErr, err)
 			}
+		}
+		if info.StreamTerminalRequired {
+			// Native protocols such as Anthropic terminate with a semantic event
+			// rather than by closing the connection. Drain queued events before
+			// deciding whether EOF truncated the stream.
+			close(dataChan)
+			dataChanClosed = true
+			<-dataHandlerDone
+			info.StreamStatus.SetEndReason(
+				relaycommon.StreamEndReasonIncomplete,
+				fmt.Errorf("stream ended before its terminal event"),
+			)
+			return
 		}
 		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonEOF, nil)
 	})

--- a/relay/helper/stream_scanner_test.go
+++ b/relay/helper/stream_scanner_test.go
@@ -412,6 +412,45 @@ func TestStreamScannerHandler_StreamStatus_EOFWithoutDone(t *testing.T) {
 	assert.True(t, info.StreamStatus.IsNormalEnd())
 }
 
+func TestStreamScannerHandler_StreamStatus_RequiredTerminalMissing(t *testing.T) {
+	t.Parallel()
+
+	c, resp, info := setupStreamTest(t, strings.NewReader("data: first\ndata: second\n"))
+	info.StreamTerminalRequired = true
+
+	StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {})
+
+	require.NotNil(t, info.StreamStatus)
+	assert.Equal(t, relaycommon.StreamEndReasonIncomplete, info.StreamStatus.EndReason)
+	assert.Error(t, info.StreamStatus.EndError)
+	assert.False(t, info.StreamStatus.IsNormalEnd())
+}
+
+func TestStreamScannerHandler_StreamStatus_RequiredTerminalDrainsQueuedEvents(t *testing.T) {
+	t.Parallel()
+
+	var body strings.Builder
+	for i := 0; i < 20; i++ {
+		fmt.Fprintf(&body, "data: chunk_%d\n", i)
+	}
+	body.WriteString("data: terminal\n")
+	c, resp, info := setupStreamTest(t, strings.NewReader(body.String()))
+	info.StreamTerminalRequired = true
+
+	var count atomic.Int64
+	StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {
+		count.Add(1)
+		if data == "terminal" {
+			sr.Done()
+		}
+	})
+
+	assert.Equal(t, int64(21), count.Load())
+	require.NotNil(t, info.StreamStatus)
+	assert.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
+	assert.True(t, info.StreamStatus.IsNormalEnd())
+}
+
 func TestStreamScannerHandler_StreamStatus_HandlerStop(t *testing.T) {
 	t.Parallel()
 

--- a/relaykit/dto/claude.go
+++ b/relaykit/dto/claude.go
@@ -488,6 +488,28 @@ type ClaudeErrorWithStatusCode struct {
 	LocalError bool
 }
 
+// ClaudeCountTokensRequest contains only fields accepted by Anthropic's
+// /v1/messages/count_tokens endpoint. Generation-only fields such as
+// max_tokens and temperature must not leak into token-count requests.
+type ClaudeCountTokensRequest struct {
+	Model             string          `json:"model"`
+	System            any             `json:"system,omitempty"`
+	Messages          []ClaudeMessage `json:"messages"`
+	CacheControl      json.RawMessage `json:"cache_control,omitempty"`
+	ContextManagement json.RawMessage `json:"context_management,omitempty"`
+	McpServers        json.RawMessage `json:"mcp_servers,omitempty"`
+	OutputConfig      json.RawMessage `json:"output_config,omitempty"`
+	OutputFormat      json.RawMessage `json:"output_format,omitempty"`
+	Speed             json.RawMessage `json:"speed,omitempty"`
+	Thinking          *Thinking       `json:"thinking,omitempty"`
+	ToolChoice        any             `json:"tool_choice,omitempty"`
+	Tools             any             `json:"tools,omitempty"`
+}
+
+type ClaudeCountTokensResponse struct {
+	InputTokens *int `json:"input_tokens"`
+}
+
 type ClaudeResponse struct {
 	Id           string               `json:"id,omitempty"`
 	Type         string               `json:"type"`

--- a/relaykit/relayconvert/convmeta/format.go
+++ b/relaykit/relayconvert/convmeta/format.go
@@ -13,7 +13,8 @@ func GuessRelayFormatFromRequest(req any) (types.RelayFormat, bool) {
 		return types.RelayFormatOpenAI, true
 	case *dto.OpenAIResponsesRequest, dto.OpenAIResponsesRequest:
 		return types.RelayFormatOpenAIResponses, true
-	case *dto.ClaudeRequest, dto.ClaudeRequest:
+	case *dto.ClaudeRequest, dto.ClaudeRequest,
+		*dto.ClaudeCountTokensRequest, dto.ClaudeCountTokensRequest:
 		return types.RelayFormatClaude, true
 	case *dto.GeminiChatRequest, dto.GeminiChatRequest:
 		return types.RelayFormatGemini, true

--- a/relaykit/relayconvert/internal/claude_messages/to_oai_chat_resp.go
+++ b/relaykit/relayconvert/internal/claude_messages/to_oai_chat_resp.go
@@ -13,12 +13,13 @@ import (
 )
 
 type ClaudeResponseInfo struct {
-	ResponseId   string
-	Created      int64
-	Model        string
-	ResponseText strings.Builder
-	Usage        *dto.Usage
-	Done         bool
+	ResponseId          string
+	Created             int64
+	Model               string
+	ResponseText        strings.Builder
+	Usage               *dto.Usage
+	Done                bool
+	MessageStopReceived bool
 }
 
 func StopReasonClaudeToOpenAI(reason string) string {
@@ -331,6 +332,10 @@ func setMessageDeltaUsageInt(data string, path string, localValue int) string {
 
 func FormatClaudeResponseInfo(claudeResponse *dto.ClaudeResponse, oaiResponse *dto.ChatCompletionsStreamResponse, claudeInfo *ClaudeResponseInfo) bool {
 	if claudeInfo == nil {
+		return false
+	}
+	if claudeResponse.Type == "message_stop" {
+		claudeInfo.MessageStopReceived = true
 		return false
 	}
 	if claudeInfo.Usage == nil {

--- a/relaykit/types/error.go
+++ b/relaykit/types/error.go
@@ -23,6 +23,12 @@ type ClaudeError struct {
 	Message string `json:"message,omitempty"`
 }
 
+type ClaudeErrorResponse struct {
+	Type      string      `json:"type"`
+	Error     ClaudeError `json:"error"`
+	RequestID string      `json:"request_id,omitempty"`
+}
+
 type ErrorType string
 
 const (
@@ -88,14 +94,15 @@ const (
 )
 
 type NewAPIError struct {
-	Err            error
-	RelayError     any
-	skipRetry      bool
-	recordErrorLog *bool
-	errorType      ErrorType
-	errorCode      ErrorCode
-	StatusCode     int
-	Metadata       json.RawMessage
+	Err             error
+	RelayError      any
+	skipRetry       bool
+	recordErrorLog  *bool
+	errorType       ErrorType
+	errorCode       ErrorCode
+	StatusCode      int
+	Metadata        json.RawMessage
+	claudeRequestID string
 }
 
 // Unwrap enables errors.Is / errors.As to work with NewAPIError by exposing the underlying error.
@@ -215,9 +222,13 @@ func (e *NewAPIError) ToClaudeError() ClaudeError {
 	switch e.errorType {
 	case ErrorTypeOpenAIError:
 		if openAIError, ok := e.RelayError.(OpenAIError); ok {
+			code := ""
+			if openAIError.Code != nil {
+				code = fmt.Sprintf("%v", openAIError.Code)
+			}
 			result = ClaudeError{
 				Message: e.Error(),
-				Type:    fmt.Sprintf("%v", openAIError.Code),
+				Type:    normalizeClaudeErrorType(e.StatusCode, openAIError.Type, code, string(e.errorCode)),
 			}
 		}
 	case ErrorTypeClaudeError:
@@ -227,8 +238,11 @@ func (e *NewAPIError) ToClaudeError() ClaudeError {
 	default:
 		result = ClaudeError{
 			Message: e.Error(),
-			Type:    string(e.errorType),
+			Type:    normalizeClaudeErrorType(e.StatusCode, string(e.errorCode), string(e.errorType)),
 		}
+	}
+	if result.Type == "" {
+		result.Type = normalizeClaudeErrorType(e.StatusCode, string(e.errorCode))
 	}
 	if e.errorCode != ErrorCodeCountTokenFailed {
 		result.Message = kitutil.MaskSensitiveInfo(result.Message)
@@ -237,6 +251,90 @@ func (e *NewAPIError) ToClaudeError() ClaudeError {
 		result.Message = string(e.errorType)
 	}
 	return result
+}
+
+func (e *NewAPIError) ToClaudeErrorResponse(fallbackRequestID ...string) ClaudeErrorResponse {
+	requestID := e.claudeRequestID
+	if requestID == "" && len(fallbackRequestID) > 0 {
+		requestID = strings.TrimSpace(fallbackRequestID[0])
+	}
+	return ClaudeErrorResponse{
+		Type:      "error",
+		Error:     e.ToClaudeError(),
+		RequestID: requestID,
+	}
+}
+
+func normalizeClaudeErrorType(statusCode int, candidates ...string) string {
+	for _, candidate := range candidates {
+		switch strings.ToLower(strings.TrimSpace(candidate)) {
+		case "invalid_request_error":
+			return "invalid_request_error"
+		case "invalid_request", "bad_request", "bad_request_body", "context_length_exceeded":
+			return "invalid_request_error"
+		case "authentication_error":
+			return "authentication_error"
+		case "invalid_api_key", "unauthorized", "unauthorized_error":
+			return "authentication_error"
+		case "billing_error":
+			return "billing_error"
+		case "payment_required":
+			return "billing_error"
+		case "permission_error":
+			return "permission_error"
+		case "access_denied", "forbidden":
+			return "permission_error"
+		case "not_found_error":
+			return "not_found_error"
+		case "model_not_found":
+			return "not_found_error"
+		case "conflict_error":
+			return "conflict_error"
+		case "conflict":
+			return "conflict_error"
+		case "request_too_large":
+			return "request_too_large"
+		case "rate_limit_error":
+			return "rate_limit_error"
+		case "rate_limit_exceeded", "insufficient_quota":
+			return "rate_limit_error"
+		case "overloaded_error":
+			return "overloaded_error"
+		case "timeout_error":
+			return "timeout_error"
+		case "gateway_timeout":
+			return "timeout_error"
+		case "api_error":
+			return "api_error"
+		}
+	}
+
+	switch statusCode {
+	case http.StatusBadRequest:
+		return "invalid_request_error"
+	case http.StatusUnauthorized:
+		return "authentication_error"
+	case http.StatusPaymentRequired:
+		return "billing_error"
+	case http.StatusForbidden:
+		return "permission_error"
+	case http.StatusNotFound:
+		return "not_found_error"
+	case http.StatusConflict:
+		return "conflict_error"
+	case http.StatusRequestEntityTooLarge:
+		return "request_too_large"
+	case http.StatusTooManyRequests:
+		return "rate_limit_error"
+	case http.StatusGatewayTimeout, 524:
+		return "timeout_error"
+	case http.StatusServiceUnavailable, 529:
+		return "overloaded_error"
+	}
+	if statusCode >= 400 && statusCode < 500 {
+		return "invalid_request_error"
+	}
+	return "api_error"
 }
 
 type NewAPIErrorOptions func(*NewAPIError)
@@ -286,6 +384,13 @@ func NewOpenAIError(err error, errorCode ErrorCode, statusCode int, ops ...NewAP
 		Code:    errorCode,
 	}
 	return WithOpenAIError(openaiError, statusCode, ops...)
+}
+
+func NewClaudeError(err error, errorCode ErrorCode, statusCode int, ops ...NewAPIErrorOptions) *NewAPIError {
+	return WithClaudeError(ClaudeError{
+		Message: err.Error(),
+		Type:    normalizeClaudeErrorType(statusCode, string(errorCode)),
+	}, statusCode, ops...)
 }
 
 func InitOpenAIError(errorCode ErrorCode, statusCode int, ops ...NewAPIErrorOptions) *NewAPIError {
@@ -387,6 +492,12 @@ func ErrOptionWithSkipRetry() NewAPIErrorOptions {
 func ErrOptionWithNoRecordErrorLog() NewAPIErrorOptions {
 	return func(e *NewAPIError) {
 		e.recordErrorLog = kitutil.GetPointer(false)
+	}
+}
+
+func ErrOptionWithClaudeRequestID(requestID string) NewAPIErrorOptions {
+	return func(e *NewAPIError) {
+		e.claudeRequestID = strings.TrimSpace(requestID)
 	}
 }
 

--- a/relaykit/types/error_test.go
+++ b/relaykit/types/error_test.go
@@ -1,0 +1,99 @@
+package types
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToClaudeErrorUsesOpenAITypeWhenCodeIsNil(t *testing.T) {
+	t.Parallel()
+
+	newAPIError := WithOpenAIError(OpenAIError{
+		Message: "upstream overloaded",
+		Type:    "overloaded_error",
+		Code:    nil,
+	}, http.StatusServiceUnavailable)
+
+	claudeError := newAPIError.ToClaudeError()
+
+	require.Equal(t, "overloaded_error", claudeError.Type)
+	require.Equal(t, "upstream overloaded", claudeError.Message)
+	require.NotEqual(t, "<nil>", claudeError.Type)
+}
+
+func TestToClaudeErrorMapsHTTPStatusToAnthropicType(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		statusCode int
+		wantType   string
+	}{
+		{http.StatusBadRequest, "invalid_request_error"},
+		{http.StatusUnauthorized, "authentication_error"},
+		{http.StatusPaymentRequired, "billing_error"},
+		{http.StatusForbidden, "permission_error"},
+		{http.StatusNotFound, "not_found_error"},
+		{http.StatusRequestTimeout, "invalid_request_error"},
+		{http.StatusConflict, "conflict_error"},
+		{http.StatusRequestEntityTooLarge, "request_too_large"},
+		{http.StatusTooManyRequests, "rate_limit_error"},
+		{http.StatusInternalServerError, "api_error"},
+		{http.StatusServiceUnavailable, "overloaded_error"},
+		{http.StatusGatewayTimeout, "timeout_error"},
+		{524, "timeout_error"},
+		{529, "overloaded_error"},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.wantType, func(t *testing.T) {
+			t.Parallel()
+			newAPIError := NewErrorWithStatusCode(errors.New("failure"), ErrorCodeBadResponse, testCase.statusCode)
+			assert.Equal(t, testCase.wantType, newAPIError.ToClaudeError().Type)
+		})
+	}
+}
+
+func TestToClaudeErrorPreservesOfficialCandidateTypes(t *testing.T) {
+	t.Parallel()
+
+	for _, errorType := range []string{"billing_error", "conflict_error", "timeout_error"} {
+		errorType := errorType
+		t.Run(errorType, func(t *testing.T) {
+			t.Parallel()
+			newAPIError := WithOpenAIError(OpenAIError{
+				Message: "failure",
+				Type:    errorType,
+			}, http.StatusInternalServerError)
+			require.Equal(t, errorType, newAPIError.ToClaudeError().Type)
+		})
+	}
+}
+
+func TestToClaudeErrorResponsePreservesRequestID(t *testing.T) {
+	t.Parallel()
+
+	newAPIError := WithClaudeError(
+		ClaudeError{Type: "rate_limit_error", Message: "slow down"},
+		http.StatusTooManyRequests,
+		ErrOptionWithClaudeRequestID(" req_native "),
+	)
+
+	require.Equal(t, ClaudeErrorResponse{
+		Type:      "error",
+		Error:     ClaudeError{Type: "rate_limit_error", Message: "slow down"},
+		RequestID: "req_native",
+	}, newAPIError.ToClaudeErrorResponse())
+}
+
+func TestToClaudeErrorResponseUsesFallbackRequestID(t *testing.T) {
+	t.Parallel()
+
+	newAPIError := NewClaudeError(errors.New("failure"), ErrorCodeBadResponse, http.StatusInternalServerError)
+
+	require.Equal(t, "req_local", newAPIError.ToClaudeErrorResponse(" req_local ").RequestID)
+}

--- a/router/relay-router.go
+++ b/router/relay-router.go
@@ -85,6 +85,9 @@ func SetRelayRouter(router *gin.Engine) {
 		httpRouter.Use(middleware.Distribute())
 
 		// claude related routes
+		httpRouter.POST("/messages/count_tokens", func(c *gin.Context) {
+			controller.Relay(c, types.RelayFormatClaude)
+		})
 		httpRouter.POST("/messages", func(c *gin.Context) {
 			controller.Relay(c, types.RelayFormatClaude)
 		})

--- a/service/error.go
+++ b/service/error.go
@@ -137,6 +137,54 @@ func RelayErrorHandler(ctx context.Context, resp *http.Response, showBodyWhenFai
 	return
 }
 
+type claudeUpstreamErrorResponse struct {
+	Type      string            `json:"type"`
+	Error     types.ClaudeError `json:"error"`
+	RequestID string            `json:"request_id"`
+}
+
+// RelayClaudeErrorHandler preserves the native Anthropic error envelope.
+// Claude relays must not round-trip errors through OpenAIError because
+// Anthropic's error.type has no required OpenAI code equivalent.
+func RelayClaudeErrorHandler(ctx context.Context, resp *http.Response, showBodyWhenFail bool) *types.NewAPIError {
+	statusCode := resp.StatusCode
+	responseBody, err := io.ReadAll(resp.Body)
+	CloseResponseBodyGracefully(resp)
+	if err != nil {
+		return types.NewClaudeError(err, types.ErrorCodeReadResponseBodyFailed, statusCode)
+	}
+
+	var errorResponse claudeUpstreamErrorResponse
+	if err := common.Unmarshal(responseBody, &errorResponse); err == nil &&
+		errorResponse.Type == "error" &&
+		errorResponse.Error.Type != "" {
+		requestID := errorResponse.RequestID
+		if requestID == "" {
+			requestID = resp.Header.Get("request-id")
+		}
+		return types.WithClaudeError(
+			errorResponse.Error,
+			statusCode,
+			types.ErrOptionWithClaudeRequestID(requestID),
+		)
+	}
+
+	responseBodyText := string(responseBody)
+	responseBodyPreview := common.LocalLogPreview(responseBodyText)
+	message := fmt.Sprintf("bad response status code %d", statusCode)
+	if showBodyWhenFail {
+		message = fmt.Sprintf("%s, body: %s", message, responseBodyText)
+	} else {
+		logger.LogError(ctx, fmt.Sprintf("Claude upstream returned an invalid error envelope, status %d, body: %s", statusCode, responseBodyPreview))
+	}
+	return types.NewClaudeError(
+		errors.New(message),
+		types.ErrorCodeBadResponseStatusCode,
+		statusCode,
+		types.ErrOptionWithClaudeRequestID(resp.Header.Get("request-id")),
+	)
+}
+
 func ResetStatusCode(newApiErr *types.NewAPIError, statusCodeMappingStr string) {
 	if newApiErr == nil {
 		return

--- a/service/error.go
+++ b/service/error.go
@@ -151,7 +151,12 @@ func RelayClaudeErrorHandler(ctx context.Context, resp *http.Response, showBodyW
 	responseBody, err := io.ReadAll(resp.Body)
 	CloseResponseBodyGracefully(resp)
 	if err != nil {
-		return types.NewClaudeError(err, types.ErrorCodeReadResponseBodyFailed, statusCode)
+		return types.NewClaudeError(
+			err,
+			types.ErrorCodeReadResponseBodyFailed,
+			statusCode,
+			types.ErrOptionWithClaudeRequestID(resp.Header.Get("request-id")),
+		)
 	}
 
 	var errorResponse claudeUpstreamErrorResponse

--- a/service/error_test.go
+++ b/service/error_test.go
@@ -150,6 +150,44 @@ func TestRelayErrorHandlerKeepsInvalidJSONBodyInDebugLog(t *testing.T) {
 	require.Contains(t, logBuffer.String(), body)
 }
 
+func TestRelayClaudeErrorHandlerPreservesNativeEnvelope(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Header:     http.Header{"Request-Id": []string{"req_header_fallback"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"type":"error","error":{"type":"overloaded_error","message":"upstream overloaded"}}`,
+		)),
+	}
+
+	newAPIError := RelayClaudeErrorHandler(context.Background(), resp, false)
+
+	require.NotNil(t, newAPIError)
+	require.Equal(t, http.StatusServiceUnavailable, newAPIError.StatusCode)
+	require.Equal(t, types.ErrorTypeClaudeError, newAPIError.GetErrorType())
+	require.Equal(t, types.ErrorCode("overloaded_error"), newAPIError.GetErrorCode())
+	require.Equal(t, types.ClaudeErrorResponse{
+		Type:      "error",
+		Error:     types.ClaudeError{Type: "overloaded_error", Message: "upstream overloaded"},
+		RequestID: "req_header_fallback",
+	}, newAPIError.ToClaudeErrorResponse())
+}
+
+func TestRelayClaudeErrorHandlerMapsMalformed503WithoutLeakingBody(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Body:       io.NopCloser(strings.NewReader(`{"secret":"do-not-return"}`)),
+	}
+
+	newAPIError := RelayClaudeErrorHandler(context.Background(), resp, false)
+
+	require.NotNil(t, newAPIError)
+	claudeError := newAPIError.ToClaudeError()
+	require.Equal(t, "overloaded_error", claudeError.Type)
+	require.NotContains(t, claudeError.Message, "do-not-return")
+}
+
 func withDebugEnabled(t *testing.T, enabled bool) {
 	t.Helper()
 

--- a/service/error_test.go
+++ b/service/error_test.go
@@ -15,6 +15,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type failingReadCloser struct{}
+
+func (failingReadCloser) Read([]byte) (int, error) {
+	return 0, io.ErrUnexpectedEOF
+}
+
+func (failingReadCloser) Close() error {
+	return nil
+}
+
 func TestResetStatusCode(t *testing.T) {
 	t.Parallel()
 
@@ -172,6 +182,26 @@ func TestRelayClaudeErrorHandlerPreservesNativeEnvelope(t *testing.T) {
 		Error:     types.ClaudeError{Type: "overloaded_error", Message: "upstream overloaded"},
 		RequestID: "req_header_fallback",
 	}, newAPIError.ToClaudeErrorResponse())
+}
+
+func TestRelayClaudeErrorHandlerPreservesRequestIDWhenBodyReadFails(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Header:     http.Header{"Request-Id": []string{"req_body_read_failed"}},
+		Body:       failingReadCloser{},
+	}
+
+	newAPIError := RelayClaudeErrorHandler(context.Background(), resp, false)
+
+	require.NotNil(t, newAPIError)
+	require.Equal(t, http.StatusServiceUnavailable, newAPIError.StatusCode)
+	require.Equal(
+		t,
+		"req_body_read_failed",
+		newAPIError.ToClaudeErrorResponse().RequestID,
+	)
 }
 
 func TestRelayClaudeErrorHandlerMapsMalformed503WithoutLeakingBody(t *testing.T) {

--- a/service/log_info_generate.go
+++ b/service/log_info_generate.go
@@ -131,7 +131,7 @@ func appendStreamStatus(relayInfo *relaycommon.RelayInfo, other map[string]inter
 	}
 	ss := relayInfo.StreamStatus
 	status := "ok"
-	if !ss.IsNormalEnd() || ss.HasErrors() {
+	if !ss.IsSuccessful() {
 		status = "error"
 	}
 	streamInfo := map[string]interface{}{

--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -537,7 +537,8 @@ func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, us
 		Group:            relayInfo.UsingGroup,
 		Other:            other,
 	})
+	relaySucceeded := relayInfo.StreamStatus.IsSuccessful()
 	gopool.Go(func() {
-		perfmetrics.RecordRelaySample(relayInfo, true, int64(summary.CompletionTokens))
+		perfmetrics.RecordRelaySample(relayInfo, relaySucceeded, int64(summary.CompletionTokens))
 	})
 }


### PR DESCRIPTION
## 变更描述 / Description

补齐 Claude Messages 接口的几个原生行为：目前 `/v1/messages` 已经可以使用，但还有几个地方会影响 Claude Code 一类的客户端：
- 缺少 `/v1/messages/count_tokens`
- Claude 错误会经过 OpenAI 错误格式转换
- 流式连接结束时，没有区分正常的 `message_stop` 和意外断开

本 PR 做了以下调整：

- 增加原生 `/v1/messages/count_tokens`
- Claude 上游错误按 Anthropic 格式返回，并保留 `request_id`
- Claude 流式请求只有收到 `message_stop` 才记为正常完成
- 连接提前断开时标记为 incomplete，避免误判成功
- 抽出 Claude 请求的公共准备逻辑，Messages 和 count_tokens 共用
- 不支持原生 count_tokens 的渠道会明确返回错误，不会偷偷改用本地估算或触发生成请求

这些不影响现有 OpenAI 接口

## 变更类型 / Type of change

- [x] 新功能 (New feature)
- [x] 性能优化 / 重构 (Refactor)


## 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 本 PR 不作为 Bug fix 提交。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 运行证明 / Proof of Work

改动在下述情况生效：
- 普通 Messages 请求
- SSE 流式事件顺序
- tool use
- thinking/signature
- 图片输入
- 长请求传输
- count_tokens
- Anthropic 原生错误
- 流式中断处理



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude token-counting support through `POST /v1/messages/count_tokens`.
  * Preserved native Claude error formats, request IDs, and status details.
* **Bug Fixes**
  * Improved Claude request validation, error handling, and upstream response processing.
  * Improved streaming completion handling, including detection of incomplete streams and proper terminal-event processing.
  * Corrected relay performance reporting to reflect actual request outcomes.
* **Tests**
  * Added coverage for token counting, Claude errors, streaming completion, and response validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->