### PR TITLE
fix(relay): preserve presence/frequency penalty in Responses conversion

### DIFF
--- a/relay/channel/codex/adaptor.go
+++ b/relay/channel/codex/adaptor.go
@@ -104,6 +104,8 @@ func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommo
 	// rm max_output_tokens
 	request.MaxOutputTokens = nil
 	request.Temperature = nil
+	request.FrequencyPenalty = nil
+	request.PresencePenalty = nil
 	return request, nil
 }
 

--- a/relay/channel/codex/adaptor_test.go
+++ b/relay/channel/codex/adaptor_test.go
@@ -1,11 +1,14 @@
 package codex
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/QuantumNous/new-api/constant"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,4 +26,31 @@ func TestGetRequestURLAlphaSearch(t *testing.T) {
 	url, err := adaptor.GetRequestURL(info)
 	require.NoError(t, err)
 	assert.Equal(t, "https://chatgpt.com/backend-api/codex/alpha/search", url)
+}
+
+// The Codex backend rejects these fields, so the adaptor clears them rather
+// than forwarding what the client sent.
+func TestConvertOpenAIResponsesRequestDropsPenalties(t *testing.T) {
+	adaptor := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{ChannelType: constant.ChannelTypeCodex},
+		RelayMode:   relayconstant.RelayModeResponses,
+	}
+
+	converted, err := adaptor.ConvertOpenAIResponsesRequest(nil, info, dto.OpenAIResponsesRequest{
+		Model:            "gpt-5-codex",
+		Input:            json.RawMessage(`"hello"`),
+		MaxOutputTokens:  lo.ToPtr(uint(128)),
+		Temperature:      lo.ToPtr(1.0),
+		FrequencyPenalty: lo.ToPtr(1.5),
+		PresencePenalty:  lo.ToPtr(1.5),
+	})
+	require.NoError(t, err)
+
+	request, ok := converted.(dto.OpenAIResponsesRequest)
+	require.True(t, ok)
+	assert.Nil(t, request.MaxOutputTokens)
+	assert.Nil(t, request.Temperature)
+	assert.Nil(t, request.FrequencyPenalty)
+	assert.Nil(t, request.PresencePenalty)
 }

--- a/relay/channel/codex/adaptor_test.go
+++ b/relay/channel/codex/adaptor_test.go
@@ -42,8 +42,8 @@ func TestConvertOpenAIResponsesRequestDropsPenalties(t *testing.T) {
 		Input:            json.RawMessage(`"hello"`),
 		MaxOutputTokens:  lo.ToPtr(uint(128)),
 		Temperature:      lo.ToPtr(1.0),
-		FrequencyPenalty: lo.ToPtr(1.5),
-		PresencePenalty:  lo.ToPtr(1.5),
+		FrequencyPenalty: json.RawMessage(`1.5`),
+		PresencePenalty:  json.RawMessage(`1.5`),
 	})
 	require.NoError(t, err)
 

--- a/relaykit/dto/openai_request.go
+++ b/relaykit/dto/openai_request.go
@@ -861,12 +861,14 @@ type OpenAIResponsesRequest struct {
 	// Background         json.RawMessage `json:"background,omitempty"`
 	Conversation       json.RawMessage `json:"conversation,omitempty"`
 	ContextManagement  json.RawMessage `json:"context_management,omitempty"`
+	FrequencyPenalty   *float64        `json:"frequency_penalty,omitempty"`
 	Instructions       json.RawMessage `json:"instructions,omitempty"`
 	MaxOutputTokens    *uint           `json:"max_output_tokens,omitempty"`
 	TopLogProbs        *int            `json:"top_logprobs,omitempty"`
 	Metadata           json.RawMessage `json:"metadata,omitempty"`
 	Moderation         json.RawMessage `json:"moderation,omitempty"`
 	ParallelToolCalls  json.RawMessage `json:"parallel_tool_calls,omitempty"`
+	PresencePenalty    *float64        `json:"presence_penalty,omitempty"`
 	PreviousResponseID string          `json:"previous_response_id,omitempty"`
 	Reasoning          *Reasoning      `json:"reasoning,omitempty"`
 	// ServiceTier specifies upstream service level and may affect billing.

--- a/relaykit/dto/openai_request.go
+++ b/relaykit/dto/openai_request.go
@@ -861,14 +861,17 @@ type OpenAIResponsesRequest struct {
 	// Background         json.RawMessage `json:"background,omitempty"`
 	Conversation       json.RawMessage `json:"conversation,omitempty"`
 	ContextManagement  json.RawMessage `json:"context_management,omitempty"`
-	FrequencyPenalty   *float64        `json:"frequency_penalty,omitempty"`
 	Instructions       json.RawMessage `json:"instructions,omitempty"`
 	MaxOutputTokens    *uint           `json:"max_output_tokens,omitempty"`
 	TopLogProbs        *int            `json:"top_logprobs,omitempty"`
 	Metadata           json.RawMessage `json:"metadata,omitempty"`
 	Moderation         json.RawMessage `json:"moderation,omitempty"`
 	ParallelToolCalls  json.RawMessage `json:"parallel_tool_calls,omitempty"`
-	PresencePenalty    *float64        `json:"presence_penalty,omitempty"`
+	// FrequencyPenalty/PresencePenalty are not part of the official OpenAI
+	// Responses API; they are forwarded verbatim for OpenAI-compatible upstreams
+	// (e.g. vLLM) that accept them.
+	FrequencyPenalty   json.RawMessage `json:"frequency_penalty,omitempty"`
+	PresencePenalty    json.RawMessage `json:"presence_penalty,omitempty"`
 	PreviousResponseID string          `json:"previous_response_id,omitempty"`
 	Reasoning          *Reasoning      `json:"reasoning,omitempty"`
 	// ServiceTier specifies upstream service level and may affect billing.

--- a/relaykit/dto/openai_request_zero_value_test.go
+++ b/relaykit/dto/openai_request_zero_value_test.go
@@ -123,7 +123,9 @@ func TestOpenAIResponsesRequestPreserveExplicitZeroValues(t *testing.T) {
 		"max_output_tokens":0,
 		"max_tool_calls":0,
 		"stream":false,
-		"top_p":0
+		"top_p":0,
+		"frequency_penalty":0,
+		"presence_penalty":0
 	}`)
 
 	var req OpenAIResponsesRequest
@@ -137,6 +139,8 @@ func TestOpenAIResponsesRequestPreserveExplicitZeroValues(t *testing.T) {
 	require.True(t, gjson.GetBytes(encoded, "max_tool_calls").Exists())
 	require.True(t, gjson.GetBytes(encoded, "stream").Exists())
 	require.True(t, gjson.GetBytes(encoded, "top_p").Exists())
+	require.True(t, gjson.GetBytes(encoded, "frequency_penalty").Exists())
+	require.True(t, gjson.GetBytes(encoded, "presence_penalty").Exists())
 }
 
 func TestOpenAIResponsesRequestPreserveQwenThinkingBudget(t *testing.T) {

--- a/relaykit/relayconvert/internal/oai_chat/to_oai_responses_req.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_oai_responses_req.go
@@ -382,6 +382,8 @@ func ChatCompletionsRequestToResponsesRequest(req *dto.GeneralOpenAIRequest) (*d
 		ToolChoice:        toolChoiceRaw,
 		Tools:             toolsRaw,
 		TopP:              topP,
+		FrequencyPenalty:  req.FrequencyPenalty,
+		PresencePenalty:   req.PresencePenalty,
 		User:              req.User,
 		ParallelToolCalls: parallelToolCallsRaw,
 		Store:             req.Store,

--- a/relaykit/relayconvert/internal/oai_chat/to_oai_responses_req.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_oai_responses_req.go
@@ -372,6 +372,14 @@ func ChatCompletionsRequestToResponsesRequest(req *dto.GeneralOpenAIRequest) (*d
 		topP = kitutil.GetPointer(lo.FromPtr(req.TopP))
 	}
 
+	var frequencyPenaltyRaw, presencePenaltyRaw json.RawMessage
+	if req.FrequencyPenalty != nil {
+		frequencyPenaltyRaw, _ = kitutil.Marshal(req.FrequencyPenalty)
+	}
+	if req.PresencePenalty != nil {
+		presencePenaltyRaw, _ = kitutil.Marshal(req.PresencePenalty)
+	}
+
 	out := &dto.OpenAIResponsesRequest{
 		Model:             req.Model,
 		Input:             inputRaw,
@@ -382,8 +390,8 @@ func ChatCompletionsRequestToResponsesRequest(req *dto.GeneralOpenAIRequest) (*d
 		ToolChoice:        toolChoiceRaw,
 		Tools:             toolsRaw,
 		TopP:              topP,
-		FrequencyPenalty:  req.FrequencyPenalty,
-		PresencePenalty:   req.PresencePenalty,
+		FrequencyPenalty:  frequencyPenaltyRaw,
+		PresencePenalty:   presencePenaltyRaw,
 		User:              req.User,
 		ParallelToolCalls: parallelToolCallsRaw,
 		Store:             req.Store,

--- a/relaykit/relayconvert/internal/oai_chat/to_oai_responses_req_test.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_oai_responses_req_test.go
@@ -84,6 +84,33 @@ func TestChatCompletionsRequestToResponsesRequestRejectsMultipleChoices(t *testi
 	assert.Contains(t, err.Error(), "n>1")
 }
 
+func TestChatCompletionsRequestToResponsesRequestPreservesPenalties(t *testing.T) {
+	tests := []struct {
+		name      string
+		frequency *float64
+		presence  *float64
+	}{
+		{name: "positive values", frequency: lo.ToPtr(0.5), presence: lo.ToPtr(1.5)},
+		{name: "explicit zero values", frequency: lo.ToPtr(0.0), presence: lo.ToPtr(0.0)},
+		{name: "unset stays nil", frequency: nil, presence: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ChatCompletionsRequestToResponsesRequest(&dto.GeneralOpenAIRequest{
+				Model:            "gpt-test",
+				Messages:         []dto.Message{{Role: "user", Content: "hello"}},
+				FrequencyPenalty: tt.frequency,
+				PresencePenalty:  tt.presence,
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.frequency, got.FrequencyPenalty)
+			assert.Equal(t, tt.presence, got.PresencePenalty)
+		})
+	}
+}
+
 func assistantMessageWithTool(content string, id string, name string, args string) dto.Message {
 	msg := dto.Message{Role: "assistant", Content: content}
 	msg.SetToolCalls([]dto.ToolCallRequest{

--- a/relaykit/relayconvert/internal/oai_chat/to_oai_responses_req_test.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_oai_responses_req_test.go
@@ -86,13 +86,31 @@ func TestChatCompletionsRequestToResponsesRequestRejectsMultipleChoices(t *testi
 
 func TestChatCompletionsRequestToResponsesRequestPreservesPenalties(t *testing.T) {
 	tests := []struct {
-		name      string
-		frequency *float64
-		presence  *float64
+		name          string
+		frequency     *float64
+		frequencyWant json.RawMessage
+		presence      *float64
+		presenceWant  json.RawMessage
 	}{
-		{name: "positive values", frequency: lo.ToPtr(0.5), presence: lo.ToPtr(1.5)},
-		{name: "explicit zero values", frequency: lo.ToPtr(0.0), presence: lo.ToPtr(0.0)},
-		{name: "unset stays nil", frequency: nil, presence: nil},
+		{
+			name:          "positive values",
+			frequency:     lo.ToPtr(0.5),
+			frequencyWant: json.RawMessage(`0.5`),
+			presence:      lo.ToPtr(1.5),
+			presenceWant:  json.RawMessage(`1.5`),
+		},
+		{
+			name:          "explicit zero values",
+			frequency:     lo.ToPtr(0.0),
+			frequencyWant: json.RawMessage(`0`),
+			presence:      lo.ToPtr(0.0),
+			presenceWant:  json.RawMessage(`0`),
+		},
+		{
+			name:      "unset stays nil",
+			frequency: nil,
+			presence:  nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -105,8 +123,8 @@ func TestChatCompletionsRequestToResponsesRequestPreservesPenalties(t *testing.T
 			})
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.frequency, got.FrequencyPenalty)
-			assert.Equal(t, tt.presence, got.PresencePenalty)
+			assert.Equal(t, tt.frequencyWant, got.FrequencyPenalty)
+			assert.Equal(t, tt.presenceWant, got.PresencePenalty)
 		})
 	}
 }

--- a/relaykit/relayconvert/internal/oai_responses/to_oai_chat_req.go
+++ b/relaykit/relayconvert/internal/oai_responses/to_oai_chat_req.go
@@ -63,6 +63,8 @@ func ResponsesRequestToChatCompletionsRequest(req *dto.OpenAIResponsesRequest) (
 		MaxCompletionTokens:  req.MaxOutputTokens,
 		Temperature:          req.Temperature,
 		TopP:                 req.TopP,
+		FrequencyPenalty:     req.FrequencyPenalty,
+		PresencePenalty:      req.PresencePenalty,
 		TopLogProbs:          req.TopLogProbs,
 		ResponseFormat:       responseFormat,
 		Tools:                tools,

--- a/relaykit/relayconvert/internal/oai_responses/to_oai_chat_req.go
+++ b/relaykit/relayconvert/internal/oai_responses/to_oai_chat_req.go
@@ -63,8 +63,6 @@ func ResponsesRequestToChatCompletionsRequest(req *dto.OpenAIResponsesRequest) (
 		MaxCompletionTokens:  req.MaxOutputTokens,
 		Temperature:          req.Temperature,
 		TopP:                 req.TopP,
-		FrequencyPenalty:     req.FrequencyPenalty,
-		PresencePenalty:      req.PresencePenalty,
 		TopLogProbs:          req.TopLogProbs,
 		ResponseFormat:       responseFormat,
 		Tools:                tools,
@@ -76,6 +74,15 @@ func ResponsesRequestToChatCompletionsRequest(req *dto.OpenAIResponsesRequest) (
 		PromptCacheRetention: req.PromptCacheRetention,
 		EnableThinking:       req.EnableThinking,
 		ThinkingBudget:       req.ThinkingBudget,
+	}
+
+	out.FrequencyPenalty, err = responsesRawFloat(req.FrequencyPenalty)
+	if err != nil {
+		return nil, fmt.Errorf("invalid frequency_penalty: %w", err)
+	}
+	out.PresencePenalty, err = responsesRawFloat(req.PresencePenalty)
+	if err != nil {
+		return nil, fmt.Errorf("invalid presence_penalty: %w", err)
 	}
 
 	if req.Reasoning != nil {
@@ -527,6 +534,17 @@ func responseToolOutputToChatContent(value any) any {
 		}
 		return string(raw)
 	}
+}
+
+func responsesRawFloat(raw json.RawMessage) (*float64, error) {
+	if !rawJSONPresent(raw) {
+		return nil, nil
+	}
+	var value float64
+	if err := kitutil.Unmarshal(raw, &value); err != nil {
+		return nil, err
+	}
+	return &value, nil
 }
 
 func responsesJSONString(raw json.RawMessage) (string, error) {

--- a/relaykit/relayconvert/internal/oai_responses/to_oai_chat_req_test.go
+++ b/relaykit/relayconvert/internal/oai_responses/to_oai_chat_req_test.go
@@ -295,6 +295,33 @@ func TestResponsesRequestToChatCompletionsRequestRejectsStatefulFields(t *testin
 	}
 }
 
+func TestResponsesRequestToChatCompletionsRequestPreservesPenalties(t *testing.T) {
+	tests := []struct {
+		name      string
+		frequency *float64
+		presence  *float64
+	}{
+		{name: "positive values", frequency: lo.ToPtr(0.5), presence: lo.ToPtr(1.5)},
+		{name: "explicit zero values", frequency: lo.ToPtr(0.0), presence: lo.ToPtr(0.0)},
+		{name: "unset stays nil", frequency: nil, presence: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResponsesRequestToChatCompletionsRequest(&dto.OpenAIResponsesRequest{
+				Model:            "gpt-test",
+				Input:            mustRawMessage(t, "hello"),
+				FrequencyPenalty: tt.frequency,
+				PresencePenalty:  tt.presence,
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.frequency, got.FrequencyPenalty)
+			assert.Equal(t, tt.presence, got.PresencePenalty)
+		})
+	}
+}
+
 func mustRawMessage(t *testing.T, value any) []byte {
 	t.Helper()
 	raw, err := kitutil.Marshal(value)

--- a/relaykit/relayconvert/internal/oai_responses/to_oai_chat_req_test.go
+++ b/relaykit/relayconvert/internal/oai_responses/to_oai_chat_req_test.go
@@ -297,13 +297,31 @@ func TestResponsesRequestToChatCompletionsRequestRejectsStatefulFields(t *testin
 
 func TestResponsesRequestToChatCompletionsRequestPreservesPenalties(t *testing.T) {
 	tests := []struct {
-		name      string
-		frequency *float64
-		presence  *float64
+		name          string
+		frequencyRaw  json.RawMessage
+		frequencyWant *float64
+		presenceRaw   json.RawMessage
+		presenceWant  *float64
 	}{
-		{name: "positive values", frequency: lo.ToPtr(0.5), presence: lo.ToPtr(1.5)},
-		{name: "explicit zero values", frequency: lo.ToPtr(0.0), presence: lo.ToPtr(0.0)},
-		{name: "unset stays nil", frequency: nil, presence: nil},
+		{
+			name:          "positive values",
+			frequencyRaw:  json.RawMessage(`0.5`),
+			frequencyWant: lo.ToPtr(0.5),
+			presenceRaw:   json.RawMessage(`1.5`),
+			presenceWant:  lo.ToPtr(1.5),
+		},
+		{
+			name:          "explicit zero values",
+			frequencyRaw:  json.RawMessage(`0.0`),
+			frequencyWant: lo.ToPtr(0.0),
+			presenceRaw:   json.RawMessage(`0.0`),
+			presenceWant:  lo.ToPtr(0.0),
+		},
+		{
+			name:         "unset stays nil",
+			frequencyRaw: nil,
+			presenceRaw:  nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -311,15 +329,25 @@ func TestResponsesRequestToChatCompletionsRequestPreservesPenalties(t *testing.T
 			got, err := ResponsesRequestToChatCompletionsRequest(&dto.OpenAIResponsesRequest{
 				Model:            "gpt-test",
 				Input:            mustRawMessage(t, "hello"),
-				FrequencyPenalty: tt.frequency,
-				PresencePenalty:  tt.presence,
+				FrequencyPenalty: tt.frequencyRaw,
+				PresencePenalty:  tt.presenceRaw,
 			})
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.frequency, got.FrequencyPenalty)
-			assert.Equal(t, tt.presence, got.PresencePenalty)
+			assert.Equal(t, tt.frequencyWant, got.FrequencyPenalty)
+			assert.Equal(t, tt.presenceWant, got.PresencePenalty)
 		})
 	}
+}
+
+func TestResponsesRequestToChatCompletionsRequestRejectsMalformedPenalty(t *testing.T) {
+	_, err := ResponsesRequestToChatCompletionsRequest(&dto.OpenAIResponsesRequest{
+		Model:            "gpt-test",
+		Input:            mustRawMessage(t, "hello"),
+		FrequencyPenalty: json.RawMessage(`"not-a-number"`),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "frequency_penalty")
 }
 
 func mustRawMessage(t *testing.T, value any) []byte {


### PR DESCRIPTION
`dto.OpenAIResponsesRequest` never declared `presence_penalty` / `frequency_penalty`. The non-passthrough path parses the request into that struct and re-marshals it, so both fields were silently dropped before reaching the upstream, while `temperature` / `top_p` survived because they are declared. Passthrough mode forwards the raw body and was unaffected.

- Declare both fields as `*float64` with `omitempty` so an explicit `0` is preserved and an absent field stays omitted.
- Carry them across the Responses <-> Chat Completions converters, which rebuild the request field by field.
- Clear them in the Codex adaptor next to `temperature`, since the Codex backend rejects sampling parameters it does not accept.

Note that the official OpenAI Responses API does not accept these two parameters; OpenAI-compatible upstreams such as vLLM do, and forwarding them is what the reporter's setup needs.

Fixes #6614

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

`/v1/responses` 在非透传模式下会丢掉 `presence_penalty` 和 `frequency_penalty`。

根因是 `dto.OpenAIResponsesRequest` 从来没声明过这两个字段。非透传路径的流程是「按结构体解析请求 → 重新序列化发给上游」，结构体里没有的键在序列化那一步就没了；`temperature`、`top_p` 因为声明了所以能正常到达。透传模式直接转发原始 body，所以不受影响 —— 这也解释了 issue 里三组对比的结果差异。

改动分三处：

1. **补字段**：`OpenAIResponsesRequest` 加上这两个字段，类型用 `*float64` + `omitempty`。用指针是为了区分「没传」和「显式传 0」—— 不传是 `nil` 不下发，传 `0` 是非 `nil` 照常下发；非指针配 `omitempty` 会把 `0` 静默吃掉。
2. **补转换器**：Responses ↔ Chat Completions 两个转换器是逐字段重建请求的，不补的话 Responses 请求落到只支持 chat 的渠道时照样丢，反方向同理。
3. **Codex 剥离**：Codex 适配器里跟 `temperature` 一起置空。Codex 后端会拒绝它不认的采样参数，字段加进 DTO 后会开始转发出去，这里补上剥离以保持原有行为。

测试覆盖了显式零值不被 `omitempty` 吞掉、两个转换器方向的正值/零值/未设置三种情况，以及 Codex 的剥离。

> 本 PR 代码为 AI 辅助生成，已由提交者逐处审阅确认。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6614

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [ ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved frequency and presence penalty settings when converting between supported OpenAI request formats.
  * Explicit zero values and unset penalty fields are now handled correctly.
  * Removed unsupported penalty settings before forwarding Codex Responses requests.
  * Added clear validation errors for invalid penalty values.

* **Tests**
  * Added coverage for positive, zero, unset, and invalid penalty values across request conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->