### PR TITLE
fix(doubao): honor the documented duration field for video tasks

### DIFF
--- a/relay/channel/task/doubao/adaptor.go
+++ b/relay/channel/task/doubao/adaptor.go
@@ -294,7 +294,11 @@ func (a *TaskAdaptor) convertToRequestPayload(req *relaycommon.TaskSubmitReq) (*
 		return nil, errors.Wrap(err, "unmarshal metadata failed")
 	}
 
-	if sec, _ := strconv.Atoi(req.Seconds); sec > 0 {
+	sec := req.Duration
+	if sec <= 0 {
+		sec, _ = strconv.Atoi(req.Seconds)
+	}
+	if sec > 0 {
 		r.Duration = lo.ToPtr(dto.IntValue(sec))
 	}
 

--- a/relay/channel/task/doubao/adaptor_test.go
+++ b/relay/channel/task/doubao/adaptor_test.go
@@ -1,0 +1,52 @@
+package doubao
+
+import (
+	"testing"
+
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertToRequestPayloadDurationPrefersDurationField(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	req := relaycommon.TaskSubmitReq{
+		Model:    "doubao-seedance-2.0",
+		Prompt:   "a cute girl dancing",
+		Duration: 7,
+		Seconds:  "10",
+	}
+
+	payload, err := adaptor.convertToRequestPayload(&req)
+
+	require.NoError(t, err)
+	require.NotNil(t, payload.Duration)
+	require.Equal(t, 7, int(*payload.Duration))
+}
+
+func TestConvertToRequestPayloadDurationFallsBackToSeconds(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	req := relaycommon.TaskSubmitReq{
+		Model:   "doubao-seedance-2.0",
+		Prompt:  "a cute girl dancing",
+		Seconds: "7",
+	}
+
+	payload, err := adaptor.convertToRequestPayload(&req)
+
+	require.NoError(t, err)
+	require.NotNil(t, payload.Duration)
+	require.Equal(t, 7, int(*payload.Duration))
+}
+
+func TestConvertToRequestPayloadDurationEmptyLeavesUnset(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	req := relaycommon.TaskSubmitReq{
+		Model:  "doubao-seedance-2.0",
+		Prompt: "a cute girl dancing",
+	}
+
+	payload, err := adaptor.convertToRequestPayload(&req)
+
+	require.NoError(t, err)
+	require.Nil(t, payload.Duration)
+}


### PR DESCRIPTION
## Problem

`relay/channel/task/doubao/adaptor.go`'s `convertToRequestPayload` only reads `req.Seconds` and ignores the `duration` field documented in the official OpenAPI spec (`POST /v1/video/generations`). Requests passing `duration: 7` get their duration silently dropped, falling back to the upstream default of 5s.

## Root cause

Every other video adaptor honors `duration` (ali/gemini/vertex/hailuo/jimeng/kling/vidu read `req.Duration`; sora uses seconds with a duration fallback). Doubao is the only one reading `seconds` exclusively, with no fallback.

## Fix

Make `duration` take precedence with `seconds` as fallback, consistent with the other adaptors:

```go
sec := req.Duration
if sec <= 0 {
    sec, _ = strconv.Atoi(req.Seconds)
}
if sec > 0 {
    r.Duration = lo.ToPtr(dto.IntValue(sec))
}
```

## Tests

Added `relay/channel/task/doubao/adaptor_test.go` covering:

- `duration` takes precedence over `seconds`
- `seconds` fallback when `duration` is unset
- both unset leaves duration unset (upstream default applies)

`go test ./relay/channel/task/doubao/` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task duration handling by prioritizing the explicitly provided duration.
  * Added fallback support for duration values supplied in seconds.
  * Ensured missing or non-positive durations do not populate the outgoing request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->