### PR TITLE
fix(ali): stop injecting top_p into requests that omit it

### DIFF
--- a/relay/channel/ali/text.go
+++ b/relay/channel/ali/text.go
@@ -18,11 +18,19 @@ func requestOpenAI2Ali(request dto.GeneralOpenAIRequest, upstreamModelName strin
 		request.ThinkingBudget = nil
 	}
 
-	topP := lo.FromPtrOr(request.TopP, 0)
-	if topP >= 1 {
-		request.TopP = lo.ToPtr(0.999)
-	} else if topP <= 0 {
-		request.TopP = lo.ToPtr(0.001)
+	// DashScope rejects top_p at the 0 and 1 boundaries, so an explicit value is
+	// clamped into the open interval. The clamp stays at two decimals because
+	// some models on the platform reject a third decimal with
+	// "top_p参数非法：限制小数点[2]位".
+	//
+	// A request that omits top_p is left untouched: injecting a value would
+	// silently replace the model's own default with near-greedy decoding.
+	if request.TopP != nil {
+		if *request.TopP >= 1 {
+			request.TopP = lo.ToPtr(0.99)
+		} else if *request.TopP <= 0 {
+			request.TopP = lo.ToPtr(0.01)
+		}
 	}
 	return &request
 }

--- a/relay/channel/ali/text_test.go
+++ b/relay/channel/ali/text_test.go
@@ -1,0 +1,59 @@
+package ali
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestOpenAI2AliTopP(t *testing.T) {
+	tests := []struct {
+		name string
+		topP *float64
+		want *float64
+	}{
+		{
+			name: "omitted top_p is not injected",
+			topP: nil,
+			want: nil,
+		},
+		{
+			name: "in-range top_p is preserved",
+			topP: lo.ToPtr(0.8),
+			want: lo.ToPtr(0.8),
+		},
+		{
+			name: "top_p of 1 is clamped to two decimals",
+			topP: lo.ToPtr(1.0),
+			want: lo.ToPtr(0.99),
+		},
+		{
+			name: "top_p above 1 is clamped to two decimals",
+			topP: lo.ToPtr(1.5),
+			want: lo.ToPtr(0.99),
+		},
+		{
+			name: "top_p of 0 is clamped to two decimals",
+			topP: lo.ToPtr(0.0),
+			want: lo.ToPtr(0.01),
+		},
+		{
+			name: "negative top_p is clamped to two decimals",
+			topP: lo.ToPtr(-0.3),
+			want: lo.ToPtr(0.01),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := requestOpenAI2Ali(dto.GeneralOpenAIRequest{
+				Model: "qwen-plus",
+				TopP:  tt.topP,
+			}, "qwen-plus")
+
+			assert.Equal(t, tt.want, got.TopP)
+		})
+	}
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

`requestOpenAI2Ali` 需要把 `top_p` 收进开区间，因为 DashScope 不接受 0 和 1 这两个边界值。但它是用 `lo.FromPtrOr(request.TopP, 0)` 读取指针的，这样**"没传 top_p"和"传了 0"就无法区分**——两者都会落进 `topP <= 0` 分支，被注入 `0.001`。

这带来两个后果：

1. **部分模型直接 400。** `0.001` / `0.999` 都是三位小数，平台上部分模型只接受两位，会以 `top_p参数非法：限制小数点[2]位` 拒绝整个请求。实测 `ZHIPU/GLM-5.2`、`xiaomi/mimo-v2.5-pro` 在客户端不传 `top_p` 时 100% 失败。
2. **不校验小数位的模型被静默改变采样行为。** 请求不报错，但 `top_p` 被设成 `0.001`，等价于近乎贪婪解码，取代了模型自己的默认值。调用方无从察觉。

改法是把边界收敛限定在"调用方确实传了 `top_p`"的情况，并把 clamp 值改成两位小数：

- `request.TopP == nil` 时原样返回，交由上游使用模型默认值 → 修复第 2 点
- 显式传值时 clamp 到 `0.01` / `0.99` → 修复第 1 点

`ThinkingBudget` 的处理逻辑未改动。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6671

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
  - 说明：本 PR 由 AI 协助完成，描述与代码均经我逐行复核后提交。为如实告知，此项不勾选。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 已提交并关联对应 Issue #6671；该问题为网关替调用方注入了未传的参数，属于实现缺陷而非设计取舍。
- [x] **变更理解:** 影响范围仅限 Ali 渠道（`type=17`）的 chat 请求转换。显式传入的 `top_p` 行为只在边界值上由三位小数变为两位小数；未传 `top_p` 的请求改为不再携带该字段，由上游使用模型默认值。
- [x] **范围聚焦:** 仅改动 `relay/channel/ali/text.go` 与新增对应单元测试，无其他无关改动。
- [x] **本地验证:** 已运行下方列出的测试与构建。
- [x] **安全合规:** 无任何凭据或敏感信息；沿用现有 testify 表驱动测试风格。

## 📸 运行证明 / Proof of Work

新增 `relay/channel/ali/text_test.go`，覆盖 6 种输入：

| 输入 `top_p` | 期望输出 | 说明 |
|---|---|---|
| 未传（`nil`） | `nil` | 不注入，回归本 PR 修复的核心问题 |
| `0.8` | `0.8` | 正常值原样通过 |
| `1.0` | `0.99` | 上边界，两位小数 |
| `1.5` | `0.99` | 越界，两位小数 |
| `0.0` | `0.01` | 下边界，两位小数 |
| `-0.3` | `0.01` | 越界，两位小数 |

```
$ go test ./relay/channel/ali/...
ok      github.com/QuantumNous/new-api/relay/channel/ali 0.833s

$ go vet ./relay/channel/ali/...
（无输出）

$ go build ./relay/... ./controller/... ./service/... ./model/... ./middleware/...
（无输出，退出码 0）
```

另在生产环境验证过等效行为：通过渠道 `param_override` 条件删除被注入的 `top_p` 后，`ZHIPU/GLM-5.2` 与 `xiaomi/mimo-v2.5-pro` 立即恢复正常，同渠道其余 11 个模型不受影响。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the optional `top_p` setting.
  * Preserved omitted values instead of applying an unintended default.
  * Ensured out-of-range values are safely constrained between `0.01` and `0.99`.

* **Tests**
  * Added coverage for omitted, valid, boundary, zero, negative, and excessive values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->