### PR TITLE
fix(setting): take a write lock when replacing the rate limit group map

### DIFF
--- a/setting/rate_limit.go
+++ b/setting/rate_limit.go
@@ -1,7 +1,6 @@
 package setting
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
 	"sync"
@@ -20,7 +19,7 @@ func ModelRequestRateLimitGroup2JSONString() string {
 	ModelRequestRateLimitMutex.RLock()
 	defer ModelRequestRateLimitMutex.RUnlock()
 
-	jsonBytes, err := json.Marshal(ModelRequestRateLimitGroup)
+	jsonBytes, err := common.Marshal(ModelRequestRateLimitGroup)
 	if err != nil {
 		common.SysLog("error marshalling model ratio: " + err.Error())
 	}
@@ -28,11 +27,21 @@ func ModelRequestRateLimitGroup2JSONString() string {
 }
 
 func UpdateModelRequestRateLimitGroupByJSONString(jsonStr string) error {
-	ModelRequestRateLimitMutex.RLock()
-	defer ModelRequestRateLimitMutex.RUnlock()
+	// 先在锁外解析到局部 map：解析失败时正在生效的限流配置必须原样保留。
+	// 原先的写法是先清空全局 map 再反序列化，非法 JSON 会让限流配置被清空且不再恢复。
+	parsed := make(map[string][2]int)
+	if err := common.Unmarshal([]byte(jsonStr), &parsed); err != nil {
+		return err
+	}
 
-	ModelRequestRateLimitGroup = make(map[string][2]int)
-	return json.Unmarshal([]byte(jsonStr), &ModelRequestRateLimitGroup)
+	// 必须是写锁。这里原先取的是 RLock，而 RWMutex 允许多个读锁持有者同时进入，
+	// 因此这个写函数会与 GetGroupRateLimit 真正并发地访问同一个 map，
+	// 被 Go 运行时判定为并发读写并终止进程。
+	ModelRequestRateLimitMutex.Lock()
+	defer ModelRequestRateLimitMutex.Unlock()
+
+	ModelRequestRateLimitGroup = parsed
+	return nil
 }
 
 func GetGroupRateLimit(group string) (totalCount, successCount int, found bool) {
@@ -52,7 +61,7 @@ func GetGroupRateLimit(group string) (totalCount, successCount int, found bool) 
 
 func CheckModelRequestRateLimitGroup(jsonStr string) error {
 	checkModelRequestRateLimitGroup := make(map[string][2]int)
-	err := json.Unmarshal([]byte(jsonStr), &checkModelRequestRateLimitGroup)
+	err := common.Unmarshal([]byte(jsonStr), &checkModelRequestRateLimitGroup)
 	if err != nil {
 		return err
 	}

--- a/setting/rate_limit_test.go
+++ b/setting/rate_limit_test.go
@@ -1,0 +1,79 @@
+package setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func restoreRateLimitGroup(t *testing.T) {
+	t.Helper()
+	ModelRequestRateLimitMutex.RLock()
+	orig := ModelRequestRateLimitGroup
+	ModelRequestRateLimitMutex.RUnlock()
+	t.Cleanup(func() {
+		ModelRequestRateLimitMutex.Lock()
+		ModelRequestRateLimitGroup = orig
+		ModelRequestRateLimitMutex.Unlock()
+	})
+}
+
+// 解析失败必须原样保留正在生效的配置。
+//
+// 原先的写法是先把全局 map 清空再反序列化，非法 JSON 会让限流配置整体失效且不再恢复——
+// 而周期同步路径不经过 CheckModelRequestRateLimitGroup，数据库里的非法值可以直接走到这里。
+func TestUpdateRateLimitGroupKeepsPreviousConfigOnParseError(t *testing.T) {
+	restoreRateLimitGroup(t)
+
+	require.NoError(t, UpdateModelRequestRateLimitGroupByJSONString(`{"default":[100,50],"vip":[200,100]}`))
+
+	require.Error(t, UpdateModelRequestRateLimitGroupByJSONString(`not json`))
+
+	total, success, found := GetGroupRateLimit("default")
+	assert.True(t, found, "解析失败不应清空已生效的限流配置")
+	assert.Equal(t, 100, total)
+	assert.Equal(t, 50, success)
+
+	_, _, found = GetGroupRateLimit("vip")
+	assert.True(t, found)
+}
+
+// 成功的更新必须整体替换，被移除的分组不能残留。
+func TestUpdateRateLimitGroupReplacesRemovedGroups(t *testing.T) {
+	restoreRateLimitGroup(t)
+
+	require.NoError(t, UpdateModelRequestRateLimitGroupByJSONString(`{"default":[100,50],"vip":[200,100]}`))
+	_, _, found := GetGroupRateLimit("vip")
+	require.True(t, found)
+
+	require.NoError(t, UpdateModelRequestRateLimitGroupByJSONString(`{"default":[300,150]}`))
+
+	total, success, found := GetGroupRateLimit("default")
+	assert.True(t, found)
+	assert.Equal(t, 300, total)
+	assert.Equal(t, 150, success)
+
+	_, _, found = GetGroupRateLimit("vip")
+	assert.False(t, found, "被移除的分组应查不到")
+}
+
+func TestGetGroupRateLimitReportsMissingGroup(t *testing.T) {
+	restoreRateLimitGroup(t)
+
+	require.NoError(t, UpdateModelRequestRateLimitGroupByJSONString(`{"default":[100,50]}`))
+
+	total, success, found := GetGroupRateLimit("nonexistent")
+	assert.False(t, found)
+	assert.Zero(t, total)
+	assert.Zero(t, success)
+}
+
+// 序列化形式必须保持不变，否则升级后数据库中已有的行会读不出来。
+func TestRateLimitGroupSerializationRoundTrip(t *testing.T) {
+	restoreRateLimitGroup(t)
+
+	require.NoError(t, UpdateModelRequestRateLimitGroupByJSONString(`{"default":[100,50]}`))
+
+	assert.JSONEq(t, `{"default":[100,50]}`, ModelRequestRateLimitGroup2JSONString())
+}

--- a/setting/user_usable_group.go
+++ b/setting/user_usable_group.go
@@ -1,7 +1,6 @@
 package setting
 
 import (
-	"encoding/json"
 	"sync"
 
 	"github.com/QuantumNous/new-api/common"
@@ -28,7 +27,7 @@ func UserUsableGroups2JSONString() string {
 	userUsableGroupsMutex.RLock()
 	defer userUsableGroupsMutex.RUnlock()
 
-	jsonBytes, err := json.Marshal(userUsableGroups)
+	jsonBytes, err := common.Marshal(userUsableGroups)
 	if err != nil {
 		common.SysLog("error marshalling user groups: " + err.Error())
 	}
@@ -36,11 +35,18 @@ func UserUsableGroups2JSONString() string {
 }
 
 func UpdateUserUsableGroupsByJSONString(jsonStr string) error {
+	// 先在锁外解析到局部 map：解析失败时正在生效的分组配置必须原样保留。
+	// 原先的写法是先清空全局 map 再反序列化，非法 JSON 会让分组配置被清空且不再恢复。
+	parsed := make(map[string]string)
+	if err := common.Unmarshal([]byte(jsonStr), &parsed); err != nil {
+		return err
+	}
+
 	userUsableGroupsMutex.Lock()
 	defer userUsableGroupsMutex.Unlock()
 
-	userUsableGroups = make(map[string]string)
-	return json.Unmarshal([]byte(jsonStr), &userUsableGroups)
+	userUsableGroups = parsed
+	return nil
 }
 
 func GetUsableGroupDescription(groupName string) string {

--- a/setting/user_usable_group_test.go
+++ b/setting/user_usable_group_test.go
@@ -1,0 +1,58 @@
+package setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func restoreUserUsableGroups(t *testing.T) {
+	t.Helper()
+	orig := GetUserUsableGroupsCopy()
+	t.Cleanup(func() {
+		userUsableGroupsMutex.Lock()
+		userUsableGroups = orig
+		userUsableGroupsMutex.Unlock()
+	})
+}
+
+// 与限流分组同源的缺陷：该函数的锁本身是正确的，但同样先清空再反序列化，
+// 非法 JSON 会让可用分组配置整体失效且不再恢复。触发路径同为周期同步
+// （model/option.go:561），且该路径不经过任何保存前校验。
+func TestUpdateUserUsableGroupsKeepsPreviousConfigOnParseError(t *testing.T) {
+	restoreUserUsableGroups(t)
+
+	require.NoError(t, UpdateUserUsableGroupsByJSONString(`{"default":"默认分组","vip":"vip分组"}`))
+
+	require.Error(t, UpdateUserUsableGroupsByJSONString(`not json`))
+
+	groups := GetUserUsableGroupsCopy()
+	assert.Len(t, groups, 2, "解析失败不应清空已生效的分组配置")
+	assert.Equal(t, "默认分组", groups["default"])
+	assert.Equal(t, "vip分组", GetUsableGroupDescription("vip"))
+}
+
+func TestUpdateUserUsableGroupsReplacesRemovedGroups(t *testing.T) {
+	restoreUserUsableGroups(t)
+
+	require.NoError(t, UpdateUserUsableGroupsByJSONString(`{"default":"默认分组","vip":"vip分组"}`))
+	require.Len(t, GetUserUsableGroupsCopy(), 2)
+
+	require.NoError(t, UpdateUserUsableGroupsByJSONString(`{"default":"默认分组"}`))
+
+	groups := GetUserUsableGroupsCopy()
+	assert.Len(t, groups, 1)
+	assert.NotContains(t, groups, "vip", "被移除的分组应查不到")
+	// 未配置的分组回落为分组名本身
+	assert.Equal(t, "vip", GetUsableGroupDescription("vip"))
+}
+
+// 序列化形式必须保持不变，否则升级后数据库中已有的行会读不出来。
+func TestUserUsableGroupsSerializationRoundTrip(t *testing.T) {
+	restoreUserUsableGroups(t)
+
+	require.NoError(t, UpdateUserUsableGroupsByJSONString(`{"default":"默认分组"}`))
+
+	assert.JSONEq(t, `{"default":"默认分组"}`, UserUsableGroups2JSONString())
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

## 📝 变更描述 / Description

`UpdateModelRequestRateLimitGroupByJSONString` 是一个写函数，但它取的是 `RLock`。`sync.RWMutex` 允许任意多个读锁持有者同时进入，所以这个"写者"会与同样只持读锁的 `GetGroupRateLimit` **真正并发地**访问同一个 map。

这不是管理员改配置时的瞬时窗口。写入方位于 `model/option.go:547`，在 `updateOptionMap` 内，因此 `SyncOptions` 每 `SYNC_FREQUENCY` 秒（默认 60）无条件重写一次，与是否有人修改配置无关；读取方在 `ModelRequestRateLimit` 中间件里，注册在 `/v1` 与 Gemini 两条中继路由上（`router/relay-router.go:73,198`），每个请求执行一次。

### 实测结果（`0ab02020`，go1.26.5 darwin/arm64）

6 个读 goroutine + 1 个写 goroutine：

```
fatal error: concurrent map read and map write

goroutine 38 [running]:
internal/runtime/maps.fatal(...)
github.com/QuantumNous/new-api/setting.GetGroupRateLimit(...)
	setting/rate_limit.go:46
```

| 指标 | 修复前 | 修复后 |
| --- | --- | --- |
| 上述崩溃 | **3/3 轮** | 0/3 轮 |
| `go test -race` | **2 处**，写入侧 `rate_limit.go:34` | 0 处 |

### 第二个问题：解析失败会清空正在生效的配置

两个文件都是先 `make` 清空全局 map、再反序列化。非法 JSON 会让配置整体失效且不再恢复。

这条路径是可达的，因为**周期同步不做校验**：`CheckModelRequestRateLimitGroup` 只在管理员保存路径（`controller/option.go:303`）被调用，而可用分组根本没有校验函数。

现在改为在锁外解析到局部 map，成功后才替换全局引用。

### 改动内容

- **`setting/rate_limit.go`**：`RLock` → `Lock`；解析后替换。
- **`setting/user_usable_group.go`**：锁**本来就是对的**，不存在崩溃问题，只修「清空-重填」这一半。

两个文件原先都直接调用 `encoding/json`，按 `AGENTS.md` 要求改为 `common` 封装。

改动前确认过：两个 map 及其互斥量的全部访问都在各自文件内，外部只经访问器，因此**没有调用点需要修改**。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

无关联 Issue。但需要说明一处重要前情：

**[#5212](https://github.com/QuantumNous/new-api/pull/5212)（@zhao8899，2026-05-31）此前已提出过实质相同的修复**，覆盖同样这两个文件。该 PR **由作者本人于 2026-06-04 关闭，并非被维护者拒绝** —— 整个生命周期内没有任何人工评论，Copilot 与 CodeRabbit 两个自动审查均未提出问题（CodeRabbit 的结论是 "No actionable comments were generated"）。

因此该方案在技术上从未被否定，而缺陷确实仍存在于 `0ab02020`。本 PR 系独立核实推导，但方案与 #5212 高度重合，在此明确引用并致谢 @zhao8899。如果维护者更希望恢复原 PR，我乐意关闭本 PR 配合。

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs。唯一相关的是已关闭的 #5212，已在上方说明。
- [x] **Bug fix 说明:** 这是可复现的运行时崩溃，非设计取舍或预期不一致。
- [x] **变更理解:** 已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 仅改动这两个文件及其测试。
- [x] **本地验证:** 见下方运行证明。
- [x] **安全合规:** 无敏感凭据。

## 📸 运行证明 / Proof of Work

**修复前（3/3 轮崩溃）：**

```
fatal error: concurrent map read and map write
github.com/QuantumNous/new-api/setting.GetGroupRateLimit(...)
	setting/rate_limit.go:46
```

**修复后（同一复现，3 轮）：**

```
第 1 轮: 退出码=0  fatal=0
第 2 轮: 退出码=0  fatal=0
第 3 轮: 退出码=0  fatal=0
```

**竞争检测：**

```
修复前：go test -race → 2 处 WARNING: DATA RACE（写入侧 rate_limit.go:34）
修复后：go test -race ./setting/... ./middleware/... → 0 处
```

**常规检查：**

| 项目 | 结果 |
| --- | --- |
| `go build ./...` | 通过 |
| `cd relaykit && GOWORK=off go build ./...` | 通过 |
| `go vet ./...` | 通过 |
| `gofmt -l`（改动的 4 个文件） | 无输出 |
| `go test ./...` | 32 个包通过 |
| `go test -race ./setting/... ./middleware/...` | 通过，0 竞争 |

`service` 包在 `-race` 下有 3 处竞争（`task_polling.go`、`logger.go`、`model/task.go`），已用基线 worktree 对照确认修复前同样是 3 处且调用栈一致，属既有问题，与本 PR 无关。

**新增测试**（确定性断言，未包含压测代码）：

- `setting/rate_limit_test.go` —— 解析失败保留配置、成功更新整体替换、缺失分组返回 `found=false`、序列化形式不变
- `setting/user_usable_group_test.go` —— 同上三条对应契约

两个「解析失败保留配置」的测试是核心契约，**均已做负向对照**：把同一断言放到修复前的代码上执行，确认会失败，排除测试抓不到问题的可能。

> **声明：** 本 PR 的代码与描述由 AI 辅助完成。上述崩溃复现、竞争数量、测试结果均为实际命令输出，非估计值。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid rate-limit and user-group configuration updates from overwriting existing settings.
  * Ensured updates fully replace removed groups and report missing rate-limit groups correctly.
  * Preserved expected configuration data during serialization and deserialization.

* **Tests**
  * Added coverage for invalid input handling, group replacement, missing groups, and configuration round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->