### PR TITLE
fix(openai): reject malformed Responses reasoning item IDs

### DIFF
--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -17,6 +17,49 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const (
+	responsesOutputTypeReasoning = "reasoning"
+	responsesReasoningIDPrefix   = "rs_"
+)
+
+func validateResponsesReasoningOutput(output *dto.ResponsesOutput) error {
+	if output == nil || output.Type != responsesOutputTypeReasoning {
+		return nil
+	}
+	// Reasoning items can be replayed as Responses input. Reject malformed
+	// upstream IDs instead of rewriting provider-owned opaque identifiers.
+	if !strings.HasPrefix(output.ID, responsesReasoningIDPrefix) {
+		return fmt.Errorf(
+			"invalid Responses reasoning item id %q: expected prefix %q",
+			output.ID,
+			responsesReasoningIDPrefix,
+		)
+	}
+	return nil
+}
+
+func validateResponsesReasoningOutputs(outputs []dto.ResponsesOutput) error {
+	for i := range outputs {
+		if err := validateResponsesReasoningOutput(&outputs[i]); err != nil {
+			return fmt.Errorf("output[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func validateResponsesStreamReasoningOutputs(streamResponse *dto.ResponsesStreamResponse) error {
+	if streamResponse == nil {
+		return nil
+	}
+	if err := validateResponsesReasoningOutput(streamResponse.Item); err != nil {
+		return err
+	}
+	if streamResponse.Response != nil {
+		return validateResponsesReasoningOutputs(streamResponse.Response.Output)
+	}
+	return nil
+}
+
 func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
 	defer service.CloseResponseBodyGracefully(resp)
 
@@ -32,6 +75,9 @@ func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 	}
 	if oaiError := responsesResponse.GetOpenAIError(); oaiError != nil && oaiError.Type != "" {
 		return nil, types.WithOpenAIError(*oaiError, resp.StatusCode)
+	}
+	if err := validateResponsesReasoningOutputs(responsesResponse.Output); err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusBadGateway)
 	}
 
 	// 写入新的 response body
@@ -84,6 +130,7 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 	var responseTextBuilder strings.Builder
 	imageCounter := &relaycommon.ImageGenerationCallCounter{}
 	imageCommitted := false
+	var streamErr *types.NewAPIError
 
 	helper.StreamScannerHandler(c, resp, info, func(data string, sr *helper.StreamResult) {
 
@@ -92,6 +139,12 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 		if err := common.UnmarshalJsonStr(data, &streamResponse); err != nil {
 			logger.LogError(c, "failed to unmarshal stream response: "+err.Error())
 			sr.Error(err)
+			return
+		}
+		if err := validateResponsesStreamReasoningOutputs(&streamResponse); err != nil {
+			logger.LogError(c, "invalid Responses stream item: "+err.Error())
+			streamErr = types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusBadGateway)
+			sr.Stop(streamErr)
 			return
 		}
 		sendResponsesStreamData(c, streamResponse, data)
@@ -157,6 +210,10 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 			}
 		}
 	})
+
+	if streamErr != nil {
+		return nil, streamErr
+	}
 
 	if usage.CompletionTokens == 0 {
 		// 计算输出文本的 token 数量

--- a/relay/channel/openai/relay_responses_validation_test.go
+++ b/relay/channel/openai/relay_responses_validation_test.go
@@ -1,0 +1,179 @@
+package openai
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateResponsesReasoningOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  *dto.ResponsesOutput
+		wantErr string
+	}{
+		{
+			name:   "valid reasoning id",
+			output: &dto.ResponsesOutput{Type: responsesOutputTypeReasoning, ID: "rs_123"},
+		},
+		{
+			name:    "generic item id",
+			output:  &dto.ResponsesOutput{Type: responsesOutputTypeReasoning, ID: "item_123"},
+			wantErr: `invalid Responses reasoning item id "item_123": expected prefix "rs_"`,
+		},
+		{
+			name:    "missing reasoning id",
+			output:  &dto.ResponsesOutput{Type: responsesOutputTypeReasoning},
+			wantErr: `invalid Responses reasoning item id "": expected prefix "rs_"`,
+		},
+		{
+			name:   "other output type is unchanged",
+			output: &dto.ResponsesOutput{Type: "message", ID: "item_123"},
+		},
+		{
+			name: "nil output",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateResponsesReasoningOutput(tt.output)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestOaiResponsesHandlerRejectsInvalidReasoningItemID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body, err := common.Marshal(dto.OpenAIResponsesResponse{
+		Status: []byte(`"completed"`),
+		Output: []dto.ResponsesOutput{
+			{Type: responsesOutputTypeReasoning, ID: "item_bad"},
+		},
+		Usage: &dto.Usage{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
+	})
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+
+	usage, apiErr := OaiResponsesHandler(c, &relaycommon.RelayInfo{}, resp)
+
+	require.Nil(t, usage)
+	require.NotNil(t, apiErr)
+	assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
+	assert.Equal(t, types.ErrorCodeBadResponseBody, apiErr.GetErrorCode())
+	assert.Contains(t, apiErr.Error(), `"item_bad"`)
+	assert.Empty(t, w.Body.String())
+}
+
+func TestOaiResponsesStreamHandlerStopsBeforeInvalidReasoningItem(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() {
+		constant.StreamingTimeout = oldTimeout
+	})
+
+	body := strings.Join([]string{
+		`data: {"type":"response.created","response":{"id":"resp_1","status":"in_progress","output":[]}}`,
+		"",
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"item_bad","status":"in_progress"}}`,
+		"",
+		`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"item_bad","status":"completed"}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Set(common.RequestIdKey, "responses-reasoning-validation-test")
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "gpt-test",
+		DisablePing:     true,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "gpt-test",
+		},
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+
+	usage, apiErr := OaiResponsesStreamHandler(c, info, resp)
+
+	require.Nil(t, usage)
+	require.NotNil(t, apiErr)
+	assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
+	assert.Equal(t, types.ErrorCodeBadResponseBody, apiErr.GetErrorCode())
+	assert.Contains(t, apiErr.Error(), `"item_bad"`)
+	assert.Contains(t, w.Body.String(), `"response.created"`)
+	assert.NotContains(t, w.Body.String(), `"item_bad"`)
+}
+
+func TestOaiResponsesStreamHandlerAllowsValidReasoningItemID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() {
+		constant.StreamingTimeout = oldTimeout
+	})
+
+	body := strings.Join([]string{
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_valid","status":"in_progress"}}`,
+		"",
+		`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"rs_valid","status":"completed"}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Set(common.RequestIdKey, "responses-reasoning-validation-test")
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "gpt-test",
+		DisablePing:     true,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "gpt-test",
+		},
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+
+	usage, apiErr := OaiResponsesStreamHandler(c, info, resp)
+
+	require.Nil(t, apiErr)
+	require.NotNil(t, usage)
+	assert.Contains(t, w.Body.String(), `"rs_valid"`)
+}

--- a/relay/channel/openai/relay_responses_validation_test.go
+++ b/relay/channel/openai/relay_responses_validation_test.go
@@ -137,6 +137,52 @@ func TestOaiResponsesStreamHandlerStopsBeforeInvalidReasoningItem(t *testing.T) 
 	assert.NotContains(t, w.Body.String(), `"item_bad"`)
 }
 
+func TestOaiResponsesStreamHandlerStopsBeforeInvalidTerminalReasoningItem(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() {
+		constant.StreamingTimeout = oldTimeout
+	})
+
+	body := strings.Join([]string{
+		`data: {"type":"response.created","response":{"id":"resp_1","status":"in_progress","output":[]}}`,
+		"",
+		`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[{"type":"reasoning","id":"item_bad"}]}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Set(common.RequestIdKey, "responses-reasoning-validation-terminal-test")
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "gpt-test",
+		DisablePing:     true,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "gpt-test",
+		},
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+
+	usage, apiErr := OaiResponsesStreamHandler(c, info, resp)
+
+	require.Nil(t, usage)
+	require.NotNil(t, apiErr)
+	assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
+	assert.Equal(t, types.ErrorCodeBadResponseBody, apiErr.GetErrorCode())
+	assert.Contains(t, apiErr.Error(), `"item_bad"`)
+	assert.Contains(t, w.Body.String(), `"response.created"`)
+	assert.NotContains(t, w.Body.String(), `"response.completed"`)
+	assert.NotContains(t, w.Body.String(), `"item_bad"`)
+}
+
 func TestOaiResponsesStreamHandlerAllowsValidReasoningItemID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	oldTimeout := constant.StreamingTimeout


### PR DESCRIPTION
## 📝 变更描述 / Description

The direct OpenAI Responses relay currently forwards successful upstream reasoning items without validating their IDs. If an upstream emits `{"type":"reasoning","id":"item_..."}`, clients can persist that output and replay it later, where a conforming endpoint rejects it because reasoning item IDs must use the `rs_` prefix.

This change validates reasoning output items before forwarding them:

- Non-streaming responses return `bad_response_body` with HTTP 502 before writing the malformed body.
- Streaming responses stop before writing a malformed `response.output_item.*` event, and also validate reasoning items in terminal `response.output` arrays.
- Valid `rs_` IDs and non-reasoning item IDs are unchanged.
- Opaque upstream IDs are rejected rather than rewritten.

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #6677

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 已关联对应 Issue。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行相关测试。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

Passed:

```text
go test ./relay/channel/openai
go test -race ./relay/channel/openai
go test ./relay/...
```

`go test ./...` was also run. All discovered packages passed except the root package setup, which requires the generated `web/dist` directory that is absent in a clean backend worktree:

```text
main.go:42:12: pattern web/dist: no matching files found
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Responses containing malformed reasoning item IDs are now rejected instead of being forwarded.
  - Streaming responses stop processing when an invalid reasoning item is detected and return an appropriate error.
  - Valid reasoning items and other response types continue to be handled normally.
  - Missing or incorrectly formatted reasoning IDs now produce clear API errors.

- **Tests**
  - Added coverage for valid and invalid reasoning IDs in both streaming and non-streaming responses.
  - Added checks confirming terminal and non-terminal invalid items are handled safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->