### PR TITLE
fix(responses): fix streaming EOF, missing [DONE], reasoning_tokens and created_at float

### DIFF
--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -34,8 +34,26 @@ func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 		return nil, types.WithOpenAIError(*oaiError, resp.StatusCode)
 	}
 
-	// 写入新的 response body
-	service.IOCopyBytesGracefully(c, resp, responseBody)
+	// Ensure output_tokens_details is populated for Responses API compatibility.
+	// Some upstreams (e.g. Moonshot/Kimi) report reasoning_tokens at the top
+	// level of usage rather than inside output_tokens_details.
+	if responsesResponse.Usage != nil {
+		if responsesResponse.Usage.OutputTokensDetails == nil && responsesResponse.Usage.ReasoningTokens != 0 {
+			responsesResponse.Usage.OutputTokensDetails = &dto.OutputTokenDetails{
+				ReasoningTokens: responsesResponse.Usage.ReasoningTokens,
+			}
+		}
+	}
+
+	// Re-serialize to ensure created_at is always a clean integer (not float)
+	// and usage includes output_tokens_details with reasoning_tokens.
+	reSerializedBody, err := common.Marshal(responsesResponse)
+	if err != nil {
+		// Fallback to raw body if re-serialization fails
+		service.IOCopyBytesGracefully(c, resp, responseBody)
+	} else {
+		service.IOCopyBytesGracefully(c, resp, reSerializedBody)
+	}
 
 	// compute usage
 	usage := dto.Usage{}
@@ -94,7 +112,15 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 			sr.Error(err)
 			return
 		}
-		sendResponsesStreamData(c, streamResponse, data)
+		// Re-serialize to ensure created_at is always a clean integer (not float)
+		// and usage includes output_tokens_details with reasoning_tokens.
+		reSerialized, err := common.Marshal(streamResponse)
+		if err != nil {
+			// Fallback to raw data if re-serialization fails
+			sendResponsesStreamData(c, streamResponse, data)
+		} else {
+			sendResponsesStreamData(c, streamResponse, string(reSerialized))
+		}
 		switch streamResponse.Type {
 		case "response.completed", "response.done":
 			if streamResponse.Response != nil {
@@ -111,6 +137,21 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 					if streamResponse.Response.Usage.InputTokensDetails != nil {
 						usage.PromptTokensDetails.CachedTokens = streamResponse.Response.Usage.InputTokensDetails.CachedTokens
 						usage.PromptTokensDetails.CacheWriteTokens = streamResponse.Response.Usage.InputTokensDetails.CacheWriteTokens
+					}
+					// Ensure reasoning_tokens is captured from top-level or output_tokens_details
+					rt := streamResponse.Response.Usage.ReasoningTokens
+					if rt == 0 && streamResponse.Response.Usage.OutputTokensDetails != nil {
+						rt = streamResponse.Response.Usage.OutputTokensDetails.ReasoningTokens
+					}
+					if rt != 0 {
+						usage.ReasoningTokens = rt
+						usage.CompletionTokenDetails.ReasoningTokens = rt
+						// Ensure the event sent to client has output_tokens_details
+						if streamResponse.Response.Usage.OutputTokensDetails == nil {
+							streamResponse.Response.Usage.OutputTokensDetails = &dto.OutputTokenDetails{
+								ReasoningTokens: rt,
+							}
+						}
 					}
 				}
 				if !imageCommitted {
@@ -173,6 +214,8 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 	}
 
 	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+
+	helper.Done(c)
 
 	return usage, nil
 }

--- a/relay/channel/openai/responses_via_chat.go
+++ b/relay/channel/openai/responses_via_chat.go
@@ -154,5 +154,7 @@ func OaiChatToResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 		}
 	}
 
+	helper.Done(c)
+
 	return usage, nil
 }

--- a/relaykit/dto/openai_response.go
+++ b/relaykit/dto/openai_response.go
@@ -234,6 +234,13 @@ type Usage struct {
 	InputTokens            int                `json:"input_tokens"`
 	OutputTokens           int                `json:"output_tokens"`
 	InputTokensDetails     *InputTokenDetails `json:"input_tokens_details"`
+	OutputTokensDetails    *OutputTokenDetails `json:"output_tokens_details,omitempty"`
+
+	// ReasoningTokens is populated when the upstream reports reasoning tokens at
+	// the top level of the usage object (e.g. Moonshot/Kimi) rather than inside
+	// completion_tokens_details. It is used to ensure output_tokens_details is
+	// always populated in Responses API responses.
+	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
 
 	// claude cache 1h
 	ClaudeCacheCreation5mTokens int `json:"claude_cache_creation_5_m_tokens"`

--- a/relaykit/relayconvert/internal/oai_chat/to_oai_responses_resp.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_oai_responses_resp.go
@@ -148,6 +148,21 @@ func UsageFromChatUsage(src *dto.Usage) *dto.Usage {
 		src.CompletionTokenDetails.ImageTokens != 0 {
 		usage.CompletionTokenDetails = src.CompletionTokenDetails
 	}
+
+	// Ensure reasoning_tokens is captured from both sources:
+	// 1. Top-level reasoning_tokens (e.g. Moonshot/Kimi upstream)
+	// 2. completion_tokens_details.reasoning_tokens (standard OpenAI)
+	reasoningTokens := src.ReasoningTokens
+	if reasoningTokens == 0 {
+		reasoningTokens = src.CompletionTokenDetails.ReasoningTokens
+	}
+	usage.ReasoningTokens = reasoningTokens
+	if reasoningTokens != 0 {
+		usage.OutputTokensDetails = &dto.OutputTokenDetails{
+			ReasoningTokens: reasoningTokens,
+		}
+	}
+
 	usage.ClaudeCacheCreation5mTokens = src.ClaudeCacheCreation5mTokens
 	usage.ClaudeCacheCreation1hTokens = src.ClaudeCacheCreation1hTokens
 	return usage


### PR DESCRIPTION
## Problem

When using Codex client (`wire_api = "responses"`) with NewAPI gateway, streaming responses fail with:

```
ERROR: stream disconnected before completion: failed to parse ResponseCompleted: missing field `reasoning_tokens`
ERROR: Reconnecting... 1/5
json: cannot unmarshal number 1785990796.0 into Go struct field OpenAIResponsesResponse.response.created_at of type int
```

This causes repeated retries and duplicate responses.

## Root Causes

### Bug 1: Missing `[DONE]` terminator in stream

`OaiResponsesStreamHandler` and `OaiChatToResponsesStreamHandler` did not call `helper.Done(c)` at the end of the stream. Clients (e.g. Codex) receive EOF and treat it as an abnormal disconnection, triggering reconnection loops.

### Bug 2: Missing `reasoning_tokens` in `output_tokens_details`

Some upstreams (e.g. Moonshot/Kimi) report `reasoning_tokens` at the top level of the usage object:

```json
{"usage":{"prompt_tokens":86,"completion_tokens":417,"total_tokens":503,"reasoning_tokens":398}}
```

The `Usage` struct had no `reasoning_tokens` top-level field and no `output_tokens_details` field, so the value was silently dropped. Clients parsing `response.completed` events fail with `missing field reasoning_tokens`.

### Bug 3: `created_at` float transparent passthrough

In passthrough mode, `created_at` was forwarded as raw JSON from upstream. Some upstreams serialize it as a float (e.g. `1785990796.0`), which Go clients with strict `int` types cannot parse.

## Fix

### 1. `relaykit/dto/openai_response.go`
Added `OutputTokensDetails *OutputTokenDetails` and `ReasoningTokens int` fields to the `Usage` struct.

### 2. `relaykit/relayconvert/internal/oai_chat/to_oai_responses_resp.go`
`UsageFromChatUsage` now extracts `reasoning_tokens` from both top-level and `completion_tokens_details`, and populates `OutputTokensDetails`.

### 3. `relay/channel/openai/relay_responses.go`
- **Non-stream**: Re-serialize response body (guarantees integer `created_at`), populate `output_tokens_details`
- **Stream**: Re-serialize each event, extract `reasoning_tokens` into `output_tokens_details`, call `helper.Done(c)` at stream end

### 4. `relay/channel/openai/responses_via_chat.go`
Call `helper.Done(c)` at stream end.

## Impact

- `/v1/chat/completions` — unchanged, no impact
- `/v1/responses` — all three bugs fixed
- No breaking changes to existing API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Responses API usage reporting by consistently capturing reasoning token counts.
  * Added missing output token details to non-streaming and streaming responses.
  * Improved response delivery reliability with safe fallback handling when re-serialization fails.
  * Ensured streaming requests complete cleanly after all events are delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->