### PR TITLE
fix: 修复兑换码额度删除全部数值时强制为0的问题

### DIFF
--- a/web/src/features/redemption-codes/components/redemptions-mutate-drawer.tsx
+++ b/web/src/features/redemption-codes/components/redemptions-mutate-drawer.tsx
@@ -63,7 +63,7 @@ import {
   transformFormDataToPayload,
   transformRedemptionToFormDefaults,
 } from '../lib'
-import { type Redemption } from '../types'
+import type { Redemption } from '../types'
 import { useRedemptions } from './redemptions-provider'
 
 type RedemptionsMutateDrawerProps = {
@@ -91,11 +91,13 @@ export function RedemptionsMutateDrawer({
   useEffect(() => {
     if (open && isUpdate && currentRow) {
       // For update, fetch fresh data
-      getRedemption(currentRow.id).then((result) => {
-        if (result.success && result.data) {
-          form.reset(transformRedemptionToFormDefaults(result.data))
-        }
-      })
+      getRedemption(currentRow.id)
+        .then((result) => {
+          if (result.success && result.data) {
+            form.reset(transformRedemptionToFormDefaults(result.data))
+          }
+        })
+        .catch(() => undefined)
     } else if (open && !isUpdate) {
       // For create, reset to defaults
       form.reset(REDEMPTION_FORM_DEFAULT_VALUES)
@@ -222,11 +224,12 @@ export function RedemptionsMutateDrawer({
                     <FormControl>
                       <Input
                         {...field}
+                        value={Number.isNaN(field.value) ? '' : field.value}
                         type='number'
                         step={tokensOnly ? 1 : 0.01}
                         placeholder={quotaPlaceholder}
-                        onChange={(e) =>
-                          field.onChange(parseFloat(e.target.value) || 0)
+                        onChange={(event) =>
+                          field.onChange(event.target.valueAsNumber)
                         }
                       />
                     </FormControl>


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 修复兑换码额度数值删除全部数字后强制显示0的问题

## 📝 变更描述 / Description
 - 删除最后一位数字后，输入框现在会保持为空，不再强制显示 0。
  - 空输入在表单状态中使用 NaN 表示，并由 Zod 在提交时进行校验。


## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - #6881


## 🔗 关联任务 / Related Issue
- Closes #6881

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ ] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [ ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [ ] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
已支持删除后为空
<img width="401" height="373" alt="image" src="https://github.com/user-attachments/assets/ec73549a-e58e-4e38-b65c-c1125b54fdc1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redemption loading so rejected requests are handled gracefully.
  * Updated quota input behavior to preserve empty and invalid values instead of converting them to zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->