### PR TITLE
fix(channel): prevent InitChannelCache panic caused by case-insensitive duplicate groups

### DIFF
--- a/model/ability.go
+++ b/model/ability.go
@@ -196,10 +196,38 @@ func filterAbilitiesByRequestPathAndModel(abilities []Ability, requestPath strin
 func (channel *Channel) AddAbilities(tx *gorm.DB) error {
 	models_ := strings.Split(channel.Models, ",")
 	groups_ := strings.Split(channel.Group, ",")
+
+	normalizedGroups := make([]string, 0, len(groups_))
+	seenGroups := make(map[string]string)
+
+	for _, group := range groups_ {
+        	group = strings.TrimSpace(group)
+	        if group == "" {
+	                continue
+	        }
+
+        	key := strings.ToLower(group)
+
+	        if old, ok := seenGroups[key]; ok {
+ 		  	common.SysLog(
+                		fmt.Sprintf(
+                        		"duplicate channel group ignored: %q conflicts with %q (case-insensitive MySQL collation)",
+                        		group,
+                        		old,
+                		),
+        		)
+	        	continue
+		}
+
+        	seenGroups[key] = group
+	        normalizedGroups = append(normalizedGroups, group)
+	}
+
 	abilitySet := make(map[string]struct{})
 	abilities := make([]Ability, 0, len(models_))
+
 	for _, model := range models_ {
-		for _, group := range groups_ {
+		for _, group := range normalizedGroups {
 			key := group + "|" + model
 			if _, exists := abilitySet[key]; exists {
 				continue
@@ -268,10 +296,38 @@ func (channel *Channel) UpdateAbilities(tx *gorm.DB) error {
 	// Then add new abilities
 	models_ := strings.Split(channel.Models, ",")
 	groups_ := strings.Split(channel.Group, ",")
+
+	normalizedGroups := make([]string, 0, len(groups_))
+	seenGroups := make(map[string]string)
+
+	for _, group := range groups_ {
+        	group = strings.TrimSpace(group)
+        	if group == "" {
+                	continue
+        	}
+
+        	key := strings.ToLower(group)
+
+	        if old, ok := seenGroups[key]; ok {
+        	        common.SysLog(
+                	        fmt.Sprintf(
+                        	        "duplicate channel group ignored: %q conflicts with %q (case-insensitive MySQL collation)",
+                                	group,
+	                                old,
+        	                ),
+                	)
+	                continue
+	        }
+
+	        seenGroups[key] = group
+	        normalizedGroups = append(normalizedGroups, group)
+	}
+
 	abilitySet := make(map[string]struct{})
 	abilities := make([]Ability, 0, len(models_))
+	
 	for _, model := range models_ {
-		for _, group := range groups_ {
+		for _, group := range normalizedGroups {
 			key := group + "|" + model
 			if _, exists := abilitySet[key]; exists {
 				continue

--- a/model/channel_cache.go
+++ b/model/channel_cache.go
@@ -56,13 +56,19 @@ func InitChannelCache() {
 		}
 		groups := strings.Split(channel.Group, ",")
 		for _, group := range groups {
+    			group = strings.TrimSpace(group)
+			if _, ok := newGroup2model2channels[group]; !ok {
+		        newGroup2model2channels[group] = make(map[string][]int)
+			}
 			models := strings.Split(channel.Models, ",")
 			for _, model := range models {
-				if _, ok := newGroup2model2channels[group][model]; !ok {
-					newGroup2model2channels[group][model] = make([]int, 0)
-				}
-				newGroup2model2channels[group][model] = append(newGroup2model2channels[group][model], channel.Id)
-			}
+			        model = strings.TrimSpace(model)
+			        if _, ok := newGroup2model2channels[group][model]; !ok {
+				        newGroup2model2channels[group][model] = make([]int, 0)
+			        }
+			        newGroup2model2channels[group][model] =
+			        append(newGroup2model2channels[group][model], channel.Id)
+    			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fix a startup panic in `InitChannelCache()` caused by duplicate channel groups under case-insensitive MySQL collations.

## Root Cause

The `abilities` table uses a composite primary key:

- group
- model
- channel_id

With MySQL's default case-insensitive collation (`utf8mb4_0900_ai_ci`), values such as `OPS` and `Ops` are treated as identical.

During `AddAbilities()` / `UpdateAbilities()`, one record is skipped because of:

```go
OnConflict{DoNothing: true}
```

`InitChannelCache()` later assumes every configured group exists, resulting in:

```
panic: assignment to entry in nil map
```

## Changes

- Prevent nil map panic in `InitChannelCache()`.
- Normalize duplicate channel groups in `AddAbilities()`.
- Normalize duplicate channel groups in `UpdateAbilities()`.
- Ignore duplicate groups differing only by case while preserving existing behavior.

## Verification

- Reproduced on `v1.0.0-rc.21`
- Reproduced on `v1.0.0-rc.22`
- Verified with MySQL 8 (`utf8mb4_0900_ai_ci`)
- Verified Docker startup
- Verified Web UI
- Verified channel update
- Verified channel cache synchronization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of channel groups by removing surrounding whitespace and ignoring empty entries.
  * Prevented duplicate channel groups that differ only by capitalization.
  * Improved channel and model indexing when names contain extra spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->