### PR TITLE
fix(relayconvert): Claude Messages 转 OpenAI 时不再向非 OpenRouter 上游透传 cache_control

### DIFF
--- a/relaykit/relayconvert/claude_to_openai_cache_test.go
+++ b/relaykit/relayconvert/claude_to_openai_cache_test.go
@@ -1,0 +1,125 @@
+package relayconvert
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/relayconvert/convmeta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// claudeRequestWithCacheControl builds an Anthropic-format request whose user
+// message carries a cache_control breakpoint, which is what Claude Code and
+// similar clients send.
+func claudeRequestWithCacheControl() dto.ClaudeRequest {
+	return dto.ClaudeRequest{
+		Model: "gpt-4o",
+		Messages: []dto.ClaudeMessage{
+			{
+				Role: "user",
+				Content: []map[string]any{
+					{
+						"type":          "text",
+						"text":          "hello",
+						"cache_control": map[string]string{"type": "ephemeral"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// cache_control is an Anthropic/OpenRouter-only field. Forwarding it to a plain
+// OpenAI-compatible upstream destroys prompt caching: clients move the
+// breakpoint as the conversation grows, so the marker lands on a different
+// message each request and truncates the upstream longest-common-prefix match
+// at exactly the point it moved.
+func TestClaudeMessagesToOpenAIChat_StripsCacheControlForNonOpenRouterUpstream(t *testing.T) {
+	meta := &convmeta.Values{
+		UpstreamModelName: "gpt-4o",
+		Options:           &convmeta.Options{OpenRouterDialect: false},
+	}
+
+	got, err := ClaudeMessagesRequestToOpenAIChat(claudeRequestWithCacheControl(), meta)
+	require.NoError(t, err)
+	require.Len(t, got.Messages, 1)
+
+	contents := got.Messages[0].ParseContent()
+	require.Len(t, contents, 1)
+	assert.Empty(t, contents[0].CacheControl,
+		"cache_control must not reach a non-OpenRouter upstream")
+	assert.Equal(t, "hello", contents[0].Text,
+		"stripping the marker must not drop the message text")
+}
+
+// OpenRouter proxying Anthropic models does understand cache_control, and
+// forwarding it there is what lets those requests cache at all.
+func TestClaudeMessagesToOpenAIChat_KeepsCacheControlForOpenRouterClaude(t *testing.T) {
+	meta := &convmeta.Values{
+		UpstreamModelName:   "anthropic/claude-sonnet-4",
+		ChannelMetaAttached: true,
+		Options:             &convmeta.Options{OpenRouterDialect: true},
+	}
+
+	got, err := ClaudeMessagesRequestToOpenAIChat(claudeRequestWithCacheControl(), meta)
+	require.NoError(t, err)
+	require.Len(t, got.Messages, 1)
+
+	contents := got.Messages[0].ParseContent()
+	require.Len(t, contents, 1)
+	assert.NotEmpty(t, contents[0].CacheControl,
+		"OpenRouter Anthropic upstreams rely on cache_control being forwarded")
+}
+
+// prompt_cache_key gives OpenAI a stable routing key for a conversation. It must
+// come from the client's own identifier, and must stay unset when the client
+// sends nothing usable: a key that varies per request is worse than no key,
+// because it pins otherwise-cacheable requests to different cache nodes.
+func TestClaudeMessagesToOpenAIChat_PromptCacheKeyFromMetadata(t *testing.T) {
+	cases := []struct {
+		name     string
+		metadata string
+		want     string
+	}{
+		{"forwards metadata.user_id", `{"user_id":"user-abc123"}`, "user-abc123"},
+		{"trims whitespace", `{"user_id":"  user-abc123  "}`, "user-abc123"},
+		{"absent metadata", ``, ""},
+		{"metadata without user_id", `{"session":"x"}`, ""},
+		{"empty user_id", `{"user_id":""}`, ""},
+		{"non-string user_id is ignored, not fatal", `{"user_id":{"nested":true}}`, ""},
+		{"malformed metadata is ignored, not fatal", `{"user_id":`, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			request := claudeRequestWithCacheControl()
+			if tc.metadata != "" {
+				request.Metadata = json.RawMessage(tc.metadata)
+			}
+
+			got, err := ClaudeMessagesRequestToOpenAIChat(request, &convmeta.Values{
+				UpstreamModelName: "gpt-4o",
+				Options:           &convmeta.Options{},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got.PromptCacheKey)
+		})
+	}
+}
+
+// omitempty must keep the field off the wire when unset, so its absence cannot
+// itself become a byte-level difference between two requests.
+func TestClaudeMessagesToOpenAIChat_OmitsEmptyPromptCacheKey(t *testing.T) {
+	got, err := ClaudeMessagesRequestToOpenAIChat(claudeRequestWithCacheControl(), &convmeta.Values{
+		UpstreamModelName: "gpt-4o",
+		Options:           &convmeta.Options{},
+	})
+	require.NoError(t, err)
+	require.Empty(t, got.PromptCacheKey)
+
+	encoded, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "prompt_cache_key")
+}

--- a/relaykit/relayconvert/internal/claude_messages/to_oai_chat_req.go
+++ b/relaykit/relayconvert/internal/claude_messages/to_oai_chat_req.go
@@ -41,6 +41,12 @@ func ClaudeMessagesRequestToOpenAIChat(claudeRequest dto.ClaudeRequest, info con
 	}
 
 	isOpenRouter := convmeta.OptionsOf(info).OpenRouterDialect
+	// cache_control is an Anthropic/OpenRouter-only field. Forwarding it to a
+	// plain OpenAI-compatible upstream both sends an unknown field and, worse,
+	// destroys prompt caching: clients move the breakpoint as the conversation
+	// grows, so the marker lands on a different message each request and
+	// truncates the upstream longest-common-prefix match at the point it moved.
+	keepCacheControl := isOpenRouter && strings.HasPrefix(convmeta.UpstreamModelName(info), "anthropic/claude")
 	if isOpenRouter {
 		if effort := claudeRequest.GetEfforts(); effort != "" {
 			effortBytes, _ := kitutil.Marshal(effort)
@@ -107,8 +113,7 @@ func ClaudeMessagesRequestToOpenAIChat(claudeRequest dto.ClaudeRequest, info con
 				openAIMessage := dto.Message{
 					Role: "system",
 				}
-				isOpenRouterClaude := isOpenRouter && strings.HasPrefix(convmeta.UpstreamModelName(info), "anthropic/claude")
-				if isOpenRouterClaude {
+				if keepCacheControl {
 					systemMediaMessages := make([]dto.MediaContent, 0, len(systems))
 					for _, system := range systems {
 						message := dto.MediaContent{
@@ -151,9 +156,11 @@ func ClaudeMessagesRequestToOpenAIChat(claudeRequest dto.ClaudeRequest, info con
 				switch mediaMsg.Type {
 				case "text", "input_text":
 					message := dto.MediaContent{
-						Type:         "text",
-						Text:         mediaMsg.GetText(),
-						CacheControl: mediaMsg.CacheControl,
+						Type: "text",
+						Text: mediaMsg.GetText(),
+					}
+					if keepCacheControl {
+						message.CacheControl = mediaMsg.CacheControl
 					}
 					mediaMessages = append(mediaMessages, message)
 				case "image":
@@ -207,7 +214,33 @@ func ClaudeMessagesRequestToOpenAIChat(claudeRequest dto.ClaudeRequest, info con
 	}
 
 	openAIRequest.Messages = openAIMessages
+
+	// Forward the client's stable conversation identifier as prompt_cache_key.
+	// OpenAI routes requests sharing a cache key to the same cache node, which
+	// lifts the hit rate well above what prefix-hashing alone achieves on a
+	// shared tenant. Anthropic clients carry this as metadata.user_id; without
+	// it the converted request has no cache affinity at all.
+	if promptCacheKey := claudeRequestPromptCacheKey(claudeRequest); promptCacheKey != "" {
+		openAIRequest.PromptCacheKey = promptCacheKey
+	}
+
 	return &openAIRequest, nil
+}
+
+// claudeRequestPromptCacheKey extracts the stable per-conversation identifier an
+// Anthropic-format request carries in metadata.user_id. It returns "" when the
+// client sent no usable value, in which case the caller leaves prompt_cache_key
+// unset rather than inventing one: a key that varies between requests is worse
+// than no key, because it pins otherwise-cacheable requests to different nodes.
+func claudeRequestPromptCacheKey(claudeRequest dto.ClaudeRequest) string {
+	if len(claudeRequest.Metadata) == 0 {
+		return ""
+	}
+	var metadata dto.ClaudeMetadata
+	if err := kitutil.Unmarshal(claudeRequest.Metadata, &metadata); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(metadata.UserId)
 }
 
 func requestToJSONString(v interface{}) string {


### PR DESCRIPTION
## 📝 变更描述 / Description

Claude Messages → OpenAI chat 的转换中，`cache_control` 这个 Anthropic/OpenRouter 专属字段被无条件透传给了所有上游。

同一个函数里，system 部分有 `isOpenRouterClaude` 判断保护（`to_oai_chat_req.go:110`），但消息内容部分漏了同样的判断（`:156`），导致普通 OpenAI 兼容上游也会收到这个它并不认识的字段。字段定义处的注释本身就标明了 `// OpenRouter Params`。

这个字段造成两种不同的故障：

**严格上游直接返回 400**，即 #5982 报告的现象。该 issue 评论中 @haowang02 的对照测试已独立验证，400 的成因是 `cache_control` 本身，与 content 数组结构无关。

**宽松上游不报错，但会静默破坏 prompt 缓存**，这一面此前没有被记录。Claude Code 这类客户端会随对话轮次增长把缓存断点向后移动，所以这个标记每次落在不同的消息下标上。OpenAI 的自动缓存按最长公共前缀匹配，标记一移动，前缀匹配就在移动点被截断——本该轮轮命中的对话变成反复冷启动。

本 PR 把该判断提升为函数级变量 `keepCacheControl`，两处统一使用，对 OpenRouter 的行为保持不变。

同时补上了 `prompt_cache_key`：这条路径此前从未设置该字段（全仓库仅 `oai_responses/to_oai_chat_req.go:91` 的 Responses→Chat 路径传递过）。现从客户端的 `metadata.user_id` 转发，让上游能把同一会话路由到同一缓存节点。客户端未提供可用标识时保持不设置，而非自行生成——每次请求都变化的 key 比没有 key 更糟，会把本可命中的请求打散到不同节点。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- Fixes part of #5982 — 该 issue 同时报告了 content 数组结构与 `cache_control` 两个问题，本 PR 只修复后者；数组结构部分留给维护者判断是否需要一并处理。
- Refs #6538 — 同类遗漏。该 issue 针对 Responses 路径的 `prompt_cache_key`，本 PR 顺带修复了 Chat 路径上的同一问题。
- 缺陷由 #983 引入：该 PR 为 OpenRouter 添加 Claude 缓存支持时，system 分支加了条件判断，消息分支遗漏。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述基于对代码逻辑的实际排查撰写，已人工审阅并经生产环境验证。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，未发现重复的修复 PR。
- [x] **Bug fix 说明:** 已关联 #5982。这是明确的实现遗漏而非设计取舍——同一函数内两处等价逻辑，一处有保护一处没有，且字段定义处注释即标明用途限于 OpenRouter。
- [x] **变更理解:** 已理解其工作原理及影响范围。
- [x] **范围聚焦:** 仅改动目标文件与配套测试。
- [x] **本地验证:** `relaykit` 子模块与主模块 `./relay/...` 全量测试通过。
- [x] **安全合规:** 无敏感凭据，符合项目代码规范。

## 📸 运行证明 / Proof of Work

**生产环境实测**，控制变量为同一渠道、同一模型 `gpt-5.6-sol`、输入规模相当：

| 入口路径 | 请求数 | 平均输入 token | 缓存未命中率 |
|---|---|---|---|
| `/v1/responses`（原生，不受影响） | 118 | 60,985 | **14.4%** |
| `/v1/messages`（转换，修复前） | 55 | 62,994 | **74.5%** |
| `/v1/messages`（转换，修复后） | 79 | — | **13.3%** |

修复后转换路径与原生路径持平。以下干扰因素已排除：

- **非缓存过期**：间隔 30 秒内的连续请求同样有 51% 未命中
- **非渠道切换**：受影响会话全程固定同一渠道，且该渠道为单密钥
- **非渠道配置**：该渠道 `param_override` 为空，无 system_prompt 注入，强制缓存关闭

**测试结果**：

```
ok  github.com/QuantumNous/new-api/relaykit/relayconvert           1.340s
ok  github.com/QuantumNous/new-api/relaykit/dto                    1.169s
ok  github.com/QuantumNous/new-api/relaykit/relayconvert/convmeta  1.154s
ok  github.com/QuantumNous/new-api/relaykit/relayconvert/internal/oai_chat       1.215s
ok  github.com/QuantumNous/new-api/relaykit/relayconvert/internal/oai_responses  1.204s
ok  github.com/QuantumNous/new-api/relaykit/relayconvert/kitutil   1.119s
```

主模块 `./relay/...` 19 个包全部通过。

新增 4 组回归测试，覆盖 `cache_control` 门控的两个方向，以及 `prompt_cache_key` 的提取（含字段缺失、空值、非字符串、JSON 格式错误等边界）。已验证这些测试能真正捕获回归：临时还原旧逻辑后测试立即失败。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved prompt caching compatibility when converting Claude requests to OpenAI format.
  - Cache-control metadata is now retained for supported OpenRouter Claude models and excluded for other providers.
  - Valid user metadata can now be forwarded as a prompt cache key.
  - Invalid, empty, or missing metadata no longer produces an unusable cache key.
  - Requests without a cache key omit the field from serialized output.

- **Tests**
  - Added coverage for provider-specific cache handling and metadata validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->