### PR TITLE
feat(video): support Agnes task status and result URLs

### DIFF
--- a/controller/video_proxy.go
+++ b/controller/video_proxy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/logger"
 	"github.com/QuantumNous/new-api/model"
+	taskcommon "github.com/QuantumNous/new-api/relay/channel/task/taskcommon"
 	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting/system_setting"
 
@@ -112,8 +113,11 @@ func VideoProxy(c *gin.Context) {
 			return
 		}
 	case constant.ChannelTypeOpenAI, constant.ChannelTypeSora:
-		videoURL = fmt.Sprintf("%s/v1/videos/%s/content", baseURL, task.GetUpstreamTaskID())
-		req.Header.Set("Authorization", "Bearer "+channel.Key)
+		var useChannelAuth bool
+		videoURL, useChannelAuth = resolveOpenAIVideoContentURL(baseURL, task.GetUpstreamTaskID(), task.GetResultURL())
+		if useChannelAuth {
+			req.Header.Set("Authorization", "Bearer "+channel.Key)
+		}
 	default:
 		// Video URL is stored in PrivateData.ResultURL (fallback to FailReason for old data)
 		videoURL = task.GetResultURL()
@@ -180,6 +184,21 @@ func VideoProxy(c *gin.Context) {
 	if _, err = io.Copy(c.Writer, resp.Body); err != nil {
 		logger.LogError(c.Request.Context(), fmt.Sprintf("Failed to stream video content: %s", err.Error()))
 	}
+}
+
+func resolveOpenAIVideoContentURL(baseURL, upstreamTaskID, resultURL string) (string, bool) {
+	if taskcommon.IsAgnesAPIBaseURL(baseURL) {
+		candidate := strings.TrimSpace(resultURL)
+		parsed, err := url.Parse(candidate)
+		if err == nil &&
+			parsed.IsAbs() &&
+			parsed.Host != "" &&
+			(parsed.Scheme == "http" || parsed.Scheme == "https") {
+			return candidate, false
+		}
+	}
+
+	return fmt.Sprintf("%s/v1/videos/%s/content", baseURL, upstreamTaskID), true
 }
 
 func writeVideoDataURL(c *gin.Context, dataURL string) error {

--- a/controller/video_proxy_test.go
+++ b/controller/video_proxy_test.go
@@ -1,0 +1,58 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveOpenAIVideoContentURLIsScopedToAgnes(t *testing.T) {
+	tests := []struct {
+		name            string
+		baseURL         string
+		resultURL       string
+		wantURL         string
+		wantChannelAuth bool
+	}{
+		{
+			name:            "Agnes uses completed metadata URL",
+			baseURL:         "https://apihub.agnes-ai.com",
+			resultURL:       "https://cdn.agnes-ai.com/video.mp4",
+			wantURL:         "https://cdn.agnes-ai.com/video.mp4",
+			wantChannelAuth: false,
+		},
+		{
+			name:            "Agnes without absolute metadata URL falls back",
+			baseURL:         "https://apihub.agnes-ai.com",
+			resultURL:       "/video.mp4",
+			wantURL:         "https://apihub.agnes-ai.com/v1/videos/task-123/content",
+			wantChannelAuth: true,
+		},
+		{
+			name:            "other provider keeps existing content endpoint",
+			baseURL:         "https://video.example.com",
+			resultURL:       "https://cdn.example.com/video.mp4",
+			wantURL:         "https://video.example.com/v1/videos/task-123/content",
+			wantChannelAuth: true,
+		},
+		{
+			name:            "Agnes lookalike keeps existing content endpoint",
+			baseURL:         "https://apihub.agnes-ai.com.evil.example",
+			resultURL:       "https://cdn.example.com/video.mp4",
+			wantURL:         "https://apihub.agnes-ai.com.evil.example/v1/videos/task-123/content",
+			wantChannelAuth: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, gotChannelAuth := resolveOpenAIVideoContentURL(
+				tt.baseURL,
+				"task-123",
+				tt.resultURL,
+			)
+			assert.Equal(t, tt.wantURL, gotURL)
+			assert.Equal(t, tt.wantChannelAuth, gotChannelAuth)
+		})
+	}
+}

--- a/relay/channel/task/sora/adaptor.go
+++ b/relay/channel/task/sora/adaptor.go
@@ -7,6 +7,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -263,7 +264,10 @@ func (a *TaskAdaptor) FetchTask(baseUrl, key string, body map[string]any, proxy 
 		return nil, fmt.Errorf("invalid task_id")
 	}
 
-	uri := fmt.Sprintf("%s/v1/videos/%s", baseUrl, taskID)
+	uri, err := buildTaskFetchURL(baseUrl, taskID)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
@@ -277,6 +281,22 @@ func (a *TaskAdaptor) FetchTask(baseUrl, key string, body map[string]any, proxy 
 		return nil, fmt.Errorf("new proxy http client failed: %w", err)
 	}
 	return client.Do(req)
+}
+
+func buildTaskFetchURL(baseURL, taskID string) (string, error) {
+	if !taskcommon.IsAgnesAPIBaseURL(baseURL) {
+		return fmt.Sprintf("%s/v1/videos/%s", baseURL, taskID), nil
+	}
+
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", errors.Wrap(err, "parse Agnes base URL failed")
+	}
+	parsed.Path = "/agnesapi"
+	parsed.RawPath = ""
+	parsed.RawQuery = url.Values{"video_id": []string{taskID}}.Encode()
+	parsed.Fragment = ""
+	return parsed.String(), nil
 }
 
 func (a *TaskAdaptor) GetModelList() []string {
@@ -304,7 +324,18 @@ func (a *TaskAdaptor) ParseTaskResult(respBody []byte) (*relaycommon.TaskInfo, e
 		taskResult.Status = model.TaskStatusInProgress
 	case "completed":
 		taskResult.Status = model.TaskStatusSuccess
-		// Url intentionally left empty — the caller constructs the proxy URL using the public task ID
+		if taskcommon.IsAgnesAPIBaseURL(a.baseURL) {
+			var agnesResult struct {
+				Metadata struct {
+					URL string `json:"url"`
+				} `json:"metadata"`
+			}
+			if err := common.Unmarshal(respBody, &agnesResult); err != nil {
+				return nil, errors.Wrap(err, "unmarshal Agnes task metadata failed")
+			}
+			taskResult.Url = strings.TrimSpace(agnesResult.Metadata.URL)
+		}
+		// Other providers leave Url empty so the caller constructs the public proxy URL.
 	case "failed", "cancelled":
 		taskResult.Status = model.TaskStatusFailure
 		if resTask.Error != nil {

--- a/relay/channel/task/sora/adaptor_test.go
+++ b/relay/channel/task/sora/adaptor_test.go
@@ -39,3 +39,47 @@ func TestSoraBuildRequestBodyReturnsReplayablePassThroughBody(t *testing.T) {
 	require.NoError(t, replayBody.Close())
 	assert.Equal(t, payload, replay)
 }
+
+func TestBuildTaskFetchURLUsesAgnesStatusEndpointOnlyForAgnes(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{
+			name:    "Agnes",
+			baseURL: "https://apihub.agnes-ai.com/v1",
+			want:    "https://apihub.agnes-ai.com/agnesapi?video_id=task-123",
+		},
+		{
+			name:    "other OpenAI-compatible provider",
+			baseURL: "https://video.example.com",
+			want:    "https://video.example.com/v1/videos/task-123",
+		},
+		{
+			name:    "Agnes lookalike",
+			baseURL: "https://apihub.agnes-ai.com.evil.example",
+			want:    "https://apihub.agnes-ai.com.evil.example/v1/videos/task-123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildTaskFetchURL(tt.baseURL, "task-123")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseTaskResultUsesMetadataURLOnlyForAgnes(t *testing.T) {
+	body := []byte(`{"id":"task-123","status":"completed","metadata":{"url":"https://cdn.agnes-ai.com/video.mp4"}}`)
+
+	agnesResult, err := (&TaskAdaptor{baseURL: "https://apihub.agnes-ai.com"}).ParseTaskResult(body)
+	require.NoError(t, err)
+	assert.Equal(t, "https://cdn.agnes-ai.com/video.mp4", agnesResult.Url)
+
+	otherResult, err := (&TaskAdaptor{baseURL: "https://video.example.com"}).ParseTaskResult(body)
+	require.NoError(t, err)
+	assert.Empty(t, otherResult.Url)
+}

--- a/relay/channel/task/taskcommon/provider.go
+++ b/relay/channel/task/taskcommon/provider.go
@@ -1,0 +1,17 @@
+package taskcommon
+
+import (
+	"net/url"
+	"strings"
+)
+
+const agnesAPIHostname = "apihub.agnes-ai.com"
+
+// IsAgnesAPIBaseURL reports whether baseURL points to Agnes' official API host.
+func IsAgnesAPIBaseURL(baseURL string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(parsed.Hostname(), agnesAPIHostname)
+}

--- a/relay/channel/task/taskcommon/provider_test.go
+++ b/relay/channel/task/taskcommon/provider_test.go
@@ -1,0 +1,29 @@
+package taskcommon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAgnesAPIBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		want    bool
+	}{
+		{name: "official host", baseURL: "https://apihub.agnes-ai.com", want: true},
+		{name: "official host with path", baseURL: "https://apihub.agnes-ai.com/v1", want: true},
+		{name: "case insensitive", baseURL: "https://APIHUB.AGNES-AI.COM", want: true},
+		{name: "different provider", baseURL: "https://api.openai.com", want: false},
+		{name: "lookalike suffix", baseURL: "https://apihub.agnes-ai.com.evil.example", want: false},
+		{name: "lookalike subdomain", baseURL: "https://cdn.apihub.agnes-ai.com", want: false},
+		{name: "invalid URL", baseURL: "://invalid", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsAgnesAPIBaseURL(tt.baseURL))
+		})
+	}
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
为 Agnes 官方 API 主机 `apihub.agnes-ai.com` 补充异步视频任务兼容：

- 状态轮询改用 `/agnesapi?video_id=<id>`。
- 任务完成后读取 `metadata.url`，并由现有视频代理在 SSRF 校验后转发该绝对 URL。
- 转发 Agnes CDN 结果时不携带渠道密钥。
- 使用 URL 解析后的精确 hostname 判断 Agnes；其他 OpenAI/Sora 渠道继续使用原有 `/v1/videos/{id}`、`/content` 路径和鉴权逻辑。

AI assistance disclosure: This change was prepared with AI assistance. The scope constraints, implementation, and tests were reviewed during preparation; no credentials or deployment changes are included.

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- N/A

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```text
go test ./relay/channel/task/taskcommon ./relay/channel/task/sora ./controller
ok github.com/QuantumNous/new-api/relay/channel/task/taskcommon
ok github.com/QuantumNous/new-api/relay/channel/task/sora
ok github.com/QuantumNous/new-api/controller

go test ./relay/channel/task/... ./service
# all task adapter packages passed; the one unrelated service package failure passed when rerun in isolation
go test ./service -run TestObserveChannelAffinityUsageCacheByRelayFormat_UnsupportedModeKeepsEmpty -count=1
ok github.com/QuantumNous/new-api/service
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video task handling for Agnes API endpoints.
  * Completed Agnes video tasks now use the returned video URL when available.
  * Agnes tasks use the appropriate status endpoint for reliable progress updates.
  * Preserved standard video URL and authentication behavior for other providers.
  * Added safeguards to prevent lookalike or invalid domains from being treated as Agnes endpoints.
  * Improved reliability when retrieving and displaying completed video results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->