### PR TITLE
fix: 对齐 Replicate 原生图片参数

### DIFF
--- a/relay/channel/replicate/adaptor.go
+++ b/relay/channel/replicate/adaptor.go
@@ -73,10 +73,6 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 			request.Prompt = v
 		}
 	}
-	if strings.TrimSpace(request.Prompt) == "" {
-		return nil, errors.New("replicate adaptor: prompt is required")
-	}
-
 	modelName := strings.TrimSpace(info.UpstreamModelName)
 	if modelName == "" {
 		modelName = strings.TrimSpace(request.Model)
@@ -87,6 +83,33 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 	info.UpstreamModelName = modelName
 
 	info.RequestURLPath = fmt.Sprintf("/v1/models/%s/predictions", modelName)
+	nativeInputRaw, hasNativeInput := request.Extra["input"]
+	if hasNativeInput {
+		if common.GetJsonType(nativeInputRaw) != "object" {
+			return nil, errors.New("replicate adaptor: input must be a JSON object")
+		}
+		inputPayload := make(map[string]any)
+		if err := common.Unmarshal(nativeInputRaw, &inputPayload); err != nil {
+			return nil, fmt.Errorf("replicate adaptor: failed to decode input: %w", err)
+		}
+		if _, ok := inputPayload["prompt"]; !ok {
+			if strings.TrimSpace(request.Prompt) == "" {
+				return nil, errors.New("replicate adaptor: prompt is required")
+			}
+			inputPayload["prompt"] = request.Prompt
+		}
+		_, hasNumberOfImages := inputPayload["number_of_images"]
+		_, hasNumOutputs := inputPayload["num_outputs"]
+		if lo.FromPtrOr(request.N, uint(0)) > 1 && !hasNumberOfImages && !hasNumOutputs {
+			return nil, errors.New("replicate adaptor: n greater than 1 requires input.number_of_images or input.num_outputs")
+		}
+		return map[string]any{
+			"input": inputPayload,
+		}, nil
+	}
+	if strings.TrimSpace(request.Prompt) == "" {
+		return nil, errors.New("replicate adaptor: prompt is required")
+	}
 
 	inputPayload := make(map[string]any)
 	inputPayload["prompt"] = request.Prompt
@@ -146,16 +169,6 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 	}
 
 	for key, raw := range request.Extra {
-		if strings.EqualFold(key, "input") {
-			var extraInput map[string]any
-			if err := common.Unmarshal(raw, &extraInput); err != nil {
-				return nil, fmt.Errorf("replicate adaptor: failed to decode extra input: %w", err)
-			}
-			for k, v := range extraInput {
-				inputPayload[k] = v
-			}
-			continue
-		}
 		if raw == nil {
 			continue
 		}

--- a/relay/channel/replicate/adaptor_test.go
+++ b/relay/channel/replicate/adaptor_test.go
@@ -1,0 +1,163 @@
+package replicate
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertImageRequestNativeInputIsAuthoritative(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+
+	n := uint(2)
+	request := dto.ImageRequest{
+		Model:        "public-model-name",
+		Prompt:       "outer prompt",
+		N:            &n,
+		Size:         "1792x1024",
+		Quality:      "high",
+		OutputFormat: []byte(`"jpeg"`),
+		Extra: map[string]json.RawMessage{
+			"input": []byte(`{
+				"prompt":"native prompt",
+				"input_images":["data:image/png;base64,abc","data:image/png;base64,def"],
+				"number_of_images":2,
+				"aspect_ratio":"16:9",
+				"quality":"low",
+				"output_format":"png"
+			}`),
+		},
+	}
+	info := &relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeImagesGenerations,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "openai/gpt-image-2",
+		},
+	}
+
+	copiedRequest, err := common.DeepCopy(&request)
+	require.NoError(t, err)
+	converted, err := (&Adaptor{}).ConvertImageRequest(c, info, *copiedRequest)
+	require.NoError(t, err)
+	payload, ok := converted.(map[string]any)
+	require.True(t, ok)
+	input, ok := payload["input"].(map[string]any)
+	require.True(t, ok)
+
+	assert.Equal(t, "native prompt", input["prompt"])
+	assert.Equal(t, float64(2), input["number_of_images"])
+	assert.Equal(t, "16:9", input["aspect_ratio"])
+	assert.Equal(t, "low", input["quality"])
+	assert.Equal(t, "png", input["output_format"])
+	assert.NotContains(t, input, "num_outputs")
+	assert.NotContains(t, input, "prompt_upsampling")
+	assert.NotContains(t, input, "image_prompt")
+	assert.Equal(t, "/v1/models/openai/gpt-image-2/predictions", info.RequestURLPath)
+}
+
+func TestConvertImageRequestNativeInputCanProvidePrompt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name        string
+		outerPrompt string
+		nativeInput string
+		wantPrompt  string
+	}{
+		{
+			name:        "native prompt supports absent outer prompt",
+			nativeInput: `{"prompt":"native prompt","quality":"high"}`,
+			wantPrompt:  "native prompt",
+		},
+		{
+			name:        "outer prompt fills missing native prompt",
+			outerPrompt: "outer prompt",
+			nativeInput: `{"quality":"high"}`,
+			wantPrompt:  "outer prompt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+
+			converted, err := (&Adaptor{}).ConvertImageRequest(c, &relaycommon.RelayInfo{
+				ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "custom/model"},
+			}, dto.ImageRequest{
+				Prompt: tt.outerPrompt,
+				Extra: map[string]json.RawMessage{
+					"input": []byte(tt.nativeInput),
+				},
+			})
+			require.NoError(t, err)
+
+			payload, ok := converted.(map[string]any)
+			require.True(t, ok)
+			input, ok := payload["input"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantPrompt, input["prompt"])
+		})
+	}
+}
+
+func TestConvertImageRequestRejectsUnreconciledNativeCount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+
+	n := uint(3)
+	_, err := (&Adaptor{}).ConvertImageRequest(c, &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{},
+	}, dto.ImageRequest{
+		Model:  "openai/gpt-image-2",
+		Prompt: "a cat",
+		N:      &n,
+		Extra: map[string]json.RawMessage{
+			"input": []byte(`{"quality":"high"}`),
+		},
+	})
+
+	require.EqualError(t, err, "replicate adaptor: n greater than 1 requires input.number_of_images or input.num_outputs")
+}
+
+func TestConvertImageRequestLegacyFluxMappingRemainsCompatible(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+
+	n := uint(2)
+	converted, err := (&Adaptor{}).ConvertImageRequest(c, &relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeImagesGenerations,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: ModelFlux11Pro,
+		},
+	}, dto.ImageRequest{
+		Prompt:  "a cat",
+		N:       &n,
+		Size:    "1792x1024",
+		Quality: "high",
+	})
+	require.NoError(t, err)
+	payload, ok := converted.(map[string]any)
+	require.True(t, ok)
+	input, ok := payload["input"].(map[string]any)
+	require.True(t, ok)
+
+	assert.Equal(t, "a cat", input["prompt"])
+	assert.Equal(t, 2, input["num_outputs"])
+	assert.Equal(t, "16:9", input["aspect_ratio"])
+	assert.Equal(t, true, input["prompt_upsampling"])
+}

--- a/relay/helper/openai_image_request_test.go
+++ b/relay/helper/openai_image_request_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/gin-gonic/gin"
@@ -157,4 +158,123 @@ func TestGetAndValidOpenAIImageRequestNBounds(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), boundErr)
 	})
+}
+
+func TestGetAndValidOpenAIImageRequestReplicateCount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name    string
+		body    string
+		wantN   uint
+		wantErr string
+	}{
+		{
+			name:  "number_of_images controls billing count",
+			body:  `{"model":"openai/gpt-image-2","prompt":"a cat","input":{"number_of_images":10}}`,
+			wantN: 10,
+		},
+		{
+			name:  "num_outputs controls billing count",
+			body:  `{"model":"black-forest-labs/flux-1.1-pro","prompt":"a cat","input":{"num_outputs":4}}`,
+			wantN: 4,
+		},
+		{
+			name:  "matching outer and native counts are accepted",
+			body:  `{"model":"openai/gpt-image-2","prompt":"a cat","n":3,"input":{"number_of_images":3}}`,
+			wantN: 3,
+		},
+		{
+			name:    "conflicting native count fields are rejected",
+			body:    `{"model":"openai/gpt-image-2","prompt":"a cat","input":{"number_of_images":2,"num_outputs":3}}`,
+			wantErr: "input.num_outputs must match input.number_of_images",
+		},
+		{
+			name:    "outer count mismatch is rejected",
+			body:    `{"model":"openai/gpt-image-2","prompt":"a cat","n":2,"input":{"number_of_images":3}}`,
+			wantErr: "n must match input.number_of_images",
+		},
+		{
+			name:    "zero native count is rejected",
+			body:    `{"model":"openai/gpt-image-2","prompt":"a cat","input":{"number_of_images":0}}`,
+			wantErr: "input.number_of_images must be an integer between 1",
+		},
+		{
+			name:    "native count above shared maximum is rejected",
+			body:    fmt.Sprintf(`{"model":"openai/gpt-image-2","prompt":"a cat","input":{"number_of_images":%d}}`, dto.MaxImageN+1),
+			wantErr: "input.number_of_images must be an integer between 1",
+		},
+		{
+			name:    "native input must be an object",
+			body:    `{"model":"openai/gpt-image-2","prompt":"a cat","input":[]}`,
+			wantErr: "input must be a JSON object",
+		},
+		{
+			name:  "native input without count defaults billing to one",
+			body:  `{"model":"openai/gpt-image-2","prompt":"a cat","input":{"quality":"high"}}`,
+			wantN: 1,
+		},
+		{
+			name:    "outer count requires a native count declaration",
+			body:    `{"model":"openai/gpt-image-2","prompt":"a cat","n":3,"input":{"quality":"high"}}`,
+			wantErr: "n greater than 1 requires input.number_of_images or input.num_outputs",
+		},
+		{
+			name:  "legacy top-level count controls billing",
+			body:  `{"model":"custom-replicate-model","prompt":"a cat","number_of_images":5}`,
+			wantN: 5,
+		},
+		{
+			name:  "legacy extra_fields count controls billing",
+			body:  `{"model":"custom-replicate-model","prompt":"a cat","extra_fields":{"num_outputs":6}}`,
+			wantN: 6,
+		},
+		{
+			name:    "legacy top-level count cannot bypass outer n",
+			body:    `{"model":"custom-replicate-model","prompt":"a cat","n":1,"num_outputs":6}`,
+			wantErr: "n must match num_outputs",
+		},
+		{
+			name:    "legacy extra_fields count is bounded",
+			body:    fmt.Sprintf(`{"model":"custom-replicate-model","prompt":"a cat","extra_fields":{"num_outputs":%d}}`, dto.MaxImageN+1),
+			wantErr: "extra_fields.num_outputs must be an integer between 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewBufferString(tt.body))
+			c.Request.Header.Set("Content-Type", "application/json")
+			common.SetContextKey(c, constant.ContextKeyChannelType, constant.ChannelTypeReplicate)
+
+			req, err := GetAndValidOpenAIImageRequest(c, relayconstant.RelayModeImagesGenerations)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, req.N)
+			require.Equal(t, tt.wantN, *req.N)
+			require.Equal(t, float64(tt.wantN), req.GetTokenCountMeta().BillingRatios["n"])
+		})
+	}
+}
+
+func TestGetAndValidOpenAIImageRequestDoesNotApplyReplicateCountsToOtherChannels(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/v1/images/generations",
+		bytes.NewBufferString(`{"model":"gpt-image-1","prompt":"a cat","number_of_images":"provider-specific"}`),
+	)
+	c.Request.Header.Set("Content-Type", "application/json")
+	common.SetContextKey(c, constant.ContextKeyChannelType, constant.ChannelTypeOpenAI)
+
+	req, err := GetAndValidOpenAIImageRequest(c, relayconstant.RelayModeImagesGenerations)
+	require.NoError(t, err)
+	require.NotNil(t, req.N)
+	require.Equal(t, uint(1), *req.N)
 }

--- a/relay/helper/valid_request.go
+++ b/relay/helper/valid_request.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/logger"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/relaykit/dto"
@@ -121,6 +122,11 @@ func GetAndValidateEmbeddingRequest(c *gin.Context, relayMode int) (*dto.Embeddi
 // overflow the conversion and corrupt billing.
 const maxTokensLimit = math.MaxInt32 / 2
 
+type imageCountDeclaration struct {
+	name  string
+	value uint
+}
+
 func exceedsMaxTokensLimit(values ...*uint) bool {
 	for _, v := range values {
 		if lo.FromPtrOr(v, uint(0)) > maxTokensLimit {
@@ -128,6 +134,78 @@ func exceedsMaxTokensLimit(values ...*uint) bool {
 		}
 	}
 	return false
+}
+
+func imageCountDeclarationsFromObject(raw []byte, source string) ([]imageCountDeclaration, error) {
+	if common.GetJsonType(raw) != "object" {
+		return nil, fmt.Errorf("%s must be a JSON object", source)
+	}
+	var fields struct {
+		NumberOfImages *uint `json:"number_of_images"`
+		NumOutputs     *uint `json:"num_outputs"`
+	}
+	if err := common.Unmarshal(raw, &fields); err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", source, err)
+	}
+
+	declarations := make([]imageCountDeclaration, 0, 2)
+	if fields.NumberOfImages != nil {
+		declarations = append(declarations, imageCountDeclaration{name: source + ".number_of_images", value: *fields.NumberOfImages})
+	}
+	if fields.NumOutputs != nil {
+		declarations = append(declarations, imageCountDeclaration{name: source + ".num_outputs", value: *fields.NumOutputs})
+	}
+	return declarations, nil
+}
+
+func normalizeImageRequestCount(imageRequest *dto.ImageRequest) error {
+	declarations := make([]imageCountDeclaration, 0, 4)
+	nativeInputRaw, hasNativeInput := imageRequest.Extra["input"]
+	if hasNativeInput {
+		nativeDeclarations, err := imageCountDeclarationsFromObject(nativeInputRaw, "input")
+		if err != nil {
+			return err
+		}
+		declarations = append(declarations, nativeDeclarations...)
+	} else {
+		if len(imageRequest.ExtraFields) > 0 {
+			extraDeclarations, err := imageCountDeclarationsFromObject(imageRequest.ExtraFields, "extra_fields")
+			if err != nil {
+				return err
+			}
+			declarations = append(declarations, extraDeclarations...)
+		}
+		for _, name := range []string{"number_of_images", "num_outputs"} {
+			raw, ok := imageRequest.Extra[name]
+			if !ok {
+				continue
+			}
+			var value uint
+			if err := common.Unmarshal(raw, &value); err != nil {
+				return fmt.Errorf("invalid %s: %w", name, err)
+			}
+			declarations = append(declarations, imageCountDeclaration{name: name, value: value})
+		}
+	}
+
+	effectiveName := "n"
+	for _, declaration := range declarations {
+		if declaration.value == 0 || declaration.value > dto.MaxImageN {
+			return fmt.Errorf("%s must be an integer between 1 and %d", declaration.name, dto.MaxImageN)
+		}
+		if imageRequest.N != nil && *imageRequest.N != 0 && *imageRequest.N != declaration.value {
+			if effectiveName == "n" {
+				return fmt.Errorf("n must match %s", declaration.name)
+			}
+			return fmt.Errorf("%s must match %s", declaration.name, effectiveName)
+		}
+		imageRequest.N = common.GetPointer(declaration.value)
+		effectiveName = declaration.name
+	}
+	if hasNativeInput && len(declarations) == 0 && imageRequest.N != nil && *imageRequest.N > 1 {
+		return errors.New("n greater than 1 requires input.number_of_images or input.num_outputs for Replicate native input")
+	}
+	return nil
 }
 
 func GetAndValidateResponsesRequest(c *gin.Context) (*dto.OpenAIResponsesRequest, error) {
@@ -235,6 +313,11 @@ func GetAndValidOpenAIImageRequest(c *gin.Context, relayMode int) (*dto.ImageReq
 		err := common.UnmarshalBodyReusable(c, imageRequest)
 		if err != nil {
 			return nil, err
+		}
+		if common.GetContextKeyInt(c, constant.ContextKeyChannelType) == constant.ChannelTypeReplicate {
+			if err := normalizeImageRequestCount(imageRequest); err != nil {
+				return nil, err
+			}
 		}
 
 		if imageRequest.Model == "" {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本次实现与测试由 Codex 辅助完成；以下摘要已按实际代码路径和验证结果人工整理。

## 📝 变更描述 / Description

NewAPI 的 Replicate 图片适配默认按 Flux 参数组装请求。客户端为其他 Replicate 模型提供原生 `input` 时，旧逻辑仍会注入或转换 `num_outputs`、`image_prompt`、`prompt_upsampling` 等 Flux 参数，可能造成参数冲突或语义不一致。

本 PR 仅处理 Replicate 参数对齐：

- 客户端提供原生 `input` 时，将其作为上游参数的权威来源；仅在其中缺少 `prompt` 时补充外层提示词，不再注入 Flux 专用参数。
- 未提供原生 `input` 时，继续使用现有 Flux 参数转换，保持旧调用兼容。
- 在计费前统一校验 Replicate 的 `n`、`number_of_images` 和 `num_outputs`，覆盖原生 `input`、`extra_fields` 及兼容扩展字段；拒绝超限值和相互冲突的数量，避免实际生成数量与计费数量不一致。
- 数量校验只对 Replicate 渠道生效，不影响其他图片渠道携带同名扩展字段。

例如 `openai/gpt-image-2` 使用 `number_of_images`、`input_images`、`quality` 等原生字段时，不会再被追加 Flux 的 `num_outputs`、`image_prompt` 或 `prompt_upsampling`。

根据维护者建议，本次已移除前端测试迁移、长任务轮询、下载鉴权及通用 `service` 修改；这些内容不在本 PR 范围内。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 暂无关联 Issue；问题来自 Replicate 非 Flux 模型的原生参数兼容场景。

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

已通过：

- `go test ./relay/channel/replicate ./relay/helper -count=1`
- `go test ./relay/... -count=1`
- `go test -race ./relay/channel/replicate -count=1`
- `go test -race ./relay/helper -run 'TestGetAndValidOpenAIImageRequest' -count=1`
- `GOWORK=off go vet ./...`
- `GOWORK=off go build ./...`
- `cd relaykit && GOWORK=off go vet ./...`
- `cd relaykit && GOWORK=off go build ./...`
- `make test`
- `git diff --check`

未执行会产生费用的 Replicate 真机生成；参数转换、旧 Flux 兼容、数量归一化、冲突与边界校验均由确定性回归测试覆盖。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Replicate image requests now support a native `input` object, including prompts supplied within that object.
  - Image counts can be specified using `number_of_images` or `num_outputs`.
  - Image-count values are normalized across supported request formats.

- **Bug Fixes**
  - Added validation for invalid, conflicting, or excessive image-count requests.
  - Native Replicate inputs now take precedence without unintended field merging.
  - Preserved compatibility with legacy Flux request fields and configured prediction paths.
  - Replicate-specific image-count handling no longer affects other channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->