### PR TITLE
relay: emit streamed tool metadata only once

### DIFF
--- a/relaykit/dto/openai_response.go
+++ b/relaykit/dto/openai_response.go
@@ -123,7 +123,7 @@ type ToolCallResponse struct {
 	// Index is not nil only in chat completion chunk object
 	Index    *int             `json:"index,omitempty"`
 	ID       string           `json:"id,omitempty"`
-	Type     any              `json:"type"`
+	Type     any              `json:"type,omitempty"`
 	Function FunctionResponse `json:"function"`
 }
 

--- a/relaykit/relayconvert/internal/oai_responses/to_oai_chat_resp_test.go
+++ b/relaykit/relayconvert/internal/oai_responses/to_oai_chat_resp_test.go
@@ -1,6 +1,7 @@
 package oairesponses
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/QuantumNous/new-api/relaykit/dto"
@@ -244,6 +245,91 @@ func TestResponsesStreamEventToChatChunksCustomToolAndReasoning(t *testing.T) {
 	assert.Equal(t, "patch body", chunks[3].Choices[0].Delta.ToolCalls[0].Function.Arguments)
 	require.NotNil(t, chunks[4].Choices[0].FinishReason)
 	assert.Equal(t, "content_filter", *chunks[4].Choices[0].FinishReason)
+}
+
+func TestResponsesStreamEventToChatChunksEmitsToolMetadataOnlyOnce(t *testing.T) {
+	state := newTestResponsesStreamState()
+	outputIndex := 0
+
+	itemChunks := mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type:        responsesEventOutputItemAdded,
+		OutputIndex: &outputIndex,
+		Item: &dto.ResponsesOutput{
+			Type:   responsesOutputTypeFunctionCall,
+			ID:     "fc_1",
+			CallId: "call_1",
+			Name:   "show_widget",
+		},
+	})
+	firstArgsChunks := mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type:        responsesEventFunctionArgsDelta,
+		OutputIndex: &outputIndex,
+		Delta:       `{"widget_code":"<svg>`,
+	})
+	secondArgsChunks := mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type:        responsesEventFunctionArgsDelta,
+		OutputIndex: &outputIndex,
+		Delta:       `</svg>"}`,
+	})
+
+	require.Len(t, itemChunks, 2)
+	require.Len(t, firstArgsChunks, 1)
+	require.Len(t, secondArgsChunks, 1)
+
+	first := itemChunks[1].Choices[0].Delta.ToolCalls[0]
+	assert.Equal(t, "call_1", first.ID)
+	assert.Equal(t, "function", first.Type)
+	assert.Equal(t, "show_widget", first.Function.Name)
+
+	for _, chunks := range [][]dto.ChatCompletionsStreamResponse{firstArgsChunks, secondArgsChunks} {
+		continuation := chunks[0].Choices[0].Delta.ToolCalls[0]
+		assert.Empty(t, continuation.ID)
+		assert.Nil(t, continuation.Type)
+		assert.Empty(t, continuation.Function.Name)
+
+		encoded, err := json.Marshal(continuation)
+		require.NoError(t, err)
+		assert.NotContains(t, string(encoded), `"id"`)
+		assert.NotContains(t, string(encoded), `"type"`)
+		assert.NotContains(t, string(encoded), `"name"`)
+	}
+}
+
+func TestResponsesStreamEventToChatChunksEmitsMetadataForEachParallelTool(t *testing.T) {
+	state := newTestResponsesStreamState()
+	firstOutputIndex := 0
+	secondOutputIndex := 1
+
+	firstChunks := mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type:        responsesEventOutputItemAdded,
+		OutputIndex: &firstOutputIndex,
+		Item: &dto.ResponsesOutput{
+			Type:   responsesOutputTypeFunctionCall,
+			CallId: "call_1",
+			Name:   "first_tool",
+		},
+	})
+	secondChunks := mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type:        responsesEventOutputItemAdded,
+		OutputIndex: &secondOutputIndex,
+		Item: &dto.ResponsesOutput{
+			Type:   responsesOutputTypeFunctionCall,
+			CallId: "call_2",
+			Name:   "second_tool",
+		},
+	})
+
+	require.Len(t, firstChunks, 2)
+	require.Len(t, secondChunks, 1)
+
+	first := firstChunks[1].Choices[0].Delta.ToolCalls[0]
+	second := secondChunks[0].Choices[0].Delta.ToolCalls[0]
+	assert.Equal(t, "call_1", first.ID)
+	assert.Equal(t, "function", first.Type)
+	assert.Equal(t, 0, *first.Index)
+	assert.Equal(t, "call_2", second.ID)
+	assert.Equal(t, "function", second.Type)
+	assert.Equal(t, 1, *second.Index)
 }
 
 func TestResponsesStreamEventToChatChunksUsesTerminalDoneOutput(t *testing.T) {

--- a/relaykit/relayconvert/internal/oai_responses/to_oai_chat_resp_test.go
+++ b/relaykit/relayconvert/internal/oai_responses/to_oai_chat_resp_test.go
@@ -281,8 +281,11 @@ func TestResponsesStreamEventToChatChunksEmitsToolMetadataOnlyOnce(t *testing.T)
 	assert.Equal(t, "function", first.Type)
 	assert.Equal(t, "show_widget", first.Function.Name)
 
-	for _, chunks := range [][]dto.ChatCompletionsStreamResponse{firstArgsChunks, secondArgsChunks} {
+	for i, chunks := range [][]dto.ChatCompletionsStreamResponse{firstArgsChunks, secondArgsChunks} {
 		continuation := chunks[0].Choices[0].Delta.ToolCalls[0]
+		require.NotNil(t, continuation.Index)
+		assert.Equal(t, 0, *continuation.Index)
+		assert.Equal(t, []string{`{"widget_code":"<svg>`, `</svg>"}`}[i], continuation.Function.Arguments)
 		assert.Empty(t, continuation.ID)
 		assert.Nil(t, continuation.Type)
 		assert.Empty(t, continuation.Function.Name)
@@ -318,6 +321,26 @@ func TestResponsesStreamEventToChatChunksEmitsMetadataForEachParallelTool(t *tes
 			Name:   "second_tool",
 		},
 	})
+	firstArgsChunks := mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type:        responsesEventFunctionArgsDelta,
+		OutputIndex: &firstOutputIndex,
+		Delta:       `{"first":`,
+	})
+	secondArgsChunks := mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type:        responsesEventFunctionArgsDelta,
+		OutputIndex: &secondOutputIndex,
+		Delta:       `{"second":`,
+	})
+	firstArgsEndChunks := mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type:        responsesEventFunctionArgsDelta,
+		OutputIndex: &firstOutputIndex,
+		Delta:       `"one"}`,
+	})
+	secondArgsEndChunks := mustStreamChunks(t, state, &dto.ResponsesStreamResponse{
+		Type:        responsesEventFunctionArgsDelta,
+		OutputIndex: &secondOutputIndex,
+		Delta:       `"two"}`,
+	})
 
 	require.Len(t, firstChunks, 2)
 	require.Len(t, secondChunks, 1)
@@ -330,6 +353,27 @@ func TestResponsesStreamEventToChatChunksEmitsMetadataForEachParallelTool(t *tes
 	assert.Equal(t, "call_2", second.ID)
 	assert.Equal(t, "function", second.Type)
 	assert.Equal(t, 1, *second.Index)
+
+	continuations := []struct {
+		chunks    []dto.ChatCompletionsStreamResponse
+		index     int
+		arguments string
+	}{
+		{firstArgsChunks, 0, `{"first":`},
+		{secondArgsChunks, 1, `{"second":`},
+		{firstArgsEndChunks, 0, `"one"}`},
+		{secondArgsEndChunks, 1, `"two"}`},
+	}
+	for _, tt := range continuations {
+		require.Len(t, tt.chunks, 1)
+		continuation := tt.chunks[0].Choices[0].Delta.ToolCalls[0]
+		require.NotNil(t, continuation.Index)
+		assert.Equal(t, tt.index, *continuation.Index)
+		assert.Equal(t, tt.arguments, continuation.Function.Arguments)
+		assert.Empty(t, continuation.ID)
+		assert.Nil(t, continuation.Type)
+		assert.Empty(t, continuation.Function.Name)
+	}
 }
 
 func TestResponsesStreamEventToChatChunksUsesTerminalDoneOutput(t *testing.T) {

--- a/relaykit/relayconvert/internal/oai_responses/to_oai_chat_stream_resp.go
+++ b/relaykit/relayconvert/internal/oai_responses/to_oai_chat_stream_resp.go
@@ -397,24 +397,24 @@ func (s *ResponsesToChatStreamState) toolDelta(tool *responsesStreamTool, explic
 	}
 
 	chunks := s.ensureStart()
-	callID := strings.TrimSpace(tool.CallID)
-	if callID == "" {
-		callID = tool.Key
-	}
 	responseTool := dto.ToolCallResponse{
-		ID:   callID,
-		Type: "function",
 		Function: dto.FunctionResponse{
 			Arguments: argsDelta,
 		},
 	}
 	responseTool.SetIndex(tool.Index)
+	if !tool.Sent {
+		callID := strings.TrimSpace(tool.CallID)
+		if callID == "" {
+			callID = tool.Key
+		}
+		responseTool.ID = callID
+		responseTool.Type = "function"
+		tool.Sent = true
+	}
 	if !tool.NameSent && tool.Name != "" {
 		responseTool.Function.Name = tool.Name
 		tool.NameSent = true
-	}
-	if !tool.Sent {
-		tool.Sent = true
 	}
 	if argsDelta != "" {
 		tool.ArgsSentAt += len(argsDelta)


### PR DESCRIPTION
## Summary

- emit `id`, `type`, and function `name` only on the first Responses-to-Chat tool-call chunk
- keep continuation chunks keyed by `index` with argument deltas only
- omit an empty `type` field instead of serializing it as `null`
- add regressions for long argument continuations and parallel tool calls

## Why

The Responses-to-Chat streaming converter currently repeats the same call ID and type on every function-argument delta. Although the chunks keep the same tool index, some OpenAI-compatible clients interpret each repeated ID as a new tool call. For a large tool payload, one logical call can therefore become many calls; only the first fragment has a function name and later fragments fail as unnamed tools.

This is distinct from the duplicate-index issue fixed in #6225: the tool index is stable, but call metadata is still repeated on every continuation chunk.

OpenAI-style streaming only needs the call metadata on the initial chunk. Subsequent chunks can safely contain the stable index and argument delta.

## Validation

- `cd relaykit && GOMAXPROCS=2 go test -p 2 ./...`
- production-shaped long tool stream: 857 chunks, one tool index, exactly one ID/type/name, and arguments reconstructed as valid JSON
- parallel-tool regression confirms each new tool still receives its own metadata and index
- end-to-end client validation completed a 200-line streamed tool write without producing unnamed or duplicate tool calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed tool-call responses so identifiers and types appear only on the initial chunk.
  * Prevented repeated tool metadata in subsequent argument updates.
  * Preserved correct metadata handling for multiple parallel tool calls.

* **Tests**
  * Added coverage for streamed tool calls, including incremental arguments and parallel calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->