### PR TITLE
fix: finalize Claude streams after upstream EOF

### DIFF
--- a/relay/channel/openai/claude_stream_terminal_test.go
+++ b/relay/channel/openai/claude_stream_terminal_test.go
@@ -1,0 +1,79 @@
+package openai
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/relaykit/relayconvert/convmeta"
+	"github.com/QuantumNous/new-api/relaykit/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOaiStreamHandlerFinalizesClaudeStreamWithoutTerminalChunk(t *testing.T) {
+	oldMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(oldMode) })
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1710000000,"model":"coding-deepseek","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1710000000,"model":"coding-deepseek","choices":[{"index":0,"delta":{"reasoning_content":"thinking"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1710000000,"model":"coding-deepseek","choices":[{"index":0,"delta":{"content":"XAG_OK"},"finish_reason":null}]}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	c.Set(common.RequestIdKey, "claude-terminal-test")
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "coding-deepseek",
+		},
+		RelayMode:   relayconstant.RelayModeChatCompletions,
+		RelayFormat: types.RelayFormatClaude,
+		DisablePing: true,
+		ClaudeConvertInfo: &convmeta.ClaudeConvertInfo{
+			LastMessagesType: convmeta.LastMessageTypeNone,
+		},
+	}
+
+	usage, relayErr := OaiStreamHandler(c, info, resp)
+	require.Nil(t, relayErr)
+	require.NotNil(t, usage)
+
+	got := recorder.Body.String()
+	assert.Equal(t, 1, strings.Count(got, "event: message_start\n"))
+	assert.Equal(t, 2, strings.Count(got, "event: content_block_stop\n"))
+	assert.Equal(t, 1, strings.Count(got, "event: message_delta\n"))
+	assert.Equal(t, 1, strings.Count(got, "event: message_stop\n"))
+	assert.Contains(t, got, `"text":"XAG_OK"`)
+	assert.Contains(t, got, `"stop_reason":"end_turn"`)
+	requireOrderedSubstrings(t, got,
+		"event: message_start\n",
+		`"type":"thinking_delta"`,
+		"event: content_block_stop\n",
+		`"type":"text_delta","text":"XAG_OK"`,
+		"event: content_block_stop\n",
+		"event: message_delta\n",
+		"event: message_stop\n",
+	)
+}

--- a/relay/channel/openai/helper.go
+++ b/relay/channel/openai/helper.go
@@ -194,7 +194,9 @@ func HandleFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, lastStream
 		for _, resp := range claudeResponses {
 			_ = helper.ClaudeData(c, *resp)
 		}
-		info.ClaudeConvertInfo.Done = true
+		for _, resp := range relayconvert.FinalizeStreamResponseOpenAI2Claude(info) {
+			_ = helper.ClaudeData(c, *resp)
+		}
 
 	case types.RelayFormatGemini:
 		var streamResponse dto.ChatCompletionsStreamResponse

--- a/relaykit/relayconvert/response_compat.go
+++ b/relaykit/relayconvert/response_compat.go
@@ -28,6 +28,10 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 	return oaichat.StreamResponseOpenAI2Claude(openAIResponse, info)
 }
 
+func FinalizeStreamResponseOpenAI2Claude(info convmeta.Meta) []*dto.ClaudeResponse {
+	return oaichat.FinalizeStreamResponseOpenAI2Claude(info)
+}
+
 func StopReasonClaudeToOpenAI(reason string) string {
 	return claudemessages.StopReasonClaudeToOpenAI(reason)
 }


### PR DESCRIPTION
## 📝 变更描述 / Description

修复 OpenAI 兼容流在发送 `[DONE]` 或直接 EOF、但没有可转换的终止 chunk 时，Claude Messages 流缺少结束事件的问题。

此前 `HandleFinalResponse` 只处理最后一个普通 chunk，随后直接将转换状态标记为完成。若上游没有提供 `finish_reason` 终止 chunk，当前 content block 不会关闭，`message_delta` 和 `message_stop` 也不会发送，Claude Code 等严格等待 Anthropic SSE 结束事件的客户端会一直停留在生成状态。

本次改动在处理最后一个 chunk 后调用现有的 Claude 流 finalizer，由转换状态统一补齐仍未发送的 `content_block_stop`、`message_delta` 和 `message_stop`。正常已完成的流会由 `Done` 状态阻止重复结束事件。

同时增加端到端回归测试，覆盖 reasoning、text、`[DONE]` 的事件顺序及终止事件数量。

与 #5345 的区别：该 PR 修改的是重构前的 `service/convert.go` 路径；本 PR 针对当前 `relaykit` 架构下无 `finish_reason` 终止 chunk 的 `[DONE]`/EOF 收尾路径，不改变正常终止 chunk 的 usage 处理逻辑。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Related to #4697

## ✅ 提交前检查项 / Checklist

- [x] **非重复提交:** 已检索现有 Issues 与 PRs，并在变更描述中说明与相近 PR 的差异。
- [x] **Bug fix 说明:** 已关联相同结束事件缺失症状的 Issue。
- [x] **变更理解:** 已确认 EOF 收尾路径通过现有 finalizer 生成完整 Claude SSE 生命周期。
- [x] **范围聚焦:** 本 PR 未包含与当前问题无关的代码改动。
- [x] **本地验证:** 已运行定向回归测试并通过。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```text
$ GOWORK=off go test -vet=off ./relay/channel/openai -run TestOaiStreamHandlerFinalizesClaudeStreamWithoutTerminalChunk -count=1
ok  github.com/QuantumNous/new-api/relay/channel/openai  0.941s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Claude-format streaming responses when the upstream stream ends with `[DONE]` without a separate terminal chunk.
  - Final response events are now emitted correctly, including the completed text, usage information, event ordering, and `end_turn` stop reason.
  - Ensures streamed Claude responses conclude reliably and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->