### PR TITLE
fix: finalize Claude streams after upstream EOF

### DIFF
--- a/relay/channel/openai/helper.go
+++ b/relay/channel/openai/helper.go
@@ -194,7 +194,9 @@ func HandleFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, lastStream
 		for _, resp := range claudeResponses {
 			_ = helper.ClaudeData(c, *resp)
 		}
-		info.ClaudeConvertInfo.Done = true
+		for _, resp := range relayconvert.FinalizeStreamResponseOpenAI2Claude(info) {
+			_ = helper.ClaudeData(c, *resp)
+		}
 
 	case types.RelayFormatGemini:
 		var streamResponse dto.ChatCompletionsStreamResponse

--- a/relaykit/relayconvert/response_compat.go
+++ b/relaykit/relayconvert/response_compat.go
@@ -28,6 +28,10 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 	return oaichat.StreamResponseOpenAI2Claude(openAIResponse, info)
 }
 
+func FinalizeStreamResponseOpenAI2Claude(info convmeta.Meta) []*dto.ClaudeResponse {
+	return oaichat.FinalizeStreamResponseOpenAI2Claude(info)
+}
+
 func StopReasonClaudeToOpenAI(reason string) string {
 	return claudemessages.StopReasonClaudeToOpenAI(reason)
 }


### PR DESCRIPTION
## 📝 变更描述 / Description

修复 OpenAI 兼容流在发送 `[DONE]` 或直接 EOF、但没有可转换的终止 chunk 时，Claude Messages 流缺少结束事件的问题。

此前 `HandleFinalResponse` 处理最后一个普通 chunk 后会直接将转换状态标记为完成。若上游没有提供 `finish_reason` 终止 chunk，当前 content block 不会关闭，`message_delta` 和 `message_stop` 也不会发送，Claude Code 等等待 Anthropic SSE 结束事件的客户端会一直停留在生成状态。

本次改动在处理最后一个 chunk 后调用现有的 Claude 流 finalizer，由转换状态统一补齐仍未发送的 `content_block_stop`、`message_delta` 和 `message_stop`。正常已完成的流会由 `Done` 状态阻止重复结束事件。

同时在 `relayconvert` 兼容入口中暴露 finalizer，供 OpenAI relay 的 EOF 收尾路径调用。

本 PR 仅修改两个源码文件，不包含测试文件。

与 #5345 的区别：该 PR 修改的是重构前的 `service/convert.go` 路径；本 PR 针对当前 `relaykit` 架构下无 `finish_reason` 终止 chunk 的 `[DONE]`/EOF 收尾路径，不改变正常终止 chunk 的 usage 处理逻辑。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Related to #4697

## ✅ 提交前检查项 / Checklist

- [x] **非重复提交:** 已检索现有 Issues 与 PRs，并在变更描述中说明与相近 PR 的差异。
- [x] **Bug fix 说明:** 已关联相同结束事件缺失症状的 Issue。
- [x] **变更理解:** 已确认 EOF 收尾路径通过现有 finalizer 生成完整 Claude SSE 生命周期。
- [x] **范围聚焦:** 本 PR 仅包含两个相关源码文件的修改。
- [x] **本地验证:** 已通过包级编译检查。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```text
$ GOWORK=off go test -vet=off ./relay/channel/openai -run '^$' -count=1
ok  github.com/QuantumNous/new-api/relay/channel/openai  0.686s [no tests to run]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude response handling when using OpenAI-compatible streaming.
  * Ensured final streamed responses are emitted correctly after conversion completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->