### PR TITLE
fix(profile): stop regenerating the access token when the dialog opens

### DIFF
--- a/web/src/features/profile/components/dialogs/access-token-dialog.tsx
+++ b/web/src/features/profile/components/dialogs/access-token-dialog.tsx
@@ -16,10 +16,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { RefreshCw, Loader2 } from 'lucide-react'
-import { useEffect } from 'react'
+import { RefreshCw, Loader2, KeyRound } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import { CopyButton } from '@/components/copy-button'
 import { Dialog } from '@/components/dialog'
 import { Button } from '@/components/ui/button'
@@ -43,76 +44,114 @@ export function AccessTokenDialog({
 }: AccessTokenDialogProps) {
   const { t } = useTranslation()
   const { token, generating, generate } = useAccessToken()
+  const [confirmOpen, setConfirmOpen] = useState(false)
 
-  // Auto-generate token when dialog opens if no token exists
+  // Regenerating invalidates the previous token server-side and cannot be
+  // undone, so it must never happen as a side effect of opening this dialog.
+  // The confirmation state is reset on close so a reopened dialog starts idle.
   useEffect(() => {
-    if (open && !token) {
-      generate()
+    if (!open) {
+      setConfirmOpen(false)
     }
-  }, [open, token, generate])
+  }, [open])
+
+  const handleConfirm = async () => {
+    setConfirmOpen(false)
+    await generate()
+  }
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={onOpenChange}
-      title={t('Access Token')}
-      description={t(
-        "Your system access token for API authentication. Keep it secure and don't share it with others."
-      )}
-      contentClassName='sm:max-w-md'
-      contentHeight='auto'
-      bodyClassName='space-y-4'
-      footer={
-        <>
-          <Button
-            type='button'
-            variant='outline'
-            onClick={() => onOpenChange(false)}
-          >
-            {t('Close')}
-          </Button>
-          <Button
-            type='button'
-            onClick={generate}
-            disabled={generating}
-            className='gap-2'
-          >
-            {generating ? (
-              <Loader2 className='h-4 w-4 animate-spin' />
-            ) : (
-              <RefreshCw className='h-4 w-4' />
-            )}
-            {generating ? t('Generating...') : t('Regenerate')}
-          </Button>
-        </>
-      }
-    >
-      <div className='my-6 space-y-4'>
-        <div className='space-y-2'>
-          <Label htmlFor='token'>{t('Token')}</Label>
-          <div className='flex gap-2'>
-            <Input
-              id='token'
-              type='text'
-              value={token}
-              readOnly
-              className='font-mono text-xs'
-              placeholder={t('Click "Generate" to create a token')}
-            />
-            <CopyButton
-              value={token}
+    <>
+      <Dialog
+        open={open}
+        onOpenChange={onOpenChange}
+        title={t('Access Token')}
+        description={t(
+          "Your system access token for API authentication. Keep it secure and don't share it with others."
+        )}
+        contentClassName='sm:max-w-md'
+        contentHeight='auto'
+        bodyClassName='space-y-4'
+        footer={
+          <>
+            <Button
+              type='button'
               variant='outline'
-              className='size-9'
-              iconClassName='size-4'
-              tooltip={t('Copy token')}
-              aria-label={t('Copy token')}
-            />
-          </div>
-          <p className='text-muted-foreground text-xs'>
-            {t('Use this token for API authentication')}
-          </p>
+              onClick={() => onOpenChange(false)}
+            >
+              {t('Close')}
+            </Button>
+            <Button
+              type='button'
+              variant={token ? 'default' : 'destructive'}
+              onClick={() => setConfirmOpen(true)}
+              disabled={generating}
+              className='gap-2'
+            >
+              {generating ? (
+                <Loader2 className='h-4 w-4 animate-spin' />
+              ) : (
+                <RefreshCw className='h-4 w-4' />
+              )}
+              {generating ? t('Generating...') : t('Regenerate')}
+            </Button>
+          </>
+        }
+      >
+        <div className='my-6 space-y-4'>
+          {token ? (
+            <div className='space-y-2'>
+              <Label htmlFor='token'>{t('Token')}</Label>
+              <div className='flex gap-2'>
+                <Input
+                  id='token'
+                  type='text'
+                  value={token}
+                  readOnly
+                  className='font-mono text-xs'
+                />
+                <CopyButton
+                  value={token}
+                  variant='outline'
+                  className='size-9'
+                  iconClassName='size-4'
+                  tooltip={t('Copy token')}
+                  aria-label={t('Copy token')}
+                />
+              </div>
+              <p className='text-muted-foreground text-xs'>
+                {t(
+                  'This token is shown only once. Store it now — it cannot be retrieved later.'
+                )}
+              </p>
+            </div>
+          ) : (
+            <div className='flex flex-col items-center gap-3 py-4 text-center'>
+              <div className='bg-muted flex size-10 items-center justify-center rounded-full'>
+                <KeyRound className='text-muted-foreground size-5' />
+              </div>
+              <p className='text-muted-foreground text-sm'>
+                {t(
+                  'For security reasons the existing token cannot be displayed again. Regenerating creates a new token and invalidates the current one immediately.'
+                )}
+              </p>
+            </div>
+          )}
         </div>
-      </div>
-    </Dialog>
+      </Dialog>
+
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        destructive
+        isLoading={generating}
+        title={t('Regenerate access token?')}
+        desc={t(
+          'The current token stops working immediately. Any integration still using it will fail until you update it with the new token.'
+        )}
+        confirmText={t('Regenerate')}
+        handleConfirm={handleConfirm}
+      />
+    </>
   )
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -5248,6 +5248,10 @@
     "Zero retention": "Zero retention",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Regenerate access token?": "Regenerate access token?",
+    "This token is shown only once. Store it now — it cannot be retrieved later.": "This token is shown only once. Store it now — it cannot be retrieved later.",
+    "For security reasons the existing token cannot be displayed again. Regenerating creates a new token and invalidates the current one immediately.": "For security reasons the existing token cannot be displayed again. Regenerating creates a new token and invalidates the current one immediately.",
+    "The current token stops working immediately. Any integration still using it will fail until you update it with the new token.": "The current token stops working immediately. Any integration still using it will fail until you update it with the new token."
   }
 }

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -5248,6 +5248,10 @@
     "Zero retention": "Aucune rétention",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Regenerate access token?": "Régénérer le jeton d'accès ?",
+    "This token is shown only once. Store it now — it cannot be retrieved later.": "Ce jeton n'est affiché qu'une seule fois. Enregistrez-le maintenant, il ne pourra plus être récupéré ensuite.",
+    "For security reasons the existing token cannot be displayed again. Regenerating creates a new token and invalidates the current one immediately.": "Pour des raisons de sécurité, le jeton existant ne peut pas être affiché à nouveau. La régénération crée un nouveau jeton et invalide immédiatement l'actuel.",
+    "The current token stops working immediately. Any integration still using it will fail until you update it with the new token.": "Le jeton actuel cesse de fonctionner immédiatement. Toute intégration l'utilisant encore échouera jusqu'à ce que vous la mettiez à jour avec le nouveau jeton."
   }
 }

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -5248,6 +5248,10 @@
     "Zero retention": "データ保持なし",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V 4",
-    "Zoom": "ズーム"
+    "Zoom": "ズーム",
+    "Regenerate access token?": "アクセストークンを再生成しますか？",
+    "This token is shown only once. Store it now — it cannot be retrieved later.": "このトークンは一度しか表示されません。今すぐ保存してください。後から取得することはできません。",
+    "For security reasons the existing token cannot be displayed again. Regenerating creates a new token and invalidates the current one immediately.": "セキュリティ上の理由により、既存のトークンを再表示することはできません。再生成すると新しいトークンが作成され、現在のトークンは直ちに無効になります。",
+    "The current token stops working immediately. Any integration still using it will fail until you update it with the new token.": "現在のトークンは直ちに使用できなくなります。それを使用している連携は、新しいトークンに更新するまですべて失敗します。"
   }
 }

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -5248,6 +5248,10 @@
     "Zero retention": "Без хранения данных",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Regenerate access token?": "Перегенерировать токен доступа?",
+    "This token is shown only once. Store it now — it cannot be retrieved later.": "Этот токен отображается только один раз. Сохраните его сейчас — позже получить его будет невозможно.",
+    "For security reasons the existing token cannot be displayed again. Regenerating creates a new token and invalidates the current one immediately.": "В целях безопасности существующий токен нельзя показать повторно. Перегенерация создаёт новый токен и немедленно делает текущий недействительным.",
+    "The current token stops working immediately. Any integration still using it will fail until you update it with the new token.": "Текущий токен немедленно перестанет работать. Все интеграции, которые его используют, будут завершаться ошибкой, пока вы не обновите их новым токеном."
   }
 }

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -5248,6 +5248,10 @@
     "Zero retention": "Không lưu dữ liệu",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Regenerate access token?": "Tạo lại token truy cập?",
+    "This token is shown only once. Store it now — it cannot be retrieved later.": "Token này chỉ hiển thị một lần. Hãy lưu lại ngay — sau này không thể xem lại được.",
+    "For security reasons the existing token cannot be displayed again. Regenerating creates a new token and invalidates the current one immediately.": "Vì lý do bảo mật, token hiện tại không thể hiển thị lại. Việc tạo lại sẽ sinh ra token mới và vô hiệu hóa ngay token hiện tại.",
+    "The current token stops working immediately. Any integration still using it will fail until you update it with the new token.": "Token hiện tại sẽ ngừng hoạt động ngay lập tức. Mọi tích hợp còn dùng nó sẽ lỗi cho đến khi bạn cập nhật sang token mới."
   }
 }

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -5248,6 +5248,10 @@
     "Zero retention": "零數據保留",
     "Zhipu": "智譜",
     "Zhipu V4": "智譜 V4",
-    "Zoom": "縮放"
+    "Zoom": "縮放",
+    "Regenerate access token?": "重新生成存取令牌？",
+    "This token is shown only once. Store it now — it cannot be retrieved later.": "此令牌僅顯示一次，請立即儲存，之後無法再次查看。",
+    "For security reasons the existing token cannot be displayed again. Regenerating creates a new token and invalidates the current one immediately.": "出於安全考量，現有令牌無法再次顯示。重新生成會建立新令牌，並立即使目前的令牌失效。",
+    "The current token stops working immediately. Any integration still using it will fail until you update it with the new token.": "目前的令牌會立即停止運作。仍在使用它的整合將全部失敗，直到你更新為新令牌。"
   }
 }

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -5248,6 +5248,10 @@
     "Zero retention": "零数据保留",
     "Zhipu": "智谱",
     "Zhipu V4": "智谱 V4",
-    "Zoom": "缩放"
+    "Zoom": "缩放",
+    "Regenerate access token?": "重新生成访问令牌？",
+    "This token is shown only once. Store it now — it cannot be retrieved later.": "此令牌仅显示一次，请立即保存，之后无法再次查看。",
+    "For security reasons the existing token cannot be displayed again. Regenerating creates a new token and invalidates the current one immediately.": "出于安全考虑，现有令牌无法再次显示。重新生成会创建新令牌，并立即使当前令牌失效。",
+    "The current token stops working immediately. Any integration still using it will fail until you update it with the new token.": "当前令牌会立即停止工作。仍在使用它的集成将全部失败，直到你更新为新令牌。"
   }
 }


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

「访问令牌」弹窗在打开时会自动重新生成令牌：

```tsx
useEffect(() => {
  if (open && !token) {
    generate()
  }
}, [open, token, generate])
```

`token` 是组件内的 `useState`，每次挂载都是空字符串，所以只要弹窗打开，`generate()` 必然执行。而 `generate()` 会让服务端无条件覆盖旧令牌，且 `User.AccessToken` 的 json tag 是 `json:"-"`，令牌只在生成那一刻返回一次、事后无法读回 —— 也就是说这次误触**不可撤销、原值也找不回来**。

结果是：用户只想点开看一眼，所有仍持有旧令牌的集成就全部失效了。卡片文案「生成和管理您的 API 访问令牌」也强化了"这是个查看入口"的误解。

本 PR 把这个副作用去掉，并让销毁性操作变成需要明确意图的动作：

1. 移除自动生成的 `useEffect`
2. 未持有令牌时展示说明文案，讲清楚"现有令牌无法再次显示、重新生成会立即使其失效"，而不是给一个空输入框
3. 「重新生成」改为先弹二次确认（复用现有 `ConfirmDialog` 的 `destructive` 变体），确认文案说明后果
4. 生成成功后的展示与复制行为保持不变，并补充"仅显示一次"的提示

未改动任何服务端逻辑与接口契约。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6725

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
  - 说明：本 PR 由 AI 协助完成，描述与代码均经我逐行复核后提交。为如实告知，此项不勾选。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 已提交并关联 Issue #6725。这是"打开弹窗即产生不可逆副作用"的实现缺陷，不是设计取舍。
- [x] **变更理解:** 仅影响个人设置页的访问令牌弹窗。服务端 `POST /api/user/token` 的行为未改，只是不再被自动触发。
- [x] **范围聚焦:** 仅改动该弹窗组件与其新增文案对应的 7 个语言文件，无其他无关改动。
- [x] **本地验证:** 已运行下方列出的检查。
- [x] **安全合规:** 无凭据或敏感信息；新增文案已按 `i18n:sync` 流程补齐全部语言，未引入未翻译项。

## 📸 运行证明 / Proof of Work

```
$ bun run typecheck
$ tsgo -b
（无输出，退出码 0）

$ bunx oxlint -c .oxlintrc.json src/features/profile/components/dialogs/access-token-dialog.tsx
（无输出，退出码 0）

$ bun run build
Total: 57301.2 kB / 16638.6 kB（构建成功）

$ node scripts/sync-i18n.mjs
en     missing=0  untranslated=0
fr     missing=0  untranslated=0
ja     missing=0  untranslated=0
ru     missing=0  untranslated=0
vi     missing=0  untranslated=0
zh-TW  missing=0  untranslated=0
zh     missing=0  untranslated=0
```

新增 4 条文案已提供全部 7 个语言的译文，`_sync-report.json` 的 `missingCount` 与 `untranslatedCount` 保持为 0，与改动前一致。

**行为对照**

| 操作 | 改动前 | 改动后 |
|---|---|---|
| 打开弹窗 | 立即重置令牌，旧令牌失效 | 无副作用，展示说明文案 |
| 点击「重新生成」 | 直接重置 | 弹出二次确认，说明旧令牌将立即失效 |
| 确认重新生成 | — | 生成新令牌并展示、可复制，提示仅显示一次 |
| 关闭后重新打开 | 再次重置 | 无副作用 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Access-token dialogs now show an explanatory empty state when no token exists.
  - Regenerating a token requires explicit confirmation and clearly warns that the current token will be invalidated.
  - Newly generated tokens are shown once, with loading states and copy controls.
  - Dialog state resets when closed.

- **Localization**
  - Added regeneration and security warning translations across English, French, Japanese, Russian, Vietnamese, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->