### PR TITLE
fix(web): 导入 CC Switch 弹窗 - 模型列表未按 API 密钥分组过滤

### DIFF
--- a/web/src/features/keys/components/api-keys-dialogs.tsx
+++ b/web/src/features/keys/components/api-keys-dialogs.tsx
@@ -36,6 +36,7 @@ export function ApiKeysDialogs() {
         open={open === 'cc-switch'}
         onOpenChange={(isOpen) => !isOpen && setOpen(null)}
         tokenKey={resolvedKey}
+        tokenGroup={currentRow?.group ?? ''}
       />
     </>
   )

--- a/web/src/features/keys/components/dialogs/cc-switch-dialog.tsx
+++ b/web/src/features/keys/components/dialogs/cc-switch-dialog.tsx
@@ -92,6 +92,7 @@ interface Props {
   open: boolean
   onOpenChange: (open: boolean) => void
   tokenKey: string
+  tokenGroup?: string | null
 }
 
 export function CCSwitchDialog(props: Props) {
@@ -100,9 +101,12 @@ export function CCSwitchDialog(props: Props) {
   const [name, setName] = useState<string>(APP_CONFIGS.claude.defaultName)
   const [models, setModels] = useState<Record<string, string>>({})
 
+  // 按当前 key 的分组过滤模型列表；分组为空或未设时不过滤（返回全部可用模型）
+  const effectiveGroup = props.tokenGroup || undefined
+
   const { data: modelsData } = useQuery({
-    queryKey: ['user-models-ccswitch'],
-    queryFn: getUserModels,
+    queryKey: ['user-models-ccswitch', props.tokenGroup ?? ''],
+    queryFn: () => getUserModels(effectiveGroup),
     enabled: props.open,
     staleTime: 5 * 60 * 1000,
   })

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -45,12 +45,13 @@ export async function getSelf() {
   return res.data
 }
 
-export async function getUserModels(): Promise<{
+export async function getUserModels(group?: string): Promise<{
   success: boolean
   message?: string
   data?: string[]
 }> {
-  const res = await api.get('/api/user/models')
+  const params = group ? `?group=${encodeURIComponent(group)}` : ''
+  const res = await api.get(`/api/user/models${params}`)
   return res.data
 }
 


### PR DESCRIPTION
## 修改说明

修复用户在 API 密钥列表中导入 CC Switch 配置时，模型选择框展示了该用户全部可用模型，而不是当前 API 密钥所属分组模型的问题。

## 问题原因

CC Switch 弹窗调用 `getUserModels()` 时没有传入当前密钥的分组，因此请求 `/api/user/models` 时缺少 `group` 查询参数。后端在未指定分组时会返回用户所有可用分组的模型。

## 修改内容

- 为 `getUserModels` 增加可选的 `group` 参数，并对查询参数进行 URL 编码
- 从当前密钥记录中把 `group` 传入 CC Switch 弹窗
- 将分组加入 React Query 的缓存键，避免切换不同分组的密钥时复用错误的模型列表
- 保持未设置分组时的原有行为；`auto` 分组继续交由现有后端逻辑展开

## 用户影响

修复后，CC Switch 弹窗中的模型选择框只会展示当前 API 密钥所属分组可用的模型，降低误选不可用模型的可能性。

## 验证

- `oxfmt --check`：通过（本次涉及的 3 个文件）
- `oxlint`：通过；仅有该组件原有的 2 条警告，与本次修改无关
- `git diff --check`：通过
- 完整前端 typecheck 未执行：当前 npm 源缺少项目依赖 `baseline-browser-mapping@^2.11.12`，导致依赖安装失败

Closes #6745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API key model switching now filters available models by the selected key’s group.
  * Model results are refreshed correctly when switching between different key groups.
  * Existing behavior remains unchanged when no group is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->