### PR TITLE
test: derive expired auth flow fixture from cleanup retention constant

### DIFF
--- a/service/auth_session_test.go
+++ b/service/auth_session_test.go
@@ -269,7 +269,7 @@ func TestCleanupAuthArtifactsRemovesOnlyExpiredRecords(t *testing.T) {
 	}).Error)
 	require.NoError(t, model.DB.Create(&model.AuthFlow{
 		TokenHash: "expired-flow", Purpose: model.AuthFlowPurposeTwoFALogin,
-		ExpiresAt: oldExpiry,
+		ExpiresAt: now.Add(-(model.AuthFlowDefaultCleanupRetention + time.Hour)),
 	}).Error)
 	require.NoError(t, model.DB.Create(&model.AuthFlow{
 		TokenHash: "recent-flow", Purpose: model.AuthFlowPurposeTwoFALogin,


### PR DESCRIPTION
## 📝 变更描述 / Description
修复 go test ./... 测试错误 

`TestCleanupAuthArtifactsRemovesOnlyExpiredRecords` 里过期 flow 的 fixture 硬编码了 25 小时前,和 `AuthFlowDefaultCleanupRetention`(24h)是隐式耦合的——改保留期常量测试就会静默挂。改成直接用 `retention + 1h` 构造,当前语义完全不变,以后调保留期测试也不用跟着改。

## 🚀 变更类型 / Type of change
- [x] ⚡ 性能优化 / 重构 (Refactor)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```
$ go test ./service/ -run TestCleanupAuthArtifactsRemovesOnlyExpiredRecords
ok  	github.com/QuantumNous/new-api/service	0.5s
```

```
go test ./...
ok      github.com/QuantumNous/new-api  (cached)
...
?       github.com/QuantumNous/new-api/types    [no test files]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated authentication-flow cleanup test coverage to calculate expiration relative to the configured cleanup retention period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->