### PR TITLE
fix(gemini): normalize nullable and literal tool schemas

### DIFF
--- a/relaykit/relayconvert/internal/oai_chat/to_gemini_chat_req_test.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_gemini_chat_req_test.go
@@ -1,0 +1,41 @@
+package oaichat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/relayconvert/convmeta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAIChatRequestToGeminiNormalizesNullableToolParameter(t *testing.T) {
+	got, err := OpenAIChatRequestToGeminiGenerateContent(context.Background(), dto.GeneralOpenAIRequest{
+		Model: "gemini-test",
+		Tools: []dto.ToolCallRequest{{
+			Type: "function",
+			Function: dto.FunctionRequest{
+				Name: "update_task",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"due_date": map[string]interface{}{
+							"anyOf": []interface{}{
+								map[string]interface{}{"type": "string"},
+								map[string]interface{}{"type": "null"},
+							},
+						},
+					},
+				},
+			},
+		}},
+	}, &convmeta.Values{})
+	require.NoError(t, err)
+
+	path := "0.functionDeclarations.0.parameters.properties.due_date"
+	assert.Equal(t, "STRING", gjson.GetBytes(got.Tools, path+".type").String())
+	assert.True(t, gjson.GetBytes(got.Tools, path+".nullable").Bool())
+	assert.False(t, gjson.GetBytes(got.Tools, path+".anyOf").Exists())
+}

--- a/relaykit/relayconvert/internal/oai_responses/to_gemini_chat_req_test.go
+++ b/relaykit/relayconvert/internal/oai_responses/to_gemini_chat_req_test.go
@@ -1,0 +1,27 @@
+package oairesponses
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/relayconvert/convmeta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAIResponsesRequestToGeminiNormalizesLiteralToolUnion(t *testing.T) {
+	got, err := OpenAIResponsesRequestToGeminiChat(context.Background(), &dto.OpenAIResponsesRequest{
+		Model: "gemini-test",
+		Tools: json.RawMessage(`[{"type":"function","name":"update_task","parameters":{"type":"object","properties":{"status":{"anyOf":[{"type":"string","const":"open"},{"type":"string","const":"completed"}]}}}}]`),
+	}, &convmeta.Values{})
+	require.NoError(t, err)
+
+	path := "0.functionDeclarations.0.parameters.properties.status"
+	assert.Equal(t, "STRING", gjson.GetBytes(got.Tools, path+".type").String())
+	assert.Equal(t, "open", gjson.GetBytes(got.Tools, path+".enum.0").String())
+	assert.Equal(t, "completed", gjson.GetBytes(got.Tools, path+".enum.1").String())
+	assert.False(t, gjson.GetBytes(got.Tools, path+".anyOf").Exists())
+}

--- a/relaykit/relayconvert/internal/shared/gemini/schema.go
+++ b/relaykit/relayconvert/internal/shared/gemini/schema.go
@@ -8,6 +8,7 @@ import (
 
 var geminiOpenAPISchemaAllowedFields = map[string]struct{}{
 	"anyOf":            {},
+	"const":            {},
 	"default":          {},
 	"description":      {},
 	"enum":             {},
@@ -80,6 +81,10 @@ func cleanGeminiFunctionParametersWithDepth(params interface{}, depth int) inter
 			cleanedMap["anyOf"] = cleanedNested
 		}
 
+		normalizeGeminiSchemaConst(cleanedMap)
+		normalizeGeminiSchemaAnyOf(cleanedMap)
+		delete(cleanedMap, "const")
+
 		return cleanedMap
 	case []interface{}:
 		cleanedArray := make([]interface{}, len(v))
@@ -102,15 +107,125 @@ func cleanGeminiFunctionParametersShallow(params interface{}) interface{} {
 			}
 		}
 		normalizeGeminiSchemaTypeAndNullable(cleanedMap)
+		normalizeGeminiSchemaConst(cleanedMap)
 		delete(cleanedMap, "properties")
 		delete(cleanedMap, "items")
 		delete(cleanedMap, "anyOf")
+		delete(cleanedMap, "const")
 		return cleanedMap
 	case []interface{}:
 		return []interface{}{}
 	default:
 		return params
 	}
+}
+
+func normalizeGeminiSchemaConst(schema map[string]interface{}) {
+	constValue, ok := schema["const"]
+	if !ok {
+		return
+	}
+	if _, hasEnum := schema["enum"]; !hasEnum {
+		schema["enum"] = []interface{}{constValue}
+	}
+}
+
+func normalizeGeminiSchemaAnyOf(schema map[string]interface{}) {
+	branches, ok := schema["anyOf"].([]interface{})
+	if !ok || len(branches) == 0 {
+		return
+	}
+
+	concreteBranches := make([]map[string]interface{}, 0, len(branches))
+	nullable := false
+	for _, branch := range branches {
+		branchSchema, ok := branch.(map[string]interface{})
+		if !ok {
+			return
+		}
+		if isGeminiNullSchema(branchSchema) {
+			nullable = true
+			continue
+		}
+		concreteBranches = append(concreteBranches, branchSchema)
+	}
+
+	if len(concreteBranches) == 1 && nullable {
+		mergeGeminiSchema(schema, concreteBranches[0])
+		schema["nullable"] = true
+		delete(schema, "anyOf")
+		return
+	}
+
+	commonType, sameType := commonGeminiSchemaType(concreteBranches)
+	if sameType {
+		if _, hasType := schema["type"]; !hasType {
+			schema["type"] = commonType
+		}
+	}
+	if nullable {
+		schema["nullable"] = true
+	}
+
+	values, enumOnly := geminiEnumUnionValues(concreteBranches)
+	if sameType && enumOnly {
+		schema["enum"] = values
+		delete(schema, "anyOf")
+	}
+}
+
+func isGeminiNullSchema(schema map[string]interface{}) bool {
+	if nullable, ok := schema["nullable"].(bool); !ok || !nullable {
+		return false
+	}
+	for key := range schema {
+		if key != "nullable" {
+			return false
+		}
+	}
+	return true
+}
+
+func mergeGeminiSchema(target map[string]interface{}, source map[string]interface{}) {
+	for key, value := range source {
+		if _, exists := target[key]; !exists {
+			target[key] = value
+		}
+	}
+}
+
+func commonGeminiSchemaType(branches []map[string]interface{}) (string, bool) {
+	if len(branches) == 0 {
+		return "", false
+	}
+	commonType, ok := branches[0]["type"].(string)
+	if !ok || commonType == "" {
+		return "", false
+	}
+	for _, branch := range branches[1:] {
+		branchType, ok := branch["type"].(string)
+		if !ok || branchType != commonType {
+			return "", false
+		}
+	}
+	return commonType, true
+}
+
+func geminiEnumUnionValues(branches []map[string]interface{}) ([]interface{}, bool) {
+	values := make([]interface{}, 0, len(branches))
+	for _, branch := range branches {
+		for key := range branch {
+			if key != "type" && key != "enum" {
+				return nil, false
+			}
+		}
+		branchValues, ok := branch["enum"].([]interface{})
+		if !ok || len(branchValues) == 0 {
+			return nil, false
+		}
+		values = append(values, branchValues...)
+	}
+	return values, true
 }
 
 func normalizeGeminiSchemaTypeAndNullable(schema map[string]interface{}) {

--- a/relaykit/relayconvert/internal/shared/gemini/schema.go
+++ b/relaykit/relayconvert/internal/shared/gemini/schema.go
@@ -1,6 +1,7 @@
 package gemini
 
 import (
+	"reflect"
 	"strings"
 
 	"github.com/QuantumNous/new-api/relaykit/dto"
@@ -125,9 +126,17 @@ func normalizeGeminiSchemaConst(schema map[string]interface{}) {
 	if !ok {
 		return
 	}
-	if _, hasEnum := schema["enum"]; !hasEnum {
-		schema["enum"] = []interface{}{constValue}
+	values := []interface{}{constValue}
+	if existing, ok := schema["enum"].([]interface{}); ok {
+		values = []interface{}{}
+		for _, value := range existing {
+			if reflect.DeepEqual(value, constValue) {
+				values = []interface{}{constValue}
+				break
+			}
+		}
 	}
+	schema["enum"] = values
 }
 
 func normalizeGeminiSchemaAnyOf(schema map[string]interface{}) {

--- a/relaykit/relayconvert/internal/shared/gemini/schema_test.go
+++ b/relaykit/relayconvert/internal/shared/gemini/schema_test.go
@@ -1,0 +1,53 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanFunctionParametersNormalizesNullableUnion(t *testing.T) {
+	cleaned := CleanFunctionParameters(map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"due_date": map[string]interface{}{
+				"description": "Optional due date",
+				"anyOf": []interface{}{
+					map[string]interface{}{"type": "string"},
+					map[string]interface{}{"type": "null"},
+				},
+			},
+		},
+	})
+
+	root, ok := cleaned.(map[string]interface{})
+	require.True(t, ok)
+	properties, ok := root["properties"].(map[string]interface{})
+	require.True(t, ok)
+	dueDate, ok := properties["due_date"].(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, "OBJECT", root["type"])
+	assert.Equal(t, "STRING", dueDate["type"])
+	assert.Equal(t, true, dueDate["nullable"])
+	assert.Equal(t, "Optional due date", dueDate["description"])
+	assert.NotContains(t, dueDate, "anyOf")
+}
+
+func TestCleanFunctionParametersNormalizesLiteralUnion(t *testing.T) {
+	cleaned := CleanFunctionParameters(map[string]interface{}{
+		"anyOf": []interface{}{
+			map[string]interface{}{"type": "string", "const": "open"},
+			map[string]interface{}{"type": "string", "const": "completed"},
+		},
+	})
+
+	schema, ok := cleaned.(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, "STRING", schema["type"])
+	assert.Equal(t, []interface{}{"open", "completed"}, schema["enum"])
+	assert.NotContains(t, schema, "anyOf")
+	assert.NotContains(t, schema, "const")
+}

--- a/relaykit/relayconvert/internal/shared/gemini/schema_test.go
+++ b/relaykit/relayconvert/internal/shared/gemini/schema_test.go
@@ -51,3 +51,39 @@ func TestCleanFunctionParametersNormalizesLiteralUnion(t *testing.T) {
 	assert.NotContains(t, schema, "anyOf")
 	assert.NotContains(t, schema, "const")
 }
+
+// TestCleanFunctionParametersPreservesConst 验证常量与已有枚举的交集不会放宽约束。
+func TestCleanFunctionParametersPreservesConst(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		values []interface{}
+		want   []interface{}
+	}{
+		{"overlapping", []interface{}{"open", "completed"}, []interface{}{"open"}},
+		{"disjoint", []interface{}{"completed"}, []interface{}{}},
+		{"empty", []interface{}{}, []interface{}{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cleaned := CleanFunctionParameters(map[string]interface{}{"type": "string", "const": "open", "enum": tc.values})
+			schema, ok := cleaned.(map[string]interface{})
+			require.True(t, ok)
+			assert.Equal(t, tc.want, schema["enum"])
+			assert.NotContains(t, schema, "const")
+		})
+	}
+}
+
+// TestCleanFunctionParametersPreservesConstrainedUnion 验证同类型分支的独立约束得到保留。
+func TestCleanFunctionParametersPreservesConstrainedUnion(t *testing.T) {
+	cleaned := CleanFunctionParameters(map[string]interface{}{"anyOf": []interface{}{
+		map[string]interface{}{"type": "string", "pattern": "^a"},
+		map[string]interface{}{"type": "string", "pattern": "^b"},
+	}})
+	schema, ok := cleaned.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "STRING", schema["type"])
+	assert.Equal(t, []interface{}{
+		map[string]interface{}{"type": "STRING", "pattern": "^a"},
+		map[string]interface{}{"type": "STRING", "pattern": "^b"},
+	}, schema["anyOf"])
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本 PR 的实现与测试由提交者使用 AI Coding Agent 协助完成，描述已根据实际代码路径整理。

## 📝 变更描述 / Description
修复 OpenAI Chat Completions / Responses 转 Gemini `generateContent` 时，tool function parameters 中的 JSON Schema union 不符合 Gemini OpenAPI Schema 约束的问题。

之前 `string | null` 会被转换成一个本身没有 `type` 的 `anyOf`，导致 Gemini / Vertex 在提交 function declaration 时返回 `schema didn't specify the schema type field`。TypeBox literal union 里的 `const` 也会被 allowlist 静默丢弃，使枚举约束失效。

现在共享 Gemini schema cleaner 会：

- 将单一具体类型与 `null` 的 union 折叠为明确 `type` + `nullable: true`。
- 将同类型 literal union 折叠为明确 `type` + `enum`。
- 对其他同类型 `anyOf` 补充父层 `type`，同时保留原有分支约束。
- 在发送上游前删除 Gemini 不支持的 `const`。

修复位于 `relaykit` 共享转换层，因此同时覆盖 Gemini 渠道、Vertex Gemini 模式和使用相同 converter 的 Advanced Custom 路由。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 暂无对应 Issue；错误由 Gemini / Vertex function declaration 校验稳定复现。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，未发现相同的 nullable/literal tool schema 修复。
- [ ] **Bug fix 说明:** 当前未关联 Issue；PR 中已写明上游 400 的稳定触发条件。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已运行 relaykit 定向与全量测试、独立 build 及 vet。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- `cd relaykit && GOWORK=off go test ./...`
- `cd relaykit && GOWORK=off go build ./...`
- `cd relaykit && GOWORK=off go vet ./...`
- 根仓除 `main` package 外的 Go packages 测试通过；`main` package 在本地因未生成 `web/dist` embed 产物而无法 setup，与本次 relaykit 改动无关。
- 回归测试覆盖共享 cleaner、Chat Completions 接线和 Responses 接线。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion of nullable and literal union tool parameters for Gemini.
  * Preserved string types, nullability, allowed values, and constant restrictions during schema conversion.
  * Normalized compatible unions while retaining distinct constraints when they cannot be safely combined.

* **Tests**
  * Added regression coverage for nullable parameters, literal value unions, constants, and constrained schemas across supported request formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->