### PR TITLE
fix: prevent Stripe checkout popup blocking in default frontend

### DIFF
--- a/web/src/features/subscriptions/components/dialogs/subscription-purchase-dialog.tsx
+++ b/web/src/features/subscriptions/components/dialogs/subscription-purchase-dialog.tsx
@@ -405,10 +405,12 @@ export function SubscriptionPurchaseDialog(props: Props) {
             {hasEpay && (
               <div className='grid grid-cols-[minmax(0,1fr)_auto] gap-2'>
                 <Select
-                  items={(props.epayMethods || []).map((m) => ({
-                    value: m.type,
-                    label: m.name || m.type,
-                  }))}
+                  items={[
+                    ...(props.epayMethods || []).map((m) => ({
+                      value: m.type,
+                      label: m.name || m.type,
+                    })),
+                  ]}
                   value={selectedEpayMethod}
                   onValueChange={(v) => v !== null && setSelectedEpayMethod(v)}
                   disabled={limitReached}

--- a/web/src/features/subscriptions/components/dialogs/subscription-purchase-dialog.tsx
+++ b/web/src/features/subscriptions/components/dialogs/subscription-purchase-dialog.tsx
@@ -36,6 +36,7 @@ import {
 import { Separator } from '@/components/ui/separator'
 import { useSystemConfig } from '@/hooks/use-system-config'
 import { formatQuota } from '@/lib/format'
+import { redirectToStripeCheckout } from '@/lib/stripe-checkout'
 import { DEFAULT_CURRENCY_CONFIG } from '@/stores/system-config-store'
 
 import {
@@ -119,9 +120,8 @@ export function SubscriptionPurchaseDialog(props: Props) {
     try {
       const res = await paySubscriptionStripe({ plan_id: plan.id })
       if (res.message === 'success' && res.data?.pay_link) {
-        window.open(res.data.pay_link, '_blank')
-        toast.success(t('Payment page opened'))
-        props.onOpenChange(false)
+        toast.success(t('Redirecting to payment page...'))
+        redirectToStripeCheckout(res.data.pay_link)
       } else {
         toast.error(
           res.message && res.message !== 'success'
@@ -405,12 +405,10 @@ export function SubscriptionPurchaseDialog(props: Props) {
             {hasEpay && (
               <div className='grid grid-cols-[minmax(0,1fr)_auto] gap-2'>
                 <Select
-                  items={[
-                    ...(props.epayMethods || []).map((m) => ({
-                      value: m.type,
-                      label: m.name || m.type,
-                    })),
-                  ]}
+                  items={(props.epayMethods || []).map((m) => ({
+                    value: m.type,
+                    label: m.name || m.type,
+                  }))}
                   value={selectedEpayMethod}
                   onValueChange={(v) => v !== null && setSelectedEpayMethod(v)}
                   disabled={limitReached}

--- a/web/src/features/wallet/hooks/use-payment.ts
+++ b/web/src/features/wallet/hooks/use-payment.ts
@@ -20,6 +20,8 @@ import i18next from 'i18next'
 import { useState, useCallback } from 'react'
 import { toast } from 'sonner'
 
+import { redirectToStripeCheckout } from '@/lib/stripe-checkout'
+
 import {
   calculateAmount,
   calculateStripeAmount,
@@ -131,8 +133,8 @@ export function usePayment() {
 
         // Handle Stripe payment
         if (isStripe && response.data?.pay_link) {
-          window.open(response.data.pay_link as string, '_blank')
           toast.success(i18next.t('Redirecting to payment page...'))
+          redirectToStripeCheckout(response.data.pay_link as string)
           return true
         }
 

--- a/web/src/lib/stripe-checkout.ts
+++ b/web/src/lib/stripe-checkout.ts
@@ -1,0 +1,26 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+/**
+ * Continue an asynchronously-created Stripe Checkout in the active tab.
+ * Browsers can block a new tab once the initiating user gesture has crossed
+ * an await boundary.
+ */
+export function redirectToStripeCheckout(checkoutUrl: string): void {
+  window.location.href = checkoutUrl
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - This description was organized specifically for this PR. The change was AI-assisted and manually reviewed and tested.

## 📝 变更描述 / Description
Stripe Checkout was opened with `window.open(..., '_blank')` only after the asynchronous Checkout Session request completed. At that point browsers such as mobile Safari may no longer consider the call part of the original user gesture and can block the new tab.

This change sends both Default UI Stripe entry points—the wallet top-up flow and subscription purchase flow—to Checkout in the active tab. It keeps the fix frontend-only and does not change Stripe customer IDs, database schema, or backend payment behavior.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Related to #4484
- This intentionally covers only the Default UI popup-blocking portion. #4477 also includes Classic UI and test/live Customer ID changes, while this PR contains no schema or backend changes.

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** This description was organized for this PR. The change was AI-assisted and manually reviewed and tested.
- [x] **非重复提交:** I searched existing Issues and PRs. #4477 has overlapping intent but a broader, currently conflicting scope; this PR isolates the Default UI navigation fix.
- [x] **Bug fix 说明:** This PR is associated with #4484 and addresses the reported browser popup blocking behavior.
- [x] **变更理解:** The change replaces an asynchronous new-tab attempt with active-tab navigation after Stripe returns its hosted Checkout URL.
- [x] **范围聚焦:** The PR changes only the two Default UI Stripe entry points and their shared Stripe-specific navigation helper.
- [x] **本地验证:** Type checking, changed-code lint/format checks, and the production frontend build pass. The flow was also manually verified on a live deployment.
- [x] **安全合规:** No credentials or payment data are included in the code or this PR.

## 📸 运行证明 / Proof of Work
- `cd web && bun run typecheck` — passed
- `cd web && bunx oxlint -c .oxlintrc.json src/features/wallet/hooks/use-payment.ts src/lib/stripe-checkout.ts` — passed
- `cd web && bunx oxfmt -c .oxfmtrc.json --check src/features/subscriptions/components/dialogs/subscription-purchase-dialog.tsx src/features/wallet/hooks/use-payment.ts src/lib/stripe-checkout.ts` — passed
- `cd web && bun run build` — passed
- Live manual verification: creating a Stripe Checkout Session navigated the top-level browser tab to Stripe Checkout and rendered the US$1.00 payment page. No payment was submitted.

Repository-wide baseline checks currently report unrelated pre-existing files:

- `oxlint` on the full subscription dialog: its unchanged EPay list at line 409 triggers `unicorn(no-useless-spread)`
- `bun run format:check`: `channel-mutate-drawer.tsx`, `channel-form.ts`, `api-key-group-cell.tsx`, and `redemption-form.ts`
- `bun run copyright:check`: `oauth-callback-mode.ts`, `channel-field-update.ts`, and `model-categories.ts`

Known boundary: this navigation targets the active browsing context. Deployments that intentionally embed the dashboard in a cross-origin iframe should open it as a top-level page before starting Stripe Checkout, because Stripe Checkout cannot render inside that iframe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Stripe payments now open in the current browser tab through a streamlined checkout redirect.
  - Added a “Redirecting to payment page…” notification while checkout loads.
  - Added confirmation feedback when the payment page opens.

- **Bug Fixes**
  - Improved payment navigation by avoiding separate browser tabs during Stripe checkout.
  - Simplified payment-method selection behavior in the purchase dialog.
  - Purchase dialogs now close after checkout begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->