### PR TITLE
feat(channel): add SiftQ video generation provider

### DIFF
--- a/common/endpoint_type.go
+++ b/common/endpoint_type.go
@@ -28,7 +28,7 @@ func GetEndpointTypesByChannelType(channelType int, modelName string) []constant
 		endpointTypes = []constant.EndpointType{constant.EndpointTypeOpenAI}
 	case constant.ChannelTypeXai:
 		endpointTypes = []constant.EndpointType{constant.EndpointTypeOpenAI, constant.EndpointTypeOpenAIResponse}
-	case constant.ChannelTypeSora:
+	case constant.ChannelTypeSora, constant.ChannelTypeSiftQ:
 		endpointTypes = []constant.EndpointType{constant.EndpointTypeOpenAIVideo}
 	case constant.ChannelTypeSub2API, constant.ChannelTypeNewAPI:
 		endpointTypes = []constant.EndpointType{

--- a/constant/channel.go
+++ b/constant/channel.go
@@ -58,6 +58,7 @@ const (
 	ChannelTypeAdvancedCustom = 58
 	ChannelTypeSub2API        = 59
 	ChannelTypeNewAPI         = 60
+	ChannelTypeSiftQ          = 61
 	ChannelTypeDummy          // this one is only for count, do not add any channel after this
 
 )
@@ -124,6 +125,7 @@ var ChannelBaseURLs = []string{
 	"",                                          //58
 	"",                                          //59
 	"",                                          //60
+	"https://siftq.com/api/minimax/",            //61
 }
 
 var ChannelTypeNames = map[int]string{
@@ -184,6 +186,7 @@ var ChannelTypeNames = map[int]string{
 	ChannelTypeAdvancedCustom: "Advanced Custom",
 	ChannelTypeSub2API:        "Sub2API",
 	ChannelTypeNewAPI:         "New API",
+	ChannelTypeSiftQ:          "SiftQ",
 }
 
 func GetChannelTypeName(channelType int) string {

--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -82,6 +82,7 @@ func testChannel(ctx context.Context, channel *model.Channel, testUserID int, te
 		constant.ChannelTypeJimeng,
 		constant.ChannelTypeDoubaoVideo,
 		constant.ChannelTypeVidu,
+		constant.ChannelTypeSiftQ,
 	}
 	if lo.Contains(unsupportedTestChannelTypes, channel.Type) {
 		channelTypeName := constant.GetChannelTypeName(channel.Type)

--- a/controller/channel_test_internal_test.go
+++ b/controller/channel_test_internal_test.go
@@ -95,6 +95,16 @@ func TestNewAPIChannelRegistration(t *testing.T) {
 	assert.Empty(t, constant.ChannelBaseURLs[constant.ChannelTypeNewAPI])
 }
 
+func TestSiftQChannelRegistration(t *testing.T) {
+	assert.Equal(t, "SiftQ", constant.GetChannelTypeName(constant.ChannelTypeSiftQ))
+	require.Greater(t, len(constant.ChannelBaseURLs), constant.ChannelTypeSiftQ)
+	assert.Equal(t, "https://siftq.com/api/minimax/", constant.ChannelBaseURLs[constant.ChannelTypeSiftQ])
+	assert.Equal(t,
+		[]constant.EndpointType{constant.EndpointTypeOpenAIVideo},
+		common.GetEndpointTypesByChannelType(constant.ChannelTypeSiftQ, "MiniMax-H3"),
+	)
+}
+
 func TestResponsesCompactChannelSupport(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/controller/model.go
+++ b/controller/model.go
@@ -14,6 +14,7 @@ import (
 	"github.com/QuantumNous/new-api/relay/channel/lingyiwanwu"
 	"github.com/QuantumNous/new-api/relay/channel/minimax"
 	"github.com/QuantumNous/new-api/relay/channel/moonshot"
+	"github.com/QuantumNous/new-api/relay/channel/task/siftq"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/relaykit/dto"
@@ -81,6 +82,14 @@ func init() {
 			OwnedBy: minimax.ChannelName,
 		})
 	}
+	for _, modelName := range siftq.ModelList {
+		openAIModels = append(openAIModels, dto.OpenAIModels{
+			Id:      modelName,
+			Object:  "model",
+			Created: 1626777600,
+			OwnedBy: siftq.ChannelName,
+		})
+	}
 	for modelName, _ := range constant.MidjourneyModel2Action {
 		openAIModels = append(openAIModels, dto.OpenAIModels{
 			Id:      modelName,
@@ -95,6 +104,10 @@ func init() {
 	}
 	channelId2Models = make(map[int][]string)
 	for i := 1; i <= constant.ChannelTypeDummy; i++ {
+		if i == constant.ChannelTypeSiftQ {
+			channelId2Models[i] = append([]string(nil), siftq.ModelList...)
+			continue
+		}
 		apiType, success := common.ChannelType2APIType(i)
 		if !success || apiType == constant.APITypeAIProxyLibrary {
 			continue

--- a/docs/siftq-video.md
+++ b/docs/siftq-video.md
@@ -27,9 +27,9 @@ Send a request to either `POST /v1/video/generations` or `POST /v1/videos`:
 }
 ```
 
-Supported standard fields include `prompt`, `image`, `images`, `duration`, and `size`. `size` accepts `768P` or `2K`.
+Supported standard fields include `prompt`, `image`, `images`, `duration`, and `size`. `duration` must be an integer from 4 through 15, and `size` accepts `768P` or `2K`.
 
-For first-frame input, pass `image`. For first-and-last-frame input, pass two entries in `images`. These modes use the input frame ratio and are submitted upstream with `ratio: "adaptive"`.
+For first-frame input, pass `image`. For first-and-last-frame input, pass two entries in `images`. These modes use the input frame ratio and are always submitted upstream with `ratio: "adaptive"`; a `metadata.ratio` value is ignored for frame-based requests.
 
 For reference image, video, or audio inputs, pass the SiftQ `content` array through `metadata`:
 

--- a/docs/siftq-video.md
+++ b/docs/siftq-video.md
@@ -1,0 +1,69 @@
+# SiftQ video channel
+
+SiftQ is available as a native asynchronous video channel. It exposes one fixed routing model, `MiniMax-H3`, through new-api's video endpoints and maps requests to the SiftQ V2 contract.
+
+## Channel configuration
+
+- Channel type: `SiftQ`
+- API key: a SiftQ bearer key
+- Default Base URL: `https://siftq.com/api/minimax/`
+- Model: `MiniMax-H3`
+
+The Base URL can be overridden per channel. The adaptor joins the configured Base URL and V2 paths with exactly one slash.
+
+## Create a task
+
+Send a request to either `POST /v1/video/generations` or `POST /v1/videos`:
+
+```json
+{
+  "model": "MiniMax-H3",
+  "prompt": "A cinematic ocean sunrise.",
+  "duration": 5,
+  "size": "2K",
+  "metadata": {
+    "ratio": "16:9"
+  }
+}
+```
+
+Supported standard fields include `prompt`, `image`, `images`, `duration`, and `size`. `size` accepts `768P` or `2K`.
+
+For first-frame input, pass `image`. For first-and-last-frame input, pass two entries in `images`. These modes use the input frame ratio and are submitted upstream with `ratio: "adaptive"`.
+
+For reference image, video, or audio inputs, pass the SiftQ `content` array through `metadata`:
+
+```json
+{
+  "model": "MiniMax-H3",
+  "prompt": "Match the motion and atmosphere of the references.",
+  "duration": 7,
+  "metadata": {
+    "resolution": "2K",
+    "ratio": "4:3",
+    "callback_url": "https://example.com/webhooks/siftq",
+    "content": [
+      { "type": "text", "text": "Match the motion and atmosphere of the references." },
+      {
+        "type": "image_url",
+        "image_url": { "url": "https://example.com/reference.png" },
+        "role": "reference_image"
+      },
+      {
+        "type": "video_url",
+        "video_url": { "url": "https://example.com/reference.mp4" },
+        "role": "reference_video"
+      },
+      {
+        "type": "audio_url",
+        "audio_url": { "url": "https://example.com/reference.mp3" },
+        "role": "reference_audio"
+      }
+    ]
+  }
+}
+```
+
+The task response uses new-api's public task ID. Query it with `GET /v1/video/generations/{task_id}` or `GET /v1/videos/{task_id}`. Background task polling queries the native SiftQ V2 status endpoint and records `task.content.url` when generation succeeds.
+
+`callback_url` is forwarded for users who also consume SiftQ webhooks. new-api continues to manage task polling independently; it does not expose or require the upstream task ID.

--- a/relay/channel/adapter.go
+++ b/relay/channel/adapter.go
@@ -82,3 +82,7 @@ type TaskAdaptor interface {
 type OpenAIVideoConverter interface {
 	ConvertToOpenAIVideo(originTask *model.Task) ([]byte, error)
 }
+
+type TaskErrorParser interface {
+	ParseErrorResponse(statusCode int, body []byte) *taskdto.TaskError
+}

--- a/relay/channel/task/siftq/adaptor.go
+++ b/relay/channel/task/siftq/adaptor.go
@@ -28,13 +28,11 @@ const requestContextKey = "siftq_video_request"
 
 type TaskAdaptor struct {
 	taskcommon.BaseBilling
-	apiKey  string
-	baseURL string
+	apiKey string
 }
 
 func (a *TaskAdaptor) Init(info *relaycommon.RelayInfo) {
 	a.apiKey = info.ApiKey
-	a.baseURL = info.ChannelBaseUrl
 }
 
 func (a *TaskAdaptor) ValidateRequestAndSetAction(c *gin.Context, info *relaycommon.RelayInfo) *taskdto.TaskError {
@@ -218,15 +216,22 @@ func (a *TaskAdaptor) ParseTaskResult(body []byte) (*relaycommon.TaskInfo, error
 }
 
 func (a *TaskAdaptor) AdjustBillingOnComplete(task *model.Task, result *relaycommon.TaskInfo) int {
+	quota, _ := a.AdjustBillingOnCompleteWithClamp(task, result)
+	return quota
+}
+
+// AdjustBillingOnCompleteWithClamp preserves quota saturation metadata for the
+// polling settlement path while AdjustBillingOnComplete remains compatible
+// with task adaptors that only return a quota.
+func (a *TaskAdaptor) AdjustBillingOnCompleteWithClamp(task *model.Task, result *relaycommon.TaskInfo) (int, *common.QuotaClamp) {
 	if task == nil || result == nil || result.OutputSeconds <= 0 || task.PrivateData.BillingContext == nil {
-		return 0
+		return 0, nil
 	}
 	estimated := task.PrivateData.BillingContext.OtherRatios["seconds"]
 	if estimated <= 0 {
-		return 0
+		return 0, nil
 	}
-	quota, _ := common.QuotaFromFloatChecked(float64(task.Quota) * float64(result.OutputSeconds) / estimated)
-	return quota
+	return common.QuotaFromFloatChecked(float64(task.Quota) * float64(result.OutputSeconds) / estimated)
 }
 
 func (a *TaskAdaptor) GetModelList() []string { return ModelList }
@@ -255,21 +260,32 @@ func convertRequest(req relaycommon.TaskSubmitReq) (*videoRequest, string, error
 	if err := req.UnmarshalMetadata(&overrides); err != nil {
 		return nil, "", errors.Wrap(err, "parse SiftQ metadata")
 	}
-	duration := req.Duration
+	duration := 0
 	if overrides.Duration != nil {
 		duration = *overrides.Duration
-	}
-	if duration == 0 && req.Seconds != "" {
-		duration, _ = strconv.Atoi(req.Seconds)
-	}
-	if duration == 0 {
-		duration = defaultDuration
+	} else {
+		duration = req.Duration
+		if duration == 0 && req.Seconds != "" {
+			var err error
+			duration, err = strconv.Atoi(strings.TrimSpace(req.Seconds))
+			if err != nil {
+				return nil, "", fmt.Errorf("seconds must be an integer")
+			}
+		}
+		if duration == 0 {
+			duration = defaultDuration
+		}
 	}
 	if duration < 4 || duration > 15 {
 		return nil, "", fmt.Errorf("duration must be an integer from 4 through 15")
 	}
-	resolution := strings.ToUpper(strings.TrimSpace(overrides.Resolution))
-	if resolution == "" {
+	resolution := ""
+	if overrides.Resolution != nil {
+		resolution = strings.ToUpper(strings.TrimSpace(*overrides.Resolution))
+		if resolution == "" {
+			return nil, "", fmt.Errorf("resolution cannot be empty")
+		}
+	} else {
 		resolution = strings.ToUpper(strings.TrimSpace(req.Size))
 	}
 	if resolution == "" {
@@ -304,25 +320,31 @@ func convertRequest(req relaycommon.TaskSubmitReq) (*videoRequest, string, error
 	if err != nil {
 		return nil, "", err
 	}
-	ratio := strings.TrimSpace(overrides.Ratio)
-	if ratio == "" {
-		if mode == "text" {
-			ratio = defaultTextRatio
+	ratio := adaptiveRatio
+	if mode == "frame" {
+		// Frame-based generation always derives its ratio from the input image.
+	} else {
+		if overrides.Ratio != nil {
+			ratio = strings.TrimSpace(*overrides.Ratio)
+			if ratio == "" {
+				return nil, "", fmt.Errorf("ratio cannot be empty")
+			}
 		} else {
-			ratio = adaptiveRatio
+			if mode == "text" {
+				ratio = defaultTextRatio
+			}
+		}
+		if _, ok := validRatios[ratio]; !ok {
+			return nil, "", fmt.Errorf("invalid ratio %q", ratio)
+		}
+		if mode == "text" && ratio == adaptiveRatio {
+			return nil, "", fmt.Errorf("text-to-video requires a concrete ratio")
 		}
 	}
-	if _, ok := validRatios[ratio]; !ok {
-		return nil, "", fmt.Errorf("invalid ratio %q", ratio)
-	}
-	if mode == "text" && ratio == adaptiveRatio {
-		return nil, "", fmt.Errorf("text-to-video requires a concrete ratio")
-	}
-	if mode == "frame" {
-		ratio = adaptiveRatio
-	}
-	if overrides.CallbackURL != "" {
-		parsed, err := url.ParseRequestURI(overrides.CallbackURL)
+	callbackURL := ""
+	if overrides.CallbackURL != nil {
+		callbackURL = strings.TrimSpace(*overrides.CallbackURL)
+		parsed, err := url.ParseRequestURI(callbackURL)
 		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
 			return nil, "", fmt.Errorf("callback_url must be an absolute HTTP(S) URL")
 		}
@@ -340,7 +362,7 @@ func convertRequest(req relaycommon.TaskSubmitReq) (*videoRequest, string, error
 		Resolution:  resolution,
 		Duration:    duration,
 		Ratio:       ratio,
-		CallbackURL: overrides.CallbackURL,
+		CallbackURL: callbackURL,
 	}, action, nil
 }
 
@@ -451,11 +473,11 @@ func validateMediaURL(value, mediaType string, maxBytes int) error {
 		if !validMediaMIME(mediaType, mime) {
 			return fmt.Errorf("unsupported %s MIME type %q", mediaType, mime)
 		}
-		if _, err := base64.StdEncoding.DecodeString(parts[1]); err != nil {
-			return fmt.Errorf("invalid base64 data URI")
-		}
 		if base64.StdEncoding.DecodedLen(len(parts[1])) > maxBytes {
 			return fmt.Errorf("%s exceeds size limit", mediaType)
+		}
+		if _, err := base64.StdEncoding.DecodeString(parts[1]); err != nil {
+			return fmt.Errorf("invalid base64 data URI")
 		}
 		return nil
 	}

--- a/relay/channel/task/siftq/adaptor.go
+++ b/relay/channel/task/siftq/adaptor.go
@@ -1,0 +1,511 @@
+package siftq
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	taskdto "github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/relay/channel"
+	taskcommon "github.com/QuantumNous/new-api/relay/channel/task/taskcommon"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	kitdto "github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+)
+
+const requestContextKey = "siftq_video_request"
+
+type TaskAdaptor struct {
+	taskcommon.BaseBilling
+	apiKey  string
+	baseURL string
+}
+
+func (a *TaskAdaptor) Init(info *relaycommon.RelayInfo) {
+	a.apiKey = info.ApiKey
+	a.baseURL = info.ChannelBaseUrl
+}
+
+func (a *TaskAdaptor) ValidateRequestAndSetAction(c *gin.Context, info *relaycommon.RelayInfo) *taskdto.TaskError {
+	if taskErr := relaycommon.ValidateBasicTaskRequest(c, info, constant.TaskActionTextGenerate); taskErr != nil {
+		return taskErr
+	}
+	req, err := relaycommon.GetTaskRequest(c)
+	if err != nil {
+		return service.TaskErrorWrapperLocal(err, "invalid_request", http.StatusBadRequest)
+	}
+	if strings.TrimSpace(req.Model) != ModelName {
+		return service.TaskErrorWrapperLocal(fmt.Errorf("model must be %s", ModelName), "invalid_model", http.StatusBadRequest)
+	}
+	payload, action, err := convertRequest(req)
+	if err != nil {
+		return service.TaskErrorWrapperLocal(err, "invalid_request", http.StatusBadRequest)
+	}
+	info.Action = action
+	c.Set(requestContextKey, payload)
+	return nil
+}
+
+func (a *TaskAdaptor) EstimateBilling(c *gin.Context, _ *relaycommon.RelayInfo) map[string]float64 {
+	payload, ok := c.Get(requestContextKey)
+	if !ok {
+		return nil
+	}
+	req, ok := payload.(*videoRequest)
+	if !ok || req.Duration <= 0 {
+		return nil
+	}
+	return map[string]float64{"seconds": float64(req.Duration)}
+}
+
+func (a *TaskAdaptor) BuildRequestURL(info *relaycommon.RelayInfo) (string, error) {
+	return joinURL(info.ChannelBaseUrl, createVideoPath), nil
+}
+
+func (a *TaskAdaptor) BuildRequestHeader(_ *gin.Context, req *http.Request, _ *relaycommon.RelayInfo) error {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+a.apiKey)
+	return nil
+}
+
+func (a *TaskAdaptor) BuildRequestBody(c *gin.Context, _ *relaycommon.RelayInfo) (io.Reader, error) {
+	payload, ok := c.Get(requestContextKey)
+	if !ok {
+		return nil, fmt.Errorf("validated SiftQ request not found in context")
+	}
+	req, ok := payload.(*videoRequest)
+	if !ok {
+		return nil, fmt.Errorf("invalid SiftQ request in context")
+	}
+	body, err := common.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxRequestBytes {
+		return nil, fmt.Errorf("request body exceeds 64 MB")
+	}
+	return bytes.NewReader(body), nil
+}
+
+func (a *TaskAdaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBody io.Reader) (*http.Response, error) {
+	return channel.DoTaskApiRequest(a, c, info, requestBody)
+}
+
+func (a *TaskAdaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (string, []byte, *taskdto.TaskError) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", nil, service.TaskErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError)
+	}
+	_ = resp.Body.Close()
+
+	var result createResponse
+	if err := common.Unmarshal(body, &result); err != nil {
+		return "", nil, service.TaskErrorWrapper(errors.Wrap(err, "unmarshal SiftQ create response"), "unmarshal_response_body_failed", http.StatusBadGateway)
+	}
+	if strings.TrimSpace(result.TaskID) == "" {
+		return "", nil, service.TaskErrorWrapperLocal(fmt.Errorf("SiftQ response is missing task_id"), "invalid_upstream_response", http.StatusBadGateway)
+	}
+
+	video := kitdto.NewOpenAIVideo()
+	video.ID = info.PublicTaskID
+	video.TaskID = info.PublicTaskID
+	video.CreatedAt = time.Now().Unix()
+	video.Model = ModelName
+	c.JSON(http.StatusOK, video)
+	return result.TaskID, body, nil
+}
+
+func (a *TaskAdaptor) ParseErrorResponse(statusCode int, body []byte) *taskdto.TaskError {
+	var envelope errorEnvelope
+	if err := common.Unmarshal(body, &envelope); err != nil || strings.TrimSpace(envelope.Error.Message) == "" {
+		return service.TaskErrorWrapper(fmt.Errorf("SiftQ request failed with status %d", statusCode), "siftq_api_error", statusCode)
+	}
+	code := strings.TrimSpace(envelope.Error.Type)
+	if code == "" {
+		code = "siftq_api_error"
+	}
+	message := envelope.Error.Message
+	if envelope.RequestID != "" {
+		message = fmt.Sprintf("%s (request_id: %s)", message, envelope.RequestID)
+	}
+	return service.TaskErrorWrapper(errors.New(message), code, statusCode)
+}
+
+func (a *TaskAdaptor) FetchTask(baseURL, key string, body map[string]any, proxy string) (*http.Response, error) {
+	taskID, ok := body["task_id"].(string)
+	if !ok || strings.TrimSpace(taskID) == "" {
+		return nil, fmt.Errorf("invalid task_id")
+	}
+	requestURL := joinURL(baseURL, queryVideoPath+"/"+url.PathEscape(taskID))
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+key)
+	client, err := service.GetHttpClientWithProxy(proxy)
+	if err != nil {
+		return nil, fmt.Errorf("new proxy http client failed: %w", err)
+	}
+	return client.Do(req)
+}
+
+func (a *TaskAdaptor) ParseTaskResult(body []byte) (*relaycommon.TaskInfo, error) {
+	var result queryResponse
+	if err := common.Unmarshal(body, &result); err != nil {
+		return nil, errors.Wrap(err, "unmarshal SiftQ task response")
+	}
+	if result.Task.ID == "" {
+		var envelope errorEnvelope
+		if err := common.Unmarshal(body, &envelope); err == nil && envelope.Error.Message != "" {
+			code, _ := strconv.Atoi(envelope.Error.HTTPCode)
+			if code == http.StatusTooManyRequests || code >= http.StatusInternalServerError {
+				return nil, fmt.Errorf("transient SiftQ error: %s", envelope.Error.Message)
+			}
+			return relaycommon.FailTaskInfo(envelope.Error.Message), nil
+		}
+		return nil, fmt.Errorf("SiftQ task response is missing task.id")
+	}
+
+	info := &relaycommon.TaskInfo{
+		TaskID:        result.Task.ID,
+		OutputSeconds: result.Task.Usage.OutputSeconds,
+		TotalTokens:   result.Task.Usage.TotalTokens,
+	}
+	switch result.Task.Status {
+	case "queued":
+		info.Status = model.TaskStatusQueued
+		info.Progress = taskcommon.ProgressQueued
+	case "running":
+		info.Status = model.TaskStatusInProgress
+		info.Progress = taskcommon.ProgressInProgress
+	case "succeeded":
+		if result.Task.Modality == "text" || result.Task.TaskType == "h3_context_ir" {
+			return nil, fmt.Errorf("SiftQ Context-IR tasks are not video outputs")
+		}
+		if strings.TrimSpace(result.Task.Content.URL) == "" {
+			return nil, fmt.Errorf("succeeded SiftQ video task is missing content.url")
+		}
+		info.Status = model.TaskStatusSuccess
+		info.Progress = taskcommon.ProgressComplete
+		info.Url = result.Task.Content.URL
+	case "failed", "cancelled":
+		info.Status = model.TaskStatusFailure
+		info.Progress = taskcommon.ProgressComplete
+		if result.Task.Error != nil {
+			info.Code, _ = strconv.Atoi(result.Task.Error.Code)
+			info.Reason = result.Task.Error.Message
+		}
+		if info.Reason == "" {
+			info.Reason = "SiftQ task " + result.Task.Status
+		}
+	default:
+		return nil, fmt.Errorf("unknown SiftQ task status %q", result.Task.Status)
+	}
+	return info, nil
+}
+
+func (a *TaskAdaptor) AdjustBillingOnComplete(task *model.Task, result *relaycommon.TaskInfo) int {
+	if task == nil || result == nil || result.OutputSeconds <= 0 || task.PrivateData.BillingContext == nil {
+		return 0
+	}
+	estimated := task.PrivateData.BillingContext.OtherRatios["seconds"]
+	if estimated <= 0 {
+		return 0
+	}
+	quota, _ := common.QuotaFromFloatChecked(float64(task.Quota) * float64(result.OutputSeconds) / estimated)
+	return quota
+}
+
+func (a *TaskAdaptor) GetModelList() []string { return ModelList }
+func (a *TaskAdaptor) GetChannelName() string { return ChannelName }
+
+func (a *TaskAdaptor) ConvertToOpenAIVideo(task *model.Task) ([]byte, error) {
+	video := task.ToOpenAIVideo()
+	video.Model = ModelName
+	// A freshly persisted async task is NOT_START until the polling worker runs.
+	// The upstream task has already been accepted at this point, so expose the
+	// public state as queued instead of the generic unknown fallback.
+	if task.Status == model.TaskStatusNotStart {
+		video.Status = kitdto.VideoStatusQueued
+	}
+	if task.Status == model.TaskStatusFailure {
+		video.Error = &kitdto.OpenAIVideoError{Message: task.FailReason, Code: "siftq_task_failed"}
+	}
+	return common.Marshal(video)
+}
+
+func convertRequest(req relaycommon.TaskSubmitReq) (*videoRequest, string, error) {
+	if metadataModel, ok := req.Metadata["model"].(string); ok && strings.TrimSpace(metadataModel) != "" && metadataModel != ModelName {
+		return nil, "", fmt.Errorf("metadata.model cannot override fixed model %s", ModelName)
+	}
+	overrides := requestOverrides{}
+	if err := req.UnmarshalMetadata(&overrides); err != nil {
+		return nil, "", errors.Wrap(err, "parse SiftQ metadata")
+	}
+	duration := req.Duration
+	if overrides.Duration != nil {
+		duration = *overrides.Duration
+	}
+	if duration == 0 && req.Seconds != "" {
+		duration, _ = strconv.Atoi(req.Seconds)
+	}
+	if duration == 0 {
+		duration = defaultDuration
+	}
+	if duration < 4 || duration > 15 {
+		return nil, "", fmt.Errorf("duration must be an integer from 4 through 15")
+	}
+	resolution := strings.ToUpper(strings.TrimSpace(overrides.Resolution))
+	if resolution == "" {
+		resolution = strings.ToUpper(strings.TrimSpace(req.Size))
+	}
+	if resolution == "" {
+		resolution = defaultResolution
+	}
+	if _, ok := validResolutions[resolution]; !ok {
+		return nil, "", fmt.Errorf("resolution must be 768P or 2K")
+	}
+
+	content := overrides.Content
+	if len(content) == 0 {
+		content = []contentItem{{Type: "text", Text: strings.TrimSpace(req.Prompt)}}
+		images := normalizedImages(req)
+		switch {
+		case strings.EqualFold(req.Mode, "reference") || len(images) > 2:
+			for _, image := range images {
+				content = append(content, contentItem{Type: "image_url", ImageURL: &mediaURL{URL: image}, Role: "reference_image"})
+			}
+		case len(images) == 2:
+			content = append(content,
+				contentItem{Type: "image_url", ImageURL: &mediaURL{URL: images[0]}, Role: "first_frame"},
+				contentItem{Type: "image_url", ImageURL: &mediaURL{URL: images[1]}, Role: "last_frame"},
+			)
+		case len(images) == 1:
+			content = append(content, contentItem{Type: "image_url", ImageURL: &mediaURL{URL: images[0]}, Role: "first_frame"})
+		}
+	} else if !containsText(content) {
+		content = append([]contentItem{{Type: "text", Text: strings.TrimSpace(req.Prompt)}}, content...)
+	}
+
+	mode, err := validateAndNormalizeContent(content)
+	if err != nil {
+		return nil, "", err
+	}
+	ratio := strings.TrimSpace(overrides.Ratio)
+	if ratio == "" {
+		if mode == "text" {
+			ratio = defaultTextRatio
+		} else {
+			ratio = adaptiveRatio
+		}
+	}
+	if _, ok := validRatios[ratio]; !ok {
+		return nil, "", fmt.Errorf("invalid ratio %q", ratio)
+	}
+	if mode == "text" && ratio == adaptiveRatio {
+		return nil, "", fmt.Errorf("text-to-video requires a concrete ratio")
+	}
+	if mode == "frame" {
+		ratio = adaptiveRatio
+	}
+	if overrides.CallbackURL != "" {
+		parsed, err := url.ParseRequestURI(overrides.CallbackURL)
+		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+			return nil, "", fmt.Errorf("callback_url must be an absolute HTTP(S) URL")
+		}
+	}
+
+	action := constant.TaskActionTextGenerate
+	if mode == "frame" {
+		action = constant.TaskActionGenerate
+	} else if mode == "reference" {
+		action = constant.TaskActionReferenceGenerate
+	}
+	return &videoRequest{
+		Model:       ModelName,
+		Content:     content,
+		Resolution:  resolution,
+		Duration:    duration,
+		Ratio:       ratio,
+		CallbackURL: overrides.CallbackURL,
+	}, action, nil
+}
+
+func validateAndNormalizeContent(content []contentItem) (string, error) {
+	textCount, firstCount, lastCount := 0, 0, 0
+	referenceImages, referenceVideos, referenceAudios := 0, 0, 0
+	imageCount := 0
+	for i := range content {
+		item := &content[i]
+		item.Type = strings.TrimSpace(item.Type)
+		item.Role = strings.TrimSpace(item.Role)
+		switch item.Type {
+		case "text":
+			if strings.TrimSpace(item.Text) == "" {
+				return "", fmt.Errorf("content[%d].text is required", i)
+			}
+			if len([]rune(item.Text)) > 7000 {
+				return "", fmt.Errorf("content[%d].text exceeds 7000 characters", i)
+			}
+			textCount++
+		case "image_url":
+			if item.ImageURL == nil {
+				return "", fmt.Errorf("content[%d].image_url is required", i)
+			}
+			imageCount++
+			if item.Role == "" {
+				item.Role = "first_frame"
+			}
+			if err := validateMediaURL(item.ImageURL.URL, "image", 30<<20); err != nil {
+				return "", fmt.Errorf("content[%d]: %w", i, err)
+			}
+			switch item.Role {
+			case "first_frame":
+				firstCount++
+			case "last_frame":
+				lastCount++
+			case "reference_image":
+				referenceImages++
+			default:
+				return "", fmt.Errorf("content[%d] has invalid image role %q", i, item.Role)
+			}
+		case "video_url":
+			if item.VideoURL == nil || item.Role != "reference_video" {
+				return "", fmt.Errorf("content[%d] video_url requires role reference_video", i)
+			}
+			if err := validateMediaURL(item.VideoURL.URL, "video", 50<<20); err != nil {
+				return "", fmt.Errorf("content[%d]: %w", i, err)
+			}
+			referenceVideos++
+		case "audio_url":
+			if item.AudioURL == nil || item.Role != "reference_audio" {
+				return "", fmt.Errorf("content[%d] audio_url requires role reference_audio", i)
+			}
+			if err := validateMediaURL(item.AudioURL.URL, "audio", 15<<20); err != nil {
+				return "", fmt.Errorf("content[%d]: %w", i, err)
+			}
+			referenceAudios++
+		default:
+			return "", fmt.Errorf("content[%d] has unsupported type %q", i, item.Type)
+		}
+	}
+	if textCount == 0 {
+		return "", fmt.Errorf("content requires at least one non-empty text item")
+	}
+	if firstCount > 1 || lastCount > 1 {
+		return "", fmt.Errorf("content supports at most one first frame and one last frame")
+	}
+	if lastCount > 0 && firstCount == 0 {
+		return "", fmt.Errorf("last_frame requires first_frame")
+	}
+	if referenceImages > 9 || referenceVideos > 3 || referenceAudios > 3 {
+		return "", fmt.Errorf("reference media count exceeds SiftQ limits")
+	}
+	if imageCount > 11 {
+		return "", fmt.Errorf("image count exceeds SiftQ limits")
+	}
+	hasFrames := firstCount+lastCount > 0
+	hasReferences := referenceImages+referenceVideos+referenceAudios > 0
+	if hasFrames && hasReferences {
+		return "", fmt.Errorf("first/last frames cannot be combined with reference media")
+	}
+	if hasFrames {
+		return "frame", nil
+	}
+	if hasReferences {
+		return "reference", nil
+	}
+	return "text", nil
+}
+
+func validateMediaURL(value, mediaType string, maxBytes int) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("%s URL is required", mediaType)
+	}
+	if strings.HasPrefix(value, "mm_file://") {
+		if strings.TrimPrefix(value, "mm_file://") == "" {
+			return fmt.Errorf("invalid mm_file reference")
+		}
+		return nil
+	}
+	if strings.HasPrefix(value, "data:") {
+		parts := strings.SplitN(value, ",", 2)
+		if len(parts) != 2 || !strings.HasSuffix(parts[0], ";base64") {
+			return fmt.Errorf("invalid base64 data URI")
+		}
+		mime := strings.TrimSuffix(strings.TrimPrefix(parts[0], "data:"), ";base64")
+		if !validMediaMIME(mediaType, mime) {
+			return fmt.Errorf("unsupported %s MIME type %q", mediaType, mime)
+		}
+		if _, err := base64.StdEncoding.DecodeString(parts[1]); err != nil {
+			return fmt.Errorf("invalid base64 data URI")
+		}
+		if base64.StdEncoding.DecodedLen(len(parts[1])) > maxBytes {
+			return fmt.Errorf("%s exceeds size limit", mediaType)
+		}
+		return nil
+	}
+	parsed, err := url.ParseRequestURI(value)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return fmt.Errorf("%s must use http, https, mm_file, or a supported data URI", mediaType)
+	}
+	return nil
+}
+
+func validMediaMIME(mediaType, mime string) bool {
+	allowed := map[string]map[string]struct{}{
+		"image": {"image/jpg": {}, "image/jpeg": {}, "image/png": {}, "image/webp": {}, "image/heic": {}, "image/heif": {}},
+		"video": {"video/mp4": {}, "video/quicktime": {}},
+		"audio": {"audio/wav": {}, "audio/x-wav": {}, "audio/mpeg": {}, "audio/mp3": {}},
+	}
+	_, ok := allowed[mediaType][mime]
+	return ok
+}
+
+func normalizedImages(req relaycommon.TaskSubmitReq) []string {
+	images := make([]string, 0, len(req.Images)+1)
+	if image := strings.TrimSpace(req.Image); image != "" {
+		images = append(images, image)
+	}
+	for _, image := range req.Images {
+		if image = strings.TrimSpace(image); image != "" && (len(images) == 0 || images[len(images)-1] != image) {
+			images = append(images, image)
+		}
+	}
+	if len(images) == 0 {
+		if image := strings.TrimSpace(req.InputReference); image != "" {
+			images = append(images, image)
+		}
+	}
+	return images
+}
+
+func containsText(content []contentItem) bool {
+	for _, item := range content {
+		if item.Type == "text" && strings.TrimSpace(item.Text) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func joinURL(baseURL, path string) string {
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = DefaultBaseURL
+	}
+	return strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(path, "/")
+}

--- a/relay/channel/task/siftq/adaptor_test.go
+++ b/relay/channel/task/siftq/adaptor_test.go
@@ -111,7 +111,12 @@ func TestConvertRequestRejectsInvalidContractCombinations(t *testing.T) {
 		req  relaycommon.TaskSubmitReq
 	}{
 		{name: "duration too short", req: relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "x", Duration: 3}},
+		{name: "zero duration override", req: relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "x", Duration: 5, Metadata: map[string]interface{}{"duration": 0}}},
+		{name: "non-integer seconds", req: relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "x", Seconds: "five"}},
 		{name: "invalid resolution", req: relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "x", Duration: 5, Size: "1080P"}},
+		{name: "empty resolution override", req: relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "x", Duration: 5, Metadata: map[string]interface{}{"resolution": ""}}},
+		{name: "empty ratio override", req: relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "x", Duration: 5, Metadata: map[string]interface{}{"ratio": ""}}},
+		{name: "empty callback override", req: relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "x", Duration: 5, Metadata: map[string]interface{}{"callback_url": ""}}},
 		{name: "adaptive text ratio", req: relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "x", Duration: 5, Metadata: map[string]interface{}{"ratio": "adaptive"}}},
 		{name: "last frame without first", req: relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "x", Duration: 5, Metadata: map[string]interface{}{"content": []interface{}{
 			map[string]interface{}{"type": "text", "text": "x"},
@@ -131,6 +136,18 @@ func TestConvertRequestRejectsInvalidContractCombinations(t *testing.T) {
 	}
 }
 
+func TestConvertRequestIgnoresFrameRatioOverride(t *testing.T) {
+	payload, _, err := convertRequest(relaycommon.TaskSubmitReq{
+		Model:    ModelName,
+		Prompt:   "camera pushes in",
+		Duration: 5,
+		Image:    "https://example.com/first.png",
+		Metadata: map[string]interface{}{"ratio": "not-a-ratio"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, adaptiveRatio, payload.Ratio)
+}
+
 func TestConvertRequestRejectsMetadataDurationOutsideBillingBounds(t *testing.T) {
 	_, _, err := convertRequest(relaycommon.TaskSubmitReq{
 		Model:    ModelName,
@@ -144,6 +161,11 @@ func TestConvertRequestRejectsMetadataDurationOutsideBillingBounds(t *testing.T)
 func TestValidateMediaURLRejectsMalformedBase64(t *testing.T) {
 	err := validateMediaURL("data:image/png;base64,not-base64!", "image", 30<<20)
 	require.ErrorContains(t, err, "invalid base64")
+}
+
+func TestValidateMediaURLRejectsOversizedBase64BeforeDecoding(t *testing.T) {
+	err := validateMediaURL("data:image/png;base64,%%%%", "image", 2)
+	require.ErrorContains(t, err, "exceeds size limit")
 }
 
 func TestValidateRequestRequiresFixedModel(t *testing.T) {
@@ -197,6 +219,8 @@ func TestParseTaskResult(t *testing.T) {
 		{name: "running", body: `{"task":{"id":"1","status":"running"}}`, wantStatus: model.TaskStatusInProgress},
 		{name: "succeeded", body: `{"task":{"id":"1","status":"succeeded","content":{"url":"https://example.com/out.mp4"},"modality":"video","usage":{"output_seconds":5}}}`, wantStatus: model.TaskStatusSuccess, wantURL: "https://example.com/out.mp4"},
 		{name: "failed", body: `{"task":{"id":"1","status":"failed","error":{"code":"2013","message":"invalid request"}}}`, wantStatus: model.TaskStatusFailure},
+		{name: "cancelled", body: `{"task":{"id":"1","status":"cancelled"}}`, wantStatus: model.TaskStatusFailure},
+		{name: "unknown status remains retriable", body: `{"task":{"id":"1","status":"pausing"}}`, wantErr: true},
 		{name: "missing terminal url", body: `{"task":{"id":"1","status":"succeeded","modality":"video"}}`, wantErr: true},
 		{name: "legacy shape rejected", body: `{"task_id":"1","status":"Success","file_id":"2"}`, wantErr: true},
 	}
@@ -210,6 +234,62 @@ func TestParseTaskResult(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, test.wantStatus, model.TaskStatus(result.Status))
 			assert.Equal(t, test.wantURL, result.Url)
+		})
+	}
+}
+
+func TestAdjustBillingOnComplete(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	tests := []struct {
+		name      string
+		task      *model.Task
+		result    *relaycommon.TaskInfo
+		wantQuota int
+		wantClamp common.QuotaClampKind
+	}{
+		{
+			name: "scales pre-charge by actual duration",
+			task: &model.Task{Quota: 1000, PrivateData: model.TaskPrivateData{BillingContext: &model.TaskBillingContext{
+				OtherRatios: map[string]float64{"seconds": 5},
+			}}},
+			result:    &relaycommon.TaskInfo{OutputSeconds: 10},
+			wantQuota: 2000,
+		},
+		{
+			name:      "missing billing context keeps pre-charge",
+			task:      &model.Task{Quota: 1000},
+			result:    &relaycommon.TaskInfo{OutputSeconds: 10},
+			wantQuota: 0,
+		},
+		{
+			name: "zero output duration keeps pre-charge",
+			task: &model.Task{Quota: 1000, PrivateData: model.TaskPrivateData{BillingContext: &model.TaskBillingContext{
+				OtherRatios: map[string]float64{"seconds": 5},
+			}}},
+			result:    &relaycommon.TaskInfo{},
+			wantQuota: 0,
+		},
+		{
+			name: "reports saturated quota",
+			task: &model.Task{Quota: common.MaxQuota, PrivateData: model.TaskPrivateData{BillingContext: &model.TaskBillingContext{
+				OtherRatios: map[string]float64{"seconds": 0.01},
+			}}},
+			result:    &relaycommon.TaskInfo{OutputSeconds: 15},
+			wantQuota: common.MaxQuota,
+			wantClamp: common.QuotaClampOverflow,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			quota, clamp := adaptor.AdjustBillingOnCompleteWithClamp(test.task, test.result)
+			assert.Equal(t, test.wantQuota, quota)
+			if test.wantClamp == "" {
+				assert.Nil(t, clamp)
+			} else {
+				require.NotNil(t, clamp)
+				assert.Equal(t, test.wantClamp, clamp.Kind)
+			}
 		})
 	}
 }

--- a/relay/channel/task/siftq/adaptor_test.go
+++ b/relay/channel/task/siftq/adaptor_test.go
@@ -1,0 +1,270 @@
+package siftq
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/model"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJoinURLUsesExactlyOneBoundarySlash(t *testing.T) {
+	tests := []struct {
+		base string
+		want string
+	}{
+		{base: "https://siftq.com/api/minimax/", want: "https://siftq.com/api/minimax/v2/video_generation"},
+		{base: "https://siftq.com/api/minimax", want: "https://siftq.com/api/minimax/v2/video_generation"},
+		{base: "", want: "https://siftq.com/api/minimax/v2/video_generation"},
+	}
+	for _, test := range tests {
+		assert.Equal(t, test.want, joinURL(test.base, "/v2/video_generation"))
+	}
+}
+
+func TestConvertRequestSupportsTextAndFrameModes(t *testing.T) {
+	tests := []struct {
+		name       string
+		req        relaycommon.TaskSubmitReq
+		wantAction string
+		wantRatio  string
+		wantRoles  []string
+	}{
+		{
+			name:       "text to video",
+			req:        relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "ocean sunrise", Duration: 5, Size: "2K"},
+			wantAction: constant.TaskActionTextGenerate,
+			wantRatio:  "16:9",
+		},
+		{
+			name:       "first frame",
+			req:        relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "camera pushes in", Duration: 5, Image: "https://example.com/first.png"},
+			wantAction: constant.TaskActionGenerate,
+			wantRatio:  "adaptive",
+			wantRoles:  []string{"first_frame"},
+		},
+		{
+			name:       "first and last frame",
+			req:        relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "interpolate", Duration: 6, Images: []string{"https://example.com/first.png", "https://example.com/last.png"}},
+			wantAction: constant.TaskActionGenerate,
+			wantRatio:  "adaptive",
+			wantRoles:  []string{"first_frame", "last_frame"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			payload, action, err := convertRequest(test.req)
+			require.NoError(t, err)
+			assert.Equal(t, ModelName, payload.Model)
+			assert.Equal(t, test.wantAction, action)
+			assert.Equal(t, test.wantRatio, payload.Ratio)
+			roles := make([]string, 0)
+			for _, item := range payload.Content {
+				if item.Role != "" {
+					roles = append(roles, item.Role)
+				}
+			}
+			assert.ElementsMatch(t, test.wantRoles, roles)
+		})
+	}
+}
+
+func TestConvertRequestSupportsMultimodalReferences(t *testing.T) {
+	req := relaycommon.TaskSubmitReq{
+		Model:    ModelName,
+		Prompt:   "match the references",
+		Duration: 7,
+		Metadata: map[string]interface{}{
+			"resolution":   "2K",
+			"ratio":        "4:3",
+			"callback_url": "https://example.com/webhooks/siftq",
+			"content": []interface{}{
+				map[string]interface{}{"type": "text", "text": "match the references"},
+				map[string]interface{}{"type": "image_url", "image_url": map[string]interface{}{"url": "https://example.com/ref.png"}, "role": "reference_image"},
+				map[string]interface{}{"type": "video_url", "video_url": map[string]interface{}{"url": "https://example.com/ref.mp4"}, "role": "reference_video"},
+				map[string]interface{}{"type": "audio_url", "audio_url": map[string]interface{}{"url": "https://example.com/ref.mp3"}, "role": "reference_audio"},
+			},
+		},
+	}
+
+	payload, action, err := convertRequest(req)
+	require.NoError(t, err)
+	assert.Equal(t, constant.TaskActionReferenceGenerate, action)
+	assert.Equal(t, "2K", payload.Resolution)
+	assert.Equal(t, "4:3", payload.Ratio)
+	assert.Equal(t, "https://example.com/webhooks/siftq", payload.CallbackURL)
+	require.Len(t, payload.Content, 4)
+}
+
+func TestConvertRequestRejectsInvalidContractCombinations(t *testing.T) {
+	tests := []struct {
+		name string
+		req  relaycommon.TaskSubmitReq
+	}{
+		{name: "duration too short", req: relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "x", Duration: 3}},
+		{name: "invalid resolution", req: relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "x", Duration: 5, Size: "1080P"}},
+		{name: "adaptive text ratio", req: relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "x", Duration: 5, Metadata: map[string]interface{}{"ratio": "adaptive"}}},
+		{name: "last frame without first", req: relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "x", Duration: 5, Metadata: map[string]interface{}{"content": []interface{}{
+			map[string]interface{}{"type": "text", "text": "x"},
+			map[string]interface{}{"type": "image_url", "image_url": map[string]interface{}{"url": "https://example.com/last.png"}, "role": "last_frame"},
+		}}}},
+		{name: "frames mixed with references", req: relaycommon.TaskSubmitReq{Model: ModelName, Prompt: "x", Duration: 5, Metadata: map[string]interface{}{"content": []interface{}{
+			map[string]interface{}{"type": "text", "text": "x"},
+			map[string]interface{}{"type": "image_url", "image_url": map[string]interface{}{"url": "https://example.com/first.png"}, "role": "first_frame"},
+			map[string]interface{}{"type": "audio_url", "audio_url": map[string]interface{}{"url": "https://example.com/ref.mp3"}, "role": "reference_audio"},
+		}}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := convertRequest(test.req)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestConvertRequestRejectsMetadataDurationOutsideBillingBounds(t *testing.T) {
+	_, _, err := convertRequest(relaycommon.TaskSubmitReq{
+		Model:    ModelName,
+		Prompt:   "test",
+		Duration: 5,
+		Metadata: map[string]interface{}{"duration": 16},
+	})
+	require.ErrorContains(t, err, "duration")
+}
+
+func TestValidateMediaURLRejectsMalformedBase64(t *testing.T) {
+	err := validateMediaURL("data:image/png;base64,not-base64!", "image", 30<<20)
+	require.ErrorContains(t, err, "invalid base64")
+}
+
+func TestValidateRequestRequiresFixedModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/video/generations", bytes.NewBufferString(`{"model":"other","prompt":"test","duration":5}`))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+	defer common.CleanupBodyStorage(ctx)
+	info := &relaycommon.RelayInfo{TaskRelayInfo: &relaycommon.TaskRelayInfo{}}
+
+	taskErr := (&TaskAdaptor{}).ValidateRequestAndSetAction(ctx, info)
+	require.NotNil(t, taskErr)
+	assert.Equal(t, "invalid_model", taskErr.Code)
+}
+
+func TestBuildRequestBodyAndHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	payload := &videoRequest{
+		Model:      ModelName,
+		Content:    []contentItem{{Type: "text", Text: "test"}},
+		Resolution: "768P",
+		Duration:   5,
+		Ratio:      "16:9",
+	}
+	ctx.Set(requestContextKey, payload)
+	adaptor := &TaskAdaptor{apiKey: "test-secret"}
+
+	body, err := adaptor.BuildRequestBody(ctx, &relaycommon.RelayInfo{})
+	require.NoError(t, err)
+	data, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"model":"MiniMax-H3","content":[{"type":"text","text":"test"}],"resolution":"768P","duration":5,"ratio":"16:9"}`, string(data))
+
+	req := httptest.NewRequest(http.MethodPost, "https://example.com", nil)
+	require.NoError(t, adaptor.BuildRequestHeader(ctx, req, &relaycommon.RelayInfo{}))
+	assert.Equal(t, "Bearer test-secret", req.Header.Get("Authorization"))
+	assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
+}
+
+func TestParseTaskResult(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus model.TaskStatus
+		wantURL    string
+		wantErr    bool
+	}{
+		{name: "queued", body: `{"task":{"id":"1","status":"queued"}}`, wantStatus: model.TaskStatusQueued},
+		{name: "running", body: `{"task":{"id":"1","status":"running"}}`, wantStatus: model.TaskStatusInProgress},
+		{name: "succeeded", body: `{"task":{"id":"1","status":"succeeded","content":{"url":"https://example.com/out.mp4"},"modality":"video","usage":{"output_seconds":5}}}`, wantStatus: model.TaskStatusSuccess, wantURL: "https://example.com/out.mp4"},
+		{name: "failed", body: `{"task":{"id":"1","status":"failed","error":{"code":"2013","message":"invalid request"}}}`, wantStatus: model.TaskStatusFailure},
+		{name: "missing terminal url", body: `{"task":{"id":"1","status":"succeeded","modality":"video"}}`, wantErr: true},
+		{name: "legacy shape rejected", body: `{"task_id":"1","status":"Success","file_id":"2"}`, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := adaptor.ParseTaskResult([]byte(test.body))
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.wantStatus, model.TaskStatus(result.Status))
+			assert.Equal(t, test.wantURL, result.Url)
+		})
+	}
+}
+
+func TestParseErrorResponsePreservesStructuredError(t *testing.T) {
+	taskErr := (&TaskAdaptor{}).ParseErrorResponse(http.StatusUnauthorized, []byte(`{"type":"error","error":{"type":"authorized_error","message":"invalid key","http_code":"401"},"request_id":"req_123"}`))
+	require.NotNil(t, taskErr)
+	assert.Equal(t, "authorized_error", taskErr.Code)
+	assert.Equal(t, http.StatusUnauthorized, taskErr.StatusCode)
+	assert.Contains(t, taskErr.Message, "req_123")
+	assert.False(t, taskErr.LocalError)
+}
+
+func TestFetchTaskUsesV2PathAndBearerAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/api/minimax/v2/query/video_generation/task%2Fwith%2Fslash", req.URL.EscapedPath())
+		assert.Equal(t, "Bearer test-key", req.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"task":{"id":"task/with/slash","status":"queued"}}`))
+	}))
+	defer server.Close()
+
+	resp, err := (&TaskAdaptor{}).FetchTask(server.URL+"/api/minimax/", "test-key", map[string]any{"task_id": "task/with/slash"}, "")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestDoResponseReturnsPublicTaskID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	resp := &http.Response{Body: io.NopCloser(bytes.NewBufferString(`{"task_id":"upstream-123"}`))}
+	info := &relaycommon.RelayInfo{
+		OriginModelName: ModelName,
+		TaskRelayInfo:   &relaycommon.TaskRelayInfo{PublicTaskID: "task_public"},
+	}
+
+	taskID, _, taskErr := (&TaskAdaptor{}).DoResponse(ctx, resp, info)
+	require.Nil(t, taskErr)
+	assert.Equal(t, "upstream-123", taskID)
+	assert.NotContains(t, recorder.Body.String(), "upstream-123")
+	assert.Contains(t, recorder.Body.String(), "task_public")
+}
+
+func TestConvertToOpenAIVideoTreatsFreshTaskAsQueued(t *testing.T) {
+	task := &model.Task{
+		TaskID: "task_public",
+		Status: model.TaskStatusNotStart,
+		Properties: model.Properties{
+			OriginModelName: ModelName,
+		},
+	}
+
+	body, err := (&TaskAdaptor{}).ConvertToOpenAIVideo(task)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"id":"task_public","object":"video","status":"queued","progress":0,"created_at":0,"model":"MiniMax-H3","metadata":{"url":""}}`, string(body))
+}

--- a/relay/channel/task/siftq/constants.go
+++ b/relay/channel/task/siftq/constants.go
@@ -1,0 +1,33 @@
+package siftq
+
+const (
+	ChannelName    = "siftq-video"
+	ModelName      = "MiniMax-H3"
+	DefaultBaseURL = "https://siftq.com/api/minimax/"
+
+	createVideoPath = "v2/video_generation"
+	queryVideoPath  = "v2/query/video_generation"
+
+	defaultDuration   = 5
+	defaultResolution = "768P"
+	defaultTextRatio  = "16:9"
+	adaptiveRatio     = "adaptive"
+	maxRequestBytes   = 64 << 20
+)
+
+var ModelList = []string{ModelName}
+
+var validResolutions = map[string]struct{}{
+	"768P": {},
+	"2K":   {},
+}
+
+var validRatios = map[string]struct{}{
+	"adaptive": {},
+	"21:9":     {},
+	"16:9":     {},
+	"4:3":      {},
+	"1:1":      {},
+	"3:4":      {},
+	"9:16":     {},
+}

--- a/relay/channel/task/siftq/models.go
+++ b/relay/channel/task/siftq/models.go
@@ -25,9 +25,9 @@ type videoRequest struct {
 type requestOverrides struct {
 	Content     []contentItem `json:"content,omitempty"`
 	Duration    *int          `json:"duration,omitempty"`
-	Resolution  string        `json:"resolution,omitempty"`
-	Ratio       string        `json:"ratio,omitempty"`
-	CallbackURL string        `json:"callback_url,omitempty"`
+	Resolution  *string       `json:"resolution,omitempty"`
+	Ratio       *string       `json:"ratio,omitempty"`
+	CallbackURL *string       `json:"callback_url,omitempty"`
 }
 
 type createResponse struct {

--- a/relay/channel/task/siftq/models.go
+++ b/relay/channel/task/siftq/models.go
@@ -1,0 +1,85 @@
+package siftq
+
+type mediaURL struct {
+	URL string `json:"url"`
+}
+
+type contentItem struct {
+	Type     string    `json:"type"`
+	Text     string    `json:"text,omitempty"`
+	ImageURL *mediaURL `json:"image_url,omitempty"`
+	VideoURL *mediaURL `json:"video_url,omitempty"`
+	AudioURL *mediaURL `json:"audio_url,omitempty"`
+	Role     string    `json:"role,omitempty"`
+}
+
+type videoRequest struct {
+	Model       string        `json:"model"`
+	Content     []contentItem `json:"content"`
+	Resolution  string        `json:"resolution"`
+	Duration    int           `json:"duration"`
+	Ratio       string        `json:"ratio"`
+	CallbackURL string        `json:"callback_url,omitempty"`
+}
+
+type requestOverrides struct {
+	Content     []contentItem `json:"content,omitempty"`
+	Duration    *int          `json:"duration,omitempty"`
+	Resolution  string        `json:"resolution,omitempty"`
+	Ratio       string        `json:"ratio,omitempty"`
+	CallbackURL string        `json:"callback_url,omitempty"`
+}
+
+type createResponse struct {
+	TaskID string `json:"task_id"`
+}
+
+type errorEnvelope struct {
+	Type      string `json:"type"`
+	RequestID string `json:"request_id"`
+	Error     struct {
+		Type     string `json:"type"`
+		Message  string `json:"message"`
+		HTTPCode string `json:"http_code"`
+	} `json:"error"`
+}
+
+type taskContent struct {
+	URL    string `json:"url,omitempty"`
+	Prompt string `json:"prompt,omitempty"`
+}
+
+type taskError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type taskUsage struct {
+	TotalSeconds     int `json:"total_seconds,omitempty"`
+	InputSeconds     int `json:"input_seconds,omitempty"`
+	OutputSeconds    int `json:"output_seconds,omitempty"`
+	InputImageCount  int `json:"input_image_count,omitempty"`
+	TotalTokens      int `json:"total_tokens,omitempty"`
+	PromptTokens     int `json:"prompt_tokens,omitempty"`
+	CompletionTokens int `json:"completion_tokens,omitempty"`
+}
+
+type videoTask struct {
+	ID         string      `json:"id"`
+	Model      string      `json:"model"`
+	Status     string      `json:"status"`
+	Error      *taskError  `json:"error,omitempty"`
+	CreatedAt  int64       `json:"created_at,omitempty"`
+	UpdatedAt  int64       `json:"updated_at,omitempty"`
+	Content    taskContent `json:"content,omitempty"`
+	Resolution string      `json:"resolution,omitempty"`
+	Duration   int         `json:"duration,omitempty"`
+	Ratio      string      `json:"ratio,omitempty"`
+	TaskType   string      `json:"task_type,omitempty"`
+	Modality   string      `json:"modality,omitempty"`
+	Usage      taskUsage   `json:"usage,omitempty"`
+}
+
+type queryResponse struct {
+	Task videoTask `json:"task"`
+}

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -957,6 +957,7 @@ type TaskInfo struct {
 	Progress         string `json:"progress,omitempty"`
 	CompletionTokens int    `json:"completion_tokens,omitempty"` // 用于按倍率计费
 	TotalTokens      int    `json:"total_tokens,omitempty"`      // 用于按倍率计费
+	OutputSeconds    int    `json:"output_seconds,omitempty"`    // 用于视频任务完成后的实际时长结算
 }
 
 func FailTaskInfo(reason string) *TaskInfo {

--- a/relay/relay_adaptor.go
+++ b/relay/relay_adaptor.go
@@ -39,6 +39,7 @@ import (
 	"github.com/QuantumNous/new-api/relay/channel/task/hailuo"
 	taskjimeng "github.com/QuantumNous/new-api/relay/channel/task/jimeng"
 	"github.com/QuantumNous/new-api/relay/channel/task/kling"
+	"github.com/QuantumNous/new-api/relay/channel/task/siftq"
 	tasksora "github.com/QuantumNous/new-api/relay/channel/task/sora"
 	"github.com/QuantumNous/new-api/relay/channel/task/suno"
 	taskvertex "github.com/QuantumNous/new-api/relay/channel/task/vertex"
@@ -168,6 +169,8 @@ func GetTaskAdaptor(platform constant.TaskPlatform) channel.TaskAdaptor {
 			return &taskGemini.TaskAdaptor{}
 		case constant.ChannelTypeMiniMax:
 			return &hailuo.TaskAdaptor{}
+		case constant.ChannelTypeSiftQ:
+			return &siftq.TaskAdaptor{}
 		}
 	}
 	return nil

--- a/relay/relay_task.go
+++ b/relay/relay_task.go
@@ -223,6 +223,9 @@ func RelayTaskSubmit(c *gin.Context, info *relaycommon.RelayInfo) (*TaskSubmitRe
 	}
 	if resp != nil && resp.StatusCode != http.StatusOK {
 		responseBody, _ := io.ReadAll(resp.Body)
+		if parser, ok := adaptor.(channel.TaskErrorParser); ok {
+			return nil, parser.ParseErrorResponse(resp.StatusCode, responseBody)
+		}
 		return nil, service.TaskErrorWrapper(fmt.Errorf("%s", string(responseBody)), "fail_to_fetch_task", resp.StatusCode)
 	}
 

--- a/relay/relay_task.go
+++ b/relay/relay_task.go
@@ -224,7 +224,9 @@ func RelayTaskSubmit(c *gin.Context, info *relaycommon.RelayInfo) (*TaskSubmitRe
 	if resp != nil && resp.StatusCode != http.StatusOK {
 		responseBody, _ := io.ReadAll(resp.Body)
 		if parser, ok := adaptor.(channel.TaskErrorParser); ok {
-			return nil, parser.ParseErrorResponse(resp.StatusCode, responseBody)
+			if taskErr := parser.ParseErrorResponse(resp.StatusCode, responseBody); taskErr != nil {
+				return nil, taskErr
+			}
 		}
 		return nil, service.TaskErrorWrapper(fmt.Errorf("%s", string(responseBody)), "fail_to_fetch_task", resp.StatusCode)
 	}

--- a/service/task_billing_test.go
+++ b/service/task_billing_test.go
@@ -749,6 +749,7 @@ func TestNonTerminalUpdate_NoBilling(t *testing.T) {
 
 type mockAdaptor struct {
 	adjustReturn int
+	adjustClamp  *common.QuotaClamp
 }
 
 func (m *mockAdaptor) Init(_ *relaycommon.RelayInfo) {}
@@ -758,6 +759,9 @@ func (m *mockAdaptor) FetchTask(string, string, map[string]any, string) (*http.R
 func (m *mockAdaptor) ParseTaskResult([]byte) (*relaycommon.TaskInfo, error) { return nil, nil }
 func (m *mockAdaptor) AdjustBillingOnComplete(_ *model.Task, _ *relaycommon.TaskInfo) int {
 	return m.adjustReturn
+}
+func (m *mockAdaptor) AdjustBillingOnCompleteWithClamp(_ *model.Task, _ *relaycommon.TaskInfo) (int, *common.QuotaClamp) {
+	return m.adjustReturn, m.adjustClamp
 }
 
 // ===========================================================================
@@ -847,4 +851,37 @@ func TestSettle_NonPerCallBilling_AppliesAdaptorAdjustment(t *testing.T) {
 	log := getLastLog(t)
 	require.NotNil(t, log)
 	assert.Equal(t, model.LogTypeRefund, log.Type)
+}
+
+func TestSettle_NonPerCallBilling_RecordsAdaptorQuotaClamp(t *testing.T) {
+	truncate(t)
+	ctx := context.Background()
+
+	const userID, tokenID, channelID = 33, 33, 33
+	const initQuota, preConsumed, actualQuota = 10000, 1000, 1500
+
+	seedUser(t, userID, initQuota)
+	seedToken(t, tokenID, userID, "sk-checked-adaptor", 8000)
+	seedChannel(t, channelID)
+
+	task := makeTask(userID, channelID, preConsumed, tokenID, BillingSourceWallet, 0)
+	clamp := &common.QuotaClamp{
+		Op:       "QuotaFromFloat",
+		Kind:     common.QuotaClampOverflow,
+		Original: 3e9,
+		Clamped:  actualQuota,
+	}
+	adaptor := &mockAdaptor{adjustReturn: actualQuota, adjustClamp: clamp}
+
+	settleTaskBillingOnComplete(ctx, adaptor, task, &relaycommon.TaskInfo{Status: model.TaskStatusSuccess})
+
+	log := getLastLog(t)
+	require.NotNil(t, log)
+	var other map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(log.Other), &other))
+	adminInfo, ok := other["admin_info"].(map[string]interface{})
+	require.True(t, ok)
+	saturation, ok := adminInfo["quota_saturation"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, string(common.QuotaClampOverflow), saturation["kind"])
 }

--- a/service/task_polling.go
+++ b/service/task_polling.go
@@ -34,6 +34,13 @@ type TaskPollingAdaptor interface {
 	AdjustBillingOnComplete(task *model.Task, taskResult *relaycommon.TaskInfo) int
 }
 
+// TaskPollingBillingClampAdaptor is an optional extension for adaptors whose
+// completion-time quota calculation can saturate. The polling service records
+// the returned clamp in the task billing log.
+type TaskPollingBillingClampAdaptor interface {
+	AdjustBillingOnCompleteWithClamp(task *model.Task, taskResult *relaycommon.TaskInfo) (int, *common.QuotaClamp)
+}
+
 // GetTaskAdaptorFunc 由 main 包注入，用于获取指定平台的任务适配器。
 // 打破 service -> relay -> relay/channel -> service 的循环依赖。
 var GetTaskAdaptorFunc func(platform constant.TaskPlatform) TaskPollingAdaptor
@@ -647,8 +654,15 @@ func settleTaskBillingOnComplete(ctx context.Context, adaptor TaskPollingAdaptor
 		return
 	}
 	// 1. 优先让 adaptor 决定最终额度
-	if actualQuota := adaptor.AdjustBillingOnComplete(task, taskResult); actualQuota > 0 {
-		RecalculateTaskQuota(ctx, task, actualQuota, "adaptor计费调整")
+	actualQuota := 0
+	var clamp *common.QuotaClamp
+	if checkedAdaptor, ok := adaptor.(TaskPollingBillingClampAdaptor); ok {
+		actualQuota, clamp = checkedAdaptor.AdjustBillingOnCompleteWithClamp(task, taskResult)
+	} else {
+		actualQuota = adaptor.AdjustBillingOnComplete(task, taskResult)
+	}
+	if actualQuota > 0 {
+		RecalculateTaskQuota(ctx, task, actualQuota, "adaptor billing adjustment", clamp)
 		return
 	}
 	// 2. 回退到 token 重算

--- a/web/src/assets/custom/icon-siftq.tsx
+++ b/web/src/assets/custom/icon-siftq.tsx
@@ -1,0 +1,55 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import type { SVGProps } from 'react'
+
+type IconSiftQProps = SVGProps<SVGSVGElement> & {
+  size?: number
+}
+
+export function IconSiftQ({ size = 20, ...props }: IconSiftQProps) {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      viewBox='0 0 48 48'
+      width={size}
+      height={size}
+      fill='none'
+      aria-hidden='true'
+      {...props}
+    >
+      <rect x='4' y='4' width='31' height='40' rx='10' fill='#176b62' />
+      <path
+        fill='#f7f7f3'
+        d='M13 14.4c0-2.2 2.5-3.5 4.3-2.2l12.2 8.5a3 3 0 0 1 0 4.6l-12.2 8.5c-1.8 1.3-4.3 0-4.3-2.2V14.4Z'
+      />
+      <path
+        fill='#9edfd1'
+        d='m34 18.2 9.8-5.5a1.9 1.9 0 0 1 2.8 1.7v1.1c0 .7-.4 1.4-1 1.7L34 23.1v-4.9Z'
+      />
+      <path
+        fill='#9edfd1'
+        d='m34 23.1 10.5-1.8a1.9 1.9 0 0 1 2.2 1.9v1.4a1.9 1.9 0 0 1-2.2 1.9L34 24.7v-1.6Z'
+      />
+      <path
+        fill='#9edfd1'
+        d='m34 26.5 11.6 5.9c.6.3 1 .9 1 1.6v1.1a1.9 1.9 0 0 1-2.8 1.7L34 31.4v-4.9Z'
+      />
+    </svg>
+  )
+}

--- a/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
+++ b/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
@@ -888,6 +888,7 @@ export function ChannelMutateDrawer({
 
   // Get basic models for the current channel type
   const basicModels = useMemo(() => {
+    if (currentType === 61) return ['MiniMax-H3']
     if (!allModelsList.length) return []
     // Filter models based on common patterns for specific types
     if (currentType === 1) {
@@ -1284,6 +1285,14 @@ export function ChannelMutateDrawer({
       if (!currentOther || currentOther === '') {
         form.setValue('other', 'v2.1')
       }
+    }
+
+    // SiftQ exposes one fixed video model, so keep the routing model exact.
+    if (currentType === 61) {
+      form.setValue('models', 'MiniMax-H3', {
+        shouldDirty: true,
+        shouldValidate: true,
+      })
     }
   }, [currentType, isEditing, form])
 
@@ -4233,9 +4242,7 @@ export function ChannelMutateDrawer({
                                         <SelectValue />
                                       </SelectTrigger>
                                     </FormControl>
-                                    <SelectContent
-                                      alignItemWithTrigger={false}
-                                    >
+                                    <SelectContent alignItemWithTrigger={false}>
                                       <SelectGroup>
                                         <SelectItem value='auto'>
                                           {t('Auto')}

--- a/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
+++ b/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
@@ -740,6 +740,7 @@ export function ChannelMutateDrawer({
   const currentAutoBan = form.watch('auto_ban')
   const currentTag = form.watch('tag')
   const currentRemark = form.watch('remark')
+  const modelsLocked = currentType === 61
   const currentStatusCodeMapping = form.watch('status_code_mapping')
   const currentParamOverride = form.watch('param_override')
   const currentHeaderOverride = form.watch('header_override')
@@ -1428,13 +1429,14 @@ export function ChannelMutateDrawer({
   // Unified function to update models
   const updateModels = useCallback(
     (newModels: string[], merge: boolean = false) => {
+      if (modelsLocked) return 0
       const finalModels = merge
         ? formatModelsArray([...currentModelsArray, ...newModels])
         : formatModelsArray(newModels)
       form.setValue('models', finalModels)
       return newModels.length
     },
-    [currentModelsArray, form]
+    [currentModelsArray, form, modelsLocked]
   )
 
   // Handle fetching models from upstream
@@ -1512,9 +1514,10 @@ export function ChannelMutateDrawer({
   }, [allModelsList, updateModels, t])
 
   const handleClearModels = useCallback(() => {
+    if (modelsLocked) return
     form.setValue('models', '')
     toast.success(t('Cleared all models'))
-  }, [form, t])
+  }, [form, modelsLocked, t])
 
   const handleCopyModels = useCallback(async () => {
     const models = form.getValues('models')
@@ -1554,9 +1557,10 @@ export function ChannelMutateDrawer({
   // Handle model selection change from MultiSelect
   const handleModelsChange = useCallback(
     (selected: string[]) => {
+      if (modelsLocked) return
       form.setValue('models', selected.join(','))
     },
-    [form]
+    [form, modelsLocked]
   )
 
   // Handle successful submission
@@ -3313,6 +3317,7 @@ export function ChannelMutateDrawer({
                                           type='button'
                                           variant='outline'
                                           size='sm'
+                                          disabled={modelsLocked}
                                           onClick={() => {
                                             const hiddenTargets = new Set(
                                               modelMappingGuardrail.exposedTargetModels
@@ -3354,7 +3359,7 @@ export function ChannelMutateDrawer({
                                   variant='outline'
                                   size='sm'
                                   onClick={handleFillRelatedModels}
-                                  disabled={!basicModels.length}
+                                  disabled={modelsLocked || !basicModels.length}
                                 >
                                   <FileText
                                     className='mr-2 h-4 w-4'
@@ -3367,7 +3372,9 @@ export function ChannelMutateDrawer({
                                   variant='outline'
                                   size='sm'
                                   onClick={handleFillAllModels}
-                                  disabled={!allModelsList.length}
+                                  disabled={
+                                    modelsLocked || !allModelsList.length
+                                  }
                                 >
                                   <Plus
                                     className='mr-2 h-4 w-4'
@@ -3417,7 +3424,10 @@ export function ChannelMutateDrawer({
                                   variant='ghost'
                                   size='sm'
                                   onClick={handleClearModels}
-                                  disabled={currentModelsArray.length === 0}
+                                  disabled={
+                                    modelsLocked ||
+                                    currentModelsArray.length === 0
+                                  }
                                 >
                                   <Eraser
                                     className='mr-2 h-4 w-4'
@@ -3437,6 +3447,7 @@ export function ChannelMutateDrawer({
                                       type='button'
                                       variant='secondary'
                                       size='sm'
+                                      disabled={modelsLocked}
                                       onClick={() =>
                                         handleAddPrefillGroup(group)
                                       }
@@ -3570,6 +3581,7 @@ export function ChannelMutateDrawer({
                                           type='button'
                                           variant='outline'
                                           size='sm'
+                                          disabled={modelsLocked}
                                           onClick={() => {
                                             updateModels([
                                               ...currentModelsArray,
@@ -4825,6 +4837,7 @@ export function ChannelMutateDrawer({
         open={fetchModelsDialogOpen}
         onOpenChange={setFetchModelsDialogOpen}
         onModelsSelected={(models) => {
+          if (modelsLocked) return
           form.setValue('models', formatModelsArray(models))
         }}
         redirectModels={redirectModelList}

--- a/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
+++ b/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
@@ -1143,12 +1143,15 @@ export function ChannelMutateDrawer({
 
   // Transform models to multi-select options
   const modelOptions = useMemo(() => {
+    if (currentType === 61) {
+      return [{ value: 'MiniMax-H3', label: 'MiniMax-H3' }]
+    }
     const allModels = new Set([...allModelsList, ...currentModelsArray])
     return [...allModels].map((model) => ({
       value: model,
       label: model,
     }))
-  }, [allModelsList, currentModelsArray])
+  }, [allModelsList, currentModelsArray, currentType])
 
   const modelMappingGuardrail = useMemo<ModelMappingGuardrail>(() => {
     if (!currentModelMapping?.trim()) {
@@ -1267,6 +1270,14 @@ export function ChannelMutateDrawer({
     }
   }, [isEditing, channelData, form])
 
+  useEffect(() => {
+    if (currentType !== 61 || currentModels === 'MiniMax-H3') return
+    form.setValue('models', 'MiniMax-H3', {
+      shouldDirty: true,
+      shouldValidate: true,
+    })
+  }, [currentModels, currentType, form])
+
   // Handle type change - set default values for specific types
   useEffect(() => {
     if (isEditing) return // Don't auto-set defaults when editing
@@ -1285,14 +1296,6 @@ export function ChannelMutateDrawer({
       if (!currentOther || currentOther === '') {
         form.setValue('other', 'v2.1')
       }
-    }
-
-    // SiftQ exposes one fixed video model, so keep the routing model exact.
-    if (currentType === 61) {
-      form.setValue('models', 'MiniMax-H3', {
-        shouldDirty: true,
-        shouldValidate: true,
-      })
     }
   }, [currentType, isEditing, form])
 
@@ -3286,7 +3289,8 @@ export function ChannelMutateDrawer({
                                       placeholder={t(
                                         'Select models or add custom ones'
                                       )}
-                                      allowCreate
+                                      allowCreate={currentType !== 61}
+                                      disabled={currentType === 61}
                                       createLabel='Add custom model "{{value}}"'
                                       maxVisibleChips={8}
                                       copyChipOnClick

--- a/web/src/features/channels/constants.ts
+++ b/web/src/features/channels/constants.ts
@@ -22,6 +22,7 @@ For commercial licensing, please contact support@quantumnous.com
 // ============================================================================
 
 export const CHANNEL_TYPE_NEW_API = 60
+export const CHANNEL_TYPE_SIFTQ = 61
 
 export const CHANNEL_TYPES = {
   0: 'Unknown',
@@ -81,12 +82,13 @@ export const CHANNEL_TYPES = {
   58: 'Advanced Custom',
   59: 'Sub2API',
   60: 'New API',
+  61: 'SiftQ',
 } as const
 
 const CHANNEL_TYPE_DISPLAY_ORDER: number[] = [
   1, 14, 33, 24, 43, 3, 41, 48, 60, 58, 42, 34, 20, 4, 40, 27, 25, 17, 26, 15,
   46, 23, 18, 45, 31, 35, 49, 19, 47, 37, 38, 39, 11, 8, 57, 59, 22, 21, 44, 2,
-  5, 36, 50, 51, 52, 53, 54, 55, 56,
+  5, 36, 50, 51, 52, 53, 54, 55, 61, 56,
 ]
 
 export const CHANNEL_TYPE_OPTIONS: { value: number; label: string }[] = (() => {

--- a/web/src/features/channels/lib/__tests__/siftq-channel.test.ts
+++ b/web/src/features/channels/lib/__tests__/siftq-channel.test.ts
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { CHANNEL_TYPES } from '../../constants'
+import { getChannelTypeConfig } from '../channel-type-config'
+import { getChannelTypeIcon, getChannelTypeLabel } from '../channel-utils'
+
+const SIFTQ_CHANNEL_TYPE = 61
+
+test('registers the SiftQ channel defaults', () => {
+  assert.equal(CHANNEL_TYPES[SIFTQ_CHANNEL_TYPE], 'SiftQ')
+  assert.equal(getChannelTypeLabel(SIFTQ_CHANNEL_TYPE), 'SiftQ')
+  assert.equal(getChannelTypeIcon(SIFTQ_CHANNEL_TYPE), 'SiftQ')
+  assert.deepEqual(getChannelTypeConfig(SIFTQ_CHANNEL_TYPE), {
+    id: SIFTQ_CHANNEL_TYPE,
+    name: 'SiftQ',
+    icon: 'SiftQ',
+    defaultBaseUrl: 'https://siftq.com/api/minimax/',
+    supportedModels: ['MiniMax-H3'],
+    hints: {
+      baseUrl: 'Default: https://siftq.com/api/minimax/',
+      key: 'SiftQ API Key',
+      models: 'MiniMax-H3',
+    },
+  })
+})

--- a/web/src/features/channels/lib/channel-type-config.ts
+++ b/web/src/features/channels/lib/channel-type-config.ts
@@ -164,6 +164,18 @@ export const CHANNEL_TYPE_CONFIGS: Record<number, ChannelTypeConfig> = {
       models: 'Models',
     },
   },
+  61: {
+    id: 61,
+    name: CHANNEL_TYPES[61],
+    icon: 'SiftQ',
+    defaultBaseUrl: 'https://siftq.com/api/minimax/',
+    supportedModels: ['MiniMax-H3'],
+    hints: {
+      baseUrl: 'Default: https://siftq.com/api/minimax/',
+      key: 'SiftQ API Key',
+      models: 'MiniMax-H3',
+    },
+  },
 }
 
 /**

--- a/web/src/features/channels/lib/channel-utils.ts
+++ b/web/src/features/channels/lib/channel-utils.ts
@@ -104,6 +104,7 @@ export function getChannelTypeIcon(type: number): string {
     55: 'OpenAI', // Sora
     54: 'Doubao', // DoubaoVideo
     56: 'Replicate', // Replicate
+    61: 'SiftQ', // SiftQ
 
     // Tools & Platforms
     37: 'Dify', // Dify

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -4230,6 +4230,7 @@
     "Sidebar collapsed by default for new users": "Sidebar collapsed by default for new users",
     "Sidebar modules": "Sidebar modules",
     "Sidebar Personal Settings": "Sidebar Personal Settings",
+    "SiftQ": "SiftQ",
     "Sign in": "Sign in",
     "Sign In": "Sign In",
     "Sign in now": "Sign in now",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -4230,6 +4230,7 @@
     "Sidebar collapsed by default for new users": "Barre latérale masquée par défaut pour les nouveaux utilisateurs",
     "Sidebar modules": "Modules de la barre latérale",
     "Sidebar Personal Settings": "Paramètres personnels de la barre latérale",
+    "SiftQ": "SiftQ",
     "Sign in": "Se connecter",
     "Sign In": "Se connecter",
     "Sign in now": "Se connecter maintenant",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -4230,6 +4230,7 @@
     "Sidebar collapsed by default for new users": "新規ユーザー向けにサイドバーをデフォルトで折りたたむ",
     "Sidebar modules": "サイドバーモジュール",
     "Sidebar Personal Settings": "サイドバー個人設定",
+    "SiftQ": "SiftQ",
     "Sign in": "ログイン",
     "Sign In": "ログイン",
     "Sign in now": "今すぐログイン",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -4230,6 +4230,7 @@
     "Sidebar collapsed by default for new users": "Боковая панель свернута по умолчанию для новых пользователей",
     "Sidebar modules": "Модули боковой панели",
     "Sidebar Personal Settings": "Личные настройки боковой панели",
+    "SiftQ": "SiftQ",
     "Sign in": "Войти",
     "Sign In": "Войти",
     "Sign in now": "Войти сейчас",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -4230,6 +4230,7 @@
     "Sidebar collapsed by default for new users": "Thanh bên được thu gọn theo mặc định đối với người dùng mới",
     "Sidebar modules": "Mô-đun thanh bên",
     "Sidebar Personal Settings": "Cài đặt cá nhân thanh bên",
+    "SiftQ": "SiftQ",
     "Sign in": "Đăng nhập",
     "Sign In": "Đăng nhập",
     "Sign in now": "Đăng nhập ngay",

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -4230,6 +4230,7 @@
     "Sidebar collapsed by default for new users": "預設情況下為新用戶摺疊側邊欄",
     "Sidebar modules": "側邊欄模組",
     "Sidebar Personal Settings": "左側邊欄個人設定",
+    "SiftQ": "SiftQ",
     "Sign in": "登入",
     "Sign In": "登入",
     "Sign in now": "立即登入",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -4230,6 +4230,7 @@
     "Sidebar collapsed by default for new users": "默认情况下为新用户折叠侧边栏",
     "Sidebar modules": "侧边栏模块",
     "Sidebar Personal Settings": "左侧边栏个人设置",
+    "SiftQ": "SiftQ",
     "Sign in": "登录",
     "Sign In": "登录",
     "Sign in now": "立即登录",

--- a/web/src/lib/lobe-icon.tsx
+++ b/web/src/lib/lobe-icon.tsx
@@ -28,9 +28,11 @@ For commercial licensing, please contact support@quantumnous.com
 import * as LobeIcons from '@lobehub/icons'
 import type React from 'react'
 
+import { IconSiftQ } from '@/assets/custom/icon-siftq'
 import { IconSub2api } from '@/assets/custom/icon-sub2api'
 
 const CUSTOM_ICONS: Record<string, React.ComponentType<{ size?: number }>> = {
+  SiftQ: IconSiftQ,
   Sub2API: IconSub2api,
 }
 


### PR DESCRIPTION
# Pull Request Notice

> [!IMPORTANT]
>
> This description was reviewed and edited by the contributor to reflect the implemented behavior and verification results.

## Description

Add SiftQ as a native asynchronous video-generation channel using new-api's existing video task workflow.

The channel exposes one fixed routing model, `MiniMax-H3`, and maps text-to-video, first-frame, first-and-last-frame, and multimodal reference requests to the SiftQ V2 API. It preserves new-api's public task IDs, background polling, structured errors, result URL handling, and output-duration billing.

The implementation also registers the channel in backend and frontend metadata, adds SiftQ branding and localized labels, locks the channel editor to the fixed model, documents the request contract, and adds focused request, polling, billing, registration, and UI contract tests.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor or performance improvement
- [x] Documentation

## Related Issue

- Closes #6784

## ✅ 提交前检查项 / Checklist

- [x] **Human review:** I reviewed the implementation, verification results, and this description.
- [x] **No duplicate:** I searched existing issues and pull requests before submitting.
- [x] **Bug-fix classification:** This pull request is not classified as a bug fix.
- [x] **Change understanding:** I understand the implementation and its operational impact.
- [x] **Focused scope:** The changes are limited to the SiftQ video channel and the shared task boundaries it uses.
- [x] **Local verification:** The relevant tests and checks listed below passed locally.
- [x] **Security:** No API keys, authorization headers, upstream task IDs, or temporary result URLs are committed or included here.

## Proof of Work

Automated verification:

- `go test ./relay/channel/task/siftq`
- Targeted completion-billing settlement tests in `./service`
- `go test ./... -run '^$'` for full Go compile coverage
- Frontend TypeScript typecheck
- Changed-file frontend formatting and lint checks
- `git diff --check`

End-to-end verification used a local new-api instance connected to the live SiftQ API. Text-to-video and first-frame requests completed successfully through `POST /v1/videos`; background polling reached the terminal success state, the public task response returned a result URL, and output-duration accounting recorded the generated four-second result.

## Review Follow-up

The follow-up commits address review feedback by:

- documenting the 4-15 second duration range and frame-mode adaptive ratio behavior;
- rejecting malformed scalar overrides and non-integer `seconds` values;
- checking Base64 size bounds before decoding media data URIs;
- preserving the structured-error fallback when a provider parser returns no error;
- propagating quota saturation metadata into asynchronous settlement logs;
- locking all channel-editor model mutation paths for the fixed SiftQ model; and
- adding regression coverage for terminal statuses, unknown statuses, media limits, request boundaries, and completion billing.

The SiftQ contract documents `cancelled` as the terminal cancellation spelling. Undocumented statuses remain retriable by returning a polling error instead of being guessed as terminal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SiftQ as a configurable video-generation channel with MiniMax-H3 support.
  - Added support for text, frame, reference-media, callback, asynchronous task polling, and result handling.
  - Added channel settings, fixed model selection, API guidance, icon, localized labels, and setup documentation.

- **Bug Fixes**
  - Improved upstream task error reporting with structured provider responses.
  - Improved billing accuracy using completed video duration and quota adjustments.
  - Added validation for media inputs and request combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->