### PR TITLE
fix: pass turnstile token when sending email bind verification code

### DIFF
--- a/web/src/features/profile/components/dialogs/email-bind-dialog.tsx
+++ b/web/src/features/profile/components/dialogs/email-bind-dialog.tsx
@@ -17,14 +17,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import { Loader2 } from 'lucide-react'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
 import { Dialog } from '@/components/dialog'
+import { Turnstile } from '@/components/turnstile'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { useTurnstile } from '@/features/auth/hooks/use-turnstile'
 import { useCountdown } from '@/hooks/use-countdown'
 
 import { sendEmailVerification, bindEmail } from '../../api'
@@ -59,20 +61,36 @@ export function EmailBindDialog({
   } = useCountdown({
     initialSeconds: 60,
   })
+  const {
+    isTurnstileEnabled,
+    turnstileSiteKey,
+    turnstileToken,
+    setTurnstileToken,
+    validateTurnstile,
+  } = useTurnstile()
+  const [turnstileWidgetKey, setTurnstileWidgetKey] = useState(0)
+  const turnstileReady = !isTurnstileEnabled || Boolean(turnstileToken)
+  const handleTurnstileExpire = useCallback(() => {
+    setTurnstileToken('')
+  }, [setTurnstileToken])
 
   const handleSendCode = async () => {
     if (!email || !email.includes('@')) {
       toast.error(t('Please enter a valid email address'))
       return
     }
+    if (!validateTurnstile()) return
 
     try {
       setSendingCode(true)
-      const response = await sendEmailVerification(email)
+      const response = await sendEmailVerification(email, turnstileToken)
 
       if (response.success) {
         toast.success(t('Verification code sent! Please check your email.'))
         startCountdown()
+        // Tokens are single-use; require a fresh challenge before resend
+        setTurnstileToken('')
+        setTurnstileWidgetKey((v) => v + 1)
       } else {
         toast.error(response.message || t('Failed to send verification code'))
       }
@@ -100,6 +118,7 @@ export function EmailBindDialog({
         // Reset form
         setEmail('')
         setCode('')
+        setTurnstileToken('')
         resetCountdown()
       } else {
         toast.error(response.message || t('Failed to bind email'))
@@ -118,6 +137,7 @@ export function EmailBindDialog({
         // Reset form when closing
         setEmail('')
         setCode('')
+        setTurnstileToken('')
         resetCountdown()
       }
     }
@@ -187,7 +207,7 @@ export function EmailBindDialog({
               type='button'
               variant='outline'
               onClick={handleSendCode}
-              disabled={sendingCode || isActive || !email}
+              disabled={sendingCode || isActive || !email || !turnstileReady}
             >
               {isActive
                 ? `${secondsLeft}s`
@@ -197,6 +217,15 @@ export function EmailBindDialog({
             </Button>
           </div>
         </div>
+
+        {isTurnstileEnabled && (
+          <Turnstile
+            key={turnstileWidgetKey}
+            siteKey={turnstileSiteKey}
+            onVerify={setTurnstileToken}
+            onExpire={handleTurnstileExpire}
+          />
+        )}
       </div>
     </Dialog>
   )


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

站点开启 Turnstile 校验后，个人设置里的"绑定邮箱"弹窗发验证码必报 "Turnstile token 为空"：`/api/verification` 挂了 TurnstileCheck 中间件，但这个弹窗没接 Turnstile，发请求不带 token，会造成无法发送验证码


## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closed: #6344

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
复现路径：运营设置开启 Turnstile → 个人设置 → 绑定邮箱 → 输入邮箱点"发送"，修复前必报 "Turnstile token 为空"。修复后弹窗内出现 Turnstile 组件，过校验后才能发送，验证码正常送达。`bun run typecheck` 通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added CAPTCHA verification to the email-binding process when enabled.
  * Users must complete the CAPTCHA challenge before requesting a verification code.
  * A new challenge is required after each request, and verification resets when the dialog closes or binding succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->