### PR TITLE
fix(oauth): allow oidc login when userinfo has no email

### DIFF
--- a/oauth/oidc.go
+++ b/oauth/oidc.go
@@ -144,8 +144,8 @@ func (p *OIDCProvider) GetUserInfo(ctx context.Context, token *OAuthToken) (*OAu
 		return nil, err
 	}
 
-	if oidcUser.OpenID == "" || oidcUser.Email == "" {
-		logger.LogError(ctx, fmt.Sprintf("[OAuth-OIDC] GetUserInfo failed: empty fields (sub=%s, email=%s)", oidcUser.OpenID, oidcUser.Email))
+	if oidcUser.OpenID == "" {
+		logger.LogError(ctx, "[OAuth-OIDC] GetUserInfo failed: empty sub")
 		return nil, NewOAuthError(i18n.MsgOAuthUserInfoEmpty, map[string]any{"Provider": "OIDC"})
 	}
 


### PR DESCRIPTION
## 📝 变更描述 / Description

内置 OIDC 登录时，userinfo 里拿不到 email 会被直接拒绝（报"用户信息为空"）。但不少 IdP 的 userinfo 本来就不返回 email，而 email 在系统里也不是必填项：

- 自定义提供商（generic）按 EmailField 取值，取不到就是空串，照常登录；
- GitHub 登录 email 为空也放行；
- `findOrCreateOAuthUser` 只在 email 非空时才写入用户。

这个 PR 把内置 OIDC 对齐到同样行为：只校验 sub，email 缺失不再拦登录。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [x] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```
$ go test ./oauth/
ok  	github.com/QuantumNous/new-api/oauth	0.615s
```

已在自有部署上验证：OIDC IdP userinfo 无 email 时可正常登录，email 留空，用户后续可在个人页自行绑定邮箱。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC authentication now succeeds when a user’s profile does not include an email address, as long as the required OpenID identifier is present.
  * Improved error reporting for invalid OIDC user information by focusing on missing identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->