### PR TITLE
fix(relay): forward bare-JSON stream frames without "data:" prefix

### DIFF
--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -254,10 +254,15 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 			if len(data) < 6 {
 				continue
 			}
-			if data[:5] != "data:" && data[:6] != "[DONE]" {
+			// 标准 SSE 帧以 "data:" 前缀下发;部分上游(如 Console Go 网关的某些
+			// 模型)直接输出无前缀的裸 JSON 行,如 {"type":"content_block_delta",...}。
+			// 二者都按数据帧转发;空对象 "{}" 心跳帧已被 len<6 提前过滤。
+			if data[:5] != "data:" && data[:6] != "[DONE]" && data[0] != '{' {
 				continue
 			}
-			data = data[5:]
+			if strings.HasPrefix(data, "data:") {
+				data = data[5:]
+			}
 			data = strings.TrimSpace(data)
 			if data == "" {
 				continue

--- a/relay/helper/stream_scanner_test.go
+++ b/relay/helper/stream_scanner_test.go
@@ -211,6 +211,57 @@ func TestStreamScannerHandler_DataWithExtraSpaces(t *testing.T) {
 	assert.Equal(t, "{\"trimmed\":true}", got)
 }
 
+func TestStreamScannerHandler_BareJSONFrames(t *testing.T) {
+	t.Parallel()
+
+	// Some upstreams (e.g. the Console Go gateway for certain models) emit
+	// stream frames as bare JSON lines without the "data:" SSE prefix.
+	var b strings.Builder
+	for i := 0; i < 3; i++ {
+		b.WriteString("{}\n") // heartbeat frames, must be skipped
+	}
+	b.WriteString("{\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n")
+	b.WriteString("{\"type\":\"message_delta\"}\n")
+	// No [DONE]; stream ends by EOF.
+
+	c, resp, info := setupStreamTest(t, strings.NewReader(b.String()))
+
+	var mu sync.Mutex
+	var got []string
+	StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {
+		mu.Lock()
+		got = append(got, data)
+		mu.Unlock()
+	})
+
+	require.Equal(t, []string{
+		"{\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}",
+		"{\"type\":\"message_delta\"}",
+	}, got, "bare JSON frames should be forwarded, {} heartbeats skipped")
+}
+
+func TestStreamScannerHandler_MixedSSEAndBareJSON(t *testing.T) {
+	t.Parallel()
+
+	body := "data: {\"sse\":true}\n" +
+		"{\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n" +
+		"data: [DONE]\n"
+	c, resp, info := setupStreamTest(t, strings.NewReader(body))
+
+	var mu sync.Mutex
+	var got []string
+	StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {
+		mu.Lock()
+		got = append(got, data)
+		mu.Unlock()
+	})
+
+	require.Equal(t, []string{
+		"{\"sse\":true}",
+		"{\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}",
+	}, got, "both SSE-prefixed and bare JSON frames should be forwarded")
+}
+
 // TestStreamScannerHandler_ClientCancelAbortsUpstreamAndReturns pins the
 // disconnect contract: when the client goes away, the handler must return
 // promptly (all goroutines joined, so the gin.Context can never leak into a


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - AI-generated: this PR was written with Claude Code assistance.

## 📝 变更描述 / Description

`StreamScannerHandler`（`relay/helper/stream_scanner.go`）此前只转发以 `data:` 或 `[DONE]` 开头的行，其余行一律丢弃。部分上游（如 Console Go 网关的 `deepseek-v4-pro`）的 Anthropic stream 直接下发**无 `data:` 前缀的裸 JSON 帧**（`{"type":"content_block_delta",...}`，以及若干 `{}` 心跳帧），导致这些帧全部被丢弃，客户端收到 HTTP 200 + 空 body。对照 `deepseek-v4-flash`（上游用标准 `data:` SSE）则正常。

改动：在原有过滤条件上，额外接受以 `{` 开头的行作为数据帧；仅在存在 `data:` 前缀时剥离前缀。空对象 `{}` 心跳帧继续由既有 `len(data) < 6` 守卫过滤，无需特殊处理。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- Closes #6797

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述已人工整理（含 AI 生成声明）。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs（#5846 为已关闭的 SSE raw passthrough，处理 `event:` 行过滤，与本缺陷无前缀裸 JSON 行不同）。
- [x] **Bug fix 说明:** 已关联 Issue #6797。
- [x] **变更理解:** 理解改动：通用流扫描器多接受 `{` 开头裸 JSON 行，已由直连上游 vs 经 new-api 对比验证根因。
- [x] **范围聚焦:** 仅改 `stream_scanner.go` 及其测试，不含无关改动。
- [x] **本地验证:** `go test ./relay/...` 全部通过（含新增 `TestStreamScannerHandler_BareJSONFrames`、`TestStreamScannerHandler_MixedSSEAndBareJSON`）。
- [x] **安全合规:** 无敏感凭据，符合项目规范（relaykit 独立构建通过、go vet 通过）。

## 📸 运行证明 / Proof of Work

```bash
go test ./relay/helper/ -run TestStreamScannerHandler -v
# PASS 全部用例，含新增 BareJSONFrames / MixedSSEAndBareJSON

go test ./relay/...     # 全绿
GOWORK=off go build ./...  # relaykit 独立构建通过
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stream processing now supports JSON lines without the `data:` prefix.
  * Mixed SSE and unprefixed JSON streams are handled correctly.
  * Unrecognized lines and `{}` heartbeat frames continue to be ignored.
  * Streams can end at EOF without requiring a `[DONE]` marker.

* **Tests**
  * Added coverage for bare JSON and mixed-format streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->