### PR TITLE
feat(web): hide password-register entry points when disabled

### DIFF
--- a/web/src/features/auth/lib/password-register-guard.ts
+++ b/web/src/features/auth/lib/password-register-guard.ts
@@ -1,0 +1,40 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { isRedirect, redirect } from '@tanstack/react-router'
+
+import { getStatus } from '@/lib/api'
+
+// The sign-up and forgot-password pages (and their links on the sign-in
+// page) only make sense while password registration is enabled, so routes
+// gated by this helper redirect to sign-in when it is disabled. Defaults to
+// enabled when the status endpoint is unreachable so a transient failure
+// does not lock users out.
+export async function redirectIfPasswordRegisterDisabled(): Promise<void> {
+  try {
+    const status = await getStatus()
+    if (status?.password_register_enabled === false) {
+      throw redirect({ to: '/sign-in', replace: true })
+    }
+  } catch (error) {
+    if (isRedirect(error)) {
+      throw error
+    }
+    // status fetch failed: keep the page accessible
+  }
+}

--- a/web/src/features/auth/sign-in/components/user-auth-form.tsx
+++ b/web/src/features/auth/sign-in/components/user-auth-form.tsx
@@ -391,12 +391,14 @@ export function UserAuthForm({
                     />
                   </FormControl>
                   <FormMessage />
-                  <Link
-                    to='/forgot-password'
-                    className='text-muted-foreground absolute end-0 -top-0.5 z-10 text-sm font-medium hover:opacity-75'
-                  >
-                    {t('Forgot password?')}
-                  </Link>
+                  {status?.password_register_enabled !== false && (
+                    <Link
+                      to='/forgot-password'
+                      className='text-muted-foreground absolute end-0 -top-0.5 z-10 text-sm font-medium hover:opacity-75'
+                    >
+                      {t('Forgot password?')}
+                    </Link>
+                  )}
                 </FormItem>
               )}
             />

--- a/web/src/features/auth/sign-in/index.tsx
+++ b/web/src/features/auth/sign-in/index.tsx
@@ -38,7 +38,8 @@ export function SignIn() {
             {t('Sign in')}
           </h2>
           {!status?.self_use_mode_enabled &&
-            status?.register_enabled !== false && (
+            status?.register_enabled !== false &&
+            status?.password_register_enabled !== false && (
               <p className='text-muted-foreground text-left text-sm sm:text-base'>
                 {t("Don't have an account?")}{' '}
                 <Link

--- a/web/src/routes/(auth)/forgot-password.tsx
+++ b/web/src/routes/(auth)/forgot-password.tsx
@@ -18,8 +18,13 @@ For commercial licensing, please contact support@quantumnous.com
 */
 import { createFileRoute } from '@tanstack/react-router'
 
+import { redirectIfPasswordRegisterDisabled } from '@/features/auth/lib/password-register-guard'
 import { ForgotPassword } from '@/features/auth/forgot-password'
 
 export const Route = createFileRoute('/(auth)/forgot-password')({
   component: ForgotPassword,
+  beforeLoad: async () => {
+    // 密码注册关闭时禁止访问忘记密码页
+    await redirectIfPasswordRegisterDisabled()
+  },
 })

--- a/web/src/routes/(auth)/sign-up.tsx
+++ b/web/src/routes/(auth)/sign-up.tsx
@@ -18,12 +18,16 @@ For commercial licensing, please contact support@quantumnous.com
 */
 import { createFileRoute, redirect } from '@tanstack/react-router'
 
+import { redirectIfPasswordRegisterDisabled } from '@/features/auth/lib/password-register-guard'
 import { SignUp } from '@/features/auth/sign-up'
 import { useAuthStore } from '@/stores/auth-store'
 
 export const Route = createFileRoute('/(auth)/sign-up')({
   component: SignUp,
   beforeLoad: async () => {
+    // 密码注册关闭时禁止访问注册页
+    await redirectIfPasswordRegisterDisabled()
+
     const { auth } = useAuthStore.getState()
 
     // 如果已经有用户信息，说明已登录，注册页对其无意义，跳转到 dashboard


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

在「系统设置 → 认证」关闭密码注册（`PasswordRegisterEnabled=false`）后，登录页仍然展示「Sign up」和「Forgot password?」两个链接，且 `/sign-up`、`/forgot-password` 路由仍可被直接访问——密码注册接口在后端是关闭的，这些入口点击后只会失败，属于无效入口。

改动（仅前端）：

1. 登录页隐藏两个入口链接：`sign-in/index.tsx` 的注册链接、`user-auth-form.tsx` 的忘记密码链接，均追加 `status?.password_register_enabled !== false` 判断（status 未加载完成时默认显示，避免闪烁）。
2. 路由级禁止访问：新增共享守卫 `features/auth/lib/password-register-guard.ts`，在 `/sign-up` 和 `/forgot-password` 的 `beforeLoad` 中请求 `/api/status`，若 `password_register_enabled === false` 则重定向到 `/sign-in`；status 请求失败时保持页面可访问，避免网络抖动把用户锁在外面。首页 hero/CTA 等其他指向 `/sign-up` 的入口由路由守卫统一兜底，无需逐个改动。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无对应 Issue。适用场景：仅允许企业 OAuth（钉钉/飞书/OIDC 等）登录的私有化部署，关闭密码注册后登录页不再出现无效入口。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。（说明：本 PR 代码为 AI 辅助生成，描述已经人工核对。）
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

本地验证（密码注册关闭状态下）：
1. 登录页不再显示「Sign up」与「Forgot password?」链接；
2. 直接访问 `/sign-up`、`/forgot-password` 均被重定向回 `/sign-in`；
3. 重新开启密码注册后，两个链接恢复显示、两个路由恢复可访问；
4. 已登录用户访问 `/sign-up` 仍按原逻辑跳转 dashboard（守卫在登录态判断之前执行，互不影响）。

`tsc --noEmit` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic redirection to the sign-in page when password registration is disabled.
  * Sign-up and forgot-password pages are now inaccessible when password registration is unavailable.
  * Sign-in pages hide sign-up and forgot-password options when registration is disabled.
* **Bug Fixes**
  * Authentication options now consistently reflect the configured password-registration availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->