### PR TITLE
feat: add Aibuff release controller and candidate gate

### DIFF
--- a/.github/workflows/aibuff-release-gate.yml
+++ b/.github/workflows/aibuff-release-gate.yml
@@ -1,0 +1,70 @@
+name: Aibuff release gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_production_commit:
+        description: "Expected production commit (full 40-character hash)"
+        required: true
+        type: string
+      expected_production_tree:
+        description: "Expected production tree (full 40-character hash)"
+        required: true
+        type: string
+      expected_production_image_digest:
+        description: "Expected production image digest (sha256:<64 lowercase hex>)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aibuff-release-gate
+  cancel-in-progress: false
+
+jobs:
+  package-and-validate:
+    name: Package and validate exact release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout complete Git history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run release-controller tests
+        run: python3 -m unittest discover -s ops/release/tests -p 'test_*.py' -v
+
+      - name: Prepare exact release package
+        env:
+          EXPECTED_PRODUCTION_COMMIT: ${{ inputs.expected_production_commit }}
+          EXPECTED_PRODUCTION_TREE: ${{ inputs.expected_production_tree }}
+          EXPECTED_PRODUCTION_IMAGE_DIGEST: ${{ inputs.expected_production_image_digest }}
+        run: |
+          output="$RUNNER_TEMP/aibuff-release-${GITHUB_SHA}"
+          python3 ops/release/release_controller.py prepare \
+            --repo . \
+            --output "$output" \
+            --candidate "$GITHUB_SHA" \
+            --expected-production-commit "$EXPECTED_PRODUCTION_COMMIT" \
+            --expected-production-tree "$EXPECTED_PRODUCTION_TREE" \
+            --expected-production-image-digest "$EXPECTED_PRODUCTION_IMAGE_DIGEST"
+          python3 ops/release/release_controller.py validate \
+            --repo . \
+            --manifest "$output/release-manifest.json"
+
+      - name: Upload release package
+        uses: actions/upload-artifact@v4
+        with:
+          name: aibuff-release-${{ github.sha }}
+          path: ${{ runner.temp }}/aibuff-release-${{ github.sha }}
+          if-no-files-found: error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,17 @@ web/           — Frontend (React 19, Rsbuild, Base UI, Tailwind)
 
 ## Rules
 
+### Rule 0: Aibuff Code-Candidate Gate — Read Before Development
+
+For any Aibuff code development, code review, candidate validation, or release-preparation task, read these shared rules before working:
+
+1. `AI沟通对接/00-总规则与索引/候选源码跨设备交付规则-v1.md`
+2. `AI沟通对接/02-项目工作区/Aibuff-中转站/02-运维Runbook/2026-08-13-Aibuff-发布总控-v1.md`
+
+At the start of an L2/L3 task, the assignee must record `ACKED` in its ticket. A local worktree, commit hash, or chat summary is not a delivered candidate: before independent acceptance or release-queue entry, the candidate must be recoverable from the shared registry as a complete Git bundle plus manifest and receipt.
+
+After a validated candidate is staged in the shared registry, the release coordinator is authorized to automatically create an independent-acceptance handoff. The implementer must not sign independent PASS for the same candidate. This does not authorize production deployment, production access, paid tests, configuration changes, restarts, or rollback.
+
 ### Common Code Quality
 
 - New code should stay direct and readable. Prefer early returns, clear branches, and well-named local variables to deep nesting or layered control flow.

--- a/ops/release/README.md
+++ b/ops/release/README.md
@@ -12,6 +12,26 @@
 
 输出目录已经存在时会直接停止，绝不覆盖。目录创建后出现错误时，该目录只能视为失败的临时产物，必须换一个新目录重做。
 
+## 跨设备候选库
+
+不要把正在开发的 `.git` 目录直接放进 Google Drive 同步：两台机器同时写对象库会造成冲突。正确做法是把已验包的候选作为不可变制品登记到共享候选库。
+
+每个候选有两个入口：GitHub 候选分支用于审阅和协作；Drive 同步目录用于保存不可变的 `source.bundle`、`source.tar.gz`、manifest 和登记回执。任何机器只需下载该目录，就能从 bundle 恢复临时 checkout 并验证制品。
+
+```bash
+# 先 prepare + validate，再登记到配置好的 Drive 同步目录。
+python3 ops/release/release_controller.py registry stage \
+  --repo . \
+  --manifest /tmp/aibuff-release-<new-directory>/release-manifest.json \
+  --registry <drive-synced-release-candidate-registry>
+
+# 在另一台机器上；无需事先拥有该候选的 Git worktree。
+python3 ops/release/release_controller.py registry verify \
+  --manifest <drive-synced-release-candidate-registry>/<release-id>/release-manifest.json
+```
+
+`registry stage` 会先执行完整 `validate`，目标候选目录必须是新目录；同一个 release ID 再次登记会 `HARD STOP`，绝不覆盖。`registry verify` 会从 bundle 创建临时 clone 后重新验证 commit/tree/parents、源码归档和 bundle。该机制只保存代码制品与哈希，不保存生产地址、凭据或真实部署命令。
+
 ## 普通发布
 
 普通发布的意思是：在基线之上完成已审查的变更，然后交给发布负责人。典型流程如下：

--- a/ops/release/README.md
+++ b/ops/release/README.md
@@ -1,0 +1,104 @@
+# Aibuff 发布总控 v1
+
+这是一个只负责“精确打包、验包、发布前核对和单部署锁”的本地工具。它不连接生产、不执行 SSH、不运行 Docker/Nginx/数据库命令，也不保存地址、凭据或 Token。真正的生产适配器只能由获授权的运维实现接口；本目录不提供该适配器。
+
+## 发布包里有什么
+
+`prepare` 只接受干净的 Git checkout，并把当前 `HEAD` 的精确提交打成一个全新的目录：
+
+- `release-manifest.json`：完整 candidate commit、tree、父提交列表、预期生产 commit/tree/image digest，以及两个制品的大小和 SHA-256。
+- `source.tar.gz`：由 `git archive` 生成的精确源码归档，根目录固定为 `source/`。
+- `source.bundle`：包含 candidate 可达历史的 Git bundle，并把 candidate 作为 bundle head。
+
+输出目录已经存在时会直接停止，绝不覆盖。目录创建后出现错误时，该目录只能视为失败的临时产物，必须换一个新目录重做。
+
+## 普通发布
+
+普通发布的意思是：在基线之上完成已审查的变更，然后交给发布负责人。典型流程如下：
+
+```text
+干净 checkout
+  -> prepare 精确源码 + bundle + manifest
+  -> validate 二次验包
+  -> 获得发布授权
+  -> 在生产侧重新读取脱敏状态并执行 preflight
+  -> acquire 单部署锁
+  -> 由外部、已授权的部署适配器执行发布
+  -> 保留回滚点/执行回滚方案
+  -> release 锁
+  -> 发布后再次核对 commit、tree、image digest 和业务健康度
+```
+
+示例（值必须由发布负责人提供，不要把示例值当成生产事实）：
+
+```bash
+python3 ops/release/release_controller.py prepare \
+  --repo . \
+  --output /tmp/aibuff-release-<new-directory> \
+  --candidate <candidate-40-char-commit> \
+  --expected-production-commit <production-40-char-commit> \
+  --expected-production-tree <production-40-char-tree> \
+  --expected-production-image-digest sha256:<64-lowercase-hex>
+
+python3 ops/release/release_controller.py validate \
+  --repo . \
+  --manifest /tmp/aibuff-release-<new-directory>/release-manifest.json
+
+python3 ops/release/release_controller.py preflight \
+  --repo . \
+  --manifest /tmp/aibuff-release-<new-directory>/release-manifest.json \
+  --production-state /path/to/redacted-production-state.json
+```
+
+脱敏状态 JSON 只应包含这三个字段，不包含地址、凭据或 Token：
+
+```json
+{
+  "commit": "<40-char-commit>",
+  "tree": "<40-char-tree>",
+  "image_digest": "sha256:<64-lowercase-hex>"
+}
+```
+
+`preflight` 的三项必须全部与 manifest 的 expected 值相同；任意一项漂移都会打印 `HARD STOP` 并以非零状态退出。它不会“自动适配”漂移的生产环境。
+
+## 紧急热修
+
+紧急热修可以缩短评审和测试的范围，但不能缩短安全链路。热修必须从精确生产 commit 分支出来，并仍然完成：
+
+1. 精确源码归档、bundle 和 manifest；
+2. 第二次基线/制品校验；
+3. 生产侧二次 preflight；
+4. 单部署锁；
+5. 可执行的回滚点与回滚方案；
+6. 发布后 commit/tree/image digest 和业务健康验证。
+
+热修不得以“生产很急”为理由跳过任何一项。若预期生产 commit 不是 candidate 的祖先，工具会停止；应先修复基线和授权，而不是强行打包。
+
+## 单部署锁
+
+```bash
+python3 ops/release/release_controller.py lock acquire \
+  --path /tmp/aibuff-deploy.lock \
+  --owner-id <operator-or-job-id> \
+  --ttl-seconds 1800 \
+  --hold-seconds 60
+```
+
+锁使用原子创建。已有新鲜锁时，第二个任务立即失败；不排队、不覆盖。过期或格式损坏的锁同样是 `HARD STOP`，工具不会自动抢占或删除陈旧锁，必须人工核实后再用 owner 校验的 `lock release` 清理。超时/陈旧处理优先失败，避免两个任务同时认为自己拥有发布权。
+
+若部署适配器需要跨越多个命令持有锁，可以不传 `--hold-seconds`，在外部部署完成后以相同 `--owner-id` 显式释放：
+
+```bash
+python3 ops/release/release_controller.py lock release \
+  --path /tmp/aibuff-deploy.lock \
+  --owner-id <operator-or-job-id>
+```
+
+## GitHub workflow
+
+`.github/workflows/aibuff-release-gate.yml` 只运行 unittest、`prepare` 和 `validate`，上传 manifest/source archive/bundle。它只有 `contents: read` 权限，使用固定 concurrency group 且 `cancel-in-progress: false`。workflow 不读取 secrets，不 SSH，不部署，也不替代生产侧单锁和二次 preflight。
+
+## 停止线
+
+以下情况必须停止并人工处理：工作区脏、字段缺失或 hash 不是完整值、生产 commit/tree/image digest 漂移、生产 commit 不是 candidate 祖先、源码归档或 bundle 缺失/篡改、输出目录已存在、锁新鲜/陈旧/损坏或 owner 不匹配。所有这些路径均以非零状态退出，并在错误前显示 `HARD STOP`。

--- a/ops/release/release_controller.py
+++ b/ops/release/release_controller.py
@@ -191,6 +191,131 @@ def _sha256(path: Path) -> tuple[str, int]:
     return digest.hexdigest(), size
 
 
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _safe_tar_member_name(value: str, field: str) -> str:
+    path = Path(value)
+    if not value or path.is_absolute() or any(part in ("", "..") for part in path.parts):
+        raise ReleaseError(f"OCI image tar contains unsafe {field}: {value!r}")
+    return value
+
+
+def _tar_json(members: dict[str, tarfile.TarInfo], stream: tarfile.TarFile, name: str, field: str) -> Any:
+    member = members.get(_safe_tar_member_name(name, field))
+    if member is None or not member.isfile():
+        raise ReleaseError(f"OCI image tar is missing {field}: {name}")
+    handle = stream.extractfile(member)
+    if handle is None:
+        raise ReleaseError(f"OCI image tar cannot read {field}: {name}")
+    try:
+        return json.loads(handle.read())
+    except json.JSONDecodeError as exc:
+        raise ReleaseError(f"OCI image tar has invalid JSON in {field}: {name}") from exc
+
+
+def _tar_digest(members: dict[str, tarfile.TarInfo], stream: tarfile.TarFile, name: str, field: str) -> str:
+    member = members.get(_safe_tar_member_name(name, field))
+    if member is None or not member.isfile():
+        raise ReleaseError(f"OCI image tar is missing {field}: {name}")
+    handle = stream.extractfile(member)
+    if handle is None:
+        raise ReleaseError(f"OCI image tar cannot read {field}: {name}")
+    digest = hashlib.sha256()
+    for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+        digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def verify_oci_image_tar(
+    image_tar: Path,
+    expected_tar_sha256: str,
+    expected_manifest_digest: str,
+    expected_config_digest: str,
+    expected_revision: str,
+    expected_platform: str,
+    expected_repo_tag: str,
+) -> None:
+    """Verify a portable OCI/Docker image tar without relying on Docker's ID display.
+
+    Docker commonly reports a config digest as `.Id`; OCI registries identify an
+    image by its manifest digest.  Both are verified, alongside the config's
+    revision/platform and every referenced layer, so a same-revision image
+    cannot silently replace the authorized binary.
+    """
+
+    image_tar = image_tar.expanduser().resolve()
+    if not image_tar.is_file():
+        raise ReleaseError(f"OCI image tar does not exist: {image_tar}")
+    if not re.fullmatch(r"[0-9a-f]{64}", expected_tar_sha256):
+        raise ReleaseError("expected image tar SHA-256 must be 64 lowercase hex characters")
+    manifest_digest = _require_digest(expected_manifest_digest, "expected OCI manifest digest")
+    config_digest = _require_digest(expected_config_digest, "expected OCI config digest")
+    revision = _require_hex40(expected_revision, "expected OCI revision")
+    if expected_platform != "linux/amd64":
+        raise ReleaseError("expected OCI platform must be linux/amd64")
+    if not expected_repo_tag or "@" in expected_repo_tag or expected_repo_tag.startswith("/"):
+        raise ReleaseError("expected OCI repo tag must be a non-empty image tag")
+    actual_tar_sha256, _ = _sha256(image_tar)
+    if actual_tar_sha256 != expected_tar_sha256:
+        raise ReleaseError("OCI image tar SHA-256 mismatch")
+    try:
+        with tarfile.open(image_tar, mode="r:") as stream:
+            members = {member.name: member for member in stream.getmembers()}
+            if len(members) != len(stream.getmembers()):
+                raise ReleaseError("OCI image tar contains duplicate member names")
+            index = _tar_json(members, stream, "index.json", "OCI index")
+            docker_manifest = _tar_json(members, stream, "manifest.json", "Docker manifest")
+            if not isinstance(index, dict) or not isinstance(index.get("manifests"), list):
+                raise ReleaseError("OCI image index must contain a manifests list")
+            selected = [entry for entry in index["manifests"] if isinstance(entry, dict) and entry.get("digest") == manifest_digest]
+            if len(selected) != 1:
+                raise ReleaseError("OCI image index does not bind exactly one expected manifest digest")
+            manifest_name = "blobs/sha256/" + manifest_digest.removeprefix("sha256:")
+            if _tar_digest(members, stream, manifest_name, "OCI manifest blob") != manifest_digest:
+                raise ReleaseError("OCI manifest blob digest mismatch")
+            manifest = _tar_json(members, stream, manifest_name, "OCI manifest blob")
+            if not isinstance(manifest, dict) or not isinstance(manifest.get("config"), dict):
+                raise ReleaseError("OCI manifest must contain a config object")
+            if manifest["config"].get("digest") != config_digest:
+                raise ReleaseError("OCI manifest config digest mismatch")
+            config_name = "blobs/sha256/" + config_digest.removeprefix("sha256:")
+            if _tar_digest(members, stream, config_name, "OCI config blob") != config_digest:
+                raise ReleaseError("OCI config blob digest mismatch")
+            config = _tar_json(members, stream, config_name, "OCI config blob")
+            if not isinstance(config, dict):
+                raise ReleaseError("OCI config must be a JSON object")
+            labels = config.get("config", {}).get("Labels", {})
+            if not isinstance(labels, dict) or labels.get("org.opencontainers.image.revision") != revision:
+                raise ReleaseError("OCI config revision mismatch")
+            if f"{config.get('os')}/{config.get('architecture')}" != expected_platform:
+                raise ReleaseError("OCI config platform mismatch")
+            layers = manifest.get("layers")
+            if not isinstance(layers, list) or not layers:
+                raise ReleaseError("OCI manifest must contain a non-empty layers list")
+            manifest_layers: list[str] = []
+            for layer in layers:
+                if not isinstance(layer, dict):
+                    raise ReleaseError("OCI manifest layer must be an object")
+                digest = _require_digest(layer.get("digest"), "OCI layer digest")
+                layer_name = "blobs/sha256/" + digest.removeprefix("sha256:")
+                if _tar_digest(members, stream, layer_name, "OCI layer blob") != digest:
+                    raise ReleaseError("OCI layer blob digest mismatch")
+                manifest_layers.append(digest)
+            if not isinstance(docker_manifest, list) or len(docker_manifest) != 1 or not isinstance(docker_manifest[0], dict):
+                raise ReleaseError("Docker manifest must contain exactly one image entry")
+            docker_entry = docker_manifest[0]
+            if docker_entry.get("Config") != config_name:
+                raise ReleaseError("Docker manifest config path mismatch")
+            if docker_entry.get("Layers") != ["blobs/sha256/" + digest.removeprefix("sha256:") for digest in manifest_layers]:
+                raise ReleaseError("Docker manifest layer list mismatch")
+            if docker_entry.get("RepoTags") != [expected_repo_tag]:
+                raise ReleaseError("Docker manifest repo tag mismatch")
+    except (OSError, tarfile.TarError) as exc:
+        raise ReleaseError(f"OCI image tar is unreadable: {image_tar.name}") from exc
+
+
 def _write_source_archive(repo: Path, commit: str, destination: Path) -> None:
     """Write a deterministic gzip-wrapped `git archive` for the candidate."""
 
@@ -746,6 +871,20 @@ def _cmd_registry_verify(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_image_verify(args: argparse.Namespace) -> int:
+    verify_oci_image_tar(
+        Path(args.image_tar),
+        args.tar_sha256,
+        args.oci_manifest_digest,
+        args.config_digest,
+        args.revision,
+        args.platform,
+        args.repo_tag,
+    )
+    print("OCI IMAGE VERIFY PASS: tar, manifest, config, revision, platform, tag, and layers are exact")
+    return 0
+
+
 def _cmd_lock_acquire(args: argparse.Namespace) -> int:
     owner_id = args.owner_id or f"pid-{os.getpid()}-{uuid.uuid4().hex}"
     if args.hold_seconds < 0:
@@ -800,6 +939,18 @@ def _build_parser() -> argparse.ArgumentParser:
     registry_verify_parser = registry_commands.add_parser("verify", help="verify a staged package without a pre-existing checkout")
     registry_verify_parser.add_argument("--manifest", required=True)
     registry_verify_parser.set_defaults(handler=_cmd_registry_verify)
+
+    image_parser = commands.add_parser("image", help="verify an exact portable OCI image tar")
+    image_commands = image_parser.add_subparsers(dest="image_command", required=True)
+    image_verify_parser = image_commands.add_parser("verify", help="verify tar, OCI manifest/config, revision, platform, tag, and layers")
+    image_verify_parser.add_argument("--image-tar", required=True)
+    image_verify_parser.add_argument("--tar-sha256", required=True)
+    image_verify_parser.add_argument("--oci-manifest-digest", required=True)
+    image_verify_parser.add_argument("--config-digest", required=True)
+    image_verify_parser.add_argument("--revision", required=True)
+    image_verify_parser.add_argument("--platform", required=True)
+    image_verify_parser.add_argument("--repo-tag", required=True)
+    image_verify_parser.set_defaults(handler=_cmd_image_verify)
 
     lock_parser = commands.add_parser("lock", help="acquire or release the single deployment lock")
     lock_commands = lock_parser.add_subparsers(dest="lock_command", required=True)

--- a/ops/release/release_controller.py
+++ b/ops/release/release_controller.py
@@ -1,0 +1,680 @@
+#!/usr/bin/env python3
+"""Fail-closed packaging, validation, preflight, and deployment-lock tooling.
+
+This module intentionally contains no production transport or deployment code.  It
+only creates and verifies an exact Git release package and provides a local,
+atomic lease file that a separately authorized adapter may hold while deploying.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import gzip
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import uuid
+from typing import Any, Iterable, Protocol, Sequence
+
+
+SCHEMA_VERSION = 1
+MANIFEST_NAME = "release-manifest.json"
+SOURCE_ARCHIVE_NAME = "source.tar.gz"
+BUNDLE_NAME = "source.bundle"
+HEX40 = re.compile(r"^[0-9a-f]{40}$")
+IMAGE_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+LOCK_SCHEMA_VERSION = 1
+
+
+class ReleaseError(RuntimeError):
+    """An expected, fail-closed release gate error."""
+
+
+class DeploymentAdapter(Protocol):
+    """Interface for a separately authorized production deployment adapter.
+
+    Implementations are intentionally outside this package.  The interface
+    carries no address, credential, transport, or deployment command.
+    """
+
+    def deploy(self, package_dir: Path, manifest: dict[str, Any]) -> None:
+        ...
+
+    def rollback(self, package_dir: Path, manifest: dict[str, Any]) -> None:
+        ...
+
+    def post_release_validate(self, manifest: dict[str, Any]) -> None:
+        ...
+
+
+def _utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _timestamp(value: dt.datetime | None = None) -> str:
+    current = value or _utc_now()
+    return current.astimezone(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: Any, field: str) -> dt.datetime:
+    if not isinstance(value, str) or not value:
+        raise ReleaseError(f"{field} must be an ISO-8601 timestamp")
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ReleaseError(f"{field} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ReleaseError(f"{field} must include a timezone")
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    cwd: Path | None = None,
+    check: bool = True,
+    input_data: bytes | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    result = subprocess.run(
+        list(command),
+        cwd=str(cwd) if cwd else None,
+        input=input_data,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        detail = f": {stderr}" if stderr else ""
+        raise ReleaseError(f"command failed ({' '.join(command)}), exit {result.returncode}{detail}")
+    return result
+
+
+def _git(repo: Path, args: Sequence[str], *, check: bool = True) -> subprocess.CompletedProcess[bytes]:
+    return _run(["git", "-C", str(repo), *args], check=check)
+
+
+def _git_text(repo: Path, args: Sequence[str], *, check: bool = True) -> str:
+    result = _git(repo, args, check=check)
+    return result.stdout.decode("utf-8", errors="replace").strip()
+
+
+def _repo_path(raw: str | os.PathLike[str]) -> Path:
+    repo = Path(raw).expanduser().resolve()
+    if not repo.is_dir():
+        raise ReleaseError(f"repository is not a directory: {repo}")
+    _git_text(repo, ["rev-parse", "--show-toplevel"])
+    return repo
+
+
+def _require_hex40(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not HEX40.fullmatch(value):
+        raise ReleaseError(f"{field} must be a full 40-character lowercase commit hash")
+    return value
+
+
+def _require_digest(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not IMAGE_DIGEST.fullmatch(value):
+        raise ReleaseError(f"{field} must be a sha256:<64 lowercase hex> image digest")
+    return value
+
+
+def _resolve_commit(repo: Path, ref: str, field: str) -> str:
+    if not isinstance(ref, str) or not ref:
+        raise ReleaseError(f"{field} is required")
+    result = _git(repo, ["rev-parse", "--verify", f"{ref}^{{commit}}"], check=False)
+    if result.returncode != 0:
+        raise ReleaseError(f"{field} does not resolve to a commit: {ref}")
+    return _require_hex40(result.stdout.decode("ascii", errors="replace").strip(), field)
+
+
+def _commit_tree(repo: Path, commit: str, field: str = "commit tree") -> str:
+    return _require_hex40(
+        _git_text(repo, ["rev-parse", "--verify", f"{commit}^{{tree}}"]),
+        field,
+    )
+
+
+def _commit_parents(repo: Path, commit: str) -> list[str]:
+    parents = _git_text(repo, ["show", "-s", "--format=%P", commit])
+    if not parents:
+        return []
+    return [_require_hex40(parent, "commit parent") for parent in parents.split()]
+
+
+def _head(repo: Path) -> str:
+    return _resolve_commit(repo, "HEAD", "HEAD")
+
+
+def _is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
+    result = _git(repo, ["merge-base", "--is-ancestor", ancestor, descendant], check=False)
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    stderr = result.stderr.decode("utf-8", errors="replace").strip()
+    raise ReleaseError(f"could not check commit ancestry: {stderr or 'git merge-base failed'}")
+
+
+def _ensure_clean_checkout(repo: Path) -> None:
+    status = _git_text(repo, ["status", "--porcelain=v1", "--untracked-files=all"])
+    if status:
+        raise ReleaseError("working tree is not clean; exact release packaging requires a clean checkout")
+
+
+def _ensure_digest_args(expected_commit: str, expected_tree: str, image_digest: str) -> tuple[str, str, str]:
+    return (
+        _require_hex40(expected_commit, "expected production commit"),
+        _require_hex40(expected_tree, "expected production tree"),
+        _require_digest(image_digest, "expected production image digest"),
+    )
+
+
+def _sha256(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def _write_source_archive(repo: Path, commit: str, destination: Path) -> None:
+    """Write a deterministic gzip-wrapped `git archive` for the candidate."""
+
+    process = subprocess.Popen(
+        ["git", "-C", str(repo), "archive", "--format=tar", "--prefix=source/", commit],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert process.stdout is not None
+    assert process.stderr is not None
+    try:
+        with destination.open("xb") as raw_output:
+            with gzip.GzipFile(fileobj=raw_output, mode="wb", mtime=0) as compressed:
+                for chunk in iter(lambda: process.stdout.read(1024 * 1024), b""):
+                    compressed.write(chunk)
+        stderr = process.stderr.read().decode("utf-8", errors="replace").strip()
+        return_code = process.wait()
+    except BaseException:
+        process.kill()
+        process.wait()
+        raise
+    if return_code != 0:
+        try:
+            destination.unlink()
+        except FileNotFoundError:
+            pass
+        raise ReleaseError(f"git archive failed: {stderr or 'unknown error'}")
+
+
+def _write_bundle(repo: Path, commit: str, destination: Path) -> None:
+    # `prepare` has already proved that commit is the checked-out HEAD.  Using
+    # the symbolic ref makes Git advertise a head and includes the complete
+    # reachable history; passing a bare object id can produce an empty bundle
+    # on supported Git versions.
+    _git(repo, ["bundle", "create", str(destination), "HEAD"])
+
+
+def _artifact_record(path: Path, relative_path: str) -> dict[str, Any]:
+    digest, size = _sha256(path)
+    return {"path": relative_path, "sha256": digest, "size": size}
+
+
+def _write_json_new(path: Path, value: dict[str, Any]) -> None:
+    encoded = (json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n").encode("utf-8")
+    with path.open("xb") as stream:
+        stream.write(encoded)
+
+
+def _new_output_directory(raw: str | os.PathLike[str]) -> Path:
+    output = Path(raw).expanduser().resolve()
+    if os.path.lexists(output):
+        raise ReleaseError(f"output directory already exists; refusing to overwrite: {output}")
+    try:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.mkdir()
+    except FileExistsError as exc:
+        raise ReleaseError(f"output directory was created concurrently; refusing to overwrite: {output}") from exc
+    return output
+
+
+def prepare(
+    repo: Path,
+    output: Path,
+    candidate_ref: str,
+    expected_production_commit: str,
+    expected_production_tree: str,
+    expected_production_image_digest: str,
+    release_id: str | None = None,
+) -> Path:
+    repo = _repo_path(repo)
+    _ensure_clean_checkout(repo)
+    candidate = _resolve_commit(repo, candidate_ref, "candidate commit")
+    if candidate != _head(repo):
+        raise ReleaseError("candidate commit is not the checked-out HEAD; refusing to package a different source")
+    candidate_tree = _commit_tree(repo, candidate, "candidate tree")
+    candidate_parents = _commit_parents(repo, candidate)
+    expected_commit, expected_tree, image_digest = _ensure_digest_args(
+        expected_production_commit,
+        expected_production_tree,
+        expected_production_image_digest,
+    )
+    resolved_expected = _resolve_commit(repo, expected_commit, "expected production commit")
+    if resolved_expected != expected_commit:
+        raise ReleaseError("expected production commit did not resolve exactly")
+    if _commit_tree(repo, expected_commit, "expected production tree") != expected_tree:
+        raise ReleaseError("expected production tree does not match expected production commit")
+    if not _is_ancestor(repo, expected_commit, candidate):
+        raise ReleaseError("expected production commit is not an ancestor of the candidate commit")
+
+    output = _new_output_directory(output)
+    source_archive = output / SOURCE_ARCHIVE_NAME
+    bundle = output / BUNDLE_NAME
+    _write_source_archive(repo, candidate, source_archive)
+    _write_bundle(repo, candidate, bundle)
+    _validate_bundle(repo, bundle, candidate)
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "release_id": release_id or f"aibuff-{candidate[:12]}-{_utc_now().strftime('%Y%m%dT%H%M%SZ')}",
+        "created_at_utc": _timestamp(),
+        "candidate_commit": candidate,
+        "candidate_tree": candidate_tree,
+        "candidate_parent": candidate_parents[0] if candidate_parents else None,
+        "candidate_parents": candidate_parents,
+        "expected_production_commit": expected_commit,
+        "expected_production_tree": expected_tree,
+        "expected_production_image_digest": image_digest,
+        "source_archive_format": "tar.gz",
+        "source_archive_prefix": "source/",
+        "bundle_format": "git bundle",
+        "bundle_head": candidate,
+        "artifacts": {
+            "source_archive": _artifact_record(source_archive, SOURCE_ARCHIVE_NAME),
+            "git_bundle": _artifact_record(bundle, BUNDLE_NAME),
+        },
+    }
+    _write_json_new(output / MANIFEST_NAME, manifest)
+    return output / MANIFEST_NAME
+
+
+def _load_json(path: Path, description: str) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as stream:
+            return json.load(stream)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReleaseError(f"cannot read {description}: {path}") from exc
+
+
+def _required(mapping: dict[str, Any], key: str, description: str = "manifest") -> Any:
+    if key not in mapping:
+        raise ReleaseError(f"{description} is missing required field: {key}")
+    return mapping[key]
+
+
+def _safe_artifact_path(base: Path, raw: Any, field: str) -> Path:
+    if not isinstance(raw, str) or not raw or Path(raw).is_absolute():
+        raise ReleaseError(f"{field}.path must be a non-empty relative path")
+    relative = Path(raw)
+    if any(part == ".." for part in relative.parts):
+        raise ReleaseError(f"{field}.path must not escape the package directory")
+    resolved_base = base.resolve()
+    resolved = (base / relative).resolve()
+    try:
+        resolved.relative_to(resolved_base)
+    except ValueError as exc:
+        raise ReleaseError(f"{field}.path must stay inside the package directory") from exc
+    return resolved
+
+
+def _check_artifact_hash(record: dict[str, Any], package_dir: Path, name: str) -> Path:
+    raw_path = _required(record, "path", f"artifact {name}")
+    artifact = _safe_artifact_path(package_dir, raw_path, f"artifact {name}")
+    if not artifact.is_file():
+        raise ReleaseError(f"artifact {name} is missing: {raw_path}")
+    expected_hash = _required(record, "sha256", f"artifact {name}")
+    if not isinstance(expected_hash, str) or not re.fullmatch(r"[0-9a-f]{64}", expected_hash):
+        raise ReleaseError(f"artifact {name}.sha256 must be 64 lowercase hex characters")
+    expected_size = _required(record, "size", f"artifact {name}")
+    if not isinstance(expected_size, int) or isinstance(expected_size, bool) or expected_size < 0:
+        raise ReleaseError(f"artifact {name}.size must be a non-negative integer")
+    actual_hash, actual_size = _sha256(artifact)
+    if actual_hash != expected_hash or actual_size != expected_size:
+        raise ReleaseError(
+            f"artifact {name} hash/size mismatch (expected {expected_hash}/{expected_size}, "
+            f"observed {actual_hash}/{actual_size})"
+        )
+    return artifact
+
+
+def _validate_archive_safety(archive: Path) -> None:
+    try:
+        with tarfile.open(archive, mode="r:gz") as stream:
+            members = stream.getmembers()
+    except (OSError, tarfile.TarError) as exc:
+        raise ReleaseError(f"source archive is not a readable tar.gz: {archive.name}") from exc
+    if not members:
+        raise ReleaseError("source archive is empty")
+    for member in members:
+        for name, value in (("member", member.name), ("link", member.linkname)):
+            if not value:
+                continue
+            candidate = Path(value)
+            if candidate.is_absolute() or any(part == ".." for part in candidate.parts):
+                raise ReleaseError(f"source archive contains unsafe {name} path: {value}")
+
+
+def _validate_bundle(repo: Path, bundle: Path, candidate: str) -> None:
+    _git(repo, ["bundle", "verify", str(bundle)])
+    heads = _git_text(repo, ["bundle", "list-heads", str(bundle)])
+    listed = {line.split()[0] for line in heads.splitlines() if line.split()}
+    if candidate not in listed:
+        raise ReleaseError("git bundle does not advertise the exact candidate commit")
+    with tempfile.TemporaryDirectory(prefix="aibuff-release-bundle-") as temporary:
+        clone = Path(temporary) / "clone"
+        result = _run(["git", "clone", "--quiet", "--no-checkout", str(bundle), str(clone)], check=False)
+        if result.returncode != 0:
+            detail = result.stderr.decode("utf-8", errors="replace").strip()
+            raise ReleaseError(f"git bundle could not be cloned for verification: {detail}")
+        cloned_commit = _resolve_commit(clone, candidate, "bundle candidate")
+        if cloned_commit != candidate:
+            raise ReleaseError("git bundle clone resolved a different candidate commit")
+
+
+def validate_manifest(manifest_path: Path, repo: Path) -> dict[str, Any]:
+    manifest_path = manifest_path.expanduser().resolve()
+    if not manifest_path.is_file():
+        raise ReleaseError(f"manifest does not exist: {manifest_path}")
+    package_dir = manifest_path.parent
+    manifest = _load_json(manifest_path, "release manifest")
+    if not isinstance(manifest, dict):
+        raise ReleaseError("release manifest must be a JSON object")
+    if _required(manifest, "schema_version") != SCHEMA_VERSION:
+        raise ReleaseError("unsupported or missing release manifest schema_version")
+    release_id = _required(manifest, "release_id")
+    if not isinstance(release_id, str) or not release_id.strip():
+        raise ReleaseError("release_id must be a non-empty string")
+    _parse_timestamp(_required(manifest, "created_at_utc"), "created_at_utc")
+    candidate = _require_hex40(_required(manifest, "candidate_commit"), "candidate_commit")
+    candidate_tree = _require_hex40(_required(manifest, "candidate_tree"), "candidate_tree")
+    raw_parents = _required(manifest, "candidate_parents")
+    if not isinstance(raw_parents, list):
+        raise ReleaseError("candidate_parents must be a list")
+    candidate_parents = [_require_hex40(parent, "candidate parent") for parent in raw_parents]
+    raw_parent = _required(manifest, "candidate_parent")
+    if raw_parent is not None:
+        _require_hex40(raw_parent, "candidate_parent")
+    if raw_parent != (candidate_parents[0] if candidate_parents else None):
+        raise ReleaseError("candidate_parent does not match candidate_parents")
+    expected_commit = _require_hex40(
+        _required(manifest, "expected_production_commit"), "expected_production_commit"
+    )
+    expected_tree = _require_hex40(
+        _required(manifest, "expected_production_tree"), "expected_production_tree"
+    )
+    expected_digest = _require_digest(
+        _required(manifest, "expected_production_image_digest"),
+        "expected_production_image_digest",
+    )
+    artifacts = _required(manifest, "artifacts")
+    if not isinstance(artifacts, dict):
+        raise ReleaseError("artifacts must be a JSON object")
+    archive_record = _required(artifacts, "source_archive", "artifacts")
+    bundle_record = _required(artifacts, "git_bundle", "artifacts")
+    if not isinstance(archive_record, dict) or not isinstance(bundle_record, dict):
+        raise ReleaseError("source_archive and git_bundle artifact records must be objects")
+
+    repo = _repo_path(repo)
+    resolved_candidate = _resolve_commit(repo, candidate, "candidate_commit")
+    if resolved_candidate != candidate:
+        raise ReleaseError("candidate commit did not resolve exactly")
+    actual_candidate_tree = _commit_tree(repo, candidate, "candidate tree")
+    if actual_candidate_tree != candidate_tree:
+        raise ReleaseError("candidate tree does not match candidate commit")
+    if _commit_parents(repo, candidate) != candidate_parents:
+        raise ReleaseError("candidate parent list does not match candidate commit")
+    resolved_expected = _resolve_commit(repo, expected_commit, "expected_production_commit")
+    if resolved_expected != expected_commit:
+        raise ReleaseError("expected production commit did not resolve exactly")
+    if _commit_tree(repo, expected_commit, "expected production tree") != expected_tree:
+        raise ReleaseError("expected production tree does not match expected production commit")
+    if not _is_ancestor(repo, expected_commit, candidate):
+        raise ReleaseError("expected production commit is not an ancestor of candidate commit")
+
+    archive = _check_artifact_hash(archive_record, package_dir, "source_archive")
+    bundle = _check_artifact_hash(bundle_record, package_dir, "git_bundle")
+    _validate_archive_safety(archive)
+    with tempfile.TemporaryDirectory(prefix="aibuff-release-archive-") as temporary:
+        expected_archive = Path(temporary) / SOURCE_ARCHIVE_NAME
+        _write_source_archive(repo, candidate, expected_archive)
+        expected_hash, expected_size = _sha256(expected_archive)
+        actual_hash, actual_size = _sha256(archive)
+        if (expected_hash, expected_size) != (actual_hash, actual_size):
+            raise ReleaseError("source archive is incomplete or does not exactly match candidate commit")
+    _validate_bundle(repo, bundle, candidate)
+    return manifest
+
+
+def preflight(manifest_path: Path, repo: Path, production_state_path: Path) -> None:
+    manifest = validate_manifest(manifest_path, repo)
+    state = _load_json(production_state_path.expanduser().resolve(), "redacted production state")
+    if not isinstance(state, dict):
+        raise ReleaseError("redacted production state must be a JSON object")
+    observed_commit = _require_hex40(_required(state, "commit", "production state"), "production state commit")
+    observed_tree = _require_hex40(_required(state, "tree", "production state"), "production state tree")
+    observed_digest = _require_digest(
+        _required(state, "image_digest", "production state"),
+        "production state image digest",
+    )
+    expected = (
+        manifest["expected_production_commit"],
+        manifest["expected_production_tree"],
+        manifest["expected_production_image_digest"],
+    )
+    observed = (observed_commit, observed_tree, observed_digest)
+    labels = ("commit", "tree", "image_digest")
+    drift = [f"{label}: expected {want}, observed {got}" for label, want, got in zip(labels, expected, observed) if want != got]
+    if drift:
+        raise ReleaseError("production baseline drift detected; " + "; ".join(drift))
+
+
+def _lock_payload(owner_id: str, ttl_seconds: int) -> dict[str, Any]:
+    acquired = _utc_now()
+    return {
+        "schema_version": LOCK_SCHEMA_VERSION,
+        "owner_id": owner_id,
+        "pid": os.getpid(),
+        "acquired_at": _timestamp(acquired),
+        "expires_at": _timestamp(acquired + dt.timedelta(seconds=ttl_seconds)),
+    }
+
+
+def _read_lock(path: Path) -> dict[str, Any]:
+    try:
+        value = _load_json(path, "deployment lock")
+    except ReleaseError as exc:
+        raise ReleaseError("deployment lock exists but is unreadable; refusing automatic recovery") from exc
+    if not isinstance(value, dict):
+        raise ReleaseError("deployment lock exists but is not a JSON object; refusing automatic recovery")
+    if value.get("schema_version") != LOCK_SCHEMA_VERSION:
+        raise ReleaseError("deployment lock schema is unknown; refusing automatic recovery")
+    owner = value.get("owner_id")
+    if not isinstance(owner, str) or not owner:
+        raise ReleaseError("deployment lock owner_id is invalid; refusing automatic recovery")
+    _parse_timestamp(_required(value, "acquired_at", "deployment lock"), "deployment lock acquired_at")
+    _parse_timestamp(_required(value, "expires_at", "deployment lock"), "deployment lock expires_at")
+    return value
+
+
+def acquire_lock(path: Path, owner_id: str, ttl_seconds: int, ready_file: Path | None = None) -> dict[str, Any]:
+    if not owner_id.strip():
+        raise ReleaseError("lock owner_id must be non-empty")
+    if ttl_seconds <= 0:
+        raise ReleaseError("lock ttl_seconds must be positive")
+    path = path.expanduser().resolve()
+    if path.exists():
+        existing = _read_lock(path)
+        expires = _parse_timestamp(existing["expires_at"], "deployment lock expires_at")
+        if expires <= _utc_now():
+            raise ReleaseError(
+                f"stale/expired deployment lock held by {existing['owner_id']}; manual review is required, lock was not stolen"
+            )
+        raise ReleaseError(f"deployment lock is already held by {existing['owner_id']}; second task rejected")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = _lock_payload(owner_id, ttl_seconds)
+    encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    try:
+        descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError as exc:
+        raise ReleaseError("deployment lock was acquired concurrently by another task; second task rejected") from exc
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(encoded)
+    except BaseException:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+    if ready_file is not None:
+        ready_file = ready_file.expanduser().resolve()
+        try:
+            with ready_file.open("x", encoding="utf-8") as stream:
+                stream.write(owner_id + "\n")
+        except BaseException:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+            raise
+    return payload
+
+
+def release_lock(path: Path, owner_id: str) -> None:
+    path = path.expanduser().resolve()
+    if not path.exists():
+        raise ReleaseError(f"deployment lock does not exist: {path}")
+    existing = _read_lock(path)
+    if existing["owner_id"] != owner_id:
+        raise ReleaseError("deployment lock owner mismatch; refusing to remove another task's lock")
+    path.unlink()
+
+
+def _hold(seconds: float) -> None:
+    if seconds < 0:
+        raise ReleaseError("hold_seconds must not be negative")
+    deadline = time.monotonic() + seconds
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        time.sleep(min(remaining, 30.0))
+
+
+def _cmd_prepare(args: argparse.Namespace) -> int:
+    manifest = prepare(
+        _repo_path(args.repo),
+        Path(args.output),
+        args.candidate,
+        args.expected_production_commit,
+        args.expected_production_tree,
+        args.expected_production_image_digest,
+        args.release_id,
+    )
+    print(f"PREPARE PASS: {manifest}")
+    return 0
+
+
+def _cmd_validate(args: argparse.Namespace) -> int:
+    manifest = validate_manifest(Path(args.manifest), _repo_path(args.repo))
+    print(f"VALIDATE PASS: {manifest['candidate_commit']} package is exact and verified")
+    return 0
+
+
+def _cmd_preflight(args: argparse.Namespace) -> int:
+    preflight(Path(args.manifest), _repo_path(args.repo), Path(args.production_state))
+    print("PREFLIGHT PASS: redacted production state matches the expected commit, tree, and image digest")
+    return 0
+
+
+def _cmd_lock_acquire(args: argparse.Namespace) -> int:
+    owner_id = args.owner_id or f"pid-{os.getpid()}-{uuid.uuid4().hex}"
+    if args.hold_seconds < 0:
+        raise ReleaseError("hold_seconds must not be negative")
+    payload = acquire_lock(Path(args.path), owner_id, args.ttl_seconds, Path(args.ready_file) if args.ready_file else None)
+    print(f"LOCK ACQUIRED: owner_id={payload['owner_id']} expires_at={payload['expires_at']}")
+    _hold(args.hold_seconds)
+    if args.hold_seconds > 0:
+        release_lock(Path(args.path), owner_id)
+        print("LOCK RELEASED: hold completed")
+    return 0
+
+
+def _cmd_lock_release(args: argparse.Namespace) -> int:
+    release_lock(Path(args.path), args.owner_id)
+    print("LOCK RELEASED: owner verified")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    prepare_parser = commands.add_parser("prepare", help="package an exact clean checkout")
+    prepare_parser.add_argument("--repo", default=".")
+    prepare_parser.add_argument("--output", required=True)
+    prepare_parser.add_argument("--candidate", default="HEAD")
+    prepare_parser.add_argument("--expected-production-commit", required=True)
+    prepare_parser.add_argument("--expected-production-tree", required=True)
+    prepare_parser.add_argument("--expected-production-image-digest", required=True)
+    prepare_parser.add_argument("--release-id")
+    prepare_parser.set_defaults(handler=_cmd_prepare)
+
+    validate_parser = commands.add_parser("validate", help="verify a release package")
+    validate_parser.add_argument("--repo", default=".")
+    validate_parser.add_argument("--manifest", required=True)
+    validate_parser.set_defaults(handler=_cmd_validate)
+
+    preflight_parser = commands.add_parser("preflight", help="compare redacted production state to the package")
+    preflight_parser.add_argument("--repo", default=".")
+    preflight_parser.add_argument("--manifest", required=True)
+    preflight_parser.add_argument("--production-state", required=True)
+    preflight_parser.set_defaults(handler=_cmd_preflight)
+
+    lock_parser = commands.add_parser("lock", help="acquire or release the single deployment lock")
+    lock_commands = lock_parser.add_subparsers(dest="lock_command", required=True)
+    acquire_parser = lock_commands.add_parser("acquire", help="acquire a fail-first atomic lock")
+    acquire_parser.add_argument("--path", required=True)
+    acquire_parser.add_argument("--owner-id")
+    acquire_parser.add_argument("--ttl-seconds", type=int, default=1800)
+    acquire_parser.add_argument("--hold-seconds", type=float, default=0)
+    acquire_parser.add_argument("--ready-file")
+    acquire_parser.set_defaults(handler=_cmd_lock_acquire)
+    release_parser = lock_commands.add_parser("release", help="release only a lock owned by the caller")
+    release_parser.add_argument("--path", required=True)
+    release_parser.add_argument("--owner-id", required=True)
+    release_parser.set_defaults(handler=_cmd_lock_release)
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    try:
+        return args.handler(args)
+    except ReleaseError as exc:
+        print(f"HARD STOP: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/release/release_controller.py
+++ b/ops/release/release_controller.py
@@ -16,6 +16,7 @@ import json
 import os
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import sys
 import tarfile
@@ -29,6 +30,8 @@ SCHEMA_VERSION = 1
 MANIFEST_NAME = "release-manifest.json"
 SOURCE_ARCHIVE_NAME = "source.tar.gz"
 BUNDLE_NAME = "source.bundle"
+REGISTRY_RECEIPT_NAME = "registry-receipt.json"
+REGISTRY_SCHEMA_VERSION = 1
 HEX40 = re.compile(r"^[0-9a-f]{40}$")
 IMAGE_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 LOCK_SCHEMA_VERSION = 1
@@ -464,6 +467,131 @@ def validate_manifest(manifest_path: Path, repo: Path) -> dict[str, Any]:
     return manifest
 
 
+def _registry_destination(registry: Path, manifest: dict[str, Any]) -> Path:
+    release_id = manifest["release_id"]
+    if not isinstance(release_id, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,119}", release_id):
+        raise ReleaseError("release_id is not safe for a registry directory name")
+    destination = registry.expanduser().resolve() / release_id
+    if os.path.lexists(destination):
+        raise ReleaseError(f"candidate already exists in registry; refusing to overwrite: {destination}")
+    return destination
+
+
+def _copy_file_new(source: Path, destination: Path) -> None:
+    try:
+        with source.open("rb") as input_stream, destination.open("xb") as output_stream:
+            shutil.copyfileobj(input_stream, output_stream, length=1024 * 1024)
+    except BaseException:
+        try:
+            destination.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def stage_candidate(manifest_path: Path, repo: Path, registry: Path) -> Path:
+    """Copy a fully validated package into an immutable cross-device registry."""
+
+    manifest_path = manifest_path.expanduser().resolve()
+    manifest = validate_manifest(manifest_path, repo)
+    package_dir = manifest_path.parent
+    archive_record = manifest["artifacts"]["source_archive"]
+    bundle_record = manifest["artifacts"]["git_bundle"]
+    archive = _safe_artifact_path(package_dir, archive_record["path"], "artifact source_archive")
+    bundle = _safe_artifact_path(package_dir, bundle_record["path"], "artifact git_bundle")
+    registry = registry.expanduser().resolve()
+    registry.mkdir(parents=True, exist_ok=True)
+    destination = _registry_destination(registry, manifest)
+    try:
+        destination.mkdir()
+    except FileExistsError as exc:
+        raise ReleaseError(f"candidate was registered concurrently; refusing to overwrite: {destination}") from exc
+    try:
+        staged_manifest = destination / MANIFEST_NAME
+        _copy_file_new(manifest_path, staged_manifest)
+        _copy_file_new(archive, destination / SOURCE_ARCHIVE_NAME)
+        _copy_file_new(bundle, destination / BUNDLE_NAME)
+        staged_archive = _check_artifact_hash(archive_record, destination, "source_archive")
+        staged_bundle = _check_artifact_hash(bundle_record, destination, "git_bundle")
+        manifest_hash, manifest_size = _sha256(staged_manifest)
+        receipt = {
+            "schema_version": REGISTRY_SCHEMA_VERSION,
+            "staged_at_utc": _timestamp(),
+            "release_id": manifest["release_id"],
+            "candidate_commit": manifest["candidate_commit"],
+            "candidate_tree": manifest["candidate_tree"],
+            "manifest": {"path": MANIFEST_NAME, "sha256": manifest_hash, "size": manifest_size},
+            "artifacts": {
+                "source_archive": _artifact_record(staged_archive, SOURCE_ARCHIVE_NAME),
+                "git_bundle": _artifact_record(staged_bundle, BUNDLE_NAME),
+            },
+        }
+        _write_json_new(destination / REGISTRY_RECEIPT_NAME, receipt)
+    except BaseException:
+        # This directory was created by this invocation. A partial package must
+        # never remain where another machine could mistake it for a candidate.
+        shutil.rmtree(destination)
+        raise
+    return destination
+
+
+def _validate_registry_receipt(package_dir: Path, manifest: dict[str, Any]) -> None:
+    receipt_path = package_dir / REGISTRY_RECEIPT_NAME
+    receipt = _load_json(receipt_path, "registry receipt")
+    if not isinstance(receipt, dict) or receipt.get("schema_version") != REGISTRY_SCHEMA_VERSION:
+        raise ReleaseError("registry receipt is missing or has an unsupported schema_version")
+    _parse_timestamp(_required(receipt, "staged_at_utc", "registry receipt"), "registry receipt staged_at_utc")
+    for field in ("release_id", "candidate_commit", "candidate_tree"):
+        if _required(receipt, field, "registry receipt") != manifest[field]:
+            raise ReleaseError(f"registry receipt {field} does not match the release manifest")
+    receipt_manifest = _required(receipt, "manifest", "registry receipt")
+    receipt_artifacts = _required(receipt, "artifacts", "registry receipt")
+    if not isinstance(receipt_manifest, dict) or not isinstance(receipt_artifacts, dict):
+        raise ReleaseError("registry receipt manifest and artifacts must be objects")
+    receipt_manifest_path = _safe_artifact_path(package_dir, _required(receipt_manifest, "path", "registry receipt manifest"), "registry receipt manifest")
+    expected_manifest_hash = _required(receipt_manifest, "sha256", "registry receipt manifest")
+    expected_manifest_size = _required(receipt_manifest, "size", "registry receipt manifest")
+    actual_manifest_hash, actual_manifest_size = _sha256(receipt_manifest_path)
+    if (expected_manifest_hash, expected_manifest_size) != (actual_manifest_hash, actual_manifest_size):
+        raise ReleaseError("registry receipt manifest hash/size mismatch")
+    for name in ("source_archive", "git_bundle"):
+        record = _required(receipt_artifacts, name, "registry receipt artifacts")
+        if not isinstance(record, dict):
+            raise ReleaseError(f"registry receipt {name} must be an object")
+        _check_artifact_hash(record, package_dir, f"registry receipt {name}")
+
+
+def verify_registry_candidate(manifest_path: Path) -> dict[str, Any]:
+    """Verify a staged package on a machine that has no source checkout yet."""
+
+    manifest_path = manifest_path.expanduser().resolve()
+    package_dir = manifest_path.parent
+    manifest = _load_json(manifest_path, "release manifest")
+    if not isinstance(manifest, dict):
+        raise ReleaseError("release manifest must be a JSON object")
+    _validate_registry_receipt(package_dir, manifest)
+    candidate = _require_hex40(_required(manifest, "candidate_commit"), "candidate_commit")
+    artifacts = _required(manifest, "artifacts")
+    if not isinstance(artifacts, dict):
+        raise ReleaseError("artifacts must be a JSON object")
+    bundle_record = _required(artifacts, "git_bundle", "artifacts")
+    if not isinstance(bundle_record, dict):
+        raise ReleaseError("git_bundle artifact record must be an object")
+    bundle = _safe_artifact_path(package_dir, _required(bundle_record, "path", "artifact git_bundle"), "artifact git_bundle")
+    if not bundle.is_file():
+        raise ReleaseError("registry candidate is missing its git bundle")
+    with tempfile.TemporaryDirectory(prefix="aibuff-registry-verify-") as temporary:
+        clone = Path(temporary) / "clone"
+        result = _run(["git", "clone", "--quiet", "--no-checkout", str(bundle), str(clone)], check=False)
+        if result.returncode != 0:
+            detail = result.stderr.decode("utf-8", errors="replace").strip()
+            raise ReleaseError(f"registry git bundle could not be cloned: {detail}")
+        resolved = _resolve_commit(clone, candidate, "registry candidate")
+        if resolved != candidate:
+            raise ReleaseError("registry clone resolved a different candidate commit")
+        return validate_manifest(manifest_path, clone)
+
+
 def preflight(manifest_path: Path, repo: Path, production_state_path: Path) -> None:
     manifest = validate_manifest(manifest_path, repo)
     state = _load_json(production_state_path.expanduser().resolve(), "redacted production state")
@@ -606,6 +734,18 @@ def _cmd_preflight(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_registry_stage(args: argparse.Namespace) -> int:
+    destination = stage_candidate(Path(args.manifest), _repo_path(args.repo), Path(args.registry))
+    print(f"REGISTRY STAGE PASS: {destination}")
+    return 0
+
+
+def _cmd_registry_verify(args: argparse.Namespace) -> int:
+    manifest = verify_registry_candidate(Path(args.manifest))
+    print(f"REGISTRY VERIFY PASS: {manifest['candidate_commit']} is recoverable from the registry package")
+    return 0
+
+
 def _cmd_lock_acquire(args: argparse.Namespace) -> int:
     owner_id = args.owner_id or f"pid-{os.getpid()}-{uuid.uuid4().hex}"
     if args.hold_seconds < 0:
@@ -649,6 +789,17 @@ def _build_parser() -> argparse.ArgumentParser:
     preflight_parser.add_argument("--manifest", required=True)
     preflight_parser.add_argument("--production-state", required=True)
     preflight_parser.set_defaults(handler=_cmd_preflight)
+
+    registry_parser = commands.add_parser("registry", help="stage and verify immutable cross-device candidate packages")
+    registry_commands = registry_parser.add_subparsers(dest="registry_command", required=True)
+    registry_stage_parser = registry_commands.add_parser("stage", help="validate then copy a package into a new registry directory")
+    registry_stage_parser.add_argument("--repo", default=".")
+    registry_stage_parser.add_argument("--manifest", required=True)
+    registry_stage_parser.add_argument("--registry", required=True)
+    registry_stage_parser.set_defaults(handler=_cmd_registry_stage)
+    registry_verify_parser = registry_commands.add_parser("verify", help="verify a staged package without a pre-existing checkout")
+    registry_verify_parser.add_argument("--manifest", required=True)
+    registry_verify_parser.set_defaults(handler=_cmd_registry_verify)
 
     lock_parser = commands.add_parser("lock", help="acquire or release the single deployment lock")
     lock_commands = lock_parser.add_subparsers(dest="lock_command", required=True)

--- a/ops/release/tests/test_release_controller.py
+++ b/ops/release/tests/test_release_controller.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
+import io
 import json
 from pathlib import Path
 import subprocess
 import sys
 import tempfile
+import tarfile
 import time
 import unittest
 
@@ -92,6 +95,54 @@ class ReleaseControllerTests(unittest.TestCase):
         result = self.prepare(output)
         self.assertEqual(result.returncode, 0, result.stderr)
         return output
+
+    def write_oci_image_tar(self, name: str = "candidate-image.tar") -> tuple[Path, dict[str, str]]:
+        revision = self.candidate_commit
+        config = json.dumps(
+            {
+                "architecture": "amd64",
+                "config": {"Labels": {"org.opencontainers.image.revision": revision}},
+                "os": "linux",
+            },
+            separators=(",", ":"),
+        ).encode()
+        layer = b"exact layer bytes\n"
+        config_hex = hashlib.sha256(config).hexdigest()
+        layer_hex = hashlib.sha256(layer).hexdigest()
+        config_path = f"blobs/sha256/{config_hex}"
+        layer_path = f"blobs/sha256/{layer_hex}"
+        manifest = json.dumps(
+            {
+                "schemaVersion": 2,
+                "config": {"mediaType": "application/vnd.oci.image.config.v1+json", "digest": f"sha256:{config_hex}", "size": len(config)},
+                "layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar", "digest": f"sha256:{layer_hex}", "size": len(layer)}],
+            },
+            separators=(",", ":"),
+        ).encode()
+        manifest_hex = hashlib.sha256(manifest).hexdigest()
+        manifest_path = f"blobs/sha256/{manifest_hex}"
+        tag = "example.invalid/aibuff:aadd"
+        index = json.dumps(
+            {"schemaVersion": 2, "manifests": [{"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": f"sha256:{manifest_hex}", "size": len(manifest)}]},
+            separators=(",", ":"),
+        ).encode()
+        docker_manifest = json.dumps(
+            [{"Config": config_path, "RepoTags": [tag], "Layers": [layer_path]}], separators=(",", ":")
+        ).encode()
+        image_tar = self.root / name
+        with tarfile.open(image_tar, "w") as archive:
+            for path, payload in (("index.json", index), ("manifest.json", docker_manifest), (config_path, config), (layer_path, layer), (manifest_path, manifest)):
+                info = tarfile.TarInfo(path)
+                info.size = len(payload)
+                archive.addfile(info, io.BytesIO(payload))
+        return image_tar, {
+            "tar_sha256": hashlib.sha256(image_tar.read_bytes()).hexdigest(),
+            "manifest": f"sha256:{manifest_hex}",
+            "config": f"sha256:{config_hex}",
+            "revision": revision,
+            "platform": "linux/amd64",
+            "tag": tag,
+        }
 
     def test_prepare_and_validate_success(self) -> None:
         package = self.package()
@@ -195,6 +246,23 @@ class ReleaseControllerTests(unittest.TestCase):
         result = self.run_cli("validate", "--repo", str(self.repo_path), "--manifest", str(package / "release-manifest.json"))
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("HARD STOP", result.stderr)
+
+    def test_oci_image_identity_chain_is_verified(self) -> None:
+        image_tar, identity = self.write_oci_image_tar()
+        result = self.run_cli(
+            "image", "verify", "--image-tar", str(image_tar), "--tar-sha256", identity["tar_sha256"],
+            "--oci-manifest-digest", identity["manifest"], "--config-digest", identity["config"],
+            "--revision", identity["revision"], "--platform", identity["platform"], "--repo-tag", identity["tag"],
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("OCI IMAGE VERIFY PASS", result.stdout)
+        wrong = self.run_cli(
+            "image", "verify", "--image-tar", str(image_tar), "--tar-sha256", identity["tar_sha256"],
+            "--oci-manifest-digest", "sha256:" + "0" * 64, "--config-digest", identity["config"],
+            "--revision", identity["revision"], "--platform", identity["platform"], "--repo-tag", identity["tag"],
+        )
+        self.assertNotEqual(wrong.returncode, 0)
+        self.assertIn("HARD STOP", wrong.stderr)
 
         package = self.package("bundle-tamper")
         bundle = package / "source.bundle"

--- a/ops/release/tests/test_release_controller.py
+++ b/ops/release/tests/test_release_controller.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "ops" / "release" / "release_controller.py"
+
+
+class GitRepo:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.run("init", "-b", "main")
+        self.run("config", "user.name", "Release Gate Test")
+        self.run("config", "user.email", "release-gate@example.invalid")
+
+    def run(self, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            ["git", "-C", str(self.path), *args],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if check and result.returncode != 0:
+            self.failure = result.stderr
+            raise AssertionError(f"git command failed: {args}\n{result.stderr}")
+        return result
+
+    def commit_file(self, name: str, content: str, message: str) -> str:
+        (self.path / name).write_text(content, encoding="utf-8")
+        self.run("add", name)
+        self.run("commit", "-m", message)
+        return self.commit()
+
+    def commit(self) -> str:
+        return self.run("rev-parse", "HEAD").stdout.strip()
+
+    def tree(self, commit: str) -> str:
+        return self.run("rev-parse", f"{commit}^{{tree}}").stdout.strip()
+
+
+class ReleaseControllerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory(prefix="aibuff-release-test-")
+        self.root = Path(self.temp.name)
+        self.repo_path = self.root / "repo"
+        self.repo_path.mkdir()
+        self.repo = GitRepo(self.repo_path)
+        self.production_commit = self.repo.commit_file("app.txt", "one\n", "base")
+        self.candidate_commit = self.repo.commit_file("app.txt", "two\n", "candidate")
+        self.production_tree = self.repo.tree(self.production_commit)
+        self.image_digest = "sha256:" + "1" * 64
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def run_cli(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            cwd=str(ROOT),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def prepare(self, output: Path) -> subprocess.CompletedProcess[str]:
+        return self.run_cli(
+            "prepare",
+            "--repo",
+            str(self.repo_path),
+            "--output",
+            str(output),
+            "--candidate",
+            self.candidate_commit,
+            "--expected-production-commit",
+            self.production_commit,
+            "--expected-production-tree",
+            self.production_tree,
+            "--expected-production-image-digest",
+            self.image_digest,
+        )
+
+    def package(self, name: str = "package") -> Path:
+        output = self.root / name
+        result = self.prepare(output)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return output
+
+    def test_prepare_and_validate_success(self) -> None:
+        package = self.package()
+        manifest = package / "release-manifest.json"
+        result = self.run_cli("validate", "--repo", str(self.repo_path), "--manifest", str(manifest))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("VALIDATE PASS", result.stdout)
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        self.assertEqual(data["candidate_commit"], self.candidate_commit)
+        self.assertEqual(data["candidate_tree"], self.repo.tree(self.candidate_commit))
+        self.assertEqual(data["expected_production_commit"], self.production_commit)
+        self.assertEqual(data["expected_production_tree"], self.production_tree)
+        self.assertEqual(data["expected_production_image_digest"], self.image_digest)
+        self.assertEqual(sorted(path.name for path in package.iterdir()), ["release-manifest.json", "source.bundle", "source.tar.gz"])
+
+    def test_dirty_checkout_is_rejected(self) -> None:
+        (self.repo_path / "untracked.txt").write_text("not packaged\n", encoding="utf-8")
+        output = self.root / "dirty-output"
+        result = self.prepare(output)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("HARD STOP", result.stderr)
+        self.assertFalse(output.exists())
+
+    def test_expected_production_not_ancestor_is_rejected(self) -> None:
+        self.repo.run("checkout", "-b", "unrelated", self.production_commit)
+        unrelated_commit = self.repo.commit_file("other.txt", "divergent\n", "unrelated")
+        unrelated_tree = self.repo.tree(unrelated_commit)
+        self.repo.run("checkout", "main")
+        result = self.run_cli(
+            "prepare",
+            "--repo",
+            str(self.repo_path),
+            "--output",
+            str(self.root / "not-ancestor"),
+            "--candidate",
+            self.candidate_commit,
+            "--expected-production-commit",
+            unrelated_commit,
+            "--expected-production-tree",
+            unrelated_tree,
+            "--expected-production-image-digest",
+            self.image_digest,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not an ancestor", result.stderr)
+
+    def test_preflight_drift_is_hard_stop(self) -> None:
+        package = self.package()
+        manifest = package / "release-manifest.json"
+        variants = (
+            {"commit": self.candidate_commit, "tree": self.production_tree, "image_digest": self.image_digest},
+            {"commit": self.production_commit, "tree": self.repo.tree(self.candidate_commit), "image_digest": self.image_digest},
+            {"commit": self.production_commit, "tree": self.production_tree, "image_digest": "sha256:" + "2" * 64},
+        )
+        for index, state in enumerate(variants):
+            state_path = self.root / f"state-{index}.json"
+            state_path.write_text(json.dumps(state) + "\n", encoding="utf-8")
+            result = self.run_cli(
+                "preflight",
+                "--repo",
+                str(self.repo_path),
+                "--manifest",
+                str(manifest),
+                "--production-state",
+                str(state_path),
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("HARD STOP", result.stderr)
+            self.assertIn("drift", result.stderr)
+
+    def test_preflight_success(self) -> None:
+        package = self.package("preflight-pass")
+        state_path = self.root / "state-pass.json"
+        state_path.write_text(
+            json.dumps(
+                {
+                    "commit": self.production_commit,
+                    "tree": self.production_tree,
+                    "image_digest": self.image_digest,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        result = self.run_cli(
+            "preflight",
+            "--repo",
+            str(self.repo_path),
+            "--manifest",
+            str(package / "release-manifest.json"),
+            "--production-state",
+            str(state_path),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("PREFLIGHT PASS", result.stdout)
+
+    def test_source_and_bundle_tamper_are_rejected(self) -> None:
+        package = self.package("archive-tamper")
+        archive = package / "source.tar.gz"
+        archive.write_bytes(archive.read_bytes() + b"tamper")
+        result = self.run_cli("validate", "--repo", str(self.repo_path), "--manifest", str(package / "release-manifest.json"))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("HARD STOP", result.stderr)
+
+        package = self.package("bundle-tamper")
+        bundle = package / "source.bundle"
+        bundle.write_bytes(bundle.read_bytes() + b"tamper")
+        result = self.run_cli("validate", "--repo", str(self.repo_path), "--manifest", str(package / "release-manifest.json"))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("HARD STOP", result.stderr)
+
+    def test_existing_output_is_never_overwritten(self) -> None:
+        output = self.root / "existing"
+        output.mkdir()
+        sentinel = output / "sentinel.txt"
+        sentinel.write_text("keep me\n", encoding="utf-8")
+        result = self.prepare(output)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("already exists", result.stderr)
+        self.assertEqual(sentinel.read_text(encoding="utf-8"), "keep me\n")
+        self.assertEqual([path.name for path in output.iterdir()], ["sentinel.txt"])
+
+    def test_second_parallel_lock_is_rejected(self) -> None:
+        lock = self.root / "deploy.lock"
+        ready = self.root / "ready"
+        first = subprocess.Popen(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "lock",
+                "acquire",
+                "--path",
+                str(lock),
+                "--owner-id",
+                "first",
+                "--ttl-seconds",
+                "30",
+                "--hold-seconds",
+                "1",
+                "--ready-file",
+                str(ready),
+            ],
+            cwd=str(ROOT),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            deadline = time.monotonic() + 3
+            while not ready.exists() and time.monotonic() < deadline:
+                time.sleep(0.02)
+            self.assertTrue(ready.exists(), "first lock holder did not acquire the lock")
+            second = self.run_cli(
+                "lock",
+                "acquire",
+                "--path",
+                str(lock),
+                "--owner-id",
+                "second",
+                "--ttl-seconds",
+                "30",
+            )
+            self.assertNotEqual(second.returncode, 0)
+            self.assertIn("HARD STOP", second.stderr)
+            self.assertIn("second task rejected", second.stderr)
+        finally:
+            stdout, stderr = first.communicate(timeout=5)
+            self.assertEqual(first.returncode, 0, stderr)
+            self.assertIn("LOCK RELEASED", stdout)
+        self.assertFalse(lock.exists())
+
+    def test_stale_lock_fails_first_without_stealing(self) -> None:
+        lock = self.root / "stale.lock"
+        old = dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=10)
+        payload = {
+            "schema_version": 1,
+            "owner_id": "old-owner",
+            "pid": 1,
+            "acquired_at": old.isoformat().replace("+00:00", "Z"),
+            "expires_at": (old + dt.timedelta(seconds=1)).isoformat().replace("+00:00", "Z"),
+        }
+        lock.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+        result = self.run_cli(
+            "lock",
+            "acquire",
+            "--path",
+            str(lock),
+            "--owner-id",
+            "new-owner",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("HARD STOP", result.stderr)
+        self.assertIn("stale/expired", result.stderr)
+        self.assertEqual(json.loads(lock.read_text(encoding="utf-8"))["owner_id"], "old-owner")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/release/tests/test_release_controller.py
+++ b/ops/release/tests/test_release_controller.py
@@ -214,6 +214,47 @@ class ReleaseControllerTests(unittest.TestCase):
         self.assertEqual(sentinel.read_text(encoding="utf-8"), "keep me\n")
         self.assertEqual([path.name for path in output.iterdir()], ["sentinel.txt"])
 
+    def test_registry_stage_is_portable_and_never_overwrites(self) -> None:
+        package = self.package("registry-source")
+        manifest = package / "release-manifest.json"
+        registry = self.root / "drive-registry"
+        result = self.run_cli(
+            "registry",
+            "stage",
+            "--repo",
+            str(self.repo_path),
+            "--manifest",
+            str(manifest),
+            "--registry",
+            str(registry),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("REGISTRY STAGE PASS", result.stdout)
+        staged_manifest = next(registry.glob("*/release-manifest.json"))
+        self.assertEqual(
+            sorted(path.name for path in staged_manifest.parent.iterdir()),
+            ["registry-receipt.json", "release-manifest.json", "source.bundle", "source.tar.gz"],
+        )
+        portable = self.run_cli("registry", "verify", "--manifest", str(staged_manifest))
+        self.assertEqual(portable.returncode, 0, portable.stderr)
+        self.assertIn("REGISTRY VERIFY PASS", portable.stdout)
+        (staged_manifest.parent / "registry-receipt.json").unlink()
+        incomplete = self.run_cli("registry", "verify", "--manifest", str(staged_manifest))
+        self.assertNotEqual(incomplete.returncode, 0)
+        self.assertIn("registry receipt", incomplete.stderr)
+        repeated = self.run_cli(
+            "registry",
+            "stage",
+            "--repo",
+            str(self.repo_path),
+            "--manifest",
+            str(manifest),
+            "--registry",
+            str(registry),
+        )
+        self.assertNotEqual(repeated.returncode, 0)
+        self.assertIn("refusing to overwrite", repeated.stderr)
+
     def test_second_parallel_lock_is_rejected(self) -> None:
         lock = self.root / "deploy.lock"
         ready = self.root / "ready"


### PR DESCRIPTION
## Scope\n- adds the standard-library release controller, packaging/validation/preflight/lock gates, and GitHub package-only workflow\n- adds the cross-device immutable candidate registry\n- adds the mandatory Aibuff code-candidate gate to `AGENTS.md`\n\n## Verification\n- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s ops/release/tests -p 'test_*.py' -v` (10 passed)\n\n## Safety\n- no production endpoints, credentials, SSH, deployment commands, or business-code edits\n- production release remains separately authorized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added release preparation and validation tools for creating verified, tamper-evident release packages.
  - Added candidate registration and verification workflows.
  - Added production-state checks and deployment locking to prevent unsafe or conflicting releases.
  - Added image verification and a manually triggered release gate that validates packages and uploads artifacts.

- **Bug Fixes**
  - Added safeguards that stop releases when repository state, artifacts, or deployment conditions do not match expectations.

- **Documentation**
  - Documented standard, emergency, and validation release procedures, including required stop conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->