### PR TITLE
fix(relay): sign the mj image forward url to close unauth access and idor

### DIFF
--- a/controller/midjourney.go
+++ b/controller/midjourney.go
@@ -14,7 +14,6 @@ import (
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting"
-	"github.com/QuantumNous/new-api/setting/system_setting"
 
 	"github.com/gin-gonic/gin"
 )
@@ -309,7 +308,7 @@ func GetAllMidjourney(c *gin.Context) {
 
 	if setting.MjForwardUrlEnabled {
 		for i, midjourney := range items {
-			midjourney.ImageUrl = system_setting.ServerAddress + "/mj/image/" + midjourney.MjId
+			midjourney.ImageUrl = service.BuildMjImageForwardURL(midjourney.MjId)
 			items[i] = midjourney
 		}
 	}
@@ -334,7 +333,7 @@ func GetUserMidjourney(c *gin.Context) {
 
 	if setting.MjForwardUrlEnabled {
 		for i, midjourney := range items {
-			midjourney.ImageUrl = system_setting.ServerAddress + "/mj/image/" + midjourney.MjId
+			midjourney.ImageUrl = service.BuildMjImageForwardURL(midjourney.MjId)
 			items[i] = midjourney
 		}
 	}

--- a/relay/mjproxy_handler.go
+++ b/relay/mjproxy_handler.go
@@ -28,6 +28,16 @@ import (
 
 func RelayMidjourneyImage(c *gin.Context) {
 	taskId := c.Param("id")
+	// /mj/image/:id is intentionally outside TokenAuth so the forwarded URL can be
+	// loaded by a browser as a plain <img> src (no auth header). Access is gated by
+	// the sig query instead, an HMAC over the task id that this server mints only
+	// for the task owner and admins. Without it any id could be fetched. See #6610.
+	if !service.VerifyMjImageSignature(taskId, c.Query("sig")) {
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "invalid_image_signature",
+		})
+		return
+	}
 	midjourneyTask := model.GetByOnlyMJId(taskId)
 	if midjourneyTask == nil {
 		c.JSON(400, gin.H{
@@ -150,9 +160,9 @@ func coverMidjourneyTaskDto(c *gin.Context, originTask *model.Midjourney) (midjo
 	midjourneyTask.FinishTime = originTask.FinishTime
 	midjourneyTask.ImageUrl = ""
 	if originTask.ImageUrl != "" && setting.MjForwardUrlEnabled {
-		midjourneyTask.ImageUrl = system_setting.ServerAddress + "/mj/image/" + originTask.MjId
+		midjourneyTask.ImageUrl = service.BuildMjImageForwardURL(originTask.MjId)
 		if originTask.Status != "SUCCESS" {
-			midjourneyTask.ImageUrl += "?rand=" + strconv.FormatInt(time.Now().UnixNano(), 10)
+			midjourneyTask.ImageUrl += "&rand=" + strconv.FormatInt(time.Now().UnixNano(), 10)
 		}
 	} else {
 		midjourneyTask.ImageUrl = originTask.ImageUrl

--- a/router/relay-router.go
+++ b/router/relay-router.go
@@ -206,6 +206,9 @@ func SetRelayRouter(router *gin.Engine) {
 }
 
 func registerMjRouterGroup(relayMjRouter *gin.RouterGroup) {
+	// GET /image/:id is registered before TokenAuth on purpose: the forwarded image
+	// URL is loaded by browsers as a plain <img> src with no auth header. Access is
+	// gated by the HMAC sig on the URL inside RelayMidjourneyImage instead. See #6610.
 	relayMjRouter.GET("/image/:id", relay.RelayMidjourneyImage)
 	relayMjRouter.Use(middleware.TokenAuth(), middleware.Distribute())
 	{

--- a/router/relay_router_test.go
+++ b/router/relay_router_test.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/service"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -85,6 +87,67 @@ func TestListModelsSupportsOpenAIAndGeminiAuthentication(t *testing.T) {
 			if test.expectedObject != "" {
 				assert.Equal(t, test.expectedObject, payload["object"])
 			}
+		})
+	}
+}
+
+func TestMidjourneyImageRequiresSignedURL(t *testing.T) {
+	setupRelayRouterTestDB(t)
+	require.NoError(t, model.DB.AutoMigrate(&model.Midjourney{}))
+
+	engine := gin.New()
+	SetRelayRouter(engine)
+
+	const mjId = "1234567890"
+	// The URL the server hands to the task owner or an admin.
+	signed, err := url.Parse(service.BuildMjImageForwardURL(mjId))
+	require.NoError(t, err)
+	validSig := signed.Query().Get("sig")
+	require.NotEmpty(t, validSig)
+
+	tests := []struct {
+		name       string
+		target     string
+		wantStatus int
+		wantErr    string
+	}{
+		{
+			name:       "no signature is rejected",
+			target:     "/mj/image/" + mjId,
+			wantStatus: http.StatusForbidden,
+			wantErr:    "invalid_image_signature",
+		},
+		{
+			name:       "wrong signature is rejected",
+			target:     "/mj/image/" + mjId + "?sig=deadbeef",
+			wantStatus: http.StatusForbidden,
+			wantErr:    "invalid_image_signature",
+		},
+		{
+			name:       "signature minted for another task is rejected",
+			target:     "/mj/image/9999?sig=" + validSig,
+			wantStatus: http.StatusForbidden,
+			wantErr:    "invalid_image_signature",
+		},
+		{
+			name:       "valid signature passes the gate",
+			target:     signed.RequestURI(),
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "midjourney_task_not_found",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, test.target, nil)
+
+			engine.ServeHTTP(recorder, request)
+
+			assert.Equal(t, test.wantStatus, recorder.Code)
+			var payload map[string]any
+			require.NoError(t, common.Unmarshal(recorder.Body.Bytes(), &payload))
+			assert.Equal(t, test.wantErr, payload["error"])
 		})
 	}
 }

--- a/service/midjourney.go
+++ b/service/midjourney.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"crypto/hmac"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -15,9 +16,32 @@ import (
 	"github.com/QuantumNous/new-api/logger"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/setting"
+	"github.com/QuantumNous/new-api/setting/system_setting"
 
 	"github.com/gin-gonic/gin"
 )
+
+// BuildMjImageForwardURL returns the self-hosted URL that proxies a task's
+// upstream image through this server (used when MjForwardUrlEnabled is on).
+// The sig query is an HMAC over the task id, so the URL is a per-task capability:
+// it still loads in a browser as a plain <img> src with no auth header, but it
+// cannot be guessed or reused to read another user's image. See issue #6610.
+func BuildMjImageForwardURL(mjId string) string {
+	return system_setting.ServerAddress + "/mj/image/" + mjId + "?sig=" + mjImageSignature(mjId)
+}
+
+// VerifyMjImageSignature reports whether sig is the signature this server mints
+// for mjId. A missing, tampered or cross-task signature fails.
+func VerifyMjImageSignature(mjId, sig string) bool {
+	if sig == "" {
+		return false
+	}
+	return hmac.Equal([]byte(sig), []byte(mjImageSignature(mjId)))
+}
+
+func mjImageSignature(mjId string) string {
+	return common.GenerateHMAC("mj-image:" + mjId)
+}
 
 func CovertMjpActionToModelName(mjAction string) string {
 	modelName := "mj_" + strings.ToLower(mjAction)

--- a/service/midjourney_test.go
+++ b/service/midjourney_test.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/QuantumNous/new-api/setting/system_setting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildMjImageForwardURLIsSignedCapability(t *testing.T) {
+	previousAddress := system_setting.ServerAddress
+	system_setting.ServerAddress = "https://gw.example.com"
+	t.Cleanup(func() { system_setting.ServerAddress = previousAddress })
+
+	const mjId = "task-abc-123"
+	built, err := url.Parse(BuildMjImageForwardURL(mjId))
+	require.NoError(t, err)
+
+	assert.Equal(t, "https", built.Scheme)
+	assert.Equal(t, "gw.example.com", built.Host)
+	assert.Equal(t, "/mj/image/"+mjId, built.Path)
+
+	sig := built.Query().Get("sig")
+	require.NotEmpty(t, sig)
+	// A URL minted by the server verifies for its own task id.
+	assert.True(t, VerifyMjImageSignature(mjId, sig))
+}
+
+func TestVerifyMjImageSignatureRejectsForgery(t *testing.T) {
+	const owner = "owner-task"
+	const other = "victim-task"
+	ownerSig := mjImageSignature(owner)
+
+	tests := []struct {
+		name string
+		mjId string
+		sig  string
+		want bool
+	}{
+		{"correct signature", owner, ownerSig, true},
+		{"empty signature", owner, "", false},
+		{"garbage signature", owner, "deadbeef", false},
+		{"signature minted for another task", other, ownerSig, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, VerifyMjImageSignature(tc.mjId, tc.sig))
+		})
+	}
+}


### PR DESCRIPTION

## 📝 变更描述 / Description

`/mj/image/:id` returned Midjourney task images to anyone. In
`router/relay-router.go` the GET route was registered before the group called
`.Use(TokenAuth(), Distribute())` and gin only applies `.Use` middleware to
routes registered after it, so the route had no token check. The handler also
looked the task up by id only (`GetByOnlyMJId`), so a caller who knew a task id
could read another user's image (IDOR).

This URL is meant to be browser loadable. When `MjForwardUrlEnabled` is on the
server rewrites a task's image URL to `ServerAddress + /mj/image/<mjId>` and the
web UI renders it as a plain `<img src>`. Browsers do not send an `Authorization`
header on image loads, so putting the route behind `TokenAuth` would break the
drawing log preview and any client that shows the forwarded URL.

Fix: keep the route public but make the URL a per task capability. The forwarding
URL now carries `?sig=<HMAC(mjId)>`, minted with the existing `common.GenerateHMAC`
(keyed on the server `CryptoSecret`). `RelayMidjourneyImage` verifies the signature
first and returns 403 when it is missing or wrong. The server only mints these URLs
for the task owner (`GetUserMidjourney`) or an admin (`GetAllMidjourney`), so a user
cannot forge a signature for another user's task id. Signing is centralized in
`service.BuildMjImageForwardURL` so the mint sites and the verifier cannot drift.

Note: forward URLs generated before this change (unsigned) will now 403 and need
one more task fetch to get a signed URL. These upstream image links are short
lived anyway and the URL is recomputed on every task query, so live clients
refresh on their next poll.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6610

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

AI assistance (Claude) was used to help write this change. The design, review and
verification were done by me. I am not a core developer of this repo, so I am
disclosing the AI assistance.

Verified locally (Go 1.25.1, `GOWORK=off`):

```
$ go build ./...
(exit 0)

$ go vet ./router/... ./relay/... ./controller/... ./service/...
(exit 0, clean)

$ go test ./router/ ./service/ -run 'Mj|Midjourney|Signature' -v
--- PASS: TestMidjourneyImageRequiresSignedURL (0.01s)
    --- PASS: TestMidjourneyImageRequiresSignedURL/no_signature_is_rejected
    --- PASS: TestMidjourneyImageRequiresSignedURL/wrong_signature_is_rejected
    --- PASS: TestMidjourneyImageRequiresSignedURL/signature_minted_for_another_task_is_rejected
    --- PASS: TestMidjourneyImageRequiresSignedURL/valid_signature_passes_the_gate
--- PASS: TestBuildMjImageForwardURLIsSignedCapability (0.00s)
--- PASS: TestVerifyMjImageSignatureRejectsForgery (0.00s)
ok  	github.com/QuantumNous/new-api/router
ok  	github.com/QuantumNous/new-api/service
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Midjourney image links now require valid signed URLs.
  * Invalid, missing, or mismatched signatures are rejected with HTTP 403.
  * Signed links support secure cache-busting without weakening access controls.

* **Reliability**
  * Image forwarding now consistently generates URLs through the centralized service.
  * Added coverage for valid links, tampering, and signature validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->