### PR TITLE
feat(rate-limit): optimize in-memory limiter allocation and cleanup

### DIFF
--- a/common/rate-limit.go
+++ b/common/rate-limit.go
@@ -1,43 +1,127 @@
 package common
 
 import (
+	"container/list"
 	"sync"
 	"time"
 )
 
+const expiredRequestsCleanupLimit = 3
+
+// rateLimitRequest stores one accepted request in a key's sliding window.
+type rateLimitRequest struct {
+	next      *rateLimitRequest
+	timestamp int64
+}
+
+// rateLimitQueue keeps accepted requests ordered from oldest to newest.
+type rateLimitQueue struct {
+	head   *rateLimitRequest
+	tail   *rateLimitRequest
+	length int
+}
+
+// append adds an accepted request without preallocating for the configured limit.
+func (q *rateLimitQueue) append(timestamp int64) {
+	request := &rateLimitRequest{timestamp: timestamp}
+	if q.tail == nil {
+		q.head = request
+		q.tail = request
+	} else {
+		q.tail.next = request
+		q.tail = request
+	}
+	q.length++
+}
+
+// removeExpired bounds per-request cleanup work while removing the oldest expired requests.
+func (q *rateLimitQueue) removeExpired(now int64, duration int64) {
+	for range expiredRequestsCleanupLimit {
+		if q.head == nil || now-q.head.timestamp < duration {
+			return
+		}
+
+		expired := q.head
+		q.head = expired.next
+		expired.next = nil
+		q.length--
+		if q.head == nil {
+			q.tail = nil
+		}
+	}
+}
+
+// clear releases the whole request chain when its key expires.
+func (q *rateLimitQueue) clear() {
+	q.head = nil
+	q.tail = nil
+	q.length = 0
+}
+
+// rateLimitEntry is both a rate-limit bucket and a node in the key-level LRU.
+type rateLimitEntry struct {
+	lastActive time.Time
+	element    *list.Element
+	requests   rateLimitQueue
+	key        string
+}
+
+// InMemoryRateLimiter implements a sliding-window limiter with idle-key eviction.
 type InMemoryRateLimiter struct {
-	store              map[string]*[]int64
+	store              map[string]*rateLimitEntry
+	lru                *list.List
 	mutex              sync.Mutex
 	expirationDuration time.Duration
 }
 
+// Init initializes the limiter once. Repeated calls leave the first configuration unchanged.
 func (l *InMemoryRateLimiter) Init(expirationDuration time.Duration) {
-	if l.store == nil {
-		l.mutex.Lock()
-		if l.store == nil {
-			l.store = make(map[string]*[]int64)
-			l.expirationDuration = expirationDuration
-			if expirationDuration > 0 {
-				go l.clearExpiredItems()
-			}
-		}
-		l.mutex.Unlock()
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if l.store != nil {
+		return
+	}
+
+	l.store = make(map[string]*rateLimitEntry)
+	l.lru = list.New()
+	l.expirationDuration = expirationDuration
+	if expirationDuration > 0 {
+		go l.clearExpiredItems(time.NewTicker(expirationDuration).C)
 	}
 }
 
-func (l *InMemoryRateLimiter) clearExpiredItems() {
+// clearExpiredItems periodically removes expired entries from the LRU tail.
+func (l *InMemoryRateLimiter) clearExpiredItems(ticks <-chan time.Time) {
+	for now := range ticks {
+		l.deleteExpiredEntries(now)
+	}
+}
+
+// deleteExpiredEntries walks only the oldest LRU entries and stops at the first active key.
+func (l *InMemoryRateLimiter) deleteExpiredEntries(now time.Time) {
+	if l.expirationDuration <= 0 {
+		return
+	}
+
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
 	for {
-		time.Sleep(l.expirationDuration)
-		l.mutex.Lock()
-		now := time.Now().Unix()
-		for key := range l.store {
-			queue := l.store[key]
-			size := len(*queue)
-			if size == 0 || now-(*queue)[size-1] > int64(l.expirationDuration.Seconds()) {
-				delete(l.store, key)
-			}
+		oldest := l.lru.Back()
+		if oldest == nil {
+			return
 		}
-		l.mutex.Unlock()
+
+		entry := oldest.Value.(*rateLimitEntry)
+		if now.Sub(entry.lastActive) < l.expirationDuration {
+			return
+		}
+
+		delete(l.store, entry.key)
+		l.lru.Remove(oldest)
+		entry.element = nil
+		entry.requests.clear()
 	}
 }
 
@@ -45,26 +129,26 @@ func (l *InMemoryRateLimiter) clearExpiredItems() {
 func (l *InMemoryRateLimiter) Request(key string, maxRequestNum int, duration int64) bool {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	// [old <-- new]
-	queue, ok := l.store[key]
-	now := time.Now().Unix()
-	if ok {
-		if len(*queue) < maxRequestNum {
-			*queue = append(*queue, now)
-			return true
-		} else {
-			if now-(*queue)[0] >= duration {
-				*queue = (*queue)[1:]
-				*queue = append(*queue, now)
-				return true
-			} else {
-				return false
-			}
+
+	now := time.Now()
+	entry, ok := l.store[key]
+	if !ok {
+		entry = &rateLimitEntry{
+			key:        key,
+			lastActive: now,
 		}
+		entry.element = l.lru.PushFront(entry)
+		l.store[key] = entry
 	} else {
-		s := make([]int64, 0, maxRequestNum)
-		l.store[key] = &s
-		*(l.store[key]) = append(*(l.store[key]), now)
+		entry.lastActive = now
+		l.lru.MoveToFront(entry.element)
 	}
-	return true
+
+	entry.requests.removeExpired(now.Unix(), duration)
+	allowed := entry.requests.length < maxRequestNum
+	if allowed {
+		entry.requests.append(now.Unix())
+	}
+
+	return allowed
 }

--- a/common/rate-limit.go
+++ b/common/rate-limit.go
@@ -6,8 +6,6 @@ import (
 	"time"
 )
 
-const expiredRequestsCleanupLimit = 3
-
 // rateLimitRequest stores one accepted request in a key's sliding window.
 type rateLimitRequest struct {
 	next      *rateLimitRequest
@@ -34,20 +32,23 @@ func (q *rateLimitQueue) append(timestamp int64) {
 	q.length++
 }
 
-// removeExpired bounds per-request cleanup work while removing the oldest expired requests.
+// removeExpired releases every expired request at the front of the queue.
 func (q *rateLimitQueue) removeExpired(now int64, duration int64) {
-	for range expiredRequestsCleanupLimit {
-		if q.head == nil || now-q.head.timestamp < duration {
-			return
-		}
+	if q.head == nil || now-q.head.timestamp < duration {
+		return
+	}
 
+	// Requests are time ordered, so an expired tail means the whole queue expired.
+	if now-q.tail.timestamp >= duration {
+		q.clear()
+		return
+	}
+
+	for now-q.head.timestamp >= duration {
 		expired := q.head
 		q.head = expired.next
 		expired.next = nil
 		q.length--
-		if q.head == nil {
-			q.tail = nil
-		}
 	}
 }
 
@@ -140,11 +141,11 @@ func (l *InMemoryRateLimiter) Request(key string, maxRequestNum int, duration in
 		entry.element = l.lru.PushFront(entry)
 		l.store[key] = entry
 	} else {
+		entry.requests.removeExpired(now.Unix(), duration)
 		entry.lastActive = now
 		l.lru.MoveToFront(entry.element)
 	}
 
-	entry.requests.removeExpired(now.Unix(), duration)
 	allowed := entry.requests.length < maxRequestNum
 	if allowed {
 		entry.requests.append(now.Unix())

--- a/common/rate-limit_test.go
+++ b/common/rate-limit_test.go
@@ -1,0 +1,153 @@
+package common
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryRateLimiterAllocatesTimestampsOnDemand(t *testing.T) {
+	var limiter InMemoryRateLimiter
+	limiter.Init(0)
+
+	require.True(t, limiter.Request("client", 1_000_000, 60))
+
+	entry := limiter.store["client"]
+	require.NotNil(t, entry)
+	assert.Equal(t, 1, entry.requests.length)
+	assert.Same(t, entry.requests.head, entry.requests.tail)
+	assert.Nil(t, entry.requests.head.next)
+
+	limiter.deleteExpiredEntries(time.Now().Add(time.Hour))
+	assert.Contains(t, limiter.store, "client")
+}
+
+func TestInMemoryRateLimiterEnforcesWindowBoundary(t *testing.T) {
+	var queue rateLimitQueue
+	queue.append(100)
+	queue.append(100)
+
+	queue.removeExpired(159, 60)
+	assert.Equal(t, 2, queue.length)
+
+	queue.removeExpired(160, 60)
+	assert.Zero(t, queue.length)
+	assert.Nil(t, queue.head)
+	assert.Nil(t, queue.tail)
+}
+
+func TestInMemoryRateLimiterRemovesAtMostThreeExpiredRequestsPerCall(t *testing.T) {
+	var queue rateLimitQueue
+	for range 5 {
+		queue.append(100)
+	}
+
+	queue.removeExpired(110, 10)
+	assert.Equal(t, 2, queue.length)
+
+	queue.append(110)
+	queue.removeExpired(110, 10)
+	assert.Equal(t, 1, queue.length)
+	require.NotNil(t, queue.head)
+	assert.EqualValues(t, 110, queue.head.timestamp)
+	assert.Same(t, queue.head, queue.tail)
+}
+
+func TestInMemoryRateLimiterKeepsNonExpiredRequests(t *testing.T) {
+	var queue rateLimitQueue
+	for range 3 {
+		queue.append(100)
+	}
+
+	queue.removeExpired(109, 10)
+	assert.Equal(t, 3, queue.length)
+	assert.NotNil(t, queue.head)
+	assert.NotNil(t, queue.tail)
+}
+
+func TestInMemoryRateLimiterEvictsOnlyExpiredLRUTail(t *testing.T) {
+	var limiter InMemoryRateLimiter
+	limiter.Init(0)
+	limiter.expirationDuration = 10 * time.Second
+
+	require.True(t, limiter.Request("active", 1, 100))
+	require.True(t, limiter.Request("idle", 1, 100))
+	assert.False(t, limiter.Request("active", 1, 100))
+
+	assert.Equal(t, "active", limiter.lru.Front().Value.(*rateLimitEntry).key)
+	assert.Equal(t, "idle", limiter.lru.Back().Value.(*rateLimitEntry).key)
+
+	idleEntry := limiter.store["idle"]
+	now := time.Now()
+	idleEntry.lastActive = now.Add(-10 * time.Second)
+	limiter.store["active"].lastActive = now
+	limiter.deleteExpiredEntries(now)
+
+	assert.NotContains(t, limiter.store, "idle")
+	assert.Contains(t, limiter.store, "active")
+	assert.Equal(t, 1, limiter.lru.Len())
+	assert.Nil(t, idleEntry.element)
+	assert.Nil(t, idleEntry.requests.head)
+	assert.Nil(t, idleEntry.requests.tail)
+	assert.Zero(t, idleEntry.requests.length)
+}
+
+func TestInMemoryRateLimiterCleanupTicksEvictExpiredKeys(t *testing.T) {
+	var limiter InMemoryRateLimiter
+	limiter.Init(0)
+	limiter.expirationDuration = 10 * time.Second
+	require.True(t, limiter.Request("idle", 1, 100))
+
+	now := time.Now()
+	limiter.store["idle"].lastActive = now.Add(-10 * time.Second)
+	ticks := make(chan time.Time, 1)
+	done := make(chan struct{})
+	go func() {
+		limiter.clearExpiredItems(ticks)
+		close(done)
+	}()
+
+	ticks <- now
+	close(ticks)
+	<-done
+
+	assert.Empty(t, limiter.store)
+	assert.Zero(t, limiter.lru.Len())
+}
+
+func TestInMemoryRateLimiterInitKeepsFirstConfiguration(t *testing.T) {
+	var limiter InMemoryRateLimiter
+	limiter.Init(time.Hour)
+	limiter.Init(0)
+
+	assert.Equal(t, time.Hour, limiter.expirationDuration)
+	require.True(t, limiter.Request("client", 1, 60))
+	limiter.deleteExpiredEntries(time.Now().Add(time.Hour))
+	assert.NotContains(t, limiter.store, "client")
+}
+
+func TestInMemoryRateLimiterConcurrentInitializationAndRequests(t *testing.T) {
+	var limiter InMemoryRateLimiter
+	var allowed atomic.Int64
+	var waitGroup sync.WaitGroup
+
+	for range 100 {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			limiter.Init(0)
+			if limiter.Request("client", 10, 60) {
+				allowed.Add(1)
+			}
+		}()
+	}
+
+	waitGroup.Wait()
+	assert.EqualValues(t, 10, allowed.Load())
+	assert.Len(t, limiter.store, 1)
+	assert.Equal(t, 10, limiter.store["client"].requests.length)
+}

--- a/common/rate-limit_test.go
+++ b/common/rate-limit_test.go
@@ -40,16 +40,13 @@ func TestInMemoryRateLimiterEnforcesWindowBoundary(t *testing.T) {
 	assert.Nil(t, queue.tail)
 }
 
-func TestInMemoryRateLimiterRemovesAtMostThreeExpiredRequestsPerCall(t *testing.T) {
+func TestInMemoryRateLimiterRemovesAllExpiredRequestsPerCall(t *testing.T) {
 	var queue rateLimitQueue
 	for range 5 {
 		queue.append(100)
 	}
-
-	queue.removeExpired(110, 10)
-	assert.Equal(t, 2, queue.length)
-
 	queue.append(110)
+
 	queue.removeExpired(110, 10)
 	assert.Equal(t, 1, queue.length)
 	require.NotNil(t, queue.head)


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)
做了什么：通过链表和LRU来优化内存限流器，减少内存占用并及时释放内存
为什么这样改能生效？
原实现通过make([]int64, 0, maxRequestNum)预先占用内存，改为链表，实时分配内存
原实现通过if len(*queue) < maxRequestNum { *queue = append(*queue, now) return true }，导致切片中存在很多过期时间戳，改为每次请求都通过removeExpired删除对应key的过期时间戳（最多删除3个），及时释放内存
原实现通过clearExpiredItems遍历store来实现内存释放，优化为通过lru实现，降低时间复杂度

## 🚀 变更类型 / Type of change
- [✅] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [✅] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6732

## ✅ 提交前检查项 / Checklist
- [✅] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [✅] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [✅] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [✅] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [✅] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [✅] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [✅] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
<img width="866" height="274" alt="截屏2026-08-13 12 29 49" src="https://github.com/user-attachments/assets/d2181a1b-c803-4a45-8c8a-1a7c993c857f" />
<img width="592" height="166" alt="截屏2026-08-13 12 30 49" src="https://github.com/user-attachments/assets/ddcaf61f-8f4e-46cf-ba56-c52e506c3967" />
<img width="525" height="113" alt="截屏2026-08-13 12 34 12" src="https://github.com/user-attachments/assets/7c9ad5b6-947d-4e4f-b650-dd2492d35e4f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rate-limit accuracy by removing expired requests at the window boundary.
  - Preserved active request history while clearing expired entries.
  - Added safer handling for concurrent requests and repeated initialization.
  - Improved cleanup of inactive rate-limit entries for more consistent behavior and resource usage.

- **Tests**
  - Added comprehensive coverage for expiration, cleanup, eviction, configuration retention, and concurrent access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->