### PR TITLE
fix(relay): keep completed stream end reason when client disconnects after done

### DIFF
--- a/relay/common/stream_status.go
+++ b/relay/common/stream_status.go
@@ -31,9 +31,9 @@ type StreamErrorEntry struct {
 type StreamStatus struct {
 	EndReason StreamEndReason
 	EndError  error
-	endOnce   sync.Once
 
 	mu         sync.Mutex
+	reasonSet  bool
 	Errors     []StreamErrorEntry
 	ErrorCount int
 }
@@ -42,14 +42,33 @@ func NewStreamStatus() *StreamStatus {
 	return &StreamStatus{}
 }
 
+// SetEndReason records why the stream ended. First write wins, with one
+// exception: a normal completion (the scanner saw [DONE] or hit a clean EOF)
+// is the ground truth about the stream and corrects an earlier client_gone.
+//
+// The main select can record client_gone in the small window between a client
+// closing the socket right after the final event and the scanner recording the
+// terminal reason it already reached (see issue #6649). Without this override
+// that race mislabels a finished stream. A genuine mid-stream disconnect makes
+// the forced body close surface as scanner_error, not a completion, so it keeps
+// client_gone.
 func (s *StreamStatus) SetEndReason(reason StreamEndReason, err error) {
 	if s == nil {
 		return
 	}
-	s.endOnce.Do(func() {
-		s.EndReason = reason
-		s.EndError = err
-	})
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.reasonSet {
+		if s.EndReason == StreamEndReasonClientGone &&
+			(reason == StreamEndReasonDone || reason == StreamEndReasonEOF) {
+			s.EndReason = reason
+			s.EndError = err
+		}
+		return
+	}
+	s.reasonSet = true
+	s.EndReason = reason
+	s.EndError = err
 }
 
 func (s *StreamStatus) RecordError(msg string) {
@@ -89,6 +108,8 @@ func (s *StreamStatus) IsNormalEnd() bool {
 	if s == nil {
 		return true
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.EndReason == StreamEndReasonDone ||
 		s.EndReason == StreamEndReasonEOF ||
 		s.EndReason == StreamEndReasonHandlerStop
@@ -98,15 +119,15 @@ func (s *StreamStatus) Summary() string {
 	if s == nil {
 		return "StreamStatus<nil>"
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	b := &strings.Builder{}
 	fmt.Fprintf(b, "reason=%s", s.EndReason)
 	if s.EndError != nil {
 		fmt.Fprintf(b, " end_error=%q", s.EndError.Error())
 	}
-	s.mu.Lock()
 	if s.ErrorCount > 0 {
 		fmt.Fprintf(b, " soft_errors=%d", s.ErrorCount)
 	}
-	s.mu.Unlock()
 	return b.String()
 }

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -280,13 +280,12 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 			}
 		}
 
-		if err := scanner.Err(); err != nil {
-			if err != io.EOF {
-				logger.LogError(c, "scanner error: "+err.Error())
-				info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonScannerErr, err)
-			}
+		if err := scanner.Err(); err != nil && err != io.EOF {
+			logger.LogError(c, "scanner error: "+err.Error())
+			info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonScannerErr, err)
+		} else {
+			info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonEOF, nil)
 		}
-		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonEOF, nil)
 	})
 
 	// 主循环等待完成或超时
@@ -298,7 +297,10 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	case <-c.Request.Context().Done():
 		// 客户端断开：立即 cleanup 关闭上游 resp.Body，解除 scanner 阻塞并让上游停止生成，
 		// 避免为已放弃的请求继续消费上游 token。
-		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, c.Request.Context().Err())
+		// 若流其实已正常结束（scanner 已收到 [DONE]/EOF），不要降级为 client_gone。
+		if !info.StreamStatus.IsNormalEnd() {
+			info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, c.Request.Context().Err())
+		}
 	}
 
 	cleanup()

--- a/relay/helper/stream_scanner_test.go
+++ b/relay/helper/stream_scanner_test.go
@@ -571,3 +571,48 @@ func TestStreamScannerHandler_StreamStatus_ReplacesPreInitialized(t *testing.T) 
 	assert.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
 	assert.Equal(t, 0, info.StreamStatus.TotalErrorCount())
 }
+
+// TestStreamScannerHandler_CompletedStreamNotRelabeledClientGone covers issue
+// #6649. A client (e.g. codex CLI) can close its socket right after the final
+// event, so the handler's main select wins c.Request.Context().Done() and
+// records client_gone in the small window before the scanner records the
+// terminal reason it already reached ([DONE] or a clean EOF). The completed
+// stream must keep its completion reason, not be relabeled client_gone.
+//
+// The ordering is asserted on StreamStatus directly: the handler-level window
+// between recording client_gone and cleanup cannot be forced deterministically,
+// and a timing-based test would be flaky. This proves the fix in
+// StreamStatus.SetEndReason, which the scanner and the main select share.
+func TestStreamScannerHandler_CompletedStreamNotRelabeledClientGone(t *testing.T) {
+	t.Parallel()
+
+	// A normal stream really reaches a completed reason via the scanner.
+	c, resp, info := setupStreamTest(t, strings.NewReader(buildSSEBody(5)))
+	StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {})
+	require.NotNil(t, info.StreamStatus)
+	require.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
+	require.True(t, info.StreamStatus.IsNormalEnd())
+
+	// Regression: client_gone recorded first (main select), completion recorded
+	// after (scanner). The completion must win and clear the spurious error.
+	completions := []relaycommon.StreamEndReason{
+		relaycommon.StreamEndReasonDone,
+		relaycommon.StreamEndReasonEOF,
+	}
+	for _, completed := range completions {
+		s := relaycommon.NewStreamStatus()
+		s.SetEndReason(relaycommon.StreamEndReasonClientGone, context.Canceled)
+		s.SetEndReason(completed, nil)
+		assert.Equalf(t, completed, s.EndReason, "completion %s must override earlier client_gone", completed)
+		assert.Nilf(t, s.EndError, "completion %s must clear the client_gone error", completed)
+		assert.Truef(t, s.IsNormalEnd(), "completion %s must read as a normal end", completed)
+	}
+
+	// A genuine mid-stream disconnect surfaces as scanner_error (not a
+	// completion) after the forced body close, so it stays client_gone.
+	s := relaycommon.NewStreamStatus()
+	s.SetEndReason(relaycommon.StreamEndReasonClientGone, context.Canceled)
+	s.SetEndReason(relaycommon.StreamEndReasonScannerErr, io.ErrClosedPipe)
+	assert.Equal(t, relaycommon.StreamEndReasonClientGone, s.EndReason)
+	assert.False(t, s.IsNormalEnd())
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

Streams that finished normally were sometimes labeled `client_gone` in
`stream_status.end_reason`, which the frontend shows as a stream error. When a
client (codex CLI, curl in stream mode) closes its socket right after the last
SSE event, the gin request context is canceled. In `StreamScannerHandler` the
main select can win `c.Request.Context().Done()` and record `client_gone` in the
small window before the scanner goroutine records the terminal reason it already
reached (`[DONE]` or a clean EOF). Because `SetEndReason` was first-write-wins
(`sync.Once`), the scanner's later `Done`/`EOF` was dropped. HTTP 200, tokens
and billing were all correct, only the label was wrong.

Fix:
- `SetEndReason` still keeps the first reason, with one exception: a normal
  completion (`Done`/`EOF`) corrects an earlier `client_gone`. A genuine
  mid-stream disconnect surfaces as `scanner_error` after the forced body close,
  not a completion, so it stays `client_gone`.
- The client-gone branch in the select skips relabeling when the stream already
  ended normally. `cleanup()` still runs, so the upstream body is still closed
  and token generation still stops for an abandoned request.
- The scanner error block records `EOF` only when there was no real scanner
  error, so a forced close cannot masquerade as a normal EOF.

Added a deterministic regression test in `relay/helper` that reproduces the
documented ordering (`client_gone` recorded first, completion after) and asserts
the completion wins, plus that a real `scanner_error` after `client_gone` stays
`client_gone`.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6649

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

AI disclosure: this change was AI-assisted. I reviewed the diff, ran the builds
and tests below locally. I understand and can defend the change. Verified on
this branch with `GOWORK=off GOTOOLCHAIN=auto`:

```
$ go build ./...
(exit 0)

$ go vet ./relay/helper/... ./relay/common/...
(exit 0)

$ go test ./relay/helper/... ./relay/common/...
ok   github.com/QuantumNous/new-api/relay/helper   2.625s
ok   github.com/QuantumNous/new-api/relay/common   0.013s
```

The new test fails on unmodified `SetEndReason` (stays `client_gone`) and passes
with the fix, confirming it guards the real behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream completion reporting for normally finished streams.
  * Prevented client disconnects from incorrectly replacing successful completion statuses.
  * Preserved scanner errors when streams end unexpectedly.
  * Improved consistency of stream status and cancellation error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->