### PR TITLE
fix(keys): restore auto group badge and guard cross-group badge

### DIFF
--- a/web/src/features/keys/components/api-key-group-cell.tsx
+++ b/web/src/features/keys/components/api-key-group-cell.tsx
@@ -28,7 +28,7 @@ import {
 } from '@/components/ui/tooltip'
 
 import {
-  // AutoGroupBadge,
+  AutoGroupBadge,
   GroupRatioBadge,
   type GroupRatio,
 } from './auto-group-visuals'
@@ -66,12 +66,14 @@ export function ApiKeyGroupCell(props: ApiKeyGroupCellProps) {
           />
         }
       >
-        <StatusBadge
-          label={t('Cross-group')}
-          variant='info'
-          copyable={false}
-        />
-        {/*<AutoGroupBadge shouldReduceMotion={props.shouldReduceMotion} />*/}
+        {props.crossGroupRetry && (
+          <StatusBadge
+            label={t('Cross-group')}
+            variant='info'
+            copyable={false}
+          />
+        )}
+        <AutoGroupBadge shouldReduceMotion={props.shouldReduceMotion} />
         <GroupRatioBadge
           ratio={props.ratio}
           isAuto


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

The Group column cell for `auto` keys on `/keys` was showing the `Cross-group`
badge on every auto key and no longer showing the badge that marks the key as
`auto`. A previous "temporarily disable AutoGroupBadge" refactor commented out
`<AutoGroupBadge />` and, in the same hunk, dropped the `crossGroupRetry` guard
around the `Cross-group` badge, so the badge stopped reflecting each key's
`cross_group_retry` state and auto keys with no ratio data ended up with an
empty-looking group cell.

This restores the two removed lines in `api-key-group-cell.tsx`: it renders
`AutoGroupBadge` again and wraps the `Cross-group` `StatusBadge` in
`{props.crossGroupRetry && ...}`. `crossGroupRetry` was already declared on the
props and passed from `api-keys-columns.tsx`, it just was not read. This matches
the per-token backend semantics (`Token.CrossGroupRetry`, read in
`service/channel_select.go`, forced false for non-auto groups in
`controller/token.go`) and turns the component's own committed test file green
(it asserts two Auto frames when a ratio is present and one when it is not, plus
that `Cross-group` only appears with the flag on). Scope is this one cell.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6804

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

Ran from `web/`:

```
# component's own committed test, in isolation, AFTER the fix
$ bun test src/features/keys/components/__tests__/api-key-group-cell.test.tsx
 4 pass
 0 fail
Ran 4 tests across 1 file.

# same test BEFORE the fix (the regression this PR restores)
 1 pass
 3 fail   # lines 130, 167, 189 (the three failures CI reports on main)

$ bun run typecheck      # tsgo -b
(exit 0, no diagnostics)

$ bun run build          # rsbuild build
(exit 0, bundle emitted)

$ bunx oxlint -c .oxlintrc.json src/features/keys/components/api-key-group-cell.tsx
(exit 0, no warnings)
```

> AI assistance (Claude) was used to write this change. The author, who is not
> one of this repository's historical core developers, reviewed and verified it
> locally before submitting. Verified in `web/`: `bun run typecheck` is clean,
> `bun run build` succeeds, the component's committed test
> `api-key-group-cell.test.tsx` goes from 3 failing to 4 passing (run in
> isolation), matching the three failures the frontend CI gate reports on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected group status badges to accurately reflect automatic grouping.
  * The “Cross-group” badge now appears only when cross-group retry is enabled.
  * Automatic groups now display their appropriate badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->