### PR TITLE
fix(payment): credit Waffo Pancake orders with email buyer identity

### DIFF
--- a/controller/topup_waffo_pancake.go
+++ b/controller/topup_waffo_pancake.go
@@ -482,11 +482,16 @@ func WaffoPancakeWebhook(c *gin.Context) {
 	if isSubscription {
 		tradeNo, err := service.ResolveWaffoPancakeSubscriptionTradeNo(event)
 		if err != nil {
+			// Could not map the event to a local order, so we cannot credit a
+			// paid subscription. Return 5xx (not 200) so Waffo retries and the
+			// failure surfaces, instead of silently accepting a payment the
+			// buyer never gets. Email-form buyer identities are resolved in
+			// ResolveWaffoPancakeSubscriptionTradeNo.
 			logger.LogError(c.Request.Context(), fmt.Sprintf(
 				"Waffo Pancake webhook 订阅订单解析失败 event_id=%s order_id=%s buyer_identity=%q client_ip=%s error=%q",
 				event.ID, event.Data.OrderID, event.Data.MerchantProvidedBuyerIdentity, c.ClientIP(), err.Error(),
 			))
-			c.String(http.StatusOK, "OK")
+			c.String(http.StatusInternalServerError, "retry")
 			return
 		}
 		LockOrder(tradeNo)
@@ -503,14 +508,16 @@ func WaffoPancakeWebhook(c *gin.Context) {
 
 	tradeNo, err := service.ResolveWaffoPancakeTradeNo(event)
 	if err != nil {
-		// LogError (not LogWarn): covers order-not-found and buyer-identity
-		// mismatch — both warrant human attention. 200 OK so Waffo doesn't
-		// retry a permanently-unresolvable webhook.
+		// Could not map the event to a local order, so we cannot credit a paid
+		// top-up. Return 5xx (not 200) so Waffo retries and the failure
+		// surfaces, instead of silently accepting a payment the buyer never
+		// gets credited for. Email-form buyer identities are resolved in
+		// ResolveWaffoPancakeTradeNo.
 		logger.LogError(c.Request.Context(), fmt.Sprintf(
 			"Waffo Pancake webhook 订单解析失败 event_id=%s order_id=%s buyer_identity=%q client_ip=%s error=%q",
 			event.ID, event.Data.OrderID, event.Data.MerchantProvidedBuyerIdentity, c.ClientIP(), err.Error(),
 		))
-		c.String(http.StatusOK, "OK")
+		c.String(http.StatusInternalServerError, "retry")
 		return
 	}
 

--- a/controller/topup_waffo_pancake_test.go
+++ b/controller/topup_waffo_pancake_test.go
@@ -4,9 +4,15 @@ import (
 	"testing"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting"
 	"github.com/QuantumNous/new-api/setting/operation_setting"
+	"github.com/glebarez/sqlite"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestFormatWaffoPancakeAmount_UsesDisplayPriceString(t *testing.T) {
@@ -86,6 +92,153 @@ func TestGetWaffoPancakePayMoney(t *testing.T) {
 			operation_setting.GetGeneralSetting().QuotaDisplayType = tc.quotaDisplayType
 			actual := getWaffoPancakePayMoney(tc.amount, tc.group)
 			require.InDelta(t, tc.expected, actual, 0.000001)
+		})
+	}
+}
+
+func setupWaffoPancakeWebhookTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	previousDB := model.DB
+	previousLogDB := model.LOG_DB
+	previousRedis := common.RedisEnabled
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&model.User{}, &model.TopUp{}, &model.Log{}))
+	model.DB = db
+	model.LOG_DB = db
+	common.RedisEnabled = false
+
+	t.Cleanup(func() {
+		model.DB = previousDB
+		model.LOG_DB = previousLogDB
+		common.RedisEnabled = previousRedis
+	})
+	return db
+}
+
+// An order.completed webhook must credit the buyer even when Pancake echoes the
+// buyer identity back as the account email instead of the canonical
+// new-api-user-<id> we sent at checkout (#6633). Before the fix the email form
+// failed the strict identity check and the paid order was silently dropped.
+func TestWaffoPancakeWebhookResolvesBuyerIdentityAndCreditsUser(t *testing.T) {
+	const userID = 4242
+	const userEmail = "buyer@example.com"
+	const tradeNo = "WAFFO_PANCAKE-4242-1700000000000-abcdef"
+	const topUpAmount = int64(10)
+
+	expectedCredit, err := common.QuotaFromDecimalStrict(
+		decimal.NewFromInt(topUpAmount).Mul(decimal.NewFromFloat(common.QuotaPerUnit)),
+	)
+	require.NoError(t, err)
+	require.Greater(t, expectedCredit, 0)
+
+	testCases := []struct {
+		name          string
+		buyerIdentity string
+	}{
+		{name: "canonical identity", buyerIdentity: service.WaffoPancakeBuyerIdentityFromUserID(userID)},
+		{name: "email identity", buyerIdentity: userEmail},
+		{name: "email identity different case", buyerIdentity: "BUYER@Example.com"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := setupWaffoPancakeWebhookTestDB(t)
+			require.NoError(t, db.Create(&model.User{
+				Id: userID, Username: "buyer", Email: userEmail,
+				Status: common.UserStatusEnabled, Group: "default", Quota: 0,
+			}).Error)
+			require.NoError(t, db.Create(&model.TopUp{
+				UserId: userID, Amount: topUpAmount, Money: 20, TradeNo: tradeNo,
+				PaymentMethod: model.PaymentMethodWaffoPancake, PaymentProvider: model.PaymentProviderWaffoPancake,
+				Status: common.TopUpStatusPending,
+			}).Error)
+
+			event := &service.WaffoPancakeWebhookEvent{
+				EventType: "order.completed",
+				Data: service.WaffoPancakeWebhookData{
+					OrderMerchantExternalID:       tradeNo,
+					MerchantProvidedBuyerIdentity: tc.buyerIdentity,
+				},
+			}
+
+			resolved, err := service.ResolveWaffoPancakeTradeNo(event)
+			require.NoError(t, err)
+			require.Equal(t, tradeNo, resolved)
+
+			require.NoError(t, model.RechargeWaffoPancake(resolved))
+
+			var user model.User
+			require.NoError(t, db.First(&user, "id = ?", userID).Error)
+			assert.Equal(t, expectedCredit, user.Quota)
+
+			var topUp model.TopUp
+			require.NoError(t, db.First(&topUp, "trade_no = ?", tradeNo).Error)
+			assert.Equal(t, common.TopUpStatusSuccess, topUp.Status)
+		})
+	}
+}
+
+// A genuinely unprocessable order.completed webhook (an unknown order or an
+// identity that is neither the canonical id nor the order owner's email) must
+// fail to resolve. WaffoPancakeWebhook turns that error into an HTTP 5xx so
+// Waffo retries and the failure stays visible, instead of a 200 that silently
+// drops a paid order (#6633).
+func TestWaffoPancakeWebhookRejectsUnprocessableEvent(t *testing.T) {
+	const userID = 5252
+	const tradeNo = "WAFFO_PANCAKE-5252-1700000000000-zzzzzz"
+
+	testCases := []struct {
+		name  string
+		event *service.WaffoPancakeWebhookEvent
+	}{
+		{
+			name: "identity belongs to a different buyer",
+			event: &service.WaffoPancakeWebhookEvent{
+				EventType: "order.completed",
+				Data: service.WaffoPancakeWebhookData{
+					OrderMerchantExternalID:       tradeNo,
+					MerchantProvidedBuyerIdentity: "someone-else@example.com",
+				},
+			},
+		},
+		{
+			name: "order not found",
+			event: &service.WaffoPancakeWebhookEvent{
+				EventType: "order.completed",
+				Data: service.WaffoPancakeWebhookData{
+					OrderMerchantExternalID:       "WAFFO_PANCAKE-does-not-exist",
+					MerchantProvidedBuyerIdentity: service.WaffoPancakeBuyerIdentityFromUserID(userID),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := setupWaffoPancakeWebhookTestDB(t)
+			require.NoError(t, db.Create(&model.User{
+				Id: userID, Username: "owner", Email: "owner@example.com",
+				Status: common.UserStatusEnabled, Group: "default", Quota: 0,
+			}).Error)
+			require.NoError(t, db.Create(&model.TopUp{
+				UserId: userID, Amount: 5, Money: 10, TradeNo: tradeNo,
+				PaymentMethod: model.PaymentMethodWaffoPancake, PaymentProvider: model.PaymentProviderWaffoPancake,
+				Status: common.TopUpStatusPending,
+			}).Error)
+
+			_, err := service.ResolveWaffoPancakeTradeNo(tc.event)
+			require.Error(t, err)
+
+			// The order stays pending and the owner is not credited.
+			var topUp model.TopUp
+			require.NoError(t, db.First(&topUp, "trade_no = ?", tradeNo).Error)
+			assert.Equal(t, common.TopUpStatusPending, topUp.Status)
+
+			var user model.User
+			require.NoError(t, db.First(&user, "id = ?", userID).Error)
+			assert.Equal(t, 0, user.Quota)
 		})
 	}
 }

--- a/service/waffo_pancake.go
+++ b/service/waffo_pancake.go
@@ -159,6 +159,33 @@ func WaffoPancakeBuyerIdentityFromUserID(userID int) string {
 	return fmt.Sprintf("new-api-user-%d", userID)
 }
 
+// waffoPancakeBuyerIdentityMatches reports whether the buyer identity echoed
+// back in a webhook belongs to userID. We always send the canonical
+// new-api-user-<id> at checkout, but Pancake returns the identity it has on
+// file for the buyer, which for a buyer with an existing Waffo account comes
+// back as that account's email (buyer identity may be an email or a
+// merchant-defined id, per the SDK). Accept either form: the canonical id or
+// an email that matches the order owner's registered address. Without this an
+// email-form identity is rejected and the paid order is never credited.
+func waffoPancakeBuyerIdentityMatches(userID int, actualIdentity string) bool {
+	actualIdentity = strings.TrimSpace(actualIdentity)
+	if actualIdentity == "" {
+		return false
+	}
+	if actualIdentity == WaffoPancakeBuyerIdentityFromUserID(userID) {
+		return true
+	}
+	if !strings.Contains(actualIdentity, "@") {
+		return false
+	}
+	user, err := model.GetUserById(userID, false)
+	if err != nil || user == nil {
+		return false
+	}
+	email := model.NormalizeEmail(user.Email)
+	return email != "" && model.NormalizeEmail(actualIdentity) == email
+}
+
 // VerifyConfiguredWaffoPancakeWebhook verifies the signature header. The SDK
 // picks the matching test / prod public key from the payload's `mode` field.
 func VerifyConfiguredWaffoPancakeWebhook(payload string, signatureHeader string) (*WaffoPancakeWebhookEvent, error) {
@@ -210,7 +237,7 @@ func ResolveWaffoPancakeTradeNo(event *WaffoPancakeWebhookEvent) (string, error)
 	}
 	expectedIdentity := WaffoPancakeBuyerIdentityFromUserID(topUp.UserId)
 	actualIdentity := strings.TrimSpace(event.Data.MerchantProvidedBuyerIdentity)
-	if actualIdentity != expectedIdentity {
+	if !waffoPancakeBuyerIdentityMatches(topUp.UserId, actualIdentity) {
 		return "", fmt.Errorf(
 			"waffo pancake buyer identity mismatch for tradeNo=%s: expected=%q actual=%q",
 			tradeNo,
@@ -237,7 +264,7 @@ func ResolveWaffoPancakeSubscriptionTradeNo(event *WaffoPancakeWebhookEvent) (st
 	}
 	expectedIdentity := WaffoPancakeBuyerIdentityFromUserID(order.UserId)
 	actualIdentity := strings.TrimSpace(event.Data.MerchantProvidedBuyerIdentity)
-	if actualIdentity != expectedIdentity {
+	if !waffoPancakeBuyerIdentityMatches(order.UserId, actualIdentity) {
 		return "", fmt.Errorf(
 			"waffo pancake buyer identity mismatch for subscription tradeNo=%s: expected=%q actual=%q",
 			tradeNo,


### PR DESCRIPTION
## 📝 变更描述 / Description

Waffo Pancake authenticated checkout sends a stable buyer identity
(`new-api-user-<id>`). The `order.completed` webhook is supposed to echo that
back, but a buyer identity can be an email (SDK `docs/api-reference.md`). For a
buyer with an existing Waffo account it comes back as the account email. The
resolver compared the identity with a strict `!=`, so the email form was rejected
and the handler still answered HTTP 200. Waffo saw 200 and never retried. The
paid top-up or subscription was never credited. No error surfaced.

Two changes:

- `service/waffo_pancake.go`: accept the buyer identity when it is an email that
  matches the order owner's registered address, in addition to the canonical
  `new-api-user-<id>`. The email is mapped to the same user the trade number
  already resolved to (normalized compare, case insensitive). Applied to both the
  top-up and the subscription resolver.
- `controller/topup_waffo_pancake.go`: when the event cannot be resolved to a
  local order, return 5xx instead of 200 in both webhook branches, so the failure
  is visible and Waffo retries. This matches the existing recharge and
  subscription-complete error handling in the same file.

Regression test in `controller/topup_waffo_pancake_test.go`: an `order.completed`
webhook whose buyer identity is an email credits the correct user (with a
different-case variant). A genuinely unprocessable event (an unknown order or an
identity that is neither the canonical id nor the owner's email) fails to resolve
and leaves the order pending. The email cases fail before the fix.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6633

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

Go 1.25.1, `GOWORK=off GOTOOLCHAIN=auto`.

```
$ go build ./...
(exit 0)

$ go vet ./...
(exit 0)

$ go test -count=1 ./controller/... ./service/...
ok   github.com/QuantumNous/new-api/controller       0.871s
ok   github.com/QuantumNous/new-api/service          0.490s
ok   github.com/QuantumNous/new-api/service/authz    0.037s
?    github.com/QuantumNous/new-api/service/passkey  [no test files]
```

New test fails before the fix (email identity rejected):

```
$ git stash push -- service/waffo_pancake.go   # revert only the resolver fix
$ go test ./controller/ -run TestWaffoPancakeWebhookResolvesBuyerIdentityAndCreditsUser -v
--- FAIL: TestWaffoPancakeWebhookResolvesBuyerIdentityAndCreditsUser
    --- PASS: .../canonical_identity
    --- FAIL: .../email_identity
        Received unexpected error:
        waffo pancake buyer identity mismatch for tradeNo=WAFFO_PANCAKE-4242-1700000000000-abcdef: expected="new-api-user-4242" actual="buyer@example.com"
    --- FAIL: .../email_identity_different_case
```

And passes with the fix:

```
$ go test -count=1 ./controller/ -run 'TestWaffoPancakeWebhookResolvesBuyerIdentityAndCreditsUser|TestWaffoPancakeWebhookRejectsUnprocessableEvent' -v
--- PASS: TestWaffoPancakeWebhookResolvesBuyerIdentityAndCreditsUser (0.02s)
    --- PASS: .../canonical_identity
    --- PASS: .../email_identity
    --- PASS: .../email_identity_different_case
--- PASS: TestWaffoPancakeWebhookRejectsUnprocessableEvent (0.01s)
    --- PASS: .../identity_belongs_to_a_different_buyer
    --- PASS: .../order_not_found
```

## AI disclosure

This change was AI-assisted. The author (not a repo core developer) reviewed the
code, the SDK behavior it relies on and the test. Verified locally: `go
build ./...`, `go vet ./...` and `go test ./controller/... ./service/...` all
pass. The new regression test fails before the fix and passes after.

