### PR TITLE
fix(vertex): convert Anthropic Messages to Gemini for Gemini upstreams

### DIFF
--- a/relay/channel/vertex/adaptor.go
+++ b/relay/channel/vertex/adaptor.go
@@ -94,6 +94,21 @@ func removeFunctionResponseID(request *dto.GeminiChatRequest) {
 }
 
 func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.ClaudeRequest) (any, error) {
+	if a.RequestMode == RequestModeGemini {
+		// Gemini upstreams reject the Anthropic Messages body (anthropic_version,
+		// messages, max_tokens). The /v1/messages request must be converted to
+		// Gemini generateContent, same as the /v1/chat/completions path.
+		result, err := service.ConvertRequest(c, info, types.RelayFormatGemini, request)
+		if err != nil {
+			return nil, err
+		}
+		geminiRequest, ok := result.Value.(*dto.GeminiChatRequest)
+		if !ok {
+			return nil, fmt.Errorf("expected Gemini generateContent request, got %T", result.Value)
+		}
+		c.Set("request_model", request.Model)
+		return geminiRequest, nil
+	}
 	if v, ok := claudeModelMap[info.UpstreamModelName]; ok {
 		c.Set("request_model", v)
 	} else {

--- a/relay/channel/vertex/adaptor_test.go
+++ b/relay/channel/vertex/adaptor_test.go
@@ -1,0 +1,99 @@
+package vertex
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/types"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestClaudeRequest() *dto.ClaudeRequest {
+	maxTokens := uint(16)
+	return &dto.ClaudeRequest{
+		Model:     "gemini-2.5-pro",
+		MaxTokens: &maxTokens,
+		Messages: []dto.ClaudeMessage{
+			{Role: "user", Content: "hi"},
+		},
+	}
+}
+
+// A Vertex channel whose upstream is Gemini must convert the incoming Anthropic
+// Messages body to Gemini generateContent. Forwarding the raw Anthropic body to
+// the generateContent URL makes Vertex reject anthropic_version/messages/max_tokens
+// with HTTP 400 (issue #6715). The channel test dispatches through this same
+// ConvertClaudeRequest for the Anthropic endpoint, so this also fixes the test.
+func TestConvertClaudeRequestByRequestMode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name        string
+		requestMode int
+		wantKeys    []string
+		absentKeys  []string
+	}{
+		{
+			name:        "gemini upstream converts to generateContent",
+			requestMode: RequestModeGemini,
+			wantKeys:    []string{"contents", "generationConfig"},
+			absentKeys:  []string{"anthropic_version", "messages", "max_tokens"},
+		},
+		{
+			name:        "claude upstream keeps anthropic messages body",
+			requestMode: RequestModeClaude,
+			wantKeys:    []string{"anthropic_version", "messages", "max_tokens"},
+			absentKeys:  []string{"contents", "generationConfig"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			info := &relaycommon.RelayInfo{
+				RelayFormat: types.RelayFormatClaude,
+				ChannelMeta: &relaycommon.ChannelMeta{
+					UpstreamModelName: "gemini-2.5-pro",
+				},
+			}
+			adaptor := &Adaptor{RequestMode: tc.requestMode}
+
+			converted, err := adaptor.ConvertClaudeRequest(c, info, newTestClaudeRequest())
+			require.NoError(t, err)
+			require.NotNil(t, converted)
+
+			raw, err := common.Marshal(converted)
+			require.NoError(t, err)
+
+			var body map[string]any
+			require.NoError(t, common.Unmarshal(raw, &body))
+			for _, key := range tc.wantKeys {
+				assert.Contains(t, body, key, "expected key %q in converted body", key)
+			}
+			for _, key := range tc.absentKeys {
+				assert.NotContains(t, body, key, "unexpected key %q in converted body", key)
+			}
+
+			switch tc.requestMode {
+			case RequestModeGemini:
+				geminiReq, ok := converted.(*dto.GeminiChatRequest)
+				require.True(t, ok, "expected *dto.GeminiChatRequest, got %T", converted)
+				require.Len(t, geminiReq.Contents, 1)
+				require.Len(t, geminiReq.Contents[0].Parts, 1)
+				assert.Equal(t, "hi", geminiReq.Contents[0].Parts[0].Text)
+				require.NotNil(t, geminiReq.GenerationConfig.MaxOutputTokens)
+				assert.Equal(t, uint(16), *geminiReq.GenerationConfig.MaxOutputTokens)
+			case RequestModeClaude:
+				claudeReq, ok := converted.(*VertexAIClaudeRequest)
+				require.True(t, ok, "expected *VertexAIClaudeRequest, got %T", converted)
+				assert.Equal(t, anthropicVersion, claudeReq.AnthropicVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 📝 变更描述 / Description

Vertex 渠道当上游模型为 Gemini 时，调用 Anthropic Messages 接口 `POST /v1/messages`
会返回 HTTP 400（Vertex 报 `Unknown name anthropic_version / messages / max_tokens`）。

原因在 `relay/channel/vertex/adaptor.go` 的 `ConvertClaudeRequest`：它无论上游是
Claude 还是 Gemini，都把请求包装成 `VertexAIClaudeRequest`（`anthropic_version` +
`messages` + `max_tokens`）。但 Gemini 上游走的是 `generateContent` URL，需要的是
`contents` + `generationConfig`，所以被 Vertex 拒绝。`/v1/chat/completions` 路径没有这个
问题，因为 `ConvertOpenAIRequest` 已经按 `RequestMode` 分支，对 Gemini 调用
`service.ConvertRequest(..., RelayFormatGemini, ...)`。只有 `/v1/messages` 入口缺了这个分支。

本 PR 在 `ConvertClaudeRequest` 补上同样的分支：当 `RequestMode == RequestModeGemini`
时，用已注册的 `claude_messages_to_gemini_generate_content` 转换器（经
`service.ConvertRequest`）把 Anthropic Messages 请求转成 Gemini `generateContent`，返回
`*dto.GeminiChatRequest`；Claude 上游保持原有 Anthropic 包装不变。响应侧无需改动：
`RelayFormatClaude` 下共享的 `gemini.GeminiChatHandler` 已经把 Gemini 响应转回 Claude
Messages 格式。

关于渠道测试误报成功：渠道测试对 Anthropic 端点走的是同一个 `adaptor.ConvertClaudeRequest`，
并且会检查上游状态码与错误体。它之所以“成功”，是因为默认渠道测试用的是 OpenAI 端点
（`/v1/chat/completions`），那条路径转换本就正确，从未触发 `/v1/messages` 的缺陷。修复后，
对 Anthropic 端点做渠道测试会经过同一段修正后的转换逻辑，产生真正的 Gemini 请求体，不再掩盖问题。
因此测试代码本身无需改动。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6715

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## AI disclosure

This change was written with AI assistance (Claude). I reviewed the code and the
Vertex/Anthropic request shapes and verified it locally. Verified before
submitting: `go build ./...` (exit 0), `go vet ./relay/channel/vertex/...`
(clean), `go test ./relay/channel/vertex/...` (pass, including the new
regression test). The author is not a repo core developer, so this disclosure is
included per contribution policy.

## 📸 运行证明 / Proof of Work

New regression test `TestConvertClaudeRequestByRequestMode` fails before the fix
and passes after.

Before the fix (fix reverted, test kept):
```
--- FAIL: TestConvertClaudeRequestByRequestMode/gemini_upstream_converts_to_generateContent
    map[anthropic_version:vertex-2023-10-16 max_tokens:16 messages:[...]] should not contain "max_tokens"
    expected *dto.GeminiChatRequest, got *vertex.VertexAIClaudeRequest
FAIL
```

After the fix:
```
=== RUN   TestConvertClaudeRequestByRequestMode
--- PASS: TestConvertClaudeRequestByRequestMode (0.00s)
    --- PASS: TestConvertClaudeRequestByRequestMode/gemini_upstream_converts_to_generateContent (0.00s)
    --- PASS: TestConvertClaudeRequestByRequestMode/claude_upstream_keeps_anthropic_messages_body (0.00s)
PASS
ok  	github.com/QuantumNous/new-api/relay/channel/vertex	0.012s
```

