### PR TITLE
fix(web): auto-open homepage notice and persist close-for-today

### DIFF
--- a/web/src/features/home/components/home-notice-dialog.tsx
+++ b/web/src/features/home/components/home-notice-dialog.tsx
@@ -1,0 +1,59 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { useTranslation } from 'react-i18next'
+
+import { Dialog } from '@/components/dialog'
+import { RichContent } from '@/components/rich-content'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+
+import { useNoticePopup } from '../hooks'
+
+/**
+ * Homepage notice dialog. Auto-opens on the Home route when a non-empty notice
+ * exists and has not been dismissed for the day. Mounts once; renders through a
+ * portal so it is invisible until opened.
+ */
+export function HomeNoticeDialog() {
+  const { t } = useTranslation()
+  const { notice, open, onOpenChange, closeForToday } = useNoticePopup()
+
+  if (!notice) return null
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t('Notice')}
+      contentClassName='sm:max-w-lg'
+      footer={
+        <>
+          <Button variant='outline' onClick={closeForToday}>
+            {t('Close Today')}
+          </Button>
+          <Button onClick={() => onOpenChange(false)}>{t('Close')}</Button>
+        </>
+      }
+    >
+      <ScrollArea className='max-h-[min(58vh,520px)] pr-4'>
+        <RichContent breaks content={notice} />
+      </ScrollArea>
+    </Dialog>
+  )
+}

--- a/web/src/features/home/components/index.ts
+++ b/web/src/features/home/components/index.ts
@@ -19,5 +19,6 @@ For commercial licensing, please contact support@quantumnous.com
 export { CTA } from './sections/cta'
 export { Features } from './sections/features'
 export { Hero } from './sections/hero'
+export { HomeNoticeDialog } from './home-notice-dialog'
 export { HowItWorks } from './sections/how-it-works'
 export { Stats } from './sections/stats'

--- a/web/src/features/home/hooks/index.ts
+++ b/web/src/features/home/hooks/index.ts
@@ -17,3 +17,4 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 export { useHomePageContent } from './use-home-page-content'
+export { useNoticePopup } from './use-notice-popup'

--- a/web/src/features/home/hooks/use-notice-popup.ts
+++ b/web/src/features/home/hooks/use-notice-popup.ts
@@ -1,0 +1,70 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { useQuery } from '@tanstack/react-query'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { getNotice } from '@/lib/api'
+import { useNotificationStore } from '@/stores/notification-store'
+
+/**
+ * Drives the homepage notice dialog.
+ *
+ * Auto-opens the dialog once per mount when /api/notice returns non-empty
+ * content and the user has not clicked "Close Today" for the current day.
+ * Shares the ['notice'] React Query cache with the header bell, so it does not
+ * issue an extra request. "Close Today" persists a per-day dismissal through
+ * the notification store, which suppresses the dialog until the next day.
+ */
+export function useNoticePopup() {
+  const { data: noticeResponse } = useQuery({
+    queryKey: ['notice'],
+    queryFn: getNotice,
+    staleTime: 1000 * 60 * 5, // 5 minutes, matches the header bell query
+  })
+
+  const { isNoticeClosed, setClosedUntilDate } = useNotificationStore()
+
+  const [open, setOpen] = useState(false)
+  const hasAutoOpened = useRef(false)
+
+  const notice = noticeResponse?.success
+    ? (noticeResponse.data || '').trim()
+    : ''
+
+  useEffect(() => {
+    if (hasAutoOpened.current) return
+    if (!notice) return
+    if (isNoticeClosed()) return
+
+    hasAutoOpened.current = true
+    setOpen(true)
+  }, [notice, isNoticeClosed])
+
+  const closeForToday = useCallback(() => {
+    setClosedUntilDate(new Date().toDateString())
+    setOpen(false)
+  }, [setClosedUntilDate])
+
+  return {
+    notice,
+    open,
+    onOpenChange: setOpen,
+    closeForToday,
+  }
+}

--- a/web/src/features/home/index.tsx
+++ b/web/src/features/home/index.tsx
@@ -16,7 +16,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { PublicLayout } from '@/components/layout'
@@ -26,7 +26,7 @@ import { useTheme } from '@/context/theme-provider'
 import { isLikelyHtml } from '@/lib/content-format'
 import { useAuthStore } from '@/stores/auth-store'
 
-import { CTA, Features, Hero, HowItWorks, Stats } from './components'
+import { CTA, Features, Hero, HomeNoticeDialog, HowItWorks, Stats } from './components'
 import { useHomePageContent } from './hooks'
 
 export function Home() {
@@ -68,46 +68,42 @@ export function Home() {
     )
   }
 
-  if (content) {
-    if (isUrl) {
-      return (
-        <PublicLayout showMainContainer={false}>
-          {/*
-            allow-top-navigation-by-user-activation: the custom home page URL is
-            admin-configured (trusted); this lets its target="_top" nav/menu links
-            navigate the top-level window on user click. The default sandbox blocks
-            this on desktop, while some mobile browsers allow it via allow-popups,
-            causing inconsistent behavior. This token only permits user-activated
-            top-level navigation and does NOT grant same-origin access.
-          */}
-          <iframe
-            ref={iframeRef}
-            src={content}
-            className='h-screen w-full border-none'
-            title={t('Custom Home Page')}
-            sandbox='allow-forms allow-popups allow-popups-to-escape-sandbox allow-scripts allow-top-navigation-by-user-activation'
-            onLoad={syncIframePreferences}
-          />
-        </PublicLayout>
-      )
-    }
+  let body: ReactNode
 
-    const contentIsHtml = isLikelyHtml(content)
-
-    if (contentIsHtml) {
-      return (
-        <PublicLayout showMainContainer={false}>
-          <RichContent
-            mode='html'
-            htmlVariant='isolated'
-            content={content}
-            className='custom-home-content'
-          />
-        </PublicLayout>
-      )
-    }
-
-    return (
+  if (content && isUrl) {
+    body = (
+      <PublicLayout showMainContainer={false}>
+        {/*
+          allow-top-navigation-by-user-activation: the custom home page URL is
+          admin-configured (trusted); this lets its target="_top" nav/menu links
+          navigate the top-level window on user click. The default sandbox blocks
+          this on desktop, while some mobile browsers allow it via allow-popups,
+          causing inconsistent behavior. This token only permits user-activated
+          top-level navigation and does NOT grant same-origin access.
+        */}
+        <iframe
+          ref={iframeRef}
+          src={content}
+          className='h-screen w-full border-none'
+          title={t('Custom Home Page')}
+          sandbox='allow-forms allow-popups allow-popups-to-escape-sandbox allow-scripts allow-top-navigation-by-user-activation'
+          onLoad={syncIframePreferences}
+        />
+      </PublicLayout>
+    )
+  } else if (content && isLikelyHtml(content)) {
+    body = (
+      <PublicLayout showMainContainer={false}>
+        <RichContent
+          mode='html'
+          htmlVariant='isolated'
+          content={content}
+          className='custom-home-content'
+        />
+      </PublicLayout>
+    )
+  } else if (content) {
+    body = (
       <PublicLayout>
         <div className='mx-auto max-w-6xl px-4 py-8'>
           <RichContent
@@ -118,16 +114,23 @@ export function Home() {
         </div>
       </PublicLayout>
     )
+  } else {
+    body = (
+      <PublicLayout showMainContainer={false}>
+        <Hero isAuthenticated={isAuthenticated} />
+        <Stats />
+        <Features />
+        <HowItWorks />
+        <CTA isAuthenticated={isAuthenticated} />
+        <Footer />
+      </PublicLayout>
+    )
   }
 
   return (
-    <PublicLayout showMainContainer={false}>
-      <Hero isAuthenticated={isAuthenticated} />
-      <Stats />
-      <Features />
-      <HowItWorks />
-      <CTA isAuthenticated={isAuthenticated} />
-      <Footer />
-    </PublicLayout>
+    <>
+      <HomeNoticeDialog />
+      {body}
+    </>
   )
 }

--- a/web/src/stores/notification-store.test.ts
+++ b/web/src/stores/notification-store.test.ts
@@ -1,0 +1,82 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { afterEach, beforeEach, describe, test } from 'node:test'
+
+// Minimal in-memory localStorage so the persist middleware has real storage.
+// Installed before the store is imported, because zustand rehydrates from
+// storage when the store is created and its default storage reads
+// window.localStorage.
+const memoryStore = new Map<string, string>()
+const storage = {
+  getItem: (key: string) => memoryStore.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    memoryStore.set(key, value)
+  },
+  removeItem: (key: string) => {
+    memoryStore.delete(key)
+  },
+  clear: () => {
+    memoryStore.clear()
+  },
+  key: (index: number) => [...memoryStore.keys()][index] ?? null,
+  get length() {
+    return memoryStore.size
+  },
+} as Storage
+;(globalThis as { localStorage?: Storage }).localStorage = storage
+;(globalThis as { window?: { localStorage: Storage } }).window = {
+  localStorage: storage,
+}
+
+const { useNotificationStore } = await import('./notification-store')
+
+beforeEach(() => {
+  memoryStore.clear()
+  useNotificationStore.setState({ closedUntilDate: null })
+})
+
+afterEach(() => {
+  useNotificationStore.setState({ closedUntilDate: null })
+})
+
+describe('notification store notice dismissal', () => {
+  test('isNoticeClosed is false when the notice was never dismissed', () => {
+    assert.equal(useNotificationStore.getState().isNoticeClosed(), false)
+  })
+
+  test('close today suppresses the notice for the current day', () => {
+    const today = new Date().toDateString()
+    useNotificationStore.getState().setClosedUntilDate(today)
+    assert.equal(useNotificationStore.getState().isNoticeClosed(), true)
+  })
+
+  test('a dismissal from a previous day no longer suppresses the notice', () => {
+    useNotificationStore.getState().setClosedUntilDate('Mon Jan 01 2001')
+    assert.equal(useNotificationStore.getState().isNoticeClosed(), false)
+  })
+
+  test('the dismissal date persists to storage so it survives a reload', () => {
+    const today = new Date().toDateString()
+    useNotificationStore.getState().setClosedUntilDate(today)
+
+    const persisted = JSON.parse(memoryStore.get('notification-storage') ?? '{}')
+    assert.equal(persisted.state.closedUntilDate, today)
+  })
+})


### PR DESCRIPTION
## 📝 变更描述 / Description

The `default` theme homepage never auto-opened the notice dialog, so a
configured `/api/notice` only showed through the header bell. The store already
held the per-day "close for today" state (`closedUntilDate`,
`setClosedUntilDate`, `isNoticeClosed` in `notification-store.ts`) but nothing
read or wrote it. This restores the `classic` behavior.

What changed:
- On the Home route, open the notice dialog on mount when `/api/notice` returns
  non-empty content that was not dismissed today.
- "Close Today" persists a per-day dismissal through the existing store, which
  suppresses the popup until the next day. Plain "Close" only hides it for this
  visit.
- Reuses the existing `['notice']` React Query key, so there is no extra
  request. No backend change. The structured `announcements` timeline is left
  as is.

Why it works: `isNoticeClosed()` compares the stored `toDateString()` against
today. The store already persists `closedUntilDate` through `partialize`, so
the choice survives a reload. The unread bell keeps its own content-based signal
(`lastReadNotice`), so the two paths do not fight.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6370

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```
$ bun run typecheck
$ tsgo -b
# exit 0

$ bun run build
# exit 0, dist emitted (Total 57320.5 kB / gzip 16535.6 kB)

$ bun test src/stores/notification-store.test.ts
 4 pass
 0 fail
Ran 4 tests across 1 file.

$ bunx oxlint -c .oxlintrc.json <changed files>
# exit 0, no findings
```

> AI assistance (Claude) was used to write this change. The author is not a core
> developer of this repo, so this is disclosed. The design, review and
> verification were done by the author. Verified locally on the branch before
> submitting: `bun run typecheck` (clean), `bun run build` (succeeds), the new
> `notification-store.test.ts` (4 pass, run in isolation with `bun test`) and
> `oxlint` on the touched files (clean).

