### PR TITLE
fix: skip Claude prompt estimate for zero-frame aborts

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -150,11 +150,29 @@ func countClaudeStreamBillableTools(c *gin.Context, info *relaycommon.RelayInfo,
 	}
 }
 
+func hasClaudeStreamUsageEvidence(usage *dto.Usage) bool {
+	if usage == nil {
+		return false
+	}
+	return usage.PromptTokens != 0 ||
+		usage.CompletionTokens != 0 ||
+		usage.PromptTokensDetails.CachedTokens != 0 ||
+		usage.PromptTokensDetails.CachedCreationTokens != 0 ||
+		usage.ClaudeCacheCreation5mTokens != 0 ||
+		usage.ClaudeCacheCreation1hTokens != 0 ||
+		usage.BillingUsage != nil
+}
+
 func HandleStreamFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, claudeInfo *ClaudeResponseInfo) {
 	if claudeInfo.Usage.PromptTokens == 0 {
 		//上游出错
 	}
-	if claudeInfo.Usage.CompletionTokens == 0 || !claudeInfo.Done {
+	abnormalZeroFrameWithoutUsage := info != nil &&
+		info.StreamStatus != nil &&
+		!info.StreamStatus.IsNormalEnd() &&
+		info.ReceivedResponseCount == 0 &&
+		!hasClaudeStreamUsageEvidence(claudeInfo.Usage)
+	if !abnormalZeroFrameWithoutUsage && (claudeInfo.Usage.CompletionTokens == 0 || !claudeInfo.Done) {
 		if common.DebugEnabled {
 			common.SysLog("claude response usage is not complete, maybe upstream error")
 		}

--- a/relay/channel/claude/zero_frame_billing_test.go
+++ b/relay/channel/claude/zero_frame_billing_test.go
@@ -1,0 +1,174 @@
+package claude
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func newClaudeFinalResponseTestContext() *gin.Context {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	return c
+}
+
+func newClaudeFinalResponseTestInfo(receivedResponseCount, estimatePromptTokens int) *relaycommon.RelayInfo {
+	info := &relaycommon.RelayInfo{
+		ReceivedResponseCount: receivedResponseCount,
+		RelayFormat:           types.RelayFormatClaude,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "claude-test",
+		},
+	}
+	info.SetEstimatePromptTokens(estimatePromptTokens)
+	return info
+}
+
+func TestHandleStreamFinalResponse_ZeroFramesWithoutUsageEvidenceKeepsZeroUsage(t *testing.T) {
+	c := newClaudeFinalResponseTestContext()
+	info := newClaudeFinalResponseTestInfo(0, 1234)
+	info.StreamStatus = relaycommon.NewStreamStatus()
+	info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, nil)
+	claudeInfo := &ClaudeResponseInfo{
+		ResponseText: strings.Builder{},
+		Usage:        &dto.Usage{},
+	}
+	claudeInfo.ResponseText.WriteString("partial response text")
+
+	HandleStreamFinalResponse(c, info, claudeInfo)
+
+	require.Zero(t, claudeInfo.Usage.PromptTokens)
+	require.Zero(t, claudeInfo.Usage.CompletionTokens)
+	require.Zero(t, claudeInfo.Usage.TotalTokens)
+	require.Nil(t, claudeInfo.Usage.BillingUsage)
+	require.False(t, common.GetContextKeyBool(c, constant.ContextKeyLocalCountTokens))
+}
+
+func TestHandleStreamFinalResponse_ZeroCountWithMessageStartUsagePreservesUpstreamEvidence(t *testing.T) {
+	c := newClaudeFinalResponseTestContext()
+	info := newClaudeFinalResponseTestInfo(0, 1234)
+	info.StreamStatus = relaycommon.NewStreamStatus()
+	info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, nil)
+	claudeInfo := &ClaudeResponseInfo{Usage: &dto.Usage{}}
+
+	require.True(t, FormatClaudeResponseInfo(&dto.ClaudeResponse{
+		Type: "message_start",
+		Message: &dto.ClaudeMediaMessage{
+			Usage: &dto.ClaudeUsage{
+				InputTokens:              100,
+				CacheReadInputTokens:     30,
+				CacheCreationInputTokens: 50,
+			},
+		},
+	}, nil, claudeInfo))
+
+	HandleStreamFinalResponse(c, info, claudeInfo)
+
+	require.Equal(t, 100, claudeInfo.Usage.PromptTokens)
+	require.Equal(t, 30, claudeInfo.Usage.PromptTokensDetails.CachedTokens)
+	require.Equal(t, 50, claudeInfo.Usage.PromptTokensDetails.CachedCreationTokens)
+	require.NotNil(t, claudeInfo.Usage.BillingUsage)
+}
+
+func TestHandleStreamFinalResponse_ZeroFramesWithCacheOnlyUsagePreservesUpstreamEvidence(t *testing.T) {
+	c := newClaudeFinalResponseTestContext()
+	info := newClaudeFinalResponseTestInfo(0, 1234)
+	info.StreamStatus = relaycommon.NewStreamStatus()
+	info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, nil)
+	claudeInfo := &ClaudeResponseInfo{
+		Usage: &dto.Usage{
+			PromptTokensDetails: dto.InputTokenDetails{
+				CachedTokens: 30,
+			},
+		},
+	}
+
+	HandleStreamFinalResponse(c, info, claudeInfo)
+
+	require.Equal(t, 30, claudeInfo.Usage.PromptTokensDetails.CachedTokens)
+	require.NotNil(t, claudeInfo.Usage.BillingUsage)
+}
+
+func TestHandleStreamFinalResponse_ZeroCountWithoutAbnormalStatusKeepsLocalFallback(t *testing.T) {
+	tests := []struct {
+		name      string
+		endReason *relaycommon.StreamEndReason
+	}{
+		{name: "AWS stream status absent"},
+		{name: "normal EOF", endReason: commonPointer(relaycommon.StreamEndReasonEOF)},
+		{name: "normal done", endReason: commonPointer(relaycommon.StreamEndReasonDone)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newClaudeFinalResponseTestContext()
+			info := newClaudeFinalResponseTestInfo(0, 1234)
+			if tt.endReason != nil {
+				info.StreamStatus = relaycommon.NewStreamStatus()
+				info.StreamStatus.SetEndReason(*tt.endReason, nil)
+			}
+			claudeInfo := &ClaudeResponseInfo{
+				ResponseText: strings.Builder{},
+				Usage:        &dto.Usage{},
+			}
+			claudeInfo.ResponseText.WriteString("response text")
+
+			HandleStreamFinalResponse(c, info, claudeInfo)
+
+			require.Equal(t, 1234, claudeInfo.Usage.PromptTokens)
+			require.Positive(t, claudeInfo.Usage.CompletionTokens)
+			require.True(t, common.GetContextKeyBool(c, constant.ContextKeyLocalCountTokens))
+		})
+	}
+}
+
+func TestHandleStreamFinalResponse_ReceivedFramesWithoutUsageKeepsLocalFallback(t *testing.T) {
+	c := newClaudeFinalResponseTestContext()
+	info := newClaudeFinalResponseTestInfo(1, 1234)
+	info.StreamStatus = relaycommon.NewStreamStatus()
+	info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, nil)
+	claudeInfo := &ClaudeResponseInfo{
+		ResponseText: strings.Builder{},
+		Usage:        &dto.Usage{},
+	}
+	claudeInfo.ResponseText.WriteString("response text")
+
+	HandleStreamFinalResponse(c, info, claudeInfo)
+
+	require.Equal(t, 1234, claudeInfo.Usage.PromptTokens)
+	require.Positive(t, claudeInfo.Usage.CompletionTokens)
+	require.True(t, common.GetContextKeyBool(c, constant.ContextKeyLocalCountTokens))
+}
+
+func TestHandleStreamFinalResponse_CompleteUpstreamUsageRemainsUnchanged(t *testing.T) {
+	c := newClaudeFinalResponseTestContext()
+	info := newClaudeFinalResponseTestInfo(3, 1234)
+	billingUsage := dto.NewClaudeMessagesBillingUsage(&dto.ClaudeUsage{
+		InputTokens:  100,
+		OutputTokens: 20,
+	})
+	claudeInfo := &ClaudeResponseInfo{
+		Done: true,
+		Usage: &dto.Usage{
+			PromptTokens:     100,
+			CompletionTokens: 20,
+			TotalTokens:      120,
+			BillingUsage:     billingUsage,
+		},
+	}
+
+	HandleStreamFinalResponse(c, info, claudeInfo)
+
+	require.Equal(t, 100, claudeInfo.Usage.PromptTokens)
+	require.Equal(t, 20, claudeInfo.Usage.CompletionTokens)
+	require.Equal(t, 120, claudeInfo.Usage.TotalTokens)
+	require.Same(t, billingUsage, claudeInfo.Usage.BillingUsage)
+	require.False(t, common.GetContextKeyBool(c, constant.ContextKeyLocalCountTokens))
+}


### PR DESCRIPTION
## 📝 变更描述 / Description

Claude streaming finalization currently synthesizes prompt usage with `EstimatePromptTokens` when the stream is incomplete. If the stream aborts before any upstream SSE data frame is parsed, this turns an empty usage into a non-zero `BillingUsage` before settlement.

This change skips that local fallback only when all of the following are true:

- the stream ended abnormally;
- `ReceivedResponseCount == 0`;
- no upstream prompt, completion, cache, or billing usage has been collected.

Streams with `message_start` usage, cache-only usage, any received data frame, normal EOF/Done, and the AWS path keep the existing behavior.

This differs from #4199 and #6112: those changes only handle `usage == nil` in `service/text_quota.go`, while the Claude adapter has already converted the empty usage into a non-nil estimated usage before settlement.

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Fixes #4168
- Related: #4199, #6112

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs；本 PR 修复 Claude adapter 提前生成非 nil estimated usage 的路径，现有 #4199/#6112 未覆盖该路径。
- [x] **Bug fix 说明:** 本 PR 关联 #4168，并附有修复前失败、修复后通过的回归测试。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

Before the fix, the zero-frame regression test failed because the locally estimated prompt usage was `1234` instead of `0`.

Validated after the fix:

```text
go test ./relay/channel/claude ./relay/channel/aws -count=1
go vet ./...
go build ./...
cd relaykit && go vet ./... && go build ./...
make test
```

All commands passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude stream billing accuracy when a response ends abnormally before any usage data is received.
  * Preserved upstream token and cache usage when available.
  * Retained local usage fallback for normal responses and incomplete usage scenarios.

* **Tests**
  * Added coverage for zero-frame responses, cache-only usage, missing usage data, and complete upstream billing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->