### PR TITLE
fix: tolerate float created_at in /v1/responses payloads

### DIFF
--- a/relay/channel/openai/chat_via_responses.go
+++ b/relay/channel/openai/chat_via_responses.go
@@ -143,7 +143,7 @@ func OaiResponsesToChatBufferedStreamHandler(c *gin.Context, info *relaycommon.R
 	if finalResponse == nil {
 		finalResponse = &dto.OpenAIResponsesResponse{
 			ID:        helper.GetResponseID(c),
-			CreatedAt: int(time.Now().Unix()),
+			CreatedAt: dto.IntValue(time.Now().Unix()),
 			Model:     info.UpstreamModelName,
 			Status:    []byte(`"completed"`),
 		}

--- a/relaykit/dto/openai_response.go
+++ b/relaykit/dto/openai_response.go
@@ -293,7 +293,7 @@ type OutputTokenDetails struct {
 type OpenAIResponsesResponse struct {
 	ID                 string             `json:"id"`
 	Object             string             `json:"object"`
-	CreatedAt          int                `json:"created_at"`
+	CreatedAt          IntValue           `json:"created_at"`
 	Status             json.RawMessage    `json:"status"`
 	Error              any                `json:"error,omitempty"`
 	IncompleteDetails  *IncompleteDetails `json:"incomplete_details,omitempty"`

--- a/relaykit/dto/openai_response_created_at_test.go
+++ b/relaykit/dto/openai_response_created_at_test.go
@@ -1,0 +1,49 @@
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// 上游（如 SGLang）的 /v1/responses 流式快照会把 created_at 序列化成浮点
+// （openai SDK 契约中该字段即为 float），严格 int 会让整条快照事件反序列化
+// 失败，下游拿不到 usage。payload 为真实抓包结构。
+func TestResponsesStreamResponseUnmarshalFloatCreatedAt(t *testing.T) {
+	payload := `{"response":{"id":"resp_2489809b0c6841f3949226601c1a4b19","object":"response","created_at":1786588600.0,"model":"DeepSeek-V4-Flash-0731","output":[{"id":"msg_a1c3654451494bf7a8620aaff0effd8b","content":[{"annotations":[],"text":"1","type":"output_text","logprobs":null}],"role":"assistant","status":"completed","type":"message"}],"status":"completed","usage":{"input_tokens":12,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0},"output_tokens":48,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":60},"parallel_tool_calls":true,"tool_choice":"auto","tools":[],"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":1024,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":true,"temperature":null,"text":{"format":{"type":"text"}},"top_p":null,"truncation":"disabled","user":null,"metadata":{}},"sequence_number":12,"type":"response.completed"}`
+	var resp ResponsesStreamResponse
+	err := json.Unmarshal([]byte(payload), &resp)
+	assert.NoError(t, err)
+	assert.Equal(t, "response.completed", resp.Type)
+	assert.Equal(t, 1786588600, int(resp.Response.CreatedAt))
+	assert.Equal(t, 12, resp.Response.Usage.InputTokens)
+	assert.Equal(t, 48, resp.Response.Usage.OutputTokens)
+	assert.Equal(t, 60, resp.Response.Usage.TotalTokens)
+}
+
+// 整数格式必须保持可解析且序列化仍为整数
+func TestResponsesResponseCreatedAtFormats(t *testing.T) {
+	var resp OpenAIResponsesResponse
+	assert.NoError(t, json.Unmarshal([]byte(`{"created_at":1786587534}`), &resp))
+	assert.Equal(t, 1786587534, int(resp.CreatedAt))
+
+	out, err := json.Marshal(OpenAIResponsesResponse{CreatedAt: 1786587534})
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), `"created_at":1786587534`)
+}
+
+func TestIntValueUnmarshalFloat(t *testing.T) {
+	var v IntValue
+	assert.NoError(t, json.Unmarshal([]byte(`1786588600.0`), &v))
+	assert.Equal(t, 1786588600, int(v))
+
+	assert.NoError(t, json.Unmarshal([]byte(`42`), &v))
+	assert.Equal(t, 42, int(v))
+
+	assert.NoError(t, json.Unmarshal([]byte(`"7"`), &v))
+	assert.Equal(t, 7, int(v))
+
+	assert.Error(t, json.Unmarshal([]byte(`"abc"`), &v))
+	assert.Error(t, json.Unmarshal([]byte(`true`), &v))
+}

--- a/relaykit/dto/openai_response_created_at_test.go
+++ b/relaykit/dto/openai_response_created_at_test.go
@@ -2,9 +2,11 @@ package dto
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // 上游（如 SGLang）的 /v1/responses 流式快照会把 created_at 序列化成浮点
@@ -13,8 +15,8 @@ import (
 func TestResponsesStreamResponseUnmarshalFloatCreatedAt(t *testing.T) {
 	payload := `{"response":{"id":"resp_2489809b0c6841f3949226601c1a4b19","object":"response","created_at":1786588600.0,"model":"DeepSeek-V4-Flash-0731","output":[{"id":"msg_a1c3654451494bf7a8620aaff0effd8b","content":[{"annotations":[],"text":"1","type":"output_text","logprobs":null}],"role":"assistant","status":"completed","type":"message"}],"status":"completed","usage":{"input_tokens":12,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0},"output_tokens":48,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":60},"parallel_tool_calls":true,"tool_choice":"auto","tools":[],"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":1024,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":true,"temperature":null,"text":{"format":{"type":"text"}},"top_p":null,"truncation":"disabled","user":null,"metadata":{}},"sequence_number":12,"type":"response.completed"}`
 	var resp ResponsesStreamResponse
-	err := json.Unmarshal([]byte(payload), &resp)
-	assert.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(payload), &resp))
+	require.NotNil(t, resp.Response)
 	assert.Equal(t, "response.completed", resp.Type)
 	assert.Equal(t, 1786588600, int(resp.Response.CreatedAt))
 	assert.Equal(t, 12, resp.Response.Usage.InputTokens)
@@ -25,24 +27,37 @@ func TestResponsesStreamResponseUnmarshalFloatCreatedAt(t *testing.T) {
 // 整数格式必须保持可解析且序列化仍为整数
 func TestResponsesResponseCreatedAtFormats(t *testing.T) {
 	var resp OpenAIResponsesResponse
-	assert.NoError(t, json.Unmarshal([]byte(`{"created_at":1786587534}`), &resp))
+	require.NoError(t, json.Unmarshal([]byte(`{"created_at":1786587534}`), &resp))
 	assert.Equal(t, 1786587534, int(resp.CreatedAt))
 
 	out, err := json.Marshal(OpenAIResponsesResponse{CreatedAt: 1786587534})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, string(out), `"created_at":1786587534`)
 }
 
 func TestIntValueUnmarshalFloat(t *testing.T) {
 	var v IntValue
-	assert.NoError(t, json.Unmarshal([]byte(`1786588600.0`), &v))
+	require.NoError(t, json.Unmarshal([]byte(`1786588600.0`), &v))
 	assert.Equal(t, 1786588600, int(v))
 
-	assert.NoError(t, json.Unmarshal([]byte(`42`), &v))
+	// 小数截断：openai SDK 契约中 created_at 为 float，亚秒精度是合法形态
+	require.NoError(t, json.Unmarshal([]byte(`1786588600.9`), &v))
+	assert.Equal(t, 1786588600, int(v))
+
+	require.NoError(t, json.Unmarshal([]byte(`42`), &v))
 	assert.Equal(t, 42, int(v))
 
-	assert.NoError(t, json.Unmarshal([]byte(`"7"`), &v))
+	require.NoError(t, json.Unmarshal([]byte(`"7"`), &v))
 	assert.Equal(t, 7, int(v))
+
+	// 下界 -2^63 可被 float64 精确表示，恰好在范围内
+	require.NoError(t, json.Unmarshal([]byte(`-9223372036854775808.0`), &v))
+	assert.Equal(t, math.MinInt, int(v))
+
+	// 越界拒绝，避免依赖实现相关的转换结果
+	assert.Error(t, json.Unmarshal([]byte(`9223372036854775808.0`), &v)) // 2^63，恰好溢出
+	assert.Error(t, json.Unmarshal([]byte(`1e100`), &v))
+	assert.Error(t, json.Unmarshal([]byte(`-1e100`), &v))
 
 	assert.Error(t, json.Unmarshal([]byte(`"abc"`), &v))
 	assert.Error(t, json.Unmarshal([]byte(`true`), &v))

--- a/relaykit/dto/values.go
+++ b/relaykit/dto/values.go
@@ -35,6 +35,11 @@ func (i *IntValue) UnmarshalJSON(b []byte) error {
 		*i = IntValue(n)
 		return nil
 	}
+	var f float64
+	if err := json.Unmarshal(b, &f); err == nil {
+		*i = IntValue(int(f))
+		return nil
+	}
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err

--- a/relaykit/dto/values.go
+++ b/relaykit/dto/values.go
@@ -2,6 +2,8 @@ package dto
 
 import (
 	"encoding/json"
+	"fmt"
+	"math"
 	"strconv"
 )
 
@@ -37,8 +39,13 @@ func (i *IntValue) UnmarshalJSON(b []byte) error {
 	}
 	var f float64
 	if err := json.Unmarshal(b, &f); err == nil {
-		*i = IntValue(int(f))
-		return nil
+		// The upper bound must be < rather than <=: float64(math.MaxInt) rounds
+		// up to 2^63, which is just out of range.
+		if f >= math.MinInt && f < math.MaxInt {
+			*i = IntValue(int(f))
+			return nil
+		}
+		return fmt.Errorf("json: number %s overflows int", string(b))
 	}
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {

--- a/relaykit/relayconvert/internal/oai_chat/to_oai_responses_resp.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_oai_responses_resp.go
@@ -40,7 +40,7 @@ func ChatCompletionsResponseToResponsesResponse(resp *dto.OpenAITextResponse, id
 	out := &dto.OpenAIResponsesResponse{
 		ID:        id,
 		Object:    "response",
-		CreatedAt: chatCreatedAt(resp.Created),
+		CreatedAt: dto.IntValue(chatCreatedAt(resp.Created)),
 		Status:    []byte(`"completed"`),
 		Model:     resp.Model,
 		Output:    make([]dto.ResponsesOutput, 0),

--- a/relaykit/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
@@ -320,7 +320,7 @@ func (s *ChatToResponsesStreamState) finalResponse() *dto.OpenAIResponsesRespons
 	return &dto.OpenAIResponsesResponse{
 		ID:                s.ID,
 		Object:            "response",
-		CreatedAt:         int(s.Created),
+		CreatedAt:         dto.IntValue(s.Created),
 		Status:            []byte(fmt.Sprintf("%q", s.status)),
 		IncompleteDetails: s.incompleteDetails,
 		Model:             s.Model,
@@ -333,7 +333,7 @@ func (s *ChatToResponsesStreamState) createdResponse() *dto.OpenAIResponsesRespo
 	return &dto.OpenAIResponsesResponse{
 		ID:        s.ID,
 		Object:    "response",
-		CreatedAt: int(s.Created),
+		CreatedAt: dto.IntValue(s.Created),
 		Status:    []byte(`"in_progress"`),
 		Model:     s.Model,
 		Output:    []dto.ResponsesOutput{},

--- a/relaykit/relayconvert/internal/oai_responses/to_oai_chat_resp.go
+++ b/relaykit/relayconvert/internal/oai_responses/to_oai_chat_resp.go
@@ -65,7 +65,7 @@ func ResponsesResponseToChatCompletionsResponse(resp *dto.OpenAIResponsesRespons
 
 	usage := UsageFromResponsesUsage(resp.Usage)
 
-	created := resp.CreatedAt
+	created := int(resp.CreatedAt)
 
 	var toolCalls []dto.ToolCallResponse
 	if len(resp.Output) > 0 {


### PR DESCRIPTION
修复 `/v1/responses` 流式转发在上游把 `created_at` 序列化为浮点（如 `1786588600.0`）时，`response.created` / `response.in_progress` / `response.completed` 三个快照事件反序列化失败被整体丢弃、下游丢失 usage 且计费退化为估算的问题。

关联 issue：#6822

### 根因

`dto.OpenAIResponsesResponse.CreatedAt` 是严格 `int`。openai 官方 SDK 契约中该字段为 `float`（[response.py](https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response.py) `created_at: float`），SGLang 等上游的流式快照因此会输出 `x.0` 形态的合法 JSON 数字（上游侧成因已提报 [sgl-project/sglang#34716](https://github.com/sgl-project/sglang/issues/34716)），`encoding/json` 报 `UnmarshalTypeError`，流处理器丢弃事件。与 rc.21 修 `tool_choice`、以及 `Status`/`Instructions` 等字段改 `json.RawMessage` 属同一类问题，`created_at` 是同一模式下的遗漏点。

### 改动

| 文件 | 改动 |
|---|---|
| `relaykit/dto/values.go` | `IntValue.UnmarshalJSON` 增加浮点分支（截断取整），int/float/string 三种形态均可解析，`MarshalJSON` 仍输出整数 |
| `relaykit/dto/openai_response.go` | `OpenAIResponsesResponse.CreatedAt` 由 `int` 改为 `IntValue` |
| `relaykit/relayconvert/internal/oai_chat/to_oai_responses_resp.go`、`to_oai_responses_stream_resp.go`（2 处）、`relay/channel/openai/chat_via_responses.go` | 构造处 `int(...)` → `dto.IntValue(...)`，纯类型适配 |
| `relaykit/relayconvert/internal/oai_responses/to_oai_chat_resp.go` | `created := int(resp.CreatedAt)`，避免 `IntValue` 进入 `OpenAITextResponse.Created any` 影响下游类型断言 |
| `relaykit/dto/openai_response_created_at_test.go`（新增） | 3 个回归测试：真实抓包浮点 payload 解析成功且 usage 完整、整数格式解析/序列化不变、`IntValue` 三形态与非法输入 |

### 影响面

- 解析：`created_at` 整数、浮点、数字字符串均可接收；原来能解析的输入行为不变（纯超集）。
- 序列化：`IntValue.MarshalJSON` 输出整数，对外 JSON 形状不变。
- 透传：流式/非流式转发原文字节不经重编，下游收到的内容零变化。
- `IntValue` 现有使用方（doubao 任务适配器）无感。

### 测试

- 新增回归测试红绿实跑：在未修改 main 上 payload 解析失败于同一错误（`json: cannot unmarshal number 1786588600.0 ... of type int`），修复后通过。
- `relaykit` 模块 `go vet ./...`、`go test ./...` 全部通过；主模块 `go build` 通过，`go vet ./relay/...`、`go test ./relay/...` 通过。
- 真实环境验证：同等修复已在我们基于 rc.x 的生产分支上线验证——SGLang 链路流式 9 类事件齐全、usage 真实值落账（修复前每请求 3 条 unmarshal 错误、计费走估算）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when processing response timestamps provided as integers, decimals, or numeric strings.
  * Preserved consistent timestamp values when converting between response formats.
  * Ensured buffered and streaming responses handle varied `created_at` formats reliably.
* **Tests**
  * Added coverage for timestamp parsing, serialization, invalid values, and realistic streaming responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->