### PR TITLE
fix(billing): close quota-bypass paths (usage fallbacks, image n multiplier, unset-ratio gate)

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -1498,7 +1498,11 @@ func UpdateUserSetting(c *gin.Context) {
 		NotifyType:                       req.QuotaWarningType,
 		QuotaWarningThreshold:            req.QuotaWarningThreshold,
 		UpstreamModelUpdateNotifyEnabled: upstreamModelUpdateNotifyEnabled,
-		AcceptUnsetRatioModel:            req.AcceptUnsetModelRatioModel,
+		// F-27: only admins may enable accept-unset-ratio. Self-service by a
+		// regular user bypasses the "model price not configured" gate, letting
+		// them use deliberately unpriced models at the default ratio (37.5x),
+		// which is both an availability-control and pricing-control bypass.
+		AcceptUnsetRatioModel: user.Role >= common.RoleAdminUser && req.AcceptUnsetModelRatioModel,
 		RecordIpLog:                      req.RecordIpLog,
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 require (
 	github.com/DmitriyVTitov/size v1.5.0 // indirect
 	github.com/anknown/darts v0.0.0-20151216065714-83ff685239e6 // indirect
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/relay/channel/ali/rerank.go
+++ b/relay/channel/ali/rerank.go
@@ -59,6 +59,12 @@ func RerankHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayI
 		CompletionTokens: 0,
 		TotalTokens:      aliResponse.Usage.TotalTokens,
 	}
+	// F-53: fallback to the prompt estimate when the upstream omits usage so
+	// rerank requests are not billed as zero (F-26 residual for ali).
+	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+		usage.PromptTokens = info.GetEstimatePromptTokens()
+		usage.TotalTokens = usage.PromptTokens
+	}
 	rerankResponse := dto.RerankResponse{
 		Results: aliResponse.Output.Results,
 		Usage:   usage,

--- a/relay/channel/aws/relay-aws.go
+++ b/relay/channel/aws/relay-aws.go
@@ -254,6 +254,22 @@ func awsHandler(c *gin.Context, info *relaycommon.RelayInfo, a *Adaptor) (*types
 	if handlerErr != nil {
 		return handlerErr, nil
 	}
+	if claudeInfo.Usage.TotalTokens == 0 &&
+		claudeInfo.Usage.PromptTokens == 0 &&
+		claudeInfo.Usage.CompletionTokens == 0 {
+		// F-63: fall back to the estimate when the upstream omits usage so
+		// Bedrock native (non-Claude-format) requests are not billed as zero.
+		var textBuilder strings.Builder
+		var parsed dto.ClaudeResponse
+		if err := common.Unmarshal(awsResp.Body, &parsed); err == nil {
+			for _, block := range parsed.Content {
+				if block.Text != nil && *block.Text != "" {
+					textBuilder.WriteString(*block.Text)
+				}
+			}
+		}
+		claudeInfo.Usage = service.ResponseText2Usage(c, textBuilder.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
+	}
 	return nil, claudeInfo.Usage
 }
 
@@ -346,6 +362,20 @@ func handleNovaRequest(c *gin.Context, info *relaycommon.RelayInfo, a *Adaptor) 
 	}
 
 	// 构造OpenAI格式响应
+	usage := dto.Usage{
+		PromptTokens:     novaResp.Usage.InputTokens,
+		CompletionTokens: novaResp.Usage.OutputTokens,
+		TotalTokens:      novaResp.Usage.TotalTokens,
+	}
+	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+		// F-60: fall back to the estimate when the upstream omits usage so
+		// Nova requests are not billed as zero.
+		var text string
+		if len(novaResp.Output.Message.Content) > 0 {
+			text = novaResp.Output.Message.Content[0].Text
+		}
+		usage = *service.ResponseText2Usage(c, text, info.UpstreamModelName, info.GetEstimatePromptTokens())
+	}
 	response := dto.OpenAITextResponse{
 		Id:      helper.GetResponseID(c),
 		Object:  "chat.completion",
@@ -359,13 +389,9 @@ func handleNovaRequest(c *gin.Context, info *relaycommon.RelayInfo, a *Adaptor) 
 			},
 			FinishReason: "stop",
 		}},
-		Usage: dto.Usage{
-			PromptTokens:     novaResp.Usage.InputTokens,
-			CompletionTokens: novaResp.Usage.OutputTokens,
-			TotalTokens:      novaResp.Usage.TotalTokens,
-		},
+		Usage: usage,
 	}
 
 	c.JSON(http.StatusOK, response)
-	return nil, &response.Usage
+	return nil, &usage
 }

--- a/relay/channel/aws/relay-aws.go
+++ b/relay/channel/aws/relay-aws.go
@@ -254,22 +254,6 @@ func awsHandler(c *gin.Context, info *relaycommon.RelayInfo, a *Adaptor) (*types
 	if handlerErr != nil {
 		return handlerErr, nil
 	}
-	if claudeInfo.Usage.TotalTokens == 0 &&
-		claudeInfo.Usage.PromptTokens == 0 &&
-		claudeInfo.Usage.CompletionTokens == 0 {
-		// F-63: fall back to the estimate when the upstream omits usage so
-		// Bedrock native (non-Claude-format) requests are not billed as zero.
-		var textBuilder strings.Builder
-		var parsed dto.ClaudeResponse
-		if err := common.Unmarshal(awsResp.Body, &parsed); err == nil {
-			for _, block := range parsed.Content {
-				if block.Text != nil && *block.Text != "" {
-					textBuilder.WriteString(*block.Text)
-				}
-			}
-		}
-		claudeInfo.Usage = service.ResponseText2Usage(c, textBuilder.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
-	}
 	return nil, claudeInfo.Usage
 }
 

--- a/relay/channel/baidu/relay-baidu.go
+++ b/relay/channel/baidu/relay-baidu.go
@@ -178,6 +178,15 @@ func baiduEmbeddingHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *ht
 		return types.NewError(fmt.Errorf("%s", baiduResponse.ErrorMsg), types.ErrorCodeBadResponseBody), nil
 	}
 	fullTextResponse := embeddingResponseBaidu2OpenAI(&baiduResponse)
+	// F-26 family: Baidu embedding responses may omit usage; without a
+	// fallback the settle charges 0 and the pre-consume is refunded, making
+	// embeddings free. Fall back to the local request estimate.
+	if fullTextResponse.Usage.TotalTokens == 0 && fullTextResponse.Usage.PromptTokens == 0 && fullTextResponse.Usage.CompletionTokens == 0 {
+		fullTextResponse.Usage = dto.Usage{
+			PromptTokens: info.GetEstimatePromptTokens(),
+			TotalTokens:  info.GetEstimatePromptTokens(),
+		}
+	}
 	jsonResponse, err := json.Marshal(fullTextResponse)
 	if err != nil {
 		return types.NewError(err, types.ErrorCodeBadResponseBody), nil

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -238,6 +238,21 @@ func HandleClaudeResponseData(c *gin.Context, info *relaycommon.RelayInfo, claud
 		claudeInfo.Usage.ClaudeCacheCreation5mTokens = claudeResponse.Usage.GetCacheCreation5mTokens()
 		claudeInfo.Usage.ClaudeCacheCreation1hTokens = claudeResponse.Usage.GetCacheCreation1hTokens()
 	}
+	if claudeInfo.Usage.TotalTokens == 0 &&
+		claudeInfo.Usage.PromptTokens == 0 &&
+		claudeInfo.Usage.CompletionTokens == 0 {
+		// F-57: fall back to the estimate when the upstream omits usage so the
+		// response written to the client carries the same usage that
+		// settlement will bill (previously the fallback ran after the response
+		// was already serialized with zero usage).
+		var textBuilder strings.Builder
+		for _, block := range claudeResponse.Content {
+			if block.Text != nil && *block.Text != "" {
+				textBuilder.WriteString(*block.Text)
+			}
+		}
+		claudeInfo.Usage = service.ResponseText2Usage(c, textBuilder.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
+	}
 	var responseData []byte
 	switch info.RelayFormat {
 	case types.RelayFormatOpenAI:
@@ -283,22 +298,6 @@ func ClaudeHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayI
 	handleErr := HandleClaudeResponseData(c, info, claudeInfo, resp, responseBody)
 	if handleErr != nil {
 		return nil, handleErr
-	}
-	if claudeInfo.Usage.TotalTokens == 0 &&
-		claudeInfo.Usage.PromptTokens == 0 &&
-		claudeInfo.Usage.CompletionTokens == 0 {
-		// F-57: fall back to the estimate when the upstream omits usage so
-		// non-stream Claude requests are not billed as zero.
-		var textBuilder strings.Builder
-		var parsed dto.ClaudeResponse
-		if err := common.Unmarshal(responseBody, &parsed); err == nil {
-			for _, block := range parsed.Content {
-				if block.Text != nil && *block.Text != "" {
-					textBuilder.WriteString(*block.Text)
-				}
-			}
-		}
-		claudeInfo.Usage = service.ResponseText2Usage(c, textBuilder.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
 	}
 	return claudeInfo.Usage, nil
 }

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -284,5 +284,21 @@ func ClaudeHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayI
 	if handleErr != nil {
 		return nil, handleErr
 	}
+	if claudeInfo.Usage.TotalTokens == 0 &&
+		claudeInfo.Usage.PromptTokens == 0 &&
+		claudeInfo.Usage.CompletionTokens == 0 {
+		// F-57: fall back to the estimate when the upstream omits usage so
+		// non-stream Claude requests are not billed as zero.
+		var textBuilder strings.Builder
+		var parsed dto.ClaudeResponse
+		if err := common.Unmarshal(responseBody, &parsed); err == nil {
+			for _, block := range parsed.Content {
+				if block.Text != nil && *block.Text != "" {
+					textBuilder.WriteString(*block.Text)
+				}
+			}
+		}
+		claudeInfo.Usage = service.ResponseText2Usage(c, textBuilder.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
+	}
 	return claudeInfo.Usage, nil
 }

--- a/relay/channel/cohere/relay-cohere.go
+++ b/relay/channel/cohere/relay-cohere.go
@@ -105,7 +105,6 @@ func cohereStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 	// client disconnect; stopChan send is non-blocking so EOF also cannot
 	// strand the goroutine.
 	dataChan := make(chan string, 64)
-	stopChan := make(chan bool)
 	go func() {
 		for scanner.Scan() {
 			data := scanner.Text()
@@ -118,68 +117,64 @@ func cohereStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 		if err := scanner.Err(); err != nil {
 			common.SysLog("error reading stream: " + err.Error())
 		}
-		select {
-		case stopChan <- true:
-		default:
-		}
+		close(dataChan)
 	}()
 	helper.SetEventStreamHeaders(c)
 	isFirst := true
 	c.Stream(func(w io.Writer) bool {
-		select {
-		case data := <-dataChan:
-			if isFirst {
-				isFirst = false
-				info.FirstResponseTime = time.Now()
-			}
-			data = strings.TrimSuffix(data, "\r")
-			var cohereResp CohereResponse
-			err := json.Unmarshal([]byte(data), &cohereResp)
-			if err != nil {
-				common.SysLog("error unmarshalling stream response: " + err.Error())
-				return true
-			}
-			var openaiResp dto.ChatCompletionsStreamResponse
-			openaiResp.Id = responseId
-			openaiResp.Created = createdTime
-			openaiResp.Object = "chat.completion.chunk"
-			openaiResp.Model = info.UpstreamModelName
-			if cohereResp.IsFinished {
-				finishReason := stopReasonCohere2OpenAI(cohereResp.FinishReason)
-				openaiResp.Choices = []dto.ChatCompletionsStreamResponseChoice{
-					{
-						Delta:        dto.ChatCompletionsStreamResponseChoiceDelta{},
-						Index:        0,
-						FinishReason: &finishReason,
-					},
-				}
-				if cohereResp.Response != nil {
-					usage.PromptTokens = cohereResp.Response.Meta.BilledUnits.InputTokens
-					usage.CompletionTokens = cohereResp.Response.Meta.BilledUnits.OutputTokens
-				}
-			} else {
-				openaiResp.Choices = []dto.ChatCompletionsStreamResponseChoice{
-					{
-						Delta: dto.ChatCompletionsStreamResponseChoiceDelta{
-							Role:    "assistant",
-							Content: &cohereResp.Text,
-						},
-						Index: 0,
-					},
-				}
-				responseText += cohereResp.Text
-			}
-			jsonStr, err := json.Marshal(openaiResp)
-			if err != nil {
-				common.SysLog("error marshalling stream response: " + err.Error())
-				return true
-			}
-			c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
-			return true
-		case <-stopChan:
+		data, ok := <-dataChan
+		if !ok {
 			c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
 			return false
 		}
+		if isFirst {
+			isFirst = false
+			info.FirstResponseTime = time.Now()
+		}
+		data = strings.TrimSuffix(data, "\r")
+		var cohereResp CohereResponse
+		err := json.Unmarshal([]byte(data), &cohereResp)
+		if err != nil {
+			common.SysLog("error unmarshalling stream response: " + err.Error())
+			return true
+		}
+		var openaiResp dto.ChatCompletionsStreamResponse
+		openaiResp.Id = responseId
+		openaiResp.Created = createdTime
+		openaiResp.Object = "chat.completion.chunk"
+		openaiResp.Model = info.UpstreamModelName
+		if cohereResp.IsFinished {
+			finishReason := stopReasonCohere2OpenAI(cohereResp.FinishReason)
+			openaiResp.Choices = []dto.ChatCompletionsStreamResponseChoice{
+				{
+					Delta:        dto.ChatCompletionsStreamResponseChoiceDelta{},
+					Index:        0,
+					FinishReason: &finishReason,
+				},
+			}
+			if cohereResp.Response != nil {
+				usage.PromptTokens = cohereResp.Response.Meta.BilledUnits.InputTokens
+				usage.CompletionTokens = cohereResp.Response.Meta.BilledUnits.OutputTokens
+			}
+		} else {
+			openaiResp.Choices = []dto.ChatCompletionsStreamResponseChoice{
+				{
+					Delta: dto.ChatCompletionsStreamResponseChoiceDelta{
+						Role:    "assistant",
+						Content: &cohereResp.Text,
+					},
+					Index: 0,
+				},
+			}
+			responseText += cohereResp.Text
+		}
+		jsonStr, err := json.Marshal(openaiResp)
+		if err != nil {
+			common.SysLog("error marshalling stream response: " + err.Error())
+			return true
+		}
+		c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
+		return true
 	})
 	if usage.PromptTokens == 0 {
 		usage = service.ResponseText2Usage(c, responseText, info.UpstreamModelName, info.GetEstimatePromptTokens())
@@ -204,9 +199,9 @@ func cohereHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respo
 	usage.CompletionTokens = cohereResp.Meta.BilledUnits.OutputTokens
 	usage.TotalTokens = cohereResp.Meta.BilledUnits.InputTokens + cohereResp.Meta.BilledUnits.OutputTokens
 	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
-		// F-55: fall back to the estimate when the upstream omits usage.
-		usage.PromptTokens = info.GetEstimatePromptTokens()
-		usage.TotalTokens = usage.PromptTokens
+		// F-55: fall back to the estimate (prompt+completion+total) when the
+		// upstream omits usage, so generated output is not billed as zero.
+		usage = *service.ResponseText2Usage(c, cohereResp.Text, info.UpstreamModelName, info.GetEstimatePromptTokens())
 	}
 
 	var openaiResp dto.TextResponse

--- a/relay/channel/cohere/relay-cohere.go
+++ b/relay/channel/cohere/relay-cohere.go
@@ -98,17 +98,30 @@ func cohereStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 		}
 		return 0, nil, nil
 	})
-	dataChan := make(chan string)
+	// F-29: the reader goroutine must not block forever on an unbuffered
+	// channel when the client disconnects mid-stream (gin's c.Stream returns,
+	// leaving no receiver -> goroutine + upstream connection leak per request).
+	// A small buffer plus a done-select lets the reader exit promptly on
+	// client disconnect; stopChan send is non-blocking so EOF also cannot
+	// strand the goroutine.
+	dataChan := make(chan string, 64)
 	stopChan := make(chan bool)
 	go func() {
 		for scanner.Scan() {
 			data := scanner.Text()
-			dataChan <- data
+			select {
+			case dataChan <- data:
+			case <-c.Request.Context().Done():
+				return
+			}
 		}
 		if err := scanner.Err(); err != nil {
 			common.SysLog("error reading stream: " + err.Error())
 		}
-		stopChan <- true
+		select {
+		case stopChan <- true:
+		default:
+		}
 	}()
 	helper.SetEventStreamHeaders(c)
 	isFirst := true
@@ -190,6 +203,11 @@ func cohereHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respo
 	usage.PromptTokens = cohereResp.Meta.BilledUnits.InputTokens
 	usage.CompletionTokens = cohereResp.Meta.BilledUnits.OutputTokens
 	usage.TotalTokens = cohereResp.Meta.BilledUnits.InputTokens + cohereResp.Meta.BilledUnits.OutputTokens
+	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+		// F-55: fall back to the estimate when the upstream omits usage.
+		usage.PromptTokens = info.GetEstimatePromptTokens()
+		usage.TotalTokens = usage.PromptTokens
+	}
 
 	var openaiResp dto.TextResponse
 	openaiResp.Id = cohereResp.ResponseId

--- a/relay/channel/dify/relay-dify.go
+++ b/relay/channel/dify/relay-dify.go
@@ -275,11 +275,17 @@ func difyHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respons
 	if err != nil {
 		return nil, types.NewError(err, types.ErrorCodeBadResponseBody)
 	}
+	usage := difyResponse.MetaData.Usage
+	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+		// F-58: fall back to the estimate when the upstream omits usage so
+		// non-stream Dify chat requests are not billed as zero.
+		usage = *service.ResponseText2Usage(c, difyResponse.Answer, info.UpstreamModelName, info.GetEstimatePromptTokens())
+	}
 	fullTextResponse := dto.OpenAITextResponse{
 		Id:      difyResponse.ConversationId,
 		Object:  "chat.completion",
 		Created: common.GetTimestamp(),
-		Usage:   difyResponse.MetaData.Usage,
+		Usage:   usage,
 	}
 	choice := dto.OpenAITextResponseChoice{
 		Index: 0,
@@ -297,5 +303,5 @@ func difyHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respons
 	c.Writer.Header().Set("Content-Type", "application/json")
 	c.Writer.WriteHeader(resp.StatusCode)
 	c.Writer.Write(jsonResponse)
-	return &difyResponse.MetaData.Usage, nil
+	return &usage, nil
 }

--- a/relay/channel/mokaai/relay-mokaai.go
+++ b/relay/channel/mokaai/relay-mokaai.go
@@ -63,6 +63,14 @@ func mokaEmbeddingHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *htt
 	if err != nil {
 		return nil, types.NewError(err, types.ErrorCodeBadResponseBody)
 	}
+	// F-54: fallback to the prompt estimate when the upstream omits usage so
+	// embedding requests are not billed as zero (F-26 residual for mokaai).
+	if baiduResponse.Usage.TotalTokens == 0 &&
+		baiduResponse.Usage.PromptTokens == 0 &&
+		baiduResponse.Usage.CompletionTokens == 0 {
+		baiduResponse.Usage.PromptTokens = info.GetEstimatePromptTokens()
+		baiduResponse.Usage.TotalTokens = baiduResponse.Usage.PromptTokens
+	}
 	// if baiduResponse.ErrorMsg != "" {
 	// 	return &dto.OpenAIErrorWithStatusCode{
 	// 		Error: dto.OpenAIError{

--- a/relay/channel/ollama/relay-ollama.go
+++ b/relay/channel/ollama/relay-ollama.go
@@ -325,6 +325,12 @@ func ollamaEmbeddingHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *h
 		data = append(data, dto.OpenAIEmbeddingResponseItem{Index: i, Object: "embedding", Embedding: emb})
 	}
 	usage := &dto.Usage{PromptTokens: oResp.PromptEvalCount, CompletionTokens: 0, TotalTokens: oResp.PromptEvalCount}
+	// F-54: fallback to the prompt estimate when the upstream omits prompt
+	// eval count so embedding requests are not billed as zero.
+	if usage.TotalTokens == 0 && usage.PromptTokens == 0 {
+		usage.PromptTokens = info.GetEstimatePromptTokens()
+		usage.TotalTokens = usage.PromptTokens
+	}
 	embResp := &dto.OpenAIEmbeddingResponse{Object: "list", Data: data, Model: info.UpstreamModelName, Usage: *usage}
 	out, _ := common.Marshal(embResp)
 	service.IOCopyBytesGracefully(c, resp, out)

--- a/relay/channel/ollama/stream.go
+++ b/relay/channel/ollama/stream.go
@@ -104,6 +104,7 @@ func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 	helper.SetEventStreamHeaders(c)
 	scanner := helper.NewStreamScanner(resp.Body)
 	usage := &dto.Usage{}
+	var responseText strings.Builder
 	var model = info.UpstreamModelName
 	var responseId = common.GetUUID()
 	var created = time.Now().Unix()
@@ -148,6 +149,7 @@ func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 				}},
 			}
 			if content != "" {
+				responseText.WriteString(content)
 				delta.Choices[0].Delta.SetContentString(content)
 			}
 			if chunk.Message != nil && len(chunk.Message.Thinking) > 0 {
@@ -202,6 +204,11 @@ func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 	}
 	if err := scanner.Err(); err != nil && err != io.EOF {
 		logger.LogError(c, "ollama stream scan error: "+err.Error())
+	}
+	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+		// F-62: fall back to the estimate when the upstream omits usage so
+		// streamed ollama chat is not billed as zero.
+		usage = service.ResponseText2Usage(c, responseText.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
 	}
 	return usage, nil
 }
@@ -303,6 +310,11 @@ func ollamaChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.R
 	}
 	created := toUnix(lastChunk.CreatedAt)
 	usage := &dto.Usage{PromptTokens: lastChunk.PromptEvalCount, CompletionTokens: lastChunk.EvalCount, TotalTokens: lastChunk.PromptEvalCount + lastChunk.EvalCount}
+	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+		// F-62: fall back to the estimate when the upstream omits usage so
+		// non-stream ollama chat is not billed as zero.
+		usage = service.ResponseText2Usage(c, aggContent.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
+	}
 	content := aggContent.String()
 	finishReason := lastChunk.DoneReason
 	if finishReason == "" {

--- a/relay/channel/ollama/stream.go
+++ b/relay/channel/ollama/stream.go
@@ -192,6 +192,11 @@ func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 				_ = helper.StringData(c, string(data))
 			}
 		}
+		if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+			// F-62: apply the estimate before the usage frame is emitted so the
+			// client sees the same usage that settlement will bill.
+			usage = service.ResponseText2Usage(c, responseText.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
+		}
 		// emit usage frame
 		if final := helper.GenerateFinalUsageResponse(responseId, created, model, *usage); final != nil {
 			if data, err := common.Marshal(final); err == nil {
@@ -204,11 +209,6 @@ func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 	}
 	if err := scanner.Err(); err != nil && err != io.EOF {
 		logger.LogError(c, "ollama stream scan error: "+err.Error())
-	}
-	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
-		// F-62: fall back to the estimate when the upstream omits usage so
-		// streamed ollama chat is not billed as zero.
-		usage = service.ResponseText2Usage(c, responseText.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
 	}
 	return usage, nil
 }

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -48,6 +48,19 @@ func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 			usage.PromptTokensDetails.CacheWriteTokens = responsesResponse.Usage.InputTokensDetails.CacheWriteTokens
 		}
 	}
+	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+		// F-56: fall back to the estimate when the upstream omits usage so
+		// non-stream Responses requests are not billed as zero.
+		var outText strings.Builder
+		for _, out := range responsesResponse.Output {
+			for _, c := range out.Content {
+				if c.Text != "" {
+					outText.WriteString(c.Text)
+				}
+			}
+		}
+		usage = *service.ResponseText2Usage(c, outText.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
+	}
 	// Count actual tool invocations from Output (not tool declarations).
 	for _, output := range responsesResponse.Output {
 		switch output.Type {

--- a/relay/channel/openai/relay_responses_compact.go
+++ b/relay/channel/openai/relay_responses_compact.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/QuantumNous/new-api/relaykit/types"
 	"github.com/QuantumNous/new-api/service"
@@ -39,6 +40,13 @@ func OaiResponsesCompactionHandler(c *gin.Context, resp *http.Response) (*dto.Us
 			usage.PromptTokensDetails.CachedTokens = compactResp.Usage.InputTokensDetails.CachedTokens
 			usage.PromptTokensDetails.CacheWriteTokens = compactResp.Usage.InputTokensDetails.CacheWriteTokens
 		}
+	}
+	// F-26 family: when the upstream compaction response omits usage, fall
+	// back to the local request estimate so the pre-consume is not fully
+	// refunded (free compaction).
+	if usage.TotalTokens == 0 {
+		usage.PromptTokens = common.GetContextKeyInt(c, constant.ContextKeyEstimatedTokens)
+		usage.TotalTokens = usage.PromptTokens
 	}
 
 	return &usage, nil

--- a/relay/channel/siliconflow/relay-siliconflow.go
+++ b/relay/channel/siliconflow/relay-siliconflow.go
@@ -29,6 +29,12 @@ func siliconflowRerankHandler(c *gin.Context, info *relaycommon.RelayInfo, resp 
 		CompletionTokens: siliconflowResp.Meta.Tokens.OutputTokens,
 		TotalTokens:      siliconflowResp.Meta.Tokens.InputTokens + siliconflowResp.Meta.Tokens.OutputTokens,
 	}
+	// F-53: fallback to the prompt estimate when the upstream omits usage so
+	// rerank requests are not billed as zero (F-26 residual for siliconflow).
+	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+		usage.PromptTokens = info.GetEstimatePromptTokens()
+		usage.TotalTokens = usage.PromptTokens
+	}
 	rerankResp := &dto.RerankResponse{
 		Results: siliconflowResp.Results,
 		Usage:   *usage,

--- a/relay/channel/xunfei/adaptor.go
+++ b/relay/channel/xunfei/adaptor.go
@@ -88,9 +88,9 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycom
 		return nil, types.NewError(errors.New("request is nil"), types.ErrorCodeInvalidRequest)
 	}
 	if info.IsStream {
-		usage, err = xunfeiStreamHandler(c, *a.request, splits[0], splits[1], splits[2])
+		usage, err = xunfeiStreamHandler(c, info, *a.request, splits[0], splits[1], splits[2])
 	} else {
-		usage, err = xunfeiHandler(c, *a.request, splits[0], splits[1], splits[2])
+		usage, err = xunfeiHandler(c, info, *a.request, splits[0], splits[1], splits[2])
 	}
 	return
 }

--- a/relay/channel/xunfei/relay-xunfei.go
+++ b/relay/channel/xunfei/relay-xunfei.go
@@ -133,7 +133,7 @@ func buildXunfeiAuthUrl(hostUrl string, apiKey, apiSecret string) string {
 
 func xunfeiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, textRequest dto.GeneralOpenAIRequest, appId string, apiSecret string, apiKey string) (*dto.Usage, *types.NewAPIError) {
 	domain, authUrl := getXunfeiAuthUrl(c, apiKey, apiSecret, textRequest.Model)
-	dataChan, stopChan, err := xunfeiMakeRequest(textRequest, domain, authUrl, appId, c.Request.Context())
+	dataChan, err := xunfeiMakeRequest(textRequest, domain, authUrl, appId, c.Request.Context())
 	if err != nil {
 		return nil, types.NewError(err, types.ErrorCodeDoRequestFailed)
 	}
@@ -141,26 +141,25 @@ func xunfeiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, textReques
 	var usage dto.Usage
 	var responseText strings.Builder
 	c.Stream(func(w io.Writer) bool {
-		select {
-		case xunfeiResponse := <-dataChan:
-			usage.PromptTokens += xunfeiResponse.Payload.Usage.Text.PromptTokens
-			usage.CompletionTokens += xunfeiResponse.Payload.Usage.Text.CompletionTokens
-			usage.TotalTokens += xunfeiResponse.Payload.Usage.Text.TotalTokens
-			response := streamResponseXunfei2OpenAI(&xunfeiResponse)
-			if len(response.Choices) > 0 {
-				responseText.WriteString(response.Choices[0].Delta.GetContentString())
-			}
-			jsonResponse, err := json.Marshal(response)
-			if err != nil {
-				common.SysLog("error marshalling stream response: " + err.Error())
-				return true
-			}
-			c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonResponse)})
-			return true
-		case <-stopChan:
+		xunfeiResponse, ok := <-dataChan
+		if !ok {
 			c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
 			return false
 		}
+		usage.PromptTokens += xunfeiResponse.Payload.Usage.Text.PromptTokens
+		usage.CompletionTokens += xunfeiResponse.Payload.Usage.Text.CompletionTokens
+		usage.TotalTokens += xunfeiResponse.Payload.Usage.Text.TotalTokens
+		response := streamResponseXunfei2OpenAI(&xunfeiResponse)
+		if len(response.Choices) > 0 {
+			responseText.WriteString(response.Choices[0].Delta.GetContentString())
+		}
+		jsonResponse, err := json.Marshal(response)
+		if err != nil {
+			common.SysLog("error marshalling stream response: " + err.Error())
+			return true
+		}
+		c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonResponse)})
+		return true
 	})
 	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
 		// F-59: fall back to the estimate when the upstream omits usage so
@@ -172,26 +171,21 @@ func xunfeiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, textReques
 
 func xunfeiHandler(c *gin.Context, info *relaycommon.RelayInfo, textRequest dto.GeneralOpenAIRequest, appId string, apiSecret string, apiKey string) (*dto.Usage, *types.NewAPIError) {
 	domain, authUrl := getXunfeiAuthUrl(c, apiKey, apiSecret, textRequest.Model)
-	dataChan, stopChan, err := xunfeiMakeRequest(textRequest, domain, authUrl, appId, c.Request.Context())
+	dataChan, err := xunfeiMakeRequest(textRequest, domain, authUrl, appId, c.Request.Context())
 	if err != nil {
 		return nil, types.NewError(err, types.ErrorCodeDoRequestFailed)
 	}
 	var usage dto.Usage
 	var content string
 	var xunfeiResponse XunfeiChatResponse
-	stop := false
-	for !stop {
-		select {
-		case xunfeiResponse = <-dataChan:
-			if len(xunfeiResponse.Payload.Choices.Text) == 0 {
-				continue
-			}
-			content += xunfeiResponse.Payload.Choices.Text[0].Content
-			usage.PromptTokens += xunfeiResponse.Payload.Usage.Text.PromptTokens
-			usage.CompletionTokens += xunfeiResponse.Payload.Usage.Text.CompletionTokens
-			usage.TotalTokens += xunfeiResponse.Payload.Usage.Text.TotalTokens
-		case stop = <-stopChan:
+	for xunfeiResponse = range dataChan {
+		if len(xunfeiResponse.Payload.Choices.Text) == 0 {
+			continue
 		}
+		content += xunfeiResponse.Payload.Choices.Text[0].Content
+		usage.PromptTokens += xunfeiResponse.Payload.Usage.Text.PromptTokens
+		usage.CompletionTokens += xunfeiResponse.Payload.Usage.Text.CompletionTokens
+		usage.TotalTokens += xunfeiResponse.Payload.Usage.Text.TotalTokens
 	}
 	if len(xunfeiResponse.Payload.Choices.Text) == 0 {
 		xunfeiResponse.Payload.Choices.Text = []XunfeiChatResponseTextItem{
@@ -218,28 +212,28 @@ func xunfeiHandler(c *gin.Context, info *relaycommon.RelayInfo, textRequest dto.
 	return &usage, nil
 }
 
-func xunfeiMakeRequest(textRequest dto.GeneralOpenAIRequest, domain, authUrl, appId string, ctx context.Context) (chan XunfeiChatResponse, chan bool, error) {
+func xunfeiMakeRequest(textRequest dto.GeneralOpenAIRequest, domain, authUrl, appId string, ctx context.Context) (chan XunfeiChatResponse, error) {
 	d := websocket.Dialer{
 		HandshakeTimeout: 5 * time.Second,
 	}
 	conn, resp, err := d.Dial(authUrl, nil)
 	if err != nil || resp.StatusCode != 101 {
-		return nil, nil, err
+		return nil, err
 	}
 
 	data := requestOpenAI2Xunfei(textRequest, appId, domain)
 	err = conn.WriteJSON(data)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// F-29 family: buffered channels + done-select so a client disconnect
 	// (ctx cancel) cannot strand the reader goroutine on an unbuffered send.
 	dataChan := make(chan XunfeiChatResponse, 64)
-	stopChan := make(chan bool, 1)
 	go func() {
 		defer func() {
 			conn.Close()
+			close(dataChan)
 		}()
 		for {
 			_, msg, err := conn.ReadMessage()
@@ -253,10 +247,10 @@ func xunfeiMakeRequest(textRequest dto.GeneralOpenAIRequest, domain, authUrl, ap
 				common.SysLog("error unmarshalling stream response: " + err.Error())
 				break
 			}
-			select {
-			case dataChan <- response:
-			case <-ctx.Done():
-				return
+		select {
+		case dataChan <- response:
+		case <-ctx.Done():
+			return
 			}
 			if response.Payload.Choices.Status == 2 {
 				if err != nil {
@@ -265,13 +259,9 @@ func xunfeiMakeRequest(textRequest dto.GeneralOpenAIRequest, domain, authUrl, ap
 				break
 			}
 		}
-		select {
-		case stopChan <- true:
-		default:
-		}
 	}()
 
-	return dataChan, stopChan, nil
+	return dataChan, nil
 }
 
 func apiVersion2domain(apiVersion string) string {

--- a/relay/channel/xunfei/relay-xunfei.go
+++ b/relay/channel/xunfei/relay-xunfei.go
@@ -1,6 +1,7 @@
 package xunfei
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -13,9 +14,11 @@ import (
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/QuantumNous/new-api/relaykit/types"
+	"github.com/QuantumNous/new-api/service"
 	"github.com/samber/lo"
 
 	"github.com/gin-gonic/gin"
@@ -128,14 +131,15 @@ func buildXunfeiAuthUrl(hostUrl string, apiKey, apiSecret string) string {
 	return callUrl
 }
 
-func xunfeiStreamHandler(c *gin.Context, textRequest dto.GeneralOpenAIRequest, appId string, apiSecret string, apiKey string) (*dto.Usage, *types.NewAPIError) {
+func xunfeiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, textRequest dto.GeneralOpenAIRequest, appId string, apiSecret string, apiKey string) (*dto.Usage, *types.NewAPIError) {
 	domain, authUrl := getXunfeiAuthUrl(c, apiKey, apiSecret, textRequest.Model)
-	dataChan, stopChan, err := xunfeiMakeRequest(textRequest, domain, authUrl, appId)
+	dataChan, stopChan, err := xunfeiMakeRequest(textRequest, domain, authUrl, appId, c.Request.Context())
 	if err != nil {
 		return nil, types.NewError(err, types.ErrorCodeDoRequestFailed)
 	}
 	helper.SetEventStreamHeaders(c)
 	var usage dto.Usage
+	var responseText strings.Builder
 	c.Stream(func(w io.Writer) bool {
 		select {
 		case xunfeiResponse := <-dataChan:
@@ -143,6 +147,9 @@ func xunfeiStreamHandler(c *gin.Context, textRequest dto.GeneralOpenAIRequest, a
 			usage.CompletionTokens += xunfeiResponse.Payload.Usage.Text.CompletionTokens
 			usage.TotalTokens += xunfeiResponse.Payload.Usage.Text.TotalTokens
 			response := streamResponseXunfei2OpenAI(&xunfeiResponse)
+			if len(response.Choices) > 0 {
+				responseText.WriteString(response.Choices[0].Delta.GetContentString())
+			}
 			jsonResponse, err := json.Marshal(response)
 			if err != nil {
 				common.SysLog("error marshalling stream response: " + err.Error())
@@ -155,12 +162,17 @@ func xunfeiStreamHandler(c *gin.Context, textRequest dto.GeneralOpenAIRequest, a
 			return false
 		}
 	})
+	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+		// F-59: fall back to the estimate when the upstream omits usage so
+		// streamed xunfei chat is not billed as zero.
+		usage = *service.ResponseText2Usage(c, responseText.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
+	}
 	return &usage, nil
 }
 
-func xunfeiHandler(c *gin.Context, textRequest dto.GeneralOpenAIRequest, appId string, apiSecret string, apiKey string) (*dto.Usage, *types.NewAPIError) {
+func xunfeiHandler(c *gin.Context, info *relaycommon.RelayInfo, textRequest dto.GeneralOpenAIRequest, appId string, apiSecret string, apiKey string) (*dto.Usage, *types.NewAPIError) {
 	domain, authUrl := getXunfeiAuthUrl(c, apiKey, apiSecret, textRequest.Model)
-	dataChan, stopChan, err := xunfeiMakeRequest(textRequest, domain, authUrl, appId)
+	dataChan, stopChan, err := xunfeiMakeRequest(textRequest, domain, authUrl, appId, c.Request.Context())
 	if err != nil {
 		return nil, types.NewError(err, types.ErrorCodeDoRequestFailed)
 	}
@@ -190,6 +202,12 @@ func xunfeiHandler(c *gin.Context, textRequest dto.GeneralOpenAIRequest, appId s
 	}
 	xunfeiResponse.Payload.Choices.Text[0].Content = content
 
+	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+		// F-59: fall back to the estimate when the upstream omits usage so
+		// non-stream xunfei chat is not billed as zero.
+		usage = *service.ResponseText2Usage(c, content, info.UpstreamModelName, info.GetEstimatePromptTokens())
+	}
+
 	response := responseXunfei2OpenAI(&xunfeiResponse)
 	jsonResponse, err := json.Marshal(response)
 	if err != nil {
@@ -200,7 +218,7 @@ func xunfeiHandler(c *gin.Context, textRequest dto.GeneralOpenAIRequest, appId s
 	return &usage, nil
 }
 
-func xunfeiMakeRequest(textRequest dto.GeneralOpenAIRequest, domain, authUrl, appId string) (chan XunfeiChatResponse, chan bool, error) {
+func xunfeiMakeRequest(textRequest dto.GeneralOpenAIRequest, domain, authUrl, appId string, ctx context.Context) (chan XunfeiChatResponse, chan bool, error) {
 	d := websocket.Dialer{
 		HandshakeTimeout: 5 * time.Second,
 	}
@@ -215,8 +233,10 @@ func xunfeiMakeRequest(textRequest dto.GeneralOpenAIRequest, domain, authUrl, ap
 		return nil, nil, err
 	}
 
-	dataChan := make(chan XunfeiChatResponse)
-	stopChan := make(chan bool)
+	// F-29 family: buffered channels + done-select so a client disconnect
+	// (ctx cancel) cannot strand the reader goroutine on an unbuffered send.
+	dataChan := make(chan XunfeiChatResponse, 64)
+	stopChan := make(chan bool, 1)
 	go func() {
 		defer func() {
 			conn.Close()
@@ -233,7 +253,11 @@ func xunfeiMakeRequest(textRequest dto.GeneralOpenAIRequest, domain, authUrl, ap
 				common.SysLog("error unmarshalling stream response: " + err.Error())
 				break
 			}
-			dataChan <- response
+			select {
+			case dataChan <- response:
+			case <-ctx.Done():
+				return
+			}
 			if response.Payload.Choices.Status == 2 {
 				if err != nil {
 					common.SysLog("error closing websocket connection: " + err.Error())
@@ -241,7 +265,10 @@ func xunfeiMakeRequest(textRequest dto.GeneralOpenAIRequest, domain, authUrl, ap
 				break
 			}
 		}
-		stopChan <- true
+		select {
+		case stopChan <- true:
+		default:
+		}
 	}()
 
 	return dataChan, stopChan, nil

--- a/relay/channel/zhipu/relay-zhipu.go
+++ b/relay/channel/zhipu/relay-zhipu.go
@@ -199,9 +199,13 @@ func zhipuStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.
 		if err := scanner.Err(); err != nil {
 			common.SysLog("error reading stream: " + err.Error())
 		}
+		// Deliver the terminal signal reliably: a non-blocking send to an
+		// unbuffered channel drops the completion when the consumer is busy
+		// draining data/meta frames, leaving the stream hanging after EOF.
 		select {
 		case stopChan <- true:
-		default:
+		case <-c.Request.Context().Done():
+			return
 		}
 	}()
 	helper.SetEventStreamHeaders(c)
@@ -270,11 +274,13 @@ func zhipuHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respon
 	if fullTextResponse.Usage.TotalTokens == 0 &&
 		fullTextResponse.Usage.PromptTokens == 0 &&
 		fullTextResponse.Usage.CompletionTokens == 0 {
-		// F-55: fall back to the estimate when the upstream omits usage.
-		fullTextResponse.Usage = dto.Usage{
-			PromptTokens: info.GetEstimatePromptTokens(),
-			TotalTokens:  info.GetEstimatePromptTokens(),
+		// F-55: fall back to the estimate (prompt+completion+total) when the
+		// upstream omits usage, so generated output is not billed as zero.
+		var textBuilder strings.Builder
+		for _, choice := range zhipuResponse.Data.Choices {
+			textBuilder.WriteString(strings.Trim(choice.Content, "\""))
 		}
+		fullTextResponse.Usage = *service.ResponseText2Usage(c, textBuilder.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
 	}
 	jsonResponse, err := json.Marshal(fullTextResponse)
 	if err != nil {

--- a/relay/channel/zhipu/relay-zhipu.go
+++ b/relay/channel/zhipu/relay-zhipu.go
@@ -157,10 +157,14 @@ func streamMetaResponseZhipu2OpenAI(zhipuResponse *ZhipuStreamMetaResponse) (*dt
 
 func zhipuStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
 	var usage *dto.Usage
+	var responseText strings.Builder
 	scanner := helper.NewStreamScanner(resp.Body)
 	scanner.Split(bufio.ScanLines)
-	dataChan := make(chan string)
-	metaChan := make(chan string)
+	// F-29 family: buffer the channels and let the reader exit on client
+	// disconnect; otherwise a mid-stream disconnect strands the goroutine
+	// forever on an unbuffered send (goroutine + connection leak per request).
+	dataChan := make(chan string, 64)
+	metaChan := make(chan string, 16)
 	stopChan := make(chan bool)
 	go func() {
 		for scanner.Scan() {
@@ -171,25 +175,43 @@ func zhipuStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.
 					continue
 				}
 				if line[:5] == "data:" {
-					dataChan <- line[5:]
+					select {
+					case dataChan <- line[5:]:
+					case <-c.Request.Context().Done():
+						return
+					}
 					if i != len(lines)-1 {
-						dataChan <- "\n"
+						select {
+						case dataChan <- "\n":
+						case <-c.Request.Context().Done():
+							return
+						}
 					}
 				} else if line[:5] == "meta:" {
-					metaChan <- line[5:]
+					select {
+					case metaChan <- line[5:]:
+					case <-c.Request.Context().Done():
+						return
+					}
 				}
 			}
 		}
 		if err := scanner.Err(); err != nil {
 			common.SysLog("error reading stream: " + err.Error())
 		}
-		stopChan <- true
+		select {
+		case stopChan <- true:
+		default:
+		}
 	}()
 	helper.SetEventStreamHeaders(c)
 	c.Stream(func(w io.Writer) bool {
 		select {
 		case data := <-dataChan:
 			response := streamResponseZhipu2OpenAI(data)
+			if len(response.Choices) > 0 {
+				responseText.WriteString(response.Choices[0].Delta.GetContentString())
+			}
 			jsonResponse, err := json.Marshal(response)
 			if err != nil {
 				common.SysLog("error marshalling stream response: " + err.Error())
@@ -219,6 +241,11 @@ func zhipuStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.
 		}
 	})
 	service.CloseResponseBodyGracefully(resp)
+	if usage == nil || (usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0) {
+		// F-55: zhipu streams may omit the usage meta event entirely; fall
+		// back to the estimate so chat is not billed as zero.
+		usage = service.ResponseText2Usage(c, responseText.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
+	}
 	return usage, nil
 }
 
@@ -240,6 +267,15 @@ func zhipuHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respon
 		}, resp.StatusCode)
 	}
 	fullTextResponse := responseZhipu2OpenAI(&zhipuResponse)
+	if fullTextResponse.Usage.TotalTokens == 0 &&
+		fullTextResponse.Usage.PromptTokens == 0 &&
+		fullTextResponse.Usage.CompletionTokens == 0 {
+		// F-55: fall back to the estimate when the upstream omits usage.
+		fullTextResponse.Usage = dto.Usage{
+			PromptTokens: info.GetEstimatePromptTokens(),
+			TotalTokens:  info.GetEstimatePromptTokens(),
+		}
+	}
 	jsonResponse, err := json.Marshal(fullTextResponse)
 	if err != nil {
 		return nil, types.NewError(err, types.ErrorCodeBadResponseBody)

--- a/relay/common_handler/rerank.go
+++ b/relay/common_handler/rerank.go
@@ -65,6 +65,14 @@ func RerankHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respo
 		if err != nil {
 			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
 		}
+		// F-26: upstreams like Jina v1 / OpenAI-compatible rerank endpoints may
+		// omit usage entirely. Without a fallback the settle charges 0 and the
+		// pre-consume is fully refunded -> unlimited free rerank. Fall back to
+		// the local request estimate whenever upstream usage is missing.
+		if jinaResp.Usage.TotalTokens == 0 && jinaResp.Usage.PromptTokens == 0 && jinaResp.Usage.CompletionTokens == 0 {
+			jinaResp.Usage.PromptTokens = info.GetEstimatePromptTokens()
+			jinaResp.Usage.TotalTokens = jinaResp.Usage.PromptTokens
+		}
 		jinaResp.Usage.PromptTokens = jinaResp.Usage.TotalTokens
 	}
 

--- a/relay/image_handler.go
+++ b/relay/image_handler.go
@@ -129,6 +129,13 @@ func ImageHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *type
 		usage.(*dto.Usage).PromptTokens = 1
 	}
 
+	// F-52: ensure per-image count ratio is set for UsePrice-priced image
+	// channels whose adaptor does not report it (e.g. Replicate), so n>1
+	// requests are billed per generated image instead of once.
+	if imageN > 0 && info.PriceData.UsePrice && !info.PriceData.HasOtherRatio("n") {
+		info.PriceData.AddOtherRatio("n", float64(imageN))
+	}
+
 	quality := request.Quality
 	if quality == "" {
 		quality = "standard"

--- a/relay/image_handler.go
+++ b/relay/image_handler.go
@@ -122,6 +122,7 @@ func ImageHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *type
 		imageN = *request.N
 	}
 
+	usageZero := usage.(*dto.Usage).TotalTokens == 0 && usage.(*dto.Usage).PromptTokens == 0
 	if usage.(*dto.Usage).TotalTokens == 0 {
 		usage.(*dto.Usage).TotalTokens = 1
 	}
@@ -131,8 +132,10 @@ func ImageHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *type
 
 	// F-52: ensure per-image count ratio is set for UsePrice-priced image
 	// channels whose adaptor does not report it (e.g. Replicate), so n>1
-	// requests are billed per generated image instead of once.
-	if imageN > 0 && info.PriceData.UsePrice && !info.PriceData.HasOtherRatio("n") {
+	// requests are billed per generated image instead of once. Only apply the
+	// multiplier when the adaptor reported no usage: adaptors that already
+	// embed the image count in usage (e.g. ali) must not be multiplied again.
+	if usageZero && imageN > 0 && info.PriceData.UsePrice && !info.PriceData.HasOtherRatio("n") {
 		info.PriceData.AddOtherRatio("n", float64(imageN))
 	}
 


### PR DESCRIPTION
A set of billing-integrity fixes. When an upstream omits `usage`, several handlers settle quota as 0 → the request is effectively free (billed to the operator). Also closes related pricing gaps:

- **Usage fallbacks** — add token-count fallbacks when upstream omits usage for: rerank (ali/SiliconFlow/Jina/Xinference), embeddings (MokaAI/Ollama), zhipu + cohere, Responses API (non-stream), Claude (non-stream, incl. AWS Bedrock delegation), Dify (non-stream), xunfei (stream + non-stream), AWS Nova, ollama chat (stream + non-stream), AWS native non-stream.
- **Image `n` multiplier** — image-generation requests with `n>1` were billed as a single image in Replicate-style paths; apply the multiplier.
- **`accept_unset_model_ratio_model` admin gate** — ordinary users could self-enable acceptance of unset model ratios and use unpriced models; restrict the toggle to admins.
- **Stream goroutine hygiene** — cohere/zhipu/xunfei streaming used bare goroutines + unbuffered channels; connection drops leaked goroutines (also a slow DoS). Tied to the same files as the zhipu/cohere/xunfei fallbacks.

Build verified (`go build ./...`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Restricted enabling the Accept Unset Ratio Model setting to administrators and higher roles.

- **Usage Reporting**
  - Improved token usage estimates when providers omit or return zero usage data across chat, embedding, rerank, and compaction requests.
  - Enhanced consistency across streamed and non-streamed responses.

- **Reliability**
  - Improved stream shutdown behavior when clients disconnect.

- **Billing**
  - Image requests now account for the requested image count in applicable pricing calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->