### PR TITLE
fix(relay): stop injecting empty tools into Claude requests that omit them

### DIFF
--- a/relaykit/relayconvert/claude_default_max_tokens_test.go
+++ b/relaykit/relayconvert/claude_default_max_tokens_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/QuantumNous/new-api/relaykit/relayconvert/convmeta"
 	sharedclaude "github.com/QuantumNous/new-api/relaykit/relayconvert/internal/shared/claude"
+	kitutil "github.com/QuantumNous/new-api/relaykit/relayconvert/kitutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -102,6 +103,82 @@ func TestClaudeThinkingAdapterSatisfiesMaxTokensWithoutCallback(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got.MaxTokens)
 	assert.Equal(t, uint(1280), *got.MaxTokens)
+}
+
+func TestOpenAIChatRequestToClaudeMessagesOmitsEmptyTools(t *testing.T) {
+	maxTokens := uint(16)
+	tests := []struct {
+		name      string
+		request   dto.GeneralOpenAIRequest
+		wantTools bool
+	}{
+		{
+			name: "omitted tools",
+			request: dto.GeneralOpenAIRequest{
+				Model:     "claude-test",
+				MaxTokens: &maxTokens,
+				Messages:  []dto.Message{{Role: "user", Content: "hi"}},
+			},
+		},
+		{
+			name: "explicit empty tools",
+			request: dto.GeneralOpenAIRequest{
+				Model:     "claude-test",
+				MaxTokens: &maxTokens,
+				Messages:  []dto.Message{{Role: "user", Content: "hi"}},
+				Tools:     []dto.ToolCallRequest{},
+			},
+		},
+		{
+			name: "function tool",
+			request: dto.GeneralOpenAIRequest{
+				Model:     "claude-test",
+				MaxTokens: &maxTokens,
+				Messages:  []dto.Message{{Role: "user", Content: "hi"}},
+				Tools: []dto.ToolCallRequest{{
+					Type: "function",
+					Function: dto.FunctionRequest{
+						Name:        "get_weather",
+						Description: "Get weather by city",
+						Parameters: map[string]any{
+							"type":       "object",
+							"properties": map[string]any{"city": map[string]any{"type": "string"}},
+							"required":   []any{"city"},
+						},
+					},
+				}},
+			},
+			wantTools: true,
+		},
+		{
+			name: "web search only",
+			request: dto.GeneralOpenAIRequest{
+				Model:            "claude-test",
+				MaxTokens:        &maxTokens,
+				Messages:         []dto.Message{{Role: "user", Content: "hi"}},
+				WebSearchOptions: &dto.WebSearchOptions{SearchContextSize: "low"},
+			},
+			wantTools: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := OpenAIChatRequestToClaudeMessages(context.Background(), &convmeta.Values{}, test.request)
+			require.NoError(t, err)
+
+			body, err := kitutil.Marshal(got)
+			require.NoError(t, err)
+
+			if test.wantTools {
+				assert.NotNil(t, got.Tools)
+				assert.Contains(t, string(body), `"tools":`)
+				return
+			}
+			assert.Nil(t, got.Tools)
+			assert.NotContains(t, string(body), `"tools":`)
+		})
+	}
 }
 
 func claudeDefaultsMeta(defaultMaxTokens func(string) int) convmeta.Meta {

--- a/relaykit/relayconvert/internal/oai_chat/to_claude_messages_req.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_claude_messages_req.go
@@ -101,7 +101,9 @@ func OpenAIChatRequestToClaudeMessages(c context.Context, info convmeta.Meta, te
 		Model:         textRequest.Model,
 		StopSequences: nil,
 		Temperature:   textRequest.Temperature,
-		Tools:         claudeTools,
+	}
+	if len(claudeTools) > 0 {
+		claudeRequest.Tools = claudeTools
 	}
 	if maxTokens := textRequest.GetMaxTokens(); maxTokens > 0 {
 		claudeRequest.MaxTokens = kitutil.GetPointer(maxTokens)


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice源请求未携带 tools 时保持 Tools 为 nil，避免 omitempty 失效后序列化出 tools:[] 被上游拒绝。

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 根据 issue #6817 修复了 OpenAI 请求转 Claude 时，未传 tools 却注入空 tools:[] 数组、导致请求失败的问题。

## 📝 变更描述 / Description

### 问题现象

当 OpenAI 格式的 Chat 请求经 new-api 转发到 Anthropic 兼容渠道时，如果客户端没有传 `tools`，转换后的 Claude 请求里却会出现一个空的 `"tools": []` 字段。部分 Anthropic 兼容上游不接受空数组，会直接返回 400「tools 低于允许下限」。

同一个渠道上可以稳定复现出三种结果：

- 直连、不带 `tools`：200 正常；
- 直连、显式传 `tools: []`：400；
- 经 new-api 的 OpenAI → Claude 转换（未传 tools）：400。

### 根本原因

转换函数里用 `make([]any, 0, len(tools))` 创建了**非 nil 的空切片**，然后无条件赋给 `ClaudeRequest.Tools`。虽然该字段的 json tag 带 `omitempty`，但它的类型是 `any`，Go 对非 nil 的 interface 值不会做省略，所以即使客户端根本没有传 `tools`，最终序列化时仍然会输出 `"tools": []`。

### 修复方案

只有当转换结果中确实存在 tool（function 或 web_search）时才给 `ClaudeRequest.Tools` 赋值；没有 tool 时保持 `nil`，让 `omitempty` 正常生效，请求体里不再出现 `tools` 字段。显式传入 tools 的请求行为不受影响。

### 与 #6698 的关系

#6698 已经让 `endpoint_type=anthropic` 的渠道测试走原生 Claude 请求，不再经过本次转换；但当 `endpoint_type` 为空时，测试仍会构建 `GeneralOpenAIRequest`，而业务侧 OpenAI Chat 打到 Claude 渠道走的也是同一个转换函数，空 `tools: []` 依然会被注入。因此本 PR 直接在转换层修复，既能覆盖渠道测试的自动检测，也能修复正常转发路径。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6817

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
  - 说明：本 PR 由 AI 协助完成，描述与代码均经我逐行复核后提交，此项不勾选。
- [x] **非重复提交:** 已搜索查看 Issue 与 PR，#6817 开放且没有对应的修复 PR。#6698 只改了渠道测试的原生路径，不覆盖本次转换层。
- [x] **Bug fix 说明:** 已关联 #6817。转换层把未提供的 `tools` 序列化成空数组。
- [x] **变更理解:** 改动只影响 OpenAI Chat → Claude Messages 的 `Tools` 赋值：有 function / web_search 时仍下发 `tools`，没有时字段省略，显式传入的行为不变。
- [x] **范围聚焦:** 只修改了 `relaykit/relayconvert/internal/oai_chat/to_claude_messages_req.go`，并在现有 `claude_default_max_tokens_test.go` 中增加回归测试。
- [x] **本地验证:** 已运行下方列出的构建与测试，全部通过。
- [x] **安全合规:** 无敏感凭据；符合项目规范。

## 📸 运行证明 / Proof of Work

- 新增后端回归测试 `TestOpenAIChatRequestToClaudeMessagesOmitsEmptyTools` 通过：覆盖未传 `tools`、显式空数组 `tools: []`、function tool、仅 `WebSearchOptions` 四种输入，`go test` 全部 PASS。
- 既有相关测试通过：`TestClaudeDefaultMaxTokensPresence`、`TestClaudeThinkingAdapterSatisfiesMaxTokensWithoutCallback` 均 PASS。
- 格式检查通过：`gofmt -l` 对本次改动的两个文件无输出。
- `relaykit` 模块校验通过：`GOWORK=off go vet ./...`、`GOWORK=off go build ./...` 无输出。
- 根模块校验通过：`GOWORK=off go vet ./...`、`GOWORK=off go build ./...` 无输出。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude requests no longer include an empty `tools` field when no tools are configured.
  * Function and web-search tools continue to be included and serialized correctly when provided.

* **Tests**
  * Added coverage for requests with absent, empty, and populated tool configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->