### PR TITLE
fix(web): keep fetched model selection in sync with form

### DIFF
--- a/web/src/features/channels/components/dialogs/fetch-models-dialog.tsx
+++ b/web/src/features/channels/components/dialogs/fetch-models-dialog.tsx
@@ -53,16 +53,26 @@ function normalizeModelNameList(models: readonly string[]): string[] {
   return [...new Set(models.map((m) => normalizeModelName(m)).filter(Boolean))]
 }
 
-type FetchModelsDialogProps = {
+type FetchModelsDialogBaseProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
-  onModelsSelected?: (models: string[]) => void
   redirectModels?: string[]
   redirectSourceModels?: string[]
   customFetcher?: () => Promise<string[]>
-  existingModelsOverride?: string[]
   channelName?: string | null
 }
+
+type FetchModelsDialogProps = FetchModelsDialogBaseProps &
+  (
+    | {
+        onModelsSelected: (models: string[]) => void
+        existingModelsOverride: string[]
+      }
+    | {
+        onModelsSelected?: undefined
+        existingModelsOverride?: undefined
+      }
+  )
 
 export function FetchModelsDialog({
   open,

--- a/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
+++ b/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
@@ -4824,11 +4824,9 @@ export function ChannelMutateDrawer({
         channelName={
           shouldPreviewUnsavedModels ? currentName?.trim() : undefined
         }
-        existingModelsOverride={
-          shouldPreviewUnsavedModels
-            ? parseModelsString(form.getValues('models') || '')
-            : undefined
-        }
+        existingModelsOverride={parseModelsString(
+          form.getValues('models') || ''
+        )}
       />
 
       <SecureVerificationDialog

--- a/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
+++ b/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
@@ -4824,9 +4824,7 @@ export function ChannelMutateDrawer({
         channelName={
           shouldPreviewUnsavedModels ? currentName?.trim() : undefined
         }
-        existingModelsOverride={parseModelsString(
-          form.getValues('models') || ''
-        )}
+        existingModelsOverride={currentModelsArray}
       />
 
       <SecureVerificationDialog


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本 PR 由 AI 辅助实现，变更范围和验证结果已人工检查。

## 📝 变更描述 / Description
编辑普通渠道时，模型获取弹窗原先会从已保存的 `currentRow.models` 初始化勾选状态，而“清空模型”只修改当前表单值。因此用户清空后再获取上游模型，弹窗仍会重新勾选保存过的旧模型。

本 PR 让表单内打开的模型获取弹窗始终使用当前表单的模型列表作为选择状态来源；同时通过 TypeScript 联合类型约束表单回调模式必须显式传入该列表，避免后续调用点再次回退到已保存快照。独立的渠道列表弹窗仍保持原有行为。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6710

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```text
bun run typecheck
PASS

bunx oxlint -c .oxlintrc.json \
  src/features/channels/components/dialogs/fetch-models-dialog.tsx \
  src/features/channels/components/drawers/channel-mutate-drawer.tsx
PASS

bun test src/features/channels/lib/__tests__
9 pass, 0 fail

bun run build
PASS (Rsbuild v2.1.6)

git diff --check
PASS
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection behavior when configuring channels.
  * Ensured the model picker consistently reflects the channel’s current models, including during channel setup and editing.
  * Prevented incomplete model-selection configurations from being used.
  * Improved consistency when selecting models from both saved channel settings and newly configured channel options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->