### PR TITLE
fix(db): upgrade glebarez/sqlite to v1.11.0 — root-fix SQLite AutoMigrate crash on decimal(x,y) columns (#2823 class)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gin-contrib/gzip v0.0.6
 	github.com/gin-contrib/static v0.0.1
 	github.com/gin-gonic/gin v1.9.1
-	github.com/glebarez/sqlite v1.9.0
+	github.com/glebarez/sqlite v1.11.0
 	github.com/go-audio/aiff v1.1.0
 	github.com/go-audio/wav v1.1.0
 	github.com/go-playground/validator/v10 v10.20.0
@@ -58,7 +58,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.4.3
 	gorm.io/driver/postgres v1.5.2
-	gorm.io/gorm v1.25.2
+	gorm.io/gorm v1.25.7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1114,6 +1114,8 @@ github.com/glebarez/go-sqlite v1.21.2 h1:3a6LFC4sKahUunAmynQKLZceZCOzUthkRkEAl9g
 github.com/glebarez/go-sqlite v1.21.2/go.mod h1:sfxdZyhQjTM2Wry3gVYWaW072Ri1WMdWJi0k6+3382k=
 github.com/glebarez/sqlite v1.9.0 h1:Aj6bPA12ZEx5GbSF6XADmCkYXlljPNUY+Zf1EQxynXs=
 github.com/glebarez/sqlite v1.9.0/go.mod h1:YBYCoyupOao60lzp1MVBLEjZfgkq0tdB1voAQ09K9zw=
+github.com/glebarez/sqlite v1.11.0 h1:wSG0irqzP6VurnMEpFGer5Li19RpIRi2qvQz++w0GMw=
+github.com/glebarez/sqlite v1.11.0/go.mod h1:h8/o8j5wiAsqSPoWELDUdJXhjAhsVliSn7bWZjOhrgQ=
 github.com/go-audio/aiff v1.1.0 h1:m2LYgu/2BarpF2yZnFPWtY3Tp41k0A4y51gDRZZsEuU=
 github.com/go-audio/aiff v1.1.0/go.mod h1:sDik1muYvhPiccClfri0fv6U2fyH/dy4VRWmUz0cz9Q=
 github.com/go-audio/audio v1.0.0 h1:zS9vebldgbQqktK4H0lUqWrG8P0NxCJVqcj7ZpNnwd4=
@@ -3017,6 +3019,8 @@ gorm.io/gorm v1.23.8/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=
 gorm.io/gorm v1.24.6/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=
 gorm.io/gorm v1.25.2 h1:gs1o6Vsa+oVKG/a9ElL3XgyGfghFfkKA2SInQaCyMho=
 gorm.io/gorm v1.25.2/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=
+gorm.io/gorm v1.25.7 h1:VsD6acwRjz2zFxGO50gPO6AkNs7KKnvfzUjHQhZDz/A=
+gorm.io/gorm v1.25.7/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=

--- a/model/subscription_sqlite_migrate_test.go
+++ b/model/subscription_sqlite_migrate_test.go
@@ -1,0 +1,39 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// Regression test: a subscription_plans table created by a previous boot
+// (raw DDL with decimal(10,6), see ensureSubscriptionPlanTableSQLite) must
+// survive AutoMigrate on restart. glebarez/sqlite v1.9.0's AlterColumn
+// regex-replaces the raw DDL field and its lazy `.*?(,|...)` stops at the
+// comma inside decimal(10,6), leaving an orphan `6) NOT NULL` in the DDL;
+// the subsequent parseDDL then fails with "invalid DDL, unbalanced brackets"
+// and startup aborts. This is the root cause behind the v0.10.8 SQLite
+// boot failures (#2823), which were previously worked around by excluding
+// SubscriptionPlan from AutoMigrate on SQLite.
+func TestSubscriptionPlanAutoMigrateOnPopulatedSQLite(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(t.TempDir()+"/test.db"), &gorm.Config{})
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`CREATE TABLE `+"`subscription_plans`"+` (
+`+"`id`"+` integer,
+`+"`title`"+` varchar(128) NOT NULL,
+`+"`price_amount`"+` decimal(10,6) NOT NULL,
+`+"`currency`"+` varchar(8) NOT NULL DEFAULT 'USD',
+`+"`enabled`"+` numeric DEFAULT 1,
+`+"`created_at`"+` bigint,
+`+"`updated_at`"+` bigint,
+PRIMARY KEY (`+"`id`"+`)
+)`).Error)
+
+	// Second boot: AutoMigrate must parse the existing DDL without error.
+	require.NoError(t, db.AutoMigrate(&SubscriptionPlan{}))
+	// Repeated migrations must stay stable.
+	require.NoError(t, db.AutoMigrate(&SubscriptionPlan{}))
+}


### PR DESCRIPTION
## 📝 变更描述 / Description

升级 `github.com/glebarez/sqlite` v1.9.0 → v1.11.0(连带 `gorm.io/gorm` v1.25.2 → v1.25.7,前者必需),根治 #2823 那一类 SQLite 重启崩溃,并附回归测试。

**根因**(在 v0.10.8 复现并逐步定位):glebarez v1.9.0 的 `AlterColumn` 用正则替换原始 DDL 字段,惰性 `.*?(,|...)` 停在**第一个逗号**——`decimal(10,6)` 括号内那个——字段在 `decimal(10,` 处被截断,留下孤儿 `6) NOT NULL`,随后 `parseDDL` 括号深度归负,报 `invalid DDL, unbalanced brackets`,启动中止。且 ddlmod 的类型解析正则 `[\w\(\)\d]+` 同样遇逗号截断(存量类型永远解析成 `decimal(10` ≠ 期望值),导致**每次启动都重新触发**这条坏路径。

**历史**:v0.10.8 时 `&SubscriptionPlan{}`(`decimal(10,6)`)在 AutoMigrate 列表内,SQLite 用户第二次启动即崩(即 #2823);`ba6fa9ab7` 以"SQLite 下排除 AutoMigrate + raw DDL"绕过。这是症状性修复——driver 的 mangle bug 仍在,任何未来带 `decimal(x,y)` 列的模型都会让 SQLite 用户重现同样的致命重启循环。

**本 PR**:依赖升级到 v1.11.0(其 AlterColumn 已重写为先 parseDDL 成结构化 fields 再整字段替换,不再 regex-patch 原始 DDL),对任何 decimal(x,y) 列根治。附带回归测试:用上一次启动产生的 raw `decimal(10,6)` DDL 建表后断言 AutoMigrate 成功(v1.9.0 下 verbatim 复现同错误,升级后通过)。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Related #2823(已关闭的历史事故,本 PR 为其根因修复而非再次绕过)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述已人工整理撰写(核心结论均经本地实证,非直接粘贴原始 AI 输出;本 PR 为 AI 辅助开发,特此声明)
- [x] **非重复提交:** 已搜索 Issues 与 PRs,未见针对该根因的修复(现有 #2823 为绕过方案)
- [x] **Bug fix 说明:** 已关联 #2823;根因有 v0.10.8 时期 verbatim 复现证据
- [x] **变更理解:** 依赖升级机制、gorm 连带 bump、回归测试均已理解
- [x] **范围聚焦:** 仅 go.mod / go.sum / 一个回归测试文件,无无关改动
- [x] **本地验证:** 见下方证明
- [x] **安全合规:** 无敏感凭据,符合规范

## 📸 运行证明 / Proof of Work

RED(升级前,当前 main 依赖):
```
--- FAIL: TestSubscriptionPlanAutoMigrateOnPopulatedSQLite (0.00s)
        invalid DDL, unbalanced brackets
```

GREEN(升级后):
```
ok  	github.com/QuantumNous/new-api/model
```

全套后端测试:`go test ./...` 33 包全部通过,0 FAIL;`go build ./...` 通过。

真实场景:一张曾让 v1.9.0 binary `FATAL: failed to initialize database: invalid DDL, unbalanced brackets` 的存量 SQLite 库,用升级后的 binary 直接启动,migration 通过、服务正常起。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability for existing subscription plan tables.
  * Prevented errors when running repeated migrations on SQLite databases.

* **Tests**
  * Added regression coverage for populated tables and repeated migration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->