### PR TITLE
fix(topup): reject uncreditable orders before payment

### DIFF
--- a/controller/topup.go
+++ b/controller/topup.go
@@ -187,6 +187,54 @@ func getMinTopup() int64 {
 	return int64(minTopup)
 }
 
+func getTopUpQuota(amount int64) (int, error) {
+	quota := decimal.NewFromInt(amount)
+	if operation_setting.GetQuotaDisplayType() != operation_setting.QuotaDisplayTypeTokens {
+		quota = quota.Mul(decimal.NewFromFloat(common.QuotaPerUnit))
+	}
+	return common.QuotaFromDecimalStrict(quota)
+}
+
+func getMaxTopUpAmount() int64 {
+	if operation_setting.GetQuotaDisplayType() == operation_setting.QuotaDisplayTypeTokens {
+		return int64(common.MaxQuota - 1)
+	}
+	if common.QuotaPerUnit <= 0 {
+		return 0
+	}
+	return decimal.NewFromInt(common.MaxQuota - 1).
+		Div(decimal.NewFromFloat(common.QuotaPerUnit)).
+		Floor().IntPart()
+}
+
+func validateCreditedQuota(quota decimal.Decimal) error {
+	value, err := common.QuotaFromDecimalStrict(quota)
+	if err != nil || value <= 0 {
+		return errors.New("充值额度超出系统可表示范围")
+	}
+	return nil
+}
+
+func validateTopUpQuota(amount int64) error {
+	quota, err := getTopUpQuota(amount)
+	if err == nil && quota > 0 {
+		return nil
+	}
+	maxAmount := getMaxTopUpAmount()
+	if maxAmount > 0 && amount > maxAmount {
+		return fmt.Errorf("单笔充值数量不能大于 %d", maxAmount)
+	}
+	return errors.New("充值数量无效")
+}
+
+func rejectInvalidTopUpQuota(c *gin.Context, amount int64) bool {
+	if err := validateTopUpQuota(amount); err != nil {
+		c.JSON(http.StatusOK, gin.H{"message": "error", "data": err.Error()})
+		return true
+	}
+	return false
+}
+
 func RequestEpay(c *gin.Context) {
 	var req EpayRequest
 	err := c.ShouldBindJSON(&req)
@@ -196,6 +244,9 @@ func RequestEpay(c *gin.Context) {
 	}
 	if req.Amount < getMinTopup() {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": fmt.Sprintf("充值数量不能小于 %d", getMinTopup())})
+		return
+	}
+	if rejectInvalidTopUpQuota(c, req.Amount) {
 		return
 	}
 
@@ -410,6 +461,9 @@ func RequestAmount(c *gin.Context) {
 
 	if req.Amount < getMinTopup() {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": fmt.Sprintf("充值数量不能小于 %d", getMinTopup())})
+		return
+	}
+	if rejectInvalidTopUpQuota(c, req.Amount) {
 		return
 	}
 	id := c.GetInt("id")

--- a/controller/topup.go
+++ b/controller/topup.go
@@ -189,28 +189,40 @@ func getMinTopup() int64 {
 
 func getTopUpQuota(amount int64) (int, error) {
 	quota := decimal.NewFromInt(amount)
-	if operation_setting.GetQuotaDisplayType() != operation_setting.QuotaDisplayTypeTokens {
+	if operation_setting.GetQuotaDisplayType() == operation_setting.QuotaDisplayTypeTokens {
+		quotaPerUnit := decimal.NewFromFloat(common.QuotaPerUnit)
+		quota = decimal.NewFromInt(quota.Div(quotaPerUnit).IntPart()).Mul(quotaPerUnit)
+	} else {
 		quota = quota.Mul(decimal.NewFromFloat(common.QuotaPerUnit))
 	}
 	return common.QuotaFromDecimalStrict(quota)
 }
 
 func getMaxTopUpAmount() int64 {
-	if operation_setting.GetQuotaDisplayType() == operation_setting.QuotaDisplayTypeTokens {
-		return int64(common.MaxQuota - 1)
-	}
 	if common.QuotaPerUnit <= 0 {
 		return 0
 	}
-	return decimal.NewFromInt(common.MaxQuota - 1).
-		Div(decimal.NewFromFloat(common.QuotaPerUnit)).
-		Floor().IntPart()
+	quotaPerUnit := decimal.NewFromFloat(common.QuotaPerUnit)
+	maxStoredAmount := decimal.NewFromInt(common.MaxQuota - 1).
+		Div(quotaPerUnit).
+		Floor()
+	if operation_setting.GetQuotaDisplayType() == operation_setting.QuotaDisplayTypeTokens {
+		return maxStoredAmount.Add(decimal.NewFromInt(1)).
+			Mul(quotaPerUnit).
+			Ceil().
+			Sub(decimal.NewFromInt(1)).
+			IntPart()
+	}
+	return maxStoredAmount.IntPart()
 }
 
 func validateCreditedQuota(quota decimal.Decimal) error {
 	value, err := common.QuotaFromDecimalStrict(quota)
-	if err != nil || value <= 0 {
+	if err != nil {
 		return errors.New("充值额度超出系统可表示范围")
+	}
+	if value <= 0 {
+		return errors.New("充值额度必须大于 0")
 	}
 	return nil
 }

--- a/controller/topup_creem.go
+++ b/controller/topup_creem.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
 	"github.com/thanhpk/randstr"
 )
 
@@ -94,6 +95,10 @@ func (*CreemAdaptor) RequestPay(c *gin.Context, req *CreemPayRequest) {
 
 	if selectedProduct == nil {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "产品不存在"})
+		return
+	}
+	if err := validateCreditedQuota(decimal.NewFromInt(selectedProduct.Quota)); err != nil {
+		c.JSON(http.StatusOK, gin.H{"message": "error", "data": err.Error()})
 		return
 	}
 

--- a/controller/topup_quota_limit_test.go
+++ b/controller/topup_quota_limit_test.go
@@ -136,4 +136,7 @@ func TestStripeCreditedQuotaIncludesGroupRatio(t *testing.T) {
 
 	require.NoError(t, validateCreditedQuota(getStripeCreditedQuota(2147, "vip")))
 	require.Error(t, validateCreditedQuota(getStripeCreditedQuota(2148, "vip")))
+
+	require.NoError(t, common.UpdateTopupGroupRatioByJSONString(`{"free":0}`))
+	assert.True(t, decimal.NewFromInt(500000).Equal(getStripeCreditedQuota(1, "free")))
 }

--- a/controller/topup_quota_limit_test.go
+++ b/controller/topup_quota_limit_test.go
@@ -1,0 +1,139 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/setting/operation_setting"
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopUpQuotaValidation(t *testing.T) {
+	oldQuotaPerUnit := common.QuotaPerUnit
+	oldDisplayType := operation_setting.GetGeneralSetting().QuotaDisplayType
+	common.QuotaPerUnit = 500000
+	t.Cleanup(func() {
+		common.QuotaPerUnit = oldQuotaPerUnit
+		operation_setting.GetGeneralSetting().QuotaDisplayType = oldDisplayType
+	})
+
+	testCases := []struct {
+		name        string
+		displayType string
+		amount      int64
+		wantQuota   int
+		wantErr     bool
+	}{
+		{
+			name:        "currency amount below limit",
+			displayType: operation_setting.QuotaDisplayTypeUSD,
+			amount:      4294,
+			wantQuota:   2_147_000_000,
+		},
+		{
+			name:        "currency amount above limit",
+			displayType: operation_setting.QuotaDisplayTypeUSD,
+			amount:      4295,
+			wantErr:     true,
+		},
+		{
+			name:        "token amount below limit",
+			displayType: operation_setting.QuotaDisplayTypeTokens,
+			amount:      common.MaxQuota - 1,
+			wantQuota:   common.MaxQuota - 1,
+		},
+		{
+			name:        "token amount at strict boundary",
+			displayType: operation_setting.QuotaDisplayTypeTokens,
+			amount:      common.MaxQuota,
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			operation_setting.GetGeneralSetting().QuotaDisplayType = tc.displayType
+			quota, err := getTopUpQuota(tc.amount)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantQuota, quota)
+		})
+	}
+}
+
+func TestValidateTopUpQuotaReturnsMaximumAmount(t *testing.T) {
+	oldQuotaPerUnit := common.QuotaPerUnit
+	oldDisplayType := operation_setting.GetGeneralSetting().QuotaDisplayType
+	common.QuotaPerUnit = 500000
+	operation_setting.GetGeneralSetting().QuotaDisplayType = operation_setting.QuotaDisplayTypeUSD
+	t.Cleanup(func() {
+		common.QuotaPerUnit = oldQuotaPerUnit
+		operation_setting.GetGeneralSetting().QuotaDisplayType = oldDisplayType
+	})
+
+	maxAmount := decimal.NewFromInt(common.MaxQuota - 1).
+		Div(decimal.NewFromFloat(common.QuotaPerUnit)).
+		Floor().IntPart()
+
+	require.NoError(t, validateTopUpQuota(maxAmount))
+	err := validateTopUpQuota(maxAmount + 1)
+	require.EqualError(t, err, "单笔充值数量不能大于 4294")
+}
+
+func TestRequestAmountRejectsTopUpThatCannotBeSettled(t *testing.T) {
+	oldQuotaPerUnit := common.QuotaPerUnit
+	oldDisplayType := operation_setting.GetGeneralSetting().QuotaDisplayType
+	common.QuotaPerUnit = 500000
+	operation_setting.GetGeneralSetting().QuotaDisplayType = operation_setting.QuotaDisplayTypeUSD
+	t.Cleanup(func() {
+		common.QuotaPerUnit = oldQuotaPerUnit
+		operation_setting.GetGeneralSetting().QuotaDisplayType = oldDisplayType
+	})
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/api/user/amount",
+		strings.NewReader(`{"amount":4295}`),
+	)
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	RequestAmount(ctx)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.JSONEq(t, `{"message":"error","data":"单笔充值数量不能大于 4294"}`, recorder.Body.String())
+}
+
+func TestValidateCreditedQuotaRejectsOverflow(t *testing.T) {
+	require.NoError(t, validateCreditedQuota(decimal.NewFromInt(common.MaxQuota-1)))
+	require.EqualError(
+		t,
+		validateCreditedQuota(decimal.NewFromInt(common.MaxQuota)),
+		"充值额度超出系统可表示范围",
+	)
+}
+
+func TestStripeCreditedQuotaIncludesGroupRatio(t *testing.T) {
+	oldQuotaPerUnit := common.QuotaPerUnit
+	oldTopupGroupRatio := common.TopupGroupRatio2JSONString()
+	common.QuotaPerUnit = 500000
+	require.NoError(t, common.UpdateTopupGroupRatioByJSONString(`{"vip":2}`))
+	t.Cleanup(func() {
+		common.QuotaPerUnit = oldQuotaPerUnit
+		require.NoError(t, common.UpdateTopupGroupRatioByJSONString(oldTopupGroupRatio))
+	})
+
+	require.NoError(t, validateCreditedQuota(getStripeCreditedQuota(2147, "vip")))
+	require.Error(t, validateCreditedQuota(getStripeCreditedQuota(2148, "vip")))
+}

--- a/controller/topup_quota_limit_test.go
+++ b/controller/topup_quota_limit_test.go
@@ -43,15 +43,15 @@ func TestTopUpQuotaValidation(t *testing.T) {
 			wantErr:     true,
 		},
 		{
-			name:        "token amount below limit",
-			displayType: operation_setting.QuotaDisplayTypeTokens,
-			amount:      common.MaxQuota - 1,
-			wantQuota:   common.MaxQuota - 1,
-		},
-		{
-			name:        "token amount at strict boundary",
+			name:        "token amount preserves settlement truncation",
 			displayType: operation_setting.QuotaDisplayTypeTokens,
 			amount:      common.MaxQuota,
+			wantQuota:   2_147_000_000,
+		},
+		{
+			name:        "token amount above settlement limit",
+			displayType: operation_setting.QuotaDisplayTypeTokens,
+			amount:      2_147_500_000,
 			wantErr:     true,
 		},
 	}
@@ -117,6 +117,7 @@ func TestRequestAmountRejectsTopUpThatCannotBeSettled(t *testing.T) {
 
 func TestValidateCreditedQuotaRejectsOverflow(t *testing.T) {
 	require.NoError(t, validateCreditedQuota(decimal.NewFromInt(common.MaxQuota-1)))
+	require.EqualError(t, validateCreditedQuota(decimal.Zero), "充值额度必须大于 0")
 	require.EqualError(
 		t,
 		validateCreditedQuota(decimal.NewFromInt(common.MaxQuota)),

--- a/controller/topup_stripe.go
+++ b/controller/topup_stripe.go
@@ -17,6 +17,7 @@ import (
 	"github.com/QuantumNous/new-api/setting/operation_setting"
 
 	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
 	"github.com/stripe/stripe-go/v81"
 	"github.com/stripe/stripe-go/v81/checkout/session"
 	"github.com/stripe/stripe-go/v81/webhook"
@@ -51,6 +52,10 @@ func (*StripeAdaptor) RequestAmount(c *gin.Context, req *StripePayRequest) {
 	group, err := model.GetUserGroup(id, true)
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "获取用户分组失败"})
+		return
+	}
+	if err := validateCreditedQuota(getStripeCreditedQuota(req.Amount, group)); err != nil {
+		c.JSON(http.StatusOK, gin.H{"message": "error", "data": err.Error()})
 		return
 	}
 	payMoney := getStripePayMoney(float64(req.Amount), group)
@@ -88,6 +93,12 @@ func (*StripeAdaptor) RequestPay(c *gin.Context, req *StripePayRequest) {
 	id := c.GetInt("id")
 	user, _ := model.GetUserById(id, false)
 	chargedMoney := GetChargedAmount(float64(req.Amount), *user)
+	if err := validateCreditedQuota(
+		decimal.NewFromFloat(chargedMoney).Mul(decimal.NewFromFloat(common.QuotaPerUnit)),
+	); err != nil {
+		c.JSON(http.StatusOK, gin.H{"message": "error", "data": err.Error()})
+		return
+	}
 
 	reference := fmt.Sprintf("new-api-ref-%d-%d-%s", user.Id, time.Now().UnixMilli(), randstr.String(4))
 	referenceId := "ref_" + common.Sha1([]byte(reference))
@@ -392,6 +403,13 @@ func GetChargedAmount(count float64, user model.User) float64 {
 	}
 
 	return count * topUpGroupRatio
+}
+
+func getStripeCreditedQuota(amount int64, group string) decimal.Decimal {
+	topUpGroupRatio := common.GetTopupGroupRatio(group)
+	return decimal.NewFromInt(amount).
+		Mul(decimal.NewFromFloat(topUpGroupRatio)).
+		Mul(decimal.NewFromFloat(common.QuotaPerUnit))
 }
 
 func getStripePayMoney(amount float64, group string) float64 {

--- a/controller/topup_stripe.go
+++ b/controller/topup_stripe.go
@@ -48,6 +48,10 @@ func (*StripeAdaptor) RequestAmount(c *gin.Context, req *StripePayRequest) {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": fmt.Sprintf("充值数量不能小于 %d", getStripeMinTopup())})
 		return
 	}
+	if req.Amount > 10000 {
+		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "充值数量不能大于 10000"})
+		return
+	}
 	id := c.GetInt("id")
 	group, err := model.GetUserGroup(id, true)
 	if err != nil {

--- a/controller/topup_stripe.go
+++ b/controller/topup_stripe.go
@@ -407,6 +407,9 @@ func GetChargedAmount(count float64, user model.User) float64 {
 
 func getStripeCreditedQuota(amount int64, group string) decimal.Decimal {
 	topUpGroupRatio := common.GetTopupGroupRatio(group)
+	if topUpGroupRatio == 0 {
+		topUpGroupRatio = 1
+	}
 	return decimal.NewFromInt(amount).
 		Mul(decimal.NewFromFloat(topUpGroupRatio)).
 		Mul(decimal.NewFromFloat(common.QuotaPerUnit))

--- a/controller/topup_waffo.go
+++ b/controller/topup_waffo.go
@@ -123,6 +123,9 @@ func RequestWaffoAmount(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": fmt.Sprintf("充值数量不能小于 %d", waffoMinTopup)})
 		return
 	}
+	if rejectInvalidTopUpQuota(c, req.Amount) {
+		return
+	}
 
 	id := c.GetInt("id")
 	group, err := model.GetUserGroup(id, true)
@@ -155,6 +158,9 @@ func RequestWaffoPay(c *gin.Context) {
 	waffoMinTopup := int64(setting.WaffoMinTopUp)
 	if req.Amount < waffoMinTopup {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": fmt.Sprintf("充值数量不能小于 %d", waffoMinTopup)})
+		return
+	}
+	if rejectInvalidTopUpQuota(c, req.Amount) {
 		return
 	}
 

--- a/controller/topup_waffo_pancake.go
+++ b/controller/topup_waffo_pancake.go
@@ -33,6 +33,9 @@ func RequestWaffoPancakeAmount(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": fmt.Sprintf("充值数量不能小于 %d", setting.WaffoPancakeMinTopUp)})
 		return
 	}
+	if rejectInvalidTopUpQuota(c, req.Amount) {
+		return
+	}
 
 	id := c.GetInt("id")
 	group, err := model.GetUserGroup(id, true)
@@ -349,6 +352,9 @@ func RequestWaffoPancakePay(c *gin.Context) {
 	}
 	if req.Amount < int64(setting.WaffoPancakeMinTopUp) {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": fmt.Sprintf("充值数量不能小于 %d", setting.WaffoPancakeMinTopUp)})
+		return
+	}
+	if rejectInvalidTopUpQuota(c, req.Amount) {
 		return
 	}
 


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本 PR 由 AI 辅助实现，变更范围、支付路径和验证结果已人工检查。

## 📝 变更描述 / Description
当前充值结算会通过 `QuotaFromDecimalStrict` 拒绝超过 int32 额度域的入账，但多个支付入口仍允许用户创建并支付这种订单。支付完成后回调无法入账，订单会停留在 pending。

本 PR 在拉起支付之前复用同一 strict 额度边界进行校验：

- 易支付、Waffo、Waffo Pancake：按当前展示模式将请求数量换算成最终额度，并同时覆盖金额预览接口和支付接口；
- Stripe：按用户分组充值倍率计算最终入账额度，覆盖金额预览和支付接口；
- Creem：在创建产品订单前校验产品配置中的固定额度；
- 超过边界时返回明确错误；默认 `QuotaPerUnit=500000` 时，单笔金额上限提示为 `4294`。

结算层现有 strict 校验保持不变，继续作为最终防线。本 PR 不扩大额度域，也不修改数据库 schema。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6831

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

新增回归测试覆盖：

- 默认配置下金额 `4294` 可入账、`4295` 被提前拒绝；
- Token 展示模式的 strict 边界；
- `/api/user/amount` 在查询支付金额前返回明确上限错误；
- Creem 固定额度边界；
- Stripe 分组充值倍率参与最终额度校验。

```text
go test ./controller ./model ./common -count=1
PASS

go vet ./controller ./model ./common
PASS

go build ./...
PASS

git diff --check
PASS
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Top-up requests now reject invalid, non-positive, or unrepresentable quota amounts.
  * Added safeguards against quota overflow and amounts exceeding configured limits.
  * Improved validation across Epay, Stripe, Creem, Waffo, and Waffo Pancake payment flows.
  * Stripe quota previews and checkout calculations now accurately include applicable group ratios.

* **Tests**
  * Added coverage for quota boundaries, maximum recharge amounts, settlement validation, overflow protection, and payment calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->