### PR TITLE
fix(baidu_v2): complete Claude adapter — add anthropic endpoint routing/header/response

### DIFF
--- a/relay/channel/baidu_v2/adaptor.go
+++ b/relay/channel/baidu_v2/adaptor.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/QuantumNous/new-api/relay/channel"
+	"github.com/QuantumNous/new-api/relay/channel/claude"
 	"github.com/QuantumNous/new-api/relay/channel/openai"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/constant"
@@ -26,8 +27,10 @@ func (a *Adaptor) ConvertGeminiRequest(*gin.Context, *relaycommon.RelayInfo, *dt
 }
 
 func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, info *relaycommon.RelayInfo, req *dto.ClaudeRequest) (any, error) {
-	adaptor := openai.Adaptor{}
-	return adaptor.ConvertClaudeRequest(c, info, req)
+	if req == nil {
+		return nil, errors.New("request is nil")
+	}
+	return req, nil
 }
 
 func (a *Adaptor) ConvertAudioRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.AudioRequest) (io.Reader, error) {
@@ -44,6 +47,9 @@ func (a *Adaptor) Init(info *relaycommon.RelayInfo) {
 }
 
 func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
+	if info.RelayFormat == types.RelayFormatClaude {
+		return fmt.Sprintf("%s/anthropic/v1/messages", info.ChannelBaseUrl), nil
+	}
 	switch info.RelayMode {
 	case constant.RelayModeChatCompletions:
 		return fmt.Sprintf("%s/v2/chat/completions", info.ChannelBaseUrl), nil
@@ -70,6 +76,13 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *rel
 		if keyParts[1] != "" {
 			req.Set("appid", keyParts[1])
 		}
+	}
+	if info.RelayFormat == types.RelayFormatClaude {
+		req.Set("x-api-key", keyParts[0])
+		if req.Get("anthropic-version") == "" {
+			req.Set("anthropic-version", "2023-06-01")
+		}
+		return nil
 	}
 	req.Set("Authorization", "Bearer "+keyParts[0])
 	return nil
@@ -116,6 +129,10 @@ func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, request
 }
 
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
+	if info.RelayFormat == types.RelayFormatClaude {
+		adaptor := claude.Adaptor{}
+		return adaptor.DoResponse(c, resp, info)
+	}
 	adaptor := openai.Adaptor{}
 	usage, err = adaptor.DoResponse(c, resp, info)
 	return

--- a/relay/channel/baidu_v2/adaptor.go
+++ b/relay/channel/baidu_v2/adaptor.go
@@ -79,9 +79,12 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *rel
 	}
 	if info.RelayFormat == types.RelayFormatClaude {
 		req.Set("x-api-key", keyParts[0])
-		if req.Get("anthropic-version") == "" {
-			req.Set("anthropic-version", "2023-06-01")
+		anthropicVersion := c.Request.Header.Get("anthropic-version")
+		if anthropicVersion == "" {
+			anthropicVersion = "2023-06-01"
 		}
+		req.Set("anthropic-version", anthropicVersion)
+		claude.CommonClaudeHeadersOperation(c, req, info)
 		return nil
 	}
 	req.Set("Authorization", "Bearer "+keyParts[0])

--- a/relay/channel/baidu_v2/adaptor_test.go
+++ b/relay/channel/baidu_v2/adaptor_test.go
@@ -1,6 +1,7 @@
 package baidu_v2
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -36,7 +37,7 @@ func baiduV2RelayInfo(apiKey string, format types.RelayFormat) *relaycommon.Rela
 func baiduV2GinContext(path string, clientHeaders map[string]string) *gin.Context {
 	gin.SetMode(gin.TestMode)
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Request = httptest.NewRequest(http.MethodPost, path, nil)
+	c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodPost, path, nil)
 	c.Request.Header.Set("Content-Type", "application/json")
 	for k, v := range clientHeaders {
 		c.Request.Header.Set(k, v)

--- a/relay/channel/baidu_v2/adaptor_test.go
+++ b/relay/channel/baidu_v2/adaptor_test.go
@@ -1,0 +1,156 @@
+package baidu_v2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/relaykit/types"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// baiduV2RelayInfo builds a minimal RelayInfo for header/URL tests.
+// ApiKey format: "<bearer_token>|<appid>", matching the Baidu Qianfan v2 gateway
+// convention where the pipe splits the authorization token and app id.
+func baiduV2RelayInfo(apiKey string, format types.RelayFormat) *relaycommon.RelayInfo {
+	return &relaycommon.RelayInfo{
+		RelayFormat:     format,
+		RelayMode:       relayconstant.RelayModeChatCompletions,
+		RequestURLPath:  "/v1/chat/completions",
+		OriginModelName: "ernie-x1",
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ApiKey:            apiKey,
+			ChannelBaseUrl:    "https://qianfan.baidubce.com",
+			ChannelType:       constant.ChannelTypeBaiduV2,
+			UpstreamModelName: "ernie-x1",
+		},
+	}
+}
+
+func baiduV2GinContext(path string, clientHeaders map[string]string) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, path, nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+	for k, v := range clientHeaders {
+		c.Request.Header.Set(k, v)
+	}
+	return c
+}
+
+// TestSetupRequestHeader_OpenAI_UsesBearerAuth ensures the OpenAI-format branch
+// still writes the Authorization: Bearer <token> header (regression guard).
+func TestSetupRequestHeader_OpenAI_UsesBearerAuth(t *testing.T) {
+	adaptor := &Adaptor{}
+	info := baiduV2RelayInfo("bce-v2-token|my-app", types.RelayFormatOpenAI)
+	c := baiduV2GinContext("/v1/chat/completions", nil)
+	header := http.Header{}
+
+	require.NoError(t, adaptor.SetupRequestHeader(c, &header, info))
+	assert.Equal(t, "Bearer bce-v2-token", header.Get("Authorization"))
+	assert.Equal(t, "my-app", header.Get("appid"))
+	assert.Empty(t, header.Get("x-api-key"))
+	assert.Empty(t, header.Get("anthropic-version"))
+}
+
+// TestSetupRequestHeader_OpenAI_NoAppID handles the single-segment key case.
+func TestSetupRequestHeader_OpenAI_NoAppID(t *testing.T) {
+	adaptor := &Adaptor{}
+	info := baiduV2RelayInfo("bce-v2-token", types.RelayFormatOpenAI)
+	c := baiduV2GinContext("/v1/chat/completions", nil)
+	header := http.Header{}
+
+	require.NoError(t, adaptor.SetupRequestHeader(c, &header, info))
+	assert.Equal(t, "Bearer bce-v2-token", header.Get("Authorization"))
+	assert.Empty(t, header.Get("appid"))
+}
+
+// TestSetupRequestHeader_Claude_DefaultVersion asserts the default
+// anthropic-version fallback when the client does not send one.
+func TestSetupRequestHeader_Claude_DefaultVersion(t *testing.T) {
+	adaptor := &Adaptor{}
+	info := baiduV2RelayInfo("bce-claude-token|claude-app", types.RelayFormatClaude)
+	c := baiduV2GinContext("/anthropic/v1/messages", nil)
+	header := http.Header{}
+
+	require.NoError(t, adaptor.SetupRequestHeader(c, &header, info))
+	assert.Equal(t, "bce-claude-token", header.Get("x-api-key"))
+	assert.Equal(t, "claude-app", header.Get("appid"))
+	assert.Equal(t, "2023-06-01", header.Get("anthropic-version"))
+	assert.Empty(t, header.Get("Authorization"), "Claude branch must not set Bearer Authorization")
+}
+
+// TestSetupRequestHeader_Claude_PreservesClientVersion regressions PR #6849:
+// when the client sends anthropic-version, the adapter MUST forward it
+// instead of overwriting with the hard-coded default.
+func TestSetupRequestHeader_Claude_PreservesClientVersion(t *testing.T) {
+	adaptor := &Adaptor{}
+	info := baiduV2RelayInfo("bce-claude-token|claude-app", types.RelayFormatClaude)
+	c := baiduV2GinContext("/anthropic/v1/messages", map[string]string{
+		"anthropic-version": "2024-01-01",
+	})
+	header := http.Header{}
+
+	require.NoError(t, adaptor.SetupRequestHeader(c, &header, info))
+	assert.Equal(t, "2024-01-01", header.Get("anthropic-version"),
+		"client-provided anthropic-version must not be overwritten by the default")
+}
+
+// TestSetupRequestHeader_Claude_ForwardsAnthropicBeta regressions PR #6849:
+// anthropic-beta must be forwarded via claude.CommonClaudeHeadersOperation.
+func TestSetupRequestHeader_Claude_ForwardsAnthropicBeta(t *testing.T) {
+	adaptor := &Adaptor{}
+	info := baiduV2RelayInfo("bce-claude-token|claude-app", types.RelayFormatClaude)
+	c := baiduV2GinContext("/anthropic/v1/messages", map[string]string{
+		"anthropic-beta": "prompt-caching-2024-07-31,fine-grained-tool-streaming-2025-05-14",
+	})
+	header := http.Header{}
+
+	require.NoError(t, adaptor.SetupRequestHeader(c, &header, info))
+	assert.Equal(t,
+		"prompt-caching-2024-07-31,fine-grained-tool-streaming-2025-05-14",
+		header.Get("anthropic-beta"),
+		"anthropic-beta must be forwarded from the client request headers")
+}
+
+// TestSetupRequestHeader_InvalidKey guards against callers with an empty
+// authorization segment, which would otherwise reach the upstream with a blank
+// bearer/x-api-key.
+func TestSetupRequestHeader_InvalidKey(t *testing.T) {
+	adaptor := &Adaptor{}
+	info := baiduV2RelayInfo("|only-appid", types.RelayFormatOpenAI)
+	c := baiduV2GinContext("/v1/chat/completions", nil)
+	header := http.Header{}
+
+	err := adaptor.SetupRequestHeader(c, &header, info)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid API key")
+}
+
+// TestGetRequestURL_ClaudeRoutesToAnthropicMessages verifies the Claude branch
+// of the URL builder — the routing half of PR #6849.
+func TestGetRequestURL_ClaudeRoutesToAnthropicMessages(t *testing.T) {
+	adaptor := &Adaptor{}
+	info := baiduV2RelayInfo("bce-claude-token|claude-app", types.RelayFormatClaude)
+
+	url, err := adaptor.GetRequestURL(info)
+	require.NoError(t, err)
+	assert.Equal(t, "https://qianfan.baidubce.com/anthropic/v1/messages", url)
+}
+
+// TestGetRequestURL_OpenAIChatCompletionsUnchanged ensures the OpenAI URL is
+// still emitted for the standard chat/completions relay mode.
+func TestGetRequestURL_OpenAIChatCompletionsUnchanged(t *testing.T) {
+	adaptor := &Adaptor{}
+	info := baiduV2RelayInfo("bce-v2-token|my-app", types.RelayFormatOpenAI)
+
+	url, err := adaptor.GetRequestURL(info)
+	require.NoError(t, err)
+	assert.Equal(t, "https://qianfan.baidubce.com/v2/chat/completions", url)
+}


### PR DESCRIPTION
## Problem

Baidu Qianfan V2 supports Anthropic Claude API natively at `/anthropic/v1/messages`, but the current `baidu_v2.Adaptor` only wires up `ConvertClaudeRequest` (fixed in #2296).

Requests hitting a Baidu V2 channel with `RelayFormat=Claude` still fail with:

```
500 get request url failed: unsupported relay mode: 0
```

Root cause: `GetRequestURL`, `SetupRequestHeader` and `DoResponse` all lack a `RelayFormat=Claude` branch, so the request falls through to the OpenAI-shaped default paths.

## Solution

Complete the three remaining paths, following the same pattern already used by `minimax` adaptor for its `/anthropic/v1/messages` endpoint:

| Function | Change |
|:---|:---|
| `GetRequestURL` | Route to `{baseUrl}/anthropic/v1/messages` when `RelayFormat=Claude` |
| `SetupRequestHeader` | Switch to `x-api-key` + `anthropic-version: 2023-06-01` header (default if client did not provide one) |
| `ConvertClaudeRequest` | Pass request through natively — no OpenAI degradation, so Qianfan receives a real Anthropic Messages body preserving `tool_use`/`thinking`/content blocks |
| `DoResponse` | Delegate to `claude.Adaptor` so native Anthropic SSE events (`message_start` / `content_block_delta` / `message_stop`) are parsed correctly |

## Diff Size

`+19 / -2` on a single file (`relay/channel/baidu_v2/adaptor.go`).

## Verification

Verified end-to-end against Qianfan production:

- ✅ HTTP 200 for both streaming and non-streaming requests
- ✅ 151k prompt tokens with prompt_cache_hit correctly recorded
- ✅ Anthropic-format usage returned to client (`prompt_tokens`, `completion_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`)
- ✅ OpenAI-compatible `/v1/chat/completions` requests unaffected (existing switch branches untouched)

## References

- Qianfan Anthropic API docs: https://cloud.baidu.com/doc/qianfan-api/s/wm7rwj5nz
- Related previous PR: #2296 (initial ConvertClaudeRequest fix by @seefs001)
- Reference pattern: `relay/channel/minimax/relay-minimax.go` and `adaptor.go`

## Impact

Only affects Baidu V2 channels **and** `RelayFormat=Claude` requests. All existing `RelayMode`-driven paths (OpenAI chat / embeddings / images / rerank) are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Claude-format requests through the Baidu v2 integration.
  * Claude requests now use the appropriate messages endpoint, authentication, API-version headers, and response handling.

* **Bug Fixes**
  * Preserved existing OpenAI request and response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->