### PR TITLE
feat: add OrcaRouter channel type

### DIFF
--- a/common/api_type.go
+++ b/common/api_type.go
@@ -81,6 +81,8 @@ func ChannelType2APIType(channelType int) (int, bool) {
 		apiType = constant.APITypeSub2API
 	case constant.ChannelTypeNewAPI:
 		apiType = constant.APITypeNewAPI
+	case constant.ChannelTypeOrcaRouter:
+		apiType = constant.APITypeOrcaRouter
 	}
 	if apiType == -1 {
 		return constant.APITypeOpenAI, false

--- a/common/endpoint_type.go
+++ b/common/endpoint_type.go
@@ -26,6 +26,8 @@ func GetEndpointTypesByChannelType(channelType int, modelName string) []constant
 		endpointTypes = []constant.EndpointType{constant.EndpointTypeGemini, constant.EndpointTypeOpenAI}
 	case constant.ChannelTypeOpenRouter: // OpenRouter 只支持 OpenAI 端点
 		endpointTypes = []constant.EndpointType{constant.EndpointTypeOpenAI}
+	case constant.ChannelTypeOrcaRouter: // OrcaRouter 只支持 OpenAI 端点
+		endpointTypes = []constant.EndpointType{constant.EndpointTypeOpenAI}
 	case constant.ChannelTypeXai:
 		endpointTypes = []constant.EndpointType{constant.EndpointTypeOpenAI, constant.EndpointTypeOpenAIResponse}
 	case constant.ChannelTypeSora:

--- a/constant/api_type.go
+++ b/constant/api_type.go
@@ -39,5 +39,6 @@ const (
 	APITypeAdvancedCustom
 	APITypeSub2API
 	APITypeNewAPI
+	APITypeOrcaRouter
 	APITypeDummy // this one is only for count, do not add any channel after this
 )

--- a/constant/channel.go
+++ b/constant/channel.go
@@ -58,6 +58,7 @@ const (
 	ChannelTypeAdvancedCustom = 58
 	ChannelTypeSub2API        = 59
 	ChannelTypeNewAPI         = 60
+	ChannelTypeOrcaRouter     = 61
 	ChannelTypeDummy          // this one is only for count, do not add any channel after this
 
 )
@@ -124,6 +125,7 @@ var ChannelBaseURLs = []string{
 	"",                                          //58
 	"",                                          //59
 	"",                                          //60
+	"https://api.orcarouter.ai",                 // 61
 }
 
 var ChannelTypeNames = map[int]string{
@@ -184,6 +186,7 @@ var ChannelTypeNames = map[int]string{
 	ChannelTypeAdvancedCustom: "Advanced Custom",
 	ChannelTypeSub2API:        "Sub2API",
 	ChannelTypeNewAPI:         "New API",
+	ChannelTypeOrcaRouter:     "OrcaRouter",
 }
 
 func GetChannelTypeName(channelType int) string {

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -23,6 +23,7 @@ import (
 
 	//"github.com/QuantumNous/new-api/relay/channel/minimax"
 	"github.com/QuantumNous/new-api/relay/channel/openrouter"
+	"github.com/QuantumNous/new-api/relay/channel/orcarouter"
 	"github.com/QuantumNous/new-api/relay/channel/xinference"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/common_handler"
@@ -680,6 +681,8 @@ func (a *Adaptor) GetModelList() []string {
 		return xinference.ModelList
 	case constant.ChannelTypeOpenRouter:
 		return openrouter.ModelList
+	case constant.ChannelTypeOrcaRouter:
+		return orcarouter.ModelList
 	default:
 		return ModelList
 	}
@@ -697,6 +700,8 @@ func (a *Adaptor) GetChannelName() string {
 		return xinference.ChannelName
 	case constant.ChannelTypeOpenRouter:
 		return openrouter.ChannelName
+	case constant.ChannelTypeOrcaRouter:
+		return orcarouter.ChannelName
 	default:
 		return ChannelName
 	}

--- a/relay/channel/orcarouter/constant.go
+++ b/relay/channel/orcarouter/constant.go
@@ -1,0 +1,5 @@
+package orcarouter
+
+var ModelList = []string{}
+
+var ChannelName = "orcarouter"

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -346,6 +346,7 @@ var streamSupportedChannels = map[int]bool{
 	constant.ChannelTypeSub2API:        true,
 	constant.ChannelTypeNewAPI:         true,
 	constant.ChannelTypeTencent:        true,
+	constant.ChannelTypeOrcaRouter:     true,
 }
 
 func GenRelayInfoWs(c *gin.Context, ws *websocket.Conn) *RelayInfo {

--- a/relay/relay_adaptor.go
+++ b/relay/relay_adaptor.go
@@ -129,6 +129,8 @@ func GetAdaptor(apiType int) channel.Adaptor {
 		return &sub2api.Adaptor{}
 	case constant.APITypeNewAPI:
 		return &newapi.Adaptor{}
+	case constant.APITypeOrcaRouter:
+		return &openai.Adaptor{}
 	}
 	return nil
 }

--- a/web/src/features/channels/constants.ts
+++ b/web/src/features/channels/constants.ts
@@ -23,6 +23,8 @@ For commercial licensing, please contact support@quantumnous.com
 
 export const CHANNEL_TYPE_NEW_API = 60
 
+export const CHANNEL_TYPE_ORCA_ROUTER = 61
+
 export const CHANNEL_TYPES = {
   0: 'Unknown',
   1: 'OpenAI',
@@ -81,12 +83,13 @@ export const CHANNEL_TYPES = {
   58: 'Advanced Custom',
   59: 'Sub2API',
   60: 'New API',
+  61: 'OrcaRouter',
 } as const
 
 const CHANNEL_TYPE_DISPLAY_ORDER: number[] = [
-  1, 14, 33, 24, 43, 3, 41, 48, 60, 58, 42, 34, 20, 4, 40, 27, 25, 17, 26, 15,
-  46, 23, 18, 45, 31, 35, 49, 19, 47, 37, 38, 39, 11, 8, 57, 59, 22, 21, 44, 2,
-  5, 36, 50, 51, 52, 53, 54, 55, 56,
+  1, 14, 33, 24, 43, 3, 41, 48, 60, 58, 42, 34, 20, 61, 4, 40, 27, 25, 17, 26,
+  15, 46, 23, 18, 45, 31, 35, 49, 19, 47, 37, 38, 39, 11, 8, 57, 59, 22, 21, 44,
+  2, 5, 36, 50, 51, 52, 53, 54, 55, 56,
 ]
 
 export const CHANNEL_TYPE_OPTIONS: { value: number; label: string }[] = (() => {
@@ -389,7 +392,7 @@ export const FIELD_DESCRIPTIONS = {
 
 export const MODEL_FETCHABLE_TYPES = new Set([
   1, 4, 14, 17, 20, 23, 24, 25, 26, 27, 31, 34, 35, 40, 42, 43, 47, 48, 57, 58,
-  59, 60,
+  59, 60, 61,
 ])
 
 export const TYPE_TO_KEY_PROMPT: Record<number, string> = {
@@ -403,6 +406,7 @@ export const TYPE_TO_KEY_PROMPT: Record<number, string> = {
   57: 'Paste Codex OAuth JSON credential (access_token / refresh_token / account_id)',
   59: 'Enter API key for this channel',
   60: 'Enter API key for this channel',
+  61: 'Enter API key for this channel',
 }
 
 export const CHANNEL_TYPE_WARNINGS: Record<number, string> = {

--- a/web/src/features/channels/lib/__tests__/orcarouter-channel.test.ts
+++ b/web/src/features/channels/lib/__tests__/orcarouter-channel.test.ts
@@ -1,0 +1,82 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import {
+  CHANNEL_TYPE_OPTIONS,
+  CHANNEL_TYPE_ORCA_ROUTER,
+  MODEL_FETCHABLE_TYPES,
+} from '../../constants'
+import { CHANNEL_FORM_DEFAULT_VALUES, channelFormSchema } from '../channel-form'
+import { getChannelTypeConfig } from '../channel-type-config'
+import { getChannelTypeIcon, getKeyPromptForType } from '../channel-utils'
+
+function orcaRouterForm(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    ...CHANNEL_FORM_DEFAULT_VALUES,
+    name: 'OrcaRouter upstream',
+    type: CHANNEL_TYPE_ORCA_ROUTER,
+    key: 'sk-orca-test-key',
+    models: 'deepseek/deepseek-v4-flash',
+    ...overrides,
+  }
+}
+
+describe('OrcaRouter channel', () => {
+  test('registers selection, ordering, model discovery, and icon metadata', () => {
+    const option = CHANNEL_TYPE_OPTIONS.find(
+      (item) => item.value === CHANNEL_TYPE_ORCA_ROUTER
+    )
+
+    assert.deepEqual(option, {
+      value: CHANNEL_TYPE_ORCA_ROUTER,
+      label: 'OrcaRouter',
+    })
+    assert.equal(
+      CHANNEL_TYPE_OPTIONS.findIndex(
+        (item) => item.value === CHANNEL_TYPE_ORCA_ROUTER
+      ),
+      CHANNEL_TYPE_OPTIONS.findIndex((item) => item.value === 20) + 1
+    )
+    assert.equal(MODEL_FETCHABLE_TYPES.has(CHANNEL_TYPE_ORCA_ROUTER), true)
+    assert.equal(getChannelTypeIcon(CHANNEL_TYPE_ORCA_ROUTER), 'OpenAI')
+    assert.equal(
+      getKeyPromptForType(CHANNEL_TYPE_ORCA_ROUTER),
+      'Enter API key for this channel'
+    )
+    const config = getChannelTypeConfig(CHANNEL_TYPE_ORCA_ROUTER)
+    assert.equal(config.icon, 'OpenAI')
+    assert.equal(config.defaultBaseUrl, 'https://api.orcarouter.ai')
+  })
+
+  test('accepts an empty Base URL (default upstream base URL applies)', () => {
+    assert.equal(channelFormSchema.safeParse(orcaRouterForm({ base_url: '' }))
+      .success, true)
+  })
+
+  test('accepts a custom Base URL', () => {
+    assert.equal(
+      channelFormSchema.safeParse(
+        orcaRouterForm({ base_url: 'https://api.orcarouter.ai' })
+      ).success,
+      true
+    )
+  })
+})

--- a/web/src/features/channels/lib/channel-type-config.ts
+++ b/web/src/features/channels/lib/channel-type-config.ts
@@ -164,6 +164,17 @@ export const CHANNEL_TYPE_CONFIGS: Record<number, ChannelTypeConfig> = {
       models: 'Models',
     },
   },
+  61: {
+    id: 61,
+    name: CHANNEL_TYPES[61],
+    icon: 'OpenAI',
+    defaultBaseUrl: 'https://api.orcarouter.ai',
+    hints: {
+      baseUrl: 'Default: https://api.orcarouter.ai',
+      key: 'OrcaRouter API Key (sk-orca-...)',
+      models: 'Use model IDs from OrcaRouter',
+    },
+  },
 }
 
 /**

--- a/web/src/features/channels/lib/channel-utils.ts
+++ b/web/src/features/channels/lib/channel-utils.ts
@@ -54,6 +54,7 @@ export function getChannelTypeIcon(type: number): string {
     58: 'NewAPI', // Advanced Custom
     59: 'Sub2API', // Sub2API
     60: 'NewAPI', // New API
+    61: 'OpenAI', // OrcaRouter
     3: 'Azure', // Azure
 
     // Anthropic

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -3166,6 +3166,7 @@
     "OpenAI, Anthropic, Google, etc.": "OpenAI, Anthropic, Google, etc.",
     "OpenAIMax": "OpenAIMax",
     "OpenRouter": "OpenRouter",
+    "OrcaRouter": "OrcaRouter",
     "opens in an external client. Trigger it from the sidebar or API key actions to launch the configured application.": "opens in an external client. Trigger it from the sidebar or API key actions to launch the configured application.",
     "Operate channels": "Operate channels",
     "Operation": "Operation",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -3166,6 +3166,7 @@
     "OpenAI, Anthropic, Google, etc.": "OpenAI, Anthropic, Google, etc.",
     "OpenAIMax": "OpenAIMax",
     "OpenRouter": "OpenRouter",
+    "OrcaRouter": "OrcaRouter",
     "opens in an external client. Trigger it from the sidebar or API key actions to launch the configured application.": "s'ouvre dans un client externe. Déclenchez-le depuis la barre latérale ou les actions de clé API pour lancer l'application configurée.",
     "Operate channels": "Exploiter les canaux",
     "Operation": "Opération",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -3166,6 +3166,7 @@
     "OpenAI, Anthropic, Google, etc.": "OpenAI、Anthropic、Googleなど",
     "OpenAIMax": "OpenAIMax",
     "OpenRouter": "OpenRouter",
+    "OrcaRouter": "OrcaRouter",
     "opens in an external client. Trigger it from the sidebar or API key actions to launch the configured application.": "外部クライアントで開きます。サイドバーまたはAPIキーアクションからトリガーして、設定されたアプリケーションを起動します。",
     "Operate channels": "チャネルを運用",
     "Operation": "操作",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -3166,6 +3166,7 @@
     "OpenAI, Anthropic, Google, etc.": "OpenAI, Anthropic, Google и т.д.",
     "OpenAIMax": "OpenAIMax",
     "OpenRouter": "OpenRouter",
+    "OrcaRouter": "OrcaRouter",
     "opens in an external client. Trigger it from the sidebar or API key actions to launch the configured application.": "открывается во внешнем клиенте. Запустите его из боковой панели или действий с ключом API, чтобы запустить настроенное приложение.",
     "Operate channels": "Обслуживание каналов",
     "Operation": "Операция",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -3166,6 +3166,7 @@
     "OpenAI, Anthropic, Google, etc.": "OpenAI, Anthropic, Google, v.v.",
     "OpenAIMax": "OpenAIMax",
     "OpenRouter": "OpenRouter",
+    "OrcaRouter": "OrcaRouter",
     "opens in an external client. Trigger it from the sidebar or API key actions to launch the configured application.": "mở trong một ứng dụng bên ngoài. Kích hoạt nó từ thanh bên hoặc các hành động khóa API để khởi chạy ứng dụng đã cấu hình.",
     "Operate channels": "Vận hành kênh",
     "Operation": "Thao tác",

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -3166,6 +3166,7 @@
     "OpenAI, Anthropic, Google, etc.": "OpenAI、Anthropic、Google 等",
     "OpenAIMax": "OpenAIMax",
     "OpenRouter": "OpenRouter",
+    "OrcaRouter": "OrcaRouter",
     "opens in an external client. Trigger it from the sidebar or API key actions to launch the configured application.": "在外部用戶端中打開。從側邊欄或 API 金鑰操作中觸發，以啟動設定的套用。",
     "Operate channels": "運維渠道",
     "Operation": "操作",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -3166,6 +3166,7 @@
     "OpenAI, Anthropic, Google, etc.": "OpenAI、Anthropic、Google 等",
     "OpenAIMax": "OpenAIMax",
     "OpenRouter": "OpenRouter",
+    "OrcaRouter": "OrcaRouter",
     "opens in an external client. Trigger it from the sidebar or API key actions to launch the configured application.": "在外部客户端中打开。从侧边栏或 API 密钥操作中触发，以启动配置的应用。",
     "Operate channels": "运维渠道",
     "Operation": "操作",


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

This PR adds [OrcaRouter](https://www.orcarouter.ai) as a first-class channel type (61) in new-api, mirroring the existing OpenRouter integration pattern. OrcaRouter is an OpenAI-compatible AI model gateway that routes requests across many model providers through a single endpoint.

What changed:

- **Backend** (`constant/`, `common/`, `relay/`):
  - Added `ChannelTypeOrcaRouter = 61` and `APITypeOrcaRouter` constants.
  - Default base URL `https://api.orcarouter.ai` (the relay appends `/v1/...` request paths, same as OpenRouter).
  - Dispatch through the standard OpenAI adaptor, since OrcaRouter exposes an OpenAI-compatible API (the same approach OpenRouter uses).
  - OrcaRouter supports `stream_options`, so it was added to `streamSupportedChannels` for usage-token reporting in streamed responses.
- **Web** (`web/src/features/channels/`):
  - Registered the "OrcaRouter" channel type in the channel list and type config (icon, default base URL, input hints).
  - Enabled model discovery (`MODEL_FETCHABLE_TYPES`) and the key prompt.
  - Added i18n keys across all 7 locale files.
- **Tests**: Added `orcarouter-channel.test.ts` covering channel registration, ordering, icon metadata, model-fetchability, and form validation.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

> **AI-generated disclosure:** This change was implemented with AI assistance (Claude Code). The current git user (`Marc-oss-hub`) is not among the project's historical core developers, so this is disclosed per `AGENTS.md`.

I'm an engineer on the OrcaRouter team.

## 🚀 变更类型 / Type of change
- [x] ✨ 新功能 (New feature)

## 🔗 关联任务 / Related Issue
- N/A

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 不适用（非 bug fix）。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** `go build`、`go vet` 及 `go test ./controller ./relay/common ./relay/channel/openai` 均通过；OrcaRouter 的 `/v1/chat/completions`、`/v1/models`、`stream_options` 已用真实 API key 实测通过。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

- `go build ./constant ./common ./relay ./relay/common ./relay/channel/openai ./relay/channel/orcarouter` — OK
- `go vet` on the changed packages — OK
- `go test ./controller ./relay/common ./relay/channel/openai` — all OK
- Live verification against `https://api.orcarouter.ai` with a real API key:
  - `POST /v1/chat/completions` (non-stream) → 200 with a completion
  - `GET /v1/models` → returns the model list (used by the "fetch models" button)
  - `POST /v1/chat/completions` with `stream: true, stream_options: {include_usage: true}` → streams chunks correctly
- Frontend test `orcarouter-channel.test.ts` added (runs in CI via `bun test`; `bun`/`node_modules` are not available in the local verification environment).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OrcaRouter as a supported channel and provider.
  - Added configuration for API keys, base URLs, model retrieval, streaming, and form validation.
  - Added OrcaRouter to channel ordering and displayed it with the OpenAI icon.
  - Added localized provider names across supported languages.

- **Bug Fixes**
  - Ensured OrcaRouter requests use the appropriate API and endpoint handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->