### PR TITLE
fix(README): 修复失效的 Star History 图表链接

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -472,7 +472,7 @@ Welcome all forms of contribution!
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.com/#Calcium-Ion/new-api&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.dera.page/#Calcium-Ion/new-api&Date)
 
 </div>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -483,7 +483,7 @@ Si les politiques de votre organisation ne permettent pas l'utilisation de logic
 
 <div align="center">
 
-[![Graphique de l'historique des étoiles](https://api.star-history.com/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.com/#Calcium-Ion/new-api&Date)
+[![Graphique de l'historique des étoiles](https://star-history.dera.page/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.dera.page/#Calcium-Ion/new-api&Date)
 
 </div>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -483,7 +483,7 @@ Token、Origin 検証、PAT の契約については[ユーザー認証とログ
 
 <div align="center">
 
-[![スター履歴チャート](https://api.star-history.com/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.com/#Calcium-Ion/new-api&Date)
+[![スター履歴チャート](https://star-history.dera.page/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.dera.page/#Calcium-Ion/new-api&Date)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ If your organization's policies do not permit the use of AGPLv3-licensed softwar
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.com/#Calcium-Ion/new-api&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.dera.page/#Calcium-Ion/new-api&Date)
 
 </div>
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -483,7 +483,7 @@ Token、Origin 校验和 PAT 契约见[用户鉴权与登录会话](./docs/authe
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.com/#Calcium-Ion/new-api&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.dera.page/#Calcium-Ion/new-api&Date)
 
 </div>
 

--- a/README.zh_TW.md
+++ b/README.zh_TW.md
@@ -482,7 +482,7 @@ Token、Origin 驗證和 PAT 契約請參閱[使用者鑑權與登入工作階�
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.com/#Calcium-Ion/new-api&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.dera.page/#Calcium-Ion/new-api&Date)
 
 </div>
 


### PR DESCRIPTION
README 中的 Star History 图表当前已经失效，无法正常显示仓库的星标历史，需要尽快修复。

本变更将各语言 README（en/zh_CN/zh_TW/fr/ja）中的 Star History 图表图片地址与跳转链接统一指向可用的替代域名，使星标历史图表恢复正常展示。

**变更类型 / Type of change**
- [x] 📝 文档更新 (Documentation)

**提交前检查项 / Checklist**
- [x] 范围聚焦：本 PR 仅包含 README 文档链接更新，未涉及任何无关改动。
- [x] 本地验证：已逐一核对各语言 README 中的链接。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart links and images across all localized README files.
  * Charts now use the new Star History service URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->