### PR TITLE
fix(veo): 将 RAI 过滤的视频任务判定为失败并触发退款

### DIFF
--- a/relay/channel/task/gemini/adaptor.go
+++ b/relay/channel/task/gemini/adaptor.go
@@ -151,6 +151,9 @@ func (a *TaskAdaptor) GetModelList() []string {
 		"veo-3.0-fast-generate-001",
 		"veo-3.1-generate-preview",
 		"veo-3.1-fast-generate-preview",
+		"veo-3.1-generate-001",
+		"veo-3.1-fast-generate-001",
+		"veo-3.1-lite-generate-001",
 	}
 }
 
@@ -230,6 +233,16 @@ func (a *TaskAdaptor) ParseTaskResult(respBody []byte) (*relaycommon.TaskInfo, e
 		return ti, nil
 	}
 
+	if op.Response.RaiMediaFilteredCount > 0 {
+		ti.Status = model.TaskStatusFailure
+		ti.Progress = "100%"
+		if len(op.Response.RaiMediaFilteredReasons) > 0 {
+			ti.Reason = op.Response.RaiMediaFilteredReasons[0]
+		} else {
+			ti.Reason = "videos were filtered out due to Google's Responsible AI practices"
+		}
+		return ti, nil
+	}
 	ti.Status = model.TaskStatusSuccess
 	ti.Progress = "100%"
 

--- a/relay/channel/task/gemini/dto.go
+++ b/relay/channel/task/gemini/dto.go
@@ -51,13 +51,14 @@ type operationResponse struct {
 	Name     string `json:"name"`
 	Done     bool   `json:"done"`
 	Response struct {
-		Type                  string           `json:"@type"`
-		RaiMediaFilteredCount int              `json:"raiMediaFilteredCount"`
-		Videos                []operationVideo `json:"videos"`
-		BytesBase64Encoded    string           `json:"bytesBase64Encoded"`
-		Encoding              string           `json:"encoding"`
-		Video                 string           `json:"video"`
-		GenerateVideoResponse struct {
+		Type                    string           `json:"@type"`
+		RaiMediaFilteredCount   int              `json:"raiMediaFilteredCount"`
+		RaiMediaFilteredReasons []string         `json:"raiMediaFilteredReasons"`
+		Videos                  []operationVideo `json:"videos"`
+		BytesBase64Encoded      string           `json:"bytesBase64Encoded"`
+		Encoding                string           `json:"encoding"`
+		Video                   string           `json:"video"`
+		GenerateVideoResponse   struct {
 			GeneratedVideos []struct {
 				Video struct {
 					URI string `json:"uri"`

--- a/relay/channel/task/vertex/adaptor.go
+++ b/relay/channel/task/vertex/adaptor.go
@@ -46,12 +46,13 @@ type operationResponse struct {
 	Name     string `json:"name"`
 	Done     bool   `json:"done"`
 	Response struct {
-		Type                  string           `json:"@type"`
-		RaiMediaFilteredCount int              `json:"raiMediaFilteredCount"`
-		Videos                []operationVideo `json:"videos"`
-		BytesBase64Encoded    string           `json:"bytesBase64Encoded"`
-		Encoding              string           `json:"encoding"`
-		Video                 string           `json:"video"`
+		Type                    string           `json:"@type"`
+		RaiMediaFilteredCount   int              `json:"raiMediaFilteredCount"`
+		RaiMediaFilteredReasons []string         `json:"raiMediaFilteredReasons"`
+		Videos                  []operationVideo `json:"videos"`
+		BytesBase64Encoded      string           `json:"bytesBase64Encoded"`
+		Encoding                string           `json:"encoding"`
+		Video                   string           `json:"video"`
 	} `json:"response"`
 	Error struct {
 		Message string `json:"message"`
@@ -222,6 +223,9 @@ func (a *TaskAdaptor) GetModelList() []string {
 		"veo-3.0-fast-generate-001",
 		"veo-3.1-generate-preview",
 		"veo-3.1-fast-generate-preview",
+		"veo-3.1-generate-001",
+		"veo-3.1-fast-generate-001",
+		"veo-3.1-lite-generate-001",
 	}
 }
 func (a *TaskAdaptor) GetChannelName() string { return "vertex" }
@@ -299,6 +303,16 @@ func (a *TaskAdaptor) ParseTaskResult(respBody []byte) (*relaycommon.TaskInfo, e
 	if !op.Done {
 		ti.Status = model.TaskStatusInProgress
 		ti.Progress = "50%"
+		return ti, nil
+	}
+	if op.Response.RaiMediaFilteredCount > 0 {
+		ti.Status = model.TaskStatusFailure
+		ti.Progress = "100%"
+		if len(op.Response.RaiMediaFilteredReasons) > 0 {
+			ti.Reason = op.Response.RaiMediaFilteredReasons[0]
+		} else {
+			ti.Reason = "videos were filtered out due to Google's Responsible AI practices"
+		}
 		return ti, nil
 	}
 	ti.Status = model.TaskStatusSuccess


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> 当 done=true 且 raiMediaFilteredCount > 0 且没有视频时，代码走到第 3 步直接标记为 SUCCESS，但实际应该是 FAILURE。raiMediaFilteredCount 和 raiMediaFilteredReasons 字段已经在 operationResponse 结构体里定义了，但 ParseTaskResult 完全没有处理这个情况。
> 问题根因： ParseTaskResult 在 done=true 后直接判为 SUCCESS，没有检查 raiMediaFilteredCount。

## 📝 变更描述 / Description
[relay/channel/task/vertex/adaptor.go](vscode-webview://0a4i1cu6flvhmgku3vula4dq8q4fevr8000aim5vvv4ern5hinod/relay/channel/task/vertex/adaptor.go) — operationResponse.Response 补充 RaiMediaFilteredReasons []string，ParseTaskResult 在判成功前先检查 raiMediaFilteredCount > 0，有则取 raiMediaFilteredReasons[0] 作为 fail_reason 并返回 FAILURE
[relay/channel/task/gemini/adaptor.go](vscode-webview://0a4i1cu6flvhmgku3vula4dq8q4fevr8000aim5vvv4ern5hinod/relay/channel/task/gemini/adaptor.go) 和 [dto.go](vscode-webview://0a4i1cu6flvhmgku3vula4dq8q4fevr8000aim5vvv4ern5hinod/relay/channel/task/gemini/dto.go) — 同样修复

## 🚀 变更类型 / Type of change
- [*] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ ] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [ ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [ ] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
<img width="2660" height="1436" alt="image" src="https://github.com/user-attachments/assets/a088d31a-9df9-41be-9196-2a5a4deb3386" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three Veo 3.1 model variants.
  * Added clearer reporting when generated media is blocked by Responsible AI filtering, including the available reason when provided.
* **Bug Fixes**
  * Tasks affected by media safety filtering are now correctly reported as failed instead of appearing successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->