### PR TITLE
fix: prompt_cache_key openai chat -> openai responses

### DIFF
--- a/relaykit/relayconvert/internal/oai_chat/to_oai_responses_req.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_oai_responses_req.go
@@ -380,6 +380,14 @@ func ChatCompletionsRequestToResponsesRequest(req *dto.GeneralOpenAIRequest) (*d
 		presencePenaltyRaw, _ = kitutil.Marshal(req.PresencePenalty)
 	}
 
+	var promptCacheKeyRaw json.RawMessage
+	if req.PromptCacheKey != "" {
+		promptCacheKeyRaw, err = kitutil.Marshal(req.PromptCacheKey)
+		if err != nil {
+			return nil, fmt.Errorf("marshal prompt_cache_key: %w", err)
+		}
+	}
+
 	out := &dto.OpenAIResponsesRequest{
 		Model:             req.Model,
 		Input:             inputRaw,
@@ -396,6 +404,7 @@ func ChatCompletionsRequestToResponsesRequest(req *dto.GeneralOpenAIRequest) (*d
 		ParallelToolCalls: parallelToolCallsRaw,
 		Store:             req.Store,
 		Metadata:          req.Metadata,
+		PromptCacheKey:    promptCacheKeyRaw,
 		EnableThinking:    req.EnableThinking,
 		ThinkingBudget:    req.ThinkingBudget,
 	}

--- a/relaykit/relayconvert/internal/oai_chat/to_oai_responses_req_test.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_oai_responses_req_test.go
@@ -39,6 +39,38 @@ func TestChatCompletionsRequestToResponsesRequestInstructionsAndTools(t *testing
 	assert.Equal(t, "function_call_output", gjson.GetBytes(got.Input, "3.type").String())
 }
 
+func TestChatCompletionsRequestToResponsesRequestPreservesPromptCacheKey(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		key := "session-\"quoted\"\\path\n世界"
+		got, err := ChatCompletionsRequestToResponsesRequest(&dto.GeneralOpenAIRequest{
+			Model:          "gpt-test",
+			Messages:       []dto.Message{{Role: "user", Content: "hello"}},
+			PromptCacheKey: key,
+		})
+		require.NoError(t, err)
+
+		keyRaw, err := kitutil.Marshal(key)
+		require.NoError(t, err)
+		assert.Equal(t, keyRaw, []byte(got.PromptCacheKey))
+
+		encoded, err := kitutil.Marshal(got)
+		require.NoError(t, err)
+		assert.Equal(t, key, gjson.GetBytes(encoded, "prompt_cache_key").String())
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		got, err := ChatCompletionsRequestToResponsesRequest(&dto.GeneralOpenAIRequest{
+			Model:    "gpt-test",
+			Messages: []dto.Message{{Role: "user", Content: "hello"}},
+		})
+		require.NoError(t, err)
+
+		encoded, err := kitutil.Marshal(got)
+		require.NoError(t, err)
+		assert.False(t, gjson.GetBytes(encoded, "prompt_cache_key").Exists())
+	})
+}
+
 func TestChatCompletionsRequestToResponsesRequestPreservesQwenThinkingBudget(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

补充 chat转responses prompt_cache_key

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Related #6538 

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved prompt cache keys when converting chat completion requests to responses requests.
  * Correctly handles escaped and Unicode prompt cache key values.
  * Omits the prompt cache key when no value is provided.

* **Tests**
  * Added coverage for prompt cache key preservation and JSON serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->