### PR TITLE
fix(relaykit): preserve parameterless tools in Claude conversion

### DIFF
--- a/relaykit/relayconvert/internal/oai_chat/to_claude_messages_req.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_claude_messages_req.go
@@ -32,25 +32,14 @@ func OpenAIChatRequestToClaudeMessages(c context.Context, info convmeta.Meta, te
 	claudeTools := make([]any, 0, len(textRequest.Tools))
 
 	for _, tool := range textRequest.Tools {
-		if params, ok := tool.Function.Parameters.(map[string]any); ok {
-			claudeTool := dto.Tool{
-				Name:        tool.Function.Name,
-				Description: tool.Function.Description,
-			}
-			claudeTool.InputSchema = make(map[string]interface{})
-			if params["type"] != nil {
-				claudeTool.InputSchema["type"] = params["type"].(string)
-			}
-			claudeTool.InputSchema["properties"] = params["properties"]
-			claudeTool.InputSchema["required"] = params["required"]
-			for key, value := range params {
-				if key == "type" || key == "properties" || key == "required" {
-					continue
-				}
-				claudeTool.InputSchema[key] = value
-			}
-			claudeTools = append(claudeTools, &claudeTool)
+		if _, ok := tool.Function.Parameters.(map[string]any); !ok && tool.Type != "function" {
+			continue
 		}
+		claudeTools = append(claudeTools, &dto.Tool{
+			Name:        tool.Function.Name,
+			Description: tool.Function.Description,
+			InputSchema: sharedclaude.FunctionParametersToInputSchema(tool.Function.Parameters),
+		})
 	}
 
 	if textRequest.WebSearchOptions != nil {

--- a/relaykit/relayconvert/internal/oai_chat/to_claude_messages_req_test.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_claude_messages_req_test.go
@@ -1,0 +1,81 @@
+package oaichat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIChatRequestToClaudeMessagesNormalizesToolInputSchema(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters any
+		wantSchema map[string]any
+	}{
+		{
+			name:       "omitted parameters",
+			parameters: nil,
+			wantSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		{
+			name: "missing type and properties",
+			parameters: map[string]any{
+				"additionalProperties": false,
+			},
+			wantSchema: map[string]any{
+				"type":                 "object",
+				"properties":           map[string]any{},
+				"additionalProperties": false,
+			},
+		},
+		{
+			name: "non-string type",
+			parameters: map[string]any{
+				"type":       123,
+				"properties": map[string]any{},
+			},
+			wantSchema: map[string]any{
+				"type":       123,
+				"properties": map[string]any{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			maxTokens := uint(1024)
+			got, err := OpenAIChatRequestToClaudeMessages(context.Background(), nil, dto.GeneralOpenAIRequest{
+				Model:     "claude-test",
+				MaxTokens: &maxTokens,
+				Messages: []dto.Message{
+					{Role: "user", Content: "Call the tool."},
+				},
+				Tools: []dto.ToolCallRequest{
+					{
+						Type: "function",
+						Function: dto.FunctionRequest{
+							Name:        "get_current_time",
+							Description: "Get the current time",
+							Parameters:  tt.parameters,
+						},
+					},
+				},
+			})
+
+			require.NoError(t, err)
+			tools, ok := got.Tools.([]any)
+			require.True(t, ok)
+			require.Len(t, tools, 1)
+			tool, ok := tools[0].(*dto.Tool)
+			require.True(t, ok)
+			assert.Equal(t, "get_current_time", tool.Name)
+			assert.Equal(t, tt.wantSchema, tool.InputSchema)
+		})
+	}
+}

--- a/relaykit/relayconvert/internal/oai_responses/to_claude_messages_req.go
+++ b/relaykit/relayconvert/internal/oai_responses/to_claude_messages_req.go
@@ -134,30 +134,10 @@ func responsesFunctionDeclarationsToClaudeTools(functions []dto.FunctionRequest)
 		tools = append(tools, &dto.Tool{
 			Name:        function.Name,
 			Description: function.Description,
-			InputSchema: responsesFunctionParametersToClaudeInputSchema(function.Parameters),
+			InputSchema: sharedclaude.FunctionParametersToInputSchema(function.Parameters),
 		})
 	}
 	return tools
-}
-
-func responsesFunctionParametersToClaudeInputSchema(parameters any) map[string]interface{} {
-	if params, ok := parameters.(map[string]any); ok {
-		schema := make(map[string]interface{}, len(params))
-		for key, value := range params {
-			schema[key] = value
-		}
-		if schema["type"] == nil {
-			schema["type"] = "object"
-		}
-		if schema["properties"] == nil {
-			schema["properties"] = map[string]interface{}{}
-		}
-		return schema
-	}
-	return map[string]interface{}{
-		"type":       "object",
-		"properties": map[string]interface{}{},
-	}
 }
 
 func applyResponsesReasoningToClaude(req *dto.OpenAIResponsesRequest, claudeRequest *dto.ClaudeRequest) {

--- a/relaykit/relayconvert/internal/shared/claude/schema.go
+++ b/relaykit/relayconvert/internal/shared/claude/schema.go
@@ -1,0 +1,16 @@
+package claude
+
+func FunctionParametersToInputSchema(parameters any) map[string]any {
+	params, _ := parameters.(map[string]any)
+	schema := make(map[string]any, len(params)+2)
+	for key, value := range params {
+		schema[key] = value
+	}
+	if schema["type"] == nil {
+		schema["type"] = "object"
+	}
+	if schema["properties"] == nil {
+		schema["properties"] = map[string]any{}
+	}
+	return schema
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

修复chat到claude的无参数工具转换

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6859 

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion of tools and function parameters between OpenAI and Claude message formats.
  * Added sensible defaults for missing schema types and properties.
  * Preserved additional schema fields and non-string type values during conversion.
  * Unsupported tool definitions are now skipped safely.

* **Tests**
  * Added coverage for tool-schema normalization and parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->