### PR TITLE
feat: add official Cursor SDK channel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,4 +9,7 @@ docs
 .gocache
 /web/node_modules
 /web/dist
+/cursor_agent_sidecar/node_modules
+/cursor_agent_sidecar/.env*
+/cursor_agent_sidecar/state
 !THIRD-PARTY-LICENSES.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,25 @@ COPY . .
 COPY --from=builder /build/web/dist ./web/dist
 RUN go build -ldflags "-s -w -X 'github.com/QuantumNous/new-api/common.Version=$(cat VERSION)'" -o new-api
 
+FROM node:22-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS cursor_sidecar
+WORKDIR /opt/cursor-agent
+COPY cursor_agent_sidecar/package.json cursor_agent_sidecar/package-lock.json ./
+RUN npm ci --omit=dev
+COPY cursor_agent_sidecar/ ./
+
 FROM debian:bookworm-slim@sha256:f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates tzdata libasan8 wget \
+    && apt-get install -y --no-install-recommends ca-certificates tzdata libasan8 wget tini \
     && rm -rf /var/lib/apt/lists/* \
     && update-ca-certificates
 
 COPY --from=builder2 /build/new-api /
+COPY --from=cursor_sidecar /usr/local/bin/node /usr/local/bin/node
+COPY --from=cursor_sidecar /opt/cursor-agent /opt/cursor-agent
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 COPY LICENSE NOTICE THIRD-PARTY-LICENSES.md /licenses/
-EXPOSE 3000
+RUN chmod +x /docker-entrypoint.sh
+EXPOSE 3000 3927
 WORKDIR /data
-ENTRYPOINT ["/new-api"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/docker-entrypoint.sh"]

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -66,6 +66,7 @@ Transitive dependencies should be audited before a final external release.
 | backend     | production  | Go        | `gorm.io/gorm`                                        | `v1.25.2`                            | MIT                                                |
 | backend     | production  | Go        | `github.com/expr-lang/expr`                           | `v1.17.8`                            | MIT                                                |
 | web | production | npm | `@base-ui/react` | `1.6.0` | MIT |
+| sidecar | production | npm | `@cursor/sdk` | `1.0.27` | Cursor SDK License (included in package) |
 | web | production | npm | `@codemirror/lang-markdown` | `6.5.1` | MIT |
 | web | production | npm | `@codemirror/language` | `6.12.4` | MIT |
 | web | production | npm | `@codemirror/state` | `6.7.1` | MIT |

--- a/common/api_type.go
+++ b/common/api_type.go
@@ -81,6 +81,8 @@ func ChannelType2APIType(channelType int) (int, bool) {
 		apiType = constant.APITypeSub2API
 	case constant.ChannelTypeNewAPI:
 		apiType = constant.APITypeNewAPI
+	case constant.ChannelTypeCursorAgent:
+		apiType = constant.APITypeCursorAgent
 	}
 	if apiType == -1 {
 		return constant.APITypeOpenAI, false

--- a/common/endpoint_type.go
+++ b/common/endpoint_type.go
@@ -20,6 +20,12 @@ func GetEndpointTypesByChannelType(channelType int, modelName string) []constant
 		fallthrough
 	case constant.ChannelTypeAnthropic:
 		endpointTypes = []constant.EndpointType{constant.EndpointTypeAnthropic, constant.EndpointTypeOpenAI}
+	case constant.ChannelTypeCursorAgent:
+		endpointTypes = []constant.EndpointType{
+			constant.EndpointTypeAnthropic,
+			constant.EndpointTypeOpenAI,
+			constant.EndpointTypeOpenAIResponse,
+		}
 	case constant.ChannelTypeVertexAi:
 		fallthrough
 	case constant.ChannelTypeGemini:

--- a/constant/api_type.go
+++ b/constant/api_type.go
@@ -39,5 +39,6 @@ const (
 	APITypeAdvancedCustom
 	APITypeSub2API
 	APITypeNewAPI
+	APITypeCursorAgent
 	APITypeDummy // this one is only for count, do not add any channel after this
 )

--- a/constant/channel.go
+++ b/constant/channel.go
@@ -58,7 +58,11 @@ const (
 	ChannelTypeAdvancedCustom = 58
 	ChannelTypeSub2API        = 59
 	ChannelTypeNewAPI         = 60
-	ChannelTypeDummy          // this one is only for count, do not add any channel after this
+	// ChannelTypeCursorAgent relays through the official @cursor/sdk harness.
+	// The Go gateway owns routing and billing; the companion sidecar owns the
+	// Cursor Agent/Run lifecycle required for native tool continuation.
+	ChannelTypeCursorAgent = 61
+	ChannelTypeDummy       // this one is only for count, do not add any channel after this
 
 )
 
@@ -124,6 +128,7 @@ var ChannelBaseURLs = []string{
 	"",                                          //58
 	"",                                          //59
 	"",                                          //60
+	"http://127.0.0.1:3927",                     //61 Cursor SDK sidecar
 }
 
 var ChannelTypeNames = map[int]string{
@@ -184,6 +189,7 @@ var ChannelTypeNames = map[int]string{
 	ChannelTypeAdvancedCustom: "Advanced Custom",
 	ChannelTypeSub2API:        "Sub2API",
 	ChannelTypeNewAPI:         "New API",
+	ChannelTypeCursorAgent:    "Cursor Agent",
 }
 
 func GetChannelTypeName(channelType int) string {

--- a/controller/channel_upstream_update.go
+++ b/controller/channel_upstream_update.go
@@ -17,6 +17,7 @@ import (
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/relay/channel/advancedcustom"
+	"github.com/QuantumNous/new-api/relay/channel/cursor_agent"
 	"github.com/QuantumNous/new-api/relay/channel/gemini"
 	"github.com/QuantumNous/new-api/relay/channel/ollama"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
@@ -347,6 +348,21 @@ func fetchChannelUpstreamModelIDs(channel *model.Channel) ([]string, error) {
 		return normalizeModelNames(lo.Map(models, func(item ollama.OllamaModel, _ int) string {
 			return item.Name
 		})), nil
+	}
+
+	if channel.Type == constant.ChannelTypeCursorAgent {
+		credential, err := cursor_agent.ParseCredential(strings.TrimSpace(channel.Key))
+		if err != nil {
+			return nil, err
+		}
+		baseURL = cursor_agent.ResolveSidecarBaseURL(channel.GetBaseURL())
+		headers := GetAuthHeader(credential.APIKey)
+		headers.Set("x-api-key", credential.APIKey)
+		body, err := getFetchModelsResponseBody(http.MethodGet, baseURL+"/v1/models", channel, headers)
+		if err != nil {
+			return nil, sanitizeFetchModelsError(err, credential.APIKey)
+		}
+		return parseOpenAIModelIDs(body)
 	}
 
 	if channel.Type == constant.ChannelTypeGemini {

--- a/controller/cursor_agent_account.go
+++ b/controller/cursor_agent_account.go
@@ -1,0 +1,348 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/relay/channel/cursor_agent"
+	"github.com/QuantumNous/new-api/service"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/sync/singleflight"
+)
+
+const cursorAgentAccountResponseLimit = 1 << 20
+const cursorDashboardExchangeTimeout = 10 * time.Second
+
+var cursorDashboardAPIBaseURL = "https://api2.cursor.sh"
+var cursorDashboardExchangeGroup singleflight.Group
+
+type cursorDashboardPeriodUsage struct {
+	BillingCycleStart string `json:"billingCycleStart"`
+	BillingCycleEnd   string `json:"billingCycleEnd"`
+	PlanUsage         struct {
+		TotalSpend       float64 `json:"totalSpend"`
+		IncludedSpend    float64 `json:"includedSpend"`
+		BonusSpend       float64 `json:"bonusSpend"`
+		Remaining        float64 `json:"remaining"`
+		Limit            float64 `json:"limit"`
+		AutoPercentUsed  float64 `json:"autoPercentUsed"`
+		APIPercentUsed   float64 `json:"apiPercentUsed"`
+		TotalPercentUsed float64 `json:"totalPercentUsed"`
+	} `json:"planUsage"`
+	SpendLimitUsage struct {
+		TotalSpend          float64 `json:"totalSpend"`
+		PooledLimit         float64 `json:"pooledLimit"`
+		PooledUsed          float64 `json:"pooledUsed"`
+		PooledRemaining     float64 `json:"pooledRemaining"`
+		IndividualLimit     float64 `json:"individualLimit"`
+		IndividualUsed      float64 `json:"individualUsed"`
+		IndividualRemaining float64 `json:"individualRemaining"`
+		LimitType           string  `json:"limitType"`
+	} `json:"spendLimitUsage"`
+}
+
+type cursorDashboardPlanResponse struct {
+	PlanInfo struct {
+		PlanName            string  `json:"planName"`
+		IncludedAmountCents float64 `json:"includedAmountCents"`
+		Price               string  `json:"price"`
+		BillingCycleEnd     string  `json:"billingCycleEnd"`
+		PlanOwner           string  `json:"planOwner"`
+	} `json:"planInfo"`
+}
+
+type cursorDashboardExchangeResponse struct {
+	AccessToken string `json:"accessToken"`
+}
+
+type cursorDashboardExchangeError struct {
+	StatusCode int
+	Err        error
+}
+
+func (e *cursorDashboardExchangeError) Error() string {
+	if e.StatusCode > 0 {
+		return fmt.Sprintf("cursor api key exchange status %d", e.StatusCode)
+	}
+	return "cursor api key exchange failed: " + e.Err.Error()
+}
+
+func (e *cursorDashboardExchangeError) Unwrap() error {
+	return e.Err
+}
+
+func GetCursorAgentChannelAccount(c *gin.Context) {
+	channelID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		common.ApiError(c, fmt.Errorf("invalid channel id: %w", err))
+		return
+	}
+
+	channel, err := model.GetChannelById(channelID, true)
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	if channel == nil {
+		c.JSON(http.StatusOK, gin.H{"success": false, "message": "channel not found"})
+		return
+	}
+	if channel.Type != constant.ChannelTypeCursorAgent {
+		c.JSON(http.StatusOK, gin.H{"success": false, "message": "channel type does not use Cursor SDK credentials"})
+		return
+	}
+	if channel.ChannelInfo.IsMultiKey {
+		c.JSON(http.StatusOK, gin.H{"success": false, "message": "multi-key channel is not supported"})
+		return
+	}
+
+	credential, err := cursor_agent.ParseCredential(strings.TrimSpace(channel.Key))
+	if err != nil {
+		common.SysError("failed to parse cursor sdk credential: " + err.Error())
+		c.JSON(http.StatusOK, gin.H{"success": false, "message": "解析 Cursor SDK 凭证失败，请检查渠道配置"})
+		return
+	}
+
+	client, err := service.NewProxyHttpClient(channel.GetSetting().Proxy)
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 25*time.Second)
+	defer cancel()
+
+	payload, upstreamStatus, err := fetchCursorSDKAccount(ctx, client, channel, credential)
+	if err != nil {
+		common.SysError("failed to fetch cursor sdk account: " + err.Error())
+		c.JSON(http.StatusOK, gin.H{"success": false, "message": "获取 Cursor 帐号信息失败，请检查凭证或稍后重试"})
+		return
+	}
+
+	quota, quotaErr := fetchCursorDashboardQuota(ctx, client, credential)
+	if quotaErr != nil {
+		common.SysError(fmt.Sprintf("failed to fetch cursor dashboard quota: channel_id=%d err=%s", channel.Id, quotaErr.Error()))
+	}
+	if available, _ := quota["available"].(bool); available {
+		if remaining, ok := quota["remaining_usd"].(float64); ok {
+			channel.UpdateBalance(remaining)
+		}
+	}
+	payload["gateway"] = gin.H{
+		"used_quota":        channel.UsedQuota,
+		"balance_supported": quota["available"] == true,
+	}
+	payload["quota"] = quota
+	c.JSON(http.StatusOK, gin.H{
+		"success":         true,
+		"message":         "",
+		"upstream_status": upstreamStatus,
+		"data":            payload,
+	})
+}
+
+func fetchCursorSDKAccount(ctx context.Context, client *http.Client, channel *model.Channel, credential *cursor_agent.Credential) (map[string]any, int, error) {
+	baseURL := cursor_agent.ResolveSidecarBaseURL(channel.GetBaseURL())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v1/account", nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+credential.APIKey)
+	req.Header.Set("x-api-key", credential.APIKey)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer res.Body.Close()
+	body, err := readCursorAccountBody(res.Body)
+	if err != nil {
+		return nil, res.StatusCode, err
+	}
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		return nil, res.StatusCode, fmt.Errorf("cursor sdk account upstream status %d", res.StatusCode)
+	}
+	var payload map[string]any
+	if err := common.Unmarshal(body, &payload); err != nil {
+		return nil, res.StatusCode, fmt.Errorf("decode cursor sdk account: %w", err)
+	}
+	return payload, res.StatusCode, nil
+}
+
+func fetchCursorDashboardQuota(ctx context.Context, client *http.Client, credential *cursor_agent.Credential) (gin.H, error) {
+	if credential == nil || strings.TrimSpace(credential.APIKey) == "" {
+		return gin.H{"available": false, "source": "cursor_dashboard_rpc", "reason": "api_key_missing"}, nil
+	}
+
+	accessToken, err := exchangeCursorAPIKeyForAccessToken(ctx, client, credential.APIKey)
+	if err != nil {
+		return cursorDashboardExchangeFailure(err), err
+	}
+	statusCode, body, err := cursorDashboardPost(ctx, client, "GetCurrentPeriodUsage", accessToken)
+	if err != nil {
+		return gin.H{"available": false, "source": "cursor_dashboard_rpc", "reason": "dashboard_unreachable"}, err
+	}
+	if statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
+		accessToken, err = exchangeCursorAPIKeyForAccessToken(ctx, client, credential.APIKey)
+		if err != nil {
+			return cursorDashboardExchangeFailure(err), err
+		}
+		statusCode, body, err = cursorDashboardPost(ctx, client, "GetCurrentPeriodUsage", accessToken)
+		if err != nil {
+			return gin.H{"available": false, "source": "cursor_dashboard_rpc", "reason": "dashboard_unreachable"}, err
+		}
+	}
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		return gin.H{"available": false, "source": "cursor_dashboard_rpc", "reason": "dashboard_rejected", "status": statusCode}, nil
+	}
+
+	var usage cursorDashboardPeriodUsage
+	if err := common.Unmarshal(body, &usage); err != nil {
+		return gin.H{"available": false, "source": "cursor_dashboard_rpc", "reason": "dashboard_invalid_response"}, err
+	}
+	plan := cursorDashboardPlanResponse{}
+	if planStatus, planBody, planErr := cursorDashboardPost(ctx, client, "GetPlanInfo", accessToken); planErr == nil && planStatus >= 200 && planStatus < 300 {
+		_ = common.Unmarshal(planBody, &plan)
+	}
+
+	usedCents := usage.PlanUsage.IncludedSpend
+	if usedCents <= 0 && usage.PlanUsage.Limit > 0 {
+		usedCents = usage.PlanUsage.Limit - usage.PlanUsage.Remaining
+		if usedCents < 0 {
+			usedCents = 0
+		}
+	}
+	usedPercent := usage.PlanUsage.TotalPercentUsed
+	if usage.PlanUsage.Limit > 0 {
+		usedPercent = usedCents / usage.PlanUsage.Limit * 100
+	}
+	result := gin.H{
+		"available":                   true,
+		"source":                      "cursor_dashboard_rpc",
+		"plan_name":                   strings.TrimSpace(plan.PlanInfo.PlanName),
+		"plan_price":                  strings.TrimSpace(plan.PlanInfo.Price),
+		"plan_owner":                  strings.TrimSpace(plan.PlanInfo.PlanOwner),
+		"billing_cycle_start":         usage.BillingCycleStart,
+		"billing_cycle_end":           usage.BillingCycleEnd,
+		"used_usd":                    usedCents / 100,
+		"total_spend_usd":             usage.PlanUsage.TotalSpend / 100,
+		"remaining_usd":               usage.PlanUsage.Remaining / 100,
+		"limit_usd":                   usage.PlanUsage.Limit / 100,
+		"used_percent":                usedPercent,
+		"cursor_models_percent_used":  usage.PlanUsage.TotalPercentUsed,
+		"other_models_percent_used":   usage.PlanUsage.APIPercentUsed,
+		"auto_models_percent_used":    usage.PlanUsage.AutoPercentUsed,
+		"bonus_spend_usd":             usage.PlanUsage.BonusSpend / 100,
+		"on_demand_spend_usd":         usage.SpendLimitUsage.TotalSpend / 100,
+		"on_demand_limit_type":        strings.TrimSpace(usage.SpendLimitUsage.LimitType),
+		"on_demand_individual_limit":  usage.SpendLimitUsage.IndividualLimit / 100,
+		"on_demand_individual_used":   usage.SpendLimitUsage.IndividualUsed / 100,
+		"on_demand_individual_remain": usage.SpendLimitUsage.IndividualRemaining / 100,
+		"on_demand_pooled_limit":      usage.SpendLimitUsage.PooledLimit / 100,
+		"on_demand_pooled_used":       usage.SpendLimitUsage.PooledUsed / 100,
+		"on_demand_pooled_remain":     usage.SpendLimitUsage.PooledRemaining / 100,
+	}
+	return result, nil
+}
+
+func exchangeCursorAPIKeyForAccessToken(ctx context.Context, client *http.Client, apiKey string) (string, error) {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return "", errors.New("cursor api key is missing")
+	}
+	key := fmt.Sprintf("%x", sha256.Sum256([]byte(apiKey)))
+	resultCh := cursorDashboardExchangeGroup.DoChan(key, func() (any, error) {
+		exchangeCtx, cancel := context.WithTimeout(context.Background(), cursorDashboardExchangeTimeout)
+		defer cancel()
+		req, err := http.NewRequestWithContext(exchangeCtx, http.MethodPost, strings.TrimRight(cursorDashboardAPIBaseURL, "/")+"/auth/exchange_user_api_key", bytes.NewReader([]byte("{}")))
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		req.Header.Set("Content-Type", "application/json")
+		res, err := client.Do(req)
+		if err != nil {
+			return "", &cursorDashboardExchangeError{Err: err}
+		}
+		defer res.Body.Close()
+		body, err := readCursorAccountBody(res.Body)
+		if err != nil {
+			return "", err
+		}
+		if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+			return "", &cursorDashboardExchangeError{StatusCode: res.StatusCode, Err: errors.New("upstream rejected request")}
+		}
+		var exchanged cursorDashboardExchangeResponse
+		if err := common.Unmarshal(body, &exchanged); err != nil {
+			return "", &cursorDashboardExchangeError{StatusCode: res.StatusCode, Err: fmt.Errorf("decode response: %w", err)}
+		}
+		exchanged.AccessToken = strings.TrimSpace(exchanged.AccessToken)
+		if exchanged.AccessToken == "" {
+			return "", &cursorDashboardExchangeError{StatusCode: res.StatusCode, Err: errors.New("response contained an empty access token")}
+		}
+		return exchanged.AccessToken, nil
+	})
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case result := <-resultCh:
+		if result.Err != nil {
+			return "", result.Err
+		}
+		return result.Val.(string), nil
+	}
+}
+
+func cursorDashboardExchangeFailure(err error) gin.H {
+	result := gin.H{"available": false, "source": "cursor_dashboard_rpc", "reason": "exchange_unavailable"}
+	var exchangeErr *cursorDashboardExchangeError
+	if !errors.As(err, &exchangeErr) {
+		return result
+	}
+	if exchangeErr.StatusCode > 0 {
+		result["status"] = exchangeErr.StatusCode
+	}
+	if exchangeErr.StatusCode == http.StatusUnauthorized || exchangeErr.StatusCode == http.StatusForbidden {
+		result["reason"] = "api_key_invalid"
+	}
+	return result
+}
+
+func cursorDashboardPost(ctx context.Context, client *http.Client, method string, accessToken string) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(cursorDashboardAPIBaseURL, "/")+"/aiserver.v1.DashboardService/"+method, bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(accessToken))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Connect-Protocol-Version", "1")
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer res.Body.Close()
+	body, err := readCursorAccountBody(res.Body)
+	return res.StatusCode, body, err
+}
+
+func readCursorAccountBody(reader io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(reader, cursorAgentAccountResponseLimit+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > cursorAgentAccountResponseLimit {
+		return nil, errors.New("cursor account response too large")
+	}
+	return body, nil
+}

--- a/controller/cursor_agent_account_test.go
+++ b/controller/cursor_agent_account_test.go
@@ -1,0 +1,256 @@
+package controller
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/relay/channel/cursor_agent"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestGetCursorAgentChannelAccountUsesImmutableRuntimeAndRedactsCredential(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dsn := "file:" + t.Name() + "?mode=memory&cache=shared"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	previousDB := model.DB
+	model.DB = db
+	t.Cleanup(func() { model.DB = previousDB })
+	require.NoError(t, db.AutoMigrate(&model.Channel{}))
+
+	var sawAccount bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/account", r.URL.Path)
+		require.Equal(t, "Bearer secret-cursor-key", r.Header.Get("Authorization"))
+		require.Equal(t, "secret-cursor-key", r.Header.Get("x-api-key"))
+		sawAccount = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"account":{"api_key_name":"new-api test","email":"owner@example.com"},"catalog":{"model_count":36}}`))
+	}))
+	defer upstream.Close()
+	t.Setenv("CURSOR_AGENT_SIDECAR_BASE_URL", upstream.URL)
+
+	dashboard := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth/exchange_user_api_key":
+			require.Equal(t, "Bearer secret-cursor-key", r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(`{"accessToken":"dashboard-access"}`))
+		case "/aiserver.v1.DashboardService/GetCurrentPeriodUsage":
+			require.Equal(t, "Bearer dashboard-access", r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(`{"planUsage":{"includedSpend":100,"remaining":900,"limit":1000}}`))
+		case "/aiserver.v1.DashboardService/GetPlanInfo":
+			require.Equal(t, "Bearer dashboard-access", r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(`{"planInfo":{"planName":"Pro"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer dashboard.Close()
+	previousBaseURL := cursorDashboardAPIBaseURL
+	cursorDashboardAPIBaseURL = dashboard.URL
+	t.Cleanup(func() { cursorDashboardAPIBaseURL = previousBaseURL })
+
+	legacyBase := "http://legacy-sidecar.invalid"
+	channel := &model.Channel{
+		Type:      constant.ChannelTypeCursorAgent,
+		Key:       `{"api_key":"secret-cursor-key","access_token":"legacy-access","refresh_token":"legacy-refresh"}`,
+		Name:      "cursor-account",
+		Status:    common.ChannelStatusEnabled,
+		BaseURL:   &legacyBase,
+		UsedQuota: 12345,
+	}
+	require.NoError(t, db.Create(channel).Error)
+
+	router := gin.New()
+	router.GET("/api/channel/:id/cursor-agent/account", GetCursorAgentChannelAccount)
+	req := httptest.NewRequest(http.MethodGet, "/api/channel/"+strconv.Itoa(channel.Id)+"/cursor-agent/account", nil)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	var response map[string]any
+	require.NoError(t, common.Unmarshal(recorder.Body.Bytes(), &response))
+	require.Equal(t, true, response["success"])
+	data := response["data"].(map[string]any)
+	require.Equal(t, "owner@example.com", data["account"].(map[string]any)["email"])
+	require.Equal(t, float64(12345), data["gateway"].(map[string]any)["used_quota"])
+	require.Equal(t, true, data["quota"].(map[string]any)["available"])
+	require.InDelta(t, 9, data["quota"].(map[string]any)["remaining_usd"], 0.001)
+	require.NotContains(t, recorder.Body.String(), "secret-cursor-key")
+	require.NotContains(t, recorder.Body.String(), "dashboard-access")
+	require.NotContains(t, recorder.Body.String(), "legacy-access")
+	require.NotContains(t, recorder.Body.String(), "legacy-refresh")
+	require.True(t, sawAccount)
+}
+
+func TestFetchCursorDashboardQuotaReadsPersonalPlanUsage(t *testing.T) {
+	dashboard := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth/exchange_user_api_key":
+			require.Equal(t, "Bearer sdk-key", r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(`{"accessToken":"access"}`))
+		case "/aiserver.v1.DashboardService/GetCurrentPeriodUsage":
+			require.Equal(t, "Bearer access", r.Header.Get("Authorization"))
+			require.Equal(t, "1", r.Header.Get("Connect-Protocol-Version"))
+			_, _ = w.Write([]byte(`{"billingCycleStart":"1786520259000","billingCycleEnd":"1789198659000","planUsage":{"totalSpend":1965,"includedSpend":1965,"remaining":38035,"limit":40000,"autoPercentUsed":0.307,"apiPercentUsed":2.702,"totalPercentUsed":0.786}}`))
+		case "/aiserver.v1.DashboardService/GetPlanInfo":
+			require.Equal(t, "Bearer access", r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(`{"planInfo":{"planName":"Ultra","includedAmountCents":40000,"price":"$200/mo","billingCycleEnd":"1789198659000","planOwner":"PLAN_OWNER_STRIPE"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer dashboard.Close()
+	previousBaseURL := cursorDashboardAPIBaseURL
+	cursorDashboardAPIBaseURL = dashboard.URL
+	t.Cleanup(func() { cursorDashboardAPIBaseURL = previousBaseURL })
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	quota, err := fetchCursorDashboardQuota(ctx, dashboard.Client(), &cursor_agent.Credential{APIKey: "sdk-key"})
+	require.NoError(t, err)
+	require.Equal(t, true, quota["available"])
+	require.Equal(t, "Ultra", quota["plan_name"])
+	require.InDelta(t, 19.65, quota["used_usd"], 0.001)
+	require.InDelta(t, 380.35, quota["remaining_usd"], 0.001)
+	require.InDelta(t, 400, quota["limit_usd"], 0.001)
+	require.InDelta(t, 4.9125, quota["used_percent"], 0.001)
+	require.InDelta(t, 2.702, quota["other_models_percent_used"], 0.001)
+}
+
+func TestFetchCursorDashboardQuotaReexchangesAPIKeyAfterUnauthorized(t *testing.T) {
+	var usageCalls int
+	var exchangeCalls int
+	dashboard := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth/exchange_user_api_key":
+			exchangeCalls++
+			require.Equal(t, "Bearer sdk", r.Header.Get("Authorization"))
+			if exchangeCalls == 1 {
+				_, _ = w.Write([]byte(`{"accessToken":"stale"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"accessToken":"fresh"}`))
+		case "/aiserver.v1.DashboardService/GetCurrentPeriodUsage":
+			usageCalls++
+			if r.Header.Get("Authorization") != "Bearer fresh" {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"expired"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"planUsage":{"includedSpend":100,"remaining":900,"limit":1000}}`))
+		case "/aiserver.v1.DashboardService/GetPlanInfo":
+			_, _ = w.Write([]byte(`{"planInfo":{"planName":"Pro"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer dashboard.Close()
+	previousBaseURL := cursorDashboardAPIBaseURL
+	cursorDashboardAPIBaseURL = dashboard.URL
+	t.Cleanup(func() { cursorDashboardAPIBaseURL = previousBaseURL })
+
+	credential := &cursor_agent.Credential{APIKey: "sdk"}
+	quota, err := fetchCursorDashboardQuota(context.Background(), dashboard.Client(), credential)
+	require.NoError(t, err)
+	require.Equal(t, true, quota["available"])
+	require.Equal(t, 2, usageCalls)
+	require.Equal(t, 2, exchangeCalls)
+}
+
+func TestFetchCursorDashboardQuotaExchangeFailureDoesNotLeakAPIKey(t *testing.T) {
+	dashboard := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/auth/exchange_user_api_key", r.URL.Path)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"rejected secret-sdk-key"}`))
+	}))
+	defer dashboard.Close()
+	previousBaseURL := cursorDashboardAPIBaseURL
+	cursorDashboardAPIBaseURL = dashboard.URL
+	t.Cleanup(func() { cursorDashboardAPIBaseURL = previousBaseURL })
+
+	quota, err := fetchCursorDashboardQuota(context.Background(), dashboard.Client(), &cursor_agent.Credential{APIKey: "secret-sdk-key"})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "secret-sdk-key")
+	require.Equal(t, false, quota["available"])
+	require.Equal(t, "api_key_invalid", quota["reason"])
+	require.Equal(t, http.StatusUnauthorized, quota["status"])
+}
+
+func TestFetchCursorDashboardQuotaExchangeUnavailableIsNotReportedAsInvalidKey(t *testing.T) {
+	dashboard := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer dashboard.Close()
+	previousBaseURL := cursorDashboardAPIBaseURL
+	cursorDashboardAPIBaseURL = dashboard.URL
+	t.Cleanup(func() { cursorDashboardAPIBaseURL = previousBaseURL })
+
+	quota, err := fetchCursorDashboardQuota(context.Background(), dashboard.Client(), &cursor_agent.Credential{APIKey: "sdk-key"})
+	require.Error(t, err)
+	require.Equal(t, false, quota["available"])
+	require.Equal(t, "exchange_unavailable", quota["reason"])
+	require.Equal(t, http.StatusServiceUnavailable, quota["status"])
+}
+
+func TestExchangeCursorAPIKeyConcurrentWaiterSurvivesLeaderCancellation(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var exchangeCalls atomic.Int32
+	dashboard := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if exchangeCalls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"accessToken":"shared-access"}`))
+	}))
+	defer dashboard.Close()
+	previousBaseURL := cursorDashboardAPIBaseURL
+	cursorDashboardAPIBaseURL = dashboard.URL
+	t.Cleanup(func() { cursorDashboardAPIBaseURL = previousBaseURL })
+
+	type exchangeResult struct {
+		token string
+		err   error
+	}
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	firstResult := make(chan exchangeResult, 1)
+	go func() {
+		token, err := exchangeCursorAPIKeyForAccessToken(firstCtx, dashboard.Client(), "shared-key")
+		firstResult <- exchangeResult{token: token, err: err}
+	}()
+	<-started
+
+	secondResult := make(chan exchangeResult, 1)
+	go func() {
+		token, err := exchangeCursorAPIKeyForAccessToken(context.Background(), dashboard.Client(), "shared-key")
+		secondResult <- exchangeResult{token: token, err: err}
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancelFirst()
+	close(release)
+
+	first := <-firstResult
+	require.ErrorIs(t, first.err, context.Canceled)
+	second := <-secondResult
+	require.NoError(t, second.err)
+	require.Equal(t, "shared-access", second.token)
+	require.Equal(t, int32(1), exchangeCalls.Load())
+}

--- a/controller/cursor_agent_models_test.go
+++ b/controller/cursor_agent_models_test.go
@@ -1,0 +1,35 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchCursorAgentModelsUsesResolvedSidecarAndParsedCredential(t *testing.T) {
+	const apiKey = "cursor_test_model_key"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/models", r.URL.Path)
+		require.Equal(t, "Bearer "+apiKey, r.Header.Get("Authorization"))
+		require.Equal(t, apiKey, r.Header.Get("x-api-key"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"claude-sonnet-4-6"},{"id":"grok-4.6"}]}`))
+	}))
+	defer server.Close()
+	t.Setenv("CURSOR_AGENT_SIDECAR_BASE_URL", server.URL)
+
+	channel := &model.Channel{
+		Type:    constant.ChannelTypeCursorAgent,
+		Key:     `{"api_key":"` + apiKey + `"}`,
+		BaseURL: common.GetPointer("http://ignored.invalid"),
+	}
+	models, err := fetchChannelUpstreamModelIDs(channel)
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"claude-sonnet-4-6", "grok-4.6"}, models)
+}

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -126,60 +126,63 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 		return
 	}
 
-	needSensitiveCheck := setting.ShouldCheckPromptSensitive()
-	needCountToken := constant.CountToken
-	// Avoid building huge CombineText (strings.Join) when token counting and sensitive check are both disabled.
-	var meta *types.TokenCountMeta
-	if needSensitiveCheck || needCountToken {
-		meta = request.GetTokenCountMeta()
-	} else {
-		meta = fastTokenCountMetaForPricing(request)
-	}
-
-	if needSensitiveCheck && meta != nil {
-		contains, words := service.CheckSensitiveText(meta.CombineText)
-		if contains {
-			logger.LogWarn(c, fmt.Sprintf("user sensitive words detected: %s", strings.Join(words, ", ")))
-			newAPIError = types.NewError(err, types.ErrorCodeSensitiveWordsDetected)
-			return
+	// Claude Code uses count_tokens as a sizing probe. It still goes through
+	// authentication, routing and channel selection, but it is never billed as
+	// a model generation.
+	if relayInfo.RelayMode != relayconstant.RelayModeClaudeCountTokens {
+		needSensitiveCheck := setting.ShouldCheckPromptSensitive()
+		needCountToken := constant.CountToken
+		// Avoid building huge CombineText (strings.Join) when token counting and sensitive check are both disabled.
+		var meta *types.TokenCountMeta
+		if needSensitiveCheck || needCountToken {
+			meta = request.GetTokenCountMeta()
+		} else {
+			meta = fastTokenCountMetaForPricing(request)
 		}
-	}
 
-	tokens, err := service.EstimateRequestToken(c, meta, relayInfo)
-	if err != nil {
-		newAPIError = types.NewError(err, types.ErrorCodeCountTokenFailed)
-		return
-	}
-
-	relayInfo.SetEstimatePromptTokens(tokens)
-
-	priceData, err := helper.ModelPriceHelper(c, relayInfo, tokens, meta)
-	if err != nil {
-		newAPIError = types.NewError(err, types.ErrorCodeModelPriceError, types.ErrOptionWithStatusCode(http.StatusBadRequest))
-		return
-	}
-
-	// common.SetContextKey(c, constant.ContextKeyTokenCountMeta, meta)
-
-	if priceData.FreeModel {
-		logger.LogInfo(c, fmt.Sprintf("模型 %s 免费，跳过预扣费", relayInfo.OriginModelName))
-	} else {
-		newAPIError = service.PreConsumeBilling(c, priceData.QuotaToPreConsume, relayInfo)
-		if newAPIError != nil {
-			return
-		}
-	}
-
-	defer func() {
-		// Only return quota if downstream failed and quota was actually pre-consumed
-		if newAPIError != nil {
-			newAPIError = service.NormalizeViolationFeeError(newAPIError)
-			if relayInfo.Billing != nil {
-				relayInfo.Billing.Refund(c)
+		if needSensitiveCheck && meta != nil {
+			contains, words := service.CheckSensitiveText(meta.CombineText)
+			if contains {
+				logger.LogWarn(c, fmt.Sprintf("user sensitive words detected: %s", strings.Join(words, ", ")))
+				newAPIError = types.NewError(err, types.ErrorCodeSensitiveWordsDetected)
+				return
 			}
-			service.ChargeViolationFeeIfNeeded(c, relayInfo, newAPIError)
 		}
-	}()
+
+		tokens, err := service.EstimateRequestToken(c, meta, relayInfo)
+		if err != nil {
+			newAPIError = types.NewError(err, types.ErrorCodeCountTokenFailed)
+			return
+		}
+
+		relayInfo.SetEstimatePromptTokens(tokens)
+
+		priceData, err := helper.ModelPriceHelper(c, relayInfo, tokens, meta)
+		if err != nil {
+			newAPIError = types.NewError(err, types.ErrorCodeModelPriceError, types.ErrOptionWithStatusCode(http.StatusBadRequest))
+			return
+		}
+
+		if priceData.FreeModel {
+			logger.LogInfo(c, fmt.Sprintf("模型 %s 免费，跳过预扣费", relayInfo.OriginModelName))
+		} else {
+			newAPIError = service.PreConsumeBilling(c, priceData.QuotaToPreConsume, relayInfo)
+			if newAPIError != nil {
+				return
+			}
+		}
+
+		defer func() {
+			// Only return quota if downstream failed and quota was actually pre-consumed
+			if newAPIError != nil {
+				newAPIError = service.NormalizeViolationFeeError(newAPIError)
+				if relayInfo.Billing != nil {
+					relayInfo.Billing.Refund(c)
+				}
+				service.ChargeViolationFeeIfNeeded(c, relayInfo, newAPIError)
+			}
+		}()
+	}
 
 	retryParam := &service.RetryParam{
 		Ctx:         c,

--- a/cursor_agent_sidecar/.gitignore
+++ b/cursor_agent_sidecar/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+empty-workspace/**
+!.gitkeep

--- a/cursor_agent_sidecar/CURSOR-SDK-LICENSE.md
+++ b/cursor_agent_sidecar/CURSOR-SDK-LICENSE.md
@@ -1,0 +1,3 @@
+# Cursor SDK License
+
+© Anysphere Inc. All rights reserved. Use is subject to Cursor's [Terms of Service](https://cursor.com/terms-of-service).

--- a/cursor_agent_sidecar/README.md
+++ b/cursor_agent_sidecar/README.md
@@ -1,0 +1,96 @@
+# Cursor Agent Sidecar
+
+Official `@cursor/sdk` HTTP bridge for new-api channel type **61 (Cursor Agent)**.
+
+## Boundary
+
+- Auth: Cursor **User API Key** (`crsr_…` / `CURSOR_API_KEY`), not email/password
+- No reverse-engineered Cursor private Connect-RPC client
+- new-api converts Chat Completions and Responses requests to native Anthropic
+  Messages before they reach this sidecar.
+- `/v1/messages` tool requests use the official Cursor SDK harness with
+  `tools: ["mcp"]` and per-run `local.customTools`. The first request parks all
+  callbacks observed in the same assistant turn and returns a native Anthropic
+  `tool_use` batch; a later request carrying the exact matching `tool_result`
+  batch resumes the same live SDK Run. Agent/checkpoint metadata and a minimal
+  credential-free bridge journal are stored on the slot's persistent volume;
+  after an unexpected process restart the bridge resumes the persisted agent,
+  expires the stranded run, and continues from the submitted tool results.
+- Surface: `POST /v1/messages`, `GET /v1/models`, `GET /v1/account`, and
+  `GET /health`. The new-api gateway serves `/v1/messages/count_tokens` with a
+  local estimate because the Cursor SDK does not expose a token-count method.
+- This is **not** native Anthropic OAuth; Claude, Grok, and Composer SKUs come
+  from Cursor's model catalog and execute inside Cursor's official harness.
+- Each gateway instance owns one stateful SDK worker and one persistent state
+  directory. Every tool id includes the owning container instance. Multi-instance
+  deployments must keep tool continuations sticky to the owning instance or
+  configure an allowlisted peer route with
+  `CURSOR_AGENT_PEER_BASE_URL_TEMPLATE` and `CURSOR_AGENT_PEER_INSTANCE_IDS`.
+  Releases can put the old worker
+  into drain mode, reject new sessions there, and stop it as soon
+  as all live/replay sessions finish (15 minutes is only the hard deadline).
+  Unexpected process restarts use the official SDK store plus the bridge journal
+  for cold continuation. new-api owns channel/user concurrency limits. Prompt
+  cache controls, computer use, and Responses compaction remain absent. Anthropic
+  thinking is mapped to Cursor's official model `effort` parameter. The SDK does
+  not expose Anthropic `max_tokens`, temperature, top_p, or stop-sequence controls,
+  so generation limits remain harness-owned rather than raw Messages semantics.
+
+The worker limits live sessions globally and per Cursor credential (defaults:
+256 and 32). new-api also binds every tool continuation to the originating
+gateway user/token/channel identity before it can resume.
+
+## Run
+
+The official Docker image starts this worker automatically beside new-api and
+persists its restart metadata under `/data/cursor-agent`. Add a Cursor Agent
+channel, paste a Cursor User API Key, and leave Base URL empty. Set
+`CURSOR_AGENT_EMBEDDED_SIDECAR=0` only when operating an external worker.
+The admin account dialog gets identity/catalog data through the official SDK;
+remaining-spend data is a best-effort call to Cursor's Dashboard RPC and
+degrades to “unavailable” without affecting inference if that endpoint changes.
+
+### Direct egress (default)
+
+```bash
+cd cursor_agent_sidecar
+npm install
+./start.sh
+# listens 127.0.0.1:3927
+```
+
+### CN / laptop (Claude region block)
+
+Cursor Agent often **bypasses system HTTP_PROXY** (HTTP/2), so Claude fails with
+“provider is not supported in your region” even with a US browser exit.
+
+```bash
+CURSOR_AGENT_FORCE_PROXY=1 \
+CURSOR_AGENT_PROXY=http://127.0.0.1:7890 \
+./start.sh
+
+# strongest TCP wrap:
+PROXYCHAINS=1 CURSOR_AGENT_FORCE_PROXY=1 ./start.sh
+
+npm run smoke:claude   # expect PROXY_CLAUDE_OK
+```
+
+## new-api channel
+
+| Field | Value |
+|---|---|
+| Type | `61` Cursor Agent |
+| Key | User API Key from `Cursor.auth.login()` or Dashboard |
+| Base URL | leave empty (`http://127.0.0.1:3927` is the default) |
+| Models | bare SKUs e.g. `composer-2.5`, `claude-opus-5`, `claude-fable-5` |
+
+## Smoke
+
+```bash
+curl -s http://127.0.0.1:3927/health
+curl -s http://127.0.0.1:3927/v1/messages \
+  -H "x-api-key: $CURSOR_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"composer-2.5","max_tokens":64,"messages":[{"role":"user","content":"Reply SMOKE_OK"}],"stream":false}'
+```

--- a/cursor_agent_sidecar/cursor_account.mjs
+++ b/cursor_agent_sidecar/cursor_account.mjs
@@ -1,0 +1,40 @@
+import { Cursor } from "@cursor/sdk";
+
+function optionalString(value) {
+  const text = String(value ?? "").trim();
+  return text || null;
+}
+
+export async function fetchCursorAccount(apiKey, cursor = Cursor) {
+  const [user, models] = await Promise.all([
+    cursor.me({ apiKey }),
+    cursor.models.list({ apiKey }),
+  ]);
+
+  const firstName = optionalString(user?.userFirstName);
+  const lastName = optionalString(user?.userLastName);
+  const displayName = [firstName, lastName].filter(Boolean).join(" ") || null;
+
+  return {
+    account: {
+      api_key_name: optionalString(user?.apiKeyName),
+      user_id: Number.isFinite(Number(user?.userId))
+        ? Number(user.userId)
+        : null,
+      email: optionalString(user?.userEmail),
+      first_name: firstName,
+      last_name: lastName,
+      display_name: displayName,
+      api_key_created_at: optionalString(user?.createdAt),
+      account_kind: user?.userId == null ? "service_account" : "user",
+    },
+    catalog: {
+      model_count: Array.isArray(models) ? models.length : 0,
+    },
+    quota: {
+      available: false,
+      source: "cursor_sdk",
+      reason: "account_quota_not_exposed",
+    },
+  };
+}

--- a/cursor_agent_sidecar/cursor_account.test.mjs
+++ b/cursor_agent_sidecar/cursor_account.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { fetchCursorAccount } from "./cursor_account.mjs";
+
+test("normalizes Cursor SDK user metadata without exposing the api key", async () => {
+  const calls = [];
+  const cursor = {
+    me: async (options) => {
+      calls.push(["me", options]);
+      return {
+        apiKeyName: "new-api test",
+        userId: 1234,
+        userEmail: "owner@example.com",
+        userFirstName: "Sunny",
+        userLastName: "Ender",
+        createdAt: "2026-08-14T01:02:03.000Z",
+      };
+    },
+    models: {
+      list: async (options) => {
+        calls.push(["models", options]);
+        return [{ id: "grok-4.6" }, { id: "claude-fable-5" }];
+      },
+    },
+  };
+
+  const result = await fetchCursorAccount("secret-cursor-key", cursor);
+
+  assert.deepEqual(calls, [
+    ["me", { apiKey: "secret-cursor-key" }],
+    ["models", { apiKey: "secret-cursor-key" }],
+  ]);
+  assert.deepEqual(result.account, {
+    api_key_name: "new-api test",
+    user_id: 1234,
+    email: "owner@example.com",
+    first_name: "Sunny",
+    last_name: "Ender",
+    display_name: "Sunny Ender",
+    api_key_created_at: "2026-08-14T01:02:03.000Z",
+    account_kind: "user",
+  });
+  assert.equal(result.catalog.model_count, 2);
+  assert.equal(result.quota.available, false);
+  assert.equal(result.quota.reason, "account_quota_not_exposed");
+  assert.equal(JSON.stringify(result).includes("secret-cursor-key"), false);
+});
+
+test("marks SDK service-account keys without inventing a user identity", async () => {
+  const cursor = {
+    me: async () => ({
+      apiKeyName: "Service key",
+      createdAt: "2026-08-14T01:02:03.000Z",
+    }),
+    models: { list: async () => [] },
+  };
+
+  const result = await fetchCursorAccount("secret", cursor);
+
+  assert.equal(result.account.account_kind, "service_account");
+  assert.equal(result.account.user_id, null);
+  assert.equal(result.account.email, null);
+  assert.equal(result.catalog.model_count, 0);
+});

--- a/cursor_agent_sidecar/force_proxy.mjs
+++ b/cursor_agent_sidecar/force_proxy.mjs
@@ -1,0 +1,110 @@
+/**
+ * Optional proxy enforcement for Cursor SDK.
+ *
+ * Direct-egress hosts: leave OFF (default).
+ * CN / laptop dev: set CURSOR_AGENT_FORCE_PROXY=1 and/or CURSOR_AGENT_PROXY.
+ *
+ * Activation (any one):
+ *   - CURSOR_AGENT_FORCE_PROXY=1
+ *   - CURSOR_AGENT_PROXY=<url> explicitly set
+ *   - FORCE_PROXY=1
+ *
+ * When inactive: only light Cursor.configure (useHttp1 optional, default false).
+ */
+import { ProxyAgent, setGlobalDispatcher } from "undici";
+import { Cursor } from "@cursor/sdk";
+
+const DEFAULT_PROXY = "http://127.0.0.1:7890";
+
+function truthy(v) {
+  if (v == null) return false;
+  const s = String(v).trim().toLowerCase();
+  return s === "1" || s === "true" || s === "yes" || s === "on";
+}
+
+function shouldForceProxy() {
+  if (truthy(process.env.CURSOR_AGENT_FORCE_PROXY)) return true;
+  if (truthy(process.env.FORCE_PROXY)) return true;
+  // Explicit proxy URL set by operator (not merely inherited empty).
+  if (String(process.env.CURSOR_AGENT_PROXY || "").trim()) return true;
+  return false;
+}
+
+function resolveProxyUrl() {
+  const raw =
+    process.env.CURSOR_AGENT_PROXY ||
+    process.env.HTTPS_PROXY ||
+    process.env.HTTP_PROXY ||
+    process.env.https_proxy ||
+    process.env.http_proxy ||
+    process.env.ALL_PROXY ||
+    process.env.all_proxy ||
+    DEFAULT_PROXY;
+  const u = String(raw).trim();
+  if (!u) return DEFAULT_PROXY;
+  if (/^(https?|socks5?):\/\//i.test(u)) return u;
+  return `http://${u}`;
+}
+
+export function forceCursorProxy(options = {}) {
+  const enabled =
+    options.enabled !== undefined ? options.enabled : shouldForceProxy();
+  const useHttp1 =
+    options.useHttp1ForAgent !== undefined
+      ? options.useHttp1ForAgent
+      : truthy(process.env.CURSOR_AGENT_FORCE_HTTP1);
+
+  if (!enabled) {
+    // US default: no proxy patching. Optionally still force HTTP/1 if asked.
+    if (useHttp1) {
+      try {
+        Cursor.configure({ local: { useHttp1ForAgent: true } });
+      } catch (err) {
+        console.error("[force_proxy] Cursor.configure failed:", err?.message || err);
+      }
+    }
+    console.log(
+      `[force_proxy] inactive (US-friendly default). Set CURSOR_AGENT_FORCE_PROXY=1 or CURSOR_AGENT_PROXY=... for CN/dev.`
+    );
+    return { enabled: false, proxyUrl: null, useHttp1 };
+  }
+
+  const proxyUrl = options.proxyUrl || resolveProxyUrl();
+
+  process.env.HTTP_PROXY = proxyUrl;
+  process.env.HTTPS_PROXY = proxyUrl;
+  process.env.http_proxy = proxyUrl;
+  process.env.https_proxy = proxyUrl;
+  process.env.ALL_PROXY = proxyUrl;
+  process.env.all_proxy = proxyUrl;
+  process.env.NODE_USE_ENV_PROXY = "1";
+  if (!process.env.NO_PROXY) {
+    process.env.NO_PROXY = "localhost,127.0.0.1,::1,*.local";
+    process.env.no_proxy = process.env.NO_PROXY;
+  }
+
+  try {
+    setGlobalDispatcher(new ProxyAgent(proxyUrl));
+  } catch (err) {
+    console.error("[force_proxy] undici ProxyAgent failed:", err?.message || err);
+  }
+
+  // When forcing proxy, HTTP/1 is on by default (HTTP/2 often bypasses proxy).
+  const http1 = useHttp1 || process.env.CURSOR_AGENT_FORCE_HTTP1 !== "0";
+  try {
+    Cursor.configure({
+      local: {
+        useHttp1ForAgent: http1,
+      },
+    });
+  } catch (err) {
+    console.error("[force_proxy] Cursor.configure failed:", err?.message || err);
+  }
+
+  console.log(
+    `[force_proxy] ACTIVE proxy=${proxyUrl} useHttp1ForAgent=${http1} NODE_USE_ENV_PROXY=1`
+  );
+  return { enabled: true, proxyUrl, useHttp1: http1 };
+}
+
+forceCursorProxy();

--- a/cursor_agent_sidecar/harness_messages.mjs
+++ b/cursor_agent_sidecar/harness_messages.mjs
@@ -1,0 +1,1213 @@
+import { createHash, randomUUID } from "node:crypto";
+import { Agent } from "@cursor/sdk";
+import { deleteSdkAgentState } from "./session_state.mjs";
+
+const DEFAULT_SESSION_TTL_MS = 15 * 60 * 1000;
+const DEFAULT_REPLAY_TTL_MS = 2 * 60 * 1000;
+const DEFAULT_FIRST_EVENT_TIMEOUT_MS = 90 * 1000;
+const DEFAULT_PARALLEL_COLLECT_MS = 100;
+const ROUTED_TOOL_USE_ID_PATTERN = /^toolu_bf_([a-z0-9-]{1,24})_([a-f0-9]{32})$/;
+
+function normalizeInstanceId(value) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return "";
+  if (!/^[a-z0-9-]{1,24}$/.test(normalized)) {
+    throw new Error("cursor harness instance id must use 1-24 lowercase letters, digits, or hyphens");
+  }
+  return normalized;
+}
+
+function routedToolUseId(instanceId) {
+  return `toolu_bf_${instanceId}_${randomUUID().replaceAll("-", "")}`;
+}
+
+export function cursorHarnessInstanceFromToolUseId(toolUseId) {
+  return String(toolUseId || "").match(ROUTED_TOOL_USE_ID_PATTERN)?.[1] || "";
+}
+
+export function cursorHarnessRouteFromRequest(body) {
+  const toolResults = extractLatestToolResults(body);
+  if (toolResults.length === 0) return "";
+  const routes = new Set();
+  let legacyCount = 0;
+  for (const result of toolResults) {
+    const route = cursorHarnessInstanceFromToolUseId(result.toolUseId);
+    if (route) routes.add(route);
+    else legacyCount += 1;
+  }
+  if (routes.size > 1 || (routes.size === 1 && legacyCount > 0)) {
+    throw Object.assign(new Error("tool results span multiple harness instances"), {
+      status: 409,
+    });
+  }
+  return routes.values().next().value || "";
+}
+
+export function cursorHarnessRequestHasToolResults(body) {
+  return extractLatestToolResults(body).length > 0;
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function credentialFingerprint(apiKey) {
+  return createHash("sha256").update(String(apiKey || "")).digest("hex");
+}
+
+function tenantFingerprint(tenantId) {
+  return createHash("sha256").update(String(tenantId || "")).digest("hex");
+}
+
+function anthropicEffort(body) {
+  const explicit = String(body?.output_config?.effort || "").trim().toLowerCase();
+  if (["low", "medium", "high", "xhigh"].includes(explicit)) return explicit;
+  const thinking = body?.thinking;
+  if (!thinking || !["enabled", "adaptive"].includes(thinking.type)) return "";
+  const budget = Number(thinking.budget_tokens || 0);
+  if (budget > 0 && budget <= 2048) return "low";
+  if (budget > 10000) return "high";
+  return "medium";
+}
+
+export function cursorSdkModelSelection(model, body = undefined) {
+  const normalized = String(model || "").trim();
+  const grok = normalized.match(/^cursor-(grok-4\.(?:5|6))-(low|medium|high|xhigh)$/i);
+  if (grok) {
+    return {
+      id: grok[1].toLowerCase(),
+      params: [{ id: "effort", value: grok[2].toLowerCase() }],
+    };
+  }
+  const effort = anthropicEffort(body);
+  if (effort && /^claude-/i.test(normalized)) {
+    return { id: normalized, params: [{ id: "effort", value: effort }] };
+  }
+  return { id: normalized };
+}
+
+function textFromContent(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((block) => block?.type === "text" && typeof block.text === "string")
+    .map((block) => block.text)
+    .join("\n");
+}
+
+function serializedContent(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts = [];
+  for (const block of content) {
+    if (block?.type === "text" && typeof block.text === "string") {
+      parts.push(block.text);
+    } else if (block?.type === "tool_use" && block.id && block.name) {
+      parts.push(
+        `TOOL_USE id=${String(block.id)} name=${String(block.name)} input=${JSON.stringify(block.input || {})}`,
+      );
+    } else if (block?.type === "tool_result" && block.tool_use_id) {
+      parts.push(
+        `TOOL_RESULT tool_use_id=${String(block.tool_use_id)} is_error=${Boolean(block.is_error)} content=${JSON.stringify(textFromContent(block.content) || String(block.content || ""))}`,
+      );
+    } else if (block?.type === "image") {
+      parts.push("IMAGE_ATTACHMENT");
+    }
+  }
+  return parts.join("\n");
+}
+
+function imagesFromAnthropicRequest(body) {
+  const images = [];
+  for (const message of body?.messages || []) {
+    if (!Array.isArray(message?.content)) continue;
+    for (const block of message.content) {
+      if (block?.type !== "image" || !block.source) continue;
+      if (
+        block.source.type === "base64" &&
+        typeof block.source.data === "string" &&
+        typeof block.source.media_type === "string"
+      ) {
+        images.push({ data: block.source.data, mimeType: block.source.media_type });
+      } else if (block.source.type === "url" && typeof block.source.url === "string") {
+        images.push({ url: block.source.url });
+      }
+    }
+  }
+  return images;
+}
+
+function promptFromAnthropicRequest(body) {
+  const parts = [];
+  const system = textFromContent(body?.system);
+  if (system) parts.push(`SYSTEM:\n${system}`);
+  for (const message of body?.messages || []) {
+    const content = serializedContent(message?.content);
+    if (content) parts.push(`${String(message.role || "user").toUpperCase()}:\n${content}`);
+  }
+  const tools = Array.isArray(body?.tools) ? body.tools : [];
+  const toolChoice = body?.tool_choice;
+  if (tools.length > 0 && toolChoice?.type === "tool" && toolChoice.name) {
+    parts.push(
+      `HARNESS:\nYou must call the custom MCP tool ${String(toolChoice.name)} before answering.`,
+    );
+  } else if (
+    tools.length > 0 &&
+    toolChoice?.type === "any" &&
+    toolChoice.disable_parallel_tool_use === true
+  ) {
+    parts.push(
+      "HARNESS:\nYou must call exactly one available custom MCP tool before answering. Do not call tools in parallel.",
+    );
+  } else if (tools.length > 0 && toolChoice?.type === "any") {
+    parts.push(
+      "HARNESS:\nYou must call at least one available custom MCP tool before answering. If the task needs multiple independent tools, call all of them together in the same turn so they can run in parallel.",
+    );
+  }
+  return parts.join("\n\n");
+}
+
+function extractLatestToolResults(body) {
+  const results = [];
+  const messages = Array.isArray(body?.messages) ? body.messages : [];
+  const latestUserMessage = [...messages].reverse().find((message) => message?.role === "user");
+  if (!Array.isArray(latestUserMessage?.content)) return results;
+  for (const block of latestUserMessage.content) {
+    if (block?.type !== "tool_result" || !block.tool_use_id) continue;
+    const text = textFromContent(block.content);
+    results.push({
+      toolUseId: String(block.tool_use_id),
+      isError: Boolean(block.is_error),
+      content: text || (typeof block.content === "string" ? block.content : ""),
+    });
+  }
+  return results;
+}
+
+function latestUserHasMixedToolResultContent(body) {
+  const messages = Array.isArray(body?.messages) ? body.messages : [];
+  const latestUserMessage = [...messages].reverse().find((message) => message?.role === "user");
+  if (!Array.isArray(latestUserMessage?.content)) return false;
+  const hasToolResult = latestUserMessage.content.some(
+    (block) => block?.type === "tool_result" && block.tool_use_id,
+  );
+  return (
+    hasToolResult &&
+    latestUserMessage.content.some((block) => {
+      if (block?.type === "tool_result") return false;
+      if (block?.type === "text") return Boolean(String(block.text || "").trim());
+      return block != null;
+    })
+  );
+}
+
+function customToolsFromAnthropic(tools, onCall) {
+  const customTools = {};
+  for (const tool of tools || []) {
+    const name = String(tool?.name || "").trim();
+    if (!name || customTools[name]) continue;
+    customTools[name] = {
+      description: String(tool?.description || ""),
+      inputSchema:
+        tool?.input_schema && typeof tool.input_schema === "object"
+          ? tool.input_schema
+          : { type: "object", properties: {} },
+      execute: (args, context) => onCall(name, args || {}, context || {}),
+    };
+  }
+  return customTools;
+}
+
+function anthropicUsage(usage) {
+  return {
+    input_tokens: Number(usage?.inputTokens ?? usage?.input_tokens ?? 0) || 0,
+    output_tokens: Number(usage?.outputTokens ?? usage?.output_tokens ?? 0) || 0,
+    cache_read_input_tokens:
+      Number(usage?.cacheReadTokens ?? usage?.cache_read_input_tokens ?? 0) || 0,
+    cache_creation_input_tokens:
+      Number(usage?.cacheWriteTokens ?? usage?.cache_creation_input_tokens ?? 0) || 0,
+  };
+}
+
+function newAnthropicMessageId() {
+  return `msg_${randomUUID().replaceAll("-", "").slice(0, 24)}`;
+}
+
+function anthropicMessage({ id, model, content, stopReason, usage }) {
+  return {
+    id: id || newAnthropicMessageId(),
+    type: "message",
+    role: "assistant",
+    model,
+    content,
+    stop_reason: stopReason,
+    stop_sequence: null,
+    usage: anthropicUsage(usage),
+  };
+}
+
+function withTimeout(promise, timeoutMs, message) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    timer.unref?.();
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+function toolResultDigest(toolResult) {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        id: toolResult.toolUseId,
+        content: toolResult.content,
+        isError: toolResult.isError,
+      }),
+    )
+    .digest("hex");
+}
+
+function toolResultRequestDigest(toolResults) {
+  return createHash("sha256")
+    .update(
+      JSON.stringify(
+        toolResults
+          .map((result) => ({ id: result.toolUseId, digest: toolResultDigest(result) }))
+          .sort((a, b) => a.id.localeCompare(b.id)),
+      ),
+    )
+    .digest("hex");
+}
+
+function recoveredToolResultPrompt(record, toolResults) {
+  const names = new Map((record.pending || []).map((item) => [item.toolUseId, item.name]));
+  const lines = toolResults.map((result) =>
+    `TOOL_RESULT tool_use_id=${result.toolUseId} tool=${names.get(result.toolUseId) || "unknown"} is_error=${result.isError} content=${JSON.stringify(result.content)}`,
+  );
+  return [
+    "HOST_RECOVERY:",
+    "The host process restarted while your external tool calls were waiting for results.",
+    "Continue the same task from the persisted agent checkpoint using these exact results.",
+    "Do not repeat the completed tool calls. You may call other tools only if the task still requires them.",
+    ...lines,
+  ].join("\n");
+}
+
+export class CursorHarnessMessagesBridge {
+  constructor(options = {}) {
+    this.workspace = options.workspace;
+    this.sessionTtlMs = options.sessionTtlMs ?? DEFAULT_SESSION_TTL_MS;
+    this.replayTtlMs = options.replayTtlMs ?? DEFAULT_REPLAY_TTL_MS;
+    this.firstEventTimeoutMs =
+      options.firstEventTimeoutMs ?? DEFAULT_FIRST_EVENT_TIMEOUT_MS;
+    this.parallelCollectMs = options.parallelCollectMs ?? DEFAULT_PARALLEL_COLLECT_MS;
+    this.maxActiveSessions = options.maxActiveSessions ?? 256;
+    this.maxSessionsPerCredential = options.maxSessionsPerCredential ?? 32;
+    this.instanceId = normalizeInstanceId(options.instanceId || "");
+    this.agentFactory = options.agentFactory || ((agentOptions) => Agent.create(agentOptions));
+    this.agentResumer =
+      options.agentResumer || ((agentId, agentOptions) => Agent.resume(agentId, agentOptions));
+    this.sdkStore = options.sdkStore;
+    this.sessionState = options.sessionState;
+    this.sessionsByToolUseId = new Map();
+    this.sessions = new Set();
+    this.persistedRecoveries = new Map();
+    this.accepting = true;
+  }
+
+  async handle(body, apiKey, options = {}) {
+    const toolResults = extractLatestToolResults(body);
+    if (toolResults.length > 0) {
+      if (latestUserHasMixedToolResultContent(body)) {
+        throw Object.assign(
+          new Error("tool_result blocks and new user content require separate turns"),
+          { status: 422 },
+        );
+      }
+      return this.#resume(toolResults, body, apiKey, options);
+    }
+    if (!this.accepting) {
+      throw Object.assign(new Error("cursor harness sidecar is draining"), {
+        status: 503,
+        retryAfter: 2,
+      });
+    }
+    return this.#start(body, apiKey, options);
+  }
+
+  async #start(body, apiKey, options) {
+    const signal = options.signal;
+    const model = String(body?.model || "").trim();
+    const prompt = promptFromAnthropicRequest(body);
+    const images = imagesFromAnthropicRequest(body);
+    if (!model) throw Object.assign(new Error("model is required"), { status: 400 });
+    if (!prompt) throw Object.assign(new Error("messages are required"), { status: 400 });
+    const hasTools = Array.isArray(body?.tools) && body.tools.length > 0;
+    const fingerprint = credentialFingerprint(apiKey);
+    if (this.sessions.size >= this.maxActiveSessions) {
+      throw Object.assign(new Error("cursor harness active session limit reached"), {
+        status: 429,
+        retryAfter: 2,
+      });
+    }
+    let credentialSessions = 0;
+    for (const active of this.sessions) {
+      if (active.credentialFingerprint === fingerprint) credentialSessions += 1;
+    }
+    if (credentialSessions >= this.maxSessionsPerCredential) {
+      throw Object.assign(new Error("cursor harness credential session limit reached"), {
+        status: 429,
+        retryAfter: 2,
+      });
+    }
+    const session = this.#newSession(model, fingerprint, options);
+    session.usesSdkStore = Boolean(hasTools && this.sdkStore);
+    this.sessions.add(session);
+    if (signal) {
+      this.#bindAbort(session, signal);
+      if (signal.aborted) {
+        const error = Object.assign(new Error("cursor harness client disconnected"), {
+          status: 499,
+        });
+        await this.#closeSession(session, error);
+        throw error;
+      }
+    }
+
+    const customTools = this.#customTools(session, body.tools);
+    try {
+      session.agent = await this.agentFactory({
+        apiKey,
+        model: cursorSdkModelSelection(model, body),
+        tools: hasTools ? ["mcp"] : [],
+        disallowedTools: ["shell", "read", "edit", "task", "webSearch", "webFetch"],
+        local: {
+          cwd: this.workspace,
+          settingSources: [],
+          ...(session.usesSdkStore ? { store: this.sdkStore } : {}),
+          // This bridge exposes only deferred host callbacks through MCP; all
+          // filesystem, shell, task, and web tools are denied above. The slim
+          // production container intentionally does not ship Cursor's sandbox
+          // binary, so requesting SDK sandboxing would fail before inference.
+          sandboxOptions: { enabled: false },
+          ...(hasTools ? { customTools } : {}),
+        },
+      });
+      if (session.closed) {
+        try {
+          session.agent?.close?.();
+        } catch {
+          // Best effort: the session was closed while Agent.create was pending.
+        }
+        throw Object.assign(new Error("cursor harness client disconnected"), {
+          status: 499,
+        });
+      }
+      const run = await session.agent.send(
+        images.length > 0 ? { text: prompt, images } : prompt,
+        {
+          onDelta: ({ update }) => this.#handleInteractionUpdate(session, update),
+        },
+      );
+      if (session.closed) {
+        try {
+          if (run?.status === "running") await run.cancel();
+        } catch {
+          // Best effort: the session is already closed and forgotten.
+        }
+        throw Object.assign(new Error("cursor harness client disconnected"), {
+          status: 499,
+        });
+      }
+      session.run = run;
+      this.#drainRun(session);
+    } catch (error) {
+      await this.#closeSession(session, error);
+      throw error;
+    }
+
+    let next;
+    try {
+      await withTimeout(
+        Promise.race([
+          session.firstSemanticEvent.promise,
+          session.closeSignal.promise.then((error) => Promise.reject(error)),
+        ]),
+        this.firstEventTimeoutMs,
+        hasTools
+          ? "cursor harness timed out before tool call or final response"
+          : "cursor harness timed out before final response",
+      );
+      next = await withTimeout(
+        this.#nextToolBatchOrDone(session),
+        Math.max(
+          this.sessionTtlMs,
+          this.firstEventTimeoutMs + this.parallelCollectMs,
+        ),
+        "cursor harness timed out after the first response event",
+      );
+    } catch (error) {
+      await this.#closeSession(session, error);
+      throw Object.assign(error, { status: error?.status || 504 });
+    }
+
+    if (next.kind === "tools") {
+      this.#armExpiry(session);
+      const response = this.#toolUseMessage(session, next.pending);
+      session.onTextDelta = null;
+      session.onThinkingDelta = null;
+      return response;
+    }
+
+    try {
+      const response = this.#finalMessage(session);
+      await this.#closeSession(session);
+      return response;
+    } catch (error) {
+      await this.#closeSession(session, error);
+      throw error;
+    }
+  }
+
+  async #resume(toolResults, body, apiKey, options) {
+    const signal = options.signal;
+    const located = toolResults.map((result) => this.sessionsByToolUseId.get(result.toolUseId));
+    const liveCount = located.filter(Boolean).length;
+    if (liveCount === 0 && this.sessionState) {
+      const persisted = this.sessionState.findByToolUseIds(
+        toolResults.map((result) => result.toolUseId),
+      );
+      if (persisted) {
+        return this.#resumePersistedSingleflight(persisted, toolResults, body, apiKey, options);
+      }
+    }
+    if (liveCount > 0 && liveCount !== located.length) {
+      throw Object.assign(new Error("tool results span live and missing harness sessions"), {
+        status: 409,
+      });
+    }
+    const sessions = new Set();
+    for (const toolResult of toolResults) {
+      const session = this.sessionsByToolUseId.get(toolResult.toolUseId);
+      if (!session || (session.closed && !session.retainedForReplay)) {
+        throw Object.assign(
+          new Error(`unknown or expired tool_use_id: ${toolResult.toolUseId}`),
+          { status: 409 },
+        );
+      }
+      const pending = session.pending.get(toolResult.toolUseId);
+      if (!pending) {
+        throw Object.assign(
+          new Error(`unknown tool result in harness session: ${toolResult.toolUseId}`),
+          { status: 409 },
+        );
+      }
+      sessions.add(session);
+    }
+    if (sessions.size !== 1) {
+      throw Object.assign(new Error("tool results span multiple harness sessions"), {
+        status: 409,
+      });
+    }
+
+    const session = sessions.values().next().value;
+    if (credentialFingerprint(apiKey) !== session.credentialFingerprint) {
+      throw Object.assign(new Error("credential changed while resuming harness session"), {
+        status: 409,
+      });
+    }
+    if (tenantFingerprint(options.tenantId) !== session.tenantFingerprint) {
+      throw Object.assign(new Error("tenant changed while resuming harness session"), {
+        status: 409,
+      });
+    }
+    const requestModel = String(body?.model || "").trim();
+    if (requestModel && requestModel !== session.model) {
+      throw Object.assign(new Error("model changed while resuming harness session"), {
+        status: 409,
+      });
+    }
+
+    const requestDigest = toolResultRequestDigest(toolResults);
+    this.sessionState?.touch(session.sessionId, Date.now() + this.sessionTtlMs);
+    const cached = session.replay.get(requestDigest);
+    if (cached) return cached;
+    if (!session.closed && signal) {
+      this.#bindAbort(session, signal);
+      if (signal.aborted) {
+        const error = Object.assign(new Error("cursor harness client disconnected"), {
+          status: 499,
+        });
+        await this.#closeSession(session, error);
+        throw error;
+      }
+    }
+    const inflight = session.inflightReplay.get(requestDigest);
+    if (inflight) return inflight;
+
+    const onTextDelta =
+      typeof options.onTextDelta === "function" ? options.onTextDelta : null;
+    const onThinkingDelta =
+      typeof options.onThinkingDelta === "function"
+        ? options.onThinkingDelta
+        : null;
+    session.onTextDelta = onTextDelta;
+    session.onThinkingDelta = onThinkingDelta;
+    const resumePromise = this.#resumeOnce(session, toolResults, requestDigest);
+    session.inflightReplay.set(requestDigest, resumePromise);
+    try {
+      return await resumePromise;
+    } finally {
+      if (session.onTextDelta === onTextDelta) session.onTextDelta = null;
+      if (session.onThinkingDelta === onThinkingDelta) {
+        session.onThinkingDelta = null;
+      }
+      session.inflightReplay.delete(requestDigest);
+    }
+  }
+
+  #newSession(model, fingerprint, options = {}, sessionId = randomUUID()) {
+    return {
+      sessionId,
+      agent: null,
+      run: null,
+      model,
+      credentialFingerprint: fingerprint,
+      tenantFingerprint: tenantFingerprint(options.tenantId),
+      lastActivityAt: Date.now(),
+      pending: new Map(),
+      awaitingToolUseIds: new Set(),
+      toolCallQueue: [],
+      toolCallWaiters: [],
+      replay: new Map(),
+      inflightReplay: new Map(),
+      turnMessageId: newAnthropicMessageId(),
+      finalText: "",
+      sawAssistantText: false,
+      sawTextDelta: false,
+      usage: null,
+      runError: null,
+      onTextDelta:
+        typeof options.onTextDelta === "function" ? options.onTextDelta : null,
+      onThinkingDelta:
+        typeof options.onThinkingDelta === "function" ? options.onThinkingDelta : null,
+      firstSemanticEvent: deferred(),
+      firstSemanticEventSeen: false,
+      done: deferred(),
+      closeSignal: deferred(),
+      closed: false,
+      retainedForReplay: false,
+      preserveStateOnAbort: false,
+      usesSdkStore: false,
+    };
+  }
+
+  #customTools(session, tools) {
+    return customToolsFromAnthropic(tools, (name, args, context) => {
+      if (session.closed) throw new Error("cursor harness session is closed");
+      const toolUseId = this.instanceId
+        ? routedToolUseId(this.instanceId)
+        : String(context.toolCallId || randomUUID());
+      if (session.pending.has(toolUseId) || this.sessionsByToolUseId.has(toolUseId)) {
+        throw new Error(`duplicate cursor harness tool call id: ${toolUseId}`);
+      }
+      const result = deferred();
+      const pending = {
+        toolUseId,
+        name,
+        args,
+        result,
+        settled: false,
+        resultDigest: "",
+      };
+      session.pending.set(toolUseId, pending);
+      this.sessionsByToolUseId.set(toolUseId, session);
+      session.lastActivityAt = Date.now();
+      this.#markFirstSemanticEvent(session);
+      const waiter = session.toolCallWaiters.shift();
+      if (waiter) waiter.resolve(pending);
+      else session.toolCallQueue.push(pending);
+      return result.promise;
+    });
+  }
+
+  async #resumePersisted(record, toolResults, body, apiKey, options) {
+    const fingerprint = credentialFingerprint(apiKey);
+    if (fingerprint !== record.credentialFingerprint) {
+      throw Object.assign(new Error("credential changed while recovering harness session"), {
+        status: 409,
+      });
+    }
+    if (
+      record.tenantFingerprint &&
+      tenantFingerprint(options.tenantId) !== record.tenantFingerprint
+    ) {
+      throw Object.assign(new Error("tenant changed while recovering harness session"), {
+        status: 409,
+      });
+    }
+    const requestModel = String(body?.model || "").trim();
+    if (requestModel && requestModel !== record.model) {
+      throw Object.assign(new Error("model changed while recovering harness session"), {
+        status: 409,
+      });
+    }
+    const requestedIds = toolResults.map((result) => result.toolUseId).sort();
+    const persistedIds = [...record.toolUseIds].sort();
+    if (JSON.stringify(requestedIds) !== JSON.stringify(persistedIds)) {
+      throw Object.assign(new Error("tool results must exactly match persisted harness batch"), {
+        status: 409,
+      });
+    }
+    const requestDigest = toolResultRequestDigest(toolResults);
+    if (record.kind === "replay") {
+      if (record.requestDigest !== requestDigest) {
+        throw Object.assign(new Error("conflicting duplicate persisted tool result"), {
+          status: 409,
+        });
+      }
+      return record.response;
+    }
+    if (!this.sdkStore || !record.agentId) {
+      throw Object.assign(new Error("cursor harness recovery store is unavailable"), {
+        status: 409,
+      });
+    }
+    if (!Array.isArray(body?.tools) || body.tools.length === 0) {
+      throw Object.assign(new Error("cursor harness recovery requires the request tool catalog"), {
+        status: 409,
+      });
+    }
+
+    const session = this.#newSession(record.model, fingerprint, options, record.sessionId);
+    session.preserveStateOnAbort = true;
+    session.usesSdkStore = true;
+    this.sessionState.pin(record.sessionId);
+    this.sessionState.touch(record.sessionId, Date.now() + this.sessionTtlMs);
+    this.sessions.add(session);
+    if (options.signal) {
+      this.#bindAbort(session, options.signal);
+      if (options.signal.aborted) {
+        const error = Object.assign(new Error("cursor harness client disconnected"), {
+          status: 499,
+        });
+        await this.#closeSession(session, error, { preserveState: true });
+        throw error;
+      }
+    }
+    const customTools = this.#customTools(session, body.tools);
+    try {
+      session.agent = await this.agentResumer(record.agentId, {
+        apiKey,
+        model: cursorSdkModelSelection(record.model, body),
+        tools: ["mcp"],
+        disallowedTools: ["shell", "read", "edit", "task", "webSearch", "webFetch"],
+        local: {
+          cwd: this.workspace,
+          settingSources: [],
+          store: this.sdkStore,
+          sandboxOptions: { enabled: false },
+          customTools,
+        },
+      });
+      session.run = await session.agent.send(recoveredToolResultPrompt(record, toolResults), {
+        onDelta: ({ update }) => this.#handleInteractionUpdate(session, update),
+        local: { force: true, customTools },
+      });
+      this.#drainRun(session);
+      await withTimeout(
+        Promise.race([
+          session.firstSemanticEvent.promise,
+          session.closeSignal.promise.then((error) => Promise.reject(error)),
+        ]),
+        this.firstEventTimeoutMs,
+        "cursor harness recovery timed out before a response event",
+      );
+      const next = await withTimeout(
+        this.#nextToolBatchOrDone(session),
+        this.sessionTtlMs,
+        "cursor harness recovery timed out after tool result",
+      );
+      let response;
+      if (next.kind === "tools") {
+        response = this.#toolUseMessage(session, next.pending);
+        this.#armExpiry(session);
+      } else {
+        response = this.#finalMessage(session);
+        this.#persistReplay(session, toolResults, requestDigest, response);
+        await this.#closeSession(session, null, { retainReplay: true });
+      }
+      session.replay.set(requestDigest, response);
+      return response;
+    } catch (error) {
+      // A transient SDK/network failure must not destroy the only persisted
+      // continuation handle. The journal TTL remains the fail-closed bound.
+      await this.#closeSession(session, error, { preserveState: true });
+      throw Object.assign(error, { status: error?.status || 502 });
+    }
+  }
+
+  #resumePersistedSingleflight(record, toolResults, body, apiKey, options) {
+    const fingerprint = credentialFingerprint(apiKey);
+    if (fingerprint !== record.credentialFingerprint) {
+      throw Object.assign(new Error("credential changed while recovering harness session"), {
+        status: 409,
+      });
+    }
+    if (
+      record.tenantFingerprint &&
+      tenantFingerprint(options.tenantId) !== record.tenantFingerprint
+    ) {
+      throw Object.assign(new Error("tenant changed while recovering harness session"), {
+        status: 409,
+      });
+    }
+    const requestModel = String(body?.model || "").trim();
+    if (requestModel && requestModel !== record.model) {
+      throw Object.assign(new Error("model changed while recovering harness session"), {
+        status: 409,
+      });
+    }
+    const requestedIds = toolResults.map((result) => result.toolUseId).sort();
+    const persistedIds = [...record.toolUseIds].sort();
+    if (JSON.stringify(requestedIds) !== JSON.stringify(persistedIds)) {
+      throw Object.assign(new Error("tool results must exactly match persisted harness batch"), {
+        status: 409,
+      });
+    }
+    const requestDigest = toolResultRequestDigest(toolResults);
+    const inflight = this.persistedRecoveries.get(record.sessionId);
+    if (inflight) {
+      if (inflight.requestDigest !== requestDigest) {
+        throw Object.assign(new Error("conflicting concurrent persisted tool result"), {
+          status: 409,
+        });
+      }
+      return inflight.promise;
+    }
+    const promise = this.#resumePersisted(record, toolResults, body, apiKey, options);
+    const entry = { requestDigest, promise };
+    this.persistedRecoveries.set(record.sessionId, entry);
+    void promise.finally(() => {
+      if (this.persistedRecoveries.get(record.sessionId) === entry) {
+        this.persistedRecoveries.delete(record.sessionId);
+      }
+    }).catch(() => {});
+    return promise;
+  }
+
+  #bindAbort(session, signal) {
+    if (session.abortListener) {
+      session.abortSignal?.removeEventListener?.("abort", session.abortListener);
+    }
+    session.abortSignal = signal;
+    session.abortListener = () => {
+      void this.#closeSession(
+        session,
+        Object.assign(new Error("cursor harness client disconnected"), { status: 499 }),
+        { preserveState: session.preserveStateOnAbort },
+      );
+    };
+    signal.addEventListener("abort", session.abortListener, { once: true });
+  }
+
+  async #resumeOnce(session, toolResults, requestDigest) {
+    session.lastActivityAt = Date.now();
+    const resultIds = toolResults.map((result) => result.toolUseId);
+    const uniqueResultIds = new Set(resultIds);
+    if (
+      !session.closed &&
+      (resultIds.length !== uniqueResultIds.size ||
+        uniqueResultIds.size !== session.awaitingToolUseIds.size ||
+        [...uniqueResultIds].some((id) => !session.awaitingToolUseIds.has(id)))
+    ) {
+      throw Object.assign(
+        new Error("tool results must exactly match the current harness tool batch"),
+        { status: 409 },
+      );
+    }
+    let submittedNewResult = false;
+    for (const toolResult of toolResults) {
+      const pending = session.pending.get(toolResult.toolUseId);
+      const digest = toolResultDigest(toolResult);
+      if (pending.settled) {
+        if (pending.resultDigest !== digest) {
+          throw Object.assign(
+            new Error(`conflicting duplicate tool result: ${toolResult.toolUseId}`),
+            { status: 409 },
+          );
+        }
+        continue;
+      }
+      pending.settled = true;
+      pending.resultDigest = digest;
+      submittedNewResult = true;
+      pending.result.resolve({
+        content: [{ type: "text", text: toolResult.content }],
+        isError: toolResult.isError,
+      });
+    }
+    session.awaitingToolUseIds.clear();
+
+    if (!submittedNewResult) {
+      throw Object.assign(new Error("stale tool result retry has no cached response"), {
+        status: 409,
+      });
+    }
+
+    let next;
+    try {
+      next = await withTimeout(
+        this.#nextToolBatchOrDone(session),
+        this.sessionTtlMs,
+        "cursor harness timed out after tool result",
+      );
+    } catch (error) {
+      await this.#closeSession(session, error);
+      throw Object.assign(error, { status: error?.status || 504 });
+    }
+
+    let response;
+    try {
+      if (next.kind === "tools") {
+        response = this.#toolUseMessage(session, next.pending);
+        this.#armExpiry(session);
+      } else {
+        response = this.#finalMessage(session);
+        this.#persistReplay(session, toolResults, requestDigest, response);
+        await this.#closeSession(session, null, { retainReplay: true });
+      }
+    } catch (error) {
+      await this.#closeSession(session, error);
+      throw error;
+    }
+    session.replay.set(requestDigest, response);
+    return response;
+  }
+
+  #toolUseMessage(session, pendingCalls) {
+    session.awaitingToolUseIds = new Set(pendingCalls.map((pending) => pending.toolUseId));
+    const turnText = session.finalText;
+    session.finalText = "";
+    const response = anthropicMessage({
+      id: session.turnMessageId,
+      model: session.model,
+      content: [
+        ...(turnText.trim() ? [{ type: "text", text: turnText }] : []),
+        ...pendingCalls.map((pending) => ({
+          type: "tool_use",
+          id: pending.toolUseId,
+          name: pending.name,
+          input: pending.args,
+        })),
+      ],
+      stopReason: "tool_use",
+      usage: session.usage,
+    });
+    session.turnMessageId = newAnthropicMessageId();
+    this.#persistAwaiting(session, pendingCalls);
+    return response;
+  }
+
+  #persistAwaiting(session, pendingCalls) {
+    if (!this.sessionState) return;
+    this.sessionState.upsert({
+      kind: "awaiting",
+      sessionId: session.sessionId,
+      instanceId: this.instanceId,
+      model: session.model,
+      credentialFingerprint: session.credentialFingerprint,
+      tenantFingerprint: session.tenantFingerprint,
+      agentId: session.agent?.agentId,
+      runId: session.run?.id,
+      toolUseIds: pendingCalls.map((pending) => pending.toolUseId),
+      pending: pendingCalls.map((pending) => ({
+        toolUseId: pending.toolUseId,
+        name: pending.name,
+      })),
+      updatedAt: Date.now(),
+      expiresAt: Date.now() + this.sessionTtlMs,
+    });
+    this.sessionState.pin(session.sessionId);
+  }
+
+  #persistReplay(session, toolResults, requestDigest, response) {
+    if (!this.sessionState) return;
+    this.sessionState.upsert({
+      kind: "replay",
+      sessionId: session.sessionId,
+      instanceId: this.instanceId,
+      model: session.model,
+      credentialFingerprint: session.credentialFingerprint,
+      tenantFingerprint: session.tenantFingerprint,
+      agentId: session.agent?.agentId,
+      runId: session.run?.id,
+      toolUseIds: toolResults.map((result) => result.toolUseId),
+      pending: toolResults.map((result) => ({ toolUseId: result.toolUseId })),
+      requestDigest,
+      response,
+      updatedAt: Date.now(),
+      expiresAt: Date.now() + this.replayTtlMs,
+    });
+  }
+
+  #finalMessage(session) {
+    if (session.runError) {
+      throw Object.assign(new Error(session.runError), { status: 502 });
+    }
+    if (!session.finalText.trim()) {
+      throw Object.assign(new Error("cursor harness returned an empty final turn"), {
+        status: 502,
+      });
+    }
+    return anthropicMessage({
+      id: session.turnMessageId,
+      model: session.model,
+      content: [{ type: "text", text: session.finalText }],
+      stopReason: "end_turn",
+      usage: session.usage,
+    });
+  }
+
+  async #nextToolBatchOrDone(session) {
+    const queued = session.toolCallQueue.shift();
+    if (queued) return this.#collectToolBatch(session, queued);
+    if (session.doneSettled) return { kind: "done" };
+    const waiter = deferred();
+    session.toolCallWaiters.push(waiter);
+    const first = await Promise.race([
+      waiter.promise.then((pending) => ({ kind: "first-tool", pending })),
+      session.done.promise.then(() => ({ kind: "done" })),
+      session.closeSignal.promise.then((error) => Promise.reject(error)),
+    ]).finally(() => {
+      const index = session.toolCallWaiters.indexOf(waiter);
+      if (index >= 0) session.toolCallWaiters.splice(index, 1);
+    });
+    if (first.kind === "done") return first;
+    return this.#collectToolBatch(session, first.pending);
+  }
+
+  async #collectToolBatch(session, first) {
+    if (this.parallelCollectMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, this.parallelCollectMs));
+    }
+    if (session.closed) {
+      throw Object.assign(new Error("cursor harness session closed"), { status: 499 });
+    }
+    return {
+      kind: "tools",
+      pending: [first, ...session.toolCallQueue.splice(0)],
+    };
+  }
+
+  async #drainRun(session) {
+    try {
+      for await (const event of session.run.stream()) {
+        session.lastActivityAt = Date.now();
+        if (event?.type === "assistant") {
+          const text = (event.message?.content || [])
+            .filter((block) => block?.type === "text")
+            .map((block) => block.text || "")
+            .join("");
+          // `onDelta` is the Cursor SDK's token-level stream. The legacy
+          // assistant event can contain the same text again as a completed
+          // compatibility frame, so only use it when no text delta arrived.
+          if (text && !session.sawTextDelta) {
+            session.sawAssistantText = true;
+            session.finalText += text;
+            this.#markFirstSemanticEvent(session);
+            session.onTextDelta?.(text, {
+              id: session.turnMessageId,
+              model: session.model,
+            });
+          }
+        } else if (event?.type === "usage") {
+          session.usage = event.usage;
+        } else if (event?.type === "status" && event.status === "ERROR") {
+          session.runError = event.message || "cursor harness run failed";
+        }
+      }
+      const waited = await session.run.wait();
+      if (waited?.usage) session.usage = waited.usage;
+      if (waited?.status === "error") {
+        session.runError = waited.error?.message || "cursor harness run failed";
+      }
+      if (
+        !session.sawAssistantText &&
+        !session.finalText.trim() &&
+        typeof waited?.result === "string"
+      ) {
+        session.finalText = waited.result;
+      }
+    } catch (error) {
+      session.runError = error?.message || String(error);
+    } finally {
+      this.#markFirstSemanticEvent(session);
+      session.doneSettled = true;
+      session.done.resolve();
+    }
+  }
+
+  #handleInteractionUpdate(session, update) {
+    if (session.closed) return;
+    if (update?.type === "thinking-delta") {
+      const thinking = String(update.text || "");
+      if (!thinking) return;
+      session.lastActivityAt = Date.now();
+      this.#markFirstSemanticEvent(session);
+      session.onThinkingDelta?.(thinking, {
+        id: session.turnMessageId,
+        model: session.model,
+      });
+      return;
+    }
+    if (update?.type !== "text-delta") return;
+    const text = String(update.text || "");
+    if (!text) return;
+    session.sawTextDelta = true;
+    session.sawAssistantText = true;
+    session.finalText += text;
+    session.lastActivityAt = Date.now();
+    this.#markFirstSemanticEvent(session);
+    session.onTextDelta?.(text, {
+      id: session.turnMessageId,
+      model: session.model,
+    });
+  }
+
+  #markFirstSemanticEvent(session) {
+    if (session.firstSemanticEventSeen) return;
+    session.firstSemanticEventSeen = true;
+    session.firstSemanticEvent.resolve();
+  }
+
+  #armExpiry(session) {
+    clearTimeout(session.expiryTimer);
+    session.expiryTimer = setTimeout(async () => {
+      const idleMs = Date.now() - session.lastActivityAt;
+      if (idleMs < this.sessionTtlMs) {
+        this.#armExpiry(session);
+        return;
+      }
+      await this.#closeSession(session, new Error("cursor harness session expired"));
+    }, this.sessionTtlMs);
+    session.expiryTimer.unref?.();
+  }
+
+  async #closeSession(session, error, options = {}) {
+    if (session.closed) {
+      if (session.retainedForReplay && !options.retainReplay) this.#forgetSession(session);
+      return;
+    }
+    session.closed = true;
+    if (error) session.runError = error?.message || String(error);
+    session.closeSignal.resolve(error || new Error("cursor harness session closed"));
+    if (session.abortListener) {
+      session.abortSignal?.removeEventListener?.("abort", session.abortListener);
+    }
+    clearTimeout(session.expiryTimer);
+    for (const waiter of session.toolCallWaiters.splice(0)) {
+      waiter.reject(error || new Error("cursor harness session closed"));
+    }
+    for (const pending of session.pending.values()) {
+      if (!options.retainReplay) this.sessionsByToolUseId.delete(pending.toolUseId);
+      if (!pending.settled) {
+        pending.settled = true;
+        pending.result.reject(error || new Error("cursor harness session closed"));
+      }
+    }
+    try {
+      if (session.run?.status === "running") await session.run.cancel();
+    } catch {
+      // Best effort; agent.close below releases local resources.
+    }
+    try {
+      session.agent?.close?.();
+    } catch {
+      // Best effort.
+    }
+    if (options.retainReplay) {
+      this.sessionState?.unpin(session.sessionId);
+      session.retainedForReplay = true;
+      session.replayTimer = setTimeout(() => {
+        this.sessionState?.remove(session.sessionId);
+        this.#forgetSession(session);
+        void deleteSdkAgentState(
+          session.usesSdkStore ? this.sdkStore : undefined,
+          session.agent?.agentId,
+        ).catch((cleanupError) => {
+          console.error(
+            `[cursor-harness] failed to clean replay agent state session=${session.sessionId}: ${cleanupError?.message || cleanupError}`,
+          );
+        });
+      }, this.replayTtlMs);
+      session.replayTimer.unref?.();
+    } else {
+      try {
+        if (!options.preserveState) {
+          this.sessionState?.remove(session.sessionId);
+          await deleteSdkAgentState(
+            session.usesSdkStore ? this.sdkStore : undefined,
+            session.agent?.agentId,
+          );
+        }
+      } catch (cleanupError) {
+        console.error(
+          `[cursor-harness] failed to clean agent state session=${session.sessionId}: ${cleanupError?.message || cleanupError}`,
+        );
+      } finally {
+        this.#forgetSession(session);
+      }
+    }
+  }
+
+  #forgetSession(session) {
+    this.sessionState?.unpin(session.sessionId);
+    clearTimeout(session.replayTimer);
+    for (const pending of session.pending.values()) {
+      this.sessionsByToolUseId.delete(pending.toolUseId);
+    }
+    this.sessions.delete(session);
+  }
+
+  async shutdown(options = {}) {
+    await Promise.allSettled(
+      [...this.sessions].map((session) =>
+        this.#closeSession(session, new Error("cursor harness sidecar shutting down"), {
+          preserveState: Boolean(options.preserveState),
+        }),
+      ),
+    );
+  }
+
+  beginDrain() {
+    this.accepting = false;
+    return this.status();
+  }
+
+  status() {
+    const liveIds = new Set([...this.sessions].map((session) => session.sessionId));
+    const persistedIds = new Set(this.sessionState?.sessionIds?.() || []);
+    return {
+      accepting: this.accepting,
+      liveSessions: liveIds.size,
+      persistedSessions: persistedIds.size,
+      drainSessions: new Set([...liveIds, ...persistedIds]).size,
+      persisted: this.sessionState?.counts?.() || { awaiting: 0, replay: 0, total: 0 },
+    };
+  }
+
+  async waitForDrain(timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    while (this.status().drainSessions > 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    return this.status().drainSessions === 0;
+  }
+}

--- a/cursor_agent_sidecar/harness_messages.test.mjs
+++ b/cursor_agent_sidecar/harness_messages.test.mjs
@@ -1,0 +1,1798 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  CursorHarnessMessagesBridge,
+  cursorHarnessInstanceFromToolUseId,
+  cursorHarnessRouteFromRequest,
+  cursorSdkModelSelection,
+} from "./harness_messages.mjs";
+import { CursorHarnessSessionState } from "./session_state.mjs";
+
+function fakeAgentFactory({ emptyFinal = false } = {}) {
+  return async (options) => ({
+    agentId: "agent-test",
+    close() {},
+    async send() {
+      let result;
+      let runError;
+      let releaseDone;
+      const done = new Promise((resolve) => {
+        releaseDone = resolve;
+      });
+      return {
+        id: "run-test",
+        status: "running",
+        async *stream() {
+          try {
+            yield { type: "status", status: "RUNNING" };
+            result = await options.local.customTools.lookup_opaque_value.execute(
+              {},
+              { toolCallId: "toolu_test_1" },
+            );
+            if (!emptyFinal) {
+              yield {
+                type: "assistant",
+                message: {
+                  content: [{ type: "text", text: result.content[0].text }],
+                },
+              };
+            }
+            this.status = "finished";
+            yield { type: "status", status: "FINISHED" };
+          } catch (error) {
+            runError = error;
+            this.status = "error";
+          } finally {
+            releaseDone();
+          }
+        },
+        async wait() {
+          await done;
+          if (runError) {
+            return { status: "error", error: { message: runError.message } };
+          }
+          return { status: "finished" };
+        },
+        async cancel() {
+          this.status = "cancelled";
+          releaseDone();
+        },
+      };
+    },
+  });
+}
+
+function plainAgentFactory(text = "PLAIN_OK") {
+  return async (options) => ({
+    close() {},
+    async send() {
+      let releaseDone;
+      const done = new Promise((resolve) => {
+        releaseDone = resolve;
+      });
+      return {
+        status: "running",
+        async *stream() {
+          yield {
+            type: "assistant",
+            message: { content: [{ type: "text", text }] },
+          };
+          this.status = "finished";
+          releaseDone();
+        },
+        async wait() {
+          await done;
+          return { status: "finished" };
+        },
+        async cancel() {
+          releaseDone();
+        },
+        agentOptions: options,
+      };
+    },
+  });
+}
+
+function incrementalTextAgentFactory(releaseFinal) {
+  return async () => ({
+    close() {},
+    async send() {
+      return {
+        status: "running",
+        async *stream() {
+          yield {
+            type: "assistant",
+            message: { content: [{ type: "text", text: "EARLY_" }] },
+          };
+          await releaseFinal.promise;
+          yield {
+            type: "assistant",
+            message: { content: [{ type: "text", text: "FINAL" }] },
+          };
+          this.status = "finished";
+        },
+        async wait() {
+          await releaseFinal.promise;
+          return { status: "finished" };
+        },
+        async cancel() {
+          this.status = "cancelled";
+          releaseFinal.resolve();
+        },
+      };
+    },
+  });
+}
+
+function sdkDeltaAgentFactory(releaseFinal) {
+  return async () => ({
+    close() {},
+    async send(_message, options) {
+      await options.onDelta({
+        update: { type: "text-delta", text: "EARLY_" },
+      });
+      await releaseFinal.promise;
+      await options.onDelta({
+        update: { type: "text-delta", text: "FINAL" },
+      });
+      return {
+        status: "running",
+        async *stream() {
+          yield {
+            type: "assistant",
+            message: { content: [{ type: "text", text: "EARLY_" }] },
+          };
+          yield {
+            type: "assistant",
+            message: { content: [{ type: "text", text: "FINAL" }] },
+          };
+          this.status = "finished";
+        },
+        async wait() {
+          await releaseFinal.promise;
+          return { status: "finished" };
+        },
+        async cancel() {
+          this.status = "cancelled";
+          releaseFinal.resolve();
+        },
+      };
+    },
+  });
+}
+
+function sdkThinkingDeltaAgentFactory(releaseFinal) {
+  return async () => ({
+    close() {},
+    async send(_message, options) {
+      await options.onDelta({
+        update: { type: "thinking-delta", text: "CHECKING_" },
+      });
+      await releaseFinal.promise;
+      await options.onDelta({
+        update: { type: "text-delta", text: "ANSWER" },
+      });
+      return {
+        status: "running",
+        async *stream() {
+          yield {
+            type: "assistant",
+            message: { content: [{ type: "text", text: "ANSWER" }] },
+          };
+          this.status = "finished";
+        },
+        async wait() {
+          await releaseFinal.promise;
+          return { status: "finished" };
+        },
+        async cancel() {
+          this.status = "cancelled";
+          releaseFinal.resolve();
+        },
+      };
+    },
+  });
+}
+
+function sdkDeltaToolAgentFactory() {
+  return async (agentOptions) => ({
+    close() {},
+    async send(_message, sendOptions) {
+      await sendOptions.onDelta({
+        update: { type: "text-delta", text: "DELTA_PREAMBLE" },
+      });
+      let releaseDone;
+      const done = new Promise((resolve) => {
+        releaseDone = resolve;
+      });
+      return {
+        status: "running",
+        async *stream() {
+          yield {
+            type: "assistant",
+            message: { content: [{ type: "text", text: "DELTA_PREAMBLE" }] },
+          };
+          const result = await agentOptions.local.customTools.lookup_opaque_value.execute(
+            {},
+            { toolCallId: "toolu_delta_resume" },
+          );
+          await sendOptions.onDelta({
+            update: { type: "thinking-delta", text: "DELTA_CHECKING" },
+          });
+          await sendOptions.onDelta({
+            update: { type: "text-delta", text: result.content[0].text },
+          });
+          yield {
+            type: "assistant",
+            message: { content: [{ type: "text", text: result.content[0].text }] },
+          };
+          this.status = "finished";
+          releaseDone();
+        },
+        async wait() {
+          await done;
+          return { status: "finished" };
+        },
+        async cancel() {
+          this.status = "cancelled";
+          releaseDone();
+        },
+      };
+    },
+  });
+}
+
+function usageAgentFactory() {
+  return async () => ({
+    close() {},
+    async send() {
+      return {
+        status: "running",
+        async *stream() {
+          yield {
+            type: "usage",
+            usage: {
+              inputTokens: 11,
+              outputTokens: 7,
+              cacheReadTokens: 101,
+              cacheWriteTokens: 13,
+              totalTokens: 132,
+            },
+          };
+          yield {
+            type: "assistant",
+            message: { content: [{ type: "text", text: "USAGE_OK" }] },
+          };
+        },
+        async wait() {
+          return { status: "finished" };
+        },
+      };
+    },
+  });
+}
+
+function toolUsageAtTurnEndAgentFactory() {
+  return async (options) => ({
+    close() {},
+    async send() {
+      let releaseDone;
+      const done = new Promise((resolve) => {
+        releaseDone = resolve;
+      });
+      return {
+        status: "running",
+        async *stream() {
+          const result = await options.local.customTools.lookup_opaque_value.execute(
+            {},
+            { toolCallId: "toolu_usage_turn" },
+          );
+          yield {
+            type: "usage",
+            usage: {
+              inputTokens: 11,
+              outputTokens: 7,
+              cacheReadTokens: 101,
+              cacheWriteTokens: 13,
+              totalTokens: 132,
+            },
+          };
+          yield {
+            type: "assistant",
+            message: { content: [{ type: "text", text: result.content[0].text }] },
+          };
+          this.status = "finished";
+          releaseDone();
+        },
+        async wait() {
+          await done;
+          return { status: "finished" };
+        },
+        async cancel() {
+          this.status = "cancelled";
+          releaseDone();
+        },
+      };
+    },
+  });
+}
+
+function preToolTextAgentFactory({ emitFinal = true, waitResult = "" } = {}) {
+  return async (options) => ({
+    close() {},
+    async send() {
+      let releaseDone;
+      const done = new Promise((resolve) => {
+        releaseDone = resolve;
+      });
+      return {
+        status: "running",
+        async *stream() {
+          yield {
+            type: "assistant",
+            message: {
+              content: [{ type: "text", text: "I will use the lookup tool." }],
+            },
+          };
+          const result = await options.local.customTools.lookup_opaque_value.execute(
+            {},
+            { toolCallId: "toolu_preamble_1" },
+          );
+          if (emitFinal) {
+            yield {
+              type: "assistant",
+              message: { content: [{ type: "text", text: result.content[0].text }] },
+            };
+          }
+          this.status = "finished";
+          releaseDone();
+        },
+        async wait() {
+          await done;
+          return { status: "finished", result: waitResult };
+        },
+        async cancel() {
+          releaseDone();
+        },
+      };
+    },
+  });
+}
+
+function multiToolAgentFactory({ preambles = [] } = {}) {
+  return async (options) => ({
+    close() {},
+    async send() {
+      let releaseDone;
+      const done = new Promise((resolve) => {
+        releaseDone = resolve;
+      });
+      return {
+        status: "running",
+        async *stream() {
+          if (preambles[0]) {
+            yield {
+              type: "assistant",
+              message: { content: [{ type: "text", text: preambles[0] }] },
+            };
+          }
+          const first = await options.local.customTools.lookup_opaque_value.execute(
+            { turn: 1 },
+            { toolCallId: "toolu_multi_1" },
+          );
+          if (preambles[1]) {
+            yield {
+              type: "assistant",
+              message: { content: [{ type: "text", text: preambles[1] }] },
+            };
+          }
+          const second = await options.local.customTools.lookup_opaque_value.execute(
+            { turn: 2 },
+            { toolCallId: "toolu_multi_2" },
+          );
+          yield {
+            type: "assistant",
+            message: {
+              content: [
+                {
+                  type: "text",
+                  text: `${first.content[0].text}:${second.content[0].text}`,
+                },
+              ],
+            },
+          };
+          this.status = "finished";
+          releaseDone();
+        },
+        async wait() {
+          await done;
+          return { status: "finished" };
+        },
+        async cancel() {
+          releaseDone();
+        },
+      };
+    },
+  });
+}
+
+function parallelToolAgentFactory({ preamble = "" } = {}) {
+  return async (options) => ({
+    close() {},
+    async send() {
+      let releaseDone;
+      const done = new Promise((resolve) => {
+        releaseDone = resolve;
+      });
+      return {
+        status: "running",
+        async *stream() {
+          if (preamble) {
+            yield {
+              type: "assistant",
+              message: { content: [{ type: "text", text: preamble }] },
+            };
+          }
+          const firstResult = options.local.customTools.lookup_opaque_value.execute(
+              { slot: "alpha" },
+              { toolCallId: "toolu_parallel_alpha" },
+            );
+          const secondResult = new Promise((resolve, reject) => {
+            setTimeout(() => {
+              options.local.customTools.lookup_opaque_value
+                .execute(
+                  { slot: "beta" },
+                  { toolCallId: "toolu_parallel_beta" },
+                )
+                .then(resolve, reject);
+            }, 40);
+          });
+          const [first, second] = await Promise.all([firstResult, secondResult]);
+          yield {
+            type: "assistant",
+            message: {
+              content: [
+                {
+                  type: "text",
+                  text: `${first.content[0].text}:${second.content[0].text}`,
+                },
+              ],
+            },
+          };
+          this.status = "finished";
+          releaseDone();
+        },
+        async wait() {
+          await done;
+          return { status: "finished" };
+        },
+        async cancel() {
+          releaseDone();
+        },
+      };
+    },
+  });
+}
+
+function hangingAgentFactory() {
+  return async () => ({
+    close() {},
+    async send() {
+      let release;
+      const blocked = new Promise((resolve) => {
+        release = resolve;
+      });
+      return {
+        status: "running",
+        async *stream() {
+          await blocked;
+        },
+        async wait() {
+          await blocked;
+          return { status: "cancelled" };
+        },
+        async cancel() {
+          this.status = "cancelled";
+          release();
+        },
+      };
+    },
+  });
+}
+
+function concurrentToolAgentFactory() {
+  let nextId = 0;
+  return async (options) => {
+    const toolUseId = `toolu_concurrent_${++nextId}`;
+    return {
+      close() {},
+      async send() {
+        let releaseDone;
+        const done = new Promise((resolve) => {
+          releaseDone = resolve;
+        });
+        return {
+          status: "running",
+          async *stream() {
+            const result = await options.local.customTools.lookup_opaque_value.execute(
+              {},
+              { toolCallId: toolUseId },
+            );
+            yield {
+              type: "assistant",
+              message: { content: [{ type: "text", text: result.content[0].text }] },
+            };
+            this.status = "finished";
+            releaseDone();
+          },
+          async wait() {
+            await done;
+            return { status: "finished" };
+          },
+          async cancel() {
+            releaseDone();
+          },
+        };
+      },
+    };
+  };
+}
+
+function delayedSendAgentFactory(onCancel) {
+  return async () => ({
+    close() {},
+    async send() {
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      return {
+        status: "running",
+        async *stream() {},
+        async wait() {
+          return { status: "cancelled" };
+        },
+        async cancel() {
+          this.status = "cancelled";
+          onCancel();
+        },
+      };
+    },
+  });
+}
+
+function hangingAfterToolResultAgentFactory() {
+  return async (options) => ({
+    close() {},
+    async send() {
+      let release;
+      const blocked = new Promise((resolve) => {
+        release = resolve;
+      });
+      return {
+        status: "running",
+        async *stream() {
+          await options.local.customTools.lookup_opaque_value.execute(
+            {},
+            { toolCallId: "toolu_resume_abort" },
+          );
+          await blocked;
+        },
+        async wait() {
+          await blocked;
+          return { status: "cancelled" };
+        },
+        async cancel() {
+          this.status = "cancelled";
+          release();
+        },
+      };
+    },
+  });
+}
+
+function firstRequest() {
+  return {
+    model: "claude-sonnet-4-6",
+    messages: [{ role: "user", content: "Use the tool." }],
+    tools: [
+      {
+        name: "lookup_opaque_value",
+        description: "Return the opaque value.",
+        input_schema: { type: "object", properties: {} },
+      },
+    ],
+  };
+}
+
+function resumeRequest(toolUseId, value) {
+  return {
+    model: "claude-sonnet-4-6",
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: toolUseId, content: value }],
+      },
+    ],
+  };
+}
+
+function resumeBatchRequest(entries) {
+  return {
+    model: "claude-sonnet-4-6",
+    messages: [
+      {
+        role: "user",
+        content: entries.map(([toolUseId, value]) => ({
+          type: "tool_result",
+          tool_use_id: toolUseId,
+          content: value,
+        })),
+      },
+    ],
+  };
+}
+
+test("parks an SDK custom tool and resumes it from a second Messages request", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: fakeAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+
+  const first = await bridge.handle(firstRequest(), "test-key");
+  assert.equal(first.stop_reason, "tool_use");
+  assert.deepEqual(first.content, [
+    {
+      type: "tool_use",
+      id: "toolu_test_1",
+      name: "lookup_opaque_value",
+      input: {},
+    },
+  ]);
+
+  const second = await bridge.handle(
+    resumeRequest("toolu_test_1", "BRIDGE_OK"),
+    "test-key",
+  );
+  assert.equal(second.stop_reason, "end_turn");
+  assert.equal(second.content[0].text, "BRIDGE_OK");
+});
+
+test("keeps pre-tool assistant text in its tool-use turn instead of the final turn", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: preToolTextAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+
+  const first = await bridge.handle(firstRequest(), "test-key");
+  assert.equal(first.stop_reason, "tool_use");
+  assert.deepEqual(first.content, [
+    { type: "text", text: "I will use the lookup tool." },
+    {
+      type: "tool_use",
+      id: "toolu_preamble_1",
+      name: "lookup_opaque_value",
+      input: {},
+    },
+  ]);
+
+  const second = await bridge.handle(
+    resumeRequest("toolu_preamble_1", "PREAMBLE_BRIDGE_OK"),
+    "test-key",
+  );
+  assert.equal(second.stop_reason, "end_turn");
+  assert.deepEqual(second.content, [
+    { type: "text", text: "PREAMBLE_BRIDGE_OK" },
+  ]);
+});
+
+test("does not resurrect emitted pre-tool text from Run.wait when no final text exists", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: preToolTextAgentFactory({
+      emitFinal: false,
+      waitResult: "I will use the lookup tool.",
+    }),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+
+  const first = await bridge.handle(firstRequest(), "test-key");
+  assert.deepEqual(first.content, [
+    { type: "text", text: "I will use the lookup tool." },
+    {
+      type: "tool_use",
+      id: "toolu_preamble_1",
+      name: "lookup_opaque_value",
+      input: {},
+    },
+  ]);
+  await assert.rejects(
+    bridge.handle(
+      resumeRequest("toolu_preamble_1", "PREAMBLE_BRIDGE_OK"),
+      "test-key",
+    ),
+    (error) => error.status === 502 && /empty final turn/.test(error.message),
+  );
+});
+
+test("serves a plain Messages request without requiring tools", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: plainAgentFactory(),
+    firstEventTimeoutMs: 1000,
+  });
+  const response = await bridge.handle(
+    {
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "Reply plainly." }],
+    },
+    "test-key",
+  );
+  assert.equal(response.stop_reason, "end_turn");
+  assert.equal(response.content[0].text, "PLAIN_OK");
+});
+
+test("forwards incremental text before the turn completes", async () => {
+  let resolveFinal;
+  const releaseFinal = {
+    promise: new Promise((resolve) => {
+      resolveFinal = resolve;
+    }),
+    resolve: () => resolveFinal(),
+  };
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: incrementalTextAgentFactory(releaseFinal),
+    firstEventTimeoutMs: 20,
+    sessionTtlMs: 1000,
+  });
+  const deltas = [];
+  let firstDeltaResolve;
+  const firstDelta = new Promise((resolve) => {
+    firstDeltaResolve = resolve;
+  });
+  let handleSettled = false;
+  const handlePromise = bridge
+    .handle(
+      {
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "Stream incrementally." }],
+      },
+      "test-key",
+      {
+        onTextDelta(text, meta) {
+          deltas.push({ text, meta });
+          firstDeltaResolve();
+        },
+      },
+    )
+    .finally(() => {
+      handleSettled = true;
+    });
+
+  await firstDelta;
+  assert.equal(handleSettled, false);
+  assert.equal(deltas[0].text, "EARLY_");
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  assert.equal(handleSettled, false, "first-event timeout must not cap the full turn");
+
+  releaseFinal.resolve();
+  const response = await handlePromise;
+  assert.equal(response.content[0].text, "EARLY_FINAL");
+  assert.deepEqual(deltas.map((delta) => delta.text), ["EARLY_", "FINAL"]);
+  assert.equal(deltas[0].meta.id, response.id);
+  assert.equal(deltas[0].meta.model, response.model);
+});
+
+test("uses Cursor SDK text-delta callbacks without duplicating assistant frames", async () => {
+  let resolveFinal;
+  const releaseFinal = {
+    promise: new Promise((resolve) => {
+      resolveFinal = resolve;
+    }),
+    resolve: () => resolveFinal(),
+  };
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: sdkDeltaAgentFactory(releaseFinal),
+    firstEventTimeoutMs: 1000,
+  });
+  const deltas = [];
+  let firstDeltaResolve;
+  const firstDelta = new Promise((resolve) => {
+    firstDeltaResolve = resolve;
+  });
+  let handleSettled = false;
+  const handlePromise = bridge
+    .handle(
+      {
+        model: "cursor-grok-4.6-xhigh",
+        messages: [{ role: "user", content: "Stream through SDK deltas." }],
+      },
+      "test-key",
+      {
+        onTextDelta(text) {
+          deltas.push(text);
+          firstDeltaResolve();
+        },
+      },
+    )
+    .finally(() => {
+      handleSettled = true;
+    });
+
+  await firstDelta;
+  assert.equal(handleSettled, false);
+  assert.deepEqual(deltas, ["EARLY_"]);
+
+  releaseFinal.resolve();
+  const response = await handlePromise;
+  assert.equal(response.content[0].text, "EARLY_FINAL");
+  assert.deepEqual(deltas, ["EARLY_", "FINAL"]);
+});
+
+test("forwards Cursor SDK thinking-delta before answer text", async () => {
+  let resolveFinal;
+  const releaseFinal = {
+    promise: new Promise((resolve) => {
+      resolveFinal = resolve;
+    }),
+    resolve: () => resolveFinal(),
+  };
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: sdkThinkingDeltaAgentFactory(releaseFinal),
+    firstEventTimeoutMs: 1000,
+  });
+  const thinkingDeltas = [];
+  const textDeltas = [];
+  let firstThinkingResolve;
+  const firstThinking = new Promise((resolve) => {
+    firstThinkingResolve = resolve;
+  });
+  let handleSettled = false;
+  const handlePromise = bridge
+    .handle(
+      {
+        model: "cursor-grok-4.6-xhigh",
+        messages: [{ role: "user", content: "Think, then answer." }],
+      },
+      "test-key",
+      {
+        onThinkingDelta(text, meta) {
+          thinkingDeltas.push({ text, meta });
+          firstThinkingResolve();
+        },
+        onTextDelta: (text) => textDeltas.push(text),
+      },
+    )
+    .finally(() => {
+      handleSettled = true;
+    });
+
+  await firstThinking;
+  assert.equal(handleSettled, false);
+  assert.equal(thinkingDeltas[0].text, "CHECKING_");
+
+  releaseFinal.resolve();
+  const response = await handlePromise;
+  assert.deepEqual(textDeltas, ["ANSWER"]);
+  assert.equal(response.content[0].text, "ANSWER");
+  assert.equal(thinkingDeltas[0].meta.id, response.id);
+  assert.equal(thinkingDeltas[0].meta.model, response.model);
+});
+
+test("binds SDK text-delta callbacks to each tool continuation HTTP turn", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: sdkDeltaToolAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+  const firstDeltas = [];
+  const first = await bridge.handle(firstRequest(), "test-key", {
+    onTextDelta: (text, meta) => firstDeltas.push({ text, meta }),
+  });
+  assert.deepEqual(first.content, [
+    { type: "text", text: "DELTA_PREAMBLE" },
+    {
+      type: "tool_use",
+      id: "toolu_delta_resume",
+      name: "lookup_opaque_value",
+      input: {},
+    },
+  ]);
+  assert.deepEqual(firstDeltas.map((delta) => delta.text), ["DELTA_PREAMBLE"]);
+  assert.equal(firstDeltas[0].meta.id, first.id);
+
+  const resumedDeltas = [];
+  const resumedThinkingDeltas = [];
+  const resumed = await bridge.handle(
+    resumeRequest("toolu_delta_resume", "DELTA_FINAL"),
+    "test-key",
+    {
+      onTextDelta: (text, meta) => resumedDeltas.push({ text, meta }),
+      onThinkingDelta: (text, meta) =>
+        resumedThinkingDeltas.push({ text, meta }),
+    },
+  );
+  assert.deepEqual(resumed.content, [{ type: "text", text: "DELTA_FINAL" }]);
+  assert.deepEqual(resumedDeltas.map((delta) => delta.text), ["DELTA_FINAL"]);
+  assert.deepEqual(
+    resumedThinkingDeltas.map((delta) => delta.text),
+    ["DELTA_CHECKING"],
+  );
+  assert.equal(resumedDeltas[0].meta.id, resumed.id);
+  assert.equal(resumedThinkingDeltas[0].meta.id, resumed.id);
+  assert.notEqual(resumed.id, first.id);
+});
+
+test("binds streamed text to the correct HTTP turn across tool continuation", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: preToolTextAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+  const firstDeltas = [];
+  const first = await bridge.handle(firstRequest(), "test-key", {
+    onTextDelta: (text, meta) => firstDeltas.push({ text, meta }),
+  });
+  assert.equal(firstDeltas[0].text, "I will use the lookup tool.");
+  assert.equal(firstDeltas[0].meta.id, first.id);
+
+  const resumedDeltas = [];
+  const resumed = await bridge.handle(
+    resumeRequest("toolu_preamble_1", "STREAMED_FINAL"),
+    "test-key",
+    { onTextDelta: (text, meta) => resumedDeltas.push({ text, meta }) },
+  );
+  assert.equal(resumedDeltas[0].text, "STREAMED_FINAL");
+  assert.equal(resumedDeltas[0].meta.id, resumed.id);
+  assert.notEqual(resumed.id, first.id);
+});
+
+test("preserves Cursor SDK input and cache token usage in Anthropic fields", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: usageAgentFactory(),
+    firstEventTimeoutMs: 1000,
+  });
+  const response = await bridge.handle(
+    {
+      model: "cursor-grok-4.6-medium",
+      messages: [{ role: "user", content: "Report usage." }],
+    },
+    "test-key",
+  );
+  assert.deepEqual(response.usage, {
+    input_tokens: 11,
+    output_tokens: 7,
+    cache_read_input_tokens: 101,
+    cache_creation_input_tokens: 13,
+  });
+});
+
+test("records one authoritative usage snapshot when the logical SDK Run completes", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: toolUsageAtTurnEndAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+  const first = await bridge.handle(firstRequest(), "test-key");
+  assert.deepEqual(first.usage, {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+  });
+
+  const resumed = await bridge.handle(
+    resumeRequest(first.content[0].id, "CACHE_USAGE_OK"),
+    "test-key",
+  );
+  assert.deepEqual(resumed.usage, {
+    input_tokens: 11,
+    output_tokens: 7,
+    cache_read_input_tokens: 101,
+    cache_creation_input_tokens: 13,
+  });
+});
+
+test("embeds and parses the sidecar instance in externally visible tool ids", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: fakeAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+    instanceId: "blue",
+  });
+  const first = await bridge.handle(firstRequest(), "test-key");
+  const toolUseId = first.content[0].id;
+  assert.match(toolUseId, /^toolu_bf_blue_[a-f0-9]{32}$/);
+  assert.equal(cursorHarnessInstanceFromToolUseId(toolUseId), "blue");
+  assert.equal(cursorHarnessRouteFromRequest(resumeRequest(toolUseId, "OK")), "blue");
+
+  const resumed = await bridge.handle(resumeRequest(toolUseId, "OK"), "test-key");
+  assert.equal(resumed.content[0].text, "OK");
+});
+
+test("rejects tool result batches that span routed and legacy instances", () => {
+  assert.throws(
+    () =>
+      cursorHarnessRouteFromRequest({
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_bf_blue_0123456789abcdef0123456789abcdef",
+                content: "A",
+              },
+              { type: "tool_result", tool_use_id: "toolu_legacy", content: "B" },
+            ],
+          },
+        ],
+      }),
+    /multiple harness instances/,
+  );
+});
+
+test("uses Run.wait result when the stream has no assistant text", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    firstEventTimeoutMs: 1000,
+    agentFactory: async () => ({
+      close() {},
+      async send() {
+        return {
+          status: "finished",
+          async *stream() {},
+          async wait() {
+            return { status: "finished", result: "WAIT_RESULT_OK" };
+          },
+        };
+      },
+    }),
+  });
+  const response = await bridge.handle(
+    { model: "claude-fable-5", messages: [{ role: "user", content: "Reply." }] },
+    "test-key",
+  );
+  assert.equal(response.content[0].text, "WAIT_RESULT_OK");
+});
+
+test("passes Anthropic image blocks through the SDK user message", async () => {
+  let sentMessage;
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    firstEventTimeoutMs: 1000,
+    agentFactory: async () => ({
+      close() {},
+      async send(message) {
+        sentMessage = message;
+        return {
+          status: "finished",
+          async *stream() {
+            yield {
+              type: "assistant",
+              message: { content: [{ type: "text", text: "IMAGE_OK" }] },
+            };
+          },
+          async wait() {
+            return { status: "finished" };
+          },
+        };
+      },
+    }),
+  });
+  const response = await bridge.handle(
+    {
+      model: "claude-fable-5",
+      messages: [{
+        role: "user",
+        content: [{
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: "aW1hZ2U=" },
+        }],
+      }],
+    },
+    "test-key",
+  );
+  assert.equal(response.content[0].text, "IMAGE_OK");
+  assert.match(sentMessage.text, /IMAGE_ATTACHMENT/);
+  assert.deepEqual(sentMessage.images, [{ data: "aW1hZ2U=", mimeType: "image/png" }]);
+});
+
+test("allows a tool-capable request to finish with text without a tool call", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: plainAgentFactory("NO_TOOL_NEEDED"),
+    firstEventTimeoutMs: 1000,
+  });
+  const response = await bridge.handle(firstRequest(), "test-key");
+  assert.equal(response.stop_reason, "end_turn");
+  assert.equal(response.content[0].text, "NO_TOOL_NEEDED");
+});
+
+test("continues the same SDK run across multiple sequential tool turns", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: multiToolAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+  const first = await bridge.handle(firstRequest(), "test-key");
+  assert.equal(first.content[0].id, "toolu_multi_1");
+
+  const second = await bridge.handle(
+    resumeRequest("toolu_multi_1", "ONE"),
+    "test-key",
+  );
+  assert.equal(second.stop_reason, "tool_use");
+  assert.equal(second.content[0].id, "toolu_multi_2");
+
+  const thirdRequest = resumeRequest("toolu_multi_2", "TWO");
+  thirdRequest.messages.unshift({
+    role: "user",
+    content: [
+      { type: "tool_result", tool_use_id: "toolu_multi_1", content: "ONE" },
+    ],
+  });
+  const third = await bridge.handle(thirdRequest, "test-key");
+  assert.equal(third.stop_reason, "end_turn");
+  assert.equal(third.content[0].text, "ONE:TWO");
+
+  const replay = await bridge.handle(thirdRequest, "test-key");
+  assert.deepEqual(replay, third);
+
+  const conflicting = structuredClone(thirdRequest);
+  conflicting.messages[1].content[0].content = "DIFFERENT";
+  await assert.rejects(
+    bridge.handle(conflicting, "test-key"),
+    (error) => error.status === 409 && /conflicting duplicate/.test(error.message),
+  );
+});
+
+test("keeps each sequential pre-tool text in its own tool-use turn", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: multiToolAgentFactory({ preambles: ["FIRST.", "SECOND."] }),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+
+  const first = await bridge.handle(firstRequest(), "test-key");
+  assert.deepEqual(first.content.map((block) => block.type), ["text", "tool_use"]);
+  assert.equal(first.content[0].text, "FIRST.");
+
+  const second = await bridge.handle(
+    resumeRequest("toolu_multi_1", "ONE"),
+    "test-key",
+  );
+  assert.deepEqual(second.content.map((block) => block.type), ["text", "tool_use"]);
+  assert.equal(second.content[0].text, "SECOND.");
+
+  const final = await bridge.handle(
+    resumeRequest("toolu_multi_2", "TWO"),
+    "test-key",
+  );
+  assert.deepEqual(final.content, [{ type: "text", text: "ONE:TWO" }]);
+});
+
+test("returns and resumes a complete parallel tool batch", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: parallelToolAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+  const first = await bridge.handle(firstRequest(), "test-key");
+  assert.equal(first.stop_reason, "tool_use");
+  assert.deepEqual(
+    first.content.map((block) => block.id),
+    ["toolu_parallel_alpha", "toolu_parallel_beta"],
+  );
+
+  await assert.rejects(
+    bridge.handle(
+      resumeBatchRequest([["toolu_parallel_alpha", "ALPHA"]]),
+      "test-key",
+    ),
+    (error) => error.status === 409 && /exactly match/.test(error.message),
+  );
+
+  const final = await bridge.handle(
+    resumeBatchRequest([
+      ["toolu_parallel_alpha", "ALPHA"],
+      ["toolu_parallel_beta", "BETA"],
+    ]),
+    "test-key",
+  );
+  assert.equal(final.stop_reason, "end_turn");
+  assert.equal(final.content[0].text, "ALPHA:BETA");
+});
+
+test("returns one pre-tool text block before a parallel tool batch", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: parallelToolAgentFactory({ preamble: "BATCH." }),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+  const first = await bridge.handle(firstRequest(), "test-key");
+  assert.deepEqual(first.content.map((block) => block.type), [
+    "text",
+    "tool_use",
+    "tool_use",
+  ]);
+  assert.equal(first.content[0].text, "BATCH.");
+});
+
+test("passes Claude catalog ids through without hidden parameter overrides", () => {
+  assert.deepEqual(cursorSdkModelSelection("claude-sonnet-4-6"), {
+    id: "claude-sonnet-4-6",
+  });
+  assert.deepEqual(cursorSdkModelSelection("claude-fable-5"), {
+    id: "claude-fable-5",
+  });
+});
+
+test("maps Anthropic thinking controls to the official SDK effort parameter", () => {
+  assert.deepEqual(
+    cursorSdkModelSelection("claude-fable-5", {
+      thinking: { type: "enabled", budget_tokens: 12000 },
+    }),
+    { id: "claude-fable-5", params: [{ id: "effort", value: "high" }] },
+  );
+  assert.deepEqual(
+    cursorSdkModelSelection("claude-sonnet-4-6", {
+      output_config: { effort: "low" },
+    }),
+    { id: "claude-sonnet-4-6", params: [{ id: "effort", value: "low" }] },
+  );
+});
+
+test("maps Cursor Grok effort ids to official SDK model selections", () => {
+  assert.deepEqual(cursorSdkModelSelection("cursor-grok-4.5-high"), {
+    id: "grok-4.5",
+    params: [{ id: "effort", value: "high" }],
+  });
+  assert.deepEqual(cursorSdkModelSelection("cursor-grok-4.6-xhigh"), {
+    id: "grok-4.6",
+    params: [{ id: "effort", value: "xhigh" }],
+  });
+});
+
+test("serializes tool_choice any as at-least-one with independent parallel batching", async () => {
+  let capturedPrompt = "";
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    firstEventTimeoutMs: 1000,
+    agentFactory: async () => ({
+      async send(prompt) {
+        capturedPrompt = prompt;
+        return {
+          status: "completed",
+          async *stream() {
+            yield { type: "assistant", message: { content: [{ type: "text", text: "OK" }] } };
+          },
+          async wait() {
+            return { status: "completed" };
+          },
+        };
+      },
+      close() {},
+    }),
+  });
+
+  const response = await bridge.handle(
+    {
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "Use both tools." }],
+      tools: [
+        { name: "alpha", input_schema: { type: "object", properties: {} } },
+        { name: "beta", input_schema: { type: "object", properties: {} } },
+      ],
+      tool_choice: { type: "any" },
+    },
+    "test-key",
+  );
+  assert.equal(response.content[0].text, "OK");
+  assert.match(capturedPrompt, /at least one available custom MCP tool/);
+  assert.match(capturedPrompt, /multiple independent tools/);
+  assert.match(capturedPrompt, /call all of them together in the same turn/);
+  assert.doesNotMatch(capturedPrompt, /call one of the available/);
+});
+
+test("serializes disabled parallel tool_choice any as exactly one tool", async () => {
+  let capturedPrompt = "";
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    firstEventTimeoutMs: 1000,
+    agentFactory: async () => ({
+      async send(prompt) {
+        capturedPrompt = prompt;
+        return {
+          status: "completed",
+          async *stream() {
+            yield { type: "assistant", message: { content: [{ type: "text", text: "OK" }] } };
+          },
+          async wait() {
+            return { status: "completed" };
+          },
+        };
+      },
+      close() {},
+    }),
+  });
+
+  const response = await bridge.handle(
+    {
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "Use a tool." }],
+      tools: [
+        { name: "alpha", input_schema: { type: "object", properties: {} } },
+        { name: "beta", input_schema: { type: "object", properties: {} } },
+      ],
+      tool_choice: { type: "any", disable_parallel_tool_use: true },
+    },
+    "test-key",
+  );
+  assert.equal(response.content[0].text, "OK");
+  assert.match(capturedPrompt, /exactly one available custom MCP tool/);
+  assert.match(capturedPrompt, /Do not call tools in parallel/);
+  assert.doesNotMatch(capturedPrompt, /multiple independent tools/);
+});
+
+test("starts a new run when old tool history is followed by ordinary user text", async () => {
+  const prompts = [];
+  let creates = 0;
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+    parallelCollectMs: 0,
+    agentFactory: async (options) => {
+      creates += 1;
+      const factory = creates === 1 ? fakeAgentFactory() : plainAgentFactory("NEW_TURN_OK");
+      const agent = await factory(options);
+      const originalSend = agent.send.bind(agent);
+      agent.send = async (prompt) => {
+        prompts.push(prompt);
+        return originalSend(prompt);
+      };
+      return agent;
+    },
+  });
+
+  const first = await bridge.handle(firstRequest(), "test-key");
+  const final = await bridge.handle(
+    resumeRequest(first.content[0].id, "OLD_RESULT"),
+    "test-key",
+  );
+  assert.equal(final.content[0].text, "OLD_RESULT");
+
+  const next = await bridge.handle(
+    {
+      ...firstRequest(),
+      messages: [
+        { role: "user", content: "Use the tool." },
+        { role: "assistant", content: first.content },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: first.content[0].id,
+              content: "OLD_RESULT",
+            },
+          ],
+        },
+        { role: "assistant", content: final.content },
+        { role: "user", content: "This is a fresh turn." },
+      ],
+    },
+    "test-key",
+  );
+  assert.equal(next.content[0].text, "NEW_TURN_OK");
+  assert.equal(creates, 2);
+  assert.match(prompts[1], /TOOL_USE id=toolu_test_1/);
+  assert.match(prompts[1], /TOOL_RESULT tool_use_id=toolu_test_1/);
+  assert.match(prompts[1], /This is a fresh turn/);
+});
+
+test("rejects tool results mixed with new user instructions", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: fakeAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+  const first = await bridge.handle(firstRequest(), "test-key");
+  const mixed = resumeRequest(first.content[0].id, "RESULT");
+  mixed.messages[0].content.push({ type: "text", text: "also start another task" });
+  await assert.rejects(
+    bridge.handle(mixed, "test-key"),
+    (error) => error.status === 422 && /separate turns/.test(error.message),
+  );
+  const final = await bridge.handle(
+    resumeRequest(first.content[0].id, "RESULT"),
+    "test-key",
+  );
+  assert.equal(final.content[0].text, "RESULT");
+});
+
+test("isolates concurrent runs that share one Cursor credential", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: concurrentToolAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+    parallelCollectMs: 0,
+  });
+  const [first, second] = await Promise.all([
+    bridge.handle(firstRequest(), "shared-key"),
+    bridge.handle(firstRequest(), "shared-key"),
+  ]);
+  assert.notEqual(first.content[0].id, second.content[0].id);
+  const [firstFinal, secondFinal] = await Promise.all([
+    bridge.handle(resumeRequest(first.content[0].id, "FIRST"), "shared-key"),
+    bridge.handle(resumeRequest(second.content[0].id, "SECOND"), "shared-key"),
+  ]);
+  assert.equal(firstFinal.content[0].text, "FIRST");
+  assert.equal(secondFinal.content[0].text, "SECOND");
+});
+
+test("client abort closes a run without blocking the next request", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: hangingAgentFactory(),
+    firstEventTimeoutMs: 1000,
+  });
+  const firstAbort = new AbortController();
+  const first = bridge.handle(
+    { model: "composer-2.5", messages: [{ role: "user", content: "wait" }] },
+    "test-key",
+    { signal: firstAbort.signal },
+  );
+  setTimeout(() => firstAbort.abort(), 10);
+  await assert.rejects(first, (error) => error.status === 499);
+
+  const secondAbort = new AbortController();
+  const second = bridge.handle(
+    { model: "composer-2.5", messages: [{ role: "user", content: "wait again" }] },
+    "test-key",
+    { signal: secondAbort.signal },
+  );
+  setTimeout(() => secondAbort.abort(), 10);
+  await assert.rejects(second, (error) => error.status === 499);
+});
+
+test("client abort while agent send is pending cancels the late SDK run", async () => {
+  let cancelCount = 0;
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: delayedSendAgentFactory(() => {
+      cancelCount += 1;
+    }),
+    firstEventTimeoutMs: 1000,
+  });
+  const controller = new AbortController();
+  const request = bridge.handle(
+    { model: "composer-2.5", messages: [{ role: "user", content: "wait" }] },
+    "test-key",
+    { signal: controller.signal },
+  );
+  setTimeout(() => controller.abort(), 10);
+  await assert.rejects(request, (error) => error.status === 499);
+  assert.equal(cancelCount, 1);
+});
+
+test("client abort during tool-result continuation closes the parked run", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: hangingAfterToolResultAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+  const first = await bridge.handle(firstRequest(), "test-key");
+  const controller = new AbortController();
+  const resumed = bridge.handle(
+    resumeRequest(first.content[0].id, "RESULT"),
+    "test-key",
+    { signal: controller.signal },
+  );
+  setTimeout(() => controller.abort(), 10);
+  await assert.rejects(resumed, (error) => error.status === 499);
+});
+
+test("fails closed for an unknown tool result id", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: fakeAgentFactory(),
+  });
+  await assert.rejects(
+    bridge.handle(resumeRequest("toolu_missing", "x"), "test-key"),
+    (error) => error.status === 409 && /unknown or expired/.test(error.message),
+  );
+});
+
+test("binds tool result resume to the original Cursor credential", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: fakeAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+  const first = await bridge.handle(firstRequest(), "first-key");
+  await assert.rejects(
+    bridge.handle(resumeRequest(first.content[0].id, "x"), "different-key"),
+    (error) => error.status === 409 && /credential changed/.test(error.message),
+  );
+});
+
+test("binds tool result resume to the original gateway tenant", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: fakeAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+  const first = await bridge.handle(firstRequest(), "shared-key", {
+    tenantId: "user:1:token:10:channel:61",
+  });
+  await assert.rejects(
+    bridge.handle(resumeRequest(first.content[0].id, "x"), "shared-key", {
+      tenantId: "user:2:token:11:channel:61",
+    }),
+    (error) => error.status === 409 && /tenant changed/.test(error.message),
+  );
+});
+
+test("caps active sessions per Cursor credential", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: concurrentToolAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+    parallelCollectMs: 0,
+    maxSessionsPerCredential: 1,
+  });
+  await bridge.handle(firstRequest(), "shared-key");
+  await assert.rejects(
+    bridge.handle(firstRequest(), "shared-key"),
+    (error) => error.status === 429 && /credential session limit/.test(error.message),
+  );
+});
+
+test("expires an idle awaiting-tool session and fails resume closed", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: fakeAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 20,
+  });
+  const first = await bridge.handle(firstRequest(), "test-key");
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  await assert.rejects(
+    bridge.handle(resumeRequest(first.content[0].id, "late"), "test-key"),
+    (error) => error.status === 409 && /unknown or expired/.test(error.message),
+  );
+});
+
+test("shutdown rejects and forgets unresolved harness sessions", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: fakeAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+  const first = await bridge.handle(firstRequest(), "test-key");
+  await bridge.shutdown();
+  await assert.rejects(
+    bridge.handle(resumeRequest(first.content[0].id, "after-shutdown"), "test-key"),
+    (error) => error.status === 409 && /unknown or expired/.test(error.message),
+  );
+});
+
+test("drain rejects new sessions while allowing an existing tool continuation", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: fakeAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+    replayTtlMs: 20,
+  });
+  const first = await bridge.handle(firstRequest(), "test-key");
+  assert.equal(bridge.beginDrain().drainSessions, 1);
+  await assert.rejects(
+    bridge.handle(firstRequest(), "test-key"),
+    (error) => error.status === 503 && error.retryAfter === 2,
+  );
+  const final = await bridge.handle(
+    resumeRequest(first.content[0].id, "DRAIN_OK"),
+    "test-key",
+  );
+  assert.equal(final.content[0].text, "DRAIN_OK");
+  assert.equal(await bridge.waitForDrain(200), true);
+  assert.equal(bridge.status().drainSessions, 0);
+});
+
+test("cold-recovers a persisted tool result through Agent.resume and force send", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "cursor-bridge-recovery-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const state = new CursorHarnessSessionState(join(root, "sessions.json"));
+  const sdkStore = {};
+  const firstBridge = new CursorHarnessMessagesBridge({
+    workspace: root,
+    agentFactory: fakeAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 10_000,
+    instanceId: "blue",
+    sdkStore,
+    sessionState: state,
+  });
+  const first = await firstBridge.handle(firstRequest(), "test-key");
+  const toolUseId = first.content[0].id;
+  assert.deepEqual(state.counts(), { awaiting: 1, replay: 0, total: 1 });
+
+  let resumedAgentId = "";
+  let resumeCount = 0;
+  let recoveryPrompt = "";
+  let forced = false;
+  const recoveredBridge = new CursorHarnessMessagesBridge({
+    workspace: root,
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+    replayTtlMs: 1000,
+    instanceId: "blue",
+    sdkStore,
+    sessionState: new CursorHarnessSessionState(join(root, "sessions.json")),
+    agentResumer: async (agentId) => {
+      resumeCount += 1;
+      resumedAgentId = agentId;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return {
+        agentId,
+        close() {},
+        async send(prompt, options) {
+          recoveryPrompt = prompt;
+          forced = options.local.force;
+          return {
+            id: "run-recovered",
+            status: "running",
+            async *stream() {
+              yield {
+                type: "assistant",
+                message: { content: [{ type: "text", text: "RECOVERED_OK" }] },
+              };
+              this.status = "finished";
+            },
+            async wait() {
+              return { status: "finished" };
+            },
+            async cancel() {},
+          };
+        },
+      };
+    },
+  });
+  const recoveredRequest = resumeRequest(toolUseId, "RECOVERED_RESULT");
+  recoveredRequest.tools = firstRequest().tools;
+  const [recovered, concurrentReplay] = await Promise.all([
+    recoveredBridge.handle(recoveredRequest, "test-key"),
+    recoveredBridge.handle(structuredClone(recoveredRequest), "test-key"),
+  ]);
+  assert.equal(recovered.content[0].text, "RECOVERED_OK");
+  assert.deepEqual(concurrentReplay, recovered);
+  assert.equal(resumeCount, 1);
+  assert.equal(resumedAgentId, "agent-test");
+  assert.equal(forced, true);
+  assert.match(recoveryPrompt, /RECOVERED_RESULT/);
+  assert.match(recoveryPrompt, /Do not repeat the completed tool calls/);
+
+  const replay = await recoveredBridge.handle(recoveredRequest, "test-key");
+  assert.deepEqual(replay, recovered);
+  const conflicting = structuredClone(recoveredRequest);
+  conflicting.messages[0].content[0].content = "DIFFERENT";
+  await assert.rejects(
+    recoveredBridge.handle(conflicting, "test-key"),
+    (error) => error.status === 409 && /conflicting duplicate persisted/.test(error.message),
+  );
+});
+
+test("preserves a persisted checkpoint after a transient cold-recovery failure", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "cursor-bridge-retry-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const stateFile = join(root, "sessions.json");
+  const state = new CursorHarnessSessionState(stateFile);
+  const sdkStore = {};
+  const firstBridge = new CursorHarnessMessagesBridge({
+    workspace: root,
+    agentFactory: fakeAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 10_000,
+    instanceId: "blue",
+    sdkStore,
+    sessionState: state,
+  });
+  const first = await firstBridge.handle(firstRequest(), "test-key");
+  const recoveredRequest = resumeRequest(first.content[0].id, "RETRY_RESULT");
+  recoveredRequest.tools = firstRequest().tools;
+  let attempts = 0;
+  const recoveredState = new CursorHarnessSessionState(stateFile);
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: root,
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 10_000,
+    instanceId: "blue",
+    sdkStore,
+    sessionState: recoveredState,
+    agentResumer: async (agentId) => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("temporary SDK outage");
+      return {
+        agentId,
+        close() {},
+        async send() {
+          return {
+            id: "run-retry",
+            status: "running",
+            async *stream() {
+              yield {
+                type: "assistant",
+                message: { content: [{ type: "text", text: "RETRY_OK" }] },
+              };
+              this.status = "finished";
+            },
+            async wait() { return { status: "finished" }; },
+            async cancel() {},
+          };
+        },
+      };
+    },
+  });
+  await assert.rejects(
+    bridge.handle(recoveredRequest, "test-key"),
+    (error) => error.status === 502 && /temporary SDK outage/.test(error.message),
+  );
+  assert.deepEqual(recoveredState.counts(), { awaiting: 1, replay: 0, total: 1 });
+  const recovered = await bridge.handle(recoveredRequest, "test-key");
+  assert.equal(recovered.content[0].text, "RETRY_OK");
+  assert.equal(attempts, 2);
+});
+
+test("cleanup failure cannot leave a closed session blocking drain", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: fakeAgentFactory(),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+    sdkStore: { runs: { async list() { throw new Error("cleanup failed"); } } },
+  });
+  await bridge.handle(firstRequest(), "test-key");
+  await bridge.shutdown();
+  assert.equal(bridge.status().drainSessions, 0);
+});
+
+test("fails closed when the harness finishes without semantic output", async () => {
+  const bridge = new CursorHarnessMessagesBridge({
+    workspace: process.cwd(),
+    agentFactory: fakeAgentFactory({ emptyFinal: true }),
+    firstEventTimeoutMs: 1000,
+    sessionTtlMs: 1000,
+  });
+  const first = await bridge.handle(firstRequest(), "test-key");
+  await assert.rejects(
+    bridge.handle(resumeRequest(first.content[0].id, "x"), "test-key"),
+    (error) => error.status === 502 && /empty final turn/.test(error.message),
+  );
+});

--- a/cursor_agent_sidecar/package-lock.json
+++ b/cursor_agent_sidecar/package-lock.json
@@ -1,0 +1,453 @@
+{
+  "name": "cursor-agent-sidecar",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cursor-agent-sidecar",
+      "version": "0.1.0",
+      "dependencies": {
+        "@cursor/sdk": "1.0.27",
+        "global-agent": "^4.1.3",
+        "https-proxy-agent": "^9.1.0",
+        "undici": "^8.10.0"
+      },
+      "engines": {
+        "node": ">=22.13"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
+      "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.7.0.tgz",
+      "integrity": "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-1.7.0.tgz",
+      "integrity": "sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      }
+    },
+    "node_modules/@cursor/sdk": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.27.tgz",
+      "integrity": "sha512-QR2RYZagCUlil/A4JcRU8rI4JmYICuMdWkuIsiz/yHvd/N3bisjw9o2uXhkKitDKHgIyeGDHwrQfH/MYttM37g==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@bufbuild/protobuf": "1.10.0",
+        "@connectrpc/connect": "^1.6.1",
+        "@connectrpc/connect-node": "^1.6.1",
+        "@connectrpc/connect-web": "^1.6.1",
+        "@statsig/js-client": "3.31.0",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "optionalDependencies": {
+        "@cursor/sdk-darwin-arm64": "1.0.27",
+        "@cursor/sdk-darwin-x64": "1.0.27",
+        "@cursor/sdk-linux-arm64": "1.0.27",
+        "@cursor/sdk-linux-x64": "1.0.27",
+        "@cursor/sdk-win32-x64": "1.0.27"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-arm64": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.27.tgz",
+      "integrity": "sha512-lO9chGVwb9lISwYtfolgF9IvTLR0Z0M8vd6AqwUfl607G/hesh+LICMD/tal2JWP0rm/hds66tIRo//M4RVupA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-x64": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.27.tgz",
+      "integrity": "sha512-moYR40uq0Mu2Runm7XWa60+8n9Epyah++fkaW/avAYMAel/qOeHTH/uiNKTjwuCledQmczCYWDTVlZQOGEhrxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-linux-arm64": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.27.tgz",
+      "integrity": "sha512-caDqO0RPYmaCbQYpJwTMT5YeVqP6WkZq1y7n5v1N3rlkjdaM2mWbkdSFEUL4GOTdkm8oIEx2diRNQ1hrJbVPYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-linux-x64": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.27.tgz",
+      "integrity": "sha512-z3aVQaXk4T9QjB11u77JihHrSN0XeFYCrnuqvd9PMZQSqiXfUheqX/lQTRxFjfccoU4tK1p/nJ91IWKAUVQU4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-win32-x64": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.27.tgz",
+      "integrity": "sha512-LbkimreWuz+FsyUcRKlvgwnWbXwzzcFexCUGkHCWNuO0JSspjhqUGfDtFFxhHU5ohMMy2FpzU7qs5wKzAc8NgA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "rg": "bin/rg.exe"
+      }
+    },
+    "node_modules/@statsig/client-core": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.31.0.tgz",
+      "integrity": "sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==",
+      "license": "ISC"
+    },
+    "node_modules/@statsig/js-client": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/js-client/-/js-client-3.31.0.tgz",
+      "integrity": "sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==",
+      "license": "ISC",
+      "dependencies": {
+        "@statsig/client-core": "3.31.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-4.1.3.tgz",
+      "integrity": "sha512-KUJEViiuFT3I97t+GYMikLPJS2Lfo/S2F+DQuBWzuzaMPnvt5yyZePzArx36fBzpGTxZjIpDbXLeySLgh+k76g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "globalthis": "^1.0.2",
+        "matcher": "^4.0.0",
+        "semver": "^7.3.5",
+        "serialize-error": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-4.0.0.tgz",
+      "integrity": "sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/proxy-agent-negotiate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "kerberos": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "kerberos": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/cursor_agent_sidecar/package.json
+++ b/cursor_agent_sidecar/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "cursor-agent-sidecar",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "engines": {
+    "node": ">=22.13"
+  },
+  "scripts": {
+    "test": "node --test --test-concurrency=1 *.test.mjs",
+    "start": "bash ./start.sh",
+    "start:node": "node server.mjs",
+    "start:proxychains": "PROXYCHAINS=1 bash ./start.sh",
+    "smoke:claude": "node smoke_claude.mjs",
+    "smoke:custom-tool": "node smoke_custom_tool.mjs",
+    "smoke:messages-bridge": "node smoke_messages_bridge.mjs",
+    "smoke:messages-parallel": "node smoke_messages_parallel.mjs"
+  },
+  "dependencies": {
+    "@cursor/sdk": "1.0.27",
+    "global-agent": "^4.1.3",
+    "https-proxy-agent": "^9.1.0",
+    "undici": "^8.10.0"
+  },
+  "overrides": {
+    "@connectrpc/connect-node": {
+      "undici": "6.28.0"
+    }
+  }
+}

--- a/cursor_agent_sidecar/proxychains-agent.conf
+++ b/cursor_agent_sidecar/proxychains-agent.conf
@@ -1,0 +1,19 @@
+# TCP-level proxy for Cursor Agent when Node env proxy is incomplete.
+# Clash Verge defaults: mixed 7890 (http), socks 7898.
+dynamic_chain
+quiet_mode
+proxy_dns
+remote_dns_subnet 224
+tcp_read_time_out 15000
+tcp_connect_time_out 8000
+
+localnet 127.0.0.0/255.0.0.0
+localnet ::1/128
+localnet 10.0.0.0/255.0.0.0
+localnet 172.16.0.0/255.240.0.0
+localnet 192.168.0.0/255.255.0.0
+
+[ProxyList]
+# Prefer HTTP mixed port (Clash default). Switch to socks5 if needed:
+# socks5 127.0.0.1 7898
+http 127.0.0.1 7890

--- a/cursor_agent_sidecar/server.mjs
+++ b/cursor_agent_sidecar/server.mjs
@@ -1,0 +1,637 @@
+/**
+ * Cursor Agent sidecar for new-api.
+ *
+ * Official @cursor/sdk only — no reverse-engineered api2.cursor.sh client.
+ * Surface: Anthropic-compatible /v1/messages (+ /health, /v1/models).
+ *
+ * Safety defaults:
+ * - tools: [] (text only; no shell/fs)
+ * - empty workspace cwd
+ * - no project/user setting sources
+ * - optional force_proxy for development environments that require an egress proxy
+ */
+// Load before @cursor/sdk. force_proxy is a no-op unless CURSOR_AGENT_FORCE_PROXY
+// or CURSOR_AGENT_PROXY is set (see force_proxy.mjs).
+import "./force_proxy.mjs";
+import http from "node:http";
+import { mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Cursor, JsonlLocalAgentStore } from "@cursor/sdk";
+import { fetchCursorAccount } from "./cursor_account.mjs";
+import {
+  CursorHarnessMessagesBridge,
+  cursorHarnessRequestHasToolResults,
+  cursorHarnessRouteFromRequest,
+} from "./harness_messages.mjs";
+import { CursorHarnessSessionState, deleteSdkAgentState } from "./session_state.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PORT = Number(process.env.CURSOR_AGENT_SIDECAR_PORT || 3927);
+const HOST = process.env.CURSOR_AGENT_SIDECAR_HOST || "127.0.0.1";
+const BUILD_COMMIT = process.env.CURSOR_AGENT_BUILD_COMMIT || "unknown";
+const BUILD_TIME = process.env.CURSOR_AGENT_BUILD_TIME || "unknown";
+const INSTANCE_ID = String(
+  process.env.CURSOR_AGENT_INSTANCE_ID || process.env.HOSTNAME || "local",
+)
+  .trim()
+  .toLowerCase()
+  .replace(/[^a-z0-9-]+/g, "-")
+  .replace(/^-+|-+$/g, "")
+  .slice(0, 24) || "local";
+const PEER_BASE_URL_TEMPLATE = String(
+  process.env.CURSOR_AGENT_PEER_BASE_URL_TEMPLATE || "",
+).trim();
+const PEER_INSTANCE_IDS = new Set(
+  String(process.env.CURSOR_AGENT_PEER_INSTANCE_IDS || "")
+    .split(",")
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean),
+);
+const STATE_DIR = String(process.env.CURSOR_AGENT_STATE_DIR || "").trim();
+const WORKSPACE = resolve(
+  process.env.CURSOR_AGENT_WORKSPACE || resolve(__dirname, "empty-workspace"),
+);
+
+function integerEnv(name, fallback, { min }) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < min) {
+    throw new Error(`${name} must be an integer >= ${min}`);
+  }
+  return value;
+}
+
+const PARALLEL_TOOL_COLLECT_MS = integerEnv(
+  "CURSOR_AGENT_PARALLEL_TOOL_COLLECT_MS",
+  100,
+  { min: 0 },
+);
+const MAX_ACTIVE_SESSIONS = integerEnv("CURSOR_AGENT_MAX_ACTIVE_SESSIONS", 256, {
+  min: 1,
+});
+const MAX_SESSIONS_PER_CREDENTIAL = integerEnv(
+  "CURSOR_AGENT_MAX_SESSIONS_PER_CREDENTIAL",
+  32,
+  { min: 1 },
+);
+mkdirSync(WORKSPACE, { recursive: true });
+if (STATE_DIR) mkdirSync(STATE_DIR, { recursive: true });
+const sdkStore = STATE_DIR
+  ? new JsonlLocalAgentStore(resolve(STATE_DIR, "sdk-store"))
+  : undefined;
+const sessionState = STATE_DIR
+  ? new CursorHarnessSessionState(resolve(STATE_DIR, "bridge-sessions.json"), {
+      onExpire: (record) => deleteSdkAgentState(sdkStore, record.agentId),
+    })
+  : undefined;
+const harnessMessagesBridge = new CursorHarnessMessagesBridge({
+  workspace: WORKSPACE,
+  parallelCollectMs: PARALLEL_TOOL_COLLECT_MS,
+  instanceId: INSTANCE_ID,
+  sdkStore,
+  sessionState,
+  maxActiveSessions: MAX_ACTIVE_SESSIONS,
+  maxSessionsPerCredential: MAX_SESSIONS_PER_CREDENTIAL,
+});
+
+function readBody(req) {
+  return new Promise((resolveBody, reject) => {
+    const chunks = [];
+    let size = 0;
+    req.on("data", (c) => {
+      size += c.length;
+      if (size > 8 * 1024 * 1024) {
+        reject(new Error("body too large"));
+        req.destroy();
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on("end", () => resolveBody(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+function extractApiKey(req) {
+  const auth = req.headers.authorization || "";
+  if (auth.toLowerCase().startsWith("bearer ")) {
+    return auth.slice(7).trim();
+  }
+  const x = req.headers["x-api-key"] || req.headers["x-cursor-api-key"];
+  if (typeof x === "string" && x.trim()) return x.trim();
+  // Env fallback is opt-in only. Default off so a shared/misbound sidecar
+  // cannot serve arbitrary callers with the host CURSOR_API_KEY.
+  if (
+    process.env.CURSOR_AGENT_ALLOW_ENV_KEY === "1" &&
+    process.env.CURSOR_API_KEY
+  ) {
+    return process.env.CURSOR_API_KEY.trim();
+  }
+  return "";
+}
+
+function json(res, status, body) {
+  const data = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Content-Length": Buffer.byteLength(data),
+  });
+  res.end(data);
+}
+
+function createAnthropicSSEWriter(res) {
+  let started = false;
+  let ended = false;
+  let streamedText = false;
+  let openTextBlock = -1;
+  let openThinkingBlock = -1;
+  let nextBlockIndex = 0;
+
+  const event = (name, data) => {
+    if (ended || res.destroyed) return;
+    res.write(`event: ${name}\ndata: ${JSON.stringify(data)}\n\n`);
+  };
+
+  const start = ({ id, model }) => {
+    if (started || ended || res.destroyed) return;
+    started = true;
+    res.socket?.setNoDelay?.(true);
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+      "X-Cursor-Agent-Harness": "cursor-sdk",
+    });
+    event("message_start", {
+      type: "message_start",
+      message: {
+        id,
+        type: "message",
+        role: "assistant",
+        model,
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      },
+    });
+  };
+
+  const closeTextBlock = () => {
+    if (openTextBlock < 0) return;
+    event("content_block_stop", {
+      type: "content_block_stop",
+      index: openTextBlock,
+    });
+    openTextBlock = -1;
+  };
+
+  const closeThinkingBlock = () => {
+    if (openThinkingBlock < 0) return;
+    event("content_block_stop", {
+      type: "content_block_stop",
+      index: openThinkingBlock,
+    });
+    openThinkingBlock = -1;
+  };
+
+  const thinking = (delta, meta) => {
+    if (!delta || ended || res.destroyed) return;
+    start(meta);
+    closeTextBlock();
+    if (openThinkingBlock < 0) {
+      openThinkingBlock = nextBlockIndex++;
+      event("content_block_start", {
+        type: "content_block_start",
+        index: openThinkingBlock,
+        content_block: { type: "thinking", thinking: "" },
+      });
+    }
+    event("content_block_delta", {
+      type: "content_block_delta",
+      index: openThinkingBlock,
+      delta: { type: "thinking_delta", thinking: String(delta) },
+    });
+  };
+
+  const text = (delta, meta) => {
+    if (!delta || ended || res.destroyed) return;
+    start(meta);
+    closeThinkingBlock();
+    if (openTextBlock < 0) {
+      openTextBlock = nextBlockIndex++;
+      event("content_block_start", {
+        type: "content_block_start",
+        index: openTextBlock,
+        content_block: { type: "text", text: "" },
+      });
+    }
+    streamedText = true;
+    event("content_block_delta", {
+      type: "content_block_delta",
+      index: openTextBlock,
+      delta: { type: "text_delta", text: String(delta) },
+    });
+  };
+
+  const writeBlock = (block) => {
+    if (block.type === "text") {
+      if (streamedText) return;
+      text(String(block.text || ""), {
+        id: currentMessage.id,
+        model: currentMessage.model,
+      });
+      closeTextBlock();
+      return;
+    }
+    closeTextBlock();
+    closeThinkingBlock();
+    const index = nextBlockIndex++;
+    if (block.type === "tool_use") {
+      event("content_block_start", {
+        type: "content_block_start",
+        index,
+        content_block: {
+          type: "tool_use",
+          id: block.id,
+          name: block.name,
+          input: {},
+        },
+      });
+      event("content_block_delta", {
+        type: "content_block_delta",
+        index,
+        delta: {
+          type: "input_json_delta",
+          partial_json: JSON.stringify(block.input || {}),
+        },
+      });
+    }
+    event("content_block_stop", { type: "content_block_stop", index });
+  };
+
+  let currentMessage = null;
+  const finish = (message) => {
+    if (ended || res.destroyed) return;
+    currentMessage = message;
+    start({ id: message.id, model: message.model });
+    for (const block of message.content || []) writeBlock(block);
+    closeTextBlock();
+    closeThinkingBlock();
+    event("message_delta", {
+      type: "message_delta",
+      delta: { stop_reason: message.stop_reason, stop_sequence: null },
+      usage: {
+        input_tokens: message.usage?.input_tokens || 0,
+        output_tokens: message.usage?.output_tokens || 0,
+        cache_read_input_tokens: message.usage?.cache_read_input_tokens || 0,
+        cache_creation_input_tokens:
+          message.usage?.cache_creation_input_tokens || 0,
+      },
+    });
+    event("message_stop", { type: "message_stop" });
+    ended = true;
+    res.end();
+  };
+
+  const fail = (error) => {
+    if (!started || ended || res.destroyed) return;
+    closeTextBlock();
+    closeThinkingBlock();
+    event("error", {
+      type: "error",
+      error: { type: "api_error", message: error?.message || String(error) },
+    });
+    ended = true;
+    res.end();
+  };
+
+  return {
+    thinking,
+    text,
+    finish,
+    fail,
+    get started() {
+      return started;
+    },
+  };
+}
+
+async function handleHarnessMessages(req, res, apiKey) {
+  const raw = await readBody(req);
+  let body;
+  try {
+    body = JSON.parse(raw.toString("utf8") || "{}");
+  } catch {
+    return json(res, 400, {
+      type: "error",
+      error: { type: "invalid_request_error", message: "invalid json body" },
+    });
+  }
+  let routedInstance;
+  try {
+    routedInstance = cursorHarnessRouteFromRequest(body);
+  } catch (error) {
+    return json(res, Number(error?.status) || 409, {
+      type: "error",
+      error: { type: "conflict_error", message: error?.message || String(error) },
+    });
+  }
+  if (routedInstance && routedInstance !== INSTANCE_ID) {
+    return proxyHarnessMessages(req, res, raw, apiKey, routedInstance);
+  }
+  if (Array.isArray(body.tools) && body.tools.length > 0) {
+    console.error(
+      "[cursor-harness-request]",
+      JSON.stringify({
+        model: body.model,
+        stream: Boolean(body.stream),
+        systemLength:
+          typeof body.system === "string"
+            ? body.system.length
+            : JSON.stringify(body.system || "").length,
+        maxTokens: body.max_tokens,
+        toolChoice: body.tool_choice || null,
+        tools: body.tools.map((tool) => String(tool?.name || "")),
+        messageRoles: Array.isArray(body.messages)
+          ? body.messages.map((message) => String(message?.role || ""))
+          : [],
+      }),
+    );
+  }
+  const abortController = new AbortController();
+  const abortOnDisconnect = () => {
+    if (!res.writableEnded) abortController.abort();
+  };
+  res.once("close", abortOnDisconnect);
+  const streamWriter = body.stream ? createAnthropicSSEWriter(res) : null;
+  try {
+    const response = await harnessMessagesBridge.handle(body, apiKey, {
+      signal: abortController.signal,
+      tenantId: String(req.headers["x-cursor-agent-tenant"] || ""),
+      onTextDelta: streamWriter
+        ? (text, meta) => streamWriter.text(text, meta)
+        : undefined,
+      onThinkingDelta: streamWriter
+        ? (text, meta) => streamWriter.thinking(text, meta)
+        : undefined,
+    });
+    if (streamWriter) return streamWriter.finish(response);
+    return json(res, 200, response);
+  } catch (err) {
+    if (res.destroyed) return;
+    const peerHop = String(req.headers["x-cursor-agent-peer-hop"] || "");
+    if (
+      !streamWriter?.started &&
+      Number(err?.status) === 409 &&
+      !routedInstance &&
+      cursorHarnessRequestHasToolResults(body) &&
+      peerHop !== "1"
+    ) {
+      const legacyPeer = INSTANCE_ID === "blue" ? "green" : INSTANCE_ID === "green" ? "blue" : "";
+      if (legacyPeer) {
+        return proxyHarnessMessages(req, res, raw, apiKey, legacyPeer);
+      }
+    }
+    if (streamWriter?.started) return streamWriter.fail(err);
+    if (err?.retryAfter) res.setHeader("Retry-After", String(err.retryAfter));
+    return json(res, Number(err?.status) || 502, {
+      type: "error",
+      error: {
+        type: Number(err?.status) === 409 ? "conflict_error" : "api_error",
+        message: err?.message || String(err),
+      },
+    });
+  } finally {
+    res.off("close", abortOnDisconnect);
+  }
+}
+
+function peerBaseURL(instanceId) {
+  if (!PEER_BASE_URL_TEMPLATE.includes("{instance}")) {
+    throw Object.assign(new Error("cursor harness peer routing is not configured"), {
+      status: 503,
+    });
+  }
+  if (!/^[a-z0-9-]{1,24}$/.test(instanceId)) {
+    throw new Error("invalid cursor harness peer instance id");
+  }
+  if (!PEER_INSTANCE_IDS.has(instanceId)) {
+    throw Object.assign(new Error("cursor harness peer instance is not allowlisted"), {
+      status: 503,
+    });
+  }
+  return PEER_BASE_URL_TEMPLATE.replaceAll("{instance}", instanceId).replace(/\/$/, "");
+}
+
+async function proxyHarnessMessages(req, res, raw, apiKey, instanceId) {
+  const abortController = new AbortController();
+  const abortOnDisconnect = () => {
+    if (!res.writableEnded) abortController.abort();
+  };
+  res.once("close", abortOnDisconnect);
+  try {
+    const upstream = await fetch(`${peerBaseURL(instanceId)}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${apiKey}`,
+        "x-cursor-agent-peer-hop": "1",
+        ...(typeof req.headers["x-cursor-agent-tenant"] === "string"
+          ? { "x-cursor-agent-tenant": req.headers["x-cursor-agent-tenant"] }
+          : {}),
+        ...(typeof req.headers["anthropic-version"] === "string"
+          ? { "anthropic-version": req.headers["anthropic-version"] }
+          : {}),
+        ...(typeof req.headers["anthropic-beta"] === "string"
+          ? { "anthropic-beta": req.headers["anthropic-beta"] }
+          : {}),
+      },
+      body: raw,
+      signal: abortController.signal,
+    });
+    const headers = {
+      "Content-Type": upstream.headers.get("content-type") || "application/json; charset=utf-8",
+      "Cache-Control": upstream.headers.get("cache-control") || "no-cache, no-transform",
+      "X-Cursor-Agent-Harness": "cursor-sdk",
+      "X-Cursor-Agent-Routed-Instance": instanceId,
+    };
+    res.writeHead(upstream.status, headers);
+    if (upstream.body) {
+      for await (const chunk of upstream.body) {
+        if (res.destroyed) break;
+        res.write(chunk);
+      }
+    }
+    if (!res.writableEnded && !res.destroyed) res.end();
+  } catch (error) {
+    if (res.destroyed) return;
+    if (!res.headersSent) {
+      return json(res, 502, {
+        type: "error",
+        error: {
+          type: "api_error",
+          message: `cursor harness instance ${instanceId} is unavailable`,
+        },
+      });
+    }
+    res.end();
+  } finally {
+    res.off("close", abortOnDisconnect);
+  }
+}
+
+async function handleModels(req, res, apiKey) {
+  try {
+    const models = await Cursor.models.list({ apiKey });
+    const data = (models || []).map((m) => {
+      const id = typeof m === "string" ? m : m.id || m.name;
+      return {
+        // Bare Cursor catalog SKU — same names as other channels (no prefix).
+        id: String(id),
+        object: "model",
+        created: Math.floor(Date.now() / 1000),
+        owned_by: "cursor",
+      };
+    });
+    return json(res, 200, { object: "list", data });
+  } catch (err) {
+    return json(res, 502, {
+      error: { message: err?.message || String(err), type: "upstream_error" },
+    });
+  }
+}
+
+async function handleAccount(req, res, apiKey) {
+  try {
+    return json(res, 200, await fetchCursorAccount(apiKey));
+  } catch (err) {
+    return json(res, 502, {
+      error: { message: err?.message || String(err), type: "upstream_error" },
+    });
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url || "/", `http://${HOST}:${PORT}`);
+    const path = url.pathname;
+
+    if (req.method === "GET" && (path === "/health" || path === "/")) {
+      const sessionStatus = harnessMessagesBridge.status();
+      return json(res, 200, {
+        ok: true,
+        service: "cursor-agent-sidecar",
+        instance_id: INSTANCE_ID || null,
+        build_commit: BUILD_COMMIT,
+        build_time: BUILD_TIME,
+        accepting: sessionStatus.accepting,
+        sessions: {
+          live: sessionStatus.liveSessions,
+          persisted: sessionStatus.persistedSessions,
+          drain: sessionStatus.drainSessions,
+          awaiting: sessionStatus.persisted.awaiting,
+          replay: sessionStatus.persisted.replay,
+        },
+        // Capability matrix for the native SDK harness bridge. Assistant text
+        // is forwarded incrementally; tool args arrive complete from SDK MCP.
+        capabilities: {
+          messages_text: true,
+          messages_streaming: true,
+          thinking_streaming: true,
+          tools: true,
+          tools_streaming: false,
+          parallel_tool_calls: true,
+          sequential_tool_turns: true,
+          tool_result_replay: true,
+          process_restart_recovery: Boolean(STATE_DIR),
+          active_session_drain: true,
+          session_idle_ttl_seconds: 900,
+          count_tokens: false,
+          responses: false,
+          generation_controls: {
+            effort: true,
+            max_tokens: false,
+            temperature: false,
+            top_p: false,
+            stop_sequences: false,
+          },
+        },
+      });
+    }
+
+    if (req.method === "GET" && path === "/v1/models") {
+      const apiKey = extractApiKey(req);
+      if (!apiKey) {
+        return json(res, 401, {
+          error: { message: "missing api key", type: "authentication_error" },
+        });
+      }
+      return handleModels(req, res, apiKey);
+    }
+
+    if (req.method === "GET" && path === "/v1/account") {
+      const apiKey = extractApiKey(req);
+      if (!apiKey) {
+        return json(res, 401, {
+          error: { message: "missing api key", type: "authentication_error" },
+        });
+      }
+      return handleAccount(req, res, apiKey);
+    }
+
+    if (req.method === "POST" && path.endsWith("/messages")) {
+      const apiKey = extractApiKey(req);
+      if (!apiKey) {
+        return json(res, 401, {
+          type: "error",
+          error: { type: "authentication_error", message: "missing api key" },
+        });
+      }
+      return handleHarnessMessages(req, res, apiKey);
+    }
+
+    return json(res, 404, {
+      error: { message: `not found: ${path}`, type: "invalid_request_error" },
+    });
+  } catch (err) {
+    if (!res.headersSent) {
+      return json(res, 500, {
+        error: { message: err?.message || String(err), type: "server_error" },
+      });
+    }
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(
+    `[cursor-agent-sidecar] listening on http://${HOST}:${PORT} workspace=${WORKSPACE}`,
+  );
+});
+
+let shutdownStarted = false;
+async function shutdown(signal) {
+  if (shutdownStarted) return;
+  shutdownStarted = true;
+  console.log(`[cursor-agent-sidecar] ${signal}: draining harness sessions`);
+  harnessMessagesBridge.beginDrain();
+  const drained = await harnessMessagesBridge.waitForDrain(25_000);
+  await new Promise((resolveClose) => server.close(resolveClose));
+  await harnessMessagesBridge.shutdown({ preserveState: !drained });
+  process.exit(0);
+}
+
+process.once("SIGTERM", () => void shutdown("SIGTERM"));
+process.once("SIGINT", () => void shutdown("SIGINT"));
+process.on("SIGUSR2", () => {
+  console.log("[cursor-agent-sidecar] SIGUSR2: refusing new sessions and draining");
+  harnessMessagesBridge.beginDrain();
+});

--- a/cursor_agent_sidecar/server.test.mjs
+++ b/cursor_agent_sidecar/server.test.mjs
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import http from "node:http";
+import test from "node:test";
+
+async function reservePort() {
+  const server = http.createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address();
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function waitForHealth(port, child) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`sidecar exited with ${child.exitCode}`);
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/health`);
+      if (response.ok) return;
+    } catch {
+      // Startup has not bound the port yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error("sidecar did not become healthy");
+}
+
+test("routes a tool result back to the sidecar instance encoded in its id", async (t) => {
+  let captured;
+  const peer = http.createServer(async (req, res) => {
+    let raw = "";
+    for await (const chunk of req) raw += chunk;
+    captured = { authorization: req.headers.authorization, body: JSON.parse(raw) };
+    res.writeHead(201, { "content-type": "application/json" });
+    res.end(JSON.stringify({ routed: true }));
+  });
+  await new Promise((resolve, reject) => {
+    peer.once("error", reject);
+    peer.listen(0, "127.0.0.1", resolve);
+  });
+  t.after(() => new Promise((resolve) => peer.close(resolve)));
+
+  const peerPort = peer.address().port;
+  const sourcePort = await reservePort();
+  const child = spawn(process.execPath, ["server.mjs"], {
+    cwd: new URL(".", import.meta.url),
+    env: {
+      ...process.env,
+      CURSOR_AGENT_SIDECAR_HOST: "127.0.0.1",
+      CURSOR_AGENT_SIDECAR_PORT: String(sourcePort),
+      CURSOR_AGENT_INSTANCE_ID: "source",
+      CURSOR_AGENT_PEER_BASE_URL_TEMPLATE: "http://127.0.0.1:{instance}",
+      CURSOR_AGENT_PEER_INSTANCE_IDS: String(peerPort),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  t.after(async () => {
+    if (child.exitCode !== null) return;
+    await new Promise((resolve) => {
+      child.once("exit", resolve);
+      child.kill("SIGTERM");
+    });
+  });
+  await waitForHealth(sourcePort, child);
+
+  const body = {
+    model: "claude-sonnet-4-6",
+    max_tokens: 128,
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: `toolu_bf_${peerPort}_0123456789abcdef0123456789abcdef`,
+            content: "done",
+          },
+        ],
+      },
+    ],
+  };
+  const response = await fetch(`http://127.0.0.1:${sourcePort}/v1/messages`, {
+    method: "POST",
+    headers: {
+      authorization: "Bearer cursor-test-key",
+      "content-type": "application/json",
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify(body),
+  });
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(await response.json(), { routed: true });
+  assert.equal(response.headers.get("x-cursor-agent-routed-instance"), String(peerPort));
+  assert.equal(captured.authorization, "Bearer cursor-test-key");
+  assert.deepEqual(captured.body, body);
+});
+
+test("tries the only blue-green peer once for a legacy tool id", async (t) => {
+  let captured;
+  const peer = http.createServer(async (req, res) => {
+    let raw = "";
+    for await (const chunk of req) raw += chunk;
+    captured = {
+      url: req.url,
+      hop: req.headers["x-cursor-agent-peer-hop"],
+      body: JSON.parse(raw),
+    };
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ legacyRouted: true }));
+  });
+  await new Promise((resolve, reject) => {
+    peer.once("error", reject);
+    peer.listen(0, "127.0.0.1", resolve);
+  });
+  t.after(() => new Promise((resolve) => peer.close(resolve)));
+
+  const peerPort = peer.address().port;
+  const sourcePort = await reservePort();
+  const child = spawn(process.execPath, ["server.mjs"], {
+    cwd: new URL(".", import.meta.url),
+    env: {
+      ...process.env,
+      CURSOR_AGENT_SIDECAR_HOST: "127.0.0.1",
+      CURSOR_AGENT_SIDECAR_PORT: String(sourcePort),
+      CURSOR_AGENT_INSTANCE_ID: "blue",
+      CURSOR_AGENT_PEER_BASE_URL_TEMPLATE: `http://127.0.0.1:${peerPort}/{instance}`,
+      CURSOR_AGENT_PEER_INSTANCE_IDS: "green",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  t.after(async () => {
+    if (child.exitCode !== null) return;
+    await new Promise((resolve) => {
+      child.once("exit", resolve);
+      child.kill("SIGTERM");
+    });
+  });
+  await waitForHealth(sourcePort, child);
+
+  const body = {
+    model: "claude-sonnet-4-6",
+    max_tokens: 128,
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "toolu_legacy_sdk_id", content: "done" },
+        ],
+      },
+    ],
+  };
+  const response = await fetch(`http://127.0.0.1:${sourcePort}/v1/messages`, {
+    method: "POST",
+    headers: { authorization: "Bearer cursor-test-key", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { legacyRouted: true });
+  assert.equal(captured.url, "/green/v1/messages");
+  assert.equal(captured.hop, "1");
+  assert.deepEqual(captured.body, body);
+
+  captured = undefined;
+  const hoppedResponse = await fetch(`http://127.0.0.1:${sourcePort}/v1/messages`, {
+    method: "POST",
+    headers: {
+      authorization: "Bearer cursor-test-key",
+      "content-type": "application/json",
+      "x-cursor-agent-peer-hop": "1",
+    },
+    body: JSON.stringify(body),
+  });
+  assert.equal(hoppedResponse.status, 409);
+  assert.equal(captured, undefined);
+});
+
+test("SIGUSR2 drain makes the worker reject new sessions with Retry-After", async (t) => {
+  const port = await reservePort();
+  const child = spawn(process.execPath, ["server.mjs"], {
+    cwd: new URL(".", import.meta.url),
+    env: {
+      ...process.env,
+      CURSOR_AGENT_SIDECAR_HOST: "127.0.0.1",
+      CURSOR_AGENT_SIDECAR_PORT: String(port),
+      CURSOR_AGENT_INSTANCE_ID: "drain-test",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  t.after(async () => {
+    if (child.exitCode !== null) return;
+    await new Promise((resolve) => {
+      child.once("exit", resolve);
+      child.kill("SIGTERM");
+    });
+  });
+  await waitForHealth(port, child);
+  child.kill("SIGUSR2");
+  let accepting = true;
+  for (let attempt = 0; attempt < 40 && accepting; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    accepting = (await (await fetch(`http://127.0.0.1:${port}/health`)).json()).accepting;
+  }
+  assert.equal(accepting, false);
+
+  const response = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+    method: "POST",
+    headers: { authorization: "Bearer cursor-test-key", "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "new session" }],
+    }),
+  });
+  assert.equal(response.status, 503);
+  assert.equal(response.headers.get("retry-after"), "2");
+  assert.match((await response.json()).error.message, /draining/);
+});

--- a/cursor_agent_sidecar/session_state.mjs
+++ b/cursor_agent_sidecar/session_state.mjs
@@ -1,0 +1,177 @@
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+
+const SCHEMA_VERSION = 1;
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function validateRecord(record) {
+  if (!record || typeof record !== "object") throw new Error("invalid Cursor session record");
+  if (!record.sessionId || !record.model || !record.credentialFingerprint) {
+    throw new Error("incomplete Cursor session record");
+  }
+  if (!Array.isArray(record.toolUseIds) || record.toolUseIds.length === 0) {
+    throw new Error("Cursor session record requires tool ids");
+  }
+  if (!Number.isFinite(record.expiresAt)) throw new Error("Cursor session record requires expiry");
+  if (record.kind !== "awaiting" && record.kind !== "replay") {
+    throw new Error("unsupported Cursor session record kind");
+  }
+}
+
+export class CursorHarnessSessionState {
+  constructor(filePath, options = {}) {
+    this.filePath = String(filePath || "").trim();
+    if (!this.filePath) throw new Error("Cursor session state path is required");
+    this.now = options.now || (() => Date.now());
+    this.onExpire = options.onExpire;
+    this.records = new Map();
+    this.pins = new Set();
+    this.#load();
+  }
+
+  #load() {
+    let parsed;
+    try {
+      parsed = JSON.parse(readFileSync(this.filePath, "utf8"));
+    } catch (error) {
+      if (error?.code === "ENOENT") return;
+      throw new Error(`failed to load Cursor session state: ${error?.message || error}`);
+    }
+    if (parsed?.schemaVersion !== SCHEMA_VERSION || !Array.isArray(parsed.records)) {
+      throw new Error("unsupported Cursor session state schema");
+    }
+    for (const record of parsed.records) {
+      validateRecord(record);
+      if (record.expiresAt > this.now()) this.records.set(record.sessionId, record);
+      else this.#notifyExpired(record);
+    }
+    this.#flush();
+  }
+
+  #flush() {
+    mkdirSync(dirname(this.filePath), { recursive: true });
+    const temporary = `${this.filePath}.${process.pid}.tmp`;
+    writeFileSync(
+      temporary,
+      `${JSON.stringify({ schemaVersion: SCHEMA_VERSION, records: [...this.records.values()] })}\n`,
+      { mode: 0o600 },
+    );
+    renameSync(temporary, this.filePath);
+  }
+
+  upsert(record) {
+    validateRecord(record);
+    this.records.set(record.sessionId, clone(record));
+    this.#flush();
+  }
+
+  remove(sessionId) {
+    this.pins.delete(sessionId);
+    if (!this.records.delete(sessionId)) return false;
+    this.#flush();
+    return true;
+  }
+
+  findByToolUseIds(toolUseIds) {
+    this.sweepExpired();
+    const requested = new Set(toolUseIds.map(String));
+    const matches = [...this.records.values()].filter((record) =>
+      record.toolUseIds.some((id) => requested.has(id)),
+    );
+    if (matches.length === 0) return null;
+    if (matches.length !== 1) {
+      throw Object.assign(new Error("tool ids map to multiple persisted Cursor sessions"), {
+        status: 409,
+      });
+    }
+    return clone(matches[0]);
+  }
+
+  sweepExpired() {
+    const now = this.now();
+    let changed = false;
+    for (const [sessionId, record] of this.records) {
+      if (!this.pins.has(sessionId) && record.expiresAt <= now) {
+        this.records.delete(sessionId);
+        this.#notifyExpired(record);
+        changed = true;
+      }
+    }
+    if (changed) this.#flush();
+    return changed;
+  }
+
+  pin(sessionId) {
+    if (this.records.has(sessionId)) this.pins.add(sessionId);
+  }
+
+  unpin(sessionId) {
+    this.pins.delete(sessionId);
+  }
+
+  touch(sessionId, expiresAt) {
+    const record = this.records.get(sessionId);
+    if (!record) return false;
+    record.updatedAt = this.now();
+    record.expiresAt = expiresAt;
+    this.#flush();
+    return true;
+  }
+
+  #notifyExpired(record) {
+    if (typeof this.onExpire !== "function") return;
+    Promise.resolve(this.onExpire(clone(record))).catch((error) => {
+      console.error(
+        `[cursor-session-state] failed to clean expired agent state session=${record.sessionId}: ${error?.message || error}`,
+      );
+    });
+  }
+
+  counts() {
+    this.sweepExpired();
+    let awaiting = 0;
+    let replay = 0;
+    for (const record of this.records.values()) {
+      if (record.kind === "awaiting") awaiting += 1;
+      else replay += 1;
+    }
+    return { awaiting, replay, total: awaiting + replay };
+  }
+
+  sessionIds() {
+    this.sweepExpired();
+    return [...this.records.keys()];
+  }
+
+  clear() {
+    this.records.clear();
+    this.pins.clear();
+    rmSync(this.filePath, { force: true });
+  }
+}
+
+export async function deleteSdkAgentState(store, agentId) {
+  if (!store || !agentId) return;
+  const runIds = [];
+  let cursor;
+  do {
+    const page = await store.runs.list({
+      filter: { agentIds: [agentId], limit: 50, ...(cursor ? { cursor } : {}) },
+    });
+    runIds.push(...page.items.map((run) => run.runId));
+    cursor = page.nextCursor;
+  } while (cursor);
+  if (runIds.length > 0) await store.runEvents.delete({ filter: { runIds } });
+  await store.checkpoints.delete({ filter: { agentIds: [agentId] } });
+  await store.runs.delete({ filter: { agentIds: [agentId] } });
+  await store.agents.delete({ filter: { agentIds: [agentId] } });
+}

--- a/cursor_agent_sidecar/session_state.test.mjs
+++ b/cursor_agent_sidecar/session_state.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { CursorHarnessSessionState, deleteSdkAgentState } from "./session_state.mjs";
+
+function record(overrides = {}) {
+  return {
+    kind: "awaiting",
+    sessionId: "session-1",
+    model: "claude-sonnet-4-6",
+    credentialFingerprint: "fingerprint-only",
+    agentId: "agent-1",
+    runId: "run-1",
+    toolUseIds: ["toolu_bf_blue_0123456789abcdef0123456789abcdef"],
+    pending: [{ toolUseId: "toolu_bf_blue_0123456789abcdef0123456789abcdef", name: "lookup" }],
+    updatedAt: 1_000,
+    expiresAt: 10_000,
+    ...overrides,
+  };
+}
+
+test("persists only restart-safe Cursor session metadata", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "cursor-session-state-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const file = join(root, "sessions.json");
+  const state = new CursorHarnessSessionState(file, { now: () => 2_000 });
+  state.upsert(record());
+
+  const reloaded = new CursorHarnessSessionState(file, { now: () => 2_000 });
+  assert.deepEqual(reloaded.counts(), { awaiting: 1, replay: 0, total: 1 });
+  assert.equal(
+    reloaded.findByToolUseIds(["toolu_bf_blue_0123456789abcdef0123456789abcdef"]).agentId,
+    "agent-1",
+  );
+  const raw = readFileSync(file, "utf8");
+  assert.doesNotMatch(raw, /cursor api key|Bearer|crsr_|sk-/i);
+});
+
+test("expires stale records and persists replay responses", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "cursor-session-state-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const file = join(root, "sessions.json");
+  let now = 2_000;
+  const state = new CursorHarnessSessionState(file, { now: () => now });
+  state.upsert(record({
+    kind: "replay",
+    requestDigest: "digest",
+    response: { type: "message", content: [{ type: "text", text: "DONE" }] },
+  }));
+  assert.deepEqual(state.counts(), { awaiting: 0, replay: 1, total: 1 });
+  now = 10_001;
+  assert.equal(state.findByToolUseIds(record().toolUseIds), null);
+  assert.deepEqual(state.counts(), { awaiting: 0, replay: 0, total: 0 });
+});
+
+test("removes run events, checkpoints, runs, and agent rows in dependency order", async () => {
+  const calls = [];
+  let listPage = 0;
+  const store = {
+    runs: {
+      async list(input) {
+        calls.push(["list", input]);
+        listPage += 1;
+        if (listPage === 1) {
+          return { items: [{ runId: "run-1" }], nextCursor: "cursor-1" };
+        }
+        return { items: [{ runId: "run-2" }] };
+      },
+      async delete(input) {
+        calls.push(["runs", input]);
+      },
+    },
+    runEvents: {
+      async delete(input) {
+        calls.push(["events", input]);
+      },
+    },
+    checkpoints: {
+      async delete(input) {
+        calls.push(["checkpoints", input]);
+      },
+    },
+    agents: {
+      async delete(input) {
+        calls.push(["agents", input]);
+      },
+    },
+  };
+  await deleteSdkAgentState(store, "agent-1");
+  assert.deepEqual(calls, [
+    ["list", { filter: { agentIds: ["agent-1"], limit: 50 } }],
+    ["list", { filter: { agentIds: ["agent-1"], limit: 50, cursor: "cursor-1" } }],
+    ["events", { filter: { runIds: ["run-1", "run-2"] } }],
+    ["checkpoints", { filter: { agentIds: ["agent-1"] } }],
+    ["runs", { filter: { agentIds: ["agent-1"] } }],
+    ["agents", { filter: { agentIds: ["agent-1"] } }],
+  ]);
+});
+
+test("reports ambiguous persisted tool ids as a fail-closed conflict", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "cursor-session-state-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const state = new CursorHarnessSessionState(join(root, "sessions.json"), {
+    now: () => 2_000,
+  });
+  state.upsert(record());
+  state.upsert(record({ sessionId: "session-2" }));
+  assert.throws(
+    () => state.findByToolUseIds(record().toolUseIds),
+    (error) => error.status === 409,
+  );
+});
+
+test("pins an accepted recovery against TTL sweep and expires it after unpin", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "cursor-session-state-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  let now = 2_000;
+  let expired = 0;
+  const state = new CursorHarnessSessionState(join(root, "sessions.json"), {
+    now: () => now,
+    onExpire: () => { expired += 1; },
+  });
+  state.upsert(record({ expiresAt: 2_100 }));
+  state.pin("session-1");
+  now = 2_200;
+  assert.deepEqual(state.counts(), { awaiting: 1, replay: 0, total: 1 });
+  assert.equal(expired, 0);
+  assert.equal(state.touch("session-1", 3_000), true);
+  state.unpin("session-1");
+  assert.deepEqual(state.counts(), { awaiting: 1, replay: 0, total: 1 });
+  now = 3_001;
+  assert.deepEqual(state.counts(), { awaiting: 0, replay: 0, total: 0 });
+  assert.equal(expired, 1);
+});

--- a/cursor_agent_sidecar/smoke_claude.mjs
+++ b/cursor_agent_sidecar/smoke_claude.mjs
@@ -1,0 +1,98 @@
+/**
+ * Quick Claude-via-Cursor check with force_proxy + optional connection audit.
+ */
+import "./force_proxy.mjs";
+import { Agent } from "@cursor/sdk";
+import { mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cwd = resolve(__dirname, "empty-workspace");
+mkdirSync(cwd, { recursive: true });
+
+const apiKey =
+  process.env.CURSOR_API_KEY ||
+  (() => {
+    try {
+      const raw = execSync(
+        `python3 -c 'import json;from pathlib import Path;print(json.loads((Path.home()/".cursor"/"sdk"/"auth.json").read_text())["apiKey"])'`,
+        { encoding: "utf8" }
+      ).trim();
+      return raw;
+    } catch {
+      return "";
+    }
+  })();
+
+if (!apiKey) {
+  console.error("missing CURSOR_API_KEY / ~/.cursor/sdk/auth.json");
+  process.exit(2);
+}
+
+// show exit IP via fetch (should be US if proxy works for fetch)
+try {
+  const r = await fetch("https://ipinfo.io/json");
+  const d = await r.json();
+  console.log("fetch_exit", d.ip, d.city, d.country, d.org);
+} catch (e) {
+  console.log("fetch_exit_err", e.message);
+}
+
+const model = process.env.CURSOR_SMOKE_MODEL || "claude-sonnet-4-6";
+console.log("model", model);
+
+const agent = await Agent.create({
+  apiKey,
+  model: { id: model },
+  tools: [],
+  local: { cwd, settingSources: [] },
+});
+console.log("agentId", agent.agentId);
+
+// sample lsof mid-flight
+const pid = process.pid;
+setTimeout(() => {
+  try {
+    const out = execSync(
+      `lsof -nP -p ${pid} -iTCP -sTCP:ESTABLISHED 2>/dev/null | head -25`,
+      { encoding: "utf8" }
+    );
+    console.log("--- lsof ESTABLISHED ---\n" + out);
+  } catch {
+    /* ignore */
+  }
+}, 2000);
+
+const run = await agent.send("Reply exactly: PROXY_CLAUDE_OK");
+let err = null;
+let text = "";
+for await (const ev of run.stream()) {
+  if (ev?.type === "status" && ev.status === "ERROR") {
+    err = ev.message || ev.error || "error";
+    console.log("status_error", err);
+  }
+  if (ev?.type === "assistant" && ev.message?.content) {
+    text += (ev.message.content || []).map((b) => b?.text || "").join("");
+  }
+}
+const waited = await run.wait();
+if (waited?.status === "error") {
+  err = waited?.error?.message || err;
+}
+if (!text && waited?.result) text = String(waited.result);
+console.log(
+  JSON.stringify(
+    {
+      status: waited?.status,
+      text: (text || "").slice(0, 200),
+      err: err || null,
+      usage: waited?.usage || null,
+    },
+    null,
+    2
+  )
+);
+agent.close?.();
+process.exit(err && !text ? 1 : 0);

--- a/cursor_agent_sidecar/smoke_custom_tool.mjs
+++ b/cursor_agent_sidecar/smoke_custom_tool.mjs
@@ -1,0 +1,116 @@
+/**
+ * Verify that the official Cursor SDK harness can drive a custom MCP tool with
+ * Sonnet, execute the host callback, and continue to a final answer.
+ */
+import "./force_proxy.mjs";
+import { Agent } from "@cursor/sdk";
+import { mkdirSync, readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cwd = resolve(__dirname, "empty-workspace");
+mkdirSync(cwd, { recursive: true });
+
+function readApiKey() {
+  if (process.env.CURSOR_API_KEY) return process.env.CURSOR_API_KEY;
+  try {
+    const auth = JSON.parse(
+      readFileSync(resolve(process.env.HOME, ".cursor/sdk/auth.json"), "utf8"),
+    );
+    return auth.apiKey || "";
+  } catch {
+    return "";
+  }
+}
+
+const apiKey = readApiKey();
+if (!apiKey) {
+  console.error("missing CURSOR_API_KEY / ~/.cursor/sdk/auth.json");
+  process.exit(2);
+}
+
+const model = process.env.CURSOR_SMOKE_MODEL || "claude-sonnet-4-6";
+let executions = 0;
+const expected = "H2_MCP_HARNESS_OK_847291";
+
+const agent = await Agent.create({
+  apiKey,
+  model: { id: model },
+  tools: ["mcp"],
+  local: {
+    cwd,
+    settingSources: [],
+    sandboxOptions: { enabled: false },
+    customTools: {
+      lookup_opaque_value: {
+        description:
+          "Returns a private opaque verification value. Always call this tool when the user asks for the verification value.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+        execute: async () => {
+          executions += 1;
+          return {
+            content: [{ type: "text", text: expected }],
+            structuredContent: { value: expected },
+          };
+        },
+      },
+    },
+  },
+});
+
+const run = await agent.send(
+  "Call lookup_opaque_value exactly once. Then reply with only the value returned by the tool.",
+);
+const eventSummary = [];
+let finalText = "";
+let runError = null;
+
+for await (const event of run.stream()) {
+  if (event?.type === "tool_call") {
+    eventSummary.push({
+      type: event.type,
+      name: event.name,
+      status: event.status,
+    });
+  } else if (event?.type === "assistant") {
+    eventSummary.push({ type: event.type });
+    finalText += (event.message?.content || [])
+      .filter((block) => block?.type === "text")
+      .map((block) => block.text || "")
+      .join("");
+  } else if (event?.type === "status") {
+    eventSummary.push({ type: event.type, status: event.status });
+    if (event.status === "ERROR") runError = event.message || "run error";
+  }
+}
+
+const waited = await run.wait();
+if (waited?.status === "error") {
+  runError = waited.error?.message || runError || "run error";
+}
+
+const passed =
+  !runError && executions === 1 && finalText.trim() === expected;
+console.log(
+  JSON.stringify(
+    {
+      model,
+      status: waited?.status,
+      executions,
+      finalText: finalText.trim(),
+      eventSummary,
+      error: runError,
+      passed,
+    },
+    null,
+    2,
+  ),
+);
+
+agent.close?.();
+process.exit(passed ? 0 : 1);

--- a/cursor_agent_sidecar/smoke_messages_bridge.mjs
+++ b/cursor_agent_sidecar/smoke_messages_bridge.mjs
@@ -1,0 +1,152 @@
+/** Live two-request Anthropic tool loop against the running SDK sidecar. */
+const apiKey = process.env.CURSOR_API_KEY || "";
+const baseURL = process.env.CURSOR_AGENT_SMOKE_BASE_URL || "http://127.0.0.1:3927";
+if (!apiKey) {
+  console.error("missing CURSOR_API_KEY");
+  process.exit(2);
+}
+
+const marker = `PROD_HARNESS_OK_${Date.now()}`;
+const headers = {
+  "content-type": "application/json",
+  authorization: `Bearer ${apiKey}`,
+};
+const tool = {
+  name: "lookup_opaque_value",
+  description: "Return a private opaque verification value.",
+  input_schema: { type: "object", properties: {}, additionalProperties: false },
+};
+
+async function readAnthropicMessage(response) {
+  const contentType = response.headers.get("content-type") || "";
+  if (!contentType.includes("text/event-stream")) return response.json();
+  const message = { content: [], stop_reason: null };
+  const inputJson = new Map();
+  for (const line of (await response.text()).split("\n")) {
+    if (!line.startsWith("data: ")) continue;
+    const event = JSON.parse(line.slice(6));
+    if (event.type === "message_start") Object.assign(message, event.message);
+    if (event.type === "content_block_start") {
+      message.content[event.index] = event.content_block;
+    }
+    if (event.type === "content_block_delta") {
+      if (event.delta?.type === "text_delta") {
+        message.content[event.index].text =
+          (message.content[event.index].text || "") + event.delta.text;
+      }
+      if (event.delta?.type === "input_json_delta") {
+        inputJson.set(
+          event.index,
+          (inputJson.get(event.index) || "") + event.delta.partial_json,
+        );
+      }
+    }
+    if (event.type === "content_block_stop" && inputJson.has(event.index)) {
+      message.content[event.index].input = JSON.parse(inputJson.get(event.index));
+    }
+    if (event.type === "message_delta") {
+      message.stop_reason = event.delta?.stop_reason || message.stop_reason;
+      message.usage = { ...(message.usage || {}), ...(event.usage || {}) };
+    }
+  }
+  return message;
+}
+
+const firstResponse = await fetch(`${baseURL}/v1/messages`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({
+    model: "claude-sonnet-4-6",
+    max_tokens: 128,
+    stream: false,
+    messages: [
+      {
+        role: "user",
+        content:
+          "Call lookup_opaque_value exactly once, then return only its result.",
+      },
+    ],
+    tools: [tool],
+  }),
+});
+const first = await readAnthropicMessage(firstResponse);
+const toolUse = first.content?.find((block) => block?.type === "tool_use");
+if (firstResponse.status !== 200 || first.stop_reason !== "tool_use" || !toolUse?.id) {
+  console.log(
+    JSON.stringify({
+      firstStatus: firstResponse.status,
+      firstStop: first.stop_reason,
+      error: first.error?.message || "missing tool_use",
+      passed: false,
+    }),
+  );
+  process.exit(1);
+}
+
+const secondResponse = await fetch(`${baseURL}/v1/messages`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({
+    model: "claude-sonnet-4-6",
+    max_tokens: 128,
+    stream: false,
+    messages: [
+      { role: "assistant", content: first.content },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: toolUse.id, content: marker },
+        ],
+      },
+    ],
+    tools: [tool],
+  }),
+});
+const second = await readAnthropicMessage(secondResponse);
+const text = (second.content || []).map((block) => block?.text || "").join("");
+const replayResponse = await fetch(`${baseURL}/v1/messages`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({
+    model: "claude-sonnet-4-6",
+    max_tokens: 128,
+    stream: false,
+    messages: [
+      { role: "assistant", content: first.content },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: toolUse.id, content: marker },
+        ],
+      },
+    ],
+    tools: [tool],
+  }),
+});
+const replay = await readAnthropicMessage(replayResponse);
+const replayText = (replay.content || [])
+  .map((block) => block?.text || "")
+  .join("");
+const passed =
+  secondResponse.status === 200 &&
+  second.stop_reason === "end_turn" &&
+  text.trim() === marker &&
+  replayResponse.status === 200 &&
+  replay.stop_reason === "end_turn" &&
+  replayText.trim() === marker &&
+  replay.id === second.id;
+console.log(
+  JSON.stringify({
+    firstStatus: firstResponse.status,
+    firstStop: first.stop_reason,
+    secondStatus: secondResponse.status,
+    secondStop: second.stop_reason,
+    exactMarker: text.trim() === marker,
+    replayStatus: replayResponse.status,
+    replayStop: replay.stop_reason,
+    replayExact: replayText.trim() === marker,
+    replaySameMessage: replay.id === second.id,
+    passed,
+  }),
+);
+process.exit(passed ? 0 : 1);

--- a/cursor_agent_sidecar/smoke_messages_parallel.mjs
+++ b/cursor_agent_sidecar/smoke_messages_parallel.mjs
@@ -1,0 +1,187 @@
+/** Live parallel-tool, replay, and fresh-turn smoke for the SDK Messages bridge. */
+const apiKey = process.env.CURSOR_API_KEY || "";
+const baseURL = process.env.CURSOR_AGENT_SMOKE_BASE_URL || "http://127.0.0.1:3927";
+const model = process.env.CURSOR_AGENT_SMOKE_MODEL || "cursor-grok-4.6-xhigh";
+if (!apiKey) {
+  console.error("missing CURSOR_API_KEY");
+  process.exit(2);
+}
+
+const nonce = Date.now();
+const alpha = `ALPHA_${nonce}`;
+const beta = `BETA_${nonce}`;
+const fresh = `FRESH_${nonce}`;
+const headers = {
+  "content-type": "application/json",
+  authorization: `Bearer ${apiKey}`,
+};
+const tools = [
+  {
+    name: "probe_alpha",
+    description: "Look up an alpha record by its alpha_query. This lookup is independent of probe_beta.",
+    input_schema: {
+      type: "object",
+      properties: { alpha_query: { type: "string" } },
+      required: ["alpha_query"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "probe_beta",
+    description: "Look up a beta record by its beta_query. This lookup is independent of probe_alpha.",
+    input_schema: {
+      type: "object",
+      properties: { beta_query: { type: "string" } },
+      required: ["beta_query"],
+      additionalProperties: false,
+    },
+  },
+];
+
+async function request(body) {
+  const response = await fetch(`${baseURL}/v1/messages`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const contentType = response.headers.get("content-type") || "";
+  if (!contentType.includes("text/event-stream")) {
+    return { status: response.status, body: await response.json() };
+  }
+  const message = { content: [], stop_reason: null };
+  const inputJson = new Map();
+  for (const line of (await response.text()).split("\n")) {
+    if (!line.startsWith("data: ")) continue;
+    const event = JSON.parse(line.slice(6));
+    if (event.type === "message_start") Object.assign(message, event.message);
+    if (event.type === "content_block_start") {
+      message.content[event.index] = event.content_block;
+    }
+    if (event.type === "content_block_delta") {
+      if (event.delta?.type === "text_delta") {
+        message.content[event.index].text =
+          (message.content[event.index].text || "") + event.delta.text;
+      } else if (event.delta?.type === "input_json_delta") {
+        inputJson.set(
+          event.index,
+          (inputJson.get(event.index) || "") + event.delta.partial_json,
+        );
+      }
+    }
+    if (event.type === "content_block_stop" && inputJson.has(event.index)) {
+      message.content[event.index].input = JSON.parse(inputJson.get(event.index));
+    }
+    if (event.type === "message_delta") {
+      message.stop_reason = event.delta?.stop_reason || message.stop_reason;
+      message.usage = { ...(message.usage || {}), ...(event.usage || {}) };
+    }
+  }
+  return { status: response.status, body: message };
+}
+
+const initialUser = {
+  role: "user",
+  content:
+    "For maximum efficiency, call probe_alpha with alpha_query=alpha and probe_beta with beta_query=beta simultaneously in the same turn. These are two required independent operations. After both results arrive, reply with both result strings and no other text.",
+};
+const first = await request({
+  model,
+  max_tokens: 256,
+  stream: true,
+  messages: [initialUser],
+  tools,
+  tool_choice: { type: "any" },
+});
+const calls = (first.body.content || []).filter((block) => block?.type === "tool_use");
+const callByName = new Map(calls.map((call) => [call.name, call]));
+if (
+  first.status !== 200 ||
+  first.body.stop_reason !== "tool_use" ||
+  calls.length !== 2 ||
+  !callByName.has("probe_alpha") ||
+  !callByName.has("probe_beta")
+) {
+  console.log(
+    JSON.stringify({
+      model,
+      firstStatus: first.status,
+      firstStop: first.body.stop_reason,
+      toolCalls: calls.map((call) => call.name),
+      error: first.body.error?.message || "parallel tool batch missing",
+      passed: false,
+    }),
+  );
+  process.exit(1);
+}
+
+const resultBlocks = [
+  {
+    type: "tool_result",
+    tool_use_id: callByName.get("probe_alpha").id,
+    content: alpha,
+  },
+  {
+    type: "tool_result",
+    tool_use_id: callByName.get("probe_beta").id,
+    content: beta,
+  },
+];
+const resumeBody = {
+  model,
+  max_tokens: 256,
+  stream: true,
+  messages: [
+    initialUser,
+    { role: "assistant", content: first.body.content },
+    { role: "user", content: resultBlocks },
+  ],
+  tools,
+};
+const second = await request(resumeBody);
+const finalText = (second.body.content || []).map((block) => block?.text || "").join("");
+const replay = await request(resumeBody);
+
+const freshTurn = await request({
+  model,
+  max_tokens: 128,
+  stream: true,
+  messages: [
+    ...resumeBody.messages,
+    { role: "assistant", content: second.body.content },
+    { role: "user", content: `Reply exactly ${fresh}` },
+  ],
+});
+const freshText = (freshTurn.body.content || [])
+  .map((block) => block?.text || "")
+  .join("")
+  .trim();
+
+const passed =
+  second.status === 200 &&
+  second.body.stop_reason === "end_turn" &&
+  finalText.includes(alpha) &&
+  finalText.includes(beta) &&
+  replay.status === 200 &&
+  replay.body.id === second.body.id &&
+  freshTurn.status === 200 &&
+  freshTurn.body.stop_reason === "end_turn" &&
+  freshText === fresh;
+console.log(
+  JSON.stringify({
+    model,
+    firstStatus: first.status,
+    firstStop: first.body.stop_reason,
+    parallelToolCalls: calls.length,
+    secondStatus: second.status,
+    secondStop: second.body.stop_reason,
+    alphaReturned: finalText.includes(alpha),
+    betaReturned: finalText.includes(beta),
+    replayStatus: replay.status,
+    replaySameMessage: replay.body.id === second.body.id,
+    freshStatus: freshTurn.status,
+    freshStop: freshTurn.body.stop_reason,
+    freshExact: freshText === fresh,
+    passed,
+  }),
+);
+process.exit(passed ? 0 : 1);

--- a/cursor_agent_sidecar/start.sh
+++ b/cursor_agent_sidecar/start.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Start Cursor Agent sidecar for new-api channel type 61.
+#
+# Direct-egress host (default): no proxy.
+#   ./start.sh
+#
+# CN / laptop behind region block:
+#   CURSOR_AGENT_FORCE_PROXY=1 CURSOR_AGENT_PROXY=http://127.0.0.1:7890 ./start.sh
+#   PROXYCHAINS=1 ./start.sh   # TCP-level wrap (strongest)
+set -euo pipefail
+cd "$(dirname "$0")"
+
+export CURSOR_AGENT_SIDECAR_HOST="${CURSOR_AGENT_SIDECAR_HOST:-127.0.0.1}"
+export CURSOR_AGENT_SIDECAR_PORT="${CURSOR_AGENT_SIDECAR_PORT:-3927}"
+
+if [[ -n "${CURSOR_AGENT_PROXY:-}" ]] || [[ "${CURSOR_AGENT_FORCE_PROXY:-0}" == "1" ]]; then
+  export CURSOR_AGENT_FORCE_PROXY="${CURSOR_AGENT_FORCE_PROXY:-1}"
+  export CURSOR_AGENT_PROXY="${CURSOR_AGENT_PROXY:-http://127.0.0.1:7890}"
+  export HTTP_PROXY="${HTTP_PROXY:-$CURSOR_AGENT_PROXY}"
+  export HTTPS_PROXY="${HTTPS_PROXY:-$CURSOR_AGENT_PROXY}"
+  export ALL_PROXY="${ALL_PROXY:-$CURSOR_AGENT_PROXY}"
+  export NODE_USE_ENV_PROXY=1
+  # Prefer HTTP/1 when proxying (HTTP/2 often leaks past system proxy).
+  export CURSOR_AGENT_FORCE_HTTP1="${CURSOR_AGENT_FORCE_HTTP1:-1}"
+
+  if [[ "${PROXYCHAINS:-0}" == "1" ]] && command -v proxychains4 >/dev/null 2>&1; then
+    echo "[start] US-region workaround: proxychains4 + proxy=${CURSOR_AGENT_PROXY}"
+    exec proxychains4 -q -f ./proxychains-agent.conf node server.mjs
+  fi
+  echo "[start] US-region workaround: force_proxy=${CURSOR_AGENT_PROXY}"
+else
+  echo "[start] direct egress (US host friendly). Proxy off."
+fi
+
+exec node server.mjs

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${CURSOR_AGENT_EMBEDDED_SIDECAR:-1}" == "0" ]]; then
+  exec /new-api "$@"
+fi
+
+export CURSOR_AGENT_SIDECAR_HOST="${CURSOR_AGENT_SIDECAR_HOST:-127.0.0.1}"
+export CURSOR_AGENT_SIDECAR_PORT="${CURSOR_AGENT_SIDECAR_PORT:-3927}"
+export CURSOR_AGENT_STATE_DIR="${CURSOR_AGENT_STATE_DIR:-/data/cursor-agent}"
+export CURSOR_AGENT_SIDECAR_BASE_URL="${CURSOR_AGENT_SIDECAR_BASE_URL:-http://${CURSOR_AGENT_SIDECAR_HOST}:${CURSOR_AGENT_SIDECAR_PORT}}"
+
+node /opt/cursor-agent/server.mjs &
+sidecar_pid=$!
+
+sidecar_ready=0
+for _ in {1..30}; do
+  if wget -qO- "${CURSOR_AGENT_SIDECAR_BASE_URL}/health" >/dev/null 2>&1; then
+    sidecar_ready=1
+    break
+  fi
+  if ! kill -0 "$sidecar_pid" 2>/dev/null; then
+    wait "$sidecar_pid"
+    exit $?
+  fi
+  sleep 1
+done
+if [[ "$sidecar_ready" != "1" ]]; then
+  echo "Cursor Agent sidecar did not become healthy" >&2
+  kill -TERM "$sidecar_pid" 2>/dev/null || true
+  wait "$sidecar_pid" 2>/dev/null || true
+  exit 1
+fi
+
+/new-api "$@" &
+api_pid=$!
+
+shutdown() {
+  kill -TERM "$api_pid" "$sidecar_pid" 2>/dev/null || true
+}
+trap shutdown INT TERM
+
+set +e
+wait -n "$api_pid" "$sidecar_pid"
+status=$?
+set -e
+shutdown
+wait "$api_pid" 2>/dev/null || true
+wait "$sidecar_pid" 2>/dev/null || true
+exit "$status"

--- a/relay/channel/claude/adaptor.go
+++ b/relay/channel/claude/adaptor.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/QuantumNous/new-api/relay/channel"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/QuantumNous/new-api/relaykit/relayconvert"
 	"github.com/QuantumNous/new-api/relaykit/types"
@@ -43,7 +45,21 @@ func (a *Adaptor) Init(info *relaycommon.RelayInfo) {
 }
 
 func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
-	requestURL := fmt.Sprintf("%s/v1/messages", info.ChannelBaseUrl)
+	path := "/v1/messages"
+	if info != nil && info.RelayMode == relayconstant.RelayModeClaudeCountTokens {
+		path = "/v1/messages/count_tokens"
+	}
+	requestURL := fmt.Sprintf("%s%s", info.ChannelBaseUrl, path)
+	if info != nil && info.RelayMode == relayconstant.RelayModeClaudeCountTokens {
+		parsedURL, err := url.Parse(requestURL)
+		if err != nil {
+			return "", err
+		}
+		query := parsedURL.Query()
+		query.Set("beta", "true")
+		parsedURL.RawQuery = query.Encode()
+		return parsedURL.String(), nil
+	}
 	if !shouldAppendClaudeBetaQuery(info) {
 		return requestURL, nil
 	}
@@ -89,7 +105,31 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *rel
 	}
 	req.Set("anthropic-version", anthropicVersion)
 	CommonClaudeHeadersOperation(c, req, info)
+	if info != nil && info.RelayMode == relayconstant.RelayModeClaudeCountTokens {
+		req.Set("anthropic-beta", mergeClaudeCountTokensBeta(req.Get("anthropic-beta")))
+	}
 	return nil
+}
+
+func mergeClaudeCountTokensBeta(existing string) string {
+	const tokenCountingBeta = "token-counting-2024-11-01"
+	parts := make([]string, 0, 4)
+	seen := map[string]struct{}{}
+	for _, item := range strings.Split(existing, ",") {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		parts = append(parts, item)
+		seen[item] = struct{}{}
+	}
+	if _, ok := seen[tokenCountingBeta]; !ok {
+		parts = append(parts, tokenCountingBeta)
+	}
+	return strings.Join(parts, ",")
 }
 
 func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeneralOpenAIRequest) (any, error) {

--- a/relay/channel/claude/adaptor_count_tokens_test.go
+++ b/relay/channel/claude/adaptor_count_tokens_test.go
@@ -1,0 +1,30 @@
+package claude
+
+import (
+	"strings"
+	"testing"
+
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetRequestURLCountTokensAlwaysUsesBetaQuery(t *testing.T) {
+	info := &relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeClaudeCountTokens,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelBaseUrl: "https://api.anthropic.com",
+		},
+	}
+
+	got, err := (&Adaptor{}).GetRequestURL(info)
+
+	require.NoError(t, err)
+	require.Equal(t, "https://api.anthropic.com/v1/messages/count_tokens?beta=true", got)
+}
+
+func TestMergeClaudeCountTokensBeta(t *testing.T) {
+	require.Equal(t, "token-counting-2024-11-01", mergeClaudeCountTokensBeta(""))
+	beta := mergeClaudeCountTokensBeta("oauth-2025-04-20,token-counting-2024-11-01")
+	require.Equal(t, 1, strings.Count(beta, "token-counting-2024-11-01"))
+}

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -53,6 +53,26 @@ func cacheCreationTokensForOpenAIUsage(usage *dto.Usage) int {
 	return openAIUsage.PromptTokens - usage.PromptTokens - usage.PromptTokensDetails.CachedTokens
 }
 
+func hasClaudeInputUsage(usage *dto.Usage) bool {
+	if usage == nil {
+		return false
+	}
+	return usage.PromptTokens+usage.PromptTokensDetails.CachedTokens+cacheCreationTokensForOpenAIUsage(usage) > 0
+}
+
+func shouldDeferCursorHarnessToolUsage(info *relaycommon.RelayInfo, claudeInfo *ClaudeResponseInfo) bool {
+	return info != nil && info.ChannelMeta != nil &&
+		info.ChannelType == constant.ChannelTypeCursorAgent &&
+		claudeInfo != nil && claudeInfo.HasToolUse
+}
+
+func markDeferredCursorHarnessUsage(usage *dto.Usage, semantic string) {
+	if usage == nil {
+		return
+	}
+	*usage = dto.Usage{UsageSemantic: semantic, UsageSource: dto.UsageSourceCursorHarnessDeferred}
+}
+
 func buildOpenAIStyleUsageFromClaudeUsage(usage *dto.Usage) dto.Usage {
 	mapped := relayconvert.UsageFromClaudeUsage(usage)
 	if mapped == nil {
@@ -151,10 +171,9 @@ func countClaudeStreamBillableTools(c *gin.Context, info *relaycommon.RelayInfo,
 }
 
 func HandleStreamFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, claudeInfo *ClaudeResponseInfo) {
-	if claudeInfo.Usage.PromptTokens == 0 {
-		//上游出错
-	}
-	if claudeInfo.Usage.CompletionTokens == 0 || !claudeInfo.Done {
+	missingInputUsage := !hasClaudeInputUsage(claudeInfo.Usage)
+	deferredToolUsage := shouldDeferCursorHarnessToolUsage(info, claudeInfo)
+	if !deferredToolUsage && (missingInputUsage || claudeInfo.Usage.CompletionTokens == 0 || !claudeInfo.Done) {
 		if common.DebugEnabled {
 			common.SysLog("claude response usage is not complete, maybe upstream error")
 		}
@@ -164,13 +183,18 @@ func HandleStreamFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, clau
 			(!claudeInfo.Done && fallback.CompletionTokens > claudeInfo.Usage.CompletionTokens) {
 			claudeInfo.Usage.CompletionTokens = fallback.CompletionTokens
 		}
-		if claudeInfo.Usage.PromptTokens == 0 {
+		if missingInputUsage {
 			claudeInfo.Usage.PromptTokens = fallback.PromptTokens
+			claudeInfo.Usage.InputTokens = fallback.PromptTokens
 		}
 		claudeInfo.Usage.TotalTokens = claudeInfo.Usage.PromptTokens + claudeInfo.Usage.CompletionTokens
 	}
 	if claudeInfo.Usage != nil {
-		claudeInfo.Usage.UsageSemantic = "anthropic"
+		if deferredToolUsage {
+			markDeferredCursorHarnessUsage(claudeInfo.Usage, "anthropic")
+		} else {
+			claudeInfo.Usage.UsageSemantic = "anthropic"
+		}
 	}
 	if claudeInfo.Usage != nil && claudeInfo.Usage.BillingUsage == nil {
 		claudeInfo.Usage.BillingUsage = dto.NewClaudeMessagesBillingUsage(buildMessageDeltaPatchUsage(nil, claudeInfo))
@@ -257,6 +281,7 @@ func HandleClaudeResponseData(c *gin.Context, info *relaycommon.RelayInfo, claud
 
 	for _, block := range claudeResponse.Content {
 		if block.Type == "tool_use" {
+			claudeInfo.HasToolUse = true
 			info.CountBillableToolCall(dto.BuildInCallToolUse, block.Name)
 		}
 	}
@@ -283,6 +308,15 @@ func ClaudeHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayI
 	handleErr := HandleClaudeResponseData(c, info, claudeInfo, resp, responseBody)
 	if handleErr != nil {
 		return nil, handleErr
+	}
+	deferredToolUsage := shouldDeferCursorHarnessToolUsage(info, claudeInfo)
+	if !hasClaudeInputUsage(claudeInfo.Usage) && !deferredToolUsage {
+		claudeInfo.Usage.PromptTokens = info.GetEstimatePromptTokens()
+		claudeInfo.Usage.InputTokens = claudeInfo.Usage.PromptTokens
+		claudeInfo.Usage.TotalTokens = claudeInfo.Usage.PromptTokens + claudeInfo.Usage.CompletionTokens
+	}
+	if deferredToolUsage {
+		markDeferredCursorHarnessUsage(claudeInfo.Usage, "anthropic")
 	}
 	return claudeInfo.Usage, nil
 }

--- a/relay/channel/claude/responses_compat.go
+++ b/relay/channel/claude/responses_compat.go
@@ -1,0 +1,829 @@
+package claude
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relay/helper"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/types"
+	"github.com/QuantumNous/new-api/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+func ClaudeResponsesHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (*dto.Usage, *types.NewAPIError) {
+	defer service.CloseResponseBodyGracefully(resp)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, types.NewError(err, types.ErrorCodeBadResponseBody)
+	}
+	var claudeResponse dto.ClaudeResponse
+	if err := common.Unmarshal(body, &claudeResponse); err != nil {
+		return nil, types.NewError(err, types.ErrorCodeBadResponseBody)
+	}
+	if claudeError := claudeResponse.GetClaudeError(); claudeError != nil && claudeError.Type != "" {
+		return nil, types.WithClaudeError(*claudeError, http.StatusInternalServerError)
+	}
+	outputs := outputsFromClaudeMessage(&claudeResponse)
+	usage := usageFromClaudeUsage(claudeResponse.Usage, info)
+	usage = deferCursorHarnessResponsesUsage(info, outputsContainFunctionCall(outputs), usage)
+	response := completedResponsesResponse(
+		common.GetStringIfEmpty(claudeResponse.Id, helper.GetResponseID(c)),
+		common.GetStringIfEmpty(claudeResponse.Model, info.UpstreamModelName),
+		usage,
+		outputs,
+	)
+	data, err := common.Marshal(response)
+	if err != nil {
+		return nil, types.NewError(err, types.ErrorCodeBadResponseBody)
+	}
+	service.IOCopyBytesGracefully(c, resp, data)
+	return usage, nil
+}
+
+func ClaudeResponsesStreamHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (*dto.Usage, *types.NewAPIError) {
+	helper.SetEventStreamHeaders(c)
+	state := newClaudeResponsesStreamState(c, info)
+	var streamErr *types.NewAPIError
+
+	helper.StreamScannerHandler(c, resp, info, func(data string, sr *helper.StreamResult) {
+		var claudeResponse dto.ClaudeResponse
+		if err := common.UnmarshalJsonStr(data, &claudeResponse); err != nil {
+			streamErr = types.NewError(err, types.ErrorCodeBadResponseBody)
+			sr.Stop(streamErr)
+			return
+		}
+		if claudeError := claudeResponse.GetClaudeError(); claudeError != nil && claudeError.Type != "" {
+			streamErr = types.WithClaudeError(*claudeError, http.StatusInternalServerError)
+			sr.Stop(streamErr)
+			return
+		}
+		if err := state.handle(c, &claudeResponse); err != nil {
+			streamErr = types.NewError(err, types.ErrorCodeBadResponse)
+			sr.Stop(streamErr)
+		}
+	})
+	if streamErr != nil {
+		return nil, streamErr
+	}
+	if !state.completed {
+		if err := state.complete(c); err != nil {
+			return nil, types.NewError(err, types.ErrorCodeBadResponse)
+		}
+	}
+	return state.usage, nil
+}
+
+type claudeResponsesStreamState struct {
+	id              string
+	model           string
+	created         int
+	usage           *dto.Usage
+	outputText      strings.Builder
+	outputs         []dto.ResponsesOutput
+	textItemID      string
+	textPartOpen    bool
+	reasoningItemID string
+	reasoningText   strings.Builder
+	reasoningOpen   bool
+	blockTypeByID   map[int]string
+	toolIndexByID   map[int]string
+	toolOutputByID  map[string]*dto.ResponsesOutput
+	toolArgsByID    map[string]string
+	toolCurrentName map[int]string
+	completed       bool
+	sequence        int
+	riskWarning     string
+	riskWarningSent bool
+	cursorHarness   bool
+	hasToolUse      bool
+}
+
+func newClaudeResponsesStreamState(c *gin.Context, info *relaycommon.RelayInfo) *claudeResponsesStreamState {
+	estimatePromptTokens := info.GetEstimatePromptTokens()
+	return &claudeResponsesStreamState{
+		id:              helper.GetResponseID(c),
+		model:           info.UpstreamModelName,
+		created:         int(common.GetTimestamp()),
+		usage:           &dto.Usage{PromptTokens: estimatePromptTokens, InputTokens: estimatePromptTokens, TotalTokens: estimatePromptTokens},
+		blockTypeByID:   make(map[int]string),
+		toolIndexByID:   make(map[int]string),
+		toolOutputByID:  make(map[string]*dto.ResponsesOutput),
+		toolArgsByID:    make(map[string]string),
+		toolCurrentName: make(map[int]string),
+		riskWarning:     "",
+		cursorHarness:   info != nil && info.ChannelMeta != nil && info.ChannelType == constant.ChannelTypeCursorAgent,
+	}
+}
+
+func (s *claudeResponsesStreamState) handle(c *gin.Context, response *dto.ClaudeResponse) error {
+	switch response.Type {
+	case "message_start":
+		if response.Message != nil {
+			if response.Message.Id != "" {
+				s.id = response.Message.Id
+			}
+			if response.Message.Model != "" {
+				s.model = response.Message.Model
+			}
+			s.mergeClaudeUsage(response.Message.Usage)
+		}
+		return s.emit(c, "response.created", map[string]any{
+			"type":     "response.created",
+			"response": s.baseResponse("in_progress", nil),
+		})
+	case "content_block_start":
+		if response.ContentBlock == nil {
+			return nil
+		}
+		idx := 0
+		if response.Index != nil {
+			idx = *response.Index
+		}
+		s.blockTypeByID[idx] = response.ContentBlock.Type
+		switch response.ContentBlock.Type {
+		case "thinking":
+			return s.startReasoning(c)
+		case "text":
+			return s.startText(c)
+		case "tool_use":
+			return s.startTool(c, response)
+		}
+	case "content_block_delta":
+		if response.Delta == nil {
+			return nil
+		}
+		switch response.Delta.Type {
+		case "thinking_delta":
+			if response.Delta.Thinking != nil {
+				return s.reasoningDelta(c, *response.Delta.Thinking)
+			}
+		case "text_delta":
+			if response.Delta.Text != nil {
+				return s.textDelta(c, *response.Delta.Text)
+			}
+		case "input_json_delta":
+			if response.Index != nil && response.Delta.PartialJson != nil {
+				return s.toolDelta(c, *response.Index, *response.Delta.PartialJson)
+			}
+		}
+	case "content_block_stop":
+		if response.Index != nil {
+			return s.stopBlock(c, *response.Index)
+		}
+	case "message_delta":
+		s.mergeClaudeUsage(response.Usage)
+	case "message_stop":
+		return s.complete(c)
+	}
+	return nil
+}
+
+func (s *claudeResponsesStreamState) startReasoning(c *gin.Context) error {
+	if s.reasoningOpen {
+		return nil
+	}
+	s.reasoningItemID = fmt.Sprintf("rs_%s", common.GetUUID())
+	s.reasoningText.Reset()
+	s.reasoningOpen = true
+	item := dto.ResponsesOutput{
+		ID:      s.reasoningItemID,
+		Type:    "reasoning",
+		Status:  "in_progress",
+		Summary: []dto.ResponsesReasoningSummaryPart{},
+	}
+	s.outputs = append(s.outputs, item)
+	outputIndex := len(s.outputs) - 1
+	if err := s.emit(c, "response.output_item.added", map[string]any{
+		"type":         "response.output_item.added",
+		"output_index": outputIndex,
+		"item":         openAIReasoningItem(item),
+	}); err != nil {
+		return err
+	}
+	return s.emit(c, "response.reasoning_summary_part.added", map[string]any{
+		"type":          "response.reasoning_summary_part.added",
+		"item_id":       s.reasoningItemID,
+		"output_index":  outputIndex,
+		"summary_index": 0,
+		"part": map[string]any{
+			"type": "summary_text",
+			"text": "",
+		},
+	})
+}
+
+func (s *claudeResponsesStreamState) reasoningDelta(c *gin.Context, text string) error {
+	if err := s.startReasoning(c); err != nil {
+		return err
+	}
+	s.reasoningText.WriteString(text)
+	return s.emit(c, "response.reasoning_summary_text.delta", map[string]any{
+		"type":          "response.reasoning_summary_text.delta",
+		"item_id":       s.reasoningItemID,
+		"output_index":  outputIndexByID(s.outputs, s.reasoningItemID),
+		"summary_index": 0,
+		"delta":         text,
+	})
+}
+
+func (s *claudeResponsesStreamState) stopReasoning(c *gin.Context) error {
+	if !s.reasoningOpen {
+		return nil
+	}
+	itemID := s.reasoningItemID
+	outputIndex := outputIndexByID(s.outputs, itemID)
+	text := s.reasoningText.String()
+	if err := s.emit(c, "response.reasoning_summary_text.done", map[string]any{
+		"type":          "response.reasoning_summary_text.done",
+		"item_id":       itemID,
+		"output_index":  outputIndex,
+		"summary_index": 0,
+		"text":          text,
+	}); err != nil {
+		return err
+	}
+	part := dto.ResponsesReasoningSummaryPart{Type: "summary_text", Text: text}
+	if err := s.emit(c, "response.reasoning_summary_part.done", map[string]any{
+		"type":          "response.reasoning_summary_part.done",
+		"item_id":       itemID,
+		"output_index":  outputIndex,
+		"summary_index": 0,
+		"part":          part,
+	}); err != nil {
+		return err
+	}
+	item := dto.ResponsesOutput{
+		ID:      itemID,
+		Type:    "reasoning",
+		Status:  "completed",
+		Summary: []dto.ResponsesReasoningSummaryPart{part},
+	}
+	s.replaceOutput(item)
+	s.reasoningOpen = false
+	s.reasoningItemID = ""
+	s.reasoningText.Reset()
+	return s.emit(c, "response.output_item.done", map[string]any{
+		"type":         "response.output_item.done",
+		"output_index": outputIndex,
+		"item":         openAIReasoningItem(item),
+	})
+}
+
+func (s *claudeResponsesStreamState) startText(c *gin.Context) error {
+	if s.textItemID == "" {
+		s.textItemID = fmt.Sprintf("msg_%s", common.GetUUID())
+		item := dto.ResponsesOutput{
+			ID:      s.textItemID,
+			Type:    "message",
+			Status:  "in_progress",
+			Role:    "assistant",
+			Content: []dto.ResponsesOutputContent{},
+		}
+		s.outputs = append(s.outputs, item)
+		if err := s.emit(c, "response.output_item.added", map[string]any{
+			"type":         "response.output_item.added",
+			"output_index": len(s.outputs) - 1,
+			"item":         item,
+		}); err != nil {
+			return err
+		}
+	}
+	if s.textPartOpen {
+		return nil
+	}
+	s.textPartOpen = true
+	return s.emit(c, "response.content_part.added", map[string]any{
+		"type":          "response.content_part.added",
+		"item_id":       s.textItemID,
+		"output_index":  outputIndexByID(s.outputs, s.textItemID),
+		"content_index": 0,
+		"part": map[string]any{
+			"type":        "output_text",
+			"text":        "",
+			"annotations": []any{},
+		},
+	})
+}
+
+func (s *claudeResponsesStreamState) textDelta(c *gin.Context, text string) error {
+	if err := s.startText(c); err != nil {
+		return err
+	}
+	if err := s.emitRiskWarningDeltaIfNeeded(c); err != nil {
+		return err
+	}
+	s.outputText.WriteString(text)
+	return s.emit(c, "response.output_text.delta", map[string]any{
+		"type":          "response.output_text.delta",
+		"item_id":       s.textItemID,
+		"output_index":  outputIndexByID(s.outputs, s.textItemID),
+		"content_index": 0,
+		"delta":         text,
+	})
+}
+
+func (s *claudeResponsesStreamState) startTool(c *gin.Context, response *dto.ClaudeResponse) error {
+	s.hasToolUse = true
+	idx := 0
+	if response.Index != nil {
+		idx = *response.Index
+	}
+	callID := strings.TrimSpace(response.ContentBlock.Id)
+	if callID == "" {
+		callID = fmt.Sprintf("call_%s", common.GetUUID())
+	}
+	itemID := fmt.Sprintf("fc_%s", common.GetUUID())
+	item := dto.ResponsesOutput{
+		ID:        itemID,
+		Type:      "function_call",
+		Status:    "in_progress",
+		CallId:    callID,
+		Name:      response.ContentBlock.Name,
+		Arguments: nil,
+	}
+	s.toolIndexByID[idx] = itemID
+	s.toolOutputByID[itemID] = &item
+	s.toolCurrentName[idx] = response.ContentBlock.Name
+	s.outputs = append(s.outputs, item)
+	return s.emit(c, "response.output_item.added", map[string]any{
+		"type":         "response.output_item.added",
+		"output_index": len(s.outputs) - 1,
+		"item":         openAIFunctionCallItem(item),
+	})
+}
+
+func (s *claudeResponsesStreamState) toolDelta(c *gin.Context, index int, delta string) error {
+	itemID := s.toolIndexByID[index]
+	if itemID == "" {
+		return nil
+	}
+	s.toolArgsByID[itemID] += delta
+	if item := s.toolOutputByID[itemID]; item != nil {
+		item.Arguments = json.RawMessage(s.toolArgsByID[itemID])
+	}
+	return s.emit(c, "response.function_call_arguments.delta", map[string]any{
+		"type":         "response.function_call_arguments.delta",
+		"item_id":      itemID,
+		"output_index": outputIndexByID(s.outputs, itemID),
+		"delta":        delta,
+	})
+}
+
+func (s *claudeResponsesStreamState) stopBlock(c *gin.Context, index int) error {
+	blockType := s.blockTypeByID[index]
+	delete(s.blockTypeByID, index)
+	if blockType == "thinking" {
+		return s.stopReasoning(c)
+	}
+	if itemID := s.toolIndexByID[index]; itemID != "" {
+		args := s.toolArgsByID[itemID]
+		if err := s.emit(c, "response.function_call_arguments.done", map[string]any{
+			"type":         "response.function_call_arguments.done",
+			"item_id":      itemID,
+			"output_index": outputIndexByID(s.outputs, itemID),
+			"arguments":    args,
+		}); err != nil {
+			return err
+		}
+		if item := s.toolOutputByID[itemID]; item != nil {
+			item.Status = "completed"
+			item.Arguments = json.RawMessage(args)
+			s.replaceOutput(*item)
+			if err := s.emit(c, "response.output_item.done", map[string]any{
+				"type":         "response.output_item.done",
+				"output_index": outputIndexByID(s.outputs, itemID),
+				"item":         openAIFunctionCallItem(*item),
+			}); err != nil {
+				return err
+			}
+		}
+		delete(s.toolIndexByID, index)
+		delete(s.toolOutputByID, itemID)
+		delete(s.toolArgsByID, itemID)
+		delete(s.toolCurrentName, index)
+		return nil
+	}
+	if s.textPartOpen {
+		s.textPartOpen = false
+		text := prependClaudeRiskWarningText(s.outputText.String(), s.riskWarning)
+		if err := s.emit(c, "response.output_text.done", map[string]any{
+			"type":          "response.output_text.done",
+			"item_id":       s.textItemID,
+			"output_index":  outputIndexByID(s.outputs, s.textItemID),
+			"content_index": 0,
+			"text":          text,
+		}); err != nil {
+			return err
+		}
+		if err := s.emit(c, "response.content_part.done", map[string]any{
+			"type":          "response.content_part.done",
+			"item_id":       s.textItemID,
+			"output_index":  outputIndexByID(s.outputs, s.textItemID),
+			"content_index": 0,
+			"part": map[string]any{
+				"type":        "output_text",
+				"text":        text,
+				"annotations": []any{},
+			},
+		}); err != nil {
+			return err
+		}
+		s.replaceOutput(dto.ResponsesOutput{
+			ID:     s.textItemID,
+			Type:   "message",
+			Status: "completed",
+			Role:   "assistant",
+			Content: []dto.ResponsesOutputContent{{
+				Type:        "output_text",
+				Text:        text,
+				Annotations: []interface{}{},
+			}},
+		})
+		return s.emit(c, "response.output_item.done", map[string]any{
+			"type":         "response.output_item.done",
+			"output_index": outputIndexByID(s.outputs, s.textItemID),
+			"item":         s.outputByID(s.textItemID),
+		})
+	}
+	return nil
+}
+
+func (s *claudeResponsesStreamState) complete(c *gin.Context) error {
+	if s.completed {
+		return nil
+	}
+	if s.reasoningOpen {
+		if err := s.stopReasoning(c); err != nil {
+			return err
+		}
+	}
+	if s.textPartOpen {
+		if err := s.stopBlock(c, -1); err != nil {
+			return err
+		}
+	} else if s.riskWarning != "" && !s.riskWarningSent {
+		if err := s.emitRiskWarningDeltaIfNeeded(c); err != nil {
+			return err
+		}
+		if err := s.stopBlock(c, -1); err != nil {
+			return err
+		}
+	}
+	if s.cursorHarness && s.hasToolUse {
+		s.usage = deferredCursorHarnessResponsesUsage()
+	} else if s.usage.PromptTokens == 0 || s.usage.CompletionTokens == 0 {
+		fallback := service.ResponseText2Usage(c, s.outputText.String(), s.model, s.usage.PromptTokens)
+		if s.usage.PromptTokens == 0 {
+			s.usage.PromptTokens = fallback.PromptTokens
+			s.usage.InputTokens = fallback.PromptTokens
+		}
+		if s.usage.CompletionTokens == 0 {
+			s.usage.CompletionTokens = fallback.CompletionTokens
+			s.usage.OutputTokens = fallback.CompletionTokens
+		}
+		s.usage.TotalTokens = s.usage.PromptTokens + s.usage.CompletionTokens
+	}
+	s.completed = true
+	return s.emit(c, "response.completed", map[string]any{
+		"type":     "response.completed",
+		"response": s.baseResponse("completed", s.outputs),
+	})
+}
+
+func (s *claudeResponsesStreamState) mergeClaudeUsage(usage *dto.ClaudeUsage) {
+	if usage == nil {
+		return
+	}
+	mapped := usageFromClaudeUsage(usage, nil)
+	if mapped.PromptTokens == 0 && s.usage != nil {
+		mapped.PromptTokens = s.usage.PromptTokens
+		mapped.InputTokens = s.usage.InputTokens
+		mapped.PromptTokensDetails = s.usage.PromptTokensDetails
+		if s.usage.InputTokensDetails != nil {
+			inputDetails := *s.usage.InputTokensDetails
+			mapped.InputTokensDetails = &inputDetails
+		}
+		mapped.ClaudeCacheCreation5mTokens = s.usage.ClaudeCacheCreation5mTokens
+		mapped.ClaudeCacheCreation1hTokens = s.usage.ClaudeCacheCreation1hTokens
+	}
+	mapped.TotalTokens = mapped.PromptTokens + mapped.CompletionTokens
+	s.usage = mapped
+}
+
+func (s *claudeResponsesStreamState) baseResponse(status string, outputs []dto.ResponsesOutput) map[string]any {
+	if outputs == nil {
+		outputs = []dto.ResponsesOutput{}
+	}
+	return map[string]any{
+		"id":                   s.id,
+		"object":               "response",
+		"created_at":           s.created,
+		"status":               status,
+		"model":                s.model,
+		"output":               openAIResponsesOutputItems(outputs),
+		"parallel_tool_calls":  true,
+		"previous_response_id": nil,
+		"store":                false,
+		"temperature":          nil,
+		"tool_choice":          "auto",
+		"tools":                []any{},
+		"top_p":                nil,
+		"truncation":           nil,
+		"usage":                openAIResponsesUsage(s.usage),
+		"incomplete_details":   nil,
+		"error":                nil,
+		"max_output_tokens":    nil,
+		"metadata":             nil,
+		"reasoning":            nil,
+		"instructions":         nil,
+	}
+}
+
+func (s *claudeResponsesStreamState) emit(c *gin.Context, eventName string, payload any) error {
+	if event, ok := payload.(map[string]any); ok {
+		event["sequence_number"] = s.sequence
+		s.sequence++
+	}
+	data, err := common.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	c.Render(-1, common.CustomEvent{Data: fmt.Sprintf("event: %s\n", eventName)})
+	c.Render(-1, common.CustomEvent{Data: "data: " + string(data)})
+	return helper.FlushWriter(c)
+}
+
+func (s *claudeResponsesStreamState) emitRiskWarningDeltaIfNeeded(c *gin.Context) error {
+	if s.riskWarning == "" || s.riskWarningSent {
+		return nil
+	}
+	if err := s.startText(c); err != nil {
+		return err
+	}
+	s.riskWarningSent = true
+	return s.emit(c, "response.output_text.delta", map[string]any{
+		"type":          "response.output_text.delta",
+		"item_id":       s.textItemID,
+		"output_index":  outputIndexByID(s.outputs, s.textItemID),
+		"content_index": 0,
+		"delta":         claudeRiskWarningPrefix(s.riskWarning),
+	})
+}
+
+func (s *claudeResponsesStreamState) replaceOutput(output dto.ResponsesOutput) {
+	for i := range s.outputs {
+		if s.outputs[i].ID == output.ID {
+			s.outputs[i] = output
+			return
+		}
+	}
+	s.outputs = append(s.outputs, output)
+}
+
+func (s *claudeResponsesStreamState) outputByID(id string) *dto.ResponsesOutput {
+	for i := range s.outputs {
+		if s.outputs[i].ID == id {
+			return &s.outputs[i]
+		}
+	}
+	return nil
+}
+
+func outputIndexByID(outputs []dto.ResponsesOutput, id string) int {
+	for i := range outputs {
+		if outputs[i].ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func usageFromClaudeUsage(usage *dto.ClaudeUsage, info *relaycommon.RelayInfo) *dto.Usage {
+	if usage == nil {
+		estimate := 0
+		if info != nil {
+			estimate = info.GetEstimatePromptTokens()
+		}
+		return &dto.Usage{
+			PromptTokens:       estimate,
+			InputTokens:        estimate,
+			InputTokensDetails: &dto.InputTokenDetails{},
+			UsageSemantic:      "openai",
+			UsageSource:        "anthropic",
+		}
+	}
+	cacheCreation5m, cacheCreation1h := service.NormalizeCacheCreationSplit(
+		usage.CacheCreationInputTokens,
+		usage.GetCacheCreation5mTokens(),
+		usage.GetCacheCreation1hTokens(),
+	)
+	cacheCreationTokens := usage.CacheCreationInputTokens
+	if cacheCreationTokens < cacheCreation5m+cacheCreation1h {
+		cacheCreationTokens = cacheCreation5m + cacheCreation1h
+	}
+	inputTokens := usage.InputTokens + usage.CacheReadInputTokens + cacheCreationTokens
+	if inputTokens == 0 && info != nil {
+		inputTokens = info.GetEstimatePromptTokens()
+	}
+	return &dto.Usage{
+		PromptTokens:                inputTokens,
+		InputTokens:                 inputTokens,
+		CompletionTokens:            usage.OutputTokens,
+		OutputTokens:                usage.OutputTokens,
+		TotalTokens:                 inputTokens + usage.OutputTokens,
+		UsageSemantic:               "openai",
+		UsageSource:                 "anthropic",
+		InputTokensDetails:          &dto.InputTokenDetails{CachedTokens: usage.CacheReadInputTokens, CachedCreationTokens: usage.CacheCreationInputTokens},
+		ClaudeCacheCreation5mTokens: cacheCreation5m,
+		ClaudeCacheCreation1hTokens: cacheCreation1h,
+		PromptTokensDetails:         dto.InputTokenDetails{CachedTokens: usage.CacheReadInputTokens, CachedCreationTokens: usage.CacheCreationInputTokens},
+	}
+}
+
+func outputsContainFunctionCall(outputs []dto.ResponsesOutput) bool {
+	for _, output := range outputs {
+		if output.Type == "function_call" {
+			return true
+		}
+	}
+	return false
+}
+
+func deferredCursorHarnessResponsesUsage() *dto.Usage {
+	return &dto.Usage{
+		InputTokensDetails: &dto.InputTokenDetails{},
+		UsageSemantic:      "openai",
+		UsageSource:        dto.UsageSourceCursorHarnessDeferred,
+	}
+}
+
+func deferCursorHarnessResponsesUsage(info *relaycommon.RelayInfo, hasToolUse bool, usage *dto.Usage) *dto.Usage {
+	if info != nil && info.ChannelMeta != nil && info.ChannelType == constant.ChannelTypeCursorAgent &&
+		hasToolUse {
+		return deferredCursorHarnessResponsesUsage()
+	}
+	return usage
+}
+
+func openAIResponsesUsage(usage *dto.Usage) map[string]any {
+	if usage == nil {
+		usage = &dto.Usage{}
+	}
+	inputTokens := usage.InputTokens
+	if inputTokens == 0 {
+		inputTokens = usage.PromptTokens
+	}
+	outputTokens := usage.OutputTokens
+	if outputTokens == 0 {
+		outputTokens = usage.CompletionTokens
+	}
+	inputDetails := usage.InputTokensDetails
+	if inputDetails == nil {
+		inputDetails = &dto.InputTokenDetails{
+			CachedTokens:         usage.PromptTokensDetails.CachedTokens,
+			CachedCreationTokens: usage.PromptTokensDetails.CachedCreationTokens,
+		}
+	}
+	return map[string]any{
+		"input_tokens":          inputTokens,
+		"input_tokens_details":  inputDetails,
+		"output_tokens":         outputTokens,
+		"output_tokens_details": usage.CompletionTokenDetails,
+		"total_tokens":          inputTokens + outputTokens,
+	}
+}
+
+func openAIFunctionCallItem(item dto.ResponsesOutput) map[string]any {
+	return map[string]any{
+		"id":        item.ID,
+		"type":      item.Type,
+		"status":    item.Status,
+		"call_id":   item.CallId,
+		"name":      item.Name,
+		"arguments": string(item.Arguments),
+	}
+}
+
+func openAIReasoningItem(item dto.ResponsesOutput) map[string]any {
+	return map[string]any{
+		"id":      item.ID,
+		"type":    item.Type,
+		"status":  item.Status,
+		"summary": item.Summary,
+	}
+}
+
+func openAIResponsesOutputItems(outputs []dto.ResponsesOutput) []any {
+	items := make([]any, 0, len(outputs))
+	for _, item := range outputs {
+		if item.Type == "function_call" {
+			items = append(items, openAIFunctionCallItem(item))
+			continue
+		}
+		if item.Type == "reasoning" {
+			items = append(items, openAIReasoningItem(item))
+			continue
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+func completedResponsesResponse(id string, model string, usage *dto.Usage, outputs []dto.ResponsesOutput) map[string]any {
+	return map[string]any{
+		"id":                   id,
+		"object":               "response",
+		"created_at":           int(common.GetTimestamp()),
+		"status":               "completed",
+		"model":                model,
+		"output":               openAIResponsesOutputItems(outputs),
+		"parallel_tool_calls":  true,
+		"previous_response_id": nil,
+		"store":                false,
+		"tool_choice":          "auto",
+		"tools":                []any{},
+		"truncation":           nil,
+		"usage":                openAIResponsesUsage(usage),
+	}
+}
+
+func outputsFromClaudeMessage(response *dto.ClaudeResponse) []dto.ResponsesOutput {
+	outputs := make([]dto.ResponsesOutput, 0, len(response.Content))
+	var text strings.Builder
+	for _, content := range response.Content {
+		switch content.Type {
+		case "text":
+			text.WriteString(content.GetText())
+		case "tool_use":
+			args, _ := common.Marshal(content.Input)
+			outputs = append(outputs, dto.ResponsesOutput{
+				ID:        fmt.Sprintf("fc_%s", common.GetUUID()),
+				Type:      "function_call",
+				Status:    "completed",
+				CallId:    content.Id,
+				Name:      content.Name,
+				Arguments: json.RawMessage(args),
+			})
+		}
+	}
+	if text.Len() > 0 || len(outputs) == 0 {
+		outputs = append([]dto.ResponsesOutput{{
+			ID:     fmt.Sprintf("msg_%s", common.GetUUID()),
+			Type:   "message",
+			Status: "completed",
+			Role:   "assistant",
+			Content: []dto.ResponsesOutputContent{{
+				Type:        "output_text",
+				Text:        text.String(),
+				Annotations: []interface{}{},
+			}},
+		}}, outputs...)
+	}
+	return outputs
+}
+
+func claudeRiskWarningPrefix(warning string) string {
+	warning = strings.TrimSpace(warning)
+	if warning == "" {
+		return ""
+	}
+	return warning + "\n\n"
+}
+
+func prependClaudeRiskWarningText(text string, warning string) string {
+	prefix := claudeRiskWarningPrefix(warning)
+	if prefix == "" {
+		return text
+	}
+	if text == "" {
+		return strings.TrimSpace(warning)
+	}
+	return prefix + text
+}
+
+func prependClaudeResponsesRiskWarning(outputs []dto.ResponsesOutput, warning string) {
+	if strings.TrimSpace(warning) == "" {
+		return
+	}
+	for i := range outputs {
+		if len(outputs[i].Content) == 0 {
+			continue
+		}
+		for j := range outputs[i].Content {
+			if outputs[i].Content[j].Type != "" && outputs[i].Content[j].Type != "output_text" && outputs[i].Content[j].Type != "text" {
+				continue
+			}
+			outputs[i].Content[j].Text = prependClaudeRiskWarningText(outputs[i].Content[j].Text, warning)
+			return
+		}
+	}
+}

--- a/relay/channel/claude/responses_compat_test.go
+++ b/relay/channel/claude/responses_compat_test.go
@@ -1,0 +1,338 @@
+package claude
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	constant.StreamingTimeout = 30
+}
+
+func TestClaudeResponsesStreamHandlerEmitsResponseCompleted(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	upstream := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6","usage":{"input_tokens":11,"output_tokens":0}}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":11,"output_tokens":3}}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+		``,
+	}, "\n")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(upstream)),
+	}
+	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "claude-sonnet-4-6"}}
+
+	usage, err := ClaudeResponsesStreamHandler(c, resp, info)
+	require.Nil(t, err)
+	require.Equal(t, 11, usage.PromptTokens)
+	require.Equal(t, 3, usage.CompletionTokens)
+
+	body := w.Body.String()
+	require.Contains(t, body, "event: response.created")
+	require.Contains(t, body, `"status":"in_progress"`)
+	require.Contains(t, body, `"output":[]`)
+	require.NotContains(t, body, `"output":null`)
+	require.NotContains(t, body, `"input_tokens_details":null`)
+	require.Contains(t, body, `"output_tokens_details":`)
+	require.Contains(t, body, `"sequence_number":0`)
+	require.Contains(t, body, "event: response.output_text.delta")
+	require.Contains(t, body, "event: response.completed")
+	require.Contains(t, body, `"status":"completed"`)
+
+	var completedSeen bool
+	for _, block := range strings.Split(body, "\n\n") {
+		if strings.Contains(block, "event: response.completed") {
+			completedSeen = true
+			data := strings.TrimSpace(strings.TrimPrefix(strings.Split(block, "data: ")[1], ""))
+			var payload map[string]any
+			require.NoError(t, common.Unmarshal([]byte(data), &payload))
+			require.Equal(t, "response.completed", payload["type"])
+		}
+	}
+	require.True(t, completedSeen)
+}
+
+func TestClaudeResponsesStreamHandlerMapsThinkingToReasoningSummary(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	upstream := strings.Join([]string{
+		`data: {"type":"message_start","message":{"id":"msg_thinking","type":"message","role":"assistant","model":"grok-4.6","usage":{"input_tokens":9,"output_tokens":0}}}`,
+		``,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+		``,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"checking sources"}}`,
+		``,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		``,
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"answer"}}`,
+		``,
+		`data: {"type":"content_block_stop","index":1}`,
+		``,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":9,"output_tokens":5}}`,
+		``,
+		`data: {"type":"message_stop"}`,
+		``,
+		``,
+	}, "\n")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(upstream)),
+	}
+	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "grok-4.6"}}
+
+	_, err := ClaudeResponsesStreamHandler(c, resp, info)
+	require.Nil(t, err)
+	body := w.Body.String()
+	require.Contains(t, body, "event: response.reasoning_summary_part.added")
+	require.Contains(t, body, "event: response.reasoning_summary_text.delta")
+	require.Contains(t, body, `"delta":"checking sources"`)
+	require.Contains(t, body, "event: response.reasoning_summary_text.done")
+	require.Contains(t, body, "event: response.reasoning_summary_part.done")
+	require.Contains(t, body, `"type":"reasoning"`)
+	require.Contains(t, body, `"summary":[{"type":"summary_text","text":"checking sources"}]`)
+	require.Contains(t, body, "event: response.output_text.delta")
+	require.Less(t, strings.Index(body, "response.reasoning_summary_text.delta"), strings.Index(body, "response.output_text.delta"))
+}
+
+func TestClaudeResponsesStreamHandlerEmitsEmptyFunctionArgumentsOnAdded(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	upstream := strings.Join([]string{
+		`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"grok-4.6","usage":{"input_tokens":11,"output_tokens":0}}}`,
+		``,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call_1","name":"read_file","input":{}}}`,
+		``,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"probe.txt\"}"}}`,
+		``,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`data: {"type":"message_stop"}`,
+		``,
+		``,
+	}, "\n")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(upstream)),
+	}
+	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "grok-4.6"}}
+
+	_, err := ClaudeResponsesStreamHandler(c, resp, info)
+	require.Nil(t, err)
+	body := w.Body.String()
+	require.Contains(t, body, "event: response.output_item.added")
+	require.Contains(t, body, `"arguments":""`)
+	require.Contains(t, body, `"arguments":"{\"path\":\"probe.txt\"}"`)
+	require.Contains(t, body, `"parallel_tool_calls":true`)
+	require.NotContains(t, body, `"parallel_tool_calls":false`)
+	require.NotContains(t, body, `"role":""`)
+	require.NotContains(t, body, `"content":null`)
+	require.NotContains(t, body, `"quality":""`)
+	require.NotContains(t, body, `"prompt_tokens"`)
+
+	sequence := 0
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: {") {
+			continue
+		}
+		var event map[string]any
+		require.NoError(t, common.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &event))
+		require.Equal(t, float64(sequence), event["sequence_number"])
+		sequence++
+	}
+	require.Greater(t, sequence, 1)
+}
+
+func TestClaudeResponsesHandlerReturnsCompletedResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	text := "hello"
+	body := `{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-sonnet-4-6",
+		"content":[{"type":"text","text":"hello"}],
+		"usage":{"input_tokens":7,"output_tokens":2}
+	}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "claude-sonnet-4-6"}}
+
+	usage, err := ClaudeResponsesHandler(c, resp, info)
+	require.Nil(t, err)
+	require.Equal(t, 7, usage.PromptTokens)
+	require.Equal(t, 2, usage.CompletionTokens)
+
+	var payload map[string]any
+	require.NoError(t, common.Unmarshal(w.Body.Bytes(), &payload))
+	require.Equal(t, "response", payload["object"])
+	require.Equal(t, "completed", payload["status"])
+	require.Equal(t, "claude-sonnet-4-6", payload["model"])
+	outputs, ok := payload["output"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, outputs)
+	first, ok := outputs[0].(map[string]any)
+	require.True(t, ok)
+	content, ok := first["content"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, content)
+	firstContent, ok := content[0].(map[string]any)
+	require.True(t, ok)
+	gotText, _ := firstContent["text"].(string)
+	require.Contains(t, gotText, text)
+}
+
+func TestUsageFromClaudeUsageFallsBackWhenUpstreamInputIsZero(t *testing.T) {
+	info := &relaycommon.RelayInfo{}
+	info.SetEstimatePromptTokens(321)
+
+	usage := usageFromClaudeUsage(&dto.ClaudeUsage{OutputTokens: 7}, info)
+
+	require.Equal(t, 321, usage.PromptTokens)
+	require.Equal(t, 321, usage.InputTokens)
+	require.Equal(t, 7, usage.CompletionTokens)
+	require.Equal(t, 328, usage.TotalTokens)
+}
+
+func TestUsageFromClaudeUsageDoesNotEstimateCacheOnlyInput(t *testing.T) {
+	info := &relaycommon.RelayInfo{}
+	info.SetEstimatePromptTokens(999)
+
+	usage := usageFromClaudeUsage(&dto.ClaudeUsage{
+		OutputTokens:             7,
+		CacheReadInputTokens:     101,
+		CacheCreationInputTokens: 13,
+	}, info)
+
+	require.Equal(t, 114, usage.PromptTokens)
+	require.Equal(t, 101, usage.PromptTokensDetails.CachedTokens)
+	require.Equal(t, 13, usage.PromptTokensDetails.CachedCreationTokens)
+	require.Equal(t, 121, usage.TotalTokens)
+}
+
+func TestCursorHarnessResponsesToolTurnDefersOutputOnlyUsage(t *testing.T) {
+	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{
+		ChannelType:       constant.ChannelTypeCursorAgent,
+		UpstreamModelName: "claude-sonnet-4-6",
+	}}
+	info.SetEstimatePromptTokens(999)
+	raw := &dto.ClaudeUsage{InputTokens: 100, CacheReadInputTokens: 80, OutputTokens: 7}
+
+	usage := deferCursorHarnessResponsesUsage(info, true, usageFromClaudeUsage(raw, info))
+
+	require.Zero(t, usage.PromptTokens)
+	require.Zero(t, usage.CompletionTokens)
+	require.Zero(t, usage.TotalTokens)
+	require.Equal(t, dto.UsageSourceCursorHarnessDeferred, usage.UsageSource)
+}
+
+func TestCursorHarnessResponsesStreamToolTurnForcesDeferredUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{
+		ChannelType:       constant.ChannelTypeCursorAgent,
+		UpstreamModelName: "claude-sonnet-4-6",
+	}}
+	info.SetEstimatePromptTokens(456)
+	state := newClaudeResponsesStreamState(c, info)
+	state.hasToolUse = true
+	state.mergeClaudeUsage(&dto.ClaudeUsage{OutputTokens: 9})
+
+	require.NoError(t, state.complete(c))
+	require.Zero(t, state.usage.PromptTokens)
+	require.Zero(t, state.usage.CompletionTokens)
+	require.Zero(t, state.usage.TotalTokens)
+	require.Equal(t, dto.UsageSourceCursorHarnessDeferred, state.usage.UsageSource)
+}
+
+func TestClaudeResponsesStreamCompletionFallsBackWhenUpstreamInputIsZero(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "grok-4.6"}}
+	info.SetEstimatePromptTokens(456)
+	state := newClaudeResponsesStreamState(c, info)
+	state.mergeClaudeUsage(&dto.ClaudeUsage{OutputTokens: 9})
+
+	require.NoError(t, state.complete(c))
+	require.Equal(t, 456, state.usage.PromptTokens)
+	require.Equal(t, 456, state.usage.InputTokens)
+	require.Equal(t, 9, state.usage.CompletionTokens)
+	require.Equal(t, 465, state.usage.TotalTokens)
+}
+
+func TestClaudeResponsesStreamMergePreservesCacheAcrossOutputOnlyDelta(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "grok-4.6"}}
+	info.SetEstimatePromptTokens(999)
+	state := newClaudeResponsesStreamState(c, info)
+
+	state.mergeClaudeUsage(&dto.ClaudeUsage{
+		CacheReadInputTokens:     101,
+		CacheCreationInputTokens: 13,
+	})
+	state.mergeClaudeUsage(&dto.ClaudeUsage{OutputTokens: 7})
+
+	require.Equal(t, 114, state.usage.PromptTokens)
+	require.Equal(t, 101, state.usage.PromptTokensDetails.CachedTokens)
+	require.Equal(t, 13, state.usage.PromptTokensDetails.CachedCreationTokens)
+	require.NotNil(t, state.usage.InputTokensDetails)
+	require.Equal(t, 101, state.usage.InputTokensDetails.CachedTokens)
+	require.Equal(t, 13, state.usage.InputTokensDetails.CachedCreationTokens)
+	require.Equal(t, 7, state.usage.CompletionTokens)
+	require.Equal(t, 121, state.usage.TotalTokens)
+}

--- a/relay/channel/cursor_agent/adaptor.go
+++ b/relay/channel/cursor_agent/adaptor.go
@@ -1,0 +1,337 @@
+package cursor_agent
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/relay/channel"
+	"github.com/QuantumNous/new-api/relay/channel/claude"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/relayconvert"
+	"github.com/QuantumNous/new-api/relaykit/types"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Adaptor relays Cursor traffic to the official @cursor/sdk harness.
+//
+// Design (aligned with CPA / Claude-native channels):
+//   - Client /v1/messages is passed through as Anthropic Messages (tools included).
+//   - Client /v1/chat/completions and /v1/responses are converted to Messages.
+//   - Model names are normalized to canonical Cursor SDK catalog SKUs.
+//   - new-api keeps billing/quota; the SDK sidecar only speaks Cursor + gateway auth.
+//
+// Tool requests are forced to stream because the harness parks the first HTTP
+// response at tool_use and resumes the same SDK run on tool_result.
+type Adaptor struct{}
+
+func (a *Adaptor) ConvertGeminiRequest(*gin.Context, *relaycommon.RelayInfo, *dto.GeminiChatRequest) (any, error) {
+	return nil, errors.New("cursor_agent: Gemini endpoint is not supported")
+}
+
+// ConvertClaudeRequest passes Anthropic Messages through to /v1/messages.
+func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.ClaudeRequest) (any, error) {
+	if request == nil {
+		return nil, errors.New("cursor_agent: claude request is nil")
+	}
+	out := *request
+	normalized, err := mapModelForHarness(request.Model, claudeRequestReasoningEffort(request))
+	if err != nil {
+		return nil, err
+	}
+	if normalized == "" {
+		return nil, errors.New("cursor_agent: model is required")
+	}
+	out.Model = normalized
+	if info != nil {
+		info.UpstreamModelName = normalized
+		info.FinalRequestRelayFormat = types.RelayFormatClaude
+	}
+
+	return &out, nil
+}
+
+func claudeRequestReasoningEffort(request *dto.ClaudeRequest) string {
+	if request == nil {
+		return ""
+	}
+	if effort := request.GetEfforts(); effort != "" {
+		return effort
+	}
+	if request.Thinking == nil || (request.Thinking.Type != "enabled" && request.Thinking.Type != "adaptive") {
+		return ""
+	}
+	switch budget := request.Thinking.GetBudgetTokens(); {
+	case budget > 0 && budget <= 2048:
+		return "low"
+	case budget > 10000:
+		return "high"
+	default:
+		return "medium"
+	}
+}
+
+func (a *Adaptor) ConvertAudioRequest(*gin.Context, *relaycommon.RelayInfo, dto.AudioRequest) (io.Reader, error) {
+	return nil, errors.New("cursor_agent: audio endpoint is not supported")
+}
+
+func (a *Adaptor) ConvertImageRequest(*gin.Context, *relaycommon.RelayInfo, dto.ImageRequest) (any, error) {
+	return nil, errors.New("cursor_agent: image endpoint is not supported")
+}
+
+func (a *Adaptor) Init(*relaycommon.RelayInfo) {}
+
+func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
+	channelBaseURL := ""
+	if info != nil && info.ChannelMeta != nil {
+		channelBaseURL = strings.TrimSpace(info.ChannelBaseUrl)
+	}
+	base := ResolveSidecarBaseURL(channelBaseURL)
+	if info != nil && info.RelayMode == relayconstant.RelayModeResponsesCompact {
+		return "", errors.New("cursor_agent: responses compaction is not supported by the official SDK harness")
+	}
+	return relaycommon.GetFullRequestURL(base, "/v1/messages", constant.ChannelTypeCursorAgent), nil
+}
+
+func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *relaycommon.RelayInfo) error {
+	channel.SetupApiRequestHeader(info, c, req)
+	apiKey := ""
+	if info != nil {
+		apiKey = info.ApiKey
+	}
+	cred, err := ParseCredential(apiKey)
+	if err != nil {
+		return err
+	}
+	// The sidecar accepts either standard bearer spelling.
+	req.Set("Authorization", "Bearer "+cred.APIKey)
+	req.Set("x-api-key", cred.APIKey)
+	if info != nil && info.FinalRequestRelayFormat == types.RelayFormatClaude {
+		anthropicVersion := c.Request.Header.Get("anthropic-version")
+		if anthropicVersion == "" {
+			anthropicVersion = "2023-06-01"
+		}
+		req.Set("anthropic-version", anthropicVersion)
+		if beta := c.Request.Header.Get("anthropic-beta"); beta != "" {
+			req.Set("anthropic-beta", beta)
+		}
+	}
+	req.Set("X-Cursor-Agent-Channel", "new-api-cursor")
+	channelID := 0
+	if info != nil {
+		channelID = info.ChannelId
+	}
+	req.Set("X-Cursor-Agent-Tenant", fmt.Sprintf("user:%d:token:%d:channel:%d", c.GetInt("id"), c.GetInt("token_id"), channelID))
+	return nil
+}
+
+func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeneralOpenAIRequest) (any, error) {
+	if request == nil {
+		return nil, errors.New("cursor_agent: request is nil")
+	}
+	normalized, err := mapModelForHarness(request.Model, openAIRequestReasoningEffort(request))
+	if err != nil {
+		return nil, err
+	}
+	if normalized == "" {
+		return nil, errors.New("cursor_agent: model is required")
+	}
+	if info != nil {
+		info.UpstreamModelName = normalized
+		if info.FinalRequestRelayFormat == "" {
+			info.FinalRequestRelayFormat = types.RelayFormatOpenAI
+		}
+	}
+	out := *request
+	out.Model = normalized
+
+	if err := normalizeOpenAIToolsForClaude(&out); err != nil {
+		return nil, err
+	}
+	converted, err := relayconvert.OpenAIChatRequestToClaudeMessages(c, info, out)
+	if err != nil {
+		return nil, err
+	}
+	if info != nil {
+		info.FinalRequestRelayFormat = types.RelayFormatClaude
+	}
+	return converted, nil
+}
+
+func normalizeOpenAIToolsForClaude(request *dto.GeneralOpenAIRequest) error {
+	if request == nil {
+		return nil
+	}
+	if len(request.Functions) > 0 {
+		var functions []dto.FunctionRequest
+		if err := common.Unmarshal(request.Functions, &functions); err != nil {
+			return fmt.Errorf("cursor_agent: invalid legacy functions: %w", err)
+		}
+		for _, function := range functions {
+			request.Tools = append(request.Tools, dto.ToolCallRequest{Type: "function", Function: function})
+		}
+		request.Functions = nil
+	}
+	for index := range request.Tools {
+		parameters, err := openAIToolParametersObject(request.Tools[index].Function.Parameters)
+		if err != nil {
+			return fmt.Errorf("cursor_agent: invalid parameters for tool %q: %w", request.Tools[index].Function.Name, err)
+		}
+		request.Tools[index].Function.Parameters = parameters
+	}
+	if request.ToolChoice == nil && len(request.FunctionCall) > 0 {
+		var functionCall any
+		if err := common.Unmarshal(request.FunctionCall, &functionCall); err != nil {
+			return fmt.Errorf("cursor_agent: invalid legacy function_call: %w", err)
+		}
+		switch value := functionCall.(type) {
+		case string:
+			request.ToolChoice = value
+		case map[string]any:
+			if name, ok := value["name"].(string); ok && strings.TrimSpace(name) != "" {
+				request.ToolChoice = map[string]any{
+					"type":     "function",
+					"function": map[string]any{"name": name},
+				}
+			}
+		}
+		request.FunctionCall = nil
+	}
+	return nil
+}
+
+func openAIToolParametersObject(value any) (map[string]any, error) {
+	parameters := map[string]any{}
+	switch typed := value.(type) {
+	case nil:
+	case map[string]any:
+		for key, field := range typed {
+			parameters[key] = field
+		}
+	case []byte:
+		if len(typed) > 0 {
+			if err := common.Unmarshal(typed, &parameters); err != nil {
+				return nil, err
+			}
+		}
+	case json.RawMessage:
+		if len(typed) > 0 {
+			if err := common.Unmarshal(typed, &parameters); err != nil {
+				return nil, err
+			}
+		}
+	case string:
+		if strings.TrimSpace(typed) != "" {
+			if err := common.Unmarshal([]byte(typed), &parameters); err != nil {
+				return nil, err
+			}
+		}
+	default:
+		return nil, fmt.Errorf("expected an object schema, got %T", value)
+	}
+	if _, ok := parameters["type"]; !ok {
+		parameters["type"] = "object"
+	}
+	if _, ok := parameters["properties"]; !ok {
+		parameters["properties"] = map[string]any{}
+	}
+	return parameters, nil
+}
+
+func mapModelForHarness(model, effort string) (string, error) {
+	return MapSDKModelWithEffort(model, effort)
+}
+
+func openAIRequestReasoningEffort(request *dto.GeneralOpenAIRequest) string {
+	if request == nil {
+		return ""
+	}
+	if request.ReasoningEffort != "" {
+		return request.ReasoningEffort
+	}
+	if len(request.Reasoning) > 0 {
+		var reasoning dto.Reasoning
+		if err := common.Unmarshal(request.Reasoning, &reasoning); err == nil && reasoning.Effort != "" {
+			return reasoning.Effort
+		}
+	}
+	if len(request.THINKING) > 0 {
+		var thinking dto.Thinking
+		if err := common.Unmarshal(request.THINKING, &thinking); err == nil {
+			tmp := &dto.ClaudeRequest{Thinking: &thinking}
+			return claudeRequestReasoningEffort(tmp)
+		}
+	}
+	return ""
+}
+
+func (a *Adaptor) ConvertRerankRequest(*gin.Context, int, dto.RerankRequest) (any, error) {
+	return nil, errors.New("cursor_agent: rerank endpoint is not supported")
+}
+
+func (a *Adaptor) ConvertEmbeddingRequest(*gin.Context, *relaycommon.RelayInfo, dto.EmbeddingRequest) (any, error) {
+	return nil, errors.New("cursor_agent: embedding endpoint is not supported")
+}
+
+func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {
+	effort := ""
+	if request.Reasoning != nil {
+		effort = request.Reasoning.Effort
+	}
+	normalized, err := mapModelForHarness(request.Model, effort)
+	if err != nil {
+		return nil, err
+	}
+	if normalized == "" {
+		return nil, fmt.Errorf("cursor_agent: model is required")
+	}
+	request.Model = normalized
+	if info != nil {
+		info.UpstreamModelName = normalized
+		if effort != "" {
+			info.ReasoningEffort = effort
+		}
+	}
+	converted, err := relayconvert.OpenAIResponsesRequestToClaudeMessages(c, info, &request)
+	if err != nil {
+		return nil, err
+	}
+	if info != nil {
+		info.FinalRequestRelayFormat = types.RelayFormatClaude
+	}
+	return converted, nil
+}
+
+func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBody io.Reader) (any, error) {
+	return channel.DoApiRequest(a, c, info, requestBody)
+}
+
+func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
+	rewriteCursorResponseModel(resp, info)
+	if info != nil && info.RelayMode == relayconstant.RelayModeResponses && info.FinalRequestRelayFormat == types.RelayFormatClaude {
+		if info.IsStream {
+			return claude.ClaudeResponsesStreamHandler(c, resp, info)
+		}
+		return claude.ClaudeResponsesHandler(c, resp, info)
+	}
+	if info != nil && info.IsStream {
+		return claude.ClaudeStreamHandler(c, resp, info)
+	}
+	return claude.ClaudeHandler(c, resp, info)
+}
+
+func (a *Adaptor) GetModelList() []string {
+	return ModelList
+}
+
+func (a *Adaptor) GetChannelName() string {
+	return ChannelName
+}

--- a/relay/channel/cursor_agent/adaptor_test.go
+++ b/relay/channel/cursor_agent/adaptor_test.go
@@ -1,0 +1,357 @@
+package cursor_agent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/types"
+)
+
+func TestConvertClaudeRequestMapsSonnet46AndAllowsTools(t *testing.T) {
+	a := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{},
+	}
+	mt := uint(64)
+	stream := false
+	req := &dto.ClaudeRequest{
+		Model:     "cursor-agent/claude-sonnet-4-6",
+		MaxTokens: &mt,
+		Stream:    &stream,
+		Messages: []dto.ClaudeMessage{
+			{Role: "user", Content: "hi"},
+		},
+		Tools: []any{
+			map[string]any{
+				"name":         "get_weather",
+				"description":  "weather",
+				"input_schema": map[string]any{"type": "object"},
+			},
+		},
+		ToolChoice: map[string]any{"type": "any"},
+	}
+
+	out, err := a.ConvertClaudeRequest(nil, info, req)
+	if err != nil {
+		t.Fatalf("ConvertClaudeRequest: %v", err)
+	}
+	claude, ok := out.(*dto.ClaudeRequest)
+	if !ok {
+		t.Fatalf("expected *dto.ClaudeRequest (native passthrough), got %T", out)
+	}
+	if claude.Model != "claude-sonnet-4-6" {
+		t.Fatalf("model=%q want claude-sonnet-4-6", claude.Model)
+	}
+	if info.UpstreamModelName != "claude-sonnet-4-6" {
+		t.Fatalf("UpstreamModelName=%q", info.UpstreamModelName)
+	}
+	if info.FinalRequestRelayFormat != types.RelayFormatClaude {
+		t.Fatalf("FinalRequestRelayFormat=%q", info.FinalRequestRelayFormat)
+	}
+	if claude.Stream == nil || *claude.Stream {
+		t.Fatal("expected client stream=false to be preserved")
+	}
+	if info.IsStream {
+		t.Fatal("expected non-stream relay to stay non-stream")
+	}
+	if claude.Tools == nil {
+		t.Fatal("expected tools preserved")
+	}
+}
+
+func TestConvertRequestsApplyGrokReasoningEffort(t *testing.T) {
+	a := &Adaptor{}
+
+	chatInfo := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{ChannelBaseUrl: "http://cursor-sdk.test"}}
+	chat, err := a.ConvertOpenAIRequest(nil, chatInfo, &dto.GeneralOpenAIRequest{
+		Model:           "grok-4.6",
+		ReasoningEffort: "high",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := chat.(*dto.ClaudeRequest).Model; got != "cursor-grok-4.6-high" {
+		t.Fatalf("chat model=%q", got)
+	}
+
+	claudeInfo := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{ChannelBaseUrl: "http://cursor-sdk.test"}}
+	claude, err := a.ConvertClaudeRequest(nil, claudeInfo, &dto.ClaudeRequest{
+		Model:        "grok-4.5",
+		OutputConfig: json.RawMessage(`{"effort":"high"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := claude.(*dto.ClaudeRequest).Model; got != "cursor-grok-4.5-high" {
+		t.Fatalf("claude model=%q", got)
+	}
+
+	responsesInfo := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{ChannelBaseUrl: "http://cursor-sdk.test"}}
+	responses, err := a.ConvertOpenAIResponsesRequest(nil, responsesInfo, dto.OpenAIResponsesRequest{
+		Model:     "grok-4.6",
+		Reasoning: &dto.Reasoning{Effort: "xhigh"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := responses.(*dto.ClaudeRequest).Model; got != "cursor-grok-4.6-xhigh" {
+		t.Fatalf("responses model=%q", got)
+	}
+	if responsesInfo.FinalRequestRelayFormat != types.RelayFormatClaude {
+		t.Fatalf("FinalRequestRelayFormat=%q", responsesInfo.FinalRequestRelayFormat)
+	}
+}
+
+func TestMapSDKModelWithEffortRejectsUnsupportedGrok45Level(t *testing.T) {
+	if _, err := MapSDKModelWithEffort("grok-4.5", "bogus"); err == nil {
+		t.Fatal("expected unsupported effort error")
+	}
+}
+
+func TestAllSupportedRequestsUseMessagesEndpoint(t *testing.T) {
+	a := &Adaptor{}
+	for _, test := range []struct {
+		name string
+		mode int
+	}{
+		{name: "chat", mode: relayconstant.RelayModeChatCompletions},
+		{name: "responses", mode: relayconstant.RelayModeResponses},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			info := &relaycommon.RelayInfo{
+				RelayMode: test.mode,
+				ChannelMeta: &relaycommon.ChannelMeta{
+					ChannelBaseUrl: "http://cursor-sdk.test",
+				},
+			}
+			got, err := a.GetRequestURL(info)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != "http://cursor-sdk.test/v1/messages" {
+				t.Fatalf("url=%q", got)
+			}
+		})
+	}
+}
+
+func TestConvertClaudeRequestTextOnlyPassthrough(t *testing.T) {
+	a := &Adaptor{}
+	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{}}
+	mt := uint(32)
+	req := &dto.ClaudeRequest{
+		Model:     "claude-sonnet-4-6",
+		MaxTokens: &mt,
+		Messages:  []dto.ClaudeMessage{{Role: "user", Content: "hi"}},
+	}
+	out, err := a.ConvertClaudeRequest(nil, info, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claude := out.(*dto.ClaudeRequest)
+	if claude.Model != "claude-sonnet-4-6" {
+		t.Fatalf("model=%q", claude.Model)
+	}
+}
+
+func TestGetRequestURLUsesCustomSDKBase(t *testing.T) {
+	t.Setenv("CURSOR_AGENT_SIDECAR_BASE_URL", "")
+	a := &Adaptor{}
+	base := "http://cursor-sdk.internal:9000"
+
+	claudeInfo := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelBaseUrl: base,
+			ChannelType:    62,
+		},
+		FinalRequestRelayFormat: types.RelayFormatClaude,
+	}
+	url, err := a.GetRequestURL(claudeInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if url != base+"/v1/messages" {
+		t.Fatalf("claude url=%q", url)
+	}
+
+}
+
+func TestGetRequestURLPrefersImmutableRuntimeBase(t *testing.T) {
+	t.Setenv("CURSOR_AGENT_SIDECAR_BASE_URL", "http://cursor-sdk-runtime:3927")
+	a := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{ChannelBaseUrl: "http://legacy-sidecar:3927"},
+	}
+	url, err := a.GetRequestURL(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if url != "http://cursor-sdk-runtime:3927/v1/messages" {
+		t.Fatalf("url=%q", url)
+	}
+}
+
+func TestConvertOpenAIRequestAllowsToolsAndMapsModel(t *testing.T) {
+	a := &Adaptor{}
+	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{ChannelBaseUrl: "http://cursor-sdk.test"}}
+	stream := false
+	req := &dto.GeneralOpenAIRequest{
+		Model:  "claude-sonnet-4-6",
+		Stream: &stream,
+		Messages: []dto.Message{
+			{Role: "user", Content: "hi"},
+		},
+		Tools: []dto.ToolCallRequest{
+			{Type: "function", Function: dto.FunctionRequest{Name: "get_weather"}},
+		},
+	}
+	out, err := a.ConvertOpenAIRequest(nil, info, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	converted := out.(*dto.ClaudeRequest)
+	if converted.Model != "claude-sonnet-4-6" {
+		t.Fatalf("model=%q", converted.Model)
+	}
+	if converted.Stream != nil && *converted.Stream {
+		t.Fatal("expected stream=false preserved for tools")
+	}
+	if info.IsStream {
+		t.Fatal("expected non-stream relay")
+	}
+}
+
+func TestOfficialSDKHarnessConvertsChatToolsToMessages(t *testing.T) {
+	a := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{ChannelBaseUrl: "http://cursor-agent-sidecar:3927"},
+		RelayFormat: types.RelayFormatOpenAI,
+	}
+	req := &dto.GeneralOpenAIRequest{
+		Model:    "grok-4.6",
+		Messages: []dto.Message{{Role: "user", Content: "look it up"}},
+		Tools: []dto.ToolCallRequest{{
+			Type: "function",
+			Function: dto.FunctionRequest{
+				Name: "lookup",
+				Parameters: map[string]any{
+					"type":       "object",
+					"properties": map[string]any{},
+				},
+			},
+		}},
+	}
+	out, err := a.ConvertOpenAIRequest(nil, info, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claudeReq, ok := out.(*dto.ClaudeRequest)
+	if !ok {
+		t.Fatalf("expected *dto.ClaudeRequest, got %T", out)
+	}
+	if claudeReq.Model != "cursor-grok-4.6-medium" {
+		t.Fatalf("model=%q", claudeReq.Model)
+	}
+	if len(claudeReq.GetTools()) != 1 {
+		t.Fatalf("tools=%d", len(claudeReq.GetTools()))
+	}
+	if info.FinalRequestRelayFormat != types.RelayFormatClaude {
+		t.Fatalf("FinalRequestRelayFormat=%q", info.FinalRequestRelayFormat)
+	}
+	url, err := a.GetRequestURL(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if url != "http://cursor-agent-sidecar:3927/v1/messages" {
+		t.Fatalf("url=%q", url)
+	}
+}
+
+func TestOfficialSDKHarnessNormalizesSchemaLessAndLegacyChatTools(t *testing.T) {
+	a := &Adaptor{}
+	for _, req := range []*dto.GeneralOpenAIRequest{
+		{
+			Model:    "composer-2.5",
+			Messages: []dto.Message{{Role: "user", Content: "use it"}},
+			Tools: []dto.ToolCallRequest{{
+				Type:     "function",
+				Function: dto.FunctionRequest{Name: "schema_less"},
+			}},
+		},
+		{
+			Model:        "composer-2.5",
+			Messages:     []dto.Message{{Role: "user", Content: "use it"}},
+			Functions:    json.RawMessage(`[{"name":"legacy_tool"}]`),
+			FunctionCall: json.RawMessage(`{"name":"legacy_tool"}`),
+		},
+	} {
+		info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{ChannelBaseUrl: ""}}
+		out, err := a.ConvertOpenAIRequest(nil, info, req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		claudeReq := out.(*dto.ClaudeRequest)
+		tools, err := common.Any2Type[[]dto.Tool](claudeReq.Tools)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(tools) != 1 || tools[0].InputSchema["type"] != "object" || tools[0].InputSchema["properties"] == nil {
+			t.Fatalf("normalized tools=%#v", tools)
+		}
+		if info.FinalRequestRelayFormat != types.RelayFormatClaude {
+			t.Fatalf("FinalRequestRelayFormat=%q", info.FinalRequestRelayFormat)
+		}
+	}
+}
+
+func TestOfficialSDKHarnessConvertsResponsesToolsToMessages(t *testing.T) {
+	a := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{ChannelBaseUrl: "http://cursor-agent-sidecar:3927"},
+		RelayMode:   relayconstant.RelayModeResponses,
+		RelayFormat: types.RelayFormatOpenAIResponses,
+	}
+	out, err := a.ConvertOpenAIResponsesRequest(nil, info, dto.OpenAIResponsesRequest{
+		Model: "composer-2.5",
+		Input: json.RawMessage(`[{"role":"user","content":[{"type":"input_text","text":"look it up"}]}]`),
+		Tools: json.RawMessage(`[{"type":"function","name":"lookup","description":"lookup"}]`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claudeReq, ok := out.(*dto.ClaudeRequest)
+	if !ok {
+		t.Fatalf("expected *dto.ClaudeRequest, got %T", out)
+	}
+	if claudeReq.Model != "composer-2.5" || len(claudeReq.GetTools()) != 1 {
+		t.Fatalf("model=%q tools=%d", claudeReq.Model, len(claudeReq.GetTools()))
+	}
+	tools, err := common.Any2Type[[]dto.Tool](claudeReq.Tools)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tools[0].InputSchema["type"] != "object" || tools[0].InputSchema["properties"] == nil {
+		t.Fatalf("schema=%#v", tools[0].InputSchema)
+	}
+	if info.FinalRequestRelayFormat != types.RelayFormatClaude {
+		t.Fatalf("FinalRequestRelayFormat=%q", info.FinalRequestRelayFormat)
+	}
+}
+
+func TestOfficialSDKHarnessRejectsResponsesCompaction(t *testing.T) {
+	a := &Adaptor{}
+	_, err := a.GetRequestURL(&relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeResponsesCompact,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelBaseUrl: "http://cursor-agent-sidecar:3927",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "compaction") {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/relay/channel/cursor_agent/constants.go
+++ b/relay/channel/cursor_agent/constants.go
@@ -1,0 +1,52 @@
+package cursor_agent
+
+// Experimental Cursor Agent channel (official @cursor/sdk path).
+// Model IDs are Cursor catalog SKUs as returned by Cursor.models.list() —
+// same bare names users type elsewhere (no required cursor-agent/ prefix).
+// Traffic still goes through Cursor Agent harness, not native Anthropic OAuth.
+
+const ChannelName = "cursor_agent"
+
+// ModelList is a static fallback for admin UI. Prefer live catalog from
+// sidecar GET /v1/models when the channel key is valid.
+var ModelList = []string{
+	// Cursor-native
+	"default",
+	"composer-2.5",
+	"composer-2",
+	"grok-4.5",
+	"grok-4.6",
+	// Claude family (Cursor catalog IDs, including newer SKUs)
+	"claude-opus-5",
+	"claude-fable-5",
+	"claude-sonnet-5",
+	"claude-opus-4-8",
+	"claude-opus-4-7",
+	"claude-opus-4-6",
+	"claude-opus-4-5",
+	"claude-sonnet-4-6",
+	"claude-sonnet-4-5",
+	"claude-sonnet-4",
+	"claude-haiku-4-5",
+	// OpenAI / others commonly listed on Cursor
+	"gpt-5.5",
+	"gpt-5.4",
+	"gpt-5.4-mini",
+	"gpt-5.4-nano",
+	"gpt-5.3-codex",
+	"gpt-5.2",
+	"gpt-5.1",
+	"gpt-5-mini",
+	"gpt-5.6-sol",
+	"gpt-5.6-terra",
+	"gpt-5.6-luna",
+	"gemini-3.1-pro",
+	"gemini-3-flash",
+	"gemini-3.5-flash",
+	"gemini-3.6-flash",
+	"gemini-3.7-flash",
+	"gemini-2.5-flash",
+	"kimi-k2.7-code",
+	"kimi-k3",
+	"glm-5.2",
+}

--- a/relay/channel/cursor_agent/key.go
+++ b/relay/channel/cursor_agent/key.go
@@ -1,0 +1,193 @@
+package cursor_agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+// Credential is the channel key payload for the official Cursor SDK harness.
+// Accepts either a raw Cursor API key string or JSON:
+//
+//	{"api_key":"crsr_..."}
+type Credential struct {
+	APIKey       string `json:"api_key,omitempty"`
+	AccessToken  string `json:"access_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+}
+
+// ParseCredential normalizes channel.Key into an API key.
+func ParseCredential(raw string) (*Credential, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return nil, errors.New("cursor_agent: empty api key")
+	}
+	// JSON envelope
+	if strings.HasPrefix(s, "{") {
+		var cred Credential
+		if err := common.Unmarshal([]byte(s), &cred); err != nil {
+			return nil, errors.New("cursor_agent: invalid credential json")
+		}
+		cred.APIKey = strings.TrimSpace(cred.APIKey)
+		cred.AccessToken = strings.TrimSpace(cred.AccessToken)
+		cred.RefreshToken = strings.TrimSpace(cred.RefreshToken)
+		if cred.APIKey == "" {
+			// also accept {"key":"..."}
+			var alt struct {
+				Key string `json:"key"`
+			}
+			_ = common.Unmarshal([]byte(s), &alt)
+			cred.APIKey = strings.TrimSpace(alt.Key)
+		}
+		if cred.APIKey == "" {
+			return nil, errors.New("cursor_agent: credential json missing api_key")
+		}
+		return &cred, nil
+	}
+	// KEY=value forms
+	if strings.Contains(s, "=") && !strings.Contains(s, " ") {
+		parts := strings.SplitN(s, "=", 2)
+		k := strings.ToUpper(strings.TrimSpace(parts[0]))
+		if k == "CURSOR_API_KEY" || k == "API_KEY" || k == "KEY" {
+			s = strings.TrimSpace(parts[1])
+		}
+	}
+	s = strings.Trim(s, "\"'")
+	if s == "" {
+		return nil, errors.New("cursor_agent: empty api key")
+	}
+	return &Credential{APIKey: s}, nil
+}
+
+// MarshalCredential returns the minimal channel credential envelope. Legacy
+// OAuth fields remain accepted for backward compatibility, but both model
+// execution and dashboard usage resolve from APIKey.
+func MarshalCredential(credential *Credential) (string, error) {
+	if credential == nil || strings.TrimSpace(credential.APIKey) == "" {
+		return "", errors.New("cursor_agent: credential missing api_key")
+	}
+	normalized := Credential{
+		APIKey:       strings.TrimSpace(credential.APIKey),
+		AccessToken:  strings.TrimSpace(credential.AccessToken),
+		RefreshToken: strings.TrimSpace(credential.RefreshToken),
+	}
+	data, err := common.Marshal(normalized)
+	if err != nil {
+		return "", fmt.Errorf("cursor_agent: marshal credential: %w", err)
+	}
+	return string(data), nil
+}
+
+// DefaultSidecarBaseURL is used when the channel has no base_url.
+// Override with env CURSOR_AGENT_SIDECAR_BASE_URL.
+// Default points at the official @cursor/sdk harness sidecar.
+func DefaultSidecarBaseURL() string {
+	if v := strings.TrimSpace(os.Getenv("CURSOR_AGENT_SIDECAR_BASE_URL")); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	return "http://127.0.0.1:3927"
+}
+
+// ResolveSidecarBaseURL makes the deployment-owned immutable runtime
+// authoritative when configured. Channel base_url remains the fallback for
+// local development and legacy installations that run a standalone sidecar.
+func ResolveSidecarBaseURL(channelBaseURL string) string {
+	if v := strings.TrimSpace(os.Getenv("CURSOR_AGENT_SIDECAR_BASE_URL")); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	if v := strings.TrimSpace(channelBaseURL); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	return DefaultSidecarBaseURL()
+}
+
+// sdkModelAliases normalizes common legacy/public spellings to the bare SKUs
+// returned by Cursor.models.list(). Unknown names pass through so a catalog
+// update does not require a new-api release.
+var sdkModelAliases = map[string]string{
+	"claude-sonnet-4.6":          "claude-sonnet-4-6",
+	"claude-4.6-sonnet":          "claude-sonnet-4-6",
+	"claude-4-6-sonnet":          "claude-sonnet-4-6",
+	"claude-sonnet-4-6-thinking": "claude-sonnet-4-6",
+	"claude-sonnet-4.5":          "claude-sonnet-4-5",
+	"claude-4.5-sonnet":          "claude-sonnet-4-5",
+	"claude-haiku-4.5":           "claude-haiku-4-5",
+	"claude-opus-4.8":            "claude-opus-4-8",
+	"claude-opus-4.7":            "claude-opus-4-7",
+	"claude-opus-4.6":            "claude-opus-4-6",
+	"claude-opus-4.5":            "claude-opus-4-5",
+}
+
+// NormalizeModel accepts bare Cursor/new-api SKUs and strips a legacy optional
+// prefix if present so old channel model lists still work.
+func NormalizeModel(model string) string {
+	m := strings.TrimSpace(model)
+	for _, p := range []string{"cursor-agent/", "cr/", "cursor/", "[cursor] "} {
+		lower := strings.ToLower(m)
+		if strings.HasPrefix(lower, p) {
+			m = strings.TrimSpace(m[len(p):])
+			break
+		}
+	}
+	// strip optional bracket form leftover: "[cursor] foo" already handled
+	m = strings.TrimSpace(m)
+	return m
+}
+
+// MapSDKModel keeps the official SDK on its canonical bare catalog SKU.
+func MapSDKModel(model string) string {
+	m := NormalizeModel(model)
+	if mapped, ok := sdkModelAliases[strings.ToLower(m)]; ok {
+		return mapped
+	}
+	return m
+}
+
+// MapSDKModelWithEffort carries Grok effort to the SDK sidecar in an internal
+// selector. All other models use Cursor's canonical bare SKU and catalog
+// defaults. The public response model remains unchanged.
+func MapSDKModelWithEffort(model, effort string) (string, error) {
+	m := MapSDKModel(model)
+	if m == "" {
+		return m, nil
+	}
+	normalizedEffort := normalizeReasoningEffort(effort)
+	switch strings.ToLower(m) {
+	case "grok-4.5":
+		if normalizedEffort == "" {
+			normalizedEffort = "medium"
+		}
+		if normalizedEffort == "xhigh" {
+			normalizedEffort = "high"
+		}
+		if normalizedEffort != "low" && normalizedEffort != "medium" && normalizedEffort != "high" {
+			return "", fmt.Errorf("cursor_agent: grok-4.5 does not support reasoning effort %q", effort)
+		}
+		return "cursor-grok-4.5-" + normalizedEffort, nil
+	case "grok-4.6":
+		if normalizedEffort == "" {
+			normalizedEffort = "medium"
+		}
+		if normalizedEffort != "low" && normalizedEffort != "medium" && normalizedEffort != "high" && normalizedEffort != "xhigh" {
+			return "", fmt.Errorf("cursor_agent: grok-4.6 does not support reasoning effort %q", effort)
+		}
+		return "cursor-grok-4.6-" + normalizedEffort, nil
+	}
+	return m, nil
+}
+
+func normalizeReasoningEffort(effort string) string {
+	switch strings.ToLower(strings.TrimSpace(effort)) {
+	case "", "none":
+		return ""
+	case "minimal":
+		return "low"
+	case "max":
+		return "xhigh"
+	default:
+		return strings.ToLower(strings.TrimSpace(effort))
+	}
+}

--- a/relay/channel/cursor_agent/key_test.go
+++ b/relay/channel/cursor_agent/key_test.go
@@ -1,0 +1,122 @@
+package cursor_agent
+
+import "testing"
+
+func TestParseCredentialRaw(t *testing.T) {
+	cred, err := ParseCredential("  crsr_abc123  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cred.APIKey != "crsr_abc123" {
+		t.Fatalf("got %q", cred.APIKey)
+	}
+}
+
+func TestParseCredentialJSON(t *testing.T) {
+	cred, err := ParseCredential(`{"api_key":"crsr_from_json"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cred.APIKey != "crsr_from_json" {
+		t.Fatalf("got %q", cred.APIKey)
+	}
+}
+
+func TestParseCredentialEnvForm(t *testing.T) {
+	cred, err := ParseCredential("CURSOR_API_KEY=crsr_env")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cred.APIKey != "crsr_env" {
+		t.Fatalf("got %q", cred.APIKey)
+	}
+}
+
+func TestNormalizeModel(t *testing.T) {
+	cases := map[string]string{
+		"composer-2.5":              "composer-2.5",
+		"claude-opus-5":             "claude-opus-5",
+		"claude-fable-5":            "claude-fable-5",
+		"default":                   "default",
+		"cursor-agent/composer-2.5": "composer-2.5",
+		"cr/composer-2":             "composer-2",
+		"CURSOR-AGENT/default":      "default",
+	}
+	for in, want := range cases {
+		if got := NormalizeModel(in); got != want {
+			t.Fatalf("NormalizeModel(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestDefaultSidecarBaseURLPointsOfficialSDKHarness(t *testing.T) {
+	t.Setenv("CURSOR_AGENT_SIDECAR_BASE_URL", "")
+	got := DefaultSidecarBaseURL()
+	if got != "http://127.0.0.1:3927" {
+		t.Fatalf("DefaultSidecarBaseURL=%q", got)
+	}
+}
+
+func TestParseCredentialPreservesOptionalOAuthTokens(t *testing.T) {
+	credential, err := ParseCredential(`{"api_key":"cursor-user-key","access_token":"access","refresh_token":"refresh"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if credential.APIKey != "cursor-user-key" || credential.AccessToken != "access" || credential.RefreshToken != "refresh" {
+		t.Fatalf("credential=%+v", credential)
+	}
+}
+
+func TestMarshalCredentialKeepsSDKAndDashboardCredentials(t *testing.T) {
+	raw, err := MarshalCredential(&Credential{APIKey: " cursor-user-key ", AccessToken: " access ", RefreshToken: " refresh "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	credential, err := ParseCredential(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if credential.APIKey != "cursor-user-key" || credential.AccessToken != "access" || credential.RefreshToken != "refresh" {
+		t.Fatalf("credential=%+v", credential)
+	}
+}
+
+func TestResolveSidecarBaseURLPrefersDeploymentRuntime(t *testing.T) {
+	t.Setenv("CURSOR_AGENT_SIDECAR_BASE_URL", "http://cursor-sdk-runtime:3927/")
+	if got := ResolveSidecarBaseURL("http://legacy-sidecar:3927"); got != "http://cursor-sdk-runtime:3927" {
+		t.Fatalf("ResolveSidecarBaseURL=%q", got)
+	}
+}
+
+func TestResolveSidecarBaseURLFallsBackToChannel(t *testing.T) {
+	t.Setenv("CURSOR_AGENT_SIDECAR_BASE_URL", "")
+	if got := ResolveSidecarBaseURL("http://legacy-sidecar:3927/"); got != "http://legacy-sidecar:3927" {
+		t.Fatalf("ResolveSidecarBaseURL=%q", got)
+	}
+}
+
+func TestMapSDKModelUsesBareCatalogSKUs(t *testing.T) {
+	for _, model := range ModelList {
+		if got := MapSDKModel(model); got != model {
+			t.Fatalf("MapSDKModel(%q)=%q want live catalog SKU unchanged", model, got)
+		}
+	}
+
+	cases := map[string]string{
+		"claude-opus-5":        "claude-opus-5",
+		"claude-fable-5":       "claude-fable-5",
+		"claude-sonnet-5":      "claude-sonnet-5",
+		"claude-opus-4.8":      "claude-opus-4-8",
+		"claude-sonnet-4.6":    "claude-sonnet-4-6",
+		"claude-haiku-4.5":     "claude-haiku-4-5",
+		"cursor-agent/gpt-5.4": "gpt-5.4",
+		"gpt-5.6-sol":          "gpt-5.6-sol",
+		"glm-5.2":              "glm-5.2",
+		"unknown-future-model": "unknown-future-model",
+	}
+	for in, want := range cases {
+		if got := MapSDKModel(in); got != want {
+			t.Fatalf("MapSDKModel(%q)=%q want %q", in, got, want)
+		}
+	}
+}

--- a/relay/channel/cursor_agent/response_model.go
+++ b/relay/channel/cursor_agent/response_model.go
@@ -1,0 +1,129 @@
+package cursor_agent
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+)
+
+// rewriteCursorResponseModel keeps Cursor's effort-qualified catalog IDs inside
+// the relay. Clients continue to see the stable public model they requested.
+func rewriteCursorResponseModel(resp *http.Response, info *relaycommon.RelayInfo) {
+	if resp == nil || resp.Body == nil || info == nil {
+		return
+	}
+	internal := strings.TrimSpace(info.UpstreamModelName)
+	public := strings.TrimSpace(info.OriginModelName)
+	if internal == "" || public == "" || (internal == public && !isPublicCursorEffortFamily(public)) {
+		return
+	}
+	resp.Body = &cursorModelRewriteBody{
+		source:   bufio.NewReader(resp.Body),
+		closer:   resp.Body,
+		internal: internal,
+		public:   public,
+	}
+	// Handlers synthesize some terminal/fallback events from RelayInfo.
+	info.UpstreamModelName = public
+}
+
+func isPublicCursorEffortFamily(public string) bool {
+	switch strings.ToLower(strings.TrimSpace(public)) {
+	case "grok-4.5", "grok-4.6":
+		return true
+	default:
+		return false
+	}
+}
+
+type cursorModelRewriteBody struct {
+	source   *bufio.Reader
+	closer   io.Closer
+	internal string
+	public   string
+	pending  *bytes.Reader
+	terminal error
+}
+
+func (r *cursorModelRewriteBody) Read(p []byte) (int, error) {
+	for {
+		if r.pending != nil && r.pending.Len() > 0 {
+			return r.pending.Read(p)
+		}
+		if r.terminal != nil {
+			return 0, r.terminal
+		}
+		line, err := r.source.ReadString('\n')
+		if err != nil {
+			r.terminal = err
+		}
+		if line == "" {
+			continue
+		}
+		r.pending = bytes.NewReader(rewriteCursorModelLine(line, r.internal, r.public))
+	}
+}
+
+func (r *cursorModelRewriteBody) Close() error {
+	return r.closer.Close()
+}
+
+func rewriteCursorModelLine(line, internal, public string) []byte {
+	suffix := ""
+	payload := line
+	if strings.HasSuffix(payload, "\r\n") {
+		suffix = "\r\n"
+		payload = strings.TrimSuffix(payload, suffix)
+	} else if strings.HasSuffix(payload, "\n") {
+		suffix = "\n"
+		payload = strings.TrimSuffix(payload, suffix)
+	}
+	prefix := ""
+	if strings.HasPrefix(payload, "data: ") {
+		prefix = "data: "
+		payload = strings.TrimPrefix(payload, prefix)
+	}
+	if payload == "" || payload == "[DONE]" {
+		return []byte(prefix + payload + suffix)
+	}
+
+	var root map[string]any
+	if err := common.Unmarshal([]byte(payload), &root); err != nil {
+		return []byte(line)
+	}
+	rewriteModelField(root, internal, public)
+	for _, key := range []string{"message", "response"} {
+		if nested, ok := root[key].(map[string]any); ok {
+			rewriteModelField(nested, internal, public)
+		}
+	}
+	rewritten, err := common.Marshal(root)
+	if err != nil {
+		return []byte(line)
+	}
+	return []byte(prefix + string(rewritten) + suffix)
+}
+
+func rewriteModelField(value map[string]any, internal, public string) {
+	if model, ok := value["model"].(string); ok {
+		if model == internal || isCursorEffortVariant(model, public) {
+			value["model"] = public
+		}
+	}
+}
+
+func isCursorEffortVariant(model, public string) bool {
+	switch strings.ToLower(strings.TrimSpace(public)) {
+	case "grok-4.5":
+		return strings.HasPrefix(strings.ToLower(model), "cursor-grok-4.5-")
+	case "grok-4.6":
+		return strings.HasPrefix(strings.ToLower(model), "cursor-grok-4.6-")
+	default:
+		return false
+	}
+}

--- a/relay/channel/cursor_agent/response_model_test.go
+++ b/relay/channel/cursor_agent/response_model_test.go
@@ -1,0 +1,78 @@
+package cursor_agent
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+)
+
+func TestRewriteCursorResponseModelHidesInternalCatalogID(t *testing.T) {
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(
+		"event: message_start\n" +
+			`data: {"type":"message_start","message":{"model":"cursor-grok-4.6-high","content":[]}}` + "\n\n" +
+			`data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"cursor-grok-4.6-high stays in content"}}` + "\n",
+	))}
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "grok-4.6",
+		ChannelMeta:     &relaycommon.ChannelMeta{UpstreamModelName: "cursor-grok-4.6-high"},
+	}
+
+	rewriteCursorResponseModel(resp, info)
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	if !strings.Contains(body, `"model":"grok-4.6"`) {
+		t.Fatalf("public model missing: %s", body)
+	}
+	if !strings.Contains(body, "cursor-grok-4.6-high stays in content") {
+		t.Fatalf("content was unexpectedly rewritten: %s", body)
+	}
+	if info.UpstreamModelName != "grok-4.6" {
+		t.Fatalf("handler fallback model=%q", info.UpstreamModelName)
+	}
+}
+
+func TestRewriteCursorResponseModelHandlesResponsesJSON(t *testing.T) {
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(
+		`{"id":"resp_1","model":"cursor-grok-4.5-medium","output":[]}`,
+	))}
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "grok-4.5",
+		ChannelMeta:     &relaycommon.ChannelMeta{UpstreamModelName: "cursor-grok-4.5-medium"},
+	}
+	rewriteCursorResponseModel(resp, info)
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"model":"grok-4.5"`) {
+		t.Fatalf("rewritten response=%s", raw)
+	}
+}
+
+func TestRewriteCursorResponseModelHidesEffortVariantAfterHandlerReset(t *testing.T) {
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(
+		`data: {"model":"cursor-grok-4.6-high","choices":[{"delta":{"tool_calls":[]}}]}` + "\n",
+	))}
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "grok-4.6",
+		ChannelMeta:     &relaycommon.ChannelMeta{UpstreamModelName: "grok-4.6"},
+	}
+	rewriteCursorResponseModel(resp, info)
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(raw)
+	if strings.Contains(got, "cursor-grok-4.6-high") {
+		t.Fatalf("internal effort model leaked: %s", got)
+	}
+	if !strings.Contains(got, `"model":"grok-4.6"`) {
+		t.Fatalf("public model missing: %s", got)
+	}
+}

--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,7 +11,9 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/logger"
+	"github.com/QuantumNous/new-api/relay/channel"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/QuantumNous/new-api/relaykit/types"
@@ -24,6 +27,9 @@ import (
 func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
 
 	info.InitChannelMeta(c)
+	if info.RelayMode == relayconstant.RelayModeClaudeCountTokens {
+		return ClaudeCountTokensHelper(c, info)
+	}
 
 	claudeReq, ok := info.Request.(*dto.ClaudeRequest)
 
@@ -227,4 +233,99 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 
 	service.PostTextConsumeQuota(c, info, usage.(*dto.Usage), nil)
 	return nil
+}
+
+// ClaudeCountTokensHelper provides the Anthropic token-counting contract used
+// by Claude Code. The Cursor SDK has no count_tokens primitive, so counting is
+// intentionally local and does not create an agent run or consume quota.
+func ClaudeCountTokensHelper(c *gin.Context, info *relaycommon.RelayInfo) *types.NewAPIError {
+	claudeReq, ok := info.Request.(*dto.ClaudeRequest)
+	if !ok {
+		return types.NewErrorWithStatusCode(fmt.Errorf("invalid request type, expected *dto.ClaudeRequest, got %T", info.Request), types.ErrorCodeInvalidRequest, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+	}
+	request, err := common.DeepCopy(claudeReq)
+	if err != nil {
+		return types.NewError(fmt.Errorf("failed to copy request to ClaudeRequest: %w", err), types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
+	}
+	if err = helper.ModelMappedHelper(c, info, request); err != nil {
+		return types.NewError(err, types.ErrorCodeChannelModelMappedError, types.ErrOptionWithSkipRetry())
+	}
+	if info.ChannelType == constant.ChannelTypeCursorAgent {
+		meta := request.GetTokenCountMeta()
+		inputTokens := service.CountTextToken(meta.CombineText, info.OriginModelName)
+		for range meta.Files {
+			// Claude image token accounting is approximate in local mode; match the
+			// existing non-OpenAI media estimate without fetching remote URLs.
+			inputTokens += 520
+		}
+		common.SetContextKey(c, constant.ContextKeyLocalCountTokens, true)
+		common.SetContextKey(c, constant.ContextKeyPromptTokens, inputTokens)
+		c.JSON(http.StatusOK, gin.H{"input_tokens": inputTokens})
+		return nil
+	}
+
+	adaptor := GetAdaptor(info.ApiType)
+	if adaptor == nil {
+		return types.NewError(fmt.Errorf("invalid api type: %d", info.ApiType), types.ErrorCodeInvalidApiType, types.ErrOptionWithSkipRetry())
+	}
+	adaptor.Init(info)
+	requestBody, err := buildClaudeCountTokensRequestBody(c, info, adaptor, request)
+	if err != nil {
+		return types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
+	}
+	resp, err := adaptor.DoRequest(c, info, requestBody)
+	if err != nil {
+		return types.NewOpenAIError(err, types.ErrorCodeDoRequestFailed, http.StatusInternalServerError)
+	}
+	httpResp, ok := resp.(*http.Response)
+	if !ok || httpResp == nil {
+		return types.NewError(fmt.Errorf("invalid response type, expected *http.Response, got %T", resp), types.ErrorCodeBadResponse, types.ErrOptionWithSkipRetry())
+	}
+	defer httpResp.Body.Close()
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return types.NewErrorWithStatusCode(err, types.ErrorCodeReadResponseBodyFailed, http.StatusBadGateway, types.ErrOptionWithSkipRetry())
+	}
+	copyClaudeCountTokensResponseHeaders(c.Writer.Header(), httpResp.Header)
+	contentType := strings.TrimSpace(httpResp.Header.Get("Content-Type"))
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	c.Data(httpResp.StatusCode, contentType, respBody)
+	return nil
+}
+
+func buildClaudeCountTokensRequestBody(c *gin.Context, info *relaycommon.RelayInfo, adaptor channel.Adaptor, request *dto.ClaudeRequest) (io.Reader, error) {
+	if model_setting.GetGlobalSettings().PassThroughRequestEnabled || info.ChannelSetting.PassThroughBodyEnabled {
+		storage, err := common.GetBodyStorage(c)
+		if err != nil {
+			return nil, err
+		}
+		rawBody, err := storage.Bytes()
+		if err != nil {
+			return nil, err
+		}
+		return bytes.NewReader(helper.SanitizeClaudeCountTokensRequestBody(rawBody)), nil
+	}
+	convertedRequest, err := adaptor.ConvertClaudeRequest(c, info, request)
+	if err != nil {
+		return nil, err
+	}
+	jsonData, err := common.Marshal(convertedRequest)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(helper.SanitizeClaudeCountTokensRequestBody(jsonData)), nil
+}
+
+func copyClaudeCountTokensResponseHeaders(dst http.Header, src http.Header) {
+	for key, values := range src {
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "content-length", "content-encoding", "connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade", "set-cookie", "www-authenticate", "authorization", "x-api-key", "x-goog-api-key":
+			continue
+		}
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
 }

--- a/relay/claude_handler_test.go
+++ b/relay/claude_handler_test.go
@@ -1,0 +1,53 @@
+package relay
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/types"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestClaudeCountTokensEstimatesLocallyForCursorHarness(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	context.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", nil)
+	common.SetContextKey(context, constant.ContextKeyOriginalModel, "claude-sonnet-4-6")
+
+	request := &dto.ClaudeRequest{
+		Model:  "claude-sonnet-4-6",
+		System: "You are Claude Code.",
+		Messages: []dto.ClaudeMessage{
+			{Role: "user", Content: "Count this request without contacting the SDK sidecar."},
+		},
+	}
+	info := &relaycommon.RelayInfo{
+		RelayMode:       relayconstant.RelayModeClaudeCountTokens,
+		RelayFormat:     types.RelayFormatClaude,
+		OriginModelName: "claude-sonnet-4-6",
+		Request:         request,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelId:         61,
+			ChannelType:       constant.ChannelTypeCursorAgent,
+			ApiType:           constant.APITypeCursorAgent,
+			ChannelBaseUrl:    "http://127.0.0.1:3927",
+			UpstreamModelName: "claude-sonnet-4-6",
+		},
+	}
+
+	apiErr := ClaudeCountTokensHelper(context, info)
+
+	require.Nil(t, apiErr)
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Greater(t, gjson.Get(recorder.Body.String(), "input_tokens").Int(), int64(0))
+	require.True(t, common.GetContextKeyBool(context, constant.ContextKeyLocalCountTokens))
+}

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -345,6 +345,7 @@ var streamSupportedChannels = map[int]bool{
 	constant.ChannelTypeAdvancedCustom: true,
 	constant.ChannelTypeSub2API:        true,
 	constant.ChannelTypeNewAPI:         true,
+	constant.ChannelTypeCursorAgent:    true,
 	constant.ChannelTypeTencent:        true,
 }
 

--- a/relay/constant/relay_mode.go
+++ b/relay/constant/relay_mode.go
@@ -53,6 +53,8 @@ const (
 
 	RelayModeResponsesCompact
 
+	RelayModeClaudeCountTokens
+
 	RelayModeAlphaSearch
 )
 
@@ -78,6 +80,8 @@ func Path2RelayMode(path string) int {
 		relayMode = RelayModeResponsesCompact
 	} else if strings.HasPrefix(path, "/v1/responses") {
 		relayMode = RelayModeResponses
+	} else if strings.HasPrefix(path, "/v1/messages/count_tokens") {
+		relayMode = RelayModeClaudeCountTokens
 	} else if strings.HasPrefix(path, "/v1/alpha/search") {
 		relayMode = RelayModeAlphaSearch
 	} else if strings.HasPrefix(path, "/v1/audio/speech") {

--- a/relay/constant/relay_mode_test.go
+++ b/relay/constant/relay_mode_test.go
@@ -13,6 +13,8 @@ func TestPath2RelayMode(t *testing.T) {
 	}{
 		{path: "/v1/alpha/search", want: RelayModeAlphaSearch},
 		{path: "/v1/alpha/search?foo=1", want: RelayModeAlphaSearch},
+		{path: "/v1/messages/count_tokens", want: RelayModeClaudeCountTokens},
+		{path: "/v1/messages/count_tokens?beta=true", want: RelayModeClaudeCountTokens},
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {

--- a/relay/helper/claude_count_tokens.go
+++ b/relay/helper/claude_count_tokens.go
@@ -1,0 +1,33 @@
+package helper
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+func SanitizeClaudeCountTokensRequestBody(body []byte) []byte {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return body
+	}
+	var payload map[string]json.RawMessage
+	if err := common.Unmarshal(body, &payload); err != nil {
+		return body
+	}
+	changed := false
+	for _, field := range []string{"temperature", "top_p", "top_k", "stream", "stop_sequences", "stop"} {
+		if _, ok := payload[field]; ok {
+			delete(payload, field)
+			changed = true
+		}
+	}
+	if !changed {
+		return body
+	}
+	next, err := common.Marshal(payload)
+	if err != nil {
+		return body
+	}
+	return next
+}

--- a/relay/relay_adaptor.go
+++ b/relay/relay_adaptor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/QuantumNous/new-api/relay/channel/codex"
 	"github.com/QuantumNous/new-api/relay/channel/cohere"
 	"github.com/QuantumNous/new-api/relay/channel/coze"
+	"github.com/QuantumNous/new-api/relay/channel/cursor_agent"
 	"github.com/QuantumNous/new-api/relay/channel/deepseek"
 	"github.com/QuantumNous/new-api/relay/channel/dify"
 	"github.com/QuantumNous/new-api/relay/channel/gemini"
@@ -129,6 +130,8 @@ func GetAdaptor(apiType int) channel.Adaptor {
 		return &sub2api.Adaptor{}
 	case constant.APITypeNewAPI:
 		return &newapi.Adaptor{}
+	case constant.APITypeCursorAgent:
+		return &cursor_agent.Adaptor{}
 	}
 	return nil
 }

--- a/relaykit/dto/openai_response.go
+++ b/relaykit/dto/openai_response.go
@@ -243,6 +243,8 @@ type Usage struct {
 	Cost any `json:"cost,omitempty"`
 }
 
+const UsageSourceCursorHarnessDeferred = "cursor_harness_deferred"
+
 type OpenAIVideoResponse struct {
 	Id        string `json:"id" example:"file-abc123"`
 	Object    string `json:"object" example:"file"`
@@ -325,17 +327,18 @@ type IncompleteDetails struct {
 }
 
 type ResponsesOutput struct {
-	Type      string                   `json:"type"`
-	ID        string                   `json:"id"`
-	Status    string                   `json:"status"`
-	Role      string                   `json:"role"`
-	Content   []ResponsesOutputContent `json:"content"`
-	Quality   string                   `json:"quality"`
-	Size      string                   `json:"size"`
-	Result    string                   `json:"result,omitempty"`
-	CallId    string                   `json:"call_id,omitempty"`
-	Name      string                   `json:"name,omitempty"`
-	Arguments json.RawMessage          `json:"arguments,omitempty"`
+	Type      string                          `json:"type"`
+	ID        string                          `json:"id"`
+	Status    string                          `json:"status"`
+	Role      string                          `json:"role"`
+	Content   []ResponsesOutputContent        `json:"content"`
+	Quality   string                          `json:"quality"`
+	Size      string                          `json:"size"`
+	Result    string                          `json:"result,omitempty"`
+	CallId    string                          `json:"call_id,omitempty"`
+	Name      string                          `json:"name,omitempty"`
+	Arguments json.RawMessage                 `json:"arguments,omitempty"`
+	Summary   []ResponsesReasoningSummaryPart `json:"summary,omitempty"`
 }
 
 // ArgumentsString returns function call arguments in the string form expected by Chat Completions.

--- a/relaykit/relayconvert/internal/claude_messages/to_oai_chat_resp.go
+++ b/relaykit/relayconvert/internal/claude_messages/to_oai_chat_resp.go
@@ -19,6 +19,7 @@ type ClaudeResponseInfo struct {
 	ResponseText strings.Builder
 	Usage        *dto.Usage
 	Done         bool
+	HasToolUse   bool
 }
 
 func StopReasonClaudeToOpenAI(reason string) string {
@@ -388,6 +389,9 @@ func FormatClaudeResponseInfo(claudeResponse *dto.ClaudeResponse, oaiResponse *d
 
 		claudeInfo.Done = true
 	} else if claudeResponse.Type == "content_block_start" {
+		if claudeResponse.ContentBlock != nil && claudeResponse.ContentBlock.Type == "tool_use" {
+			claudeInfo.HasToolUse = true
+		}
 	} else {
 		return false
 	}

--- a/router/channel-router.go
+++ b/router/channel-router.go
@@ -62,6 +62,7 @@ var channelPermissionRoutes = []permissionRoute{
 	{method: http.MethodPost, path: "/fetch_models", permission: authz.ChannelSensitiveWrite, handler: controller.FetchModels},
 	{method: http.MethodPost, path: "/:id/codex/refresh", permission: authz.ChannelSensitiveWrite, handler: controller.RefreshCodexChannelCredential},
 	{method: http.MethodGet, path: "/:id/codex/usage", permission: authz.ChannelRead, handler: controller.GetCodexChannelUsage},
+	{method: http.MethodGet, path: "/:id/cursor-agent/account", permission: authz.ChannelRead, handler: controller.GetCursorAgentChannelAccount},
 	{method: http.MethodGet, path: "/:id/codex/usage/reset-credits", permission: authz.ChannelRead, handler: controller.GetCodexChannelRateLimitResetCredits},
 	{method: http.MethodPost, path: "/:id/codex/usage/reset", permission: authz.ChannelOperate, handler: controller.ResetCodexChannelUsage},
 	{method: http.MethodPost, path: "/ollama/pull", permission: authz.ChannelSensitiveWrite, handler: controller.OllamaPullModel},

--- a/router/relay-router.go
+++ b/router/relay-router.go
@@ -85,6 +85,9 @@ func SetRelayRouter(router *gin.Engine) {
 		httpRouter.Use(middleware.Distribute())
 
 		// claude related routes
+		httpRouter.POST("/messages/count_tokens", func(c *gin.Context) {
+			controller.Relay(c, types.RelayFormatClaude)
+		})
 		httpRouter.POST("/messages", func(c *gin.Context) {
 			controller.Relay(c, types.RelayFormatClaude)
 		})

--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -395,6 +395,37 @@ func usageSemanticFromUsage(relayInfo *relaycommon.RelayInfo, usage *dto.Usage) 
 }
 
 func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, usage *dto.Usage, extraContent []string) {
+	if usage != nil && usage.UsageSource == dto.UsageSourceCursorHarnessDeferred {
+		// A Cursor SDK run spans multiple HTTP requests while client tools execute.
+		// Intermediate tool_use responses do not carry the run's authoritative
+		// cumulative usage. Refund the pre-consumption now; the final continuation
+		// settles once with the SDK's terminal usage snapshot.
+		if err := SettleBilling(ctx, relayInfo, 0); err != nil {
+			logger.LogError(ctx, "error settling deferred Cursor harness billing: "+err.Error())
+		}
+		// Keep an auditable zero-quota marker for abandoned tool loops and crash
+		// recovery. The terminal SDK snapshot remains the only billable record.
+		other := map[string]interface{}{
+			"usage_source":     string(dto.UsageSourceCursorHarnessDeferred),
+			"billing_deferred": true,
+			"billing_reason":   "cursor_sdk_run_awaiting_tool_result",
+		}
+		model.RecordConsumeLog(ctx, relayInfo.UserId, model.RecordConsumeLogParams{
+			ChannelId:        relayInfo.ChannelId,
+			PromptTokens:     usage.PromptTokens,
+			CompletionTokens: usage.CompletionTokens,
+			ModelName:        relayInfo.OriginModelName,
+			TokenName:        ctx.GetString("token_name"),
+			Quota:            0,
+			Content:          "Cursor SDK run awaiting tool_result; billing deferred to terminal usage",
+			TokenId:          relayInfo.TokenId,
+			UseTimeSeconds:   int(time.Since(relayInfo.StartTime).Seconds()),
+			IsStream:         relayInfo.IsStream,
+			Group:            relayInfo.UsingGroup,
+			Other:            other,
+		})
+		return
+	}
 	originUsage := usage
 	billingUsage := effectiveBillingUsage(usage)
 	if usage == nil {

--- a/service/text_quota_test.go
+++ b/service/text_quota_test.go
@@ -2,12 +2,14 @@ package service
 
 import (
 	"math"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/pkg/billingexpr"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
@@ -21,6 +23,32 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPostTextConsumeQuotaRecordsZeroQuotaDeferredCursorHarnessAudit(t *testing.T) {
+	truncate(t)
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Set("request_id", "req-cursor-tool-continuation")
+	c.Set("token_name", "cursor-test")
+	now := time.Now()
+	relayInfo := &relaycommon.RelayInfo{
+		UserId: 42, TokenId: 7, OriginModelName: "grok-4.6",
+		StartTime: now, FirstResponseTime: now,
+		ChannelMeta: &relaycommon.ChannelMeta{ChannelType: constant.ChannelTypeCursorAgent, ChannelId: 252},
+	}
+
+	PostTextConsumeQuota(c, relayInfo, &dto.Usage{
+		UsageSemantic: "anthropic",
+		UsageSource:   dto.UsageSourceCursorHarnessDeferred,
+	}, nil)
+
+	var log model.Log
+	require.NoError(t, model.LOG_DB.
+		Where("channel_id = ? AND model_name = ?", 252, "grok-4.6").First(&log).Error)
+	require.Zero(t, log.Quota)
+	require.Contains(t, log.Other, "billing_deferred")
+}
 
 func TestCalculateTextQuotaSummaryUnifiedForClaudeSemantic(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/web/src/features/channels/api.ts
+++ b/web/src/features/channels/api.ts
@@ -332,6 +332,16 @@ export async function getCodexUsage(
   return res.data
 }
 
+export async function getCursorAgentAccount(
+  channelId: number
+): Promise<CodexUsageResponse> {
+  const res = await api.get(
+    `/api/channel/${channelId}/cursor-agent/account`,
+    channelActionConfig({ disableDuplicate: true })
+  )
+  return res.data
+}
+
 export async function getCodexResetCredits(
   channelId: number
 ): Promise<CodexResetCreditsResponse> {

--- a/web/src/features/channels/components/channels-columns.tsx
+++ b/web/src/features/channels/components/channels-columns.tsx
@@ -55,7 +55,7 @@ import {
 import { formatTimestampToDate } from '@/lib/format'
 import { truncateText } from '@/lib/utils'
 
-import { getCodexUsage } from '../api'
+import { getCodexUsage, getCursorAgentAccount } from '../api'
 import { CHANNEL_STATUS_CONFIG, MODEL_FETCHABLE_TYPES } from '../constants'
 import {
   formatRelativeTime,
@@ -85,6 +85,7 @@ import {
   CodexUsageDialog,
   type CodexUsageDialogData,
 } from './dialogs/codex-usage-dialog'
+import { CursorAccountDialog } from './dialogs/cursor-account-dialog'
 import { NumericSpinnerInput } from './numeric-spinner-input'
 
 function parseIonetMeta(otherInfo: string | null | undefined): null | {
@@ -424,9 +425,12 @@ function BalanceCell({ channel }: { channel: Channel }) {
     }
 
     setIsUpdating(true)
-    if (channel.type === 57) {
+    if (channel.type === 57 || channel.type === 61) {
       try {
-        const res = await getCodexUsage(channel.id)
+        const res =
+          channel.type === 61
+            ? await getCursorAgentAccount(channel.id)
+            : await getCodexUsage(channel.id)
         if (!res.success) {
           throw new Error(res.message || t('Failed to fetch usage'))
         }
@@ -448,17 +452,20 @@ function BalanceCell({ channel }: { channel: Channel }) {
   let remainingBadgeLabel = sensitiveVisible ? remainingDisplay : SENSITIVE_MASK
   if (sensitiveVisible && isUpdating) {
     remainingBadgeLabel = t('Updating...')
-  } else if (sensitiveVisible && channel.type === 57) {
+  } else if (sensitiveVisible && (channel.type === 57 || channel.type === 61)) {
     remainingBadgeLabel = t('Account Info')
   }
   let remainingTooltipLabel = remainingLabel
   if (!sensitiveVisible) {
     remainingTooltipLabel = maskedRemainingLabel
-  } else if (channel.type === 57) {
-    remainingTooltipLabel = t('Click to view Codex usage')
+  } else if (channel.type === 57 || channel.type === 61) {
+    remainingTooltipLabel =
+      channel.type === 61
+        ? t('Click to view Cursor account')
+        : t('Click to view Codex usage')
   }
   let remainingBadgeVariant: StatusBadgeProps['variant'] = variant
-  if (channel.type === 57) {
+  if (channel.type === 57 || channel.type === 61) {
     remainingBadgeVariant = 'info'
   } else if (isUpdating) {
     remainingBadgeVariant = 'neutral'
@@ -500,42 +507,73 @@ function BalanceCell({ channel }: { channel: Channel }) {
           />
           <TooltipContent>
             <p>{remainingTooltipLabel}</p>
-            {channel.type !== 57 && <p>{t('Click to update balance')}</p>}
+            {channel.type !== 57 && channel.type !== 61 && (
+              <p>{t('Click to update balance')}</p>
+            )}
           </TooltipContent>
         </Tooltip>
       </div>
 
-      <CodexUsageDialog
-        open={codexUsageOpen}
-        onOpenChange={setCodexUsageOpen}
-        channelName={channel.name}
-        channelId={channel.id}
-        channelDisplayName={sensitiveVisible ? undefined : SENSITIVE_MASK}
-        channelDisplayId={sensitiveVisible ? undefined : SENSITIVE_MASK}
-        response={codexUsageResponse}
-        onRefresh={async () => {
-          if (isUpdating) {
-            return
-          }
-          setIsUpdating(true)
-          try {
-            const res = await getCodexUsage(channel.id)
-            if (!res.success) {
-              throw new Error(res.message || t('Failed to fetch usage'))
+      {channel.type === 61 ? (
+        <CursorAccountDialog
+          open={codexUsageOpen}
+          onOpenChange={setCodexUsageOpen}
+          channelName={channel.name}
+          response={codexUsageResponse}
+          onRefresh={async () => {
+            if (isUpdating) return
+            setIsUpdating(true)
+            try {
+              const res = await getCursorAgentAccount(channel.id)
+              if (!res.success) {
+                throw new Error(res.message || t('Failed to fetch usage'))
+              }
+              setCodexUsageResponse(res)
+            } catch (error) {
+              toast.error(
+                error instanceof Error
+                  ? error.message
+                  : t('Failed to fetch usage')
+              )
+            } finally {
+              setIsUpdating(false)
             }
-            setCodexUsageResponse(res)
-          } catch (error) {
-            toast.error(
-              error instanceof Error
-                ? error.message
-                : t('Failed to fetch usage')
-            )
-          } finally {
-            setIsUpdating(false)
-          }
-        }}
-        isRefreshing={isUpdating}
-      />
+          }}
+          isRefreshing={isUpdating}
+        />
+      ) : (
+        <CodexUsageDialog
+          open={codexUsageOpen}
+          onOpenChange={setCodexUsageOpen}
+          channelName={channel.name}
+          channelId={channel.id}
+          channelDisplayName={sensitiveVisible ? undefined : SENSITIVE_MASK}
+          channelDisplayId={sensitiveVisible ? undefined : SENSITIVE_MASK}
+          response={codexUsageResponse}
+          onRefresh={async () => {
+            if (isUpdating) {
+              return
+            }
+            setIsUpdating(true)
+            try {
+              const res = await getCodexUsage(channel.id)
+              if (!res.success) {
+                throw new Error(res.message || t('Failed to fetch usage'))
+              }
+              setCodexUsageResponse(res)
+            } catch (error) {
+              toast.error(
+                error instanceof Error
+                  ? error.message
+                  : t('Failed to fetch usage')
+              )
+            } finally {
+              setIsUpdating(false)
+            }
+          }}
+          isRefreshing={isUpdating}
+        />
+      )}
     </TooltipProvider>
   )
 }

--- a/web/src/features/channels/components/dialogs/cursor-account-dialog.tsx
+++ b/web/src/features/channels/components/dialogs/cursor-account-dialog.tsx
@@ -1,0 +1,128 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+*/
+import { RefreshCw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Dialog } from '@/components/dialog'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Progress } from '@/components/ui/progress'
+
+import type { CodexUsageDialogData } from './codex-usage-dialog'
+
+type CursorAccountDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  channelName?: string
+  response: CodexUsageDialogData | null
+  onRefresh: () => void | Promise<void>
+  isRefreshing?: boolean
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function text(value: unknown): string {
+  return value == null || value === '' ? '-' : String(value)
+}
+
+function money(value: unknown): string {
+  const amount = Number(value)
+  return Number.isFinite(amount) ? `$${amount.toFixed(2)}` : '-'
+}
+
+export function CursorAccountDialog({
+  open,
+  onOpenChange,
+  channelName,
+  response,
+  onRefresh,
+  isRefreshing,
+}: CursorAccountDialogProps) {
+  const { t } = useTranslation()
+  const data = record(response?.data)
+  const account = record(data.account)
+  const quota = record(data.quota)
+  const catalog = record(data.catalog)
+  const usedPercent = Math.max(
+    0,
+    Math.min(100, Number(quota.used_percent) || 0)
+  )
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t('Cursor Account Info')}
+      description={channelName}
+      contentHeight='auto'
+      bodyClassName='space-y-4'
+      footer={
+        <Button onClick={onRefresh} disabled={isRefreshing}>
+          <RefreshCw className={isRefreshing ? 'animate-spin' : ''} />
+          {t('Refresh')}
+        </Button>
+      }
+    >
+      <div className='grid gap-3 md:grid-cols-2'>
+        <Card size='sm'>
+          <CardHeader>
+            <CardTitle>{t('Account Info')}</CardTitle>
+          </CardHeader>
+          <CardContent className='space-y-1 text-sm'>
+            <p>
+              {t('Email')}: {text(account.email)}
+            </p>
+            <p>
+              {t('Account Type')}: {text(account.account_kind)}
+            </p>
+            <p>
+              {t('API Key Name')}: {text(account.api_key_name)}
+            </p>
+            <p>
+              {t('Available Models')}: {text(catalog.model_count)}
+            </p>
+          </CardContent>
+        </Card>
+        <Card size='sm'>
+          <CardHeader>
+            <CardTitle>{t('Quota Usage')}</CardTitle>
+          </CardHeader>
+          <CardContent className='space-y-2 text-sm'>
+            {quota.available === true ? (
+              <>
+                <p>
+                  {t('Plan')}: {text(quota.plan_name)}
+                </p>
+                <Progress value={usedPercent} />
+                <p>
+                  {money(quota.used_usd)} / {money(quota.limit_usd)} (
+                  {usedPercent.toFixed(1)}%)
+                </p>
+                <p>
+                  {t('Remaining')}: {money(quota.remaining_usd)}
+                </p>
+                <p>
+                  {t('Billing Cycle End')}: {text(quota.billing_cycle_end)}
+                </p>
+              </>
+            ) : (
+              <p>
+                {t('Quota details are unavailable')}: {text(quota.reason)}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </Dialog>
+  )
+}

--- a/web/src/features/channels/constants.ts
+++ b/web/src/features/channels/constants.ts
@@ -22,6 +22,7 @@ For commercial licensing, please contact support@quantumnous.com
 // ============================================================================
 
 export const CHANNEL_TYPE_NEW_API = 60
+export const CHANNEL_TYPE_CURSOR_AGENT = 61
 
 export const CHANNEL_TYPES = {
   0: 'Unknown',
@@ -81,12 +82,13 @@ export const CHANNEL_TYPES = {
   58: 'Advanced Custom',
   59: 'Sub2API',
   60: 'New API',
+  61: 'Cursor Agent',
 } as const
 
 const CHANNEL_TYPE_DISPLAY_ORDER: number[] = [
-  1, 14, 33, 24, 43, 3, 41, 48, 60, 58, 42, 34, 20, 4, 40, 27, 25, 17, 26, 15,
-  46, 23, 18, 45, 31, 35, 49, 19, 47, 37, 38, 39, 11, 8, 57, 59, 22, 21, 44, 2,
-  5, 36, 50, 51, 52, 53, 54, 55, 56,
+  1, 14, 61, 33, 24, 43, 3, 41, 48, 60, 58, 42, 34, 20, 4, 40, 27, 25, 17, 26,
+  15, 46, 23, 18, 45, 31, 35, 49, 19, 47, 37, 38, 39, 11, 8, 57, 59, 22, 21, 44,
+  2, 5, 36, 50, 51, 52, 53, 54, 55, 56,
 ]
 
 export const CHANNEL_TYPE_OPTIONS: { value: number; label: string }[] = (() => {
@@ -389,7 +391,7 @@ export const FIELD_DESCRIPTIONS = {
 
 export const MODEL_FETCHABLE_TYPES = new Set([
   1, 4, 14, 17, 20, 23, 24, 25, 26, 27, 31, 34, 35, 40, 42, 43, 47, 48, 57, 58,
-  59, 60,
+  59, 60, 61,
 ])
 
 export const FIELD_PASSTHROUGH_TYPES = new Set([
@@ -399,6 +401,7 @@ export const FIELD_PASSTHROUGH_TYPES = new Set([
   58,
   59,
   CHANNEL_TYPE_NEW_API,
+  CHANNEL_TYPE_CURSOR_AGENT,
 ])
 
 export const OPENAI_FIELD_PASSTHROUGH_TYPES = new Set([
@@ -407,6 +410,7 @@ export const OPENAI_FIELD_PASSTHROUGH_TYPES = new Set([
   58,
   59,
   CHANNEL_TYPE_NEW_API,
+  CHANNEL_TYPE_CURSOR_AGENT,
 ])
 
 export const CLAUDE_FIELD_PASSTHROUGH_TYPES = new Set([
@@ -414,6 +418,7 @@ export const CLAUDE_FIELD_PASSTHROUGH_TYPES = new Set([
   58,
   59,
   CHANNEL_TYPE_NEW_API,
+  CHANNEL_TYPE_CURSOR_AGENT,
 ])
 
 export const TYPE_TO_KEY_PROMPT: Record<number, string> = {
@@ -427,6 +432,7 @@ export const TYPE_TO_KEY_PROMPT: Record<number, string> = {
   57: 'Paste Codex OAuth JSON credential (access_token / refresh_token / account_id)',
   59: 'Enter API key for this channel',
   60: 'Enter API key for this channel',
+  61: 'Enter Cursor User API Key (dashboard API key)',
 }
 
 export const CHANNEL_TYPE_WARNINGS: Record<number, string> = {

--- a/web/src/features/channels/lib/__tests__/cursor-agent-channel.test.ts
+++ b/web/src/features/channels/lib/__tests__/cursor-agent-channel.test.ts
@@ -1,0 +1,50 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { describe, expect, test } from 'vitest'
+
+import {
+  CHANNEL_TYPE_CURSOR_AGENT,
+  CHANNEL_TYPE_OPTIONS,
+  CLAUDE_FIELD_PASSTHROUGH_TYPES,
+  MODEL_FETCHABLE_TYPES,
+} from '../../constants'
+import { getChannelTypeConfig } from '../channel-type-config'
+import { getChannelTypeIcon, getKeyPromptForType } from '../channel-utils'
+
+describe('Cursor Agent channel', () => {
+  test('registers the official SDK channel and its Claude-compatible surface', () => {
+    expect(
+      CHANNEL_TYPE_OPTIONS.find(
+        (item) => item.value === CHANNEL_TYPE_CURSOR_AGENT
+      )
+    ).toEqual({ value: CHANNEL_TYPE_CURSOR_AGENT, label: 'Cursor Agent' })
+    expect(MODEL_FETCHABLE_TYPES.has(CHANNEL_TYPE_CURSOR_AGENT)).toBe(true)
+    expect(CLAUDE_FIELD_PASSTHROUGH_TYPES.has(CHANNEL_TYPE_CURSOR_AGENT)).toBe(
+      true
+    )
+    expect(getChannelTypeIcon(CHANNEL_TYPE_CURSOR_AGENT)).toBe('Claude')
+    expect(getKeyPromptForType(CHANNEL_TYPE_CURSOR_AGENT)).toContain(
+      'Cursor User API Key'
+    )
+    expect(getChannelTypeConfig(CHANNEL_TYPE_CURSOR_AGENT)).toMatchObject({
+      icon: 'Claude',
+      defaultBaseUrl: 'http://127.0.0.1:3927',
+    })
+  })
+})

--- a/web/src/features/channels/lib/channel-type-config.ts
+++ b/web/src/features/channels/lib/channel-type-config.ts
@@ -164,6 +164,27 @@ export const CHANNEL_TYPE_CONFIGS: Record<number, ChannelTypeConfig> = {
       models: 'Models',
     },
   },
+  61: {
+    id: 61,
+    name: CHANNEL_TYPES[61],
+    icon: 'Claude',
+    defaultBaseUrl: 'http://127.0.0.1:3927',
+    supportedModels: [
+      'claude-sonnet-4-6',
+      'claude-opus-4-6',
+      'grok-4.6',
+      'grok-4.5',
+      'composer-2.5',
+    ],
+    hints: {
+      baseUrl:
+        'Official @cursor/sdk sidecar URL; leave empty to use the deployment default',
+      key: 'Cursor User API Key; never paste browser cookies',
+      models: 'Cursor catalog model IDs; aliases are normalized automatically',
+      other:
+        'Native tools require the bundled SDK sidecar to remain available across tool continuations',
+    },
+  },
 }
 
 /**

--- a/web/src/features/channels/lib/channel-utils.ts
+++ b/web/src/features/channels/lib/channel-utils.ts
@@ -54,6 +54,7 @@ export function getChannelTypeIcon(type: number): string {
     58: 'NewAPI', // Advanced Custom
     59: 'Sub2API', // Sub2API
     60: 'NewAPI', // New API
+    61: 'Claude', // Cursor Agent
     3: 'Azure', // Azure
 
     // Anthropic

--- a/web/src/i18n/locales/_reports/_sync-report.json
+++ b/web/src/i18n/locales/_reports/_sync-report.json
@@ -17,13 +17,13 @@
       "file": "ja.json",
       "missingCount": 0,
       "extrasCount": 0,
-      "untranslatedCount": 0
+      "untranslatedCount": 1
     },
     "ru": {
       "file": "ru.json",
       "missingCount": 0,
       "extrasCount": 0,
-      "untranslatedCount": 0
+      "untranslatedCount": 1
     },
     "vi": {
       "file": "vi.json",
@@ -41,7 +41,7 @@
       "file": "zh.json",
       "missingCount": 0,
       "extrasCount": 0,
-      "untranslatedCount": 0
+      "untranslatedCount": 1
     }
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -5273,6 +5273,15 @@
     "Zero retention": "Zero retention",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Cursor Account Info": "Cursor Account Info",
+    "Account Type": "Account Type",
+    "API Key Name": "API Key Name",
+    "Quota Usage": "Quota Usage",
+    "Billing Cycle End": "Billing Cycle End",
+    "Quota details are unavailable": "Quota details are unavailable",
+    "Click to view Cursor account": "Click to view Cursor account",
+    "Cursor Agent": "Cursor Agent",
+    "Enter Cursor User API Key (dashboard API key)": "Enter Cursor User API Key (dashboard API key)"
   }
 }

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -5273,6 +5273,15 @@
     "Zero retention": "Aucune rétention",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Cursor Account Info": "Informations du compte Cursor",
+    "Account Type": "Type de compte",
+    "API Key Name": "Nom de la clé API",
+    "Quota Usage": "Utilisation du quota",
+    "Billing Cycle End": "Fin du cycle de facturation",
+    "Quota details are unavailable": "Les détails du quota sont indisponibles",
+    "Click to view Cursor account": "Cliquer pour voir le compte Cursor",
+    "Cursor Agent": "Cursor Agent",
+    "Enter Cursor User API Key (dashboard API key)": "Saisissez la clé API utilisateur Cursor (clé API du tableau de bord)"
   }
 }

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -5273,6 +5273,15 @@
     "Zero retention": "データ保持なし",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V 4",
-    "Zoom": "ズーム"
+    "Zoom": "ズーム",
+    "Cursor Account Info": "Cursor アカウント情報",
+    "Account Type": "アカウント種別",
+    "API Key Name": "API キー名",
+    "Quota Usage": "クォータ使用量",
+    "Billing Cycle End": "請求サイクル終了日",
+    "Quota details are unavailable": "クォータの詳細を取得できません",
+    "Click to view Cursor account": "クリックして Cursor アカウントを表示",
+    "Cursor Agent": "Cursor Agent",
+    "Enter Cursor User API Key (dashboard API key)": "Cursor User API Key（ダッシュボード API キー）を入力"
   }
 }

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -5273,6 +5273,15 @@
     "Zero retention": "Без хранения данных",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Cursor Account Info": "Информация об аккаунте Cursor",
+    "Account Type": "Тип аккаунта",
+    "API Key Name": "Имя API-ключа",
+    "Quota Usage": "Использование квоты",
+    "Billing Cycle End": "Конец расчетного периода",
+    "Quota details are unavailable": "Данные о квоте недоступны",
+    "Click to view Cursor account": "Нажмите, чтобы открыть аккаунт Cursor",
+    "Cursor Agent": "Cursor Agent",
+    "Enter Cursor User API Key (dashboard API key)": "Введите Cursor User API Key (API-ключ панели управления)"
   }
 }

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -5273,6 +5273,15 @@
     "Zero retention": "Không lưu dữ liệu",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Cursor Account Info": "Thông tin tài khoản Cursor",
+    "Account Type": "Loại tài khoản",
+    "API Key Name": "Tên khóa API",
+    "Quota Usage": "Mức sử dụng hạn ngạch",
+    "Billing Cycle End": "Kết thúc chu kỳ thanh toán",
+    "Quota details are unavailable": "Không có thông tin chi tiết hạn ngạch",
+    "Click to view Cursor account": "Nhấp để xem tài khoản Cursor",
+    "Cursor Agent": "Cursor Agent",
+    "Enter Cursor User API Key (dashboard API key)": "Nhập Cursor User API Key (API key trên bảng điều khiển)"
   }
 }

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -5273,6 +5273,15 @@
     "Zero retention": "零數據保留",
     "Zhipu": "智譜",
     "Zhipu V4": "智譜 V4",
-    "Zoom": "縮放"
+    "Zoom": "縮放",
+    "Cursor Account Info": "Cursor 帳號資訊",
+    "Account Type": "帳號類型",
+    "API Key Name": "API Key 名稱",
+    "Quota Usage": "額度用量",
+    "Billing Cycle End": "計費週期結束",
+    "Quota details are unavailable": "暫時無法取得額度詳情",
+    "Click to view Cursor account": "點擊查看 Cursor 帳號",
+    "Cursor Agent": "Cursor Agent",
+    "Enter Cursor User API Key (dashboard API key)": "請輸入 Cursor User API Key（Dashboard API Key）"
   }
 }

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -5273,6 +5273,15 @@
     "Zero retention": "零数据保留",
     "Zhipu": "智谱",
     "Zhipu V4": "智谱 V4",
-    "Zoom": "缩放"
+    "Zoom": "缩放",
+    "Cursor Account Info": "Cursor 账号信息",
+    "Account Type": "账号类型",
+    "API Key Name": "API Key 名称",
+    "Quota Usage": "额度用量",
+    "Billing Cycle End": "计费周期结束",
+    "Quota details are unavailable": "暂无法获取额度详情",
+    "Click to view Cursor account": "点击查看 Cursor 账号",
+    "Cursor Agent": "Cursor Agent",
+    "Enter Cursor User API Key (dashboard API key)": "请输入 Cursor User API Key（Dashboard API Key）"
   }
 }


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - This description is intentionally summarized for maintainers. This PR was developed with AI assistance (OpenAI Codex); all changes were reviewed and tested by the author.

## 📝 变更描述 / Description

新增一个基于官方 `@cursor/sdk` 的 Cursor Agent 渠道（type 61），将 Cursor 的 Agent harness 接入 new-api 的现有 relay、计费和渠道管理体系。

合并后，标准 Docker 镜像会同时启动 new-api 与内置 Cursor SDK sidecar。管理员可以直接新建 `Cursor Agent` 渠道，粘贴 Cursor User API Key，Base URL 留空即可使用；无需另行部署网关。渠道支持：

- Anthropic Messages、OpenAI Chat Completions 与 Responses 请求入口
- Claude / Grok / Composer 公共模型名与 effort 参数映射
- 原生工具调用、多工具并行、跨 HTTP `tool_result` 续接与短时断线恢复
- 多租户会话绑定、并发上限、实例前缀 tool id，以及可选的粘性路由/白名单 peer 转发
- `/v1/messages/count_tokens`，Cursor 请求使用无上游消耗的本地估算
- 模型目录读取与后台账号/套餐/额度弹窗；Dashboard spending 查询失败时不会影响推理
- 工具中间轮延迟计费，最终按 SDK 累计 usage 结算，避免重复扣费

SDK sidecar 和 Node runtime 已直接打入不可变镜像，并在 entrypoint 中先通过健康检查再启动 Go 服务。Cursor SDK 的许可证文本及第三方声明已一并收录。

已知边界：`@cursor/sdk` 1.0.27 不暴露 raw `max_tokens`、`temperature`、`top_p` 或 stop sequences；这些参数由 Cursor harness 管理，当前仅透传 SDK 支持的 effort。多实例部署需要会话粘性，或显式配置 allowlisted peer routing。账号 spending 使用 Cursor Dashboard RPC 的 best-effort 读取。维护者还需确认 Cursor SDK 随镜像分发符合其项目政策与 Cursor 合作条款。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [x] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无；已搜索现有 Issues 与 PRs，未发现同类官方 Cursor SDK 渠道实现。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 此 PR 未标记为 Bug fix。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 提交前已扫描 staged diff；没有 `.env`、真实 key/token、私钥、凭据 JSON、`node_modules` 或运行时 state。

## 📸 运行证明 / Proof of Work

通过的本地验证：

- `go test ./...`
- `go test ./relayconvert/...`（`relaykit`）
- `npm test`（sidecar，52/52）
- `bun run build:check`
- frontend typecheck、目标 Vitest 与 oxlint
- `bash -n docker-entrypoint.sh cursor_agent_sidecar/start.sh`
- `git diff --check`
- Grok 4.6 xhigh 二次代码复审：`approve`，无剩余 merge blocker
- 完整 Docker 镜像构建成功；镜像内 Go 服务与自定义端口 SDK sidecar 均通过健康检查
- 全新 SQLite 容器中成功创建 Cursor Agent 渠道：只填写占位 key、Base URL 留空，保存结果为 `type=61`，模型 `claude-sonnet-4-6,grok-4.6`

本 PR 的上游镜像验收没有使用或提交真实 Cursor 凭据，因此不把占位 key 的渠道保存测试表述为真实模型调用验收。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cursor Agent channel support with model discovery, API-key authentication, Claude-compatible messaging, streaming, tool use, and session recovery.
  * Added Cursor account details, model counts, quota and billing information in the channel interface.
  * Added Claude token-counting support through `/v1/messages/count_tokens`.
  * Added Docker deployment support with an integrated Cursor Agent runtime and health monitoring.
* **Bug Fixes**
  * Improved response compatibility, usage reporting, credential protection, and deferred billing behavior.
* **Documentation**
  * Added setup, configuration, licensing, and smoke-test documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->