### PR TITLE
fix(task): preserve selected key for multi-key polling

### DIFF
--- a/model/task.go
+++ b/model/task.go
@@ -178,7 +178,8 @@ func InitTask(platform constant.TaskPlatform, relayInfo *commonRelay.RelayInfo) 
 	properties := Properties{}
 	privateData := TaskPrivateData{}
 	if relayInfo != nil && relayInfo.ChannelMeta != nil {
-		if relayInfo.ChannelMeta.ChannelType == constant.ChannelTypeGemini ||
+		if relayInfo.ChannelMeta.ChannelIsMultiKey ||
+			relayInfo.ChannelMeta.ChannelType == constant.ChannelTypeGemini ||
 			relayInfo.ChannelMeta.ChannelType == constant.ChannelTypeVertexAi {
 			privateData.Key = relayInfo.ChannelMeta.ApiKey
 		}

--- a/model/task_test.go
+++ b/model/task_test.go
@@ -1,0 +1,64 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitTaskPreservesSelectedKeyForPolling(t *testing.T) {
+	tests := []struct {
+		name        string
+		channelType int
+		isMultiKey  bool
+		wantKey     string
+	}{
+		{
+			name:        "multi-key task keeps the selected key",
+			channelType: constant.ChannelTypeAli,
+			isMultiKey:  true,
+			wantKey:     "selected-key",
+		},
+		{
+			name:        "single-key task does not persist the channel key",
+			channelType: constant.ChannelTypeAli,
+			isMultiKey:  false,
+			wantKey:     "",
+		},
+		{
+			name:        "Gemini task keeps its key",
+			channelType: constant.ChannelTypeGemini,
+			isMultiKey:  false,
+			wantKey:     "selected-key",
+		},
+		{
+			name:        "Vertex AI task keeps its key",
+			channelType: constant.ChannelTypeVertexAi,
+			isMultiKey:  false,
+			wantKey:     "selected-key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			relayInfo := &relaycommon.RelayInfo{
+				UserId:     1,
+				UsingGroup: "default",
+				ChannelMeta: &relaycommon.ChannelMeta{
+					ChannelId:         2,
+					ChannelType:       tt.channelType,
+					ChannelIsMultiKey: tt.isMultiKey,
+					ApiKey:            "selected-key",
+				},
+			}
+
+			task := InitTask(constant.TaskPlatform("ali"), relayInfo)
+
+			require.NotNil(t, task)
+			assert.Equal(t, tt.wantKey, task.PrivateData.Key)
+		})
+	}
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
多密钥渠道提交异步任务时，分发器已经选出了本次请求实际使用的 API key，但任务记录只为 Gemini/Vertex AI 保存该 key。阿里视频任务因此在后台轮询时回退到包含多个换行分隔 key 的渠道原始字段，写入 `Authorization` 后触发非法 header 错误。

本 PR 在初始化多密钥任务时保存本次请求实际选中的 key。现有轮询逻辑会优先读取该私有字段，因此后续查询使用与任务提交时相同的凭据；单密钥渠道行为保持不变。

新增表驱动回归测试，覆盖多密钥、普通单密钥以及 Gemini/Vertex AI 既有行为。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6864

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
新增测试在修复前可以稳定复现失败：

```text
TestInitTaskPreservesSelectedKeyForPolling/multi-key_task_keeps_the_selected_key
expected: "selected-key"
actual:   ""
```

应用修复后：

```text
go test ./model -run TestInitTaskPreservesSelectedKeyForPolling -count=1
ok github.com/QuantumNous/new-api/model

go test ./model ./service -count=1
ok github.com/QuantumNous/new-api/model
ok github.com/QuantumNous/new-api/service

go vet ./...
go build ./...
# passed
```

补充说明：本 PR 代码为 AI-assisted 生成，并已人工复核、执行回归测试及质量检查。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved channel API keys when initializing tasks for multi-key channels.
  * Continued correct API key handling for Gemini, Vertex AI, and single-key channels.

* **Tests**
  * Added coverage for API key preservation across supported channel configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->