### PR TITLE
fix(relaykit): preserve assistant text with tool calls

### DIFF
--- a/relaykit/relayconvert/internal/claude_messages/to_oai_chat_req.go
+++ b/relaykit/relayconvert/internal/claude_messages/to_oai_chat_req.go
@@ -197,7 +197,7 @@ func ClaudeMessagesRequestToOpenAIChat(claudeRequest dto.ClaudeRequest, info con
 			if len(toolCalls) > 0 {
 				openAIMessage.SetToolCalls(toolCalls)
 			}
-			if len(mediaMessages) > 0 && len(toolCalls) == 0 {
+			if len(mediaMessages) > 0 {
 				openAIMessage.SetMediaContent(mediaMessages)
 			}
 		}

--- a/relaykit/relayconvert/request_registry_test.go
+++ b/relaykit/relayconvert/request_registry_test.go
@@ -55,6 +55,43 @@ func TestClaudeMessagesToOpenAIChatPreservesAssistantTextWithToolCalls(t *testin
 	assert.Equal(t, text, assistant.ParseContent()[0].Text)
 }
 
+func TestClaudeMessagesToOpenAIChatKeepsToolOnlyContentEmpty(t *testing.T) {
+	request := dto.ClaudeRequest{
+		Model: "claude-test",
+		Messages: []dto.ClaudeMessage{
+			{
+				Role: "assistant",
+				Content: []dto.ClaudeMediaMessage{
+					{
+						Type:  "tool_use",
+						Id:    "call_1",
+						Name:  "lookup",
+						Input: map[string]any{"query": "weather"},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := ConvertRequest(
+		context.Background(),
+		&convmeta.Values{},
+		types.RelayFormatOpenAI,
+		&request,
+	)
+	require.NoError(t, err)
+
+	converted, ok := result.Value.(*dto.GeneralOpenAIRequest)
+	require.True(t, ok)
+	require.Len(t, converted.Messages, 1)
+
+	assistant := converted.Messages[0]
+	assert.Empty(t, assistant.ParseContent())
+	toolCalls := assistant.ParseToolCalls()
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "call_1", toolCalls[0].ID)
+}
+
 func TestRequestConverterRegistryListsSupportedTextConverters(t *testing.T) {
 	tests := []struct {
 		converter      string

--- a/relaykit/relayconvert/request_registry_test.go
+++ b/relaykit/relayconvert/request_registry_test.go
@@ -1,6 +1,7 @@
 package relayconvert
 
 import (
+	"context"
 	"testing"
 
 	"github.com/QuantumNous/new-api/relaykit/dto"
@@ -11,6 +12,48 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestClaudeMessagesToOpenAIChatPreservesAssistantTextWithToolCalls(t *testing.T) {
+	text := "I will look that up."
+	request := dto.ClaudeRequest{
+		Model: "claude-test",
+		Messages: []dto.ClaudeMessage{
+			{
+				Role: "assistant",
+				Content: []dto.ClaudeMediaMessage{
+					{Type: "text", Text: &text},
+					{
+						Type:  "tool_use",
+						Id:    "call_1",
+						Name:  "lookup",
+						Input: map[string]any{"query": "weather"},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := ConvertRequest(
+		context.Background(),
+		&convmeta.Values{},
+		types.RelayFormatOpenAI,
+		&request,
+	)
+	require.NoError(t, err)
+
+	converted, ok := result.Value.(*dto.GeneralOpenAIRequest)
+	require.True(t, ok)
+	require.Len(t, converted.Messages, 1)
+
+	assistant := converted.Messages[0]
+	assert.Equal(t, "assistant", assistant.Role)
+	toolCalls := assistant.ParseToolCalls()
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "call_1", toolCalls[0].ID)
+	require.Len(t, assistant.ParseContent(), 1)
+	assert.Equal(t, "text", assistant.ParseContent()[0].Type)
+	assert.Equal(t, text, assistant.ParseContent()[0].Text)
+}
 
 func TestRequestConverterRegistryListsSupportedTextConverters(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
Claude Messages 允许 assistant 在同一轮同时返回文本和 `tool_use`。当前转换到 OpenAI Chat 时，只要存在工具调用，就不会写入同一消息中已解析出的文本内容，导致 assistant 的说明或意图上下文被静默丢弃。

本 PR 移除这个不必要的互斥条件：只要 Claude 消息包含文本/媒体内容，就写入 OpenAI message 的 `content`；工具调用继续独立写入 `tool_calls`。纯 `tool_use` 消息没有媒体内容，因此原有 `content` 为空的行为保持不变。

新增通过公共转换入口执行的回归测试，验证 assistant 的文本和 tool call 会同时保留。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6615

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
修复前，新增测试可以稳定复现 assistant 文本丢失：

```text
TestClaudeMessagesToOpenAIChatPreservesAssistantTextWithToolCalls
"[]" should have 1 item(s), but has 0
```

应用修复后：

```text
GOWORK=off go test ./relayconvert/... -count=1
# passed

GOWORK=off go vet ./...
GOWORK=off go build ./...
# passed (relaykit standalone module)

go vet ./...
go build ./...
go test ./relay/... -count=1
# passed (root module)
```

补充说明：本 PR 代码为 AI-assisted 生成，并已人工复核、执行回归测试及质量检查。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved media content when messages include both tool calls and media.
  * Preserved assistant text during conversion when tool calls are also present.
  * Ensured tool-only assistant messages remain empty while retaining their tool calls.
  * Improved compatibility and message fidelity when converting Claude messages to OpenAI Chat format.

* **Tests**
  * Added regression coverage for assistant text, media, and tool-call handling during message conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->