### PR TITLE
feat: 补充 Seedance 2.5 / 2.0 mini 的豆包视频价格表（含参考视频分档）

### DIFF
--- a/relay/channel/task/doubao/constants.go
+++ b/relay/channel/task/doubao/constants.go
@@ -9,6 +9,8 @@ var ModelList = []string{
 	"doubao-seedance-1-5-pro-251215",
 	"doubao-seedance-2-0-260128",
 	"doubao-seedance-2-0-fast-260128",
+	"doubao-seedance-2-0-mini-260615",
+	"doubao-seedance-2-5-260628",
 }
 
 var ChannelName = "doubao-video"
@@ -35,6 +37,16 @@ var videoPriceTable = map[string]map[videoPriceKey]float64{
 	"doubao-seedance-2-0-fast-260128": {
 		{hasVideo: false}: 37.0,
 		{hasVideo: true}:  22.0,
+	},
+	"doubao-seedance-2-0-mini-260615": {
+		{hasVideo: false}: 23.0,
+		{hasVideo: true}:  14.0,
+	},
+	"doubao-seedance-2-5-260628": {
+		{hasVideo: false}:                70.0,
+		{hasVideo: true}:                 42.0,
+		{is1080p: true, hasVideo: false}: 77.0,
+		{is1080p: true, hasVideo: true}:  46.0,
 	},
 }
 


### PR DESCRIPTION
## 变更内容

按火山引擎官方刊例价补充 `videoPriceTable` 中缺失的两个模型，并加入 `ModelList`：

| 模型 | 480p/720p 无视频 | 480p/720p 含视频 | 1080p 无视频 | 1080p 含视频 |
|---|---|---|---|---|
| `doubao-seedance-2-5-260628` | 70.00 | 42.00 | 77.00 | 46.00 |
| `doubao-seedance-2-0-mini-260615` | 23.00 | 14.00 | — | — |

（元/百万 token，刊例价，未含官方限时折扣；Seedance 2.5 的 1080p 官方已宣布 2026-08-17 上线。）

## 背景

Seedance 官方定价按「输出分辨率 × 输入是否含视频」分档：含参考视频时单价更低，但 token 用量按（输入时长+输出时长）计。现有表只覆盖 2.0 / 2.0-fast，2.5 与 mini 的含视频任务会一直按更贵的「无视频」基准价结算。补上后与现有条目同一机制生效（`GetVideoInputRatio` → OtherRatio，基准价 = 管理员配置的 ModelRatio），无其他代码改动。

定价来源：[火山方舟定价文档 — 视频生成模型·按 token 单价](https://www.volcengine.com/docs/82379/1544106)。

## 验证

- `go build ./relay/channel/task/doubao/` 通过，`gofmt` 无差异。
- 表结构与 2.0/fast 现有条目逐字段一致；含参考视频的 2.0 任务分档计费已在生产环境按 28/46 系数核对过结算金额，2.5/mini 沿用同一路径。

https://claude.ai/code/session_01FGGpB634111EF9SiBwYaBY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Doubao Seedance 2.0 Mini and 2.5 models.
  * Added pricing for video inputs and resolution-specific usage for supported models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->