### PR TITLE
fix(helper)：修复/v1/responses场景渠道系统提示词不生效

### DIFF
--- a/relay/channel/codex/adaptor.go
+++ b/relay/channel/codex/adaptor.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/relay/channel"
 	"github.com/QuantumNous/new-api/relay/channel/openai"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
@@ -55,41 +54,6 @@ func (a *Adaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.Rela
 func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {
 	isCompact := info != nil && info.RelayMode == relayconstant.RelayModeResponsesCompact
 
-	if info != nil && info.ChannelSetting.SystemPrompt != "" {
-		systemPrompt := info.ChannelSetting.SystemPrompt
-
-		if len(request.Instructions) == 0 {
-			if b, err := common.Marshal(systemPrompt); err == nil {
-				request.Instructions = b
-			} else {
-				return nil, err
-			}
-		} else if info.ChannelSetting.SystemPromptOverride {
-			var existing string
-			if err := common.Unmarshal(request.Instructions, &existing); err == nil {
-				existing = strings.TrimSpace(existing)
-				if existing == "" {
-					if b, err := common.Marshal(systemPrompt); err == nil {
-						request.Instructions = b
-					} else {
-						return nil, err
-					}
-				} else {
-					if b, err := common.Marshal(systemPrompt + "\n" + existing); err == nil {
-						request.Instructions = b
-					} else {
-						return nil, err
-					}
-				}
-			} else {
-				if b, err := common.Marshal(systemPrompt); err == nil {
-					request.Instructions = b
-				} else {
-					return nil, err
-				}
-			}
-		}
-	}
 	// Codex backend requires the `instructions` field to be present.
 	// Keep it consistent with Codex CLI behavior by defaulting to an empty string.
 	if len(request.Instructions) == 0 {

--- a/relay/helper/system_prompt.go
+++ b/relay/helper/system_prompt.go
@@ -1,0 +1,51 @@
+package helper
+
+import (
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ApplyResponsesSystemPrompt applies the channel prompt to a Responses request.
+func ApplyResponsesSystemPrompt(c *gin.Context, channelSetting dto.ChannelSettings, request *dto.OpenAIResponsesRequest) error {
+	if request == nil || channelSetting.SystemPrompt == "" {
+		return nil
+	}
+
+	systemPrompt := channelSetting.SystemPrompt
+	if len(request.Instructions) > 0 {
+		var existing string
+		if err := common.Unmarshal(request.Instructions, &existing); err == nil {
+			// Treat null, empty, and whitespace-only instructions as missing, so the
+			// channel prompt is applied regardless of the override setting.
+			existing = strings.TrimSpace(existing)
+			if existing != "" {
+				// Preserve non-empty user instructions unless prompt concatenation is enabled.
+				if !channelSetting.SystemPromptOverride {
+					return nil
+				}
+				systemPrompt += "\n" + existing
+				common.SetContextKey(c, constant.ContextKeySystemPromptOverride, true)
+				instructions, err := common.Marshal(systemPrompt)
+				if err != nil {
+					return err
+				}
+				request.Instructions = instructions
+				return nil
+			}
+		} else if !channelSetting.SystemPromptOverride {
+			return nil
+		}
+	}
+
+	instructions, err := common.Marshal(systemPrompt)
+	if err != nil {
+		return err
+	}
+	request.Instructions = instructions
+	return nil
+}

--- a/relay/helper/system_prompt.go
+++ b/relay/helper/system_prompt.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
-	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/relaykit/dto"
 
 	"github.com/gin-gonic/gin"
 )

--- a/relay/helper/system_prompt_test.go
+++ b/relay/helper/system_prompt_test.go
@@ -1,0 +1,121 @@
+package helper
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyResponsesSystemPrompt(t *testing.T) {
+	tests := []struct {
+		name                string
+		channelSetting      dto.ChannelSettings
+		instructions        json.RawMessage
+		wantInstructions    string
+		wantPromptOverwrite bool
+	}{
+		{
+			name:             "no channel prompt",
+			instructions:     json.RawMessage(`"user rules"`),
+			wantInstructions: `"user rules"`,
+		},
+		{
+			name: "missing instructions",
+			channelSetting: dto.ChannelSettings{
+				SystemPrompt: "channel rules",
+			},
+			wantInstructions: `"channel rules"`,
+		},
+		{
+			name: "existing instructions take priority",
+			channelSetting: dto.ChannelSettings{
+				SystemPrompt: "channel rules",
+			},
+			instructions:     json.RawMessage(`"user rules"`),
+			wantInstructions: `"user rules"`,
+		},
+		{
+			name: "null instructions become channel prompt without override",
+			channelSetting: dto.ChannelSettings{
+				SystemPrompt: "channel rules",
+			},
+			instructions:     json.RawMessage(`null`),
+			wantInstructions: `"channel rules"`,
+		},
+		{
+			name: "empty instructions become channel prompt without override",
+			channelSetting: dto.ChannelSettings{
+				SystemPrompt: "channel rules",
+			},
+			instructions:     json.RawMessage(`""`),
+			wantInstructions: `"channel rules"`,
+		},
+		{
+			name: "blank instructions become channel prompt without override",
+			channelSetting: dto.ChannelSettings{
+				SystemPrompt: "channel rules",
+			},
+			instructions:     json.RawMessage(`"   "`),
+			wantInstructions: `"channel rules"`,
+		},
+		{
+			name: "channel prompt is prepended and existing whitespace is trimmed",
+			channelSetting: dto.ChannelSettings{
+				SystemPrompt:         "channel rules",
+				SystemPromptOverride: true,
+			},
+			instructions:        json.RawMessage(`"  user rules  "`),
+			wantInstructions:    `"channel rules\nuser rules"`,
+			wantPromptOverwrite: true,
+		},
+		{
+			name: "blank instructions become channel prompt when override is enabled",
+			channelSetting: dto.ChannelSettings{
+				SystemPrompt:         "channel rules",
+				SystemPromptOverride: true,
+			},
+			instructions:     json.RawMessage(`"   "`),
+			wantInstructions: `"channel rules"`,
+		},
+		{
+			name: "non-string instructions become channel prompt when override is enabled",
+			channelSetting: dto.ChannelSettings{
+				SystemPrompt:         "channel rules",
+				SystemPromptOverride: true,
+			},
+			instructions:     json.RawMessage(`[{"role":"developer"}]`),
+			wantInstructions: `"channel rules"`,
+		},
+		{
+			name: "invalid instructions become channel prompt when override is enabled",
+			channelSetting: dto.ChannelSettings{
+				SystemPrompt:         "channel rules",
+				SystemPromptOverride: true,
+			},
+			instructions:     json.RawMessage(`invalid`),
+			wantInstructions: `"channel rules"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			request := &dto.OpenAIResponsesRequest{
+				Instructions: append(json.RawMessage(nil), tt.instructions...),
+			}
+
+			err := ApplyResponsesSystemPrompt(c, tt.channelSetting, request)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantInstructions, string(request.Instructions))
+			assert.Equal(t, tt.wantPromptOverwrite, common.GetContextKeyBool(c, constant.ContextKeySystemPromptOverride))
+		})
+	}
+}

--- a/relay/helper/system_prompt_test.go
+++ b/relay/helper/system_prompt_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
-	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -84,6 +84,11 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 		}
 		requestBody = common.NewReplayableBodyReader(storage)
 	} else {
+		if info.RelayMode == relayconstant.RelayModeResponses {
+			if err := helper.ApplyResponsesSystemPrompt(c, info.ChannelSetting, request); err != nil {
+				return types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
+			}
+		}
 		convertedRequest, err := adaptor.ConvertOpenAIResponsesRequest(c, info, *request)
 		if err != nil {
 			return types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)
原实现：/v1/responses场景渠道系统提示词不生效，在response处理逻辑中只在codex的adapter中有实现逻辑
现实现：把response渠道系统提示词操作统一放到ResponsesHelper，如果存在不同渠道的特殊适配，再在adapter中处理。只对RelayModeResponses生效，对RelayModeResponsesCompact不生效

## 🚀 变更类型 / Type of change
- [✅] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5961 

## ✅ 提交前检查项 / Checklist
- [✅] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [✅] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [✅] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [✅] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [✅] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [✅] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [✅] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
<img width="1209" height="242" alt="截屏2026-08-16 16 31 24" src="https://github.com/user-attachments/assets/c1460df3-e3b7-43e7-8cb7-150941aaf84f" />
关闭渠道提示词连接：
<img width="1453" height="532" alt="截屏2026-08-16 16 25 28" src="https://github.com/user-attachments/assets/f26efad7-bc86-41f3-a91a-2ca6256d8670" />
开启渠道提示词连接：
<img width="1457" height="539" alt="截屏2026-08-16 16 26 53" src="https://github.com/user-attachments/assets/424b6489-4194-496f-a216-887849011601" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Channel system prompts are now applied to supported Responses requests.
  - Existing user instructions are preserved or combined according to configured override behavior.
  - Empty, blank, or missing instructions are handled consistently.

- **Bug Fixes**
  - Retry attempts no longer duplicate channel prompts.
  - Compact and passthrough request modes remain unchanged.
  - Invalid instruction data now results in a handled request-conversion error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->