### PR TITLE
fix: 轮询等待 Replicate prediction 完成

### DIFF
--- a/relay/channel/replicate/adaptor.go
+++ b/relay/channel/replicate/adaptor.go
@@ -2,6 +2,7 @@ package replicate
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,8 +10,10 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
@@ -27,6 +30,15 @@ import (
 
 type Adaptor struct {
 }
+
+const (
+	predictionPollInitialInterval = time.Second
+	predictionPollMaxInterval     = 5 * time.Second
+	predictionPollTimeout         = 20 * time.Minute
+	maxPredictionResponseBytes    = 4 * 1024 * 1024
+	maxPredictionErrorPreview     = 1024
+	maxTransientPollFailures      = 3
+)
 
 func (a *Adaptor) Init(info *relaycommon.RelayInfo) {
 }
@@ -191,50 +203,12 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycom
 		return nil, types.NewError(fmt.Errorf("replicate adaptor: failed to decode response: %w", err), types.ErrorCodeBadResponseBody)
 	}
 
-	if prediction.Error != nil {
-		errMsg := prediction.Error.Message
-		if errMsg == "" {
-			errMsg = prediction.Error.Detail
-		}
-		if errMsg == "" {
-			errMsg = prediction.Error.Code
-		}
-		if errMsg == "" {
-			errMsg = "replicate adaptor: prediction error"
-		}
-		return nil, types.NewError(errors.New(errMsg), types.ErrorCodeBadResponse)
+	prediction, err = waitForPrediction(c, info, prediction)
+	if err != nil {
+		return nil, types.NewError(err, types.ErrorCodeBadResponse)
 	}
 
-	if prediction.Status != "" && !strings.EqualFold(prediction.Status, "succeeded") {
-		return nil, types.NewError(fmt.Errorf("replicate adaptor: prediction status %q", prediction.Status), types.ErrorCodeBadResponse)
-	}
-
-	var urls []string
-
-	appendOutput := func(value string) {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			return
-		}
-		urls = append(urls, value)
-	}
-
-	switch output := prediction.Output.(type) {
-	case string:
-		appendOutput(output)
-	case []any:
-		for _, item := range output {
-			if str, ok := item.(string); ok {
-				appendOutput(str)
-			}
-		}
-	case nil:
-		// no output
-	default:
-		if str, ok := output.(fmt.Stringer); ok {
-			appendOutput(str.String())
-		}
-	}
+	urls := predictionOutputURLs(prediction.Output)
 
 	if len(urls) == 0 {
 		return nil, types.NewError(errors.New("replicate adaptor: empty prediction output"), types.ErrorCodeBadResponseBody)
@@ -297,6 +271,181 @@ func (a *Adaptor) GetModelList() []string {
 
 func (a *Adaptor) GetChannelName() string {
 	return ChannelName
+}
+
+func waitForPrediction(c *gin.Context, info *relaycommon.RelayInfo, prediction PredictionResponse) (PredictionResponse, error) {
+	done, err := evaluatePrediction(prediction)
+	if err != nil {
+		return PredictionResponse{}, err
+	}
+	if done {
+		return prediction, nil
+	}
+
+	if info == nil {
+		return PredictionResponse{}, errors.New("replicate adaptor: relay info is nil while polling")
+	}
+	if strings.TrimSpace(prediction.ID) == "" {
+		return PredictionResponse{}, errors.New("replicate adaptor: pending prediction is missing id")
+	}
+
+	baseURL := info.ChannelBaseUrl
+	if baseURL == "" {
+		baseURL = constant.ChannelBaseURLs[constant.ChannelTypeReplicate]
+	}
+	pollURL := relaycommon.GetFullRequestURL(baseURL, "/v1/predictions/"+url.PathEscape(prediction.ID), info.ChannelType)
+	client, err := service.GetHttpClientWithProxySettings(info.ChannelSetting.Proxy, info.ChannelSetting)
+	if err != nil {
+		return PredictionResponse{}, fmt.Errorf("replicate adaptor: create polling client failed: %w", err)
+	}
+
+	requestContext := context.Background()
+	if c != nil && c.Request != nil {
+		requestContext = c.Request.Context()
+	}
+	pollContext, cancel := context.WithTimeout(requestContext, predictionPollTimeout)
+	defer cancel()
+
+	pollInterval := predictionPollInitialInterval
+	transientFailures := 0
+	for {
+		req, err := http.NewRequestWithContext(pollContext, http.MethodGet, pollURL, nil)
+		if err != nil {
+			return PredictionResponse{}, fmt.Errorf("replicate adaptor: create polling request failed: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+info.ApiKey)
+		req.Header.Set("Accept", "application/json")
+
+		resp, requestErr := client.Do(req)
+		if requestErr != nil {
+			if pollContext.Err() != nil {
+				return PredictionResponse{}, fmt.Errorf("replicate adaptor: prediction polling stopped: %w", pollContext.Err())
+			}
+			transientFailures++
+			if transientFailures > maxTransientPollFailures {
+				return PredictionResponse{}, fmt.Errorf("replicate adaptor: poll prediction failed after retries: %w", requestErr)
+			}
+		} else {
+			responseBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxPredictionResponseBytes+1))
+			_ = resp.Body.Close()
+			if readErr != nil {
+				return PredictionResponse{}, fmt.Errorf("replicate adaptor: read polling response failed: %w", readErr)
+			}
+			if len(responseBody) > maxPredictionResponseBytes {
+				return PredictionResponse{}, errors.New("replicate adaptor: polling response is too large")
+			}
+			responsePreview := strings.TrimSpace(string(responseBody))
+			if len(responsePreview) > maxPredictionErrorPreview {
+				responsePreview = responsePreview[:maxPredictionErrorPreview] + "..."
+			}
+
+			isTransientStatus := resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError
+			if isTransientStatus {
+				transientFailures++
+				if transientFailures > maxTransientPollFailures {
+					return PredictionResponse{}, fmt.Errorf("replicate adaptor: polling failed after retries with status %d: %s", resp.StatusCode, responsePreview)
+				}
+			} else {
+				if resp.StatusCode != http.StatusOK {
+					return PredictionResponse{}, fmt.Errorf("replicate adaptor: polling failed with status %d: %s", resp.StatusCode, responsePreview)
+				}
+
+				var polled PredictionResponse
+				if err := common.Unmarshal(responseBody, &polled); err != nil {
+					return PredictionResponse{}, fmt.Errorf("replicate adaptor: failed to decode polling response: %w", err)
+				}
+				transientFailures = 0
+				prediction = polled
+				done, err := evaluatePrediction(prediction)
+				if err != nil {
+					return PredictionResponse{}, err
+				}
+				if done {
+					return prediction, nil
+				}
+			}
+		}
+
+		timer := time.NewTimer(pollInterval)
+		select {
+		case <-pollContext.Done():
+			timer.Stop()
+			return PredictionResponse{}, fmt.Errorf("replicate adaptor: prediction polling stopped: %w", pollContext.Err())
+		case <-timer.C:
+		}
+		if pollInterval < predictionPollMaxInterval {
+			pollInterval *= 2
+			if pollInterval > predictionPollMaxInterval {
+				pollInterval = predictionPollMaxInterval
+			}
+		}
+	}
+}
+
+func evaluatePrediction(prediction PredictionResponse) (bool, error) {
+	if errMsg := predictionErrorMessage(prediction.Error); errMsg != "" {
+		return false, errors.New(errMsg)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(prediction.Status)) {
+	case "", "succeeded":
+		return true, nil
+	case "starting", "processing":
+		return false, nil
+	case "failed", "canceled", "aborted":
+		return false, fmt.Errorf("replicate adaptor: prediction status %q", prediction.Status)
+	default:
+		return false, fmt.Errorf("replicate adaptor: unknown prediction status %q", prediction.Status)
+	}
+}
+
+func predictionErrorMessage(raw []byte) string {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ""
+	}
+	if trimmed[0] == '"' {
+		var message string
+		if err := common.Unmarshal(trimmed, &message); err == nil && strings.TrimSpace(message) != "" {
+			return message
+		}
+	}
+	var predictionError PredictionError
+	if err := common.Unmarshal(trimmed, &predictionError); err == nil {
+		for _, message := range []string{predictionError.Message, predictionError.Detail, predictionError.Code} {
+			if strings.TrimSpace(message) != "" {
+				return message
+			}
+		}
+	}
+	return "replicate adaptor: prediction error"
+}
+
+func predictionOutputURLs(output any) []string {
+	urls := make([]string, 0)
+	appendOutput := func(value string) {
+		if value = strings.TrimSpace(value); value != "" {
+			urls = append(urls, value)
+		}
+	}
+
+	switch value := output.(type) {
+	case string:
+		appendOutput(value)
+	case []any:
+		for _, item := range value {
+			if str, ok := item.(string); ok {
+				appendOutput(str)
+			}
+		}
+	case []string:
+		for _, item := range value {
+			appendOutput(item)
+		}
+	case fmt.Stringer:
+		appendOutput(value.String())
+	}
+	return urls
 }
 
 func downloadImagesToBase64(urls []string) ([]string, error) {

--- a/relay/channel/replicate/adaptor_polling_test.go
+++ b/relay/channel/replicate/adaptor_polling_test.go
@@ -45,7 +45,7 @@ func TestDoResponsePollsPendingPrediction(t *testing.T) {
 		},
 	}
 	resp := &http.Response{
-		StatusCode: http.StatusCreated,
+		StatusCode: http.StatusAccepted,
 		Body: io.NopCloser(bytes.NewBufferString(
 			`{"id":"prediction-1","status":"processing","output":["https://example.com/partial.png"],"error":null}`,
 		)),

--- a/relay/channel/replicate/adaptor_polling_test.go
+++ b/relay/channel/replicate/adaptor_polling_test.go
@@ -1,0 +1,198 @@
+package replicate
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoResponsePollsPendingPrediction(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var pollCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pollCount.Add(1)
+		assert.Equal(t, "/v1/predictions/prediction-1", r.URL.Path)
+		assert.Equal(t, "Bearer replicate-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(w, `{"id":"prediction-1","status":"succeeded","output":["https://example.com/one.png","https://example.com/two.png"],"error":null}`)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/images/generations", nil)
+	info := &relaycommon.RelayInfo{
+		Request: &dto.ImageRequest{ResponseFormat: "url"},
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ApiKey:         "replicate-token",
+			ChannelBaseUrl: server.URL,
+			ChannelType:    constant.ChannelTypeReplicate,
+		},
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusCreated,
+		Body: io.NopCloser(bytes.NewBufferString(
+			`{"id":"prediction-1","status":"processing","output":["https://example.com/partial.png"],"error":null}`,
+		)),
+	}
+
+	usage, newAPIError := (&Adaptor{}).DoResponse(c, resp, info)
+	require.Nil(t, newAPIError)
+	require.NotNil(t, usage)
+	assert.Equal(t, int32(1), pollCount.Load())
+
+	var imageResponse dto.ImageResponse
+	require.NoError(t, common.Unmarshal(recorder.Body.Bytes(), &imageResponse))
+	require.Len(t, imageResponse.Data, 2)
+	assert.Equal(t, "https://example.com/one.png", imageResponse.Data[0].Url)
+	assert.Equal(t, "https://example.com/two.png", imageResponse.Data[1].Url)
+}
+
+func TestWaitForPredictionDoesNotReuseOmittedPollingFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(w, `{"id":"prediction-1","status":"succeeded","error":null}`)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/images/generations", nil)
+	prediction, err := waitForPrediction(c, replicatePollingInfo(server.URL), PredictionResponse{
+		ID:     "prediction-1",
+		Status: "processing",
+		Output: []any{"https://example.com/partial.png"},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, predictionOutputURLs(prediction.Output))
+}
+
+func TestWaitForPredictionRetriesTransientStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var pollCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if pollCount.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, err := io.WriteString(w, `{"detail":"temporarily unavailable"}`)
+			assert.NoError(t, err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(w, `{"id":"prediction-1","status":"succeeded","output":"https://example.com/final.png","error":null}`)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/images/generations", nil)
+	prediction, err := waitForPrediction(c, replicatePollingInfo(server.URL), PredictionResponse{
+		ID:     "prediction-1",
+		Status: "processing",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), pollCount.Load())
+	assert.Equal(t, []string{"https://example.com/final.png"}, predictionOutputURLs(prediction.Output))
+}
+
+func TestWaitForPredictionReturnsPollingFailures(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    string
+	}{
+		{
+			name:       "non-retryable status",
+			statusCode: http.StatusBadRequest,
+			body:       `{"detail":"invalid prediction"}`,
+			wantErr:    "polling failed with status 400",
+		},
+		{
+			name:       "failed prediction",
+			statusCode: http.StatusOK,
+			body:       `{"id":"prediction-1","status":"failed","error":{"message":"model execution failed"}}`,
+			wantErr:    "model execution failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_, err := io.WriteString(w, tt.body)
+				assert.NoError(t, err)
+			}))
+			defer server.Close()
+
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/images/generations", nil)
+			_, err := waitForPrediction(c, replicatePollingInfo(server.URL), PredictionResponse{
+				ID:     "prediction-1",
+				Status: "processing",
+			})
+
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestEvaluatePredictionReturnsProviderErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		errorRaw string
+		wantErr  string
+	}{
+		{name: "string error", errorRaw: `"model execution failed"`, wantErr: "model execution failed"},
+		{name: "object error", errorRaw: `{"detail":"content rejected"}`, wantErr: "content rejected"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			done, err := evaluatePrediction(PredictionResponse{
+				Status: "failed",
+				Error:  []byte(tt.errorRaw),
+			})
+
+			assert.False(t, done)
+			require.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestWaitForPredictionRejectsPendingResponseWithoutID(t *testing.T) {
+	_, err := waitForPrediction(nil, &relaycommon.RelayInfo{}, PredictionResponse{Status: "processing"})
+	require.EqualError(t, err, "replicate adaptor: pending prediction is missing id")
+}
+
+func replicatePollingInfo(baseURL string) *relaycommon.RelayInfo {
+	return &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ApiKey:         "replicate-token",
+			ChannelBaseUrl: baseURL,
+			ChannelType:    constant.ChannelTypeReplicate,
+		},
+	}
+}

--- a/relay/channel/replicate/dto.go
+++ b/relay/channel/replicate/dto.go
@@ -1,9 +1,12 @@
 package replicate
 
+import "encoding/json"
+
 type PredictionResponse struct {
-	Status string           `json:"status"`
-	Output any              `json:"output"`
-	Error  *PredictionError `json:"error"`
+	ID     string          `json:"id"`
+	Status string          `json:"status"`
+	Output any             `json:"output"`
+	Error  json.RawMessage `json:"error"`
 }
 
 type PredictionError struct {

--- a/relay/image_handler.go
+++ b/relay/image_handler.go
@@ -97,17 +97,14 @@ func ImageHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *type
 	if resp != nil {
 		httpResp = resp.(*http.Response)
 		info.IsStream = info.IsStream || strings.HasPrefix(httpResp.Header.Get("Content-Type"), "text/event-stream")
-		if httpResp.StatusCode != http.StatusOK {
-			if httpResp.StatusCode == http.StatusCreated && info.ApiType == constant.APITypeReplicate {
-				// replicate channel returns 201 Created when using Prefer: wait, treat it as success.
-				httpResp.StatusCode = http.StatusOK
-			} else {
-				newAPIError = service.RelayErrorHandler(c.Request.Context(), httpResp, false)
-				// reset status code 重置状态码
-				service.ResetStatusCode(newAPIError, statusCodeMappingStr)
-				return newAPIError
-			}
+		normalizedStatusCode, accepted := normalizeImageResponseStatus(httpResp.StatusCode, info.ApiType)
+		if !accepted {
+			newAPIError = service.RelayErrorHandler(c.Request.Context(), httpResp, false)
+			// reset status code 重置状态码
+			service.ResetStatusCode(newAPIError, statusCodeMappingStr)
+			return newAPIError
 		}
+		httpResp.StatusCode = normalizedStatusCode
 	}
 
 	usage, newAPIError := adaptor.DoResponse(c, httpResp, info)
@@ -148,4 +145,18 @@ func ImageHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *type
 
 	service.PostTextConsumeQuota(c, info, usage.(*dto.Usage), logContent)
 	return nil
+}
+
+func normalizeImageResponseStatus(statusCode int, apiType int) (int, bool) {
+	if statusCode == http.StatusOK {
+		return http.StatusOK, true
+	}
+	if apiType == constant.APITypeReplicate &&
+		(statusCode == http.StatusCreated || statusCode == http.StatusAccepted) {
+		// Replicate can return 201 when the prediction finishes during the
+		// synchronous wait, or 202 when it remains pending. Both responses
+		// must reach the adaptor so pending predictions can be polled.
+		return http.StatusOK, true
+	}
+	return statusCode, false
 }

--- a/relay/image_handler_test.go
+++ b/relay/image_handler_test.go
@@ -1,0 +1,64 @@
+package relay
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeImageResponseStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		statusCode     int
+		apiType        int
+		wantStatusCode int
+		wantAccepted   bool
+	}{
+		{
+			name:           "standard success",
+			statusCode:     http.StatusOK,
+			apiType:        constant.APITypeOpenAI,
+			wantStatusCode: http.StatusOK,
+			wantAccepted:   true,
+		},
+		{
+			name:           "replicate created prediction",
+			statusCode:     http.StatusCreated,
+			apiType:        constant.APITypeReplicate,
+			wantStatusCode: http.StatusOK,
+			wantAccepted:   true,
+		},
+		{
+			name:           "replicate accepted pending prediction",
+			statusCode:     http.StatusAccepted,
+			apiType:        constant.APITypeReplicate,
+			wantStatusCode: http.StatusOK,
+			wantAccepted:   true,
+		},
+		{
+			name:           "non-replicate accepted response",
+			statusCode:     http.StatusAccepted,
+			apiType:        constant.APITypeOpenAI,
+			wantStatusCode: http.StatusAccepted,
+			wantAccepted:   false,
+		},
+		{
+			name:           "replicate upstream failure",
+			statusCode:     http.StatusBadGateway,
+			apiType:        constant.APITypeReplicate,
+			wantStatusCode: http.StatusBadGateway,
+			wantAccepted:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statusCode, accepted := normalizeImageResponseStatus(tt.statusCode, tt.apiType)
+			assert.Equal(t, tt.wantStatusCode, statusCode)
+			assert.Equal(t, tt.wantAccepted, accepted)
+		})
+	}
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本次实现与测试由 Codex 辅助完成；以下摘要已按实际代码路径和验证结果整理。

## 📝 变更描述 / Description

Replicate 的同步 prediction 最多等待一段时间；任务未完成时，上游会返回 `202 Accepted`，并在响应体中保留 prediction ID 与 `starting` / `processing` 状态。

旧链路存在两个连续缺口：

1. Replicate adaptor 收到非终态 prediction 后不会继续查询，调用方无法通过 OpenAI Images 接口取得最终图片。
2. 即使 adaptor 已具备轮询能力，公共 `ImageHelper` 仍会先把 Replicate 的 `202` 当作渠道错误，导致响应无法进入 adaptor。

本 PR 一并修复这两个环节：

- Replicate 初始响应为 `starting` / `processing` 时，通过当前渠道的 base URL 和 prediction ID 查询 `/v1/predictions/{id}`，直到进入终态。
- Replicate 的 `201 Created` 与 `202 Accepted` 在图片 relay 边界被识别为合法异步响应并规范化为 `200`，再交给 adaptor 处理；其他渠道的非 `200` 响应仍沿用原错误处理。
- 使用请求 context 停止客户端已取消的轮询，并设置 20 分钟总上限。
- 轮询间隔从 1 秒退避到最多 5 秒，减少长任务产生的查询量。
- 对网络错误、HTTP 429 和 5xx 提供有限的连续重试；其他 4xx、上游失败状态和非法响应立即返回。
- 每次轮询解码到新的 response，避免上一次 partial output 在后续响应省略字段时残留。
- 同时兼容 Replicate 的字符串和对象两种 error 结构，并保留最终多图片输出。

该变更与 #6701 范围独立：#6701 处理 Replicate 原生图片参数；本 PR 处理已创建 prediction 未在同步窗口内完成，以及 `202 Accepted` 未能进入轮询的问题。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Follow-up to #6701；暂无关联 Issue。

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，未发现 Replicate prediction polling 的重复提交。
- [ ] **Bug fix 说明:** 当前没有可关联的 Issue；问题来自 Replicate 同步窗口结束后的非终态响应。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 仅修改 Replicate prediction 处理、图片响应状态边界及对应回归测试。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 轮询只使用渠道配置的 base URL，不跟随上游返回的任意查询 URL 发送渠道密钥。

## 📸 运行证明 / Proof of Work

最新提交后已通过：

- `go test ./relay/...`
- `git diff --check`
- GitHub CI：Backend vet, build, and test
- GitHub CI：Frontend typecheck and test

回归测试覆盖：

- Replicate `201 Created` 与 `202 Accepted` 均可进入 adaptor，并在内部规范化为 `200`。
- 非 Replicate 的 `202` 仍被拒绝，上游失败状态不会被误判为成功。
- `202 processing + partial output → succeeded + 完整多图输出`。
- 轮询字段不残留、短暂 5xx 重试、非重试错误、上游失败及缺少 prediction ID。

真实链路验证中，超过同步等待窗口的 Replicate 生图请求在约 3 分钟后最终返回 HTTP `200`，且未再出现 `channel error ... status code: 202`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved asynchronous prediction handling with bounded polling, timeout protection, exponential backoff, and cancellation support.
  - Added support for string, list, array, and image outputs.
  - Added response-size limits and clearer provider and prediction error handling.
  - Improved handling of accepted and pending image responses.

- **Bug Fixes**
  - Added retries for transient service failures while avoiding retries for non-recoverable errors.
  - Prevented stale outputs from being reused during polling.
  - Correctly handles failed predictions and responses missing required identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->