### PR TITLE
fix(relay): mark Responses streams done on terminal event to avoid client_gone mislabel

### DIFF
--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -131,6 +131,12 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 				imageCounter.Commit(info)
 				imageCommitted = true
 			}
+			// Responses SSE has no "data: [DONE]" sentinel: after this event the
+			// upstream simply idles until it closes the socket. Mark completion here,
+			// otherwise the end reason is decided by a race between upstream EOF and
+			// the client closing its connection right after the final event, which
+			// mislabels finished streams as client_gone (#6649).
+			sr.Done()
 		case "response.failed", "response.incomplete", "response.cancelled", "response.canceled":
 			if !imageCommitted {
 				imageCounter.Reset()

--- a/relay/channel/openai/relay_responses_stream_test.go
+++ b/relay/channel/openai/relay_responses_stream_test.go
@@ -1,0 +1,75 @@
+package openai
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Upstreams for /v1/responses do not send a "data: [DONE]" sentinel; the stream
+// simply idles after "response.completed" until the upstream closes the socket.
+// The handler must therefore mark completion itself, otherwise the end reason is
+// decided by a race between upstream EOF and the client closing its connection
+// right after the final event, which mislabels finished streams as client_gone
+// (issue #6649).
+func TestOaiResponsesStreamHandlerMarksDoneOnCompleted(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	if constant.StreamingTimeout == 0 {
+		constant.StreamingTimeout = 30
+	}
+
+	pr, pw := io.Pipe()
+	t.Cleanup(func() {
+		_ = pr.Close()
+		_ = pw.Close()
+	})
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	resp := &http.Response{Body: pr}
+	info := &relaycommon.RelayInfo{
+		DisablePing: true,
+		ChannelMeta: &relaycommon.ChannelMeta{},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		usage, apiErr := OaiResponsesStreamHandler(c, info, resp)
+		assert.Nil(t, apiErr)
+		if assert.NotNil(t, usage) {
+			assert.Equal(t, 5, usage.PromptTokens)
+			assert.Equal(t, 7, usage.CompletionTokens)
+		}
+	}()
+
+	_, err := fmt.Fprint(pw, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n")
+	require.NoError(t, err)
+	_, err = fmt.Fprint(pw, "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":5,\"output_tokens\":7,\"total_tokens\":12}}}\n")
+	require.NoError(t, err)
+
+	// Keep the pipe open: the handler must finish on the terminal event alone,
+	// without waiting for upstream EOF.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not return after response.completed (still waiting for upstream EOF)")
+	}
+
+	require.NotNil(t, info.StreamStatus)
+	assert.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
+
+	body := recorder.Body.String()
+	assert.Contains(t, body, "response.completed", "terminal event must still be forwarded to the client")
+}


### PR DESCRIPTION
## 📝 变更描述 / Description

`/v1/responses` 的 SSE 流没有 `data: [DONE]` 哨兵：上游发完 `response.completed` 后就静默，直到它自己关闭连接。`OaiResponsesStreamHandler` 此前从不向 scanner 报告"正常完成"，所以 `stream_status.end_reason` 由两个事件赛跑决定——上游 EOF 先到记 `eof`，客户端先关 socket 就记 `client_gone`。codex CLI 这类客户端收到 `response.completed` 后立即关连接，遇到收尾慢的上游时每次都输掉这场竞速，正常完成的流被整批标成 `client_gone`（#6649；评论区提到的 "codex + azure gpt-5.6 必现" 就是这个形状）。

本 PR 在 `response.completed` / `response.done` 分支调用 `sr.Done()`：终止原因在事件到达的那一刻记录，scanner 随即停止，不再等上游 EOF。附带的好处是提前释放对收尾迟缓上游的读等待。

**与 #6808 的关系**：互补，不冲突。#6808 允许正常完成（`Done`/`EOF`）纠正先写入的 `client_gone`，但对 `/v1/responses` 客户端先断开时，cleanup 强制关闭 body 会让 scanner 以 forced-close error 结束而非干净 EOF，纠正路径无从触发（见 #6808 评论区 walker1211 的分析）。本 PR 让 handler 在竞速开始前就把 `done` 写进去，两个 PR 合起来才完整覆盖。

`response.failed` / `response.incomplete` / `response.cancelled` 分支保持原状（它们不是"正常完成"，语义上是否该停 scanner 可另行讨论）。

## 复现数据（生产环境，self-hosted v1.0.0-rc.24）

同一个 codex 0.147.0 客户端、同一时段、两条渠道对照：

| 上游 | 最后事件 → EOF 间隔 | codex 流量被标 client_gone |
|---|---|---|
| 聚合商（Azure 系后端） | ~0.25s | ~100%（含全部实际成功的请求） |
| 本机反代（即时关流） | ~0.04s | 0.4–2% |

同请求用 curl（读到 EOF）得 `eof`，用 codex（completed 后即关）得 `client_gone`，HTTP 200、内容与计费完全一致。

## 测试 / Tests

- 新增 `TestOaiResponsesStreamHandlerMarksDoneOnCompleted`：管道模拟上游，发 `response.completed` 后**保持连接不关**，断言 handler 立即返回、`end_reason=done`、usage 正确、终止事件仍转发给客户端。该测试在未修复的 `main` 上失败（挂到超时），修复后通过。
- `gofmt` 干净，`go test ./relay/...` 全量通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
