### PR TITLE
fix(billing): 订阅最终结算溢出时扣除钱包差额

### DIFF
--- a/model/subscription.go
+++ b/model/subscription.go
@@ -1482,6 +1482,11 @@ type SubscriptionPlanInfo struct {
 	PlanTitle string
 }
 
+type SubscriptionSettlementResult struct {
+	SubscriptionDelta int64
+	WalletDelta       int64
+}
+
 func GetSubscriptionPlanInfoByUserSubscriptionId(userSubscriptionId int) (*SubscriptionPlanInfo, error) {
 	if userSubscriptionId <= 0 {
 		return nil, errors.New("invalid userSubscriptionId")
@@ -1531,4 +1536,73 @@ func PostConsumeUserSubscriptionDelta(userSubscriptionId int, delta int64) error
 		sub.AmountUsed = newUsed
 		return tx.Save(&sub).Error
 	})
+}
+
+// SettleUserSubscriptionDelta applies a final subscription adjustment. When a
+// positive delta exceeds the subscription's remaining quota and wallet
+// overflow is enabled, the subscription is filled to its limit and the rest
+// is deducted from the user's wallet in the same database transaction.
+func SettleUserSubscriptionDelta(userSubscriptionId int, userId int, delta int64) (SubscriptionSettlementResult, error) {
+	result := SubscriptionSettlementResult{}
+	if userSubscriptionId <= 0 {
+		return result, errors.New("invalid userSubscriptionId")
+	}
+	if userId <= 0 {
+		return result, errors.New("invalid userId")
+	}
+	if delta == 0 {
+		return result, nil
+	}
+
+	err := DB.Transaction(func(tx *gorm.DB) error {
+		var sub UserSubscription
+		if err := lockForUpdate(tx).
+			Where("id = ? AND user_id = ?", userSubscriptionId, userId).
+			First(&sub).Error; err != nil {
+			return err
+		}
+
+		newUsed := sub.AmountUsed + delta
+		if newUsed < 0 {
+			newUsed = 0
+		}
+		if delta < 0 || sub.AmountTotal <= 0 || newUsed <= sub.AmountTotal {
+			result.SubscriptionDelta = newUsed - sub.AmountUsed
+			sub.AmountUsed = newUsed
+			return tx.Save(&sub).Error
+		}
+		if !sub.AllowWalletOverflow {
+			return fmt.Errorf("subscription used exceeds total, used=%d total=%d", newUsed, sub.AmountTotal)
+		}
+
+		remaining := sub.AmountTotal - sub.AmountUsed
+		if remaining < 0 {
+			remaining = 0
+		}
+		result.SubscriptionDelta = remaining
+		result.WalletDelta = delta - remaining
+		sub.AmountUsed = sub.AmountTotal
+		if err := tx.Save(&sub).Error; err != nil {
+			return err
+		}
+		walletUpdate := tx.Model(&User{}).
+			Where("id = ?", userId).
+			Update("quota", gorm.Expr("quota - ?", result.WalletDelta))
+		if walletUpdate.Error != nil {
+			return walletUpdate.Error
+		}
+		if walletUpdate.RowsAffected != 1 {
+			return gorm.ErrRecordNotFound
+		}
+		return nil
+	})
+	if err != nil {
+		return SubscriptionSettlementResult{}, err
+	}
+	if result.WalletDelta > 0 {
+		if err := cacheDecrUserQuota(userId, result.WalletDelta); err != nil {
+			common.SysLog("failed to decrease user quota cache after subscription overflow settlement: " + err.Error())
+		}
+	}
+	return result, nil
 }

--- a/model/subscription_settlement_test.go
+++ b/model/subscription_settlement_test.go
@@ -1,0 +1,82 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedSubscriptionSettlement(t *testing.T, walletQuota int, total, used int64, allowOverflow bool) (User, UserSubscription) {
+	t.Helper()
+	user := User{Username: "subscription-settlement", Quota: walletQuota, Status: common.UserStatusEnabled}
+	require.NoError(t, DB.Create(&user).Error)
+	sub := UserSubscription{
+		UserId:              user.Id,
+		AmountTotal:         total,
+		AmountUsed:          used,
+		Status:              "active",
+		AllowWalletOverflow: allowOverflow,
+	}
+	require.NoError(t, DB.Create(&sub).Error)
+	return user, sub
+}
+
+func TestSettleUserSubscriptionDeltaWithinRemainingQuota(t *testing.T) {
+	truncateTables(t)
+	user, sub := seedSubscriptionSettlement(t, 50, 100, 40, true)
+
+	result, err := SettleUserSubscriptionDelta(sub.Id, user.Id, 30)
+
+	require.NoError(t, err)
+	assert.EqualValues(t, 30, result.SubscriptionDelta)
+	assert.Zero(t, result.WalletDelta)
+	require.NoError(t, DB.First(&sub, sub.Id).Error)
+	assert.EqualValues(t, 70, sub.AmountUsed)
+	require.NoError(t, DB.First(&user, user.Id).Error)
+	assert.Equal(t, 50, user.Quota)
+}
+
+func TestSettleUserSubscriptionDeltaOverflowsToWallet(t *testing.T) {
+	truncateTables(t)
+	user, sub := seedSubscriptionSettlement(t, 20, 100, 80, true)
+
+	result, err := SettleUserSubscriptionDelta(sub.Id, user.Id, 50)
+
+	require.NoError(t, err)
+	assert.EqualValues(t, 20, result.SubscriptionDelta)
+	assert.EqualValues(t, 30, result.WalletDelta)
+	require.NoError(t, DB.First(&sub, sub.Id).Error)
+	assert.EqualValues(t, 100, sub.AmountUsed)
+	require.NoError(t, DB.First(&user, user.Id).Error)
+	assert.Equal(t, -10, user.Quota)
+}
+
+func TestSettleUserSubscriptionDeltaRejectsOverflowWhenDisabled(t *testing.T) {
+	truncateTables(t)
+	user, sub := seedSubscriptionSettlement(t, 20, 100, 80, false)
+
+	_, err := SettleUserSubscriptionDelta(sub.Id, user.Id, 50)
+
+	require.ErrorContains(t, err, "subscription used exceeds total")
+	require.NoError(t, DB.First(&sub, sub.Id).Error)
+	assert.EqualValues(t, 80, sub.AmountUsed)
+	require.NoError(t, DB.First(&user, user.Id).Error)
+	assert.Equal(t, 20, user.Quota)
+}
+
+func TestSettleUserSubscriptionDeltaRefundOnlyTouchesSubscription(t *testing.T) {
+	truncateTables(t)
+	user, sub := seedSubscriptionSettlement(t, -10, 100, 80, true)
+
+	result, err := SettleUserSubscriptionDelta(sub.Id, user.Id, -30)
+
+	require.NoError(t, err)
+	assert.EqualValues(t, -30, result.SubscriptionDelta)
+	assert.Zero(t, result.WalletDelta)
+	require.NoError(t, DB.First(&sub, sub.Id).Error)
+	assert.EqualValues(t, 50, sub.AmountUsed)
+	require.NoError(t, DB.First(&user, user.Id).Error)
+	assert.Equal(t, -10, user.Quota)
+}

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -133,6 +133,9 @@ type RelayInfo struct {
 	SubscriptionPreConsumed int64
 	// SubscriptionPostDelta is the post-consume delta applied to amount_used (quota units; can be negative).
 	SubscriptionPostDelta int64
+	// WalletQuotaDeducted is the portion of a subscription-funded request that
+	// overflowed to the user's wallet during final settlement.
+	WalletQuotaDeducted int64
 	// SubscriptionPlanId / SubscriptionPlanTitle are used for logging/UI display.
 	SubscriptionPlanId    int
 	SubscriptionPlanTitle string

--- a/service/billing_session.go
+++ b/service/billing_session.go
@@ -71,9 +71,10 @@ func (s *BillingSession) Settle(actualQuota int) error {
 				s.relayInfo.UserId, s.relayInfo.TokenId, delta, tokenErr.Error()))
 		}
 	}
-	// 3) 更新 relayInfo 上的订阅 PostDelta（用于日志）
-	if s.funding.Source() == BillingSourceSubscription {
-		s.relayInfo.SubscriptionPostDelta += int64(delta)
+	// 3) 更新 relayInfo 上的订阅/钱包实际结算拆分（用于日志）
+	if subscriptionFunding, ok := s.funding.(*SubscriptionFunding); ok {
+		s.relayInfo.SubscriptionPostDelta += subscriptionFunding.settledSubscriptionDelta
+		s.relayInfo.WalletQuotaDeducted += subscriptionFunding.settledWalletDelta
 	}
 	s.settled = true
 	return tokenErr
@@ -339,6 +340,7 @@ func (s *BillingSession) syncRelayInfo() {
 		info.SubscriptionId = sub.subscriptionId
 		info.SubscriptionPreConsumed = sub.preConsumed + int64(s.extraReserved)
 		info.SubscriptionPostDelta = 0
+		info.WalletQuotaDeducted = 0
 		info.SubscriptionAmountTotal = sub.AmountTotal
 		info.SubscriptionAmountUsedAfterPreConsume = sub.AmountUsedAfter + int64(s.extraReserved)
 		info.SubscriptionPlanId = sub.PlanId
@@ -346,6 +348,7 @@ func (s *BillingSession) syncRelayInfo() {
 	} else {
 		info.SubscriptionId = 0
 		info.SubscriptionPreConsumed = 0
+		info.WalletQuotaDeducted = 0
 	}
 }
 

--- a/service/billing_session_subscription_test.go
+++ b/service/billing_session_subscription_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/model"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBillingSessionSettleSplitsSubscriptionOverflowAndWallet(t *testing.T) {
+	truncate(t)
+	user := model.User{Id: 801, Username: "subscription-overflow", Quota: 20, Status: common.UserStatusEnabled}
+	require.NoError(t, model.DB.Create(&user).Error)
+	sub := model.UserSubscription{
+		Id:                  802,
+		UserId:              user.Id,
+		AmountTotal:         100,
+		AmountUsed:          80,
+		Status:              "active",
+		StartTime:           time.Now().Add(-time.Hour).Unix(),
+		EndTime:             time.Now().Add(time.Hour).Unix(),
+		AllowWalletOverflow: true,
+	}
+	require.NoError(t, model.DB.Create(&sub).Error)
+
+	relayInfo := &relaycommon.RelayInfo{
+		UserId:                                user.Id,
+		IsPlayground:                          true,
+		BillingSource:                         BillingSourceSubscription,
+		SubscriptionId:                        sub.Id,
+		SubscriptionPreConsumed:               20,
+		SubscriptionAmountTotal:               100,
+		SubscriptionAmountUsedAfterPreConsume: 80,
+	}
+	session := &BillingSession{
+		relayInfo:        relayInfo,
+		funding:          &SubscriptionFunding{userId: user.Id, subscriptionId: sub.Id, preConsumed: 20},
+		preConsumedQuota: 20,
+	}
+
+	require.NoError(t, session.Settle(70))
+	assert.EqualValues(t, 20, relayInfo.SubscriptionPostDelta)
+	assert.EqualValues(t, 30, relayInfo.WalletQuotaDeducted)
+
+	other := map[string]interface{}{}
+	appendBillingInfo(relayInfo, other)
+	assert.EqualValues(t, 40, other["subscription_consumed"])
+	assert.EqualValues(t, 30, other["wallet_quota_deducted"])
+	assert.EqualValues(t, 100, other["subscription_used"])
+	assert.EqualValues(t, 0, other["subscription_remain"])
+
+	require.NoError(t, model.DB.First(&sub, sub.Id).Error)
+	assert.EqualValues(t, 100, sub.AmountUsed)
+	require.NoError(t, model.DB.First(&user, user.Id).Error)
+	assert.Equal(t, -10, user.Quota)
+}

--- a/service/funding_source.go
+++ b/service/funding_source.go
@@ -85,10 +85,12 @@ type SubscriptionFunding struct {
 	subscriptionId int
 	preConsumed    int64
 	// 以下字段在 PreConsume 成功后填充，供 RelayInfo 同步使用
-	AmountTotal     int64
-	AmountUsedAfter int64
-	PlanId          int
-	PlanTitle       string
+	AmountTotal              int64
+	AmountUsedAfter          int64
+	PlanId                   int
+	PlanTitle                string
+	settledSubscriptionDelta int64
+	settledWalletDelta       int64
 }
 
 func (s *SubscriptionFunding) Source() string { return BillingSourceSubscription }
@@ -115,7 +117,13 @@ func (s *SubscriptionFunding) Settle(delta int) error {
 	if delta == 0 {
 		return nil
 	}
-	return model.PostConsumeUserSubscriptionDelta(s.subscriptionId, int64(delta))
+	result, err := model.SettleUserSubscriptionDelta(s.subscriptionId, s.userId, int64(delta))
+	if err != nil {
+		return err
+	}
+	s.settledSubscriptionDelta = result.SubscriptionDelta
+	s.settledWalletDelta = result.WalletDelta
+	return nil
 }
 
 func (s *SubscriptionFunding) Refund() error {

--- a/service/log_info_generate.go
+++ b/service/log_info_generate.go
@@ -201,8 +201,7 @@ func appendBillingInfo(relayInfo *relaycommon.RelayInfo, other map[string]interf
 		if consumed > 0 {
 			other["subscription_consumed"] = consumed
 		}
-		// Wallet quota is not deducted when billed from subscription.
-		other["wallet_quota_deducted"] = 0
+		other["wallet_quota_deducted"] = relayInfo.WalletQuotaDeducted
 	}
 }
 


### PR DESCRIPTION
## 📝 变更描述 / Description

修复订阅请求预扣成功后，最终实际消费超过订阅剩余额度时只保留预扣、未扣除完整费用的问题。

当当前订阅允许使用余额继续时，最终补扣现在会在同一数据库事务内：

- 将订阅剩余额度扣到上限；
- 将超出部分扣入用户钱包，沿用钱包后结算允许负余额的规则；
- 分别记录 `subscription_consumed` 与 `wallet_quota_deducted`；
- 未开启 `allow_wallet_overflow` 时继续保持订阅硬上限，不改变原行为。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #6911

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 已逐项审阅实现和测试，描述按实际代码逻辑整理。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，未发现覆盖最终补扣溢出场景的修复。
- [x] **Bug fix 说明:** 已关联可复现 Issue #6911。
- [x] **变更理解:** 已确认预扣、最终结算、钱包欠费和日志拆分的调用链。
- [x] **范围聚焦:** 仅修改订阅最终结算及对应日志、测试。
- [x] **本地验证:** 已运行相关测试和静态检查。
- [x] **安全合规:** 未包含敏感凭据或生产数据。

## 📸 运行证明 / Proof of Work

通过：

```text
go test -v ./model -run TestSettleUserSubscriptionDelta -count=1
go test -v ./service -run TestBillingSessionSettleSplitsSubscriptionOverflowAndWallet -count=1
go test ./service -run 'Test(BillingSession|PrepareTiered|TryTiered|TaskBilling)' -count=1
go vet ./model ./service ./relay/common
```

新增测试覆盖：

1. 订阅余额充足时全部扣订阅；
2. 订阅不足且允许余额继续时，订阅扣满、钱包扣差额；
3. 钱包不足时仍按现有后结算规则进入负余额；
4. 禁止余额继续时事务回滚且不混扣；
5. 退款只调整订阅；
6. 日志正确拆分订阅消费与钱包消费。

额外执行 `go test ./... -run '^$'`：所有可构建 Go 包均通过，根包因仓库未包含构建后的 `web/dist`（`main.go` 的 embed 目标）而无法在纯源码副本中完成 setup。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription usage can now be settled transactionally, including refunds and bounded quota consumption.
  * When enabled, usage exceeding the remaining subscription balance can be charged to the user’s wallet.
  * Billing records and relay information now accurately report subscription and wallet deductions.

* **Bug Fixes**
  * Prevented incorrect subscription and wallet deduction reporting during billing settlement.
  * Added validation and rollback handling to protect account balances when settlement fails.

* **Tests**
  * Added coverage for normal consumption, refunds, wallet overflow, and rejected overflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->