### PR TITLE
feat: 支持 Seedance 2.5 / 2.0 mini 视频模型（含 1080p 价格分档）

### DIFF
--- a/relay/channel/task/doubao/adaptor.go
+++ b/relay/channel/task/doubao/adaptor.go
@@ -57,6 +57,7 @@ type requestPayload struct {
 	Priority         *dto.IntValue  `json:"priority,omitempty"`
 	Resolution       string         `json:"resolution,omitempty"`
 	Ratio            string         `json:"ratio,omitempty"`
+	OutputFormat     string         `json:"output_format,omitempty"`
 	Duration         *dto.IntValue  `json:"duration,omitempty"`
 	Frames           *dto.IntValue  `json:"frames,omitempty"`
 	Seed             *dto.IntValue  `json:"seed,omitempty"`

--- a/relay/channel/task/doubao/constants.go
+++ b/relay/channel/task/doubao/constants.go
@@ -9,6 +9,8 @@ var ModelList = []string{
 	"doubao-seedance-1-5-pro-251215",
 	"doubao-seedance-2-0-260128",
 	"doubao-seedance-2-0-fast-260128",
+	"doubao-seedance-2-0-mini-260615",
+	"doubao-seedance-2-5-260628",
 }
 
 var ChannelName = "doubao-video"
@@ -35,6 +37,14 @@ var videoPriceTable = map[string]map[videoPriceKey]float64{
 	"doubao-seedance-2-0-fast-260128": {
 		{hasVideo: false}: 37.0,
 		{hasVideo: true}:  22.0,
+	},
+	"doubao-seedance-2-0-mini-260615": {
+		{hasVideo: false}: 23.0,
+		{hasVideo: true}:  14.0,
+	},
+	"doubao-seedance-2-5-260628": {
+		{hasVideo: false}: 70.0,
+		{hasVideo: true}:  42.0,
 	},
 }
 

--- a/relay/channel/task/doubao/constants.go
+++ b/relay/channel/task/doubao/constants.go
@@ -43,8 +43,10 @@ var videoPriceTable = map[string]map[videoPriceKey]float64{
 		{hasVideo: true}:  14.0,
 	},
 	"doubao-seedance-2-5-260628": {
-		{hasVideo: false}: 70.0,
-		{hasVideo: true}:  42.0,
+		{hasVideo: false}:                70.0,
+		{hasVideo: true}:                 42.0,
+		{is1080p: true, hasVideo: false}: 77.0,
+		{is1080p: true, hasVideo: true}:  46.0,
 	},
 }
 


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

补上 Seedance 2.5（doubao-seedance-2-5-260628）和 2.0 mini（doubao-seedance-2-0-mini-260615）：

- 加入 ModelList，并按官方刊例价补 videoPriceTable 分档：2.5 为 70/42（480p/720p 无视频/含视频），1080p 档 77/46（官方 8-17 刚上线）；mini 为 23/14。走现有 `GetVideoInputRatio` → OtherRatio 机制，无逻辑改动。
- requestPayload 补 `output_format` 透传字段（2.5 新增参数）。

价格来源：[火山方舟视频生成定价](https://www.volcengine.com/docs/82379/1544106)。1080p 的 77 元/百万 token 与官网 3.7 元/秒的刊例口径互相印证（1080p ≈ 48.6k token/秒）。


## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)


## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
<img width="3290" height="564" alt="image" src="https://github.com/user-attachments/assets/e29a4dcf-d42f-44ac-a2d3-bd92ea56eeaf" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `doubao-seedance-2-0-mini-260615` and `doubao-seedance-2-5-260628` models.
  * Added pricing support for video inputs, including 1080p pricing for the 2.5 model.
  * Added optional output format configuration for requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->