### PR TITLE
fix(relay): support Codex channels on /v1/chat/completions (SSE without Content-Type + stream-only upstream)

### DIFF
--- a/relay/chat_completions_via_responses.go
+++ b/relay/chat_completions_via_responses.go
@@ -1,6 +1,8 @@
 package relay
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,6 +19,7 @@ import (
 	"github.com/QuantumNous/new-api/service"
 
 	"github.com/gin-gonic/gin"
+	"github.com/samber/lo"
 )
 
 func applySystemPromptIfNeeded(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeneralOpenAIRequest) {
@@ -112,6 +115,14 @@ func chatCompletionsViaResponses(c *gin.Context, info *relaycommon.RelayInfo, ad
 	info.RelayMode = relayconstant.RelayModeResponses
 	info.RequestURLPath = "/v1/responses"
 
+	// Codex 上游（chatgpt.com/backend-api/codex/responses）只接受流式请求，
+	// 非流式会被直接拒为 400 "Stream must be set to true"。客户端要非流式时，
+	// 强制上游走流式，响应再由下方 buffered handler 聚合成完整 JSON 返回给客户端。
+	// info.IsStream 保持不变，以免把 SSE 直接透传给期望 JSON 的客户端。
+	if info.ChannelType == constant.ChannelTypeCodex && !lo.FromPtrOr(responsesReq.Stream, false) {
+		responsesReq.Stream = lo.ToPtr(true)
+	}
+
 	convertedRequest, err := adaptor.ConvertOpenAIResponsesRequest(c, info, *responsesReq)
 	if err != nil {
 		return nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
@@ -149,7 +160,7 @@ func chatCompletionsViaResponses(c *gin.Context, info *relaycommon.RelayInfo, ad
 
 	httpResp = resp.(*http.Response)
 	clientStream := info.IsStream
-	upstreamStream := isResponsesEventStreamContentType(httpResp.Header.Get("Content-Type"))
+	upstreamStream := responsesUpstreamIsStream(httpResp)
 	info.IsStream = clientStream || upstreamStream
 	if httpResp.StatusCode != http.StatusOK {
 		newApiErr := service.RelayErrorHandler(c.Request.Context(), httpResp, false)
@@ -185,4 +196,41 @@ func chatCompletionsViaResponses(c *gin.Context, info *relaycommon.RelayInfo, ad
 
 func isResponsesEventStreamContentType(contentType string) bool {
 	return strings.Contains(strings.ToLower(contentType), "text/event-stream")
+}
+
+// sseBodySniffLen 覆盖最长的 SSE 行前缀 "event:"。
+const sseBodySniffLen = 6
+
+type peekedBody struct {
+	io.Reader
+	io.Closer
+}
+
+// responsesUpstreamIsStream 判断上游 Responses 响应是否为 SSE 事件流。
+//
+// Content-Type 不可信：Codex 的 chatgpt.com/backend-api/codex/responses 返回 SSE
+// 时不带该响应头，仅凭响应头判断会把事件流当成 JSON 解析，首字符 'e'（event:）
+// 直接触发 "invalid character 'e' looking for beginning of value"。
+// 因此响应头缺失或不匹配时，改为嗅探响应体首字节；被读取的字节会放回 Body，
+// 后续 handler 仍能拿到完整响应。
+func responsesUpstreamIsStream(resp *http.Response) bool {
+	if resp == nil {
+		return false
+	}
+	if isResponsesEventStreamContentType(resp.Header.Get("Content-Type")) {
+		return true
+	}
+	if resp.Body == nil {
+		return false
+	}
+
+	original := resp.Body
+	buffered := bufio.NewReader(original)
+	resp.Body = peekedBody{Reader: buffered, Closer: original}
+
+	prefix, err := buffered.Peek(sseBodySniffLen)
+	if len(prefix) == 0 && err != nil {
+		return false
+	}
+	return bytes.HasPrefix(prefix, []byte("data:")) || bytes.HasPrefix(prefix, []byte("event:"))
 }

--- a/relay/chat_completions_via_responses_stream_detect_test.go
+++ b/relay/chat_completions_via_responses_stream_detect_test.go
@@ -1,0 +1,96 @@
+package relay
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func newResp(contentType, body string) *http.Response {
+	h := http.Header{}
+	if contentType != "" {
+		h.Set("Content-Type", contentType)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+const codexSSEBody = "event: response.created\n" +
+	`data: {"type":"response.created","response":{"id":"resp_1"}}` + "\n\n"
+
+func TestResponsesUpstreamIsStream(t *testing.T) {
+	cases := []struct {
+		name        string
+		contentType string
+		body        string
+		want        bool
+	}{
+		{"标准 SSE 响应头", "text/event-stream", codexSSEBody, true},
+		{"SSE 响应头带 charset", "text/event-stream; charset=utf-8", codexSSEBody, true},
+		// Codex 的 backend-api/codex/responses 返回 SSE 却不带 Content-Type，
+		// 这是线上 500 "invalid character 'e'" 的直接成因。
+		{"无 Content-Type 但体是 SSE(event: 开头)", "", codexSSEBody, true},
+		{"无 Content-Type 但体是 SSE(data: 开头)", "", "data: {\"type\":\"x\"}\n\n", true},
+		{"无 Content-Type 且体是 JSON", "", `{"id":"resp_1","object":"response"}`, false},
+		{"JSON 响应头", "application/json", `{"id":"resp_1"}`, false},
+		{"空响应体", "", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := newResp(tc.contentType, tc.body)
+			if got := responsesUpstreamIsStream(resp); got != tc.want {
+				t.Fatalf("responsesUpstreamIsStream() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// 嗅探不能吃掉响应体，否则后续 handler 会丢事件。
+func TestResponsesUpstreamIsStreamPreservesBody(t *testing.T) {
+	resp := newResp("", codexSSEBody)
+
+	if !responsesUpstreamIsStream(resp) {
+		t.Fatal("应判定为 SSE")
+	}
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("读取响应体失败: %v", err)
+	}
+	if string(got) != codexSSEBody {
+		t.Fatalf("响应体被嗅探消耗了\n got: %q\nwant: %q", string(got), codexSSEBody)
+	}
+}
+
+// 嗅探替换 Body 后，原始 Closer 仍须被调用，避免连接泄漏。
+func TestResponsesUpstreamIsStreamClosesOriginalBody(t *testing.T) {
+	closed := false
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Body: struct {
+			io.Reader
+			io.Closer
+		}{
+			Reader: strings.NewReader(codexSSEBody),
+			Closer: closerFunc(func() error { closed = true; return nil }),
+		},
+	}
+
+	responsesUpstreamIsStream(resp)
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("关闭失败: %v", err)
+	}
+	if !closed {
+		t.Fatal("原始 Body 的 Close 未被调用")
+	}
+}
+
+type closerFunc func() error
+
+func (f closerFunc) Close() error { return f() }


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

> 说明：问题定位与代码实现有 AI（Claude）辅助，本描述由提交者审阅整理后发出；结论均来自下方可复现的实测，未直接粘贴未经处理的 AI 输出。

## 📝 变更描述 / Description

修复 Codex（ChatGPT Subscription，`ChannelTypeCodex = 57`）渠道下 `/v1/chat/completions` 完全不可用的问题。该路径由 `global.chat_completions_to_responses_policy` 启用后走 `chatCompletionsViaResponses`，目前无论客户端是否要求流式都会失败，且两种失败的成因不同：

**其一：上游返回 SSE 但不带 `Content-Type`，被当成 JSON 解析**

`chatgpt.com/backend-api/codex/responses` 返回 `200` + SSE 事件流，但**不返回任何 `Content-Type` 响应头**（实测：请求是否带 `Accept: text/event-stream` 都一样）。而判定只看响应头：

```go
upstreamStream := isResponsesEventStreamContentType(httpResp.Header.Get("Content-Type"))
```

取到空串，`strings.Contains("", "text/event-stream")` 恒为 `false`，于是流式分支与 buffered 分支双双跳过，落到最后的非流式分支，对 `event: response.created...` 开头的 SSE 直接 `Unmarshal`，首字符 `e` 触发：

```
status_code=500, invalid character 'e' looking for beginning of value
```

本 PR 在响应头判定失败时改为**嗅探响应体首字节**：`event:` / `data:` 前缀视为 SSE，`{` / `[` / `"` 提前判定为非 SSE；嗅探读到的字节经 `bufio.Reader` 放回 `Body`，下游 handler 仍能读到完整响应，并保留原始 `Closer` 以免连接泄漏。

**其二：上游只接受流式请求，非流式客户端仍然失败**

补上第一处后，`stream: true` 的请求即可正常工作，但 `stream: false` 仍然失败——Codex 上游只接受流式请求，非流式会被直接拒为 `400 Stream must be set to true`，此时响应体根本不存在，第一处的嗅探也就无从触发。

因此本 PR 对 Codex 渠道在客户端请求非流式时强制向上游发送 `stream: true`，响应交由**既有的** `OaiResponsesToChatBufferedStreamHandler` 聚合回完整 JSON；`info.IsStream` 保持不变，不会把 SSE 透传给期望 JSON 的客户端。换言之，这一步只是让仓库里已有的 buffered 分支**变得可达**，没有新增响应处理逻辑。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #6075

**与现有 PR / Issue 的关系（请维护者留意）：**

- **#6254** 已针对上述**第一处**提出等价修复，思路一致（同样是嗅探响应体并回填字节）。该 PR 的实现在细节上更细致（逐字节读取、处理 BOM 与前导空白），**如维护者更倾向合并 #6254，我完全赞成**——但请注意 **#6254 单独合并不足以修好 `/v1/chat/completions`**：非流式客户端仍会收到 `400 Stream must be set to true`（成因见上文「其二」）。这一点目前 #6075 线程中尚无人指出。届时可只取本 PR 的第二处改动。
- **#6102** 提出了通用的渠道级 Force Stream 开关。本 PR 的第二处是 Codex 渠道的自动行为（该上游在协议层面就不接受非流式），不引入新配置项；若 #6102 先行合并，本 PR 的第二处可改为复用其开关。

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 描述已由本人审阅整理，未直接粘贴未经处理的 AI 输出（AI 辅助情况已在开头说明）。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs。第一处与 #6254 存在重叠，已在上方显式说明并给出取舍建议；第二处为现有 PR 未覆盖的部分。
- [x] **Bug fix 说明:** 已关联 #6075；两处失败均有可复现的上游行为证据，非设计取舍或理解偏差。
- [x] **变更理解:** 已理解改动原理与影响面（见下方影响面说明）。
- [x] **范围聚焦:** 仅改动 `relay/chat_completions_via_responses.go` 及其测试，未夹带无关改动。
- [x] **本地验证:** 已在真实部署上完成端到端验证，并补充单元测试（见下）。
- [x] **安全合规:** 无敏感凭据。

**影响面说明：** 嗅探仅在 `Content-Type` 判定失败时触发，正常返回该响应头的上游行为完全不变；强制流式仅作用于 `ChannelTypeCodex`，不影响其他渠道。

## 📸 运行证明 / Proof of Work

**1. 上游行为实测**（直接请求 `chatgpt.com/backend-api/codex/responses`，凭据已省略）

```
$ curl -sS -D - -o body.txt ... -H 'Accept: text/event-stream' ...
HTTP/2 200
（响应头中没有任何 Content-Type 字段）

$ head -2 body.txt
event: response.created
data: {"type":"response.created","response":{"id":"resp_...","object":"response",...

# 去掉 Accept: text/event-stream 后重测，结果完全相同：仍是 200 + SSE，仍无 Content-Type
```

**2. 修复前后对比**（基于 `v1.0.0-rc.24`，Codex 渠道 + `gpt-5.6-terra` / `gpt-5.6-luna`）

| 请求 | 修复前 | 修复后 |
|---|---|---|
| `/v1/chat/completions` `stream: false` | `500 invalid character 'e'` | ✅ 正常返回 `chat.completion` JSON |
| `/v1/chat/completions` `stream: true` | `500 invalid character 'e'` | ✅ 正常返回 `chat.completion.chunk` 事件流 |
| `/v1/responses` `stream: true`（回归） | 正常 | ✅ 仍正常 |

仅打第一处补丁时，`stream: false` 会变成 `400 Stream must be set to true`（即上文「其二」），两处同时打上才完全可用。

修复后非流式返回示例（已删节）：

```json
{"object":"chat.completion","model":"gpt-5.6-terra",
 "choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],
 "usage":{"prompt_tokens":8,"completion_tokens":5,"total_tokens":13}}
```

计费链路正常：修复后请求均正确写入 `logs` 并计入配额（`billing_usage.source = oai_responses`）。

**3. 单元测试**

新增 `relay/chat_completions_via_responses_stream_detect_test.go`，覆盖：标准 SSE 响应头 / 带 charset / **无 Content-Type 但体为 SSE（`event:` 与 `data:` 两种开头）** / 无 Content-Type 且体为 JSON / JSON 响应头 / 空响应体；另有两条针对回填与资源释放的用例：嗅探后响应体内容完整未被消耗、原始 `Body` 的 `Close` 仍会被调用。

```
$ go vet ./relay/
$ go test ./relay/ -run TestResponsesUpstreamIsStream -v
--- PASS: TestResponsesUpstreamIsStream (0.00s)
    --- PASS: TestResponsesUpstreamIsStream/标准_SSE_响应头
    --- PASS: TestResponsesUpstreamIsStream/SSE_响应头带_charset
    --- PASS: TestResponsesUpstreamIsStream/无_Content-Type_但体是_SSE(event:_开头)
    --- PASS: TestResponsesUpstreamIsStream/无_Content-Type_但体是_SSE(data:_开头)
    --- PASS: TestResponsesUpstreamIsStream/无_Content-Type_且体是_JSON
    --- PASS: TestResponsesUpstreamIsStream/JSON_响应头
    --- PASS: TestResponsesUpstreamIsStream/空响应体
--- PASS: TestResponsesUpstreamIsStreamPreservesBody (0.00s)
--- PASS: TestResponsesUpstreamIsStreamClosesOriginalBody (0.00s)
PASS
ok      github.com/QuantumNous/new-api/relay

$ go test ./relay/...    # relay 全部包，无失败
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-streaming chat requests when communicating with the Responses API.
  * More reliably detects streamed responses, including responses with missing or inaccurate content-type headers.
  * Preserves response data during stream detection to prevent downstream processing issues.

* **Tests**
  * Added coverage for streamed responses, JSON and empty responses, missing headers, body preservation, and response cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->