### PR TITLE
修复：记录异常流中断到错误日志

### DIFF
--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -283,7 +283,11 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 		if err := scanner.Err(); err != nil {
 			if err != io.EOF {
 				logger.LogError(c, "scanner error: "+err.Error())
-				info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonScannerErr, err)
+				clientGone := c.Request != nil && c.Request.Context().Err() != nil
+				if !clientGone {
+					info.StreamStatus.RecordError(err.Error())
+					info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonScannerErr, err)
+				}
 			}
 		}
 		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonEOF, nil)
@@ -306,5 +310,6 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 		logger.LogInfo(c, fmt.Sprintf("stream ended: %s", info.StreamStatus.Summary()))
 	} else {
 		logger.LogError(c, fmt.Sprintf("stream ended: %s, received=%d", info.StreamStatus.Summary(), info.ReceivedResponseCount))
+		service.RecordStreamErrorLog(c, info)
 	}
 }

--- a/service/stream_error_log.go
+++ b/service/stream_error_log.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/model"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RecordStreamErrorLog writes a type=5 monitoring event when an upstream SSE
+// response ends abnormally after the HTTP response was accepted. It does not
+// return a relay error, because replaying a partially delivered request is
+// unsafe. A pure client cancellation is intentionally excluded.
+func RecordStreamErrorLog(c *gin.Context, relayInfo *relaycommon.RelayInfo) {
+	if c == nil || relayInfo == nil || relayInfo.StreamStatus == nil || !constant.ErrorLogEnabled {
+		return
+	}
+	streamStatus := relayInfo.StreamStatus
+	if (streamStatus.IsNormalEnd() && !streamStatus.HasErrors()) ||
+		(streamStatus.EndReason == relaycommon.StreamEndReasonClientGone && !streamStatus.HasErrors()) {
+		return
+	}
+
+	channelID := 0
+	if relayInfo.ChannelMeta != nil {
+		channelID = relayInfo.ChannelMeta.ChannelId
+	}
+	streamDetails := map[string]interface{}{
+		"status":      "error",
+		"end_reason":  string(streamStatus.EndReason),
+		"received":    relayInfo.ReceivedResponseCount,
+		"error_count": streamStatus.ErrorCount,
+	}
+	if streamStatus.EndError != nil {
+		streamDetails["end_error"] = streamStatus.EndError.Error()
+	}
+	if streamStatus.ErrorCount > 0 {
+		messages := make([]string, 0, len(streamStatus.Errors))
+		for _, entry := range streamStatus.Errors {
+			messages = append(messages, entry.Message)
+		}
+		streamDetails["errors"] = messages
+	}
+	other := map[string]interface{}{
+		"error_type":    "transport",
+		"error_code":    "stream_incomplete",
+		"status_code":   0,
+		"channel_id":    channelID,
+		"channel_name":  c.GetString("channel_name"),
+		"channel_type":  c.GetInt("channel_type"),
+		"request_path":  relayInfo.RequestURLPath,
+		"stream_status": streamDetails,
+	}
+	if c.Request != nil && c.Request.URL != nil {
+		other["request_path"] = c.Request.URL.Path
+	}
+
+	startTime := common.GetContextKeyTime(c, constant.ContextKeyRequestStartTime)
+	if startTime.IsZero() {
+		startTime = time.Now()
+	}
+	model.RecordErrorLog(c, relayInfo.UserId, channelID, relayInfo.OriginModelName,
+		c.GetString("token_name"), "upstream stream ended before completion", relayInfo.TokenId,
+		int(time.Since(startTime).Seconds()), true, relayInfo.UserGroup, other)
+}

--- a/service/stream_error_log_test.go
+++ b/service/stream_error_log_test.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/model"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newStreamErrorLogTestContext() *gin.Context {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Set("channel_name", "test-channel")
+	c.Set("channel_type", 1)
+	return c
+}
+
+func countErrorLogs(t *testing.T) int64 {
+	t.Helper()
+	var count int64
+	require.NoError(t, model.LOG_DB.Model(&model.Log{}).Where("type = ?", model.LogTypeError).Count(&count).Error)
+	return count
+}
+
+func TestRecordStreamErrorLogWritesMonitorEvent(t *testing.T) {
+	model.LOG_DB.Exec("DELETE FROM logs")
+	oldErrorLogEnabled := constant.ErrorLogEnabled
+	constant.ErrorLogEnabled = true
+	t.Cleanup(func() {
+		constant.ErrorLogEnabled = oldErrorLogEnabled
+		model.LOG_DB.Exec("DELETE FROM logs")
+	})
+
+	info := &relaycommon.RelayInfo{
+		UserId:          7,
+		OriginModelName: "gpt-5.6-sol",
+		UserGroup:       "default",
+		TokenId:         11,
+		ChannelMeta:     &relaycommon.ChannelMeta{ChannelId: 23},
+		RequestURLPath:  "/v1/responses",
+		StreamStatus:    relaycommon.NewStreamStatus(),
+	}
+	info.StreamStatus.RecordError("http2: response body closed")
+	info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonScannerErr, errors.New("http2: response body closed"))
+
+	RecordStreamErrorLog(newStreamErrorLogTestContext(), info)
+
+	var log model.Log
+	require.NoError(t, model.LOG_DB.Order("id DESC").First(&log).Error)
+	assert.Equal(t, model.LogTypeError, log.Type)
+	assert.Equal(t, 23, log.ChannelId)
+	assert.Equal(t, "gpt-5.6-sol", log.ModelName)
+	assert.True(t, log.IsStream)
+	other, err := common.StrToMap(log.Other)
+	require.NoError(t, err)
+	assert.Equal(t, "transport", other["error_type"])
+	assert.Equal(t, "stream_incomplete", other["error_code"])
+	assert.Equal(t, float64(0), other["status_code"])
+	streamStatus, ok := other["stream_status"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "scanner_error", streamStatus["end_reason"])
+	assert.Equal(t, float64(1), streamStatus["error_count"])
+}
+
+func TestRecordStreamErrorLogSkipsClientCancellation(t *testing.T) {
+	model.LOG_DB.Exec("DELETE FROM logs")
+	oldErrorLogEnabled := constant.ErrorLogEnabled
+	constant.ErrorLogEnabled = true
+	t.Cleanup(func() {
+		constant.ErrorLogEnabled = oldErrorLogEnabled
+		model.LOG_DB.Exec("DELETE FROM logs")
+	})
+
+	info := &relaycommon.RelayInfo{
+		ChannelMeta:  &relaycommon.ChannelMeta{ChannelId: 23},
+		StreamStatus: relaycommon.NewStreamStatus(),
+	}
+	info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, errors.New("context canceled"))
+
+	RecordStreamErrorLog(newStreamErrorLogTestContext(), info)
+
+	assert.Equal(t, int64(0), countErrorLogs(t))
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
本 PR 将为 `StreamScannerHandler` 增加异常流中断的错误日志记录：当上游 SSE 流在 HTTP 响应已建立后异常结束时，合并后会向 `logs` 表写入 `type=5` 错误日志。日志附带 `error_type=transport`、`error_code=stream_incomplete`、状态码、渠道和流结束状态等结构化字段，便于 NewapiMonitor 和后台排查及时识别上游传输故障。

合并后，纯客户端主动取消且没有其他流错误时不会写入该错误日志，避免把正常的客户端断开误判为上游故障。本变更只补充错误记录，不改变现有重试策略。

本变更由 OpenAI Codex AI 辅助完成，并经过本地测试与格式检查。当前行为仅存在于本 PR 分支，尚未合并到 `main` 或部署到生产。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 关联 #6547：流式响应中偶发 `scanner_error`，需要保留可检索的错误记录
- 关联 #5222：完善流式错误分类和日志可读性
- 相关背景 #6649：`client_gone` 结束原因竞态；本 PR 不改变该结束原因的判定逻辑

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 已关联 #6547、#5222；本变更解决异常流中断未进入错误日志的问题。
- [x] **变更理解:** 我已理解流扫描错误、流结束状态和 `type=5` 错误日志之间的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 仅包含异常流中断记录逻辑及其回归测试。
- [x] **本地验证:** 已在本地运行并通过目标 Go 测试、格式检查和 diff 检查，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- `GOMAXPROCS=4 go test -p=4 ./relay/common ./relay/helper ./service`
- `git diff --check`
- `gofmt -d relay/helper/stream_scanner.go service/stream_error_log.go service/stream_error_log_test.go`（无输出）
- 回归测试验证：scanner 中断写入 `type=5` 日志；纯 `client_gone` 不写入错误日志。