### PR TITLE
fix: 个人资料绑定卡片未应用自定义 OIDC 显示名称

### DIFF
--- a/web/src/features/profile/components/tabs/account-bindings-tab.tsx
+++ b/web/src/features/profile/components/tabs/account-bindings-tab.tsx
@@ -359,7 +359,7 @@ export function AccountBindingsTab({
       },
       {
         id: 'oidc',
-        label: t('OIDC'),
+        label: status?.oidc_display_name?.trim() || t('OIDC'),
         icon: Shield,
         value: (profile as unknown as Record<string, unknown>).oidc_id as
           | string


### PR DESCRIPTION
## 📝 变更描述 / Description
cb4c8c02 (#6012) 加了自定义 OIDC 显示名称，登录按钮已生效，但个人资料页的绑定卡片漏了，仍然写死 "OIDC"。改成读 `status.oidc_display_name`，未配置时回退原样。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 补充 #6012 遗漏的展示位

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
修复前: 
<img width="838" height="194" alt="image" src="https://github.com/user-attachments/assets/a9f93ded-cc5e-4e93-a295-5929b0de913a" />

修复后:
<img width="844" height="188" alt="image" src="https://github.com/user-attachments/assets/0b6e44a2-2799-4e6d-95b9-a46a053705cd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * OIDC account bindings now display the server-provided name when available.
  * A default “OIDC” label remains available when no valid custom name is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->