### PR TITLE
feat: add HappyHorse Ali task adapter

### DIFF
--- a/model/task.go
+++ b/model/task.go
@@ -119,7 +119,7 @@ type TaskBillingContext struct {
 	ModelRatio      float64            `json:"model_ratio,omitempty"`       // 模型倍率
 	OtherRatios     map[string]float64 `json:"other_ratios,omitempty"`      // 附加倍率（时长、分辨率等）
 	OriginModelName string             `json:"origin_model_name,omitempty"` // 模型名称，必须为OriginModelName
-	PerCallBilling  bool               `json:"per_call_billing,omitempty"`  // 按次计费：跳过轮询阶段的差额结算
+	PerCallBilling  bool               `json:"per_call_billing,omitempty"`  // 按次计费：adaptor 无调整时不回退到 token 重算
 }
 
 // GetUpstreamTaskID 获取上游真实 task ID（用于与 provider 通信）

--- a/relay/channel/ali/constants.go
+++ b/relay/channel/ali/constants.go
@@ -1,6 +1,13 @@
 package ali
 
 var ModelList = []string{
+	"happyhorse-1.1-t2v",
+	"happyhorse-1.1-i2v",
+	"happyhorse-1.1-r2v",
+	"happyhorse-1.0-t2v",
+	"happyhorse-1.0-i2v",
+	"happyhorse-1.0-r2v",
+	"happyhorse-1.0-video-edit",
 	"qwen-turbo",
 	"qwen-plus",
 	"qwen-max",

--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/QuantumNous/new-api/service"
+	hosttypes "github.com/QuantumNous/new-api/types"
 	"github.com/samber/lo"
 
 	"github.com/gin-gonic/gin"
@@ -54,13 +56,15 @@ type AliVideoInput struct {
 
 // AliVideoParameters 视频参数
 type AliVideoParameters struct {
-	Resolution   string `json:"resolution,omitempty"`    // 分辨率: 480P/720P/1080P（图生视频、首尾帧生视频）
-	Size         string `json:"size,omitempty"`          // 尺寸: 如 "832*480"（文生视频）
-	Duration     int    `json:"duration,omitempty"`      // 时长: 3-10秒
-	PromptExtend bool   `json:"prompt_extend,omitempty"` // 是否开启prompt智能改写
-	Watermark    bool   `json:"watermark,omitempty"`     // 是否添加水印
-	Audio        *bool  `json:"audio,omitempty"`         // 是否添加音频（wan2.5）
-	Seed         int    `json:"seed,omitempty"`          // 随机数种子
+	Resolution   string  `json:"resolution,omitempty"`    // 分辨率: 480P/720P/1080P（图生视频、首尾帧生视频）
+	Size         string  `json:"size,omitempty"`          // 尺寸: 如 "832*480"（文生视频）
+	Duration     int     `json:"duration,omitempty"`      // 时长: 3-15秒
+	Ratio        *string `json:"ratio,omitempty"`         // HappyHorse 输出画幅
+	PromptExtend *bool   `json:"prompt_extend,omitempty"` // 是否开启prompt智能改写
+	Watermark    *bool   `json:"watermark,omitempty"`     // 是否添加水印
+	Audio        *bool   `json:"audio,omitempty"`         // 是否添加音频（wan2.5）
+	AudioSetting *string `json:"audio_setting,omitempty"` // HappyHorse 视频编辑声音控制
+	Seed         *int    `json:"seed,omitempty"`          // 随机数种子
 }
 
 // AliVideoResponse 阿里通义万相响应
@@ -88,9 +92,11 @@ type AliVideoOutput struct {
 
 // AliUsage 使用统计
 type AliUsage struct {
-	Duration   dto.IntValue `json:"duration,omitempty"`
-	VideoCount dto.IntValue `json:"video_count,omitempty"`
-	SR         dto.IntValue `json:"SR,omitempty"`
+	Duration            dto.StringValue `json:"duration,omitempty"`
+	InputVideoDuration  dto.StringValue `json:"input_video_duration,omitempty"`
+	OutputVideoDuration dto.StringValue `json:"output_video_duration,omitempty"`
+	VideoCount          dto.IntValue    `json:"video_count,omitempty"`
+	SR                  dto.IntValue    `json:"SR,omitempty"`
 }
 
 type AliMetadata struct {
@@ -107,9 +113,11 @@ type AliMetadata struct {
 	Resolution   *string `json:"resolution,omitempty"`    // 分辨率: 480P/720P/1080P
 	Size         *string `json:"size,omitempty"`          // 尺寸: 如 "832*480"
 	Duration     *int    `json:"duration,omitempty"`      // 时长
+	Ratio        *string `json:"ratio,omitempty"`         // HappyHorse 输出画幅
 	PromptExtend *bool   `json:"prompt_extend,omitempty"` // 是否开启prompt智能改写
 	Watermark    *bool   `json:"watermark,omitempty"`     // 是否添加水印
 	Audio        *bool   `json:"audio,omitempty"`         // 是否添加音频
+	AudioSetting *string `json:"audio_setting,omitempty"` // HappyHorse 视频编辑声音控制
 	Seed         *int    `json:"seed,omitempty"`          // 随机数种子
 }
 
@@ -132,7 +140,24 @@ func (a *TaskAdaptor) Init(info *relaycommon.RelayInfo) {
 
 func (a *TaskAdaptor) ValidateRequestAndSetAction(c *gin.Context, info *relaycommon.RelayInfo) (taskErr *taskdto.TaskError) {
 	// ValidateMultipartDirect 负责解析并将原始 TaskSubmitReq 存入 context
-	return relaycommon.ValidateMultipartDirect(c, info)
+	if taskErr := relaycommon.ValidateMultipartDirect(c, info); taskErr != nil {
+		return taskErr
+	}
+	taskReq, err := relaycommon.GetTaskRequest(c)
+	if err != nil {
+		return service.TaskErrorWrapperLocal(err, "invalid_request", http.StatusBadRequest)
+	}
+	modelName := taskReq.Model
+	if info.IsModelMapped {
+		modelName = info.UpstreamModelName
+	}
+	if !isHappyHorseModel(modelName) {
+		return nil
+	}
+	if _, err := a.convertToAliRequest(info, taskReq); err != nil {
+		return service.TaskErrorWrapperLocal(err, "invalid_request", http.StatusBadRequest)
+	}
+	return nil
 }
 
 func (a *TaskAdaptor) BuildRequestURL(info *relaycommon.RelayInfo) (string, error) {
@@ -188,6 +213,253 @@ var (
 	}
 )
 
+const (
+	happyHorseMinDurationSeconds     = 3
+	happyHorseMaxDurationSeconds     = 15
+	happyHorseEditPrechargeSeconds   = 30
+	happyHorseMaxReferenceImages     = 9
+	happyHorseMaxEditReferenceImages = 5
+)
+
+var happyHorseRatios = map[string]struct{}{
+	"16:9": {},
+	"9:16": {},
+	"1:1":  {},
+	"4:3":  {},
+	"3:4":  {},
+	"4:5":  {},
+	"5:4":  {},
+	"9:21": {},
+	"21:9": {},
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func isHappyHorseModel(model string) bool {
+	return strings.HasPrefix(model, "happyhorse-1.1-") || strings.HasPrefix(model, "happyhorse-1.0-")
+}
+
+func isHappyHorse11Model(model string) bool {
+	return strings.HasPrefix(model, "happyhorse-1.1-")
+}
+
+func isHappyHorseI2VModel(model string) bool {
+	return strings.HasSuffix(model, "-i2v")
+}
+
+func isHappyHorseR2VModel(model string) bool {
+	return strings.HasSuffix(model, "-r2v")
+}
+
+func isHappyHorseT2VModel(model string) bool {
+	return strings.HasSuffix(model, "-t2v")
+}
+
+func isHappyHorseVideoEditModel(model string) bool {
+	return model == "happyhorse-1.0-video-edit"
+}
+
+func normalizeHappyHorseResolution(value string) (string, error) {
+	resolution := strings.ToUpper(strings.TrimSpace(value))
+	if resolution == "" {
+		return "", nil
+	}
+	if strings.ContainsAny(resolution, "*X") {
+		resolution = strings.ReplaceAll(resolution, "X", "*")
+		return sizeToResolution(resolution)
+	}
+	if !strings.HasSuffix(resolution, "P") {
+		resolution += "P"
+	}
+	switch resolution {
+	case "480P", "720P", "1080P":
+		return resolution, nil
+	default:
+		return "", fmt.Errorf("invalid HappyHorse resolution: %s", value)
+	}
+}
+
+func validateHappyHorseResolution(model, resolution string) error {
+	if resolution == "" {
+		return fmt.Errorf("HappyHorse resolution is required")
+	}
+	if resolution != "720P" && resolution != "1080P" {
+		return fmt.Errorf("%s only supports 720P and 1080P", model)
+	}
+	return nil
+}
+
+func appendUniqueURL(urls []string, seen map[string]struct{}, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return urls
+	}
+	if _, ok := seen[value]; ok {
+		return urls
+	}
+	seen[value] = struct{}{}
+	return append(urls, value)
+}
+
+func taskReferenceImages(req relaycommon.TaskSubmitReq, excludedURL string) []string {
+	seen := make(map[string]struct{})
+	if excludedURL != "" {
+		seen[strings.TrimSpace(excludedURL)] = struct{}{}
+	}
+	urls := make([]string, 0, len(req.Images)+2)
+	urls = appendUniqueURL(urls, seen, req.Image)
+	for _, image := range req.Images {
+		urls = appendUniqueURL(urls, seen, image)
+	}
+	urls = appendUniqueURL(urls, seen, req.InputReference)
+	return urls
+}
+
+func validateHappyHorseMedia(model string, media []AliVideoMedia) error {
+	switch {
+	case isHappyHorseT2VModel(model):
+		if len(media) != 0 {
+			return fmt.Errorf("%s does not accept input media", model)
+		}
+	case isHappyHorseI2VModel(model):
+		if len(media) != 1 || media[0].Type != "first_frame" || strings.TrimSpace(media[0].URL) == "" {
+			return fmt.Errorf("%s requires exactly one first_frame media item", model)
+		}
+	case isHappyHorseR2VModel(model):
+		if len(media) < 1 || len(media) > happyHorseMaxReferenceImages {
+			return fmt.Errorf("%s requires 1-%d reference_image items", model, happyHorseMaxReferenceImages)
+		}
+		for _, item := range media {
+			if item.Type != "reference_image" || strings.TrimSpace(item.URL) == "" {
+				return fmt.Errorf("%s only accepts non-empty reference_image items", model)
+			}
+		}
+	case isHappyHorseVideoEditModel(model):
+		videoCount := 0
+		referenceCount := 0
+		for _, item := range media {
+			if strings.TrimSpace(item.URL) == "" {
+				return fmt.Errorf("%s media URL cannot be empty", model)
+			}
+			switch item.Type {
+			case "video":
+				videoCount++
+			case "reference_image":
+				referenceCount++
+			default:
+				return fmt.Errorf("%s only accepts video and reference_image media", model)
+			}
+		}
+		if videoCount != 1 || referenceCount > happyHorseMaxEditReferenceImages {
+			return fmt.Errorf("%s requires one video and at most %d reference_image items", model, happyHorseMaxEditReferenceImages)
+		}
+	default:
+		return fmt.Errorf("unsupported HappyHorse model: %s", model)
+	}
+	return nil
+}
+
+func normalizeHappyHorseInput(aliReq *AliVideoRequest, req relaycommon.TaskSubmitReq) error {
+	model := aliReq.Model
+	if !isHappyHorseModel(model) {
+		return nil
+	}
+
+	if len(aliReq.Input.Media) == 0 {
+		switch {
+		case isHappyHorseT2VModel(model):
+			if firstTaskImage(req) != "" || aliReq.Input.FirstFrameURL != "" || aliReq.Input.LastFrameURL != "" {
+				return fmt.Errorf("%s does not accept input media", model)
+			}
+		case isHappyHorseI2VModel(model):
+			images := taskReferenceImages(req, "")
+			if len(images) != 1 {
+				return fmt.Errorf("%s requires exactly one input image", model)
+			}
+			aliReq.Input.Media = []AliVideoMedia{{Type: "first_frame", URL: images[0]}}
+		case isHappyHorseR2VModel(model):
+			for _, image := range taskReferenceImages(req, "") {
+				aliReq.Input.Media = append(aliReq.Input.Media, AliVideoMedia{Type: "reference_image", URL: image})
+			}
+		case isHappyHorseVideoEditModel(model):
+			videoURL := strings.TrimSpace(req.InputReference)
+			if videoURL != "" {
+				aliReq.Input.Media = append(aliReq.Input.Media, AliVideoMedia{Type: "video", URL: videoURL})
+			}
+			for _, image := range taskReferenceImages(req, videoURL) {
+				aliReq.Input.Media = append(aliReq.Input.Media, AliVideoMedia{Type: "reference_image", URL: image})
+			}
+		}
+	}
+
+	if err := validateHappyHorseMedia(model, aliReq.Input.Media); err != nil {
+		return err
+	}
+	aliReq.Input.ImgURL = ""
+	aliReq.Input.FirstFrameURL = ""
+	aliReq.Input.LastFrameURL = ""
+	aliReq.Input.AudioURL = ""
+	return nil
+}
+
+func validateHappyHorseParameters(aliReq *AliVideoRequest) error {
+	if aliReq.Parameters == nil {
+		return fmt.Errorf("HappyHorse parameters cannot be null")
+	}
+	model := aliReq.Model
+	if aliReq.Parameters.Size != "" {
+		return fmt.Errorf("%s does not accept parameters.size; use resolution", model)
+	}
+	if aliReq.Parameters.PromptExtend != nil || aliReq.Parameters.Audio != nil {
+		return fmt.Errorf("%s received unsupported parameters", model)
+	}
+	if aliReq.Parameters.Seed != nil && (*aliReq.Parameters.Seed < 0 || *aliReq.Parameters.Seed > common.MaxQuota) {
+		return fmt.Errorf("HappyHorse seed must be between 0 and 2147483647")
+	}
+	resolution, err := normalizeHappyHorseResolution(aliReq.Parameters.Resolution)
+	if err != nil {
+		return err
+	}
+	if err := validateHappyHorseResolution(model, resolution); err != nil {
+		return err
+	}
+	aliReq.Parameters.Resolution = resolution
+	aliReq.Parameters.Size = ""
+
+	if aliReq.Parameters.Ratio != nil {
+		ratio := strings.TrimSpace(*aliReq.Parameters.Ratio)
+		if _, ok := happyHorseRatios[ratio]; !ok {
+			return fmt.Errorf("invalid HappyHorse ratio: %s", ratio)
+		}
+		if isHappyHorseI2VModel(model) || isHappyHorseVideoEditModel(model) {
+			return fmt.Errorf("%s does not accept ratio", model)
+		}
+		aliReq.Parameters.Ratio = &ratio
+	}
+
+	if isHappyHorseVideoEditModel(model) {
+		aliReq.Parameters.Duration = 0
+		if aliReq.Parameters.AudioSetting != nil {
+			audioSetting := strings.ToLower(strings.TrimSpace(*aliReq.Parameters.AudioSetting))
+			if audioSetting != "auto" && audioSetting != "origin" {
+				return fmt.Errorf("invalid HappyHorse audio_setting: %s", audioSetting)
+			}
+			aliReq.Parameters.AudioSetting = &audioSetting
+		}
+		return nil
+	}
+
+	if aliReq.Parameters.AudioSetting != nil {
+		return fmt.Errorf("%s does not accept audio_setting", model)
+	}
+	if aliReq.Parameters.Duration < happyHorseMinDurationSeconds || aliReq.Parameters.Duration > happyHorseMaxDurationSeconds {
+		return fmt.Errorf("%s duration must be between %d and %d seconds", model, happyHorseMinDurationSeconds, happyHorseMaxDurationSeconds)
+	}
+	return nil
+}
+
 func sizeToResolution(size string) (string, error) {
 	if lo.Contains(size480p, size) {
 		return "480P", nil
@@ -201,7 +473,38 @@ func sizeToResolution(size string) (string, error) {
 
 func ProcessAliOtherRatios(aliReq *AliVideoRequest) (map[string]float64, error) {
 	otherRatios := make(map[string]float64)
+	if aliReq == nil || aliReq.Parameters == nil {
+		return otherRatios, fmt.Errorf("Ali video parameters are required")
+	}
 	aliRatios := map[string]map[string]float64{
+		"happyhorse-1.1-t2v": {
+			"720P":  1,
+			"1080P": 4.0 / 3.0,
+		},
+		"happyhorse-1.1-i2v": {
+			"720P":  1,
+			"1080P": 4.0 / 3.0,
+		},
+		"happyhorse-1.1-r2v": {
+			"720P":  1,
+			"1080P": 4.0 / 3.0,
+		},
+		"happyhorse-1.0-t2v": {
+			"720P":  1,
+			"1080P": 16.0 / 9.0,
+		},
+		"happyhorse-1.0-i2v": {
+			"720P":  1,
+			"1080P": 16.0 / 9.0,
+		},
+		"happyhorse-1.0-r2v": {
+			"720P":  1,
+			"1080P": 16.0 / 9.0,
+		},
+		"happyhorse-1.0-video-edit": {
+			"720P":  1,
+			"1080P": 16.0 / 9.0,
+		},
 		"wan2.6-i2v": {
 			"720P":  1,
 			"1080P": 1 / 0.6,
@@ -348,6 +651,58 @@ func normalizeWan27I2VInput(aliReq *AliVideoRequest, req relaycommon.TaskSubmitR
 	return nil
 }
 
+func applyFlatAliMetadata(aliReq *AliVideoRequest, metadata AliMetadata) {
+	if metadata.AudioURL != "" {
+		aliReq.Input.AudioURL = metadata.AudioURL
+	}
+	if metadata.ImgURL != "" {
+		aliReq.Input.ImgURL = metadata.ImgURL
+	}
+	if metadata.FirstFrameURL != "" {
+		aliReq.Input.FirstFrameURL = metadata.FirstFrameURL
+	}
+	if metadata.LastFrameURL != "" {
+		aliReq.Input.LastFrameURL = metadata.LastFrameURL
+	}
+	if metadata.Media != nil {
+		aliReq.Input.Media = metadata.Media
+	}
+	if metadata.NegativePrompt != "" {
+		aliReq.Input.NegativePrompt = metadata.NegativePrompt
+	}
+	if metadata.Template != "" {
+		aliReq.Input.Template = metadata.Template
+	}
+
+	if metadata.Resolution != nil {
+		aliReq.Parameters.Resolution = *metadata.Resolution
+	}
+	if metadata.Size != nil {
+		aliReq.Parameters.Size = *metadata.Size
+	}
+	if metadata.Duration != nil {
+		aliReq.Parameters.Duration = *metadata.Duration
+	}
+	if metadata.Ratio != nil {
+		aliReq.Parameters.Ratio = metadata.Ratio
+	}
+	if metadata.PromptExtend != nil {
+		aliReq.Parameters.PromptExtend = metadata.PromptExtend
+	}
+	if metadata.Watermark != nil {
+		aliReq.Parameters.Watermark = metadata.Watermark
+	}
+	if metadata.Audio != nil {
+		aliReq.Parameters.Audio = metadata.Audio
+	}
+	if metadata.AudioSetting != nil {
+		aliReq.Parameters.AudioSetting = metadata.AudioSetting
+	}
+	if metadata.Seed != nil {
+		aliReq.Parameters.Seed = metadata.Seed
+	}
+}
+
 func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relaycommon.TaskSubmitReq) (*AliVideoRequest, error) {
 	upstreamModel := req.Model
 	if info.IsModelMapped {
@@ -360,15 +715,26 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 			ImgURL: firstTaskImage(req),
 		},
 		Parameters: &AliVideoParameters{
-			PromptExtend: true, // 默认开启智能改写
-			Watermark:    false,
+			PromptExtend: boolPtr(true), // 万相默认开启智能改写
 		},
 	}
 
 	// 处理分辨率映射
-	if req.Size != "" {
+	if isHappyHorseModel(upstreamModel) {
+		resolution := "1080P"
+		if req.Size != "" {
+			var err error
+			resolution, err = normalizeHappyHorseResolution(req.Size)
+			if err != nil {
+				return nil, err
+			}
+		}
+		aliReq.Parameters.Resolution = resolution
+		// HappyHorse API 没有 prompt_extend 参数。
+		aliReq.Parameters.PromptExtend = nil
+	} else if req.Size != "" {
 		// text to video size must be contained *
-		if strings.Contains(req.Model, "t2v") && !strings.Contains(req.Size, "*") {
+		if strings.Contains(upstreamModel, "t2v") && !strings.Contains(req.Size, "*") {
 			return nil, fmt.Errorf("invalid size: %s, example: %s", req.Size, "1920*1080")
 		}
 		if strings.Contains(req.Size, "*") {
@@ -383,22 +749,22 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 		}
 	} else {
 		// 根据模型设置默认分辨率
-		if strings.Contains(req.Model, "t2v") { // image to video
-			if strings.HasPrefix(req.Model, "wan2.5") {
+		if strings.Contains(upstreamModel, "t2v") { // text to video
+			if strings.HasPrefix(upstreamModel, "wan2.5") {
 				aliReq.Parameters.Size = "1920*1080"
-			} else if strings.HasPrefix(req.Model, "wan2.2") {
+			} else if strings.HasPrefix(upstreamModel, "wan2.2") {
 				aliReq.Parameters.Size = "1920*1080"
 			} else {
 				aliReq.Parameters.Size = "1280*720"
 			}
 		} else {
-			if strings.HasPrefix(req.Model, "wan2.6") {
+			if strings.HasPrefix(upstreamModel, "wan2.6") {
 				aliReq.Parameters.Resolution = "1080P"
-			} else if strings.HasPrefix(req.Model, "wan2.5") {
+			} else if strings.HasPrefix(upstreamModel, "wan2.5") {
 				aliReq.Parameters.Resolution = "1080P"
-			} else if strings.HasPrefix(req.Model, "wan2.2-i2v-flash") {
+			} else if strings.HasPrefix(upstreamModel, "wan2.2-i2v-flash") {
 				aliReq.Parameters.Resolution = "720P"
-			} else if strings.HasPrefix(req.Model, "wan2.2-i2v-plus") {
+			} else if strings.HasPrefix(upstreamModel, "wan2.2-i2v-plus") {
 				aliReq.Parameters.Resolution = "1080P"
 			} else {
 				aliReq.Parameters.Resolution = "720P"
@@ -417,13 +783,20 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 			aliReq.Parameters.Duration = seconds
 		}
 	}
-	if aliReq.Parameters.Duration <= 0 {
+	if aliReq.Parameters.Duration <= 0 && !isHappyHorseVideoEditModel(upstreamModel) {
 		aliReq.Parameters.Duration = 5 // 默认5秒
 	}
 
 	// 从 metadata 中提取额外参数
 	if req.Metadata != nil {
 		if metadataBytes, err := common.Marshal(req.Metadata); err == nil {
+			var flatMetadata AliMetadata
+			if err := common.Unmarshal(metadataBytes, &flatMetadata); err != nil {
+				return nil, errors.Wrap(err, "unmarshal flat metadata failed")
+			}
+			applyFlatAliMetadata(aliReq, flatMetadata)
+			// Nested input/parameters follows the upstream shape and takes
+			// precedence when callers provide both metadata styles.
 			err = common.Unmarshal(metadataBytes, aliReq)
 			if err != nil {
 				return nil, errors.Wrap(err, "unmarshal metadata failed")
@@ -437,8 +810,17 @@ func (a *TaskAdaptor) convertToAliRequest(info *relaycommon.RelayInfo, req relay
 		return nil, errors.New("can't change model with metadata")
 	}
 
-	if err := normalizeWan27I2VInput(aliReq, req); err != nil {
-		return nil, err
+	if isHappyHorseModel(aliReq.Model) {
+		if err := normalizeHappyHorseInput(aliReq, req); err != nil {
+			return nil, err
+		}
+		if err := validateHappyHorseParameters(aliReq); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := normalizeWan27I2VInput(aliReq, req); err != nil {
+			return nil, err
+		}
 	}
 
 	return aliReq, nil
@@ -459,8 +841,14 @@ func (a *TaskAdaptor) EstimateBilling(c *gin.Context, info *relaycommon.RelayInf
 
 	// metadata can override Duration past standard request validation;
 	// cap it because it is used as a billing multiplier.
+	seconds := aliReq.Parameters.Duration
+	if isHappyHorseVideoEditModel(aliReq.Model) {
+		// 编辑任务按输入和输出总秒数计费。提交时未知，按两个 15 秒上限预扣，
+		// 成功轮询后再用 usage.duration 做差额结算。
+		seconds = happyHorseEditPrechargeSeconds
+	}
 	otherRatios := map[string]float64{
-		"seconds": float64(min(aliReq.Parameters.Duration, relaycommon.MaxTaskDurationSeconds)),
+		"seconds": float64(min(seconds, relaycommon.MaxTaskDurationSeconds)),
 	}
 	ratios, err := ProcessAliOtherRatios(aliReq)
 	if err != nil {
@@ -470,6 +858,125 @@ func (a *TaskAdaptor) EstimateBilling(c *gin.Context, info *relaycommon.RelayInf
 		otherRatios[k] = v
 	}
 	return otherRatios
+}
+
+func parseAliUsageSeconds(value dto.StringValue) float64 {
+	seconds, err := strconv.ParseFloat(strings.TrimSpace(string(value)), 64)
+	if err != nil || seconds <= 0 || math.IsNaN(seconds) || math.IsInf(seconds, 0) {
+		return 0
+	}
+	return seconds
+}
+
+func happyHorseBillableSeconds(modelName string, usage *AliUsage) float64 {
+	if usage == nil {
+		return 0
+	}
+	seconds := parseAliUsageSeconds(usage.Duration)
+	maxSeconds := float64(happyHorseMaxDurationSeconds)
+	if isHappyHorseVideoEditModel(modelName) {
+		maxSeconds = float64(happyHorseEditPrechargeSeconds)
+		if seconds <= 0 {
+			seconds = parseAliUsageSeconds(usage.InputVideoDuration) + parseAliUsageSeconds(usage.OutputVideoDuration)
+		}
+	} else if seconds <= 0 {
+		seconds = parseAliUsageSeconds(usage.OutputVideoDuration)
+	}
+	return min(seconds, maxSeconds)
+}
+
+func happyHorseResolutionRatio(modelName string, sr int) (string, float64, bool) {
+	resolution := fmt.Sprintf("%dP", sr)
+	if isHappyHorse11Model(modelName) {
+		switch sr {
+		case 720:
+			return resolution, 1, true
+		case 1080:
+			return resolution, 4.0 / 3.0, true
+		}
+	} else {
+		switch sr {
+		case 720:
+			return resolution, 1, true
+		case 1080:
+			return resolution, 16.0 / 9.0, true
+		}
+	}
+	return "", 0, false
+}
+
+func happyHorseTaskModelName(task *model.Task) string {
+	if task.Properties.UpstreamModelName != "" {
+		return task.Properties.UpstreamModelName
+	}
+	if task.Properties.OriginModelName != "" {
+		return task.Properties.OriginModelName
+	}
+	if billingContext := task.PrivateData.BillingContext; billingContext != nil {
+		return billingContext.OriginModelName
+	}
+	return ""
+}
+
+// AdjustBillingOnComplete replaces the conservative request-time seconds and
+// resolution multipliers with the successful task's authoritative usage.
+func (a *TaskAdaptor) AdjustBillingOnComplete(task *model.Task, taskResult *relaycommon.TaskInfo) int {
+	if task == nil || taskResult == nil || taskResult.Status != model.TaskStatusSuccess {
+		return 0
+	}
+	modelName := happyHorseTaskModelName(task)
+	if !isHappyHorseModel(modelName) {
+		return 0
+	}
+	billingContext := task.PrivateData.BillingContext
+	if billingContext == nil || billingContext.GroupRatio <= 0 {
+		return 0
+	}
+
+	var response AliVideoResponse
+	if err := common.Unmarshal(task.Data, &response); err != nil {
+		return 0
+	}
+	seconds := happyHorseBillableSeconds(modelName, response.Usage)
+	if seconds <= 0 {
+		// Missing usage is not guessed after completion: keep the conservative
+		// precharge so a malformed upstream response cannot cause underbilling.
+		return 0
+	}
+
+	baseQuota := 0.0
+	if billingContext.ModelPrice > 0 {
+		baseQuota = billingContext.ModelPrice * common.QuotaPerUnit * billingContext.GroupRatio
+	} else if billingContext.ModelRatio > 0 {
+		baseQuota = billingContext.ModelRatio / 2 * common.QuotaPerUnit * billingContext.GroupRatio
+	}
+	if baseQuota <= 0 {
+		return 0
+	}
+
+	actualRatios := &hosttypes.PriceData{}
+	for key, ratio := range billingContext.OtherRatios {
+		if key == "seconds" || strings.HasPrefix(key, "resolution-") {
+			continue
+		}
+		actualRatios.AddOtherRatio(key, ratio)
+	}
+	actualRatios.AddOtherRatio("seconds", seconds)
+	if resolution, ratio, ok := happyHorseResolutionRatio(modelName, int(response.Usage.SR)); ok {
+		actualRatios.AddOtherRatio("resolution-"+resolution, ratio)
+	} else {
+		// SR is expected on success. If it is missing, retain the request-time
+		// resolution multiplier instead of silently billing at the base tier.
+		for key, ratio := range billingContext.OtherRatios {
+			if strings.HasPrefix(key, "resolution-") {
+				actualRatios.AddOtherRatio(key, ratio)
+			}
+		}
+	}
+
+	actualQuota, clamp := common.QuotaFromFloatChecked(actualRatios.ApplyOtherRatiosToFloat(baseQuota))
+	taskResult.QuotaClamp = clamp
+	return actualQuota
 }
 
 // DoRequest delegates to common helper

--- a/relay/channel/task/ali/adaptor_test.go
+++ b/relay/channel/task/ali/adaptor_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/model"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
 
@@ -169,4 +171,246 @@ func TestConvertToAliRequestWan25I2VKeepsLegacyImgURL(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(body), `"img_url"`)
 	require.NotContains(t, string(body), `"media"`)
+}
+
+func TestHappyHorseModelsAreRegistered(t *testing.T) {
+	for _, modelName := range []string{
+		"happyhorse-1.1-t2v",
+		"happyhorse-1.1-i2v",
+		"happyhorse-1.1-r2v",
+		"happyhorse-1.0-t2v",
+		"happyhorse-1.0-i2v",
+		"happyhorse-1.0-r2v",
+		"happyhorse-1.0-video-edit",
+	} {
+		require.Contains(t, ModelList, modelName)
+	}
+}
+
+func TestConvertToAliRequestHappyHorseT2V(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	req := relaycommon.TaskSubmitReq{
+		Model:    "happyhorse-1.1-t2v",
+		Prompt:   "a horse running",
+		Size:     "720p",
+		Duration: 6,
+		Metadata: map[string]interface{}{
+			"ratio": "16:9",
+		},
+	}
+
+	aliReq, err := adaptor.convertToAliRequest(testRelayInfo(), req)
+	require.NoError(t, err)
+	require.Equal(t, "720P", aliReq.Parameters.Resolution)
+	require.Empty(t, aliReq.Parameters.Size)
+	require.Equal(t, 6, aliReq.Parameters.Duration)
+	require.NotNil(t, aliReq.Parameters.Ratio)
+	require.Equal(t, "16:9", *aliReq.Parameters.Ratio)
+	require.Empty(t, aliReq.Input.Media)
+
+	body, err := common.Marshal(aliReq)
+	require.NoError(t, err)
+	require.NotContains(t, string(body), `"prompt_extend"`)
+	require.NotContains(t, string(body), `"size"`)
+}
+
+func TestConvertToAliRequestHappyHorseI2V(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	req := relaycommon.TaskSubmitReq{
+		Model:    "happyhorse-1.1-i2v",
+		Prompt:   "animate",
+		Image:    "https://example.com/first.png",
+		Duration: 5,
+	}
+
+	aliReq, err := adaptor.convertToAliRequest(testRelayInfo(), req)
+	require.NoError(t, err)
+	require.Equal(t, []AliVideoMedia{{Type: "first_frame", URL: "https://example.com/first.png"}}, aliReq.Input.Media)
+	require.Empty(t, aliReq.Input.ImgURL)
+}
+
+func TestConvertToAliRequestHappyHorseR2V(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	req := relaycommon.TaskSubmitReq{
+		Model:    "happyhorse-1.0-r2v",
+		Prompt:   "use these characters",
+		Images:   []string{"https://example.com/a.png", "https://example.com/b.png"},
+		Size:     "1080p",
+		Duration: 8,
+	}
+
+	aliReq, err := adaptor.convertToAliRequest(testRelayInfo(), req)
+	require.NoError(t, err)
+	require.Equal(t, []AliVideoMedia{
+		{Type: "reference_image", URL: "https://example.com/a.png"},
+		{Type: "reference_image", URL: "https://example.com/b.png"},
+	}, aliReq.Input.Media)
+	require.Equal(t, "1080P", aliReq.Parameters.Resolution)
+}
+
+func TestConvertToAliRequestHappyHorseVideoEdit(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	req := relaycommon.TaskSubmitReq{
+		Model:          "happyhorse-1.0-video-edit",
+		Prompt:         "change the jacket",
+		InputReference: "https://example.com/input.mp4",
+		Images:         []string{"https://example.com/jacket.png"},
+		Size:           "720p",
+		Metadata: map[string]interface{}{
+			"audio_setting": "origin",
+		},
+	}
+
+	aliReq, err := adaptor.convertToAliRequest(testRelayInfo(), req)
+	require.NoError(t, err)
+	require.Equal(t, []AliVideoMedia{
+		{Type: "video", URL: "https://example.com/input.mp4"},
+		{Type: "reference_image", URL: "https://example.com/jacket.png"},
+	}, aliReq.Input.Media)
+	require.Zero(t, aliReq.Parameters.Duration)
+	require.NotNil(t, aliReq.Parameters.AudioSetting)
+	require.Equal(t, "origin", *aliReq.Parameters.AudioSetting)
+
+	body, err := common.Marshal(aliReq)
+	require.NoError(t, err)
+	require.NotContains(t, string(body), `"duration"`)
+}
+
+func TestConvertToAliRequestHappyHorseRejectsInvalidInputs(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	tests := []struct {
+		name string
+		req  relaycommon.TaskSubmitReq
+	}{
+		{
+			name: "1.0 480P",
+			req: relaycommon.TaskSubmitReq{
+				Model: "happyhorse-1.0-t2v", Prompt: "horse", Size: "480p", Duration: 5,
+			},
+		},
+		{
+			name: "duration below minimum",
+			req: relaycommon.TaskSubmitReq{
+				Model: "happyhorse-1.1-t2v", Prompt: "horse", Duration: 2,
+			},
+		},
+		{
+			name: "t2v with image",
+			req: relaycommon.TaskSubmitReq{
+				Model: "happyhorse-1.1-t2v", Prompt: "horse", Image: "https://example.com/a.png", Duration: 5,
+			},
+		},
+		{
+			name: "i2v with two images",
+			req: relaycommon.TaskSubmitReq{
+				Model: "happyhorse-1.1-i2v", Prompt: "horse", Images: []string{"a", "b"}, Duration: 5,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := adaptor.convertToAliRequest(testRelayInfo(), test.req)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestProcessAliOtherRatiosHappyHorse(t *testing.T) {
+	ratios, err := ProcessAliOtherRatios(&AliVideoRequest{
+		Model:      "happyhorse-1.1-t2v",
+		Parameters: &AliVideoParameters{Resolution: "1080P"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 4.0/3.0, ratios["resolution-1080P"])
+
+	ratios, err = ProcessAliOtherRatios(&AliVideoRequest{
+		Model:      "happyhorse-1.0-video-edit",
+		Parameters: &AliVideoParameters{Resolution: "720P"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1.0, ratios["resolution-720P"])
+}
+
+func TestEstimateBillingHappyHorse(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	tests := []struct {
+		name        string
+		req         relaycommon.TaskSubmitReq
+		wantSeconds float64
+		wantRatio   float64
+	}{
+		{
+			name: "generation uses requested seconds",
+			req: relaycommon.TaskSubmitReq{
+				Model: "happyhorse-1.1-t2v", Prompt: "horse", Size: "720p", Duration: 6,
+			},
+			wantSeconds: 6,
+			wantRatio:   1,
+		},
+		{
+			name: "video edit reserves maximum effective input plus output",
+			req: relaycommon.TaskSubmitReq{
+				Model: "happyhorse-1.0-video-edit", Prompt: "edit", Size: "1080p",
+				InputReference: "https://example.com/input.mp4",
+			},
+			wantSeconds: 30,
+			wantRatio:   16.0 / 9.0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			context, _ := gin.CreateTestContext(nil)
+			context.Set("task_request", test.req)
+			ratios := adaptor.EstimateBilling(context, testRelayInfo())
+			require.Equal(t, test.wantSeconds, ratios["seconds"])
+			require.Equal(t, test.wantRatio, ratios["resolution-"+strings.ToUpper(test.req.Size)])
+		})
+	}
+}
+
+func TestAdjustBillingOnCompleteHappyHorseUsesActualUsage(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	task := &model.Task{
+		Status: model.TaskStatusSuccess,
+		Properties: model.Properties{
+			UpstreamModelName: "happyhorse-1.1-t2v",
+		},
+		PrivateData: model.TaskPrivateData{
+			BillingContext: &model.TaskBillingContext{
+				ModelPrice:  0.001,
+				GroupRatio:  1,
+				OtherRatios: map[string]float64{"seconds": 15, "resolution-1080P": 4.0 / 3.0},
+			},
+		},
+		Data: []byte(`{"output":{"task_status":"SUCCEEDED"},"usage":{"duration":5.5,"output_video_duration":"5.5","SR":720}}`),
+	}
+	taskResult := &relaycommon.TaskInfo{Status: model.TaskStatusSuccess}
+
+	got := adaptor.AdjustBillingOnComplete(task, taskResult)
+
+	want := common.QuotaFromFloat(0.001 * common.QuotaPerUnit * 5.5)
+	require.Equal(t, want, got)
+	require.Nil(t, taskResult.QuotaClamp)
+}
+
+func TestAdjustBillingOnCompleteHappyHorseVideoEditUsesFractionalTotalDuration(t *testing.T) {
+	adaptor := &TaskAdaptor{}
+	task := &model.Task{
+		Properties: model.Properties{OriginModelName: "happyhorse-1.0-video-edit"},
+		PrivateData: model.TaskPrivateData{
+			BillingContext: &model.TaskBillingContext{
+				ModelPrice: 0.002, GroupRatio: 1,
+				OtherRatios: map[string]float64{"seconds": 30, "resolution-1080P": 16.0 / 9.0},
+			},
+		},
+		Data: []byte(`{"output":{"task_status":"SUCCEEDED"},"usage":{"duration":13.24,"input_video_duration":6.62,"output_video_duration":6.62,"SR":720}}`),
+	}
+	taskResult := &relaycommon.TaskInfo{Status: model.TaskStatusSuccess}
+
+	got := adaptor.AdjustBillingOnComplete(task, taskResult)
+
+	want := common.QuotaFromFloat(0.002 * common.QuotaPerUnit * 13.24)
+	require.Equal(t, want, got)
 }

--- a/relay/channel/task/ali/constants.go
+++ b/relay/channel/task/ali/constants.go
@@ -1,13 +1,20 @@
 package ali
 
 var ModelList = []string{
-	"wan2.7-i2v",         // 万相2.7图生视频（新input.media协议）
-	"wan2.7-t2v",         // 万相2.7文生视频
-	"wan2.5-i2v-preview", // 万相2.5 preview（有声视频）推荐
-	"wan2.2-i2v-flash",   // 万相2.2极速版（无声视频）
-	"wan2.2-i2v-plus",    // 万相2.2专业版（无声视频）
-	"wanx2.1-i2v-plus",   // 万相2.1专业版（无声视频）
-	"wanx2.1-i2v-turbo",  // 万相2.1极速版（无声视频）
+	"happyhorse-1.1-t2v",        // HappyHorse 1.1 文生视频
+	"happyhorse-1.1-i2v",        // HappyHorse 1.1 图生视频
+	"happyhorse-1.1-r2v",        // HappyHorse 1.1 参考生视频
+	"happyhorse-1.0-t2v",        // HappyHorse 1.0 文生视频
+	"happyhorse-1.0-i2v",        // HappyHorse 1.0 图生视频
+	"happyhorse-1.0-r2v",        // HappyHorse 1.0 参考生视频
+	"happyhorse-1.0-video-edit", // HappyHorse 1.0 视频编辑
+	"wan2.7-i2v",                // 万相2.7图生视频（新input.media协议）
+	"wan2.7-t2v",                // 万相2.7文生视频
+	"wan2.5-i2v-preview",        // 万相2.5 preview（有声视频）推荐
+	"wan2.2-i2v-flash",          // 万相2.2极速版（无声视频）
+	"wan2.2-i2v-plus",           // 万相2.2专业版（无声视频）
+	"wanx2.1-i2v-plus",          // 万相2.1专业版（无声视频）
+	"wanx2.1-i2v-turbo",         // 万相2.1极速版（无声视频）
 }
 
 var ChannelName = "ali"

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -948,15 +948,16 @@ func (t *TaskSubmitReq) UnmarshalMetadata(v any) error {
 }
 
 type TaskInfo struct {
-	Code             int    `json:"code"`
-	TaskID           string `json:"task_id"`
-	Status           string `json:"status"`
-	Reason           string `json:"reason,omitempty"`
-	Url              string `json:"url,omitempty"`
-	RemoteUrl        string `json:"remote_url,omitempty"`
-	Progress         string `json:"progress,omitempty"`
-	CompletionTokens int    `json:"completion_tokens,omitempty"` // 用于按倍率计费
-	TotalTokens      int    `json:"total_tokens,omitempty"`      // 用于按倍率计费
+	Code             int                `json:"code"`
+	TaskID           string             `json:"task_id"`
+	Status           string             `json:"status"`
+	Reason           string             `json:"reason,omitempty"`
+	Url              string             `json:"url,omitempty"`
+	RemoteUrl        string             `json:"remote_url,omitempty"`
+	Progress         string             `json:"progress,omitempty"`
+	CompletionTokens int                `json:"completion_tokens,omitempty"` // 用于按倍率计费
+	TotalTokens      int                `json:"total_tokens,omitempty"`      // 用于按倍率计费
+	QuotaClamp       *common.QuotaClamp `json:"-"`                           // 结算额度饱和审计标记
 }
 
 func FailTaskInfo(reason string) *TaskInfo {

--- a/relay/common/relay_utils.go
+++ b/relay/common/relay_utils.go
@@ -216,7 +216,10 @@ func ValidateMultipartDirect(c *gin.Context, info *RelayInfo) *dto.TaskError {
 		seconds = req.Duration
 	}
 	if req.InputReference != "" {
-		req.Images = []string{req.InputReference}
+		// input_reference can be combined with images (for example, one input
+		// video plus HappyHorse reference images). Preserve both instead of
+		// discarding the explicitly supplied image list.
+		req.Images = append([]string{req.InputReference}, req.Images...)
 	} else if len(req.Images) == 0 && strings.TrimSpace(req.Image) != "" {
 		// 兼容单图上传
 		req.Images = []string{strings.TrimSpace(req.Image)}

--- a/relay/common/relay_utils_test.go
+++ b/relay/common/relay_utils_test.go
@@ -77,6 +77,26 @@ func TestValidateMultipartDirectNormalizesImageField(t *testing.T) {
 	require.Equal(t, constant.TaskActionGenerate, info.Action)
 }
 
+func TestValidateMultipartDirectPreservesImagesWithInputReference(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := strings.NewReader(`{"model":"happyhorse-1.0-video-edit","prompt":"edit","input_reference":"https://example.com/input.mp4","images":["https://example.com/ref.png"]}`)
+	request := httptest.NewRequest(http.MethodPost, "/v1/video/generations", body)
+	request.Header.Set("Content-Type", "application/json")
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = request
+	info := &RelayInfo{TaskRelayInfo: &TaskRelayInfo{}}
+
+	taskErr := ValidateMultipartDirect(context, info)
+
+	require.Nil(t, taskErr)
+	storedReq, err := GetTaskRequest(context)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"https://example.com/input.mp4",
+		"https://example.com/ref.png",
+	}, storedReq.Images)
+}
+
 // TestTaskDurationBounds guards the billing invariant that user-supplied
 // video duration (a quota multiplier via OtherRatio "seconds") is bounded, so
 // it can never overflow quota calculation into a negative charge.

--- a/service/task_billing_test.go
+++ b/service/task_billing_test.go
@@ -1142,7 +1142,7 @@ func (m *mockAdaptor) AdjustBillingOnComplete(_ *model.Task, _ *relaycommon.Task
 // PerCallBilling tests — settleTaskBillingOnComplete
 // ===========================================================================
 
-func TestSettle_PerCallBilling_SkipsAdaptorAdjust(t *testing.T) {
+func TestSettle_PerCallBilling_AppliesAdaptorAdjust(t *testing.T) {
 	truncate(t)
 	ctx := context.Background()
 
@@ -1162,11 +1162,11 @@ func TestSettle_PerCallBilling_SkipsAdaptorAdjust(t *testing.T) {
 
 	settleTaskBillingOnComplete(ctx, adaptor, task, taskResult)
 
-	// Per-call: no adjustment despite adaptor returning 2000
-	assert.Equal(t, initQuota, getUserQuota(t, userID))
-	assert.Equal(t, tokenRemain, getTokenRemainQuota(t, tokenID))
-	assert.Equal(t, preConsumed, task.Quota)
-	assert.Equal(t, int64(0), countLogs(t))
+	// A per-call base price may still require usage-based adaptor settlement.
+	assert.Equal(t, initQuota+(preConsumed-2000), getUserQuota(t, userID))
+	assert.Equal(t, tokenRemain+(preConsumed-2000), getTokenRemainQuota(t, tokenID))
+	assert.Equal(t, 2000, task.Quota)
+	assert.Equal(t, int64(1), countLogs(t))
 }
 
 func TestSettle_PerCallBilling_SkipsTotalTokens(t *testing.T) {

--- a/service/task_polling.go
+++ b/service/task_polling.go
@@ -638,23 +638,25 @@ func truncateBase64(s string) string {
 // settleTaskBillingOnComplete 任务完成时的统一计费调整。
 // 优先级：1. adaptor.AdjustBillingOnComplete 返回正数 → 使用 adaptor 计算的额度
 //
-//  2. taskResult.TotalTokens > 0 → 按 token 重算
-//  3. 都不满足 → 保持预扣额度不变
+//  2. 按次计费且 adaptor 未调整 → 保持预扣额度不变
+//  3. taskResult.TotalTokens > 0 → 按 token 重算
+//  4. 都不满足 → 保持预扣额度不变
 func settleTaskBillingOnComplete(ctx context.Context, adaptor TaskPollingAdaptor, task *model.Task, taskResult *relaycommon.TaskInfo) {
-	// 0. 按次计费的任务不做差额结算
-	if bc := task.PrivateData.BillingContext; bc != nil && bc.PerCallBilling {
-		logger.LogInfo(ctx, fmt.Sprintf("任务 %s 按次计费，跳过差额结算", task.TaskID))
-		return
-	}
-	// 1. 优先让 adaptor 决定最终额度
+	// 1. 优先让 adaptor 决定最终额度。部分按次价格只是基础单位价，
+	// 仍需要 adaptor 根据异步响应中的实际秒数/张数完成最终结算。
 	if actualQuota := adaptor.AdjustBillingOnComplete(task, taskResult); actualQuota > 0 {
-		RecalculateTaskQuota(ctx, task, actualQuota, "adaptor计费调整")
+		RecalculateTaskQuota(ctx, task, actualQuota, "adaptor计费调整", taskResult.QuotaClamp)
 		return
 	}
-	// 2. 回退到 token 重算
+	// 2. 其他按次计费任务不回退到 token 重算。
+	if bc := task.PrivateData.BillingContext; bc != nil && bc.PerCallBilling {
+		logger.LogInfo(ctx, fmt.Sprintf("任务 %s 按次计费，adaptor 无调整，保持预扣额度", task.TaskID))
+		return
+	}
+	// 3. 回退到 token 重算
 	if taskResult.TotalTokens > 0 {
 		RecalculateTaskQuotaByTokens(ctx, task, taskResult.TotalTokens)
 		return
 	}
-	// 3. 无调整，保持预扣额度
+	// 4. 无调整，保持预扣额度
 }


### PR DESCRIPTION
## Summary

- register all seven HappyHorse 1.0/1.1 models for the Ali channel and task adapter
- translate T2V, I2V, R2V, and Video Edit requests into the HappyHorse `media`, `resolution`, `ratio`, duration, and audio-setting schema
- validate model-specific media counts, durations, seeds, ratios, and priced 720P/1080P resolution tiers before submission
- precharge bounded duration/resolution multipliers and settle successful tasks from authoritative `usage.duration` and `usage.SR`, including fractional seconds for Video Edit
- allow adapter usage settlement for model-price tasks while preserving the existing token fallback behavior for other per-call tasks

## Why

The Ali async task adapter only registered Wan video models. HappyHorse uses the same submission and polling endpoints but a different request schema, so adding model names alone produced invalid upstream requests. The completion hook was also skipped for model-price tasks, which meant actual output duration and Video Edit input-plus-output duration could not be reconciled after polling.

The provider's priced model catalog currently exposes 720P and 1080P HappyHorse SKUs. The adapter rejects 480P so an unpriced resolution cannot enter production billing.

## Impact

HappyHorse T2V, I2V, R2V, and Video Edit tasks can now be routed through the Ali channel with bounded precharge, success-only usage settlement, existing failure refunds, and quota saturation auditing. Existing Wan request conversion remains covered by regression tests.

## Validation

- `go test ./relay/channel/task/ali ./relay/common ./service`
- all non-root package trees in the main module passed (`common`, `controller`, `model`, `relay`, `service`, `setting`, and related packages)
- `cd relaykit && go test ./...`
- `go vet ./relay/channel/task/ali ./relay/common ./service`

The root package's blanket `go test ./...` requires the generated `web/dist` embed, which is not present in this source-only checkout; the non-root package trees were run explicitly instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for seven HappyHorse video generation and editing models, including text-to-video, image-to-video, reference-to-video, and video-editing workflows.
  - Added support for additional Ali video models and expanded options for aspect ratios, audio, duration, resolution, and media inputs.

- **Bug Fixes**
  - Improved billing accuracy using actual task usage, including edits with fractional durations.
  - Preserved both input references and existing images during multipart requests.
  - Improved handling of per-call billing adjustments and refunds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->