### PR TITLE
fix(relay): forward xAI upstream stream error events instead of emitting empty chunks

### DIFF
--- a/relay/channel/xai/text.go
+++ b/relay/channel/xai/text.go
@@ -44,6 +44,21 @@ func xAIStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Re
 	helper.SetEventStreamHeaders(c)
 
 	helper.StreamScannerHandler(c, resp, info, func(data string, sr *helper.StreamResult) {
+		// xAI-compatible upstreams may report errors as SSE data events, e.g.
+		// `data: {"error": {...}}`. Such an event is not a completion chunk:
+		// re-marshaling it via streamResponseXAI2OpenAI would emit a fieldless,
+		// invalid chunk (empty id/object, null choices) that strict clients
+		// reject. Forward the error event to the client unchanged instead.
+		var errPayload dto.GeneralErrorResponse
+		if err := common.UnmarshalJsonStr(data, &errPayload); err == nil && len(errPayload.Error) > 0 {
+			if sendErr := helper.StringData(c, data); sendErr != nil {
+				common.SysLog(sendErr.Error())
+				sr.Error(sendErr)
+			}
+			sr.Stop(nil)
+			return
+		}
+
 		var xAIResp *dto.ChatCompletionsStreamResponse
 		if err := common.UnmarshalJsonStr(data, &xAIResp); err != nil {
 			common.SysLog("error unmarshalling stream response: " + err.Error())

--- a/relay/channel/xai/text_test.go
+++ b/relay/channel/xai/text_test.go
@@ -1,0 +1,95 @@
+package xai
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/relaykit/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newXAIStreamContext(t *testing.T) (*httptest.ResponseRecorder, *gin.Context, *relaycommon.RelayInfo) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() {
+		constant.StreamingTimeout = oldTimeout
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	c.Set(common.RequestIdKey, "xai-stream-test")
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "grok-4",
+		RelayMode:       relayconstant.RelayModeChatCompletions,
+		RelayFormat:     types.RelayFormatOpenAI,
+		DisablePing:     true,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "grok-4",
+		},
+	}
+	return w, c, info
+}
+
+func xaiSSEBody(events ...string) io.Reader {
+	var b strings.Builder
+	for _, e := range events {
+		b.WriteString("data: ")
+		b.WriteString(e)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("data: [DONE]\n\n")
+	return strings.NewReader(b.String())
+}
+
+func xaiSSEResponse(r io.Reader) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(r),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+}
+
+// An upstream error event must be forwarded to the client intact, not
+// re-marshaled into a fieldless completion chunk.
+func TestXAIStreamForwardsUpstreamErrorEvent(t *testing.T) {
+	w, c, info := newXAIStreamContext(t)
+	errEvent := `{"error":{"message":"rate limit exceeded","type":"rate_limit_error","code":429}}`
+	resp := xaiSSEResponse(xaiSSEBody(errEvent))
+
+	usage, apiErr := xAIStreamHandler(c, info, resp)
+
+	require.Nil(t, apiErr)
+	require.NotNil(t, usage)
+	body := w.Body.String()
+	assert.Contains(t, body, "rate limit exceeded")
+	assert.Contains(t, body, `"error"`)
+	// The regression symptom: an empty id/object with null choices.
+	assert.NotContains(t, body, `"choices":null`)
+	assert.NotContains(t, body, `"id":""`)
+}
+
+// A normal completion chunk must still be converted and forwarded.
+func TestXAIStreamConvertsNormalChunk(t *testing.T) {
+	w, c, info := newXAIStreamContext(t)
+	chunk := `{"id":"chatcmpl-1","object":"chat.completion.chunk","created":123,"model":"grok-4","choices":[{"index":0,"delta":{"content":"hello"}}]}`
+	resp := xaiSSEResponse(xaiSSEBody(chunk))
+
+	usage, apiErr := xAIStreamHandler(c, info, resp)
+
+	require.Nil(t, apiErr)
+	require.NotNil(t, usage)
+	body := w.Body.String()
+	assert.Contains(t, body, "hello")
+	assert.Contains(t, body, "chat.completion.chunk")
+}


### PR DESCRIPTION
## 📝 变更描述 / Description

xAI 渠道适配器（`relay/channel/xai`）会把上游的每条 SSE 数据事件经 `streamResponseXAI2OpenAI` 重新序列化。当 xAI 兼容上游以 `data: {"error": {...}}` 形式在流中报错时，该事件被反序列化成 `ChatCompletionsStreamResponse`（`error` 字段被忽略、全字段为零），再重序列化出一个无字段的空壳 chunk（id/object 为空、choices/usage 为 null）。严格的客户端会因 schema 校验失败（`choices` 应为数组却收到 null）而报错，本应暴露的上游错误反而变成畸形成功响应。

修复：识别携带 `error` 字段的流数据事件，原样转发给客户端（与 OpenAI 透传路径行为一致）后停止流，不再重序列化成 completion chunk。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue

- 无（已搜索现有 Issues/PRs，未发现对应报告）

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 描述已整理，非直接粘贴 AI 输出。
- [x] **非重复提交:** 已搜索 Issues 与 PRs。
- [x] **变更理解:** 理解改动原理与影响（仅影响 xAI 渠道流式错误事件路径，正常 chunk 转换不变）。
- [x] **范围聚焦:** 仅改 `relay/channel/xai/text.go` 并新增其测试。
- [x] **本地验证:** `gofmt`、`go vet`、`go build ./...`、`go test ./relay/...` 均通过。
- [x] **安全合规:** 无敏感凭据。

## 📸 运行证明 / Proof of Work

- `go test ./relay/channel/xai/ -v` 通过：`TestXAIStreamForwardsUpstreamErrorEvent`、`TestXAIStreamConvertsNormalChunk`。
- 已反向验证：撤销修复后，错误事件测试失败并输出 `data: {"id":"","object":"","created":0,"model":"","system_fingerprint":null,"choices":null,"usage":null}`，与问题描述中的畸形 chunk 完全一致。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming error handling by forwarding upstream error messages intact.
  * Prevented invalid or empty completion data from appearing when a streaming request fails.
  * Ensured normal streaming responses continue to be processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->