### PR TITLE
fix(web): add trailing slash to channel list/create API endpoints

### DIFF
--- a/web/src/features/channels/api.ts
+++ b/web/src/features/channels/api.ts
@@ -83,7 +83,7 @@ export type CodexCredentialRefreshResponse = {
 export async function getChannels(
   params: GetChannelsParams = {}
 ): Promise<GetChannelsResponse> {
-  const res = await api.get('/api/channel', { params })
+  const res = await api.get('/api/channel/', { params })
   return res.data
 }
 
@@ -120,7 +120,7 @@ export async function getChannelOps(): Promise<ChannelOpsResponse> {
 export async function createChannel(
   data: AddChannelRequest
 ): Promise<{ success: boolean; message?: string }> {
-  const res = await api.post('/api/channel', data, channelActionConfig())
+  const res = await api.post('/api/channel/', data, channelActionConfig())
   return res.data
 }
 


### PR DESCRIPTION
## 📝 变更描述 / Description

The channels admin page returns `404 {"error":{"message":"Invalid URL (GET /api/channel)"...}}` when loading the channel list, and the same 404 when creating a channel.

**Root cause.** `getChannels` (GET) and `createChannel` (POST) request `/api/channel` (no trailing slash), but the backend registers the list/create/update handlers at `path: "/"` under the `/channel` group — i.e. `/api/channel/` (`router/channel-router.go`, since #5755). Every other list call in the frontend (`/api/user/`, `/api/token/`, `/api/option/`, `/api/group/`) — and this file's own `updateChannel` — already use the trailing-slash form, so they work.

For most groups Gin's `RedirectTrailingSlash` bridges the no-slash form (301 → slash), but the `/channel` group (also `/user`, `/subscription/admin`) is not bridged in Gin v1.9.1, so the no-slash request falls through to `NoRoute` → `controller.RelayNotFound` → the OpenAI-style 404.

**Fix.** Add the trailing slash to the two calls to match the rest of the codebase (and `updateChannel`):
- `GET /api/channel` → `GET /api/channel/`
- `POST /api/channel` → `POST /api/channel/`

No backend change required.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
No existing issue found (searched "channel 404" / "Invalid URL"). Happy to open one first if a maintainer prefers.

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** this description was prepared with AI assistance (Claude Code) as an organized summary, not a raw dump; submitter to review/edit before finalizing.
- [x] **非重复提交:** searched existing issues & PRs; no duplicate.
- [ ] **Bug fix 说明:** no prior issue linked yet (see Related Issue).
- [x] **变更理解:** yes — see root cause above.
- [x] **范围聚焦:** 1 file, 2 lines; no unrelated changes.
- [x] **本地验证:** see proof below.
- [x] **安全合规:** no credentials; trivial string change.

## 📸 运行证明 / Proof of Work
Running build of `main` (Gin v1.9.1), unauthenticated probes — a `401` means the route exists (auth middleware ran):

| Request | Result |
|---|---|
| `GET /api/channel` (no slash — what the frontend sent) | 404 `Invalid URL (GET /api/channel)` |
| `GET /api/channel/` (slash) | 401 (route exists) |
| `GET /api/user` (no slash) | 404 (same gap; its frontend uses `/api/user/`, so the page still works) |
| `GET /api/token` (no slash) | 301 → `/api/token/` (tsr works for this group) |

With an admin token, `GET /api/channel/` returns `200` with the channel list — which is what the frontend hits after this fix. `tsgo -b` typecheck passes.

---

> Note: this PR was prepared with AI assistance (Claude Code) under the submitter's direction, including the root-cause analysis and the 2-line fix, both verified locally. The submitter is invited to review/edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel loading and creation by correcting API endpoint handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->