### PR TITLE
fix(openai): 正确结束 Responses 流

### DIFF
--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -131,6 +131,7 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 				imageCounter.Commit(info)
 				imageCommitted = true
 			}
+			sr.Done()
 		case "response.failed", "response.incomplete", "response.cancelled", "response.canceled":
 			if !imageCommitted {
 				imageCounter.Reset()

--- a/relay/channel/openai/relay_responses_stream_test.go
+++ b/relay/channel/openai/relay_responses_stream_test.go
@@ -1,0 +1,60 @@
+package openai
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOaiResponsesStreamHandlerStopsAtCompletedEvent(t *testing.T) {
+	oldMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(oldMode) })
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 1
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	reader, writer := io.Pipe()
+	t.Cleanup(func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+	go func() {
+		_, _ = io.WriteString(writer, `data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":2,"output_tokens":3,"total_tokens":5}}}`+"\n\n")
+	}()
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Set(common.RequestIdKey, "responses-completed-test")
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "gpt-test",
+		DisablePing:     true,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "gpt-test",
+		},
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       reader,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+
+	usage, apiErr := OaiResponsesStreamHandler(c, info, resp)
+
+	require.Nil(t, apiErr)
+	require.NotNil(t, usage)
+	assert.Equal(t, 2, usage.PromptTokens)
+	assert.Equal(t, 3, usage.CompletionTokens)
+	require.NotNil(t, info.StreamStatus)
+	assert.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
+	assert.Contains(t, recorder.Body.String(), `event: response.completed`)
+}


### PR DESCRIPTION
## ⚠️ 提交说明 / PR Notice

本 PR 为 AI 辅助提交，变更内容已由提交者人工核对并整理。

## 📝 变更描述 / Description

修复 OpenAI Responses 流在收到 `response.completed` 或 `response.done` 后仍继续等待上游 EOF 的问题。处理器现在在完成事件处理完 usage 和图片计费信息后立即结束流，避免客户端已经正常收到终止事件并关闭连接时，被记录为 `client_gone`。

同时增加回归测试，验证完成事件能够保留 usage、转发完成事件，并以 `done` 结束状态收尾。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 未发现对应的开放 Issue；问题来自生产中 Responses 流完成事件被误记为 `client_gone`。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，未发现相同修复。
- [x] **Bug fix 说明:** 已说明可复现的协议终止状态误判及修复原因。
- [x] **变更理解:** 已理解完成事件、流扫描器和计费 usage 处理之间的关系。
- [x] **范围聚焦:** 本 PR 仅包含 Responses 流结束处理和回归测试。
- [x] **本地验证:** 已通过 `go test -p=4 ./relay/channel/openai ./relay/helper ./relay/common`。
- [x] **安全合规:** 代码中无敏感凭据，符合项目代码规范。

## 📸 运行证明 / Proof of Work

- 回归测试：`TestOaiResponsesStreamHandlerStopsAtCompletedEvent` 通过。
- 相关包测试：`github.com/QuantumNous/new-api/relay/channel/openai`、`relay/helper`、`relay/common` 全部通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming response handling so completed responses are properly marked as finished.
  - Ensured token usage and completion events are correctly reported when a response completes.

- **Tests**
  - Added coverage for completed streaming responses, including stream status, usage extraction, and completion events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->