### PR TITLE
fix(rate-limit): isolate model rate limiter and scope counter keys by group

### DIFF
--- a/middleware/model-rate-limit.go
+++ b/middleware/model-rate-limit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
@@ -139,11 +140,25 @@ func redisRateLimitHandler(duration int64, totalMaxCount, successMaxCount int, g
 // 共享单例在路由注册时被以 RateLimitKeyExpirationDuration（20 分钟）Init，
 // 而 Init 仅在 store 为 nil 时生效，模型限流传入的清理周期永远不生效，
 // 过期 key 长期滞留会放大共享队列被撑长的问题。
-var modelRateLimiter common.InMemoryRateLimiter
+var (
+	modelRateLimiter common.InMemoryRateLimiter
+	modelLimiterOnce sync.Once
+)
 
 // 内存限流处理器
 func memoryRateLimitHandler(duration int64, totalMaxCount, successMaxCount int, group string) gin.HandlerFunc {
-	modelRateLimiter.Init(time.Duration(setting.ModelRequestRateLimitDurationMinutes) * time.Minute)
+	// 一次性初始化：每请求调用 Init 时，并发首批请求会在 store 尚为 nil 时
+	// 进入 Request 并触发 "assignment to entry in nil map" panic。
+	// 清理周期下限 1 分钟：首请求时 DurationMinutes 可能为 0，此时 Init 不会
+	// 启动清理 goroutine 且 Once 不再重试，过期 key 将滞留到进程重启。
+	// 下限只影响 key 清理节奏，限流窗口仍按每次请求读取的配置值生效。
+	modelLimiterOnce.Do(func() {
+		minutes := setting.ModelRequestRateLimitDurationMinutes
+		if minutes <= 0 {
+			minutes = 1
+		}
+		modelRateLimiter.Init(time.Duration(minutes) * time.Minute)
+	})
 
 	return func(c *gin.Context) {
 		userId := strconv.Itoa(c.GetInt("id"))
@@ -161,10 +176,10 @@ func memoryRateLimitHandler(duration int64, totalMaxCount, successMaxCount int, 
 			return
 		}
 
-		// 2. 检查成功请求数限制
+		// 2. 检查成功请求数限制（successMaxCount 为 0 表示不限制，与 Redis 路径一致）
 		// 使用一个临时key来检查限制，这样可以避免实际记录
 		checkKey := successKey + "_check"
-		if !modelRateLimiter.Request(checkKey, successMaxCount, duration) {
+		if successMaxCount > 0 && !modelRateLimiter.Request(checkKey, successMaxCount, duration) {
 			c.Status(http.StatusTooManyRequests)
 			c.Abort()
 			return
@@ -173,8 +188,8 @@ func memoryRateLimitHandler(duration int64, totalMaxCount, successMaxCount int, 
 		// 3. 处理请求
 		c.Next()
 
-		// 4. 如果请求成功，记录到实际的成功请求计数中
-		if c.Writer.Status() < 400 {
+		// 4. 如果请求成功，记录到实际的成功请求计数中（successMaxCount 为 0 时不记录）
+		if successMaxCount > 0 && c.Writer.Status() < 400 {
 			modelRateLimiter.Request(successKey, successMaxCount, duration)
 		}
 	}

--- a/middleware/model-rate-limit.go
+++ b/middleware/model-rate-limit.go
@@ -76,14 +76,20 @@ func recordRedisRequest(ctx context.Context, rdb *redis.Client, key string, maxC
 }
 
 // Redis限流处理器
-func redisRateLimitHandler(duration int64, totalMaxCount, successMaxCount int) gin.HandlerFunc {
+func redisRateLimitHandler(duration int64, totalMaxCount, successMaxCount int, group string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userId := strconv.Itoa(c.GetInt("id"))
+		// key 带分组：限额值按组解析而计数按用户共享时，default(20)/vip(1000) 的请求
+		// 会把共享队列撑长，令 strict(3) 的滑动窗口在队头过期后永久放行
+		userKey := userId
+		if group != "" {
+			userKey = group + ":" + userId
+		}
 		ctx := context.Background()
 		rdb := common.RDB
 
 		// 1. 检查成功请求数限制
-		successKey := fmt.Sprintf("rateLimit:%s:%s", ModelRequestRateLimitSuccessCountMark, userId)
+		successKey := fmt.Sprintf("rateLimit:%s:%s", ModelRequestRateLimitSuccessCountMark, userKey)
 		allowed, err := checkRedisRateLimit(ctx, rdb, successKey, successMaxCount, duration)
 		if err != nil {
 			fmt.Println("检查成功请求数限制失败:", err.Error())
@@ -97,7 +103,7 @@ func redisRateLimitHandler(duration int64, totalMaxCount, successMaxCount int) g
 
 		//2.检查总请求数限制并记录总请求（当totalMaxCount为0时会自动跳过，使用令牌桶限流器
 		if totalMaxCount > 0 {
-			totalKey := fmt.Sprintf("rateLimit:%s", userId)
+			totalKey := fmt.Sprintf("rateLimit:%s", userKey)
 			// 初始化
 			tb := limiter.New(ctx, rdb)
 			allowed, err = tb.Allow(
@@ -129,17 +135,27 @@ func redisRateLimitHandler(duration int64, totalMaxCount, successMaxCount int) g
 	}
 }
 
+// 模型限流专用内存限流器：不能复用 middleware/rate-limit.go 的共享单例。
+// 共享单例在路由注册时被以 RateLimitKeyExpirationDuration（20 分钟）Init，
+// 而 Init 仅在 store 为 nil 时生效，模型限流传入的清理周期永远不生效，
+// 过期 key 长期滞留会放大共享队列被撑长的问题。
+var modelRateLimiter common.InMemoryRateLimiter
+
 // 内存限流处理器
-func memoryRateLimitHandler(duration int64, totalMaxCount, successMaxCount int) gin.HandlerFunc {
-	inMemoryRateLimiter.Init(time.Duration(setting.ModelRequestRateLimitDurationMinutes) * time.Minute)
+func memoryRateLimitHandler(duration int64, totalMaxCount, successMaxCount int, group string) gin.HandlerFunc {
+	modelRateLimiter.Init(time.Duration(setting.ModelRequestRateLimitDurationMinutes) * time.Minute)
 
 	return func(c *gin.Context) {
 		userId := strconv.Itoa(c.GetInt("id"))
-		totalKey := ModelRequestRateLimitCountMark + userId
-		successKey := ModelRequestRateLimitSuccessCountMark + userId
+		userKey := userId
+		if group != "" {
+			userKey = group + ":" + userId
+		}
+		totalKey := ModelRequestRateLimitCountMark + userKey
+		successKey := ModelRequestRateLimitSuccessCountMark + userKey
 
 		// 1. 检查总请求数限制（当totalMaxCount为0时跳过）
-		if totalMaxCount > 0 && !inMemoryRateLimiter.Request(totalKey, totalMaxCount, duration) {
+		if totalMaxCount > 0 && !modelRateLimiter.Request(totalKey, totalMaxCount, duration) {
 			c.Status(http.StatusTooManyRequests)
 			c.Abort()
 			return
@@ -148,7 +164,7 @@ func memoryRateLimitHandler(duration int64, totalMaxCount, successMaxCount int) 
 		// 2. 检查成功请求数限制
 		// 使用一个临时key来检查限制，这样可以避免实际记录
 		checkKey := successKey + "_check"
-		if !inMemoryRateLimiter.Request(checkKey, successMaxCount, duration) {
+		if !modelRateLimiter.Request(checkKey, successMaxCount, duration) {
 			c.Status(http.StatusTooManyRequests)
 			c.Abort()
 			return
@@ -159,7 +175,7 @@ func memoryRateLimitHandler(duration int64, totalMaxCount, successMaxCount int) 
 
 		// 4. 如果请求成功，记录到实际的成功请求计数中
 		if c.Writer.Status() < 400 {
-			inMemoryRateLimiter.Request(successKey, successMaxCount, duration)
+			modelRateLimiter.Request(successKey, successMaxCount, duration)
 		}
 	}
 }
@@ -193,9 +209,9 @@ func ModelRequestRateLimit() func(c *gin.Context) {
 
 		// 根据存储类型选择并执行限流处理器
 		if common.RedisEnabled {
-			redisRateLimitHandler(duration, totalMaxCount, successMaxCount)(c)
+			redisRateLimitHandler(duration, totalMaxCount, successMaxCount, group)(c)
 		} else {
-			memoryRateLimitHandler(duration, totalMaxCount, successMaxCount)(c)
+			memoryRateLimitHandler(duration, totalMaxCount, successMaxCount, group)(c)
 		}
 	}
 }

--- a/middleware/model_rate_limit_memory_test.go
+++ b/middleware/model_rate_limit_memory_test.go
@@ -1,0 +1,131 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/setting"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// 内存限流处理器回归：一次性初始化（并发首批请求不 panic）与
+// successMaxCount=0（不限）守卫。
+// 注意：不重置包级 modelRateLimiter —— 其实例带常驻清理 goroutine，
+// 运行中换值会与 clearExpiredItems 的无锁读竞争。各测试用不同组/用户隔离状态。
+
+func withMemoryRateLimitSettings(t *testing.T, enabled bool, durationMin, count, success int, group map[string][2]int) {
+	prev := struct {
+		enabled     bool
+		durationMin int
+		count       int
+		success     int
+		group       map[string][2]int
+	}{
+		setting.ModelRequestRateLimitEnabled,
+		setting.ModelRequestRateLimitDurationMinutes,
+		setting.ModelRequestRateLimitCount,
+		setting.ModelRequestRateLimitSuccessCount,
+		setting.ModelRequestRateLimitGroup,
+	}
+	setting.ModelRequestRateLimitEnabled = enabled
+	setting.ModelRequestRateLimitDurationMinutes = durationMin
+	setting.ModelRequestRateLimitCount = count
+	setting.ModelRequestRateLimitSuccessCount = success
+	setting.ModelRequestRateLimitGroup = group
+	t.Cleanup(func() {
+		setting.ModelRequestRateLimitEnabled = prev.enabled
+		setting.ModelRequestRateLimitDurationMinutes = prev.durationMin
+		setting.ModelRequestRateLimitCount = prev.count
+		setting.ModelRequestRateLimitSuccessCount = prev.success
+		setting.ModelRequestRateLimitGroup = prev.group
+	})
+}
+
+func memoryRateLimitStatus(h func(c *gin.Context), id int, group string) int {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("GET", "/v1/chat/completions", nil)
+	c.Set("id", id)
+	common.SetContextKey(c, constant.ContextKeyUserGroup, group)
+	h(c)
+	return c.Writer.Status()
+}
+
+// 1) 并发首批请求：修复前每请求调用 Init，store 尚为 nil 时另一 goroutine 进入
+// Request 会在 nil map 上赋值 panic。此处按生产同款模式（Once 包裹 Init +
+// Request）在零值限流器上并发压测，-race 下应无数据竞争、无 panic。
+func TestMemoryRateLimitOnceInitPatternNoRace(t *testing.T) {
+	var l common.InMemoryRateLimiter
+	var once sync.Once
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			once.Do(func() { l.Init(time.Minute) })
+			assert.True(t, l.Request("user:1", 1000, 60))
+		}()
+	}
+	wg.Wait()
+}
+
+// 2) 处理器层并发：走真实的 modelLimiterOnce/modelRateLimiter 变量路径，
+// 200 并发首批请求应无 panic、无误 429
+func TestMemoryRateLimitHandlerConcurrentNoPanic(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	prevRedis := common.RedisEnabled
+	common.RedisEnabled = false
+	t.Cleanup(func() { common.RedisEnabled = prevRedis })
+
+	withMemoryRateLimitSettings(t, true, 1, 1000, 1000, nil)
+	h := ModelRequestRateLimit()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			assert.NotPanics(t, func() {
+				assert.Equal(t, http.StatusOK, memoryRateLimitStatus(h, 7, "conc-group"))
+			})
+		}()
+	}
+	wg.Wait()
+}
+
+// 3) successMaxCount=0 表示不限制（与 Redis 路径 maxCount==0 提前返回一致）：
+// 修复前 Request(checkKey, 0, duration) 在窗口内只放行首个请求，其余全部 429
+func TestMemoryRateLimitZeroSuccessCountUnlimited(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	prevRedis := common.RedisEnabled
+	common.RedisEnabled = false
+	t.Cleanup(func() { common.RedisEnabled = prevRedis })
+
+	withMemoryRateLimitSettings(t, true, 1, 0, 0, map[string][2]int{"free": {0, 0}})
+	h := ModelRequestRateLimit()
+
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, http.StatusOK, memoryRateLimitStatus(h, 8, "free"),
+			"successMaxCount=0 时应不限制，第 %d 个请求不应 429", i+1)
+	}
+}
+
+// 4) 正常限额不受守卫影响：strict [2,2] 第 3 个请求仍应 429
+func TestMemoryRateLimitNormalLimitUnchanged(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	prevRedis := common.RedisEnabled
+	common.RedisEnabled = false
+	t.Cleanup(func() { common.RedisEnabled = prevRedis })
+
+	withMemoryRateLimitSettings(t, true, 1, 0, 1000, map[string][2]int{"strict": {2, 2}})
+	h := ModelRequestRateLimit()
+
+	assert.Equal(t, http.StatusOK, memoryRateLimitStatus(h, 9, "strict"))
+	assert.Equal(t, http.StatusOK, memoryRateLimitStatus(h, 9, "strict"))
+	assert.Equal(t, http.StatusTooManyRequests, memoryRateLimitStatus(h, 9, "strict"))
+}


### PR DESCRIPTION
## Problem

Model request rate limiting silently stops enforcing after a while and never recovers until the process is restarted. It affects both the official binaries and self-built ones, with or without Redis (in-memory path shown here; the Redis path shares the same key scheme).

Concretely: per-group quotas (e.g. `strict = [3, 3]`) work right after startup, but once any token of the same user that belongs to a group with a *higher* quota (e.g. `default = [20, 20]` or `vip = [1000, 1000]`) sends requests, the `strict` limit starts admitting every request.

## Root cause (two layers)

**1. The shared limiter singleton's cleanup window is locked to 20 minutes at startup**

`middleware/rate-limit.go` calls `inMemoryRateLimiter.Init(common.RateLimitKeyExpirationDuration)` (20 minutes) while routes are being registered. `Init()` only takes effect when `store == nil`, so the 1-minute duration that `memoryRateLimitHandler` passes in later is always a no-op. As a result, a counter key is only dropped by `clearExpiredItems` after **20 minutes with zero traffic**.

**2. Counter keys are per-user but quotas are per-group**

`memoryRateLimitHandler` uses `MRRL + userId` for all tokens of a user, while `maxRequestNum` comes from the requesting token's group. `InMemoryRateLimiter.Request()` appends while `len(queue) < maxRequestNum`, so traffic from a `default`(20)/`vip`(1000) token inflates the shared sliding-window queue beyond 3 entries. Once the queue is longer than the user's per-minute request rate, the queue head is always older than the 60s window, so **every** `strict` request hits the "oldest entry expired" branch and is admitted. Combined with layer 1, the key is never cleaned up under continuous traffic, so the failure persists until restart.

## Reproduction

Same user, token A in group `strict = [3,3]`, token B in group `default = [20,20]`:

1. Send 4 fast requests via A: `200, 200, 200, 429` (works as expected).
2. Send 1 request via B (inflates the shared queue to 4 entries), then keep B's key alive with one request every ~50s for a couple of minutes.
3. Send 5 fast requests via A again: `200, 200, 200, 200, 200` — **all admitted**; on a fixed build it stays `200, 200, 200, 429, 429`.

## Fix

- Use a dedicated `modelRateLimiter` instance for model rate limiting instead of the shared singleton, so its own (configurable) cleanup window actually applies.
- Include the group in the counter keys of both the in-memory and Redis handlers (`MRRL + group + ":" + userId`), so cross-group traffic can no longer inflate or starve another group's window. Per-group quotas are the intent of `ModelRequestRateLimitGroup`, so counting per user **and** group matches the feature's semantics.

## Verification (in-memory path, no Redis)

- `strict` baseline: `200, 200, 200, 429, 429` ✔
- After a 6-request burst from a `default` token of the same user, `strict` still returns `200, 200, 200, 429, 429` ✔ (buggy build: all 200)
- `default` group still limited at its own 20/min: exactly the 21st request in a minute gets 429 ✔
- Redis path key change is symmetric but untested locally (no Redis in the reproduction environment).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model rate limits are now tracked separately for each resolved token or user group.
  * Prevented rate-limit counters from being incorrectly shared across groups.
  * In-memory rate limiting now consistently honors the configured duration.
  * A success limit of zero now correctly disables success-request limiting.
  * Improved reliability for concurrent in-memory rate-limit requests and initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->