### PR TITLE
fix: DeepSeek 余额按人民币返回，入库前折算成美元

### DIFF
--- a/controller/channel-billing.go
+++ b/controller/channel-billing.go
@@ -300,6 +300,8 @@ func updateChannelDeepSeekBalance(channel *model.Channel) (float64, error) {
 	if err != nil {
 		return 0, err
 	}
+	// DeepSeek 余额按人民币计价，按汇率折算成美元存储
+	balance = balance / operation_setting.USDExchangeRate
 	channel.UpdateBalance(balance)
 	return balance, nil
 }


### PR DESCRIPTION
## 📝 变更描述 / Description
DeepSeek 的余额接口返回的是人民币，代码把原值直接存进了 `channel.balance`，而前端展示统一按美元 ×`USDExchangeRate` 换算，余额显示被放大了约 7.3 倍（默认汇率）。

修复：入库前先除以 `operation_setting.USDExchangeRate`。用这个变量是因为前端展示乘的就是它，折算后显示值等于上游真实余额。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- #767（issue 还提到硅基流动有同样问题，本 PR 先只处理 DeepSeek）

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
`go build ./controller/` 通过。DeepSeek 官方渠道实测：上游真实余额 ¥766.44，修复前渠道列表显示约 ¥3,829（被按美元再乘了一次汇率），修复后更新余额显示与上游一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DeepSeek balances are now converted from CNY to USD using the configured exchange rate before being displayed and stored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->