### PR TITLE
fix(codex): force streaming for Responses upstream

### DIFF
--- a/relay/channel/codex/adaptor.go
+++ b/relay/channel/codex/adaptor.go
@@ -1,8 +1,10 @@
 package codex
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -110,6 +112,27 @@ func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommo
 }
 
 func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBody io.Reader) (any, error) {
+	if info != nil && info.RelayMode == relayconstant.RelayModeResponses {
+		body, err := io.ReadAll(requestBody)
+		if err != nil {
+			return nil, fmt.Errorf("read codex responses request body: %w", err)
+		}
+
+		var fields map[string]json.RawMessage
+		if err := common.Unmarshal(body, &fields); err != nil {
+			return nil, fmt.Errorf("decode codex responses request body: %w", err)
+		}
+		if fields == nil {
+			return nil, errors.New("codex responses request body must be a JSON object")
+		}
+		fields["stream"] = json.RawMessage("true")
+		body, err = common.Marshal(fields)
+		if err != nil {
+			return nil, fmt.Errorf("encode codex responses request body: %w", err)
+		}
+		requestBody = bytes.NewReader(body)
+	}
+
 	return channel.DoApiRequest(a, c, info, requestBody)
 }
 
@@ -123,6 +146,11 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycom
 	case relayconstant.RelayModeResponses:
 		if info.IsStream {
 			return openai.OaiResponsesStreamHandler(c, info, resp)
+		}
+		// Codex Responses requests are always streamed upstream by DoRequest;
+		// buffer the SSE stream into one JSON response for non-streaming clients.
+		if resp != nil && strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "text/event-stream") {
+			return openai.OaiResponsesBufferedStreamHandler(c, info, resp)
 		}
 		return openai.OaiResponsesHandler(c, info, resp)
 	default:
@@ -190,7 +218,9 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *rel
 	// Clients may omit it or include parameters like `application/json; charset=utf-8`,
 	// which can be rejected by the upstream. Force the exact media type.
 	req.Set("Content-Type", "application/json")
-	if info.IsStream {
+	// RelayModeResponses is always streamed upstream by DoRequest, so its Accept
+	// must ask for SSE even when the client requested a buffered response.
+	if info.IsStream || info.RelayMode == relayconstant.RelayModeResponses {
 		req.Set("Accept", "text/event-stream")
 	} else if req.Get("Accept") == "" {
 		req.Set("Accept", "application/json")

--- a/relay/channel/codex/adaptor_test.go
+++ b/relay/channel/codex/adaptor_test.go
@@ -2,12 +2,18 @@ package codex
 
 import (
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/gin-gonic/gin"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,4 +59,175 @@ func TestConvertOpenAIResponsesRequestDropsPenalties(t *testing.T) {
 	assert.Nil(t, request.Temperature)
 	assert.Nil(t, request.FrequencyPenalty)
 	assert.Nil(t, request.PresencePenalty)
+}
+
+func TestDoRequestForcesStreamInFinalResponsesBody(t *testing.T) {
+	type capturedRequest struct {
+		body   []byte
+		accept string
+		path   string
+	}
+	captured := make(chan capturedRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		captured <- capturedRequest{
+			body:   body,
+			accept: r.Header.Get("Accept"),
+			path:   r.URL.Path,
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	adaptor := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelType:    constant.ChannelTypeCodex,
+			ChannelBaseUrl: server.URL,
+			ApiKey:         `{"access_token":"token","account_id":"account"}`,
+		},
+		RelayMode: relayconstant.RelayModeResponses,
+		IsStream:  false,
+	}
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "explicit false from client or parameter override",
+			body: `{"model":"gpt-5-codex","stream":false,"provider_extension":{"keep":1}}`,
+		},
+		{
+			name: "stream omitted by passthrough body",
+			body: `{"model":"gpt-5-codex","provider_extension":{"keep":1}}`,
+		},
+		{
+			name: "duplicate stream fields in passthrough body",
+			body: `{"model":"gpt-5-codex","stream":false,"stream":false,"provider_extension":{"keep":1}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			respAny, err := adaptor.DoRequest(c, info, strings.NewReader(tt.body))
+			require.NoError(t, err)
+			resp, ok := respAny.(*http.Response)
+			require.True(t, ok)
+			require.NoError(t, resp.Body.Close())
+
+			got := <-captured
+			assert.Equal(t, "/backend-api/codex/responses", got.path)
+			assert.Equal(t, "text/event-stream", got.accept)
+
+			var body map[string]json.RawMessage
+			require.NoError(t, common.Unmarshal(got.body, &body))
+			assert.JSONEq(t, `true`, string(body["stream"]))
+			assert.JSONEq(t, `{"keep":1}`, string(body["provider_extension"]))
+		})
+	}
+}
+
+func TestDoRequestRejectsNullResponsesBody(t *testing.T) {
+	adaptor := &Adaptor{}
+	info := &relaycommon.RelayInfo{RelayMode: relayconstant.RelayModeResponses}
+
+	var err error
+	require.NotPanics(t, func() {
+		_, err = adaptor.DoRequest(nil, info, strings.NewReader("null"))
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "JSON object")
+}
+
+// Regression test for upstream 400 "Stream must be set to true": a non-stream
+// client on a Codex channel receives an SSE upstream response (stream is forced
+// upstream) that must be buffered into a single aggregated JSON response.
+func TestDoResponseBuffersUpstreamSSEForNonStreamClient(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"hello"}`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-5-codex","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":{"input_tokens":5,"output_tokens":7,"total_tokens":12}}}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	adaptor := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelType:       constant.ChannelTypeCodex,
+			UpstreamModelName: "gpt-5-codex",
+		},
+		RelayMode:       relayconstant.RelayModeResponses,
+		IsStream:        false,
+		OriginModelName: "gpt-5-codex",
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+
+	usageAny, apiErr := adaptor.DoResponse(c, resp, info)
+	require.Nil(t, apiErr)
+	usage, ok := usageAny.(*dto.Usage)
+	require.True(t, ok)
+	assert.Equal(t, 5, usage.PromptTokens)
+	assert.Equal(t, 7, usage.CompletionTokens)
+	assert.Equal(t, 12, usage.TotalTokens)
+
+	got := w.Body.String()
+	assert.NotContains(t, got, "data:")
+	assert.Contains(t, got, `"id":"resp_1"`)
+	assert.Contains(t, got, `"text":"hello"`)
+}
+
+// If the upstream ever answers a non-stream request with plain JSON, the
+// adaptor must keep passing it through instead of misreading it as SSE.
+func TestDoResponseNonStreamPassesThroughJSONResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := `{"id":"resp_2","model":"gpt-5-codex","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	adaptor := &Adaptor{}
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelType:       constant.ChannelTypeCodex,
+			UpstreamModelName: "gpt-5-codex",
+		},
+		RelayMode:       relayconstant.RelayModeResponses,
+		IsStream:        false,
+		OriginModelName: "gpt-5-codex",
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+
+	usageAny, apiErr := adaptor.DoResponse(c, resp, info)
+	require.Nil(t, apiErr)
+	usage, ok := usageAny.(*dto.Usage)
+	require.True(t, ok)
+	assert.Equal(t, 3, usage.TotalTokens)
+	assert.Contains(t, w.Body.String(), `"id":"resp_2"`)
 }

--- a/relay/channel/openai/chat_via_responses.go
+++ b/relay/channel/openai/chat_via_responses.go
@@ -1,11 +1,9 @@
 package openai
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
@@ -83,72 +81,11 @@ func OaiResponsesToChatBufferedStreamHandler(c *gin.Context, info *relaycommon.R
 	}
 	defer service.CloseResponseBodyGracefully(resp)
 
-	accumulator := relayconvert.NewResponsesBufferedAccumulator()
-	var finalResponse *dto.OpenAIResponsesResponse
-	var streamErr *types.NewAPIError
-
-	scanner := helper.NewStreamScanner(resp.Body)
-	scanner.Split(bufio.ScanLines)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if len(line) < 6 || line[:5] != "data:" {
-			continue
-		}
-		data := line[5:]
-		data = strings.TrimSpace(data)
-		if data == "" || data == "[DONE]" {
-			if data == "[DONE]" {
-				break
-			}
-			continue
-		}
-
-		var streamResp dto.ResponsesStreamResponse
-		if err := common.UnmarshalJsonStr(data, &streamResp); err != nil {
-			logger.LogError(c, "failed to unmarshal buffered responses stream event: "+err.Error())
-			streamErr = types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
-			break
-		}
-		accumulator.ProcessEvent(&streamResp)
-		switch streamResp.Type {
-		case "response.completed", "response.done", "response.incomplete":
-			finalResponse = streamResp.Response
-			if streamResp.Type == "response.incomplete" {
-				if finalResponse == nil {
-					finalResponse = &dto.OpenAIResponsesResponse{}
-				}
-				if len(finalResponse.Status) == 0 {
-					finalResponse.Status = []byte(`"incomplete"`)
-				}
-			}
-		case "response.failed", "response.error":
-			if streamResp.Response != nil {
-				if oaiErr := streamResp.Response.GetOpenAIError(); oaiErr != nil && oaiErr.Type != "" {
-					streamErr = types.WithOpenAIError(*oaiErr, http.StatusInternalServerError)
-					break
-				}
-			}
-			streamErr = types.NewOpenAIError(fmt.Errorf("responses stream error: %s", streamResp.Type), types.ErrorCodeBadResponse, http.StatusInternalServerError)
-		}
-		if streamErr != nil || finalResponse != nil {
-			break
-		}
+	buffered, apiErr := bufferResponsesStreamFinalResponse(c, info, resp)
+	if apiErr != nil {
+		return nil, apiErr
 	}
-	if streamErr != nil {
-		return nil, streamErr
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponse, http.StatusInternalServerError)
-	}
-	if finalResponse == nil {
-		finalResponse = &dto.OpenAIResponsesResponse{
-			ID:        helper.GetResponseID(c),
-			CreatedAt: int(time.Now().Unix()),
-			Model:     info.UpstreamModelName,
-			Status:    []byte(`"completed"`),
-		}
-	}
-	accumulator.SupplementResponseOutput(finalResponse)
+	finalResponse := buffered.response
 
 	chatResult, err := relayconvert.ConvertResponse(c, info, types.RelayFormatOpenAI, finalResponse)
 	if err != nil {
@@ -181,6 +118,7 @@ func OaiResponsesToChatBufferedStreamHandler(c *gin.Context, info *relaycommon.R
 		return nil, types.NewOpenAIError(err, types.ErrorCodeJsonMarshalFailed, http.StatusInternalServerError)
 	}
 
+	setBufferedJSONResponseContentType(resp)
 	service.IOCopyBytesGracefully(c, resp, responseBody)
 	return usage, nil
 }

--- a/relay/channel/openai/chat_via_responses_test.go
+++ b/relay/channel/openai/chat_via_responses_test.go
@@ -163,6 +163,7 @@ func TestOaiResponsesToChatBufferedStreamHandlerReturnsJSONFromSSE(t *testing.T)
 	require.Equal(t, 3, usage.TotalTokens)
 
 	got := recorder.Body.String()
+	require.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
 	require.NotContains(t, got, `data:`)
 	require.Contains(t, got, `"object":"chat.completion"`)
 	require.Contains(t, got, `"content":"buffered text"`)

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -1,16 +1,23 @@
 package openai
 
 import (
+	"bufio"
+	"context"
+	"encoding/json"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/logger"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/relayconvert"
 	"github.com/QuantumNous/new-api/relaykit/types"
 	"github.com/QuantumNous/new-api/service"
 
@@ -30,6 +37,274 @@ func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 	if err != nil {
 		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
 	}
+
+	return writeFinalResponsesResponse(c, info, resp, &responsesResponse, responseBody)
+}
+
+// OaiResponsesBufferedStreamHandler serves non-streaming clients against
+// upstreams that only support streaming (e.g. the Codex backend): it consumes
+// the upstream SSE stream and writes a single aggregated JSON response.
+func OaiResponsesBufferedStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
+	if resp == nil || resp.Body == nil {
+		return nil, types.NewOpenAIError(fmt.Errorf("invalid response"), types.ErrorCodeBadResponse, http.StatusInternalServerError)
+	}
+	defer service.CloseResponseBodyGracefully(resp)
+
+	result, apiErr := bufferResponsesStreamFinalResponse(c, info, resp)
+	if apiErr != nil {
+		return nil, apiErr
+	}
+	if !result.terminalSeen {
+		return nil, types.NewOpenAIError(fmt.Errorf("responses stream ended without a terminal event"), types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+
+	responseBody := []byte(result.responseBody)
+	if len(responseBody) == 0 {
+		var err error
+		responseBody, err = common.Marshal(result.response)
+		if err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeJsonMarshalFailed, http.StatusInternalServerError)
+		}
+	}
+	setBufferedJSONResponseContentType(resp)
+
+	return writeFinalResponsesResponse(c, info, resp, result.response, responseBody)
+}
+
+func setBufferedJSONResponseContentType(resp *http.Response) {
+	if resp.Header == nil {
+		resp.Header = make(http.Header)
+	}
+	resp.Header.Set("Content-Type", "application/json")
+}
+
+type bufferedResponsesResult struct {
+	response     *dto.OpenAIResponsesResponse
+	responseBody json.RawMessage
+	terminalSeen bool
+}
+
+type bufferedResponsesAccumulator struct {
+	inner            *relayconvert.ResponsesBufferedAccumulator
+	itemRaws         map[int]json.RawMessage
+	supplementedRaws []json.RawMessage
+}
+
+func newBufferedResponsesAccumulator() *bufferedResponsesAccumulator {
+	return &bufferedResponsesAccumulator{
+		inner:    relayconvert.NewResponsesBufferedAccumulator(),
+		itemRaws: make(map[int]json.RawMessage),
+	}
+}
+
+func (a *bufferedResponsesAccumulator) ProcessEvent(event *dto.ResponsesStreamResponse, raw string) {
+	if a == nil || event == nil {
+		return
+	}
+	a.inner.ProcessEvent(event)
+	switch event.Type {
+	case "response.output_item.done":
+		if event.Item == nil {
+			return
+		}
+		var itemEvent struct {
+			Item json.RawMessage `json:"item"`
+		}
+		if err := common.UnmarshalJsonStr(raw, &itemEvent); err != nil || len(itemEvent.Item) == 0 {
+			return
+		}
+		key := -1
+		if event.OutputIndex != nil {
+			key = *event.OutputIndex
+		} else if event.Item.ID != "" {
+			key = int(crc32.ChecksumIEEE([]byte(event.Item.ID)))
+		}
+		a.itemRaws[key] = itemEvent.Item
+	case "response.completed", "response.done":
+		a.supplementedRaws = nil
+	}
+}
+
+func (a *bufferedResponsesAccumulator) SupplementResponseOutput(resp *dto.OpenAIResponsesResponse) {
+	if a == nil || resp == nil || len(resp.Output) > 0 {
+		return
+	}
+	typed := a.inner.BuildOutput()
+	if len(typed) == 0 && len(a.itemRaws) == 0 {
+		return
+	}
+	output := make([]json.RawMessage, 0, len(typed)+len(a.itemRaws))
+	for i := range typed {
+		raw, err := common.Marshal(&typed[i])
+		if err != nil {
+			continue
+		}
+		output = append(output, raw)
+	}
+	keys := make([]int, 0, len(a.itemRaws))
+	for key := range a.itemRaws {
+		keys = append(keys, key)
+	}
+	sort.Ints(keys)
+	for _, key := range keys {
+		output = append(output, a.itemRaws[key])
+	}
+	rawOutput, err := common.Marshal(output)
+	if err != nil {
+		return
+	}
+	if err := common.Unmarshal(rawOutput, &resp.Output); err != nil {
+		resp.Output = typed
+		return
+	}
+	a.supplementedRaws = output
+}
+
+func (a *bufferedResponsesAccumulator) SupplementedOutputRaw() json.RawMessage {
+	if a == nil || len(a.supplementedRaws) == 0 {
+		return nil
+	}
+	raw, err := common.Marshal(a.supplementedRaws)
+	if err != nil {
+		return nil
+	}
+	return raw
+}
+
+// bufferResponsesStreamFinalResponse consumes an upstream Responses SSE stream.
+// Callers can distinguish a real terminal response from the synthesized fallback
+// retained for compatibility with non-standard chat-completions upstreams.
+func bufferResponsesStreamFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*bufferedResponsesResult, *types.NewAPIError) {
+	result := &bufferedResponsesResult{}
+	accumulator := newBufferedResponsesAccumulator()
+
+	if c != nil && c.Request != nil {
+		stopCancel := context.AfterFunc(c.Request.Context(), func() {
+			_ = resp.Body.Close()
+		})
+		defer stopCancel()
+	}
+
+	scanner := helper.NewStreamScanner(resp.Body)
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		data, ok := strings.CutPrefix(scanner.Text(), "data:")
+		if !ok {
+			continue
+		}
+		data = strings.TrimSpace(data)
+		if data == "" {
+			continue
+		}
+		if data == "[DONE]" {
+			break
+		}
+
+		var streamResp dto.ResponsesStreamResponse
+		if err := common.UnmarshalJsonStr(data, &streamResp); err != nil {
+			logger.LogError(c, "failed to unmarshal buffered responses stream event: "+err.Error())
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+		if streamResp.Type == "error" {
+			var errorEvent struct {
+				Error   *types.OpenAIError `json:"error"`
+				Message string             `json:"message"`
+				Code    any                `json:"code"`
+				Param   string             `json:"param"`
+			}
+			if err := common.UnmarshalJsonStr(data, &errorEvent); err != nil {
+				return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+			}
+			if errorEvent.Error != nil {
+				if errorEvent.Error.Type == "" {
+					errorEvent.Error.Type = "server_error"
+				}
+				return nil, types.WithOpenAIError(*errorEvent.Error, http.StatusInternalServerError)
+			}
+			if errorEvent.Message == "" {
+				errorEvent.Message = "responses stream error"
+			}
+			return nil, types.WithOpenAIError(types.OpenAIError{
+				Message: errorEvent.Message,
+				Type:    "server_error",
+				Param:   errorEvent.Param,
+				Code:    errorEvent.Code,
+			}, http.StatusInternalServerError)
+		}
+
+		accumulator.ProcessEvent(&streamResp, data)
+		switch streamResp.Type {
+		case "response.completed", "response.done", "response.incomplete":
+			result.terminalSeen = true
+			result.response = streamResp.Response
+			var terminalEvent struct {
+				Response json.RawMessage `json:"response"`
+			}
+			if err := common.UnmarshalJsonStr(data, &terminalEvent); err != nil {
+				return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+			}
+			result.responseBody = terminalEvent.Response
+			if streamResp.Type == "response.incomplete" && result.response == nil {
+				result.response = &dto.OpenAIResponsesResponse{Status: json.RawMessage(`"incomplete"`)}
+				result.responseBody = nil
+			}
+			if result.response == nil {
+				return nil, types.NewOpenAIError(fmt.Errorf("responses terminal event is missing response"), types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+			}
+			if streamResp.Type == "response.incomplete" && len(result.response.Status) == 0 {
+				result.response.Status = json.RawMessage(`"incomplete"`)
+				result.responseBody = nil
+			}
+		case "response.failed", "response.error":
+			if streamResp.Response != nil {
+				if oaiErr := streamResp.Response.GetOpenAIError(); oaiErr != nil && oaiErr.Type != "" {
+					return nil, types.WithOpenAIError(*oaiErr, http.StatusInternalServerError)
+				}
+			}
+			return nil, types.NewOpenAIError(fmt.Errorf("responses stream error: %s", streamResp.Type), types.ErrorCodeBadResponse, http.StatusInternalServerError)
+		}
+		if result.terminalSeen {
+			break
+		}
+	}
+	if c != nil && c.Request != nil {
+		if err := c.Request.Context().Err(); err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponse, http.StatusInternalServerError)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponse, http.StatusInternalServerError)
+	}
+	if result.response == nil {
+		result.response = &dto.OpenAIResponsesResponse{
+			ID:        helper.GetResponseID(c),
+			CreatedAt: int(time.Now().Unix()),
+			Model:     info.UpstreamModelName,
+			Status:    json.RawMessage(`"completed"`),
+		}
+	}
+	outputWasMissing := len(result.response.Output) == 0
+	accumulator.SupplementResponseOutput(result.response)
+	if outputWasMissing {
+		if outputRaw := accumulator.SupplementedOutputRaw(); len(outputRaw) > 0 && len(result.responseBody) > 0 {
+			var responseFields map[string]json.RawMessage
+			if err := common.Unmarshal(result.responseBody, &responseFields); err != nil {
+				return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+			}
+			responseFields["output"] = outputRaw
+			var err error
+			result.responseBody, err = common.Marshal(responseFields)
+			if err != nil {
+				return nil, types.NewOpenAIError(err, types.ErrorCodeJsonMarshalFailed, http.StatusInternalServerError)
+			}
+		}
+	}
+	return result, nil
+}
+
+// writeFinalResponsesResponse writes the final Responses JSON body to the
+// client and computes usage plus per-call tool/image billing from it.
+func writeFinalResponsesResponse(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response, responsesResponse *dto.OpenAIResponsesResponse, responseBody []byte) (*dto.Usage, *types.NewAPIError) {
 	if oaiError := responsesResponse.GetOpenAIError(); oaiError != nil && oaiError.Type != "" {
 		return nil, types.WithOpenAIError(*oaiError, resp.StatusCode)
 	}

--- a/relay/channel/openai/relay_responses_buffered_test.go
+++ b/relay/channel/openai/relay_responses_buffered_test.go
@@ -1,0 +1,244 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type responsesTestContextConfig struct {
+	accept      string
+	contentType string
+}
+
+func newResponsesBufferedStreamTestContext(body string) (*gin.Context, *httptest.ResponseRecorder, *http.Response, *relaycommon.RelayInfo) {
+	return newResponsesBufferedStreamTestContextWithConfig(body, responsesTestContextConfig{contentType: "text/event-stream"})
+}
+
+func newResponsesBufferedStreamTestContextWithConfig(body string, config responsesTestContextConfig) (*gin.Context, *httptest.ResponseRecorder, *http.Response, *relaycommon.RelayInfo) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	if config.accept != "" {
+		c.Request.Header.Set("Accept", config.accept)
+	}
+
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "gpt-test",
+		},
+		OriginModelName: "gpt-test",
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{config.contentType}},
+	}
+	return c, w, resp, info
+}
+
+// Some upstreams (e.g. Codex) only support streaming. For a non-streaming
+// client the gateway must buffer the SSE stream into one aggregated JSON
+// response while preserving usage and per-call tool billing.
+func TestOaiResponsesBufferedStreamHandlerReturnsAggregatedJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"buff"}`,
+		`data: {"type":"response.output_text.delta","delta":"ered"}`,
+		`data: {"type":"response.output_item.done","item":{"type":"web_search_call","id":"ws_1"}}`,
+		`data: {"type":"response.completed","response":{"id":"resp_buf","model":"gpt-test","status":"completed","codex_extension":{"trace":"kept"},"output":[{"type":"web_search_call","id":"ws_1"},{"type":"message","role":"assistant","content":[{"type":"output_text","text":"buffered"}]}],"usage":{"input_tokens":4,"output_tokens":6,"total_tokens":10}}}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	c, w, resp, info := newResponsesBufferedStreamTestContext(body)
+
+	usage, apiErr := OaiResponsesBufferedStreamHandler(c, info, resp)
+	require.Nil(t, apiErr)
+	require.NotNil(t, usage)
+	assert.Equal(t, 4, usage.PromptTokens)
+	assert.Equal(t, 6, usage.CompletionTokens)
+	assert.Equal(t, 10, usage.TotalTokens)
+
+	got := w.Body.String()
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.NotContains(t, got, "data:")
+	assert.Contains(t, got, `"id":"resp_buf"`)
+	assert.Contains(t, got, `"text":"buffered"`)
+	assert.Contains(t, got, `"codex_extension":{"trace":"kept"}`)
+
+	// Billing parity with OaiResponsesHandler: built-in tool calls in the final
+	// response output must be counted.
+	require.NotNil(t, info.ResponsesUsageInfo)
+	require.Contains(t, info.ResponsesUsageInfo.BuiltInTools, dto.BuildInToolWebSearchPreview)
+	assert.Equal(t, 1, info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolWebSearchPreview].CallCount)
+}
+
+func TestOaiResponsesBufferedStreamHandlerReconstructsMissingTerminalOutput(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"reconstructed"}`,
+		`data: {"type":"response.completed","response":{"id":"resp_partial","model":"gpt-test","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	c, w, resp, info := newResponsesBufferedStreamTestContext(body)
+
+	usage, apiErr := OaiResponsesBufferedStreamHandler(c, info, resp)
+	require.Nil(t, apiErr)
+	require.NotNil(t, usage)
+	assert.Contains(t, w.Body.String(), `"text":"reconstructed"`)
+}
+
+func TestOaiResponsesBufferedStreamHandlerReconstructsBillableOutputs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := strings.Join([]string{
+		`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"web_search_call","id":"ws_1","status":"completed"}}`,
+		`data: {"type":"response.output_item.done","output_index":1,"item":{"type":"file_search_call","id":"fs_1","status":"completed"}}`,
+		`data: {"type":"response.output_item.done","output_index":2,"item":{"type":"image_generation_call","id":"img_1","status":"completed","result":"image-data"}}`,
+		`data: {"type":"response.completed","response":{"id":"resp_tools","model":"gpt-test","status":"completed","output":[],"usage":{"input_tokens":2,"output_tokens":3,"total_tokens":5}}}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	c, w, resp, info := newResponsesBufferedStreamTestContext(body)
+
+	usage, apiErr := OaiResponsesBufferedStreamHandler(c, info, resp)
+	require.Nil(t, apiErr)
+	require.NotNil(t, usage)
+	got := w.Body.String()
+	assert.Contains(t, got, `"type":"web_search_call"`)
+	assert.Contains(t, got, `"type":"file_search_call"`)
+	assert.Contains(t, got, `"type":"image_generation_call"`)
+
+	require.NotNil(t, info.ResponsesUsageInfo)
+	require.Contains(t, info.ResponsesUsageInfo.BuiltInTools, dto.BuildInToolWebSearchPreview)
+	require.Contains(t, info.ResponsesUsageInfo.BuiltInTools, dto.BuildInToolFileSearch)
+	require.Contains(t, info.ResponsesUsageInfo.BuiltInTools, dto.BuildInToolImageGeneration)
+	assert.Equal(t, 1, info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolWebSearchPreview].CallCount)
+	assert.Equal(t, 1, info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolFileSearch].CallCount)
+	assert.Equal(t, 1, info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolImageGeneration].CallCount)
+}
+
+func TestOaiResponsesBufferedStreamHandlerClaudeBufferedViaChat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"Claude buffered"}`,
+		`data: {"type":"response.completed","response":{"id":"resp_claude_buffered","model":"gpt-test","status":"completed","output":[],"usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7}}}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	c, w, resp, info := newResponsesBufferedStreamTestContextWithConfig(body, responsesTestContextConfig{
+		accept:      "application/json",
+		contentType: "text/event-stream",
+	})
+	info.RelayFormat = types.RelayFormatClaude
+
+	usage, apiErr := OaiResponsesToChatBufferedStreamHandler(c, info, resp)
+	require.Nil(t, apiErr)
+	require.NotNil(t, usage)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Contains(t, w.Body.String(), `"type":"message"`)
+	assert.Contains(t, w.Body.String(), `"Claude buffered"`)
+}
+
+// A terminal failure event in the stream must surface as an error instead of
+// an empty fabricated success response.
+func TestOaiResponsesBufferedStreamHandlerReturnsErrorOnFailedEvent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"partial"}`,
+		`data: {"type":"response.failed","response":{"id":"resp_fail","status":"failed","error":{"type":"server_error","message":"upstream boom"}}}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	c, _, resp, info := newResponsesBufferedStreamTestContext(body)
+
+	usage, apiErr := OaiResponsesBufferedStreamHandler(c, info, resp)
+	require.NotNil(t, apiErr)
+	assert.Contains(t, apiErr.Error(), "upstream boom")
+	assert.Nil(t, usage)
+}
+
+func TestOaiResponsesBufferedStreamHandlerReturnsTopLevelStreamError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := strings.Join([]string{
+		`data: {"type":"error","error":{"type":"server_error","code":"server_error","message":"top-level boom","param":null}}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	c, _, resp, info := newResponsesBufferedStreamTestContext(body)
+
+	usage, apiErr := OaiResponsesBufferedStreamHandler(c, info, resp)
+	require.NotNil(t, apiErr)
+	assert.Contains(t, apiErr.Error(), "top-level boom")
+	assert.Nil(t, usage)
+}
+
+func TestOaiResponsesBufferedStreamHandlerRejectsMissingTerminalEvent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"partial"}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	c, _, resp, info := newResponsesBufferedStreamTestContext(body)
+
+	usage, apiErr := OaiResponsesBufferedStreamHandler(c, info, resp)
+	require.NotNil(t, apiErr)
+	assert.Contains(t, apiErr.Error(), "terminal event")
+	assert.Nil(t, usage)
+}
+
+func TestOaiResponsesBufferedStreamHandlerStopsOnClientCancellation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	reader, writer := io.Pipe()
+	t.Cleanup(func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+
+	c, _, resp, info := newResponsesBufferedStreamTestContext("")
+	resp.Body = reader
+	requestCtx, cancel := context.WithCancel(context.Background())
+	c.Request = c.Request.WithContext(requestCtx)
+
+	result := make(chan *types.NewAPIError, 1)
+	go func() {
+		_, apiErr := OaiResponsesBufferedStreamHandler(c, info, resp)
+		result <- apiErr
+	}()
+	cancel()
+
+	select {
+	case apiErr := <-result:
+		require.NotNil(t, apiErr)
+		assert.Contains(t, apiErr.Error(), context.Canceled.Error())
+	case <-time.After(time.Second):
+		t.Fatal("buffered response handler did not stop after client cancellation")
+	}
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
Codex Responses 上游只接受 `stream=true`。本变更在最终出站边界统一覆盖该字段，因此普通转换、参数覆盖、透传请求以及重复 JSON key 都无法再将其改回 `false`。

对于非流式客户端，网关会把上游 SSE 聚合为 `application/json`：保留终止响应中的未知扩展字段；若终止响应缺少 output，则按 `output_index` 从事件完整重建文本、函数调用、web/file search 与图片输出，并沿用现有 usage、工具调用和图片计费逻辑。失败事件、顶层 `error`、缺失终止事件和客户端取消都会正确终止，不会伪造成成功响应。流式客户端和 `/v1/responses/compact` 行为保持不变。

本变更由 Claude Code 协助实现、审查和测试；当前 Git 提交者并非仓库历史核心开发者。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Related to #5662

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```text
go test ./relay/... ./controller/...                         PASS
go vet ./relay/channel/codex ./relay/channel/openai          PASS
go build ./relay/...                                         PASS
go test -race ./relay/channel/codex ./relay/channel/openai   PASS
```

新增回归覆盖：最终出站 `stream=true`、参数覆盖/透传/重复 key、非流式 SSE 聚合、JSON Content-Type、未知字段保留、delta output 补全、web/file search 与图片 output 重建及计费、失败与顶层 error、缺失终止事件、客户端取消、Claude 格式缓冲转换和 null 请求体。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Non-streaming Responses requests now receive complete JSON responses, even when the upstream service sends streamed events.
  * Responses request handling consistently enables streaming upstream while preserving other request fields.
  * Buffered responses retain generated text, tool outputs, usage details, and billing information.
  * Improved handling of missing terminal output and conversion to chat-compatible responses.

* **Bug Fixes**
  * Added clearer errors for invalid request bodies, upstream failures, stream errors, missing completion events, and canceled requests.
  * Buffered JSON responses now return the correct `application/json` content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->