### PR TITLE
fix(codex): accept nested tokens layout in OAuth credential

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -14,6 +14,7 @@ import (
 	"github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
 	relaychannel "github.com/QuantumNous/new-api/relay/channel"
+	"github.com/QuantumNous/new-api/relay/channel/codex"
 	"github.com/QuantumNous/new-api/relay/channel/ollama"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relaykit/dto"
@@ -522,14 +523,14 @@ func validateChannel(channel *model.Channel, isAdd bool) error {
 			if !strings.HasPrefix(trimmedKey, "{") {
 				return fmt.Errorf("Codex key must be a valid JSON object")
 			}
-			var keyMap map[string]any
-			if err := common.Unmarshal([]byte(trimmedKey), &keyMap); err != nil {
+			oauthKey, err := codex.ParseOAuthKey(trimmedKey)
+			if err != nil {
 				return fmt.Errorf("Codex key must be a valid JSON object")
 			}
-			if v, ok := keyMap["access_token"]; !ok || v == nil || strings.TrimSpace(fmt.Sprintf("%v", v)) == "" {
+			if strings.TrimSpace(oauthKey.AccessToken) == "" {
 				return fmt.Errorf("Codex key JSON must include access_token")
 			}
-			if v, ok := keyMap["account_id"]; !ok || v == nil || strings.TrimSpace(fmt.Sprintf("%v", v)) == "" {
+			if strings.TrimSpace(oauthKey.AccountID) == "" {
 				return fmt.Errorf("Codex key JSON must include account_id")
 			}
 		}

--- a/relay/channel/codex/oauth_key.go
+++ b/relay/channel/codex/oauth_key.go
@@ -16,6 +16,11 @@ type OAuthKey struct {
 	Email       string `json:"email,omitempty"`
 	Type        string `json:"type,omitempty"`
 	Expired     string `json:"expired,omitempty"`
+
+	// Tokens carries the same credentials nested under "tokens", which is the
+	// layout Codex CLI uses in ~/.codex/auth.json. ParseOAuthKey flattens it
+	// into the fields above, so it is never re-marshaled.
+	Tokens *OAuthKey `json:"tokens,omitempty"`
 }
 
 func ParseOAuthKey(raw string) (*OAuthKey, error) {
@@ -26,5 +31,28 @@ func ParseOAuthKey(raw string) (*OAuthKey, error) {
 	if err := common.Unmarshal([]byte(raw), &key); err != nil {
 		return nil, errors.New("codex channel: invalid oauth key json")
 	}
+	key.flattenTokens()
 	return &key, nil
+}
+
+// flattenTokens promotes credentials nested under "tokens" (the Codex CLI
+// auth.json layout) to the top level, keeping any values already set there.
+func (k *OAuthKey) flattenTokens() {
+	nested := k.Tokens
+	if nested == nil {
+		return
+	}
+	k.Tokens = nil
+	if k.IDToken == "" {
+		k.IDToken = nested.IDToken
+	}
+	if k.AccessToken == "" {
+		k.AccessToken = nested.AccessToken
+	}
+	if k.RefreshToken == "" {
+		k.RefreshToken = nested.RefreshToken
+	}
+	if k.AccountID == "" {
+		k.AccountID = nested.AccountID
+	}
 }

--- a/relay/channel/codex/oauth_key_test.go
+++ b/relay/channel/codex/oauth_key_test.go
@@ -1,0 +1,69 @@
+package codex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Codex CLI stores the OAuth credential nested under "tokens" in
+// ~/.codex/auth.json; ParseOAuthKey must flatten that layout so a pasted
+// auth.json works the same as the flattened credential.
+func TestParseOAuthKeyFlattensTokens(t *testing.T) {
+	tests := []struct {
+		name         string
+		raw          string
+		accessToken  string
+		refreshToken string
+		accountID    string
+	}{
+		{
+			name:         "flat credential",
+			raw:          `{"access_token":"at","refresh_token":"rt","account_id":"acc"}`,
+			accessToken:  "at",
+			refreshToken: "rt",
+			accountID:    "acc",
+		},
+		{
+			name:         "nested auth.json layout",
+			raw:          `{"OPENAI_API_KEY":null,"tokens":{"id_token":"id","access_token":"at","refresh_token":"rt","account_id":"acc"},"last_refresh":"2026-08-01T00:00:00Z"}`,
+			accessToken:  "at",
+			refreshToken: "rt",
+			accountID:    "acc",
+		},
+		{
+			name:         "top level wins over tokens",
+			raw:          `{"access_token":"top-at","account_id":"top-acc","tokens":{"access_token":"nested-at","refresh_token":"rt","account_id":"nested-acc"}}`,
+			accessToken:  "top-at",
+			refreshToken: "rt",
+			accountID:    "top-acc",
+		},
+		{
+			name:         "tokens fill only missing top level fields",
+			raw:          `{"access_token":"top-at","tokens":{"access_token":"nested-at","refresh_token":"rt","account_id":"acc"}}`,
+			accessToken:  "top-at",
+			refreshToken: "rt",
+			accountID:    "acc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, err := ParseOAuthKey(tt.raw)
+			require.NoError(t, err)
+			assert.Equal(t, tt.accessToken, key.AccessToken)
+			assert.Equal(t, tt.refreshToken, key.RefreshToken)
+			assert.Equal(t, tt.accountID, key.AccountID)
+			// Tokens is consumed by flattening so re-marshaling stays flat.
+			assert.Nil(t, key.Tokens)
+		})
+	}
+}
+
+func TestParseOAuthKeyRejectsInvalidInput(t *testing.T) {
+	for _, raw := range []string{"", "not json", `["access_token"]`} {
+		_, err := ParseOAuthKey(raw)
+		assert.Error(t, err, "input %q", raw)
+	}
+}

--- a/service/codex_credential_refresh.go
+++ b/service/codex_credential_refresh.go
@@ -26,6 +26,11 @@ type CodexOAuthKey struct {
 	Email       string `json:"email,omitempty"`
 	Type        string `json:"type,omitempty"`
 	Expired     string `json:"expired,omitempty"`
+
+	// Tokens carries the same credentials nested under "tokens", which is the
+	// layout Codex CLI uses in ~/.codex/auth.json. parseCodexOAuthKey flattens
+	// it into the fields above, so it is never re-marshaled.
+	Tokens *CodexOAuthKey `json:"tokens,omitempty"`
 }
 
 func parseCodexOAuthKey(raw string) (*CodexOAuthKey, error) {
@@ -36,7 +41,30 @@ func parseCodexOAuthKey(raw string) (*CodexOAuthKey, error) {
 	if err := common.Unmarshal([]byte(raw), &key); err != nil {
 		return nil, errors.New("codex channel: invalid oauth key json")
 	}
+	key.flattenTokens()
 	return &key, nil
+}
+
+// flattenTokens promotes credentials nested under "tokens" (the Codex CLI
+// auth.json layout) to the top level, keeping any values already set there.
+func (k *CodexOAuthKey) flattenTokens() {
+	nested := k.Tokens
+	if nested == nil {
+		return
+	}
+	k.Tokens = nil
+	if k.IDToken == "" {
+		k.IDToken = nested.IDToken
+	}
+	if k.AccessToken == "" {
+		k.AccessToken = nested.AccessToken
+	}
+	if k.RefreshToken == "" {
+		k.RefreshToken = nested.RefreshToken
+	}
+	if k.AccountID == "" {
+		k.AccountID = nested.AccountID
+	}
 }
 
 func RefreshCodexChannelCredential(ctx context.Context, channelID int, opts CodexCredentialRefreshOptions) (*CodexOAuthKey, *model.Channel, error) {

--- a/service/codex_credential_refresh_test.go
+++ b/service/codex_credential_refresh_test.go
@@ -1,0 +1,26 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Codex CLI stores the OAuth credential nested under "tokens" in
+// ~/.codex/auth.json; parseCodexOAuthKey must flatten that layout so refresh
+// and model discovery work on a directly pasted auth.json.
+func TestParseCodexOAuthKeyFlattensTokens(t *testing.T) {
+	key, err := parseCodexOAuthKey(`{"OPENAI_API_KEY":null,"tokens":{"id_token":"id","access_token":"at","refresh_token":"rt","account_id":"acc"},"last_refresh":"2026-08-01T00:00:00Z"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "at", key.AccessToken)
+	assert.Equal(t, "rt", key.RefreshToken)
+	assert.Equal(t, "acc", key.AccountID)
+	assert.Nil(t, key.Tokens)
+
+	// Top-level values win over the nested ones.
+	key, err = parseCodexOAuthKey(`{"access_token":"top-at","tokens":{"access_token":"nested-at","account_id":"acc"}}`)
+	require.NoError(t, err)
+	assert.Equal(t, "top-at", key.AccessToken)
+	assert.Equal(t, "acc", key.AccountID)
+}

--- a/web/src/features/channels/lib/__tests__/codex-channel.test.ts
+++ b/web/src/features/channels/lib/__tests__/codex-channel.test.ts
@@ -1,0 +1,90 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { describe, expect, test } from 'vitest'
+
+import { CHANNEL_FORM_DEFAULT_VALUES, channelFormSchema } from '../channel-form'
+
+const CHANNEL_TYPE_CODEX = 57
+
+function codexForm(key: string) {
+  return {
+    ...CHANNEL_FORM_DEFAULT_VALUES,
+    name: 'Codex',
+    type: CHANNEL_TYPE_CODEX,
+    key,
+    models: 'gpt-5-codex',
+  }
+}
+
+function keyIssue(result: ReturnType<typeof channelFormSchema.safeParse>) {
+  if (result.success) return undefined
+  return result.error.issues.find((issue) => issue.path[0] === 'key')
+}
+
+describe('Codex channel credential', () => {
+  test('accepts a flat OAuth credential', () => {
+    const result = channelFormSchema.safeParse(
+      codexForm(
+        '{"access_token":"at","refresh_token":"rt","account_id":"acc"}'
+      )
+    )
+
+    expect(result.success).toBe(true)
+  })
+
+  test('accepts the nested tokens layout from ~/.codex/auth.json', () => {
+    const authJson = JSON.stringify({
+      OPENAI_API_KEY: null,
+      tokens: {
+        id_token: 'id',
+        access_token: 'at',
+        refresh_token: 'rt',
+        account_id: 'acc',
+      },
+      last_refresh: '2026-08-01T00:00:00Z',
+    })
+
+    expect(channelFormSchema.safeParse(codexForm(authJson)).success).toBe(true)
+  })
+
+  test('rejects a credential missing access_token or account_id everywhere', () => {
+    const missing = channelFormSchema.safeParse(
+      codexForm('{"refresh_token":"rt"}')
+    )
+    expect(missing.success).toBe(false)
+    expect(keyIssue(missing)?.message).toBe(
+      'Codex credential must be a JSON object with access_token and account_id'
+    )
+
+    const nestedMissing = channelFormSchema.safeParse(
+      codexForm('{"tokens":{"refresh_token":"rt"}}')
+    )
+    expect(nestedMissing.success).toBe(false)
+    expect(keyIssue(nestedMissing)?.message).toBe(
+      'Codex credential must be a JSON object with access_token and account_id'
+    )
+  })
+
+  test('rejects a non-JSON key', () => {
+    const result = channelFormSchema.safeParse(codexForm('sk-not-json'))
+
+    expect(result.success).toBe(false)
+    expect(keyIssue(result)).toBeDefined()
+  })
+})

--- a/web/src/features/channels/lib/channel-form.ts
+++ b/web/src/features/channels/lib/channel-form.ts
@@ -155,17 +155,24 @@ function isOptionalStatusCodeMapping(value: string | undefined): boolean {
   }
 }
 
+function hasCodexOAuthTokens(value: Record<string, unknown>): boolean {
+  return (
+    typeof value.access_token === 'string' &&
+    value.access_token.trim().length > 0 &&
+    typeof value.account_id === 'string' &&
+    value.account_id.trim().length > 0
+  )
+}
+
 function isCodexCredential(value: string | undefined): boolean {
   try {
     const parsed = parseOptionalJson(value)
     if (parsed === undefined) return true
-    return (
-      isJsonObjectValue(parsed) &&
-      typeof parsed.access_token === 'string' &&
-      parsed.access_token.trim().length > 0 &&
-      typeof parsed.account_id === 'string' &&
-      parsed.account_id.trim().length > 0
-    )
+    if (!isJsonObjectValue(parsed)) return false
+    if (hasCodexOAuthTokens(parsed)) return true
+    // Codex CLI nests the OAuth credential under `tokens` in ~/.codex/auth.json;
+    // accept that layout too so the file can be pasted directly.
+    return isJsonObjectValue(parsed.tokens) && hasCodexOAuthTokens(parsed.tokens)
   } catch {
     return false
   }


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

> 🤖 **AI 辅助声明 / AI Assistance Disclosure**：提交者并非本仓库核心开发者（核心作者为 CaIon / Calcium-Ion / Seefs 等）。本 PR 由 AI（Claude Code）辅助实现；以下描述为结构化整理后的内容，而非未经处理的原始 AI 输出。

## 📝 变更描述 / Description

**问题**：Codex 渠道（类型 57）的密钥校验只接受顶层含 `access_token` / `account_id` 的扁平 JSON。但 Codex CLI 实际把 OAuth 凭证嵌套在 `~/.codex/auth.json` 的 `tokens` 字段里，用户直接粘贴真实的 auth.json 会被 `Codex credential must be a JSON object with access_token and account_id` 拒绝。

**改动**：统一为「顶层优先、`tokens` 补缺」的拍平逻辑，覆盖凭证被校验/解析的全部入口：
- `relay/channel/codex/oauth_key.go`：`OAuthKey` 增加 `tokens` 字段并在 `ParseOAuthKey` 中拍平（relay 请求 / 用量查询入口）。
- `service/codex_credential_refresh.go`：`CodexOAuthKey` 同样拍平（模型拉取 / 自动刷新入口；刷新依赖 `tokens` 里的 `refresh_token`）。
- `controller/channel.go`：保存渠道时改为复用同一个 `codex.ParseOAuthKey`，保证与 relay 路径判定一致，避免两处判定漂移。
- `web/src/features/channels/lib/channel-form.ts`：前端表单校验接受顶层或 `tokens` 嵌套任一含 `access_token` + `account_id`。

拍平时顶层已有值优先、`tokens` 仅补缺；首次刷新后凭证会被重新序列化为扁平格式存回。两种布局（扁平 / auth.json 嵌套）现在都能正常保存与 relay。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *合法输入被过度严格的校验拒绝，属兼容性修复，非设计取舍或预期不一致*

## 🔗 关联任务 / Related Issue
- 无（在实函数配置 Codex 渠道、粘贴 `~/.codex/auth.json` 时直接触发该校验报错）

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 描述已经结构化整理，非直接粘贴的原始 AI 输出（实现含 AI 辅助，见上方声明）。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，未见针对 auth.json 嵌套凭证格式的同类提交。
- [x] **Bug fix 说明:** 此为「有效凭证被误判为非法」的兼容性修复，已在上文说明，非将设计取舍/理解偏差归类为 bug。
- [x] **变更理解:** 已理解改动的工作原理及影响（凭证解析/校验全链路）。
- [x] **范围聚焦:** 本 PR 仅含凭证格式兼容改动，无任何无关代码改动。
- [x] **本地验证:** 已在本地运行并通过测试，维护者可据下方证明复核。
- [x] **安全合规:** 代码中无敏感凭据，符合项目代码规范。

## 📸 运行证明 / Proof of Work

后端（新增 `oauth_key_test.go` / `codex_credential_refresh_test.go`，覆盖扁平 / 嵌套 / 顶层优先 / 补缺 / 非法输入）：
```
ok  github.com/QuantumNous/new-api/relay/channel/codex
ok  github.com/QuantumNous/new-api/service
```

前端（channels 全套 13 例，含新增 `codex-channel.test.ts` 4 例）：
```
Test Files  4 passed (4)
Tests  13 passed (13)
```

`bun run typecheck` 通过；`gofmt` / `go vet` 对改动包无新增问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Codex OAuth credentials in the nested `tokens` format used by the Codex CLI.
  * Existing top-level credentials remain supported, with top-level values taking precedence when both formats are provided.

* **Bug Fixes**
  * Improved Codex credential validation and parsing for nested OAuth data.
  * Invalid JSON and incomplete credentials continue to be rejected with appropriate validation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->