### PR TITLE
fix(docker): copy relaykit/go.mod before go mod download in Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,6 +12,9 @@ ENV GOEXPERIMENT=greenteagc
 WORKDIR /build
 
 ADD go.mod go.sum ./
+# relaykit is a local submodule referenced via replace; its go.mod must be
+# present for go mod download to resolve the main module graph.
+ADD relaykit/go.mod ./relaykit/go.mod
 RUN go mod download
 
 COPY . .


### PR DESCRIPTION
## Description

`Dockerfile.dev` fails on a clean checkout because the root `go.mod` has:

```
replace github.com/QuantumNous/new-api/relaykit => ./relaykit
```

but `relaykit/go.mod` is not copied into the image before `go mod download` runs. The backend-only dev build dies on the first step:

```
go: github.com/QuantumNous/new-api/relaykit@v0.0.0 (replaced by ./relaykit): reading relaykit/go.mod: no such file or directory
```

The production `Dockerfile` already handles this (it ADDs `relaykit/go.mod` before `go mod download`); `Dockerfile.dev` does not. This adds the same line so the module graph resolves and the dev image builds without manual edits.

## Type of change
- [x] Bug fix

## Related Issue
- Closes #6937

## Checklist
- [x] I wrote this description myself based on my understanding of the change.
- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] This PR links issue #6937.
- [x] I understand how this change works and its impact.
- [x] This PR is scoped to the task only.
- [x] Verified locally: without `relaykit/go.mod` the build step fails; with it, it succeeds (steps below).
- [x] No credentials or sensitive data.

## Proof of Work

Simulated the Dockerfile.dev builder stage directly with the Go toolchain:

**Before (no `relaykit/go.mod`):**
```
$ go mod download
go: github.com/QuantumNous/new-api/relaykit@v0.0.0 (replaced by ./relaykit): reading relaykit/go.mod: open /tmp/builder-red/relaykit/go.mod: no such file or directory
```

**After (with `ADD relaykit/go.mod ./relaykit/go.mod`):**
```
$ go mod download    # exit 0
$ go list -m github.com/QuantumNous/new-api/relaykit
github.com/QuantumNous/new-api/relaykit v0.0.0 => ./relaykit
```

A full `docker build -f Dockerfile.dev` needs a Docker daemon; the failing step (module graph resolution) is proven fixed by the reproduction above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development-container dependency setup to ensure local module requirements are available during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->