### PR TITLE
fix: restore mapped model name in responses

### DIFF
--- a/common/model_restore.go
+++ b/common/model_restore.go
@@ -1,0 +1,123 @@
+package common
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/QuantumNous/new-api/constant"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+type modelRestorePair struct {
+	Origin   string
+	Upstream string
+}
+
+// restoreModelJSONPaths lists model-carrying fields across the OpenAI chat,
+// OpenAI Responses, Claude messages, Gemini and image/task response shapes.
+var restoreModelJSONPaths = []string{
+	"model",
+	"message.model",
+	"response.model",
+	"modelVersion",
+}
+
+var modelFieldMarker = []byte(`"model`)
+
+// SetModelRestore records the client-facing model name so the response writers
+// can rewrite the upstream model name back before the payload reaches the
+// client. Recording is skipped when the mapping did not actually rename.
+func SetModelRestore(c *gin.Context, originModelName string, upstreamModelName string) {
+	if c == nil {
+		return
+	}
+	origin := strings.TrimSpace(originModelName)
+	upstream := strings.TrimSpace(upstreamModelName)
+	if origin == "" || origin == upstream {
+		ClearModelRestore(c)
+		return
+	}
+	SetContextKey(c, constant.ContextKeyModelRestore, modelRestorePair{Origin: origin, Upstream: upstream})
+}
+
+// ClearModelRestore drops a recorded rename, used when a retry lands on a
+// channel that has no model mapping for this request.
+func ClearModelRestore(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	SetContextKey(c, constant.ContextKeyModelRestore, modelRestorePair{})
+}
+
+func getModelRestore(c *gin.Context) (modelRestorePair, bool) {
+	if c == nil {
+		return modelRestorePair{}, false
+	}
+	pair, ok := GetContextKeyType[modelRestorePair](c, constant.ContextKeyModelRestore)
+	if !ok || pair.Origin == "" {
+		return modelRestorePair{}, false
+	}
+	return pair, true
+}
+
+// RestoreModelName maps an upstream model name back to the name the client
+// asked for. Variants of the mapped name are restored as well, covering both
+// directions an adaptor may rewrite it: a dated snapshot the provider appends
+// ("deepseek-v4-flash-2026-08-01") and a suffix an adaptor strips before the
+// request goes out ("deepseek-v4-flash" for a mapped "deepseek-v4-flash-thinking").
+func RestoreModelName(c *gin.Context, model string) string {
+	pair, ok := getModelRestore(c)
+	if !ok || model == "" || model == pair.Origin {
+		return model
+	}
+	if pair.Upstream == "" || model == pair.Upstream ||
+		strings.HasPrefix(model, pair.Upstream+"-") || strings.HasPrefix(pair.Upstream, model+"-") {
+		return pair.Origin
+	}
+	return model
+}
+
+// RestoreModelNameInJSON rewrites every model-carrying field of a serialized
+// response body. The payload is returned untouched when no rename is pending or
+// when it carries no recognizable model field.
+func RestoreModelNameInJSON(c *gin.Context, body []byte) []byte {
+	if _, ok := getModelRestore(c); !ok || len(body) == 0 {
+		return body
+	}
+	// Every model-carrying path below contains "model", so a payload without it
+	// can skip the JSON scan entirely.
+	if !bytes.Contains(body, modelFieldMarker) {
+		return body
+	}
+	for _, path := range restoreModelJSONPaths {
+		result := gjson.GetBytes(body, path)
+		if !result.Exists() || result.Type != gjson.String {
+			continue
+		}
+		restored := RestoreModelName(c, result.String())
+		if restored == result.String() {
+			continue
+		}
+		patched, err := sjson.SetBytes(body, path, restored)
+		if err != nil {
+			continue
+		}
+		body = patched
+	}
+	return body
+}
+
+// RestoreModelNameInString is the string flavor used by the SSE writers that
+// forward raw upstream chunks.
+func RestoreModelNameInString(c *gin.Context, body string) string {
+	if _, ok := getModelRestore(c); !ok || body == "" {
+		return body
+	}
+	if !strings.Contains(body, string(modelFieldMarker)) {
+		return body
+	}
+	return string(RestoreModelNameInJSON(c, []byte(body)))
+}

--- a/common/model_restore_test.go
+++ b/common/model_restore_test.go
@@ -1,0 +1,114 @@
+package common
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newRestoreContext(t *testing.T, origin string, upstream string) *gin.Context {
+	t.Helper()
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	SetModelRestore(c, origin, upstream)
+	return c
+}
+
+func TestRestoreModelName(t *testing.T) {
+	tests := []struct {
+		name     string
+		origin   string
+		upstream string
+		model    string
+		want     string
+	}{
+		{"exact upstream is restored", "gpt-5.5", "deepseek-v4-flash", "deepseek-v4-flash", "gpt-5.5"},
+		{"dated upstream variant is restored", "gpt-5.5", "deepseek-v4-flash", "deepseek-v4-flash-2026-08-01", "gpt-5.5"},
+		{"adaptor-stripped suffix is restored", "gpt-5.5", "deepseek-v4-flash-thinking", "deepseek-v4-flash", "gpt-5.5"},
+		{"origin name is left alone", "gpt-5.5", "deepseek-v4-flash", "gpt-5.5", "gpt-5.5"},
+		{"unrelated model is left alone", "gpt-5.5", "deepseek-v4-flash", "claude-fable-5", "claude-fable-5"},
+		{"empty model is left alone", "gpt-5.5", "deepseek-v4-flash", "", ""},
+		{"self mapping records nothing", "gpt-5.5", "gpt-5.5", "gpt-5.5", "gpt-5.5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newRestoreContext(t, tt.origin, tt.upstream)
+			assert.Equal(t, tt.want, RestoreModelName(c, tt.model))
+		})
+	}
+}
+
+func TestRestoreModelNameWithoutMapping(t *testing.T) {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	assert.Equal(t, "deepseek-v4-flash", RestoreModelName(c, "deepseek-v4-flash"))
+	assert.Equal(t, `{"model":"deepseek-v4-flash"}`, string(RestoreModelNameInJSON(c, []byte(`{"model":"deepseek-v4-flash"}`))))
+}
+
+func TestClearModelRestore(t *testing.T) {
+	c := newRestoreContext(t, "gpt-5.5", "deepseek-v4-flash")
+	require.Equal(t, "gpt-5.5", RestoreModelName(c, "deepseek-v4-flash"))
+	ClearModelRestore(c)
+	assert.Equal(t, "deepseek-v4-flash", RestoreModelName(c, "deepseek-v4-flash"))
+}
+
+func TestRestoreModelNameInJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"openai chat completion",
+			`{"id":"chatcmpl-1","model":"deepseek-v4-flash","choices":[]}`,
+			`{"id":"chatcmpl-1","model":"gpt-5.5","choices":[]}`,
+		},
+		{
+			"claude message_start nests model",
+			`{"type":"message_start","message":{"id":"msg_1","model":"deepseek-v4-flash"}}`,
+			`{"type":"message_start","message":{"id":"msg_1","model":"gpt-5.5"}}`,
+		},
+		{
+			"openai responses nests model",
+			`{"type":"response.created","response":{"id":"resp_1","model":"deepseek-v4-flash"}}`,
+			`{"type":"response.created","response":{"id":"resp_1","model":"gpt-5.5"}}`,
+		},
+		{
+			"gemini uses modelVersion",
+			`{"candidates":[],"modelVersion":"deepseek-v4-flash"}`,
+			`{"candidates":[],"modelVersion":"gpt-5.5"}`,
+		},
+		{
+			"unrelated model is preserved",
+			`{"model":"claude-fable-5"}`,
+			`{"model":"claude-fable-5"}`,
+		},
+		{
+			"model appearing only in content is preserved",
+			`{"model":"gpt-5.5","choices":[{"delta":{"content":"deepseek-v4-flash"}}]}`,
+			`{"model":"gpt-5.5","choices":[{"delta":{"content":"deepseek-v4-flash"}}]}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newRestoreContext(t, "gpt-5.5", "deepseek-v4-flash")
+			assert.JSONEq(t, tt.want, string(RestoreModelNameInJSON(c, []byte(tt.body))))
+		})
+	}
+}
+
+func TestRestoreModelNameInStringPassesThroughNonJSON(t *testing.T) {
+	c := newRestoreContext(t, "gpt-5.5", "deepseek-v4-flash")
+	assert.Equal(t, "[DONE]", RestoreModelNameInString(c, "[DONE]"))
+	assert.Equal(t, "", RestoreModelNameInString(c, ""))
+	assert.Equal(t, "not json deepseek-v4-flash", RestoreModelNameInString(c, "not json deepseek-v4-flash"))
+}
+
+func TestRestoreModelNameInStringRewritesStreamChunk(t *testing.T) {
+	c := newRestoreContext(t, "gpt-5.5", "deepseek-v4-flash")
+	chunk := `{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"deepseek-v4-flash","choices":[{"delta":{"content":"hi"}}]}`
+	assert.JSONEq(t,
+		`{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"gpt-5.5","choices":[{"delta":{"content":"hi"}}]}`,
+		RestoreModelNameInString(c, chunk))
+}

--- a/constant/context_key.go
+++ b/constant/context_key.go
@@ -10,6 +10,11 @@ const (
 	ContextKeyOriginalModel    ContextKey = "original_model"
 	ContextKeyRequestStartTime ContextKey = "request_start_time"
 
+	// ContextKeyModelRestore holds the origin/upstream model name pair recorded
+	// when a channel model mapping renames the request model, so response
+	// writers can restore the client-facing name.
+	ContextKeyModelRestore ContextKey = "model_restore"
+
 	/* token related keys */
 	ContextKeyTokenUnlimited         ContextKey = "token_unlimited_quota"
 	ContextKeyTokenKey               ContextKey = "token_key"

--- a/relay/channel/cloudflare/relay_cloudflare.go
+++ b/relay/channel/cloudflare/relay_cloudflare.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/logger"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/helper"
@@ -115,7 +116,7 @@ func cfHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response)
 	}
 	c.Writer.Header().Set("Content-Type", "application/json")
 	c.Writer.WriteHeader(resp.StatusCode)
-	_, _ = c.Writer.Write(jsonResponse)
+	_, _ = c.Writer.Write(common.RestoreModelNameInJSON(c, jsonResponse))
 	return nil, usage
 }
 

--- a/relay/channel/cohere/relay-cohere.go
+++ b/relay/channel/cohere/relay-cohere.go
@@ -212,7 +212,7 @@ func cohereHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respo
 	}
 	c.Writer.Header().Set("Content-Type", "application/json")
 	c.Writer.WriteHeader(resp.StatusCode)
-	_, _ = c.Writer.Write(jsonResponse)
+	_, _ = c.Writer.Write(common.RestoreModelNameInJSON(c, jsonResponse))
 	return &usage, nil
 }
 

--- a/relay/channel/coze/relay-coze.go
+++ b/relay/channel/coze/relay-coze.go
@@ -92,7 +92,7 @@ func cozeChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Res
 	}
 	c.Writer.Header().Set("Content-Type", "application/json")
 	c.Writer.WriteHeader(resp.StatusCode)
-	_, _ = c.Writer.Write(jsonResponse)
+	_, _ = c.Writer.Write(common.RestoreModelNameInJSON(c, jsonResponse))
 
 	return &usage, nil
 }

--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -521,7 +521,7 @@ func GeminiImageHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.
 
 	c.Writer.Header().Set("Content-Type", "application/json")
 	c.Writer.WriteHeader(resp.StatusCode)
-	_, _ = c.Writer.Write(jsonResponse)
+	_, _ = c.Writer.Write(common.RestoreModelNameInJSON(c, jsonResponse))
 
 	// https://github.com/google-gemini/cookbook/blob/719a27d752aac33f39de18a8d3cb42a70874917e/quickstarts/Counting_Tokens.ipynb
 	// each image has fixed 258 tokens

--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -472,7 +472,7 @@ func GeminiImageHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.
 
 	c.Writer.Header().Set("Content-Type", "application/json")
 	c.Writer.WriteHeader(resp.StatusCode)
-	_, _ = c.Writer.Write(jsonResponse)
+	_, _ = c.Writer.Write(common.RestoreModelNameInJSON(c, jsonResponse))
 
 	// https://github.com/google-gemini/cookbook/blob/719a27d752aac33f39de18a8d3cb42a70874917e/quickstarts/Counting_Tokens.ipynb
 	// each image has fixed 258 tokens

--- a/relay/channel/openai/chat_via_responses.go
+++ b/relay/channel/openai/chat_via_responses.go
@@ -217,7 +217,7 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 			streamErr = types.NewOpenAIError(err, types.ErrorCodeJsonMarshalFailed, http.StatusInternalServerError)
 			return false
 		}
-		c.Render(-1, common.CustomEvent{Data: "data: " + string(geminiResponseStr)})
+		c.Render(-1, common.CustomEvent{Data: "data: " + string(common.RestoreModelNameInJSON(c, geminiResponseStr))})
 		_ = helper.FlushWriter(c)
 		return true
 	}

--- a/relay/channel/openai/chat_via_responses.go
+++ b/relay/channel/openai/chat_via_responses.go
@@ -194,7 +194,7 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 			streamErr = types.NewOpenAIError(err, types.ErrorCodeJsonMarshalFailed, http.StatusInternalServerError)
 			return false
 		}
-		c.Render(-1, common.CustomEvent{Data: "data: " + string(geminiResponseStr)})
+		c.Render(-1, common.CustomEvent{Data: "data: " + string(common.RestoreModelNameInJSON(c, geminiResponseStr))})
 		_ = helper.FlushWriter(c)
 		return true
 	}

--- a/relay/channel/openai/helper.go
+++ b/relay/channel/openai/helper.go
@@ -85,7 +85,7 @@ func handleGeminiFormat(c *gin.Context, data string, info *relaycommon.RelayInfo
 	}
 
 	// send gemini format response
-	c.Render(-1, common.CustomEvent{Data: "data: " + string(geminiResponseStr)})
+	c.Render(-1, common.CustomEvent{Data: "data: " + string(common.RestoreModelNameInJSON(c, geminiResponseStr))})
 	_ = helper.FlushWriter(c)
 	return nil
 }
@@ -231,7 +231,7 @@ func HandleFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, lastStream
 		}
 
 		// 发送最终的 Gemini 响应
-		c.Render(-1, common.CustomEvent{Data: "data: " + string(geminiResponseStr)})
+		c.Render(-1, common.CustomEvent{Data: "data: " + string(common.RestoreModelNameInJSON(c, geminiResponseStr))})
 		_ = helper.FlushWriter(c)
 	}
 }

--- a/relay/channel/openai/helper.go
+++ b/relay/channel/openai/helper.go
@@ -114,7 +114,7 @@ func sendGeminiStreamResults(c *gin.Context, results []relayconvert.ResponseResu
 			logger.LogError(c, "failed to marshal gemini response: "+err.Error())
 			return err
 		}
-		c.Render(-1, common.CustomEvent{Data: "data: " + string(data)})
+		c.Render(-1, common.CustomEvent{Data: "data: " + string(common.RestoreModelNameInJSON(c, string(data)))})
 		_ = helper.FlushWriter(c)
 	}
 	return nil

--- a/relay/helper/common.go
+++ b/relay/helper/common.go
@@ -68,7 +68,7 @@ func ClaudeData(c *gin.Context, resp dto.ClaudeResponse) error {
 		common.SysError("error marshalling stream response: " + err.Error())
 	} else {
 		c.Render(-1, common.CustomEvent{Data: fmt.Sprintf("event: %s\n", resp.Type)})
-		c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonData)})
+		c.Render(-1, common.CustomEvent{Data: "data: " + string(common.RestoreModelNameInJSON(c, jsonData))})
 	}
 	_ = FlushWriter(c)
 	return nil
@@ -80,7 +80,7 @@ func ClaudeChunkData(c *gin.Context, resp dto.ClaudeResponse, data string) {
 	}
 
 	c.Render(-1, common.CustomEvent{Data: fmt.Sprintf("event: %s\n", resp.Type)})
-	c.Render(-1, common.CustomEvent{Data: fmt.Sprintf("data: %s\n", data)})
+	c.Render(-1, common.CustomEvent{Data: fmt.Sprintf("data: %s\n", common.RestoreModelNameInString(c, data))})
 	_ = FlushWriter(c)
 }
 
@@ -90,7 +90,7 @@ func ResponseChunkData(c *gin.Context, resp dto.ResponsesStreamResponse, data st
 	}
 
 	c.Render(-1, common.CustomEvent{Data: fmt.Sprintf("event: %s\n", resp.Type)})
-	c.Render(-1, common.CustomEvent{Data: fmt.Sprintf("data: %s", data)})
+	c.Render(-1, common.CustomEvent{Data: fmt.Sprintf("data: %s", common.RestoreModelNameInString(c, data))})
 	return FlushWriter(c)
 }
 
@@ -103,7 +103,7 @@ func StringData(c *gin.Context, str string) error {
 		return fmt.Errorf("request context done: %w", c.Request.Context().Err())
 	}
 
-	c.Render(-1, common.CustomEvent{Data: "data: " + str})
+	c.Render(-1, common.CustomEvent{Data: "data: " + common.RestoreModelNameInString(c, str)})
 	return FlushWriter(c)
 }
 

--- a/relay/helper/model_mapped.go
+++ b/relay/helper/model_mapped.go
@@ -65,5 +65,10 @@ func ModelMappedHelper(c *gin.Context, info *relaycommon.RelayInfo, request dto.
 	if request != nil {
 		request.SetModelName(info.UpstreamModelName)
 	}
+	if info.IsModelMapped {
+		rootcommon.SetModelRestore(c, info.OriginModelName, info.UpstreamModelName)
+	} else {
+		rootcommon.ClearModelRestore(c)
+	}
 	return nil
 }

--- a/relay/helper/model_mapped.go
+++ b/relay/helper/model_mapped.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	hostcommon "github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/gin-gonic/gin"
@@ -58,6 +59,11 @@ func ModelMappedHelper(c *gin.Context, info *common.RelayInfo, request dto.Reque
 
 	if request != nil {
 		request.SetModelName(info.UpstreamModelName)
+	}
+	if info.IsModelMapped {
+		hostcommon.SetModelRestore(c, info.OriginModelName, info.UpstreamModelName)
+	} else {
+		hostcommon.ClearModelRestore(c)
 	}
 	return nil
 }

--- a/service/http.go
+++ b/service/http.go
@@ -46,6 +46,7 @@ func IOCopyBytesGracefully(c *gin.Context, src *http.Response, data []byte) {
 		return
 	}
 
+	data = common.RestoreModelNameInJSON(c, data)
 	body := io.NopCloser(bytes.NewBuffer(data))
 
 	// We shouldn't set the header before we parse the response body, because the parse part may fail.


### PR DESCRIPTION
## 📝 变更描述 / Description

渠道配置 `model_mapping` 把模型 a 映射到 b 之后，只有请求被改写，响应没有。客户端请求 a，拿到的 `model` 字段却是 b。

同一次请求在消费日志里记的是 a（`model_name`），映射关系另存在 `other.upstream_model_name`，所以日志和响应对同一次请求给出了两个不同的模型名。对调用方来说，按 `model` 字段做路由/统计/断言的客户端会拿到一个自己从未请求过的名字。

改法是在映射真正发生重命名时记下 origin/upstream 这一对，然后在响应写出的收口处把上游名映射回去：

- 流式：`StringData` / `ObjectData`，以及 Claude、Responses 两个 SSE 写出函数
- 非流式：`IOCopyBytesGracefully`（注意在改写之后才计算 `Content-Length`）
- 少数自行 marshal 后直接 `c.Writer.Write` 的渠道处理器（cloudflare / cohere / coze / gemini 图像）

之所以收在写出层而不是逐个改 `info.UpstreamModelName` 的赋值点，是因为后者散落在 40 多个 adaptor 里，且部分 adaptor 会在映射之后再次改写该字段（剥离 `-thinking` 后缀、OpenRouter 适配、Claude 用上游返回的 `message.model` 覆盖），逐点修改既容易漏也容易被后续改动破坏。

模型名的变体也做了还原，覆盖 adaptor 可能改写它的两个方向：上游追加的日期快照（`deepseek-v4-flash-2026-08-01`），以及 adaptor 在发出请求前剥离的后缀（映射到 `x-thinking` 但实际发出 `x`）。

不受影响的部分：没有配映射的请求原样返回；自映射（`a: a`）不记录；消费日志的 `is_model_mapped` 和 `upstream_model_name` 保持不变，审计能力没有削弱。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue
- 无对应 Issue，未在现有 Issues / PRs 中检索到重复条目。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 本 PR 的代码与描述由 AI 辅助生成（见下方说明），已逐条复核后提交。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 该行为使日志与响应对同一次请求给出不同模型名，属于自相矛盾而非设计取舍。若维护者认为当前行为是有意为之，欢迎指出，我可以改为默认关闭的开关。
- [x] **变更理解:** 已理解改动的工作原理及影响范围。
- [x] **范围聚焦:** 仅包含本次修复相关改动。
- [x] **本地验证:** 见下方运行证明。
- [x] **安全合规:** 无敏感凭据。

> **AI 声明:** 本 PR 的代码与描述为 AI 辅助生成，提交者已复核代码逻辑并完成下述本地验证。

## 📸 运行证明 / Proof of Work

**自动化测试**

新增 `common/model_restore_test.go`，覆盖名称还原规则（精确 / 日期变体 / 剥离后缀 / 无关模型不动 / 自映射不记录）、四种响应形状的 JSON 路径改写（OpenAI `model`、Claude `message.model`、Responses `response.model`、Gemini `modelVersion`）、以及非 JSON 分片（`[DONE]`）透传。

全量 `go test ./...` 通过（33 个包），`cd relaykit && GOWORK=off go build ./...` 通过。

**端到端验证**

自编译镜像起实例，接真实上游渠道，配置 `{"gpt-5.5": "deepseek-v4-flash"}`：

| 场景 | 请求 model | 响应 model |
|---|---|---|
| OpenAI 非流式 | `gpt-5.5` | `gpt-5.5` |
| OpenAI 流式（7 个分片） | `gpt-5.5` | 全部 `gpt-5.5` |
| Claude Messages 非流式 | `gpt-5.5` | `gpt-5.5` |
| Claude Messages 流式 | `gpt-5.5` | `gpt-5.5` |
| 无映射渠道（回归） | `deepseek-v4-flash` | `deepseek-v4-flash` |

修复前，前四行的响应均为 `deepseek-v4-flash`。

非流式响应：

```json
{"id":"b9e997d8-...","model":"gpt-5.5","object":"chat.completion","choices":[...]}
```

流式分片中出现的全部 model 值：

```
      7 "model":"gpt-5.5"
```

消费日志（确认审计信息未丢失）：

```
model_name = gpt-5.5
other      = {..., "is_model_mapped":true, "upstream_model_name":"deepseek-v4-flash", ...}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-facing responses now preserve the originally requested model name when an upstream model is used.
  * Supports model-name variants across JSON, text, and streaming responses.
  * Applies consistently across multiple provider integrations and response formats.

* **Bug Fixes**
  * Prevents upstream model identifiers from appearing unexpectedly in regular or streaming outputs.
  * Handles model-name restoration for streamed chunks and non-JSON response data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->