### PR TITLE
fix(rate-limit): enforce user group limits for API keys

### DIFF
--- a/middleware/model-rate-limit.go
+++ b/middleware/model-rate-limit.go
@@ -178,11 +178,8 @@ func ModelRequestRateLimit() func(c *gin.Context) {
 		totalMaxCount := setting.ModelRequestRateLimitCount
 		successMaxCount := setting.ModelRequestRateLimitSuccessCount
 
-		// 获取分组
-		group := common.GetContextKeyString(c, constant.ContextKeyTokenGroup)
-		if group == "" {
-			group = common.GetContextKeyString(c, constant.ContextKeyUserGroup)
-		}
+		// 分组限流是用户组策略，不能由用户可配置的令牌分组覆盖。
+		group := common.GetContextKeyString(c, constant.ContextKeyUserGroup)
 
 		//获取分组的限流配置
 		groupTotalCount, groupSuccessCount, found := setting.GetGroupRateLimit(group)

--- a/middleware/model_rate_limit_test.go
+++ b/middleware/model_rate_limit_test.go
@@ -2,12 +2,68 @@ package middleware
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/setting"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestModelRequestRateLimitUsesUserGroupInsteadOfTokenGroup(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	useRateLimitMiniRedis(t)
+
+	previousEnabled := setting.ModelRequestRateLimitEnabled
+	previousDuration := setting.ModelRequestRateLimitDurationMinutes
+	previousCount := setting.ModelRequestRateLimitCount
+	previousSuccessCount := setting.ModelRequestRateLimitSuccessCount
+	setting.ModelRequestRateLimitMutex.Lock()
+	previousGroups := setting.ModelRequestRateLimitGroup
+	setting.ModelRequestRateLimitGroup = map[string][2]int{
+		"paid":    {1, 100},
+		"default": {10, 100},
+	}
+	setting.ModelRequestRateLimitMutex.Unlock()
+	setting.ModelRequestRateLimitEnabled = true
+	setting.ModelRequestRateLimitDurationMinutes = 1
+	setting.ModelRequestRateLimitCount = 10
+	setting.ModelRequestRateLimitSuccessCount = 100
+	t.Cleanup(func() {
+		setting.ModelRequestRateLimitEnabled = previousEnabled
+		setting.ModelRequestRateLimitDurationMinutes = previousDuration
+		setting.ModelRequestRateLimitCount = previousCount
+		setting.ModelRequestRateLimitSuccessCount = previousSuccessCount
+		setting.ModelRequestRateLimitMutex.Lock()
+		setting.ModelRequestRateLimitGroup = previousGroups
+		setting.ModelRequestRateLimitMutex.Unlock()
+	})
+
+	router := gin.New()
+	router.GET(
+		"/limited",
+		func(c *gin.Context) {
+			c.Set("id", 6333)
+			common.SetContextKey(c, constant.ContextKeyUserGroup, "paid")
+			common.SetContextKey(c, constant.ContextKeyTokenGroup, "default")
+		},
+		ModelRequestRateLimit(),
+		func(c *gin.Context) { c.Status(http.StatusNoContent) },
+	)
+
+	first := httptest.NewRecorder()
+	router.ServeHTTP(first, httptest.NewRequest(http.MethodGet, "/limited", nil))
+	assert.Equal(t, http.StatusNoContent, first.Code)
+
+	second := httptest.NewRecorder()
+	router.ServeHTTP(second, httptest.NewRequest(http.MethodGet, "/limited", nil))
+	assert.Equal(t, http.StatusTooManyRequests, second.Code)
+}
 
 func TestModelRedisRateLimitUsesUTCRegardlessOfLocalTimezone(t *testing.T) {
 	redisServer, redisClient := useRateLimitMiniRedis(t)


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

> [!NOTE]
>
> This change and PR description were AI-assisted with Codex for LiaoQi98. The PR is opened as a draft for human and maintainer review.

## 📝 变更描述 / Description

Model request rate-limit groups are documented and configured as user-group policies, but the middleware previously preferred the API key's routing group. A user in a restricted group could therefore create a key assigned to `default` (or another less-restricted usable group) and fall back to that group's or the global request limit.

This change always selects `ContextKeyUserGroup` when resolving `ModelRequestRateLimitGroup`. API key groups continue to control routing, but can no longer override the account's rate-limit policy.

The regression test configures a `paid` user group with a one-request limit and a `default` key group with a ten-request limit. It verifies that the second request is rejected with HTTP 429, proving the user-group limit remains authoritative.

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6333

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```text
go test ./middleware -run 'TestModelRequestRateLimitUsesUserGroupInsteadOfTokenGroup|TestModelRedisRateLimitUsesUTCRegardlessOfLocalTimezone' -count=1
ok  github.com/QuantumNous/new-api/middleware

go test ./middleware -count=1
ok  github.com/QuantumNous/new-api/middleware

go test -race ./middleware -count=1
ok  github.com/QuantumNous/new-api/middleware

go vet ./middleware
passed

git diff --check
passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model request rate limiting now consistently uses the user’s assigned group limits.
  * Token-specific group settings can no longer override the applicable user-group rate limits.
* **Tests**
  * Added coverage to verify rate limiting behaves correctly when user and token groups differ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->