### PR TITLE
fix(relay): preserve upstream SSE comment heartbeats

### DIFF
--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -196,7 +196,11 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 		})
 	}
 
-	dataChan := make(chan string, 10)
+	type streamEvent struct {
+		data      string
+		heartbeat bool
+	}
+	streamChan := make(chan streamEvent, 10)
 
 	wg.Add(1)
 	gopool.Go(func() {
@@ -209,13 +213,38 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 			wg.Done()
 		}()
 		sr := newStreamResult(info.StreamStatus)
-		for data := range dataChan {
+		for event := range streamChan {
+			if event.heartbeat {
+				var err error
+				func() {
+					writeMutex.Lock()
+					defer writeMutex.Unlock()
+					// Keep the response uncommitted until a real downstream frame is written,
+					// so callers can still return or retry an upstream non-2xx response.
+					if !c.Writer.Written() {
+						return
+					}
+					ExtendWriteDeadline(c)
+					err = PingData(c)
+				}()
+				if err != nil {
+					logger.LogError(c, "upstream heartbeat relay error: "+err.Error())
+					if c.Request.Context().Err() != nil {
+						info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, c.Request.Context().Err())
+					} else {
+						info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonPingFail, err)
+					}
+					return
+				}
+				continue
+			}
+
 			sr.reset()
 			func() {
 				writeMutex.Lock()
 				defer writeMutex.Unlock()
 				ExtendWriteDeadline(c)
-				dataHandler(data, sr)
+				dataHandler(event.data, sr)
 			}()
 			if sr.IsStopped() {
 				return
@@ -227,7 +256,7 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	wg.Add(1)
 	common.RelayCtxGo(ctx, func() {
 		defer func() {
-			close(dataChan)
+			close(streamChan)
 			if r := recover(); r != nil {
 				logger.LogError(c, fmt.Sprintf("scanner goroutine panic: %v", r))
 				info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonPanic, fmt.Errorf("scanner panic: %v", r))
@@ -251,6 +280,17 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 			data := scanner.Text()
 			logger.LogDebug(c, "stream scanner data: %s", data)
 
+			if strings.HasPrefix(data, ":") {
+				select {
+				case streamChan <- streamEvent{heartbeat: true}:
+				case <-ctx.Done():
+					return
+				case <-stopChan:
+					return
+				}
+				continue
+			}
+
 			if len(data) < 6 {
 				continue
 			}
@@ -267,7 +307,7 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 				info.ReceivedResponseCount++
 
 				select {
-				case dataChan <- data:
+				case streamChan <- streamEvent{data: data}:
 				case <-ctx.Done():
 					return
 				case <-stopChan:

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -247,7 +247,9 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 				ExtendWriteDeadline(c)
 				writtenBefore := c.Writer.Size()
 				dataHandler(event.data, sr)
-				downstreamDataWritten = downstreamDataWritten || c.Writer.Size() > writtenBefore
+				writtenAfter := c.Writer.Size()
+				downstreamDataWritten = downstreamDataWritten ||
+					(writtenAfter > 0 && writtenAfter > writtenBefore)
 			}()
 			if sr.IsStopped() {
 				return

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -213,15 +213,16 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 			wg.Done()
 		}()
 		sr := newStreamResult(info.StreamStatus)
+		downstreamDataWritten := false
 		for event := range streamChan {
 			if event.heartbeat {
 				var err error
 				func() {
 					writeMutex.Lock()
 					defer writeMutex.Unlock()
-					// Keep the response uncommitted until a real downstream frame is written,
-					// so callers can still return or retry an upstream non-2xx response.
-					if !c.Writer.Written() {
+					// A generated ping may have committed the response already. Only a write
+					// from the data handler should unlock upstream heartbeat forwarding.
+					if !downstreamDataWritten {
 						return
 					}
 					ExtendWriteDeadline(c)
@@ -244,7 +245,9 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 				writeMutex.Lock()
 				defer writeMutex.Unlock()
 				ExtendWriteDeadline(c)
+				writtenBefore := c.Writer.Size()
 				dataHandler(event.data, sr)
+				downstreamDataWritten = downstreamDataWritten || c.Writer.Size() > writtenBefore
 			}()
 			if sr.IsStopped() {
 				return

--- a/relay/helper/stream_scanner_test.go
+++ b/relay/helper/stream_scanner_test.go
@@ -270,6 +270,30 @@ func TestStreamScannerHandler_SkipsUpstreamCommentBeforeData(t *testing.T) {
 	assert.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
 }
 
+func TestStreamScannerHandler_PriorPingDoesNotUnlockUpstreamComment(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	require.NoError(t, PingData(c))
+	require.Equal(t, 1, strings.Count(recorder.Body.String(), ": PING\n\n"))
+
+	body := ": upstream-private-heartbeat\n\ndata: [DONE]\n"
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
+	info := &relaycommon.RelayInfo{
+		DisablePing: true,
+		ChannelMeta: &relaycommon.ChannelMeta{},
+	}
+
+	StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {
+		_ = StringData(c, data)
+	})
+
+	assert.Equal(t, 1, strings.Count(recorder.Body.String(), ": PING\n\n"),
+		"a periodic ping must not make an upstream comment look like post-data traffic")
+	assert.NotContains(t, recorder.Body.String(), "upstream-private-heartbeat")
+	assert.Equal(t, 0, info.ReceivedResponseCount)
+}
+
 func TestStreamScannerHandler_DataWithExtraSpaces(t *testing.T) {
 	t.Parallel()
 

--- a/relay/helper/stream_scanner_test.go
+++ b/relay/helper/stream_scanner_test.go
@@ -292,6 +292,31 @@ func TestStreamScannerHandler_PriorPingDoesNotUnlockUpstreamComment(t *testing.T
 		"a periodic ping must not make an upstream comment look like post-data traffic")
 	assert.NotContains(t, recorder.Body.String(), "upstream-private-heartbeat")
 	assert.Equal(t, 0, info.ReceivedResponseCount)
+	require.NotNil(t, info.StreamStatus)
+	assert.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
+}
+
+func TestStreamScannerHandler_HeaderOnlyFlushDoesNotUnlockUpstreamComment(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	body := "data: first\n\n: upstream-private-heartbeat\n\ndata: [DONE]\n"
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
+	info := &relaycommon.RelayInfo{
+		DisablePing: true,
+		ChannelMeta: &relaycommon.ChannelMeta{},
+	}
+
+	StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {
+		_ = FlushWriter(c)
+	})
+
+	assert.NotContains(t, recorder.Body.String(), ": PING\n\n",
+		"a header-only flush must not count as a downstream data frame")
+	assert.Equal(t, 1, info.ReceivedResponseCount)
+	require.NotNil(t, info.StreamStatus)
+	assert.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
 }
 
 func TestStreamScannerHandler_DataWithExtraSpaces(t *testing.T) {

--- a/relay/helper/stream_scanner_test.go
+++ b/relay/helper/stream_scanner_test.go
@@ -197,6 +197,79 @@ func TestStreamScannerHandler_SkipsNonDataLines(t *testing.T) {
 	assert.Equal(t, int64(100), count.Load())
 }
 
+func TestStreamScannerHandler_RelaysUpstreamCommentAfterData(t *testing.T) {
+	pr, pw := io.Pipe()
+	t.Cleanup(func() {
+		_ = pr.Close()
+		_ = pw.Close()
+	})
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	resp := &http.Response{Body: pr}
+	info := &relaycommon.RelayInfo{
+		DisablePing: true,
+		ChannelMeta: &relaycommon.ChannelMeta{},
+	}
+
+	firstHandled := make(chan struct{})
+	done := make(chan struct{})
+	var writeErr error
+	go func() {
+		StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {
+			writeErr = StringData(c, data)
+			if data == "first" {
+				close(firstHandled)
+			}
+		})
+		close(done)
+	}()
+
+	_, err := fmt.Fprint(pw, "data: first\n")
+	require.NoError(t, err)
+
+	select {
+	case <-firstHandled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first data frame")
+	}
+
+	_, err = fmt.Fprint(pw, ": upstream-private-heartbeat\n\ndata: [DONE]\n")
+	require.NoError(t, err)
+	require.NoError(t, pw.Close())
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stream to finish")
+	}
+
+	require.NoError(t, writeErr)
+	assert.Contains(t, recorder.Body.String(), "data: first")
+	assert.Contains(t, recorder.Body.String(), ": PING\n\n")
+	assert.NotContains(t, recorder.Body.String(), "upstream-private-heartbeat")
+	assert.Equal(t, 1, info.ReceivedResponseCount)
+	require.NotNil(t, info.StreamStatus)
+	assert.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
+}
+
+func TestStreamScannerHandler_SkipsUpstreamCommentBeforeData(t *testing.T) {
+	body := ": upstream-private-heartbeat\n\ndata: [DONE]\n"
+	c, resp, info := setupStreamTest(t, strings.NewReader(body))
+	info.DisablePing = true
+
+	StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {
+		_ = StringData(c, data)
+	})
+
+	assert.False(t, c.Writer.Written(), "a heartbeat must not commit the response before the first data frame")
+	assert.Equal(t, 0, info.ReceivedResponseCount)
+	require.NotNil(t, info.StreamStatus)
+	assert.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
+}
+
 func TestStreamScannerHandler_DataWithExtraSpaces(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 以下摘要已根据代码路径和本地验证结果人工整理。

## 📝 变更描述 / Description

`StreamScannerHandler` 原本会用上游 SSE comment 重置内部超时，但随后把该行丢弃。因此，上游持续发送心跳时，下游仍可能长时间收不到任何字节。

本改动将数据帧和上游 comment 心跳放入同一个有序写队列。下游已经写出真实数据帧后，上游 comment 会被规范化为 `: PING` 并立即 flush；首个真实帧之前的 comment 仍保持静默，避免提前提交 HTTP 200 而影响错误返回或渠道重试。上游 comment 内容不会透传。

同时增加两个回归测试，分别覆盖首帧后的心跳转发，以及首帧前不提交响应的约束。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6981

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 此 PR 已关联可独立复现的 Bug Issue。
- [x] **变更理解:** 我已理解有序写队列、响应提交时机及失败状态处理的影响。
- [x] **范围聚焦:** 本 PR 只修改流扫描器及其回归测试。
- [x] **本地验证:** 已运行并通过目标测试、relay 全层测试和全仓测试。
- [x] **安全合规:** 代码中无敏感凭据，且上游 comment 内容不会泄露到下游。

## 📸 运行证明 / Proof of Work

修复前，新增回归测试稳定失败：下游仅收到 `data: first`，没有任何 comment heartbeat。修复后以下命令均通过：

```text
go test ./relay/helper -count=1
go test ./relay/... -count=1
go test ./... -count=1 -shuffle=on
```

全仓测试使用 `-shuffle=on`，同时规避了 Windows 下现有 channel-affinity 测试使用 `time.Now().UnixNano()` 生成隔离键时的同刻碰撞，并验证测试顺序独立性。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability by forwarding heartbeats only after actual response data has been sent downstream.
  * Prevented upstream SSE comments from being incorrectly treated as post-data traffic after a relay ping.
  * Preserved normal data delivery, stream completion, client disconnect handling, and heartbeat write-failure behavior.
* **Tests**
  * Added regression coverage for heartbeat and SSE comment handling before and after response data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->