### PR TITLE
feat: return created token info in AddToken response

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -334,10 +334,7 @@ func AddToken(c *gin.Context) {
 		common.ApiError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{
-		"success": true,
-		"message": "",
-	})
+	common.ApiSuccess(c, buildMaskedTokenResponse(&cleanToken))
 }
 
 func DeleteToken(c *gin.Context) {


### PR DESCRIPTION
## 📝 变更描述 / Description
创建令牌接口(POST /api/token/)之前只返回空 message,调用方拿不到新令牌的 id,只能再拉一遍列表过滤。
参考 GET /api/token/:id、PUT /api/token/ 返回一致格式(key 脱敏)。
完整 key 仍然需要走现有的 POST /api/token/:id/key,不改变明文 key 的收口。
改动一行,老客户端只看 success 字段,不受影响。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6954

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 不适用,本 PR 不是 Bug fix。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
本地验证,创建响应与 GET /api/token/:id 格式一致:

POST /api/token/ 响应:
```json
{"data":{"id":1,"key":"yDHR**********Ut1T","name":"selftest","remain_quota":500000,"expired_time":-1,"unlimited_quota":false,"auto_groups":null},"message":"","success":true}
```

GET /api/token/1 响应与上面逐字段一致;再用返回的 id 调 POST /api/token/1/key 可取到完整 key。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Token creation responses now include the newly created token’s masked key and associated group information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->