### PR TITLE
fix(claude): 保留 thinking signature 以修复 DeepSeek 多轮对话 400

### DIFF
--- a/relaykit/relayconvert/internal/claude_messages/to_oai_chat_resp.go
+++ b/relaykit/relayconvert/internal/claude_messages/to_oai_chat_resp.go
@@ -75,8 +75,11 @@ func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.ChatCo
 					},
 				})
 			case "signature_delta":
-				signatureContent := "\n"
-				choice.Delta.ReasoningContent = &signatureContent
+				// 将 signature 以 JSON 标记形式追加到 ReasoningContent，供下一轮请求还原 thinking 块
+				if claudeResponse.Delta.Signature != "" {
+					sigChunk := `{"_sig":"` + claudeResponse.Delta.Signature + `"}`
+					choice.Delta.ReasoningContent = &sigChunk
+				}
 			case "thinking_delta":
 				choice.Delta.ReasoningContent = claudeResponse.Delta.Thinking
 			}
@@ -136,6 +139,9 @@ func ResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.OpenAITextRe
 		case "thinking":
 			if message.Thinking != nil {
 				thinkingContent = *message.Thinking
+				if message.Signature != "" {
+					thinkingContent += `{"_sig":"` + message.Signature + `"}`
+				}
 			}
 		case "text":
 			responseText = message.GetText()

--- a/relaykit/relayconvert/internal/oai_chat/to_claude_messages_req.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_claude_messages_req.go
@@ -225,8 +225,10 @@ func OpenAIChatRequestToClaudeMessages(c context.Context, info convmeta.Meta, te
 			textRequest.Messages[i].Role = "user"
 		}
 		fmtMessage := dto.Message{
-			Role:    message.Role,
-			Content: message.Content,
+			Role:             message.Role,
+			Content:          message.Content,
+			ReasoningContent: message.ReasoningContent,
+			Reasoning:        message.Reasoning,
 		}
 		if message.Role == "tool" {
 			fmtMessage.ToolCallId = message.ToolCallId
@@ -381,6 +383,36 @@ func OpenAIChatRequestToClaudeMessages(c context.Context, info convmeta.Meta, te
 				}
 			}
 			claudeMessage.Content = claudeMediaMessages
+		}
+		// 若 assistant 消息携带了 reasoning_content，将其还原为 Claude thinking 内容块
+		// reasoning_content 格式：thinking文本 + 可选的 {"_sig":"<signature>"}
+		if message.Role == "assistant" {
+			if rc := message.GetReasoningContent(); rc != "" {
+				thinkingText := rc
+				signature := ""
+				if idx := strings.LastIndex(rc, `{"_sig":"`); idx >= 0 {
+					sigJSON := rc[idx:]
+					if len(sigJSON) > 9 && sigJSON[len(sigJSON)-2:] == `"}` {
+						signature = sigJSON[9 : len(sigJSON)-2]
+						thinkingText = rc[:idx]
+					}
+				}
+				thinkingBlock := dto.ClaudeMediaMessage{
+					Type:      "thinking",
+					Thinking:  &thinkingText,
+					Signature: signature,
+				}
+				// thinking 块需置于 text/tool_use 块之前
+				switch content := claudeMessage.Content.(type) {
+				case string:
+					claudeMessage.Content = []dto.ClaudeMediaMessage{
+						thinkingBlock,
+						{Type: "text", Text: kitutil.GetPointer[string](content)},
+					}
+				case []dto.ClaudeMediaMessage:
+					claudeMessage.Content = append([]dto.ClaudeMediaMessage{thinkingBlock}, content...)
+				}
+			}
 		}
 		claudeMessages = append(claudeMessages, claudeMessage)
 	}


### PR DESCRIPTION
Claude 适配器在 Anthropic 响应转 OpenAI 格式时丢弃了 thinking 块的 signature，并在构建 Claude 请求时忽略 reasoning_content，导致需要回传 完整 thinking 块（文本 + signature）的上游（如 DeepSeek Anthropic 渠道） 在多轮对话时报 HTTP 400 "thinking must be passed back"。

三处修复：
- 流式响应：signature_delta 编码为 {"_sig":"<sig>"} 写入 reasoning_content， 不再用换行符替换丢弃
- 非流式响应：thinking 文本末尾追加同样的 signature 标记
- 请求路径：assistant 消息的 reasoning_content 还原为完整的 {type:"thinking", thinking, signature} 块后再发送上游

无 thinking 的普通对话不受影响，新逻辑仅在 reasoning_content 非空时触发。

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> 我们公司的模型网关也基于new-api搭建，在使用过程中发现的这个bug，具体触发场景是网关配置了anthropic渠道的deepseek模型，用户本地使用codex + ccswitch采用openai的格式请求网关，会发生偶发的“ HTTP 400; cause: The request is invalid: The content[].thinking in the thinking mode must be passed back to the API.. Please check the request body, required fields, and request format.”这种报错。

经过排查发现原因其实很简单，deepSeek 要求开启 thinking 模式后，上轮产生的 thinking 内容块（含加密签名）必须在下轮请求中原样传回。但网关在 claude↔openAI 格式转换时， 响应路径丢弃了签名 ， 请求路径忽略了 reasoning_content ，导致 thinking 块在多轮对话中永久丢失，上游返回 400。

## 📝 变更描述 / Description
- 请求侧：在 OpenAI Chat 转 Claude 消息时，将 assistant 消息的 reasoning_content 还原为 {"type":"thinking","thinking":"..."} 内容块，并保证流式消息合并正确。
- 响应侧：保留 thinking 块的 signature，并定义可随响应透传、下一轮可读的承载方式，避免信息在首轮就丢失。
- 兼容性：仅在 thinking 模式开启且上游需要时插入 thinking 块，避免影响普通模型和历史兼容。

## 🚀 变更类型 / Type of change
- [ ✅ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6939

## ✅ 提交前检查项 / Checklist
- [ ✅ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ✅ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ✅ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ✅ ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ ✅ ] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [ ✅ ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [ ✅ ] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
修改前：
<img width="1280" height="1093" alt="image" src="https://github.com/user-attachments/assets/a76612f7-8c8c-46ad-81f7-d9a4ca154727" />
报错：CC Switch local proxy failed while handling Codex endpoint /responses. Provider: deepseek v4; model: deepseek-v4-pro[1m]; upstream_status: HTTP 400; cause: The request is invalid: The content[].thinking in the thinking mode must be passed back to the API.. Please check the request body, required fields, and request format.


修改后测试：
<img width="1198" height="1374" alt="image" src="https://github.com/user-attachments/assets/d6433d34-8404-4b4b-a103-03a9258f83b2" />
运行正常



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserved assistant reasoning content when converting between chat message formats.
  * Converted reasoning into Claude thinking blocks, including optional signature metadata.
  * Included signature metadata in streamed and non-streamed reasoning responses.

* **Bug Fixes**
  * Improved preservation of reasoning and thinking details across message conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->