### PR TITLE
fix(web): restore task video previews from result_url ｜修复任务日志无法预览成功生成的视频

### DIFF
--- a/web/src/features/usage-logs/components/__tests__/task-logs-columns.test.tsx
+++ b/web/src/features/usage-logs/components/__tests__/task-logs-columns.test.tsx
@@ -1,0 +1,85 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+import { render, screen } from '@testing-library/react'
+import type React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { TASK_ACTIONS, TASK_STATUS } from '../../constants'
+import type { TaskLog } from '../../types'
+import { useTaskLogsColumns } from '../columns/task-logs-columns'
+
+function DetailsCellProbe({ log }: { log: TaskLog }) {
+  const detailsColumn = useTaskLogsColumns(false).find(
+    (column) => 'accessorKey' in column && column.accessorKey === 'fail_reason'
+  )
+  if (!detailsColumn || typeof detailsColumn.cell !== 'function') {
+    throw new Error('Details column is unavailable')
+  }
+
+  const row = {
+    original: log,
+    getValue: () => log.fail_reason,
+  }
+  return detailsColumn.cell({ row } as never) as React.ReactNode
+}
+
+describe('task log details', () => {
+  test('previews a successful video when result_url is populated', () => {
+    render(
+      <DetailsCellProbe
+        log={{
+          id: 1,
+          user_id: 1,
+          platform: 'kling',
+          task_id: 'task_issue_6993',
+          action: TASK_ACTIONS.GENERATE,
+          channel_id: 1,
+          submit_time: 1,
+          status: TASK_STATUS.SUCCESS,
+          fail_reason: '',
+          result_url: 'https://example.com/video.mp4',
+        }}
+      />
+    )
+
+    expect(
+      screen.getByRole('link', { name: 'Click to preview video' })
+    ).toHaveAttribute('href', '/v1/videos/task_issue_6993/content')
+  })
+
+  test('keeps preview compatibility for legacy result URLs in fail_reason', () => {
+    render(
+      <DetailsCellProbe
+        log={{
+          id: 2,
+          user_id: 1,
+          platform: 'kling',
+          task_id: 'task_legacy_video',
+          action: TASK_ACTIONS.GENERATE,
+          channel_id: 1,
+          submit_time: 1,
+          status: TASK_STATUS.SUCCESS,
+          fail_reason: 'https://example.com/legacy-video.mp4',
+        }}
+      />
+    )
+
+    expect(
+      screen.getByRole('link', { name: 'Click to preview video' })
+    ).toHaveAttribute('href', '/v1/videos/task_legacy_video/content')
+  })
+})

--- a/web/src/features/usage-logs/components/columns/task-logs-columns.tsx
+++ b/web/src/features/usage-logs/components/columns/task-logs-columns.tsx
@@ -245,9 +245,10 @@ export function useTaskLogsColumns(isAdmin: boolean): ColumnDef<TaskLog>[] {
           log.action === TASK_ACTIONS.REFERENCE_GENERATE ||
           log.action === TASK_ACTIONS.REMIX_GENERATE
         const isSuccess = status === TASK_STATUS.SUCCESS
-        const isUrl = failReason?.startsWith('http')
+        const resultUrl = log.result_url?.trim()
+        const legacyResultUrl = failReason?.startsWith('http') ? failReason : ''
 
-        if (isSuccess && isVideoTask && isUrl) {
+        if (isSuccess && isVideoTask && (resultUrl || legacyResultUrl)) {
           const videoUrl = `/v1/videos/${log.task_id}/content`
           return (
             <a

--- a/web/src/features/usage-logs/types.ts
+++ b/web/src/features/usage-logs/types.ts
@@ -301,6 +301,7 @@ export interface TaskLog {
   progress_message_en?: string
   data?: string // JSON string
   fail_reason?: string
+  result_url?: string
   status: string // NOT_START, SUBMITTED, IN_PROGRESS, SUCCESS, FAILURE, QUEUED, UNKNOWN
   other?: string
   created_at?: number


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。


## 📝 变更描述 / Description

修复任务日志页面无法展示成功的视频任务预览入口

后端任务 DTO 已返回 `result_url`，但前端 Details 列此前只检查 `fail_reason`。对于成功任务，`fail_reason` 通常为空，因此页面会显示 `-`，用户无法打开已经生成的视频。

本次修改：

- 在 `TaskLog` 类型中补充可选字段 `result_url`；
- 成功视频任务优先使用 `result_url` 判断是否显示预览入口；
- 保留旧数据中通过 `fail_reason` 保存 HTTP 视频 URL 的兼容逻辑；
- 不修改现有视频代理路由及认证行为；
- 新增成功任务和旧格式任务的回归测试。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #6993

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已核对 Issue #6993 及当前代码路径。
- [x] **Bug fix 说明:** 问题由前端忽略后端已提供的 `result_url` 导致。
- [x] **变更理解:** 已核对后端 DTO、任务轮询、前端渲染和视频代理链路。
- [x] **范围聚焦:** 仅修改任务日志字段、视频预览判断和对应测试。
- [x] **本地验证:** 目标测试、类型检查、lint、格式检查和生产构建均通过。
- [x] **安全合规:** 未引入敏感凭据，未改变视频代理权限逻辑。

## 📸 运行证明 / Proof of Work

- `bun run test -- src/features/usage-logs/components/__tests__/task-logs-columns.test.tsx`
  - 2 tests passed
- `bun run typecheck`
  - passed
- `bunx oxlint ...`
  - passed
- `bunx oxfmt --check ...`
  - passed
- `bun run build`
  - passed

全量测试当前有 8 项失败，位于本次未修改的其他测试文件，涉及环境问题；本 PR 新增和受影响测试均通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video preview links in task logs now use the available result URL.
  * Preserved support for legacy failure-reason URLs when no result URL is available.
  * Preview links now appear reliably for completed tasks with video results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->