### PR TITLE
fix(ali): route Responses to compatible-mode endpoint

### DIFF
--- a/relay/channel/ali/adaptor.go
+++ b/relay/channel/ali/adaptor.go
@@ -108,7 +108,8 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 		case constant.RelayModeRerank:
 			fullRequestURL = fmt.Sprintf("%s/api/v1/services/rerank/text-rerank/text-rerank", info.ChannelBaseUrl)
 		case constant.RelayModeResponses:
-			fullRequestURL = fmt.Sprintf("%s/api/v2/apps/protocols/compatible-mode/v1/responses", info.ChannelBaseUrl)
+			// OpenAI-compatible Responses endpoint; /api/v2/apps/protocols is for Bailian apps, not served by direct MaaS hosts.
+			fullRequestURL = fmt.Sprintf("%s/compatible-mode/v1/responses", info.ChannelBaseUrl)
 		case constant.RelayModeImagesGenerations:
 			if isSyncImageModel(info.UpstreamModelName) {
 				fullRequestURL = fmt.Sprintf("%s/api/v1/services/aigc/multimodal-generation/generation", info.ChannelBaseUrl)


### PR DESCRIPTION
> 本 PR 由 AI 协助（Claude Code）生成，描述经人工整理核实。

## 📝 变更描述 / Description

阿里云（type 17）适配器把 `/v1/responses` 路由到 `/api/v2/apps/protocols/compatible-mode/v1/responses`（commit `5b3c8e84` 引入）。该路径在直连 MaaS host（如阿里云 Token Plan）上不被服务，阿里云对所有模型返回 `{"code":"InternalError","message":"No gRPC response received"}`（HTTP 500），而同一渠道的 `/v1/chat/completions`、`/v1/messages` 正常工作。

改为 `%s/compatible-mode/v1/responses`，与同文件 chat 端点 `%s/compatible-mode/v1/chat/completions` 对齐——这是阿里云文档（https://help.aliyun.com/zh/model-studio/base-url）所列 Token Plan OpenAI-compatible base 下的 responses 端点。

## 实测验证（Token Plan host + 真实渠道 key）

| 路径 | 模型 | 结果 |
|---|---|---|
| 旧 `apps/protocols/.../responses` | deepseek-v4-pro-0813 | HTTP 500 `No gRPC response received` |
| 新 `compatible-mode/v1/responses` | deepseek-v4-pro-0813 | HTTP 200（正常 Responses 对象） |
| 新 `compatible-mode/v1/responses` | qwen3.8-max | HTTP 200（qwen 不回归，原 `5b3c8e84` 针对的 qwen3-max 不会受影响） |

`go build` / `go vet` / `go test ./relay/channel/ali/` 通过。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)

## 🔗 关联任务 / Related Issue

- 暂无对应 Issue（如维护者需要我可另开一个并在此关联）

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 本 PR 为 AI 协助生成，已在顶部 Notice 声明，描述经人工整理核实
- [x] **非重复提交:** 已搜索 upstream Issues/PRs，未见相同修复
- [x] **Bug fix 说明:** 暂无关联 Issue，可按维护者要求补开；本 issue 系路径错配致上游 500，非设计取舍/理解偏差
- [x] **变更理解:** 路径错配致 500，改走 compatible-mode responses 端点
- [x] **范围聚焦:** 仅改 `relay/channel/ali/adaptor.go` 一行 + 注释
- [x] **本地验证:** build/vet/test 通过 + curl 实测见上
- [x] **安全合规:** 无敏感凭据

## 📸 运行证明 / Proof of Work

见上方实测表格：旧路径复现 500 `No gRPC response received`，新路径返回 200 正常 Responses 对象。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Responses API requests to use the OpenAI-compatible endpoint on the channel’s base URL.
  * Improved compatibility and routing for Responses requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->