### PR TITLE
fix(relay): auto-recovery for images, context overflow, and encrypted reasoning items

### DIFF
--- a/common/init.go
+++ b/common/init.go
@@ -175,6 +175,9 @@ func positiveUserSessionEnv(name string, fallback int) int {
 
 func initConstantEnv() {
 	constant.StreamingTimeout = GetEnvOrDefault("STREAMING_TIMEOUT", 300)
+	// ContextOverflowAutoRecovery 上游返回 context 超长错误时，自动裁剪历史消息
+	//（先剥旧图片、再丢最旧对话块）并用同渠道原地重试一次，实现用户无感知恢复
+	constant.ContextOverflowAutoRecovery = GetEnvOrDefaultBool("CONTEXT_OVERFLOW_AUTO_RECOVERY", true)
 	constant.DifyDebug = GetEnvOrDefaultBool("DIFY_DEBUG", true)
 	constant.MaxFileDownloadMB = GetEnvOrDefault("MAX_FILE_DOWNLOAD_MB", 64)
 	constant.StreamScannerMaxBufferMB = GetEnvOrDefault("STREAM_SCANNER_MAX_BUFFER_MB", 128)

--- a/constant/env.go
+++ b/constant/env.go
@@ -1,6 +1,7 @@
 package constant
 
 var StreamingTimeout int
+var ContextOverflowAutoRecovery bool
 var DifyDebug bool
 var MaxFileDownloadMB int
 var StreamScannerMaxBufferMB int

--- a/controller/context_recovery.go
+++ b/controller/context_recovery.go
@@ -1,0 +1,884 @@
+package controller
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/logger"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relaykit/types"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/gin-gonic/gin"
+)
+
+// 匹配上游 context 超长错误中的上限数字，例如：
+// deepseek: "This model's maximum context length is 1048565 tokens. However, you requested 3220751 tokens"
+// openai:   "This model's maximum context length is 128000 tokens. However, your messages resulted in 130000 tokens"
+// oc:       "Input tokens exceed the configured limit of 922000 tokens. Your messages resulted in 1055751 tokens"
+// kimi:     "Invalid request: Your request exceeded model token limit: 262144 (requested: 1055340)"
+var contextOverflowMaxPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)maximum context length is (\d+) tokens`),
+	regexp.MustCompile(`(?i)configured limit of (\d+) tokens`),
+	regexp.MustCompile(`(?i)model token limit: (\d+)`),
+}
+
+const contextRecoveredKey = "context_overflow_recovered"
+const imageUnsupportedRecoveredKey = "image_unsupported_recovered"
+
+// 裁剪目标比例：上游 tokenizer 与本地估算存在偏差，留足余量避免二次溢出
+const contextTruncateTargetRatio = 0.7
+
+// 保留图片的估算 token 数（仅最后一条含图消息的图片会被保留）
+const flatImageTokenEstimate = 2000
+
+// 剥离图片后的占位文本
+const omittedImagePlaceholder = "[历史图片已省略]"
+
+// 模型不支持图片输入时，图片被移除后的占位文本（模型可见，可据此告知用户）
+const imageRemovedPlaceholder = "[图片已移除：当前模型不支持图片输入]"
+
+func parseContextOverflowMaxTokens(msg string) (int, bool) {
+	for _, pattern := range contextOverflowMaxPatterns {
+		m := pattern.FindStringSubmatch(msg)
+		if m == nil {
+			continue
+		}
+		maxTokens, err := strconv.Atoi(m[1])
+		if err != nil || maxTokens <= 0 {
+			return 0, false
+		}
+		return maxTokens, true
+	}
+	return 0, false
+}
+
+// 匹配上游"模型不支持图片输入"类错误，例如：
+// "This model does not support images in the conversation"
+// "Image input is not supported for this model"
+// "Unsupported image input"
+// "model does not support vision"
+// deepseek-v4-flash: "Failed to deserialize the JSON body into the target type: messages[7]: unknown variant `image_url`, expected `text`"
+var imageUnsupportedPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)not support.{0,40}(?:image|vision)`),
+	regexp.MustCompile(`(?i)(?:image|vision).{0,40}(?:not support|unsupported)`),
+	regexp.MustCompile(`(?i)unsupported.{0,40}(?:image|vision)`),
+	regexp.MustCompile(`(?i)unknown variant\s+` + "`" + `image`),
+	regexp.MustCompile(`(?i)unknown variant\s+"image`),
+}
+
+func isImageUnsupportedError(msg string) bool {
+	for _, pattern := range imageUnsupportedPatterns {
+		if pattern.MatchString(msg) {
+			return true
+		}
+	}
+	return false
+}
+
+// tryContextOverflowRecovery 检测上游 context 超长错误，裁剪请求体中的历史消息
+// （先剥离旧消息中的图片，再从最旧开始丢弃对话块），并同步更新 BodyStorage 与
+// info.Request，返回 true 表示可以用同一渠道原地重试。
+// 每个请求最多恢复一次，避免死循环。
+func tryContextOverflowRecovery(c *gin.Context, info *relaycommon.RelayInfo, apiErr *types.NewAPIError) bool {
+	if !constant.ContextOverflowAutoRecovery || apiErr == nil || info == nil {
+		return false
+	}
+	if c.GetBool(contextRecoveredKey) {
+		return false
+	}
+	maxTokens, ok := parseContextOverflowMaxTokens(apiErr.Error())
+	if !ok {
+		return false
+	}
+
+	storage, err := common.GetBodyStorage(c)
+	if err != nil {
+		return false
+	}
+	raw, err := storage.Bytes()
+	if err != nil {
+		return false
+	}
+
+	model := info.UpstreamModelName
+	if model == "" {
+		model = info.OriginModelName
+	}
+	newBody, before, after, err := truncateChatMessagesBody(raw, model, maxTokens)
+	if err != nil {
+		return false
+	}
+
+	// 更新 info.Request（非透传模式 relay 使用解析后的 DTO，而非重新读 body）
+	if info.Request != nil {
+		if err := common.Unmarshal(newBody, info.Request); err != nil {
+			return false
+		}
+	}
+
+	newStorage, err := common.CreateBodyStorage(newBody)
+	if err != nil {
+		return false
+	}
+	_ = storage.Close()
+	c.Set(common.KeyBodyStorage, newStorage)
+	c.Set(contextRecoveredKey, true)
+	info.SetEstimatePromptTokens(after)
+	c.Header("X-Context-Truncated", fmt.Sprintf("%d->%d", before, after))
+	logger.LogWarn(c, fmt.Sprintf("context 超长（上限 %d tokens），已自动裁剪历史消息（估算 %d -> %d tokens）并重试", maxTokens, before, after))
+	return true
+}
+
+// truncateChatMessagesBody 裁剪 chat completions 请求体中的 messages，
+// 返回新请求体及裁剪前后的估算 token 数。
+func truncateChatMessagesBody(raw []byte, model string, maxTokens int) ([]byte, int, int, error) {
+	var reqMap map[string]any
+	if err := common.Unmarshal(raw, &reqMap); err != nil {
+		return nil, 0, 0, err
+	}
+	messagesAny, ok := reqMap["messages"]
+	if !ok {
+		return nil, 0, 0, fmt.Errorf("no messages in request body")
+	}
+	messages, ok := messagesAny.([]any)
+	if !ok || len(messages) == 0 {
+		return nil, 0, 0, fmt.Errorf("messages is empty or not an array")
+	}
+
+	target := int(float64(maxTokens) * contextTruncateTargetRatio)
+
+	// 第一步：剥离旧消息中的图片（只保留最后一条含图消息的图片）
+	stripOldImageParts(messages, []string{"content"}, "text")
+
+	// 第二步：截断超长单条消息内容（巨大的 tool 输出/文件内容做中间省略），
+	// 避免后续因尾部块不可丢弃导致裁剪失效
+	elideOversizedMessageContents(messages)
+
+	counts := perMessageTokenCounts(messages, model)
+	total := sumInts(counts)
+	before := total
+
+	// 第三步：从最旧的非 system 消息开始按块丢弃
+	//（assistant 消息与其后续连续 tool 消息为一块，避免留下孤儿 tool 响应）
+	for total > target {
+		i := firstNonSystemMessageIndex(messages)
+		if i < 0 || i >= len(messages)-1 {
+			// 只剩 system 与最后一条消息，无法再丢
+			break
+		}
+		j := i + 1
+		for j < len(messages) && messageRole(messages[j]) == "tool" {
+			j++
+		}
+		if j >= len(messages) {
+			// 块延伸到最后一条消息：丢弃会留下孤儿 tool 或丢掉最新消息，停止裁剪
+			break
+		}
+		for k := i; k < j; k++ {
+			total -= counts[k]
+		}
+		messages = append(messages[:i], messages[j:]...)
+		counts = append(counts[:i], counts[j:]...)
+	}
+
+	reqMap["messages"] = messages
+	newBody, err := common.Marshal(reqMap)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	return newBody, before, total, nil
+}
+
+func messageRole(m any) string {
+	mm, ok := m.(map[string]any)
+	if !ok {
+		return ""
+	}
+	role, _ := mm["role"].(string)
+	return role
+}
+
+func firstNonSystemMessageIndex(messages []any) int {
+	for i, m := range messages {
+		if messageRole(m) != "system" && messageRole(m) != "developer" {
+			return i
+		}
+	}
+	return -1
+}
+
+func isImagePart(pm map[string]any) bool {
+	partType, _ := pm["type"].(string)
+	switch partType {
+	case "image_url", "input_image", "image":
+		return true
+	}
+	return false
+}
+
+// itemHasImagePart 判断 item 指定字段（part 数组）中是否包含图片
+func itemHasImagePart(item any, field string) bool {
+	mm, ok := item.(map[string]any)
+	if !ok {
+		return false
+	}
+	parts, ok := mm[field].([]any)
+	if !ok {
+		return false
+	}
+	for _, p := range parts {
+		if pm, ok := p.(map[string]any); ok && isImagePart(pm) {
+			return true
+		}
+	}
+	return false
+}
+
+// stripImageParts 将 item 指定字段中的图片 part 替换为文本占位，返回是否有修改
+func stripImageParts(mm map[string]any, field, textPartType string) bool {
+	parts, ok := mm[field].([]any)
+	if !ok {
+		return false
+	}
+	changed := false
+	newParts := make([]any, 0, len(parts))
+	for _, p := range parts {
+		pm, ok := p.(map[string]any)
+		if !ok || !isImagePart(pm) {
+			newParts = append(newParts, p)
+			continue
+		}
+		newParts = append(newParts, map[string]any{"type": textPartType, "text": omittedImagePlaceholder})
+		changed = true
+	}
+	if changed {
+		mm[field] = newParts
+	}
+	return changed
+}
+
+// stripOldImageParts 剥离 items 中除最后一条含图 item 外的所有图片 part
+// （chat messages 用 content 字段；responses input 另含 function_call_output
+// 的 output 字段），返回是否有修改
+func stripOldImageParts(items []any, fields []string, textPartType string) bool {
+	lastImageIdx := -1
+	for i, item := range items {
+		for _, field := range fields {
+			if itemHasImagePart(item, field) {
+				lastImageIdx = i
+				break
+			}
+		}
+	}
+	if lastImageIdx < 0 {
+		return false
+	}
+	changed := false
+	for i, item := range items {
+		if i == lastImageIdx {
+			continue
+		}
+		mm, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, field := range fields {
+			if stripImageParts(mm, field, textPartType) {
+				changed = true
+			}
+		}
+	}
+	return changed
+}
+
+// stripAllImageParts 剥离 items 中所有图片 part（模型不支持图片时使用），
+// 返回移除的图片数量与是否有修改。
+func stripAllImageParts(items []any, fields []string, textPartType string) (int, bool) {
+	removed := 0
+	changed := false
+	for _, item := range items {
+		mm, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, field := range fields {
+			parts, ok := mm[field].([]any)
+			if !ok {
+				continue
+			}
+			itemRemoved := 0
+			newParts := make([]any, 0, len(parts))
+			for _, p := range parts {
+				pm, ok := p.(map[string]any)
+				if !ok || !isImagePart(pm) {
+					newParts = append(newParts, p)
+					continue
+				}
+				newParts = append(newParts, map[string]any{"type": textPartType, "text": imageRemovedPlaceholder})
+				itemRemoved++
+			}
+			if itemRemoved > 0 {
+				mm[field] = newParts
+				removed += itemRemoved
+				changed = true
+			}
+		}
+	}
+	return removed, changed
+}
+
+func messageImageCount(m any) int {
+	mm, ok := m.(map[string]any)
+	if !ok {
+		return 0
+	}
+	content, ok := mm["content"].([]any)
+	if !ok {
+		return 0
+	}
+	count := 0
+	for _, p := range content {
+		pm, ok := p.(map[string]any)
+		if !ok {
+			continue
+		}
+		if isImagePart(pm) {
+			count++
+		}
+	}
+	return count
+}
+
+// perMessageTokenCounts 估算每条消息的 token 数（文本用 tokenizer，图片按固定值）
+func perMessageTokenCounts(messages []any, model string) []int {
+	counts := make([]int, len(messages))
+	for i, m := range messages {
+		mm, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		var sb strings.Builder
+		sb.WriteString(messageRole(m))
+		extractMessageText(mm["content"], &sb)
+		if tc, ok := mm["tool_calls"].([]any); ok {
+			if tcBytes, err := common.Marshal(tc); err == nil {
+				sb.Write(tcBytes)
+			}
+		}
+		if tcID, ok := mm["tool_call_id"].(string); ok {
+			sb.WriteString(tcID)
+		}
+		counts[i] = service.CountTextToken(sb.String(), model) + 4
+		counts[i] += messageImageCount(m) * flatImageTokenEstimate
+	}
+	return counts
+}
+
+func extractMessageText(content any, sb *strings.Builder) {
+	switch v := content.(type) {
+	case string:
+		sb.WriteString(v)
+	case []any:
+		for _, p := range v {
+			pm, ok := p.(map[string]any)
+			if !ok {
+				continue
+			}
+			if text, ok := pm["text"].(string); ok {
+				sb.WriteString(text)
+			}
+		}
+	}
+}
+
+func sumInts(nums []int) int {
+	total := 0
+	for _, n := range nums {
+		total += n
+	}
+	return total
+}
+
+// 单条消息内容的最大保留长度（rune 数），超过则中间省略
+const singleMessageRuneCap = 60000
+const singleMessageHeadKeep = 45000
+const singleMessageTailKeep = 15000
+const elidedContentMarker = "\n...[中间内容已省略]...\n"
+
+// elideOversizedMessageContents 截断超长单条消息内容，保留头尾
+func elideOversizedMessageContents(messages []any) {
+	for _, m := range messages {
+		mm, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch content := mm["content"].(type) {
+		case string:
+			mm["content"] = elideLongText(content)
+		case []any:
+			for _, p := range content {
+				pm, ok := p.(map[string]any)
+				if !ok {
+					continue
+				}
+				if text, ok := pm["text"].(string); ok {
+					pm["text"] = elideLongText(text)
+				}
+			}
+		}
+	}
+}
+
+func elideLongText(s string) string {
+	runes := []rune(s)
+	if len(runes) <= singleMessageRuneCap {
+		return s
+	}
+	return string(runes[:singleMessageHeadKeep]) + elidedContentMarker + string(runes[len(runes)-singleMessageTailKeep:])
+}
+
+const toolPairingSanitizedKey = "tool_pairing_sanitized"
+const toolPairingRecoveredKey = "tool_pairing_recovered"
+const omittedToolResponsePlaceholder = "[工具调用结果已省略]"
+
+func isToolPairingError(msg string) bool {
+	lower := strings.ToLower(msg)
+	return strings.Contains(lower, "must be a response to a preceding message with 'tool_calls'") ||
+		strings.Contains(lower, "must be followed by tool messages") ||
+		strings.Contains(lower, "no tool output found for tool call") ||
+		strings.Contains(lower, "no output found for function call") ||
+		(strings.Contains(lower, "tool_calls") && strings.Contains(lower, "preceding"))
+}
+
+// sanitizeToolCallPairing 修复 messages 中 tool/tool_calls 配对问题：
+//  1. 删除孤儿 tool 消息（前面没有携带对应 tool_call_id 的 assistant 消息），
+//     常见于客户端上下文压缩后残留
+//  2. 为缺失响应的 tool_calls 补充占位 tool 消息，避免
+//     "assistant message with 'tool_calls' must be followed by tool messages" 错误
+//
+// 返回处理后的消息列表与修改次数（0 表示无需改动）。
+func sanitizeToolCallPairing(messages []any) ([]any, int) {
+	changed := 0
+	out := make([]any, 0, len(messages)+2)
+	answerable := map[string]bool{} // 当前可响应的 tool_call_id（来自最近一条 assistant）
+	var unanswered []string         // 最近一条 assistant 中尚未收到响应的 tool_call_id
+
+	fabricateMissing := func() {
+		for _, id := range unanswered {
+			out = append(out, map[string]any{
+				"role":         "tool",
+				"tool_call_id": id,
+				"content":      omittedToolResponsePlaceholder,
+			})
+			changed++
+		}
+		unanswered = nil
+	}
+
+	for _, m := range messages {
+		role := messageRole(m)
+		switch role {
+		case "assistant":
+			// 新 assistant 出现前，补齐上一条 assistant 缺失的响应
+			fabricateMissing()
+			answerable = map[string]bool{}
+			out = append(out, m)
+			if mm, ok := m.(map[string]any); ok {
+				if tcs, ok := mm["tool_calls"].([]any); ok {
+					for _, tc := range tcs {
+						if tcm, ok := tc.(map[string]any); ok {
+							if id, ok := tcm["id"].(string); ok && id != "" {
+								answerable[id] = true
+								unanswered = append(unanswered, id)
+							}
+						}
+					}
+				}
+			}
+		case "tool":
+			mm, ok := m.(map[string]any)
+			if !ok {
+				out = append(out, m)
+				continue
+			}
+			id, _ := mm["tool_call_id"].(string)
+			if id != "" && answerable[id] {
+				out = append(out, m)
+				// 从 unanswered 中移除
+				for i, u := range unanswered {
+					if u == id {
+						unanswered = append(unanswered[:i], unanswered[i+1:]...)
+						break
+					}
+				}
+			} else {
+				// 孤儿 tool 消息，删除
+				changed++
+			}
+		default:
+			// user/system 等边界消息：tool 响应无法跨边界，先补齐再追加
+			fabricateMissing()
+			answerable = map[string]bool{}
+			out = append(out, m)
+		}
+	}
+	// 末尾 assistant 的未响应 tool_calls（会话结束于 tool 响应是合法的，
+	// 但结束于 assistant(tool_calls) 且无响应会被上游拒绝，补占位）
+	fabricateMissing()
+	return out, changed
+}
+
+// sanitizeChatToolPairing 请求预清洗：修复 chat completions 请求体中的
+// tool/tool_calls 配对问题，每个请求最多执行一次，仅在发现问题时改写请求。
+func sanitizeChatToolPairing(c *gin.Context, info *relaycommon.RelayInfo) {
+	if info == nil || c.GetBool(toolPairingSanitizedKey) {
+		return
+	}
+	c.Set(toolPairingSanitizedKey, true)
+
+	storage, err := common.GetBodyStorage(c)
+	if err != nil {
+		return
+	}
+	raw, err := storage.Bytes()
+	if err != nil {
+		return
+	}
+
+	var reqMap map[string]any
+	if err := common.Unmarshal(raw, &reqMap); err != nil {
+		return
+	}
+	messages, ok := reqMap["messages"].([]any)
+	if !ok || len(messages) == 0 {
+		return
+	}
+
+	sanitized, changed := sanitizeToolCallPairing(messages)
+	if changed == 0 {
+		return
+	}
+	reqMap["messages"] = sanitized
+	newBody, err := common.Marshal(reqMap)
+	if err != nil {
+		return
+	}
+
+	// 同步更新 info.Request（非透传模式 relay 使用解析后的 DTO）
+	if info.Request != nil {
+		if err := common.Unmarshal(newBody, info.Request); err != nil {
+			return
+		}
+	}
+	newStorage, err := common.CreateBodyStorage(newBody)
+	if err != nil {
+		return
+	}
+	_ = storage.Close()
+	c.Set(common.KeyBodyStorage, newStorage)
+	c.Request.Body = io.NopCloser(newStorage)
+	logger.LogWarn(c, fmt.Sprintf("检测到 %d 处 tool/tool_calls 配对问题（客户端上下文压缩残留），已自动修复", changed))
+}
+
+// tryToolPairingRecovery 上游仍报 tool 配对错误时的兜底恢复：强制清洗后原地重试一次
+func tryToolPairingRecovery(c *gin.Context, info *relaycommon.RelayInfo, apiErr *types.NewAPIError) bool {
+	if !constant.ContextOverflowAutoRecovery || apiErr == nil || info == nil {
+		return false
+	}
+	if c.GetBool(toolPairingRecoveredKey) {
+		return false
+	}
+	if !isToolPairingError(apiErr.Error()) {
+		return false
+	}
+	c.Set(toolPairingRecoveredKey, true)
+	// 重置预清洗标记，强制再清洗一次
+	c.Set(toolPairingSanitizedKey, false)
+	sanitizeChatToolPairing(c, info)
+	return true
+}
+
+const payloadRecoveredKey = "payload_too_large_recovered"
+
+const payloadCompressRecoveredKey = "payload_too_large_compress_recovered"
+
+// tryPayloadTooLargeRecovery 检测上游 413 Payload Too Large 错误（请求体字节数超限，
+// 常见于会话累积大量 base64 图片），剥离历史图片后用同一渠道原地重试一次。
+// 与 context 超长恢复互补：413 是字节级超限，与 token 估算无关。
+func tryPayloadTooLargeRecovery(c *gin.Context, info *relaycommon.RelayInfo, apiErr *types.NewAPIError) bool {
+	if !constant.ContextOverflowAutoRecovery || apiErr == nil || info == nil {
+		return false
+	}
+	if apiErr.StatusCode != http.StatusRequestEntityTooLarge {
+		return false
+	}
+	if c.GetBool(payloadRecoveredKey) {
+		return false
+	}
+
+	storage, err := common.GetBodyStorage(c)
+	if err != nil {
+		return false
+	}
+	raw, err := storage.Bytes()
+	if err != nil {
+		return false
+	}
+
+	var reqMap map[string]any
+	if err := common.Unmarshal(raw, &reqMap); err != nil {
+		return false
+	}
+
+	stripped := false
+	// chat completions：messages 数组，文本 part 类型为 text
+	if messages, ok := reqMap["messages"].([]any); ok && len(messages) > 0 {
+		if stripOldImageParts(messages, []string{"content"}, "text") {
+			reqMap["messages"] = messages
+			stripped = true
+		}
+	}
+	// responses：input 数组，message 的 content 与 function_call_output 的 output
+	// 均可能含图片 part，文本 part 类型为 input_text
+	if input, ok := reqMap["input"].([]any); ok && len(input) > 0 {
+		if stripOldImageParts(input, []string{"content", "output"}, "input_text") {
+			reqMap["input"] = input
+			stripped = true
+		}
+	}
+	if !stripped {
+		return false
+	}
+
+	newBody, err := common.Marshal(reqMap)
+	if err != nil {
+		return false
+	}
+	// 更新 info.Request（非透传模式 relay 使用解析后的 DTO，而非重读 body）
+	if info.Request != nil {
+		if err := common.Unmarshal(newBody, info.Request); err != nil {
+			return false
+		}
+	}
+	newStorage, err := common.CreateBodyStorage(newBody)
+	if err != nil {
+		return false
+	}
+	_ = storage.Close()
+	c.Set(common.KeyBodyStorage, newStorage)
+	c.Request.Body = io.NopCloser(newStorage)
+	c.Set(payloadRecoveredKey, true)
+	c.Header("X-Payload-Truncated", fmt.Sprintf("%d->%d", len(raw), len(newBody)))
+	logger.LogWarn(c, fmt.Sprintf("上游 413 Payload Too Large，已剥离历史图片（请求体 %d -> %d 字节）并重试", len(raw), len(newBody)))
+	return true
+}
+
+// tryPayloadTooLargeCompressRecovery 检测上游 413 且请求中无可剥离的历史图片时
+// （如单张超大参考图），压缩请求内的 base64 图片（降采样 + JPEG 重编码）后
+// 用同一渠道原地重试一次。与 tryPayloadTooLargeRecovery 互补：
+// 先剥离历史图片，仍 413 再压缩剩余图片。
+func tryPayloadTooLargeCompressRecovery(c *gin.Context, info *relaycommon.RelayInfo, apiErr *types.NewAPIError) bool {
+	if !constant.ContextOverflowAutoRecovery || apiErr == nil || info == nil {
+		return false
+	}
+	if apiErr.StatusCode != http.StatusRequestEntityTooLarge {
+		return false
+	}
+	if c.GetBool(payloadCompressRecoveredKey) {
+		return false
+	}
+
+	storage, err := common.GetBodyStorage(c)
+	if err != nil {
+		return false
+	}
+	raw, err := storage.Bytes()
+	if err != nil {
+		return false
+	}
+
+	var reqMap map[string]any
+	if err := common.Unmarshal(raw, &reqMap); err != nil {
+		return false
+	}
+
+	if !compressImagesInBody(reqMap) {
+		return false
+	}
+
+	newBody, err := common.Marshal(reqMap)
+	if err != nil {
+		return false
+	}
+	if len(newBody) >= len(raw) {
+		return false
+	}
+
+	// 更新 info.Request（非透传模式 relay 使用解析后的 DTO，而非重新读 body）
+	if info.Request != nil {
+		if err := common.Unmarshal(newBody, info.Request); err != nil {
+			return false
+		}
+	}
+	newStorage, err := common.CreateBodyStorage(newBody)
+	if err != nil {
+		return false
+	}
+	_ = storage.Close()
+	c.Set(common.KeyBodyStorage, newStorage)
+	c.Request.Body = io.NopCloser(newStorage)
+	c.Set(payloadCompressRecoveredKey, true)
+	c.Header("X-Images-Compressed", fmt.Sprintf("%d->%d", len(raw), len(newBody)))
+	logger.LogWarn(c, fmt.Sprintf("上游 413 Payload Too Large，已压缩请求内图片（请求体 %d -> %d 字节）并重试", len(raw), len(newBody)))
+	return true
+}
+
+// compressImagesInBody 压缩 chat completions / responses 请求体中的 base64 图片 part，
+// 返回是否有图片被压缩替换。
+func compressImagesInBody(reqMap map[string]any) bool {
+	changed := false
+	if messages, ok := reqMap["messages"].([]any); ok {
+		for _, m := range messages {
+			if mm, ok := m.(map[string]any); ok && compressImageParts(mm, "content") {
+				changed = true
+			}
+		}
+	}
+	if input, ok := reqMap["input"].([]any); ok {
+		for _, item := range input {
+			if mm, ok := item.(map[string]any); ok {
+				if compressImageParts(mm, "content") {
+					changed = true
+				}
+				if compressImageParts(mm, "output") {
+					changed = true
+				}
+			}
+		}
+	}
+	return changed
+}
+
+// compressImageParts 压缩 item 指定字段（part 数组）中的图片 part
+func compressImageParts(mm map[string]any, field string) bool {
+	parts, ok := mm[field].([]any)
+	if !ok {
+		return false
+	}
+	changed := false
+	for _, p := range parts {
+		pm, ok := p.(map[string]any)
+		if !ok {
+			continue
+		}
+		partType, _ := pm["type"].(string)
+		switch partType {
+		case "image_url", "input_image", "image":
+			if v, ok := pm["image_url"]; ok {
+				if nv, ch := compressImageURLValue(v); ch {
+					pm["image_url"] = nv
+					changed = true
+				}
+			}
+		}
+	}
+	return changed
+}
+
+// compressImageURLValue 压缩单个 image_url 值（字符串或 {url: ...} 对象）
+func compressImageURLValue(v any) (any, bool) {
+	switch vv := v.(type) {
+	case string:
+		nv, err := service.CompressImageDataURL(vv)
+		if err != nil {
+			return v, false
+		}
+		return nv, true
+	case map[string]any:
+		url, _ := vv["url"].(string)
+		nv, err := service.CompressImageDataURL(url)
+		if err != nil {
+			return v, false
+		}
+		vv["url"] = nv
+		return vv, true
+	default:
+		return v, false
+	}
+}
+
+// tryImageUnsupportedRecovery 检测上游"模型不支持图片输入"错误，剥离请求中
+// 所有图片（替换为提示占位文本）后用同一渠道原地重试一次，实现用户无感；
+// 通过占位文本与响应头 X-Images-Removed 提示用户图片已被剔除。
+func tryImageUnsupportedRecovery(c *gin.Context, info *relaycommon.RelayInfo, apiErr *types.NewAPIError) bool {
+	if !constant.ContextOverflowAutoRecovery || apiErr == nil || info == nil {
+		return false
+	}
+	if c.GetBool(imageUnsupportedRecoveredKey) {
+		return false
+	}
+	if !isImageUnsupportedError(apiErr.Error()) {
+		return false
+	}
+
+	storage, err := common.GetBodyStorage(c)
+	if err != nil {
+		return false
+	}
+	raw, err := storage.Bytes()
+	if err != nil {
+		return false
+	}
+
+	var reqMap map[string]any
+	if err := common.Unmarshal(raw, &reqMap); err != nil {
+		return false
+	}
+
+	removed := 0
+	// chat completions：messages 数组，文本 part 类型为 text
+	if messages, ok := reqMap["messages"].([]any); ok && len(messages) > 0 {
+		if n, ch := stripAllImageParts(messages, []string{"content"}, "text"); ch {
+			reqMap["messages"] = messages
+			removed = n
+		}
+	}
+	// responses：input 数组，message 的 content 与 function_call_output 的 output
+	// 均可能含图片 part，文本 part 类型为 input_text
+	if input, ok := reqMap["input"].([]any); ok && len(input) > 0 {
+		if n, ch := stripAllImageParts(input, []string{"content", "output"}, "input_text"); ch {
+			reqMap["input"] = input
+			removed += n
+		}
+	}
+	if removed == 0 {
+		return false
+	}
+
+	newBody, err := common.Marshal(reqMap)
+	if err != nil {
+		return false
+	}
+	// 更新 info.Request（非透传模式 relay 使用解析后的 DTO，而非重新读 body）
+	if info.Request != nil {
+		if err := common.Unmarshal(newBody, info.Request); err != nil {
+			return false
+		}
+	}
+	newStorage, err := common.CreateBodyStorage(newBody)
+	if err != nil {
+		return false
+	}
+	_ = storage.Close()
+	c.Set(common.KeyBodyStorage, newStorage)
+	c.Set(imageUnsupportedRecoveredKey, true)
+	c.Header("X-Images-Removed", strconv.Itoa(removed))
+	logger.LogWarn(c, fmt.Sprintf("上游不支持图片输入，已移除 %d 张图片（占位提示）并重试", removed))
+	return true
+}

--- a/controller/context_recovery_test.go
+++ b/controller/context_recovery_test.go
@@ -1,0 +1,416 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/base64"
+	"image"
+	"image/color"
+	"image/png"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+func TestStripOldImagePartsChatMessages(t *testing.T) {
+	img := func() map[string]any {
+		return map[string]any{"type": "image_url", "image_url": map[string]any{"url": "data:image/png;base64,AAAA"}}
+	}
+	messages := []any{
+		map[string]any{"role": "user", "content": []any{img(), map[string]any{"type": "text", "text": "old"}}},
+		map[string]any{"role": "assistant", "content": "ok"},
+		map[string]any{"role": "user", "content": []any{img(), map[string]any{"type": "text", "text": "new"}}},
+	}
+	changed := stripOldImageParts(messages, []string{"content"}, "text")
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	// 第一条消息的图片应被替换为文本占位
+	first := messages[0].(map[string]any)["content"].([]any)
+	if first[0].(map[string]any)["type"] != "text" {
+		t.Fatalf("expected old image replaced with text part, got %v", first[0])
+	}
+	if first[0].(map[string]any)["text"] != omittedImagePlaceholder {
+		t.Fatalf("unexpected placeholder: %v", first[0])
+	}
+	// 最后一条含图消息的图片必须保留
+	last := messages[2].(map[string]any)["content"].([]any)
+	if last[0].(map[string]any)["type"] != "image_url" {
+		t.Fatalf("expected last image kept, got %v", last[0])
+	}
+}
+
+func TestStripOldImagePartsResponsesInput(t *testing.T) {
+	imgPart := func() map[string]any {
+		return map[string]any{"type": "input_image", "image_url": "data:image/png;base64,BBBB"}
+	}
+	input := []any{
+		map[string]any{"type": "message", "role": "user", "content": []any{imgPart()}},
+		map[string]any{"type": "function_call_output", "call_id": "fc_1", "output": []any{imgPart()}},
+		map[string]any{"type": "reasoning", "id": "rs_1"},
+		map[string]any{"type": "message", "role": "user", "content": []any{imgPart()}},
+	}
+	changed := stripOldImageParts(input, []string{"content", "output"}, "input_text")
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	// message content 中的旧图片应替换为 input_text 占位
+	first := input[0].(map[string]any)["content"].([]any)
+	if first[0].(map[string]any)["type"] != "input_text" {
+		t.Fatalf("expected input_text placeholder, got %v", first[0])
+	}
+	// function_call_output 的 output 数组中的图片也应剥离
+	fco := input[1].(map[string]any)["output"].([]any)
+	if fco[0].(map[string]any)["type"] != "input_text" {
+		t.Fatalf("expected function_call_output image stripped, got %v", fco[0])
+	}
+	// reasoning item 不含图片，不受影响
+	if input[2].(map[string]any)["id"] != "rs_1" {
+		t.Fatalf("reasoning item should be untouched: %v", input[2])
+	}
+	// 最后一条含图 item 保留
+	last := input[3].(map[string]any)["content"].([]any)
+	if last[0].(map[string]any)["type"] != "input_image" {
+		t.Fatalf("expected last image kept, got %v", last[0])
+	}
+}
+
+func TestStripOldImagePartsNoImage(t *testing.T) {
+	messages := []any{
+		map[string]any{"role": "user", "content": "hello"},
+		map[string]any{"role": "assistant", "content": "hi"},
+	}
+	if stripOldImageParts(messages, []string{"content"}, "text") {
+		t.Fatal("expected changed=false for text-only messages")
+	}
+}
+
+// 模拟 413 恢复路径：请求体含 messages + 大量 base64 图片，剥离后请求体应显著缩小
+func TestPayloadRecoveryShrinksBody(t *testing.T) {
+	bigImage := "data:image/png;base64," + strings.Repeat("A", 500000)
+	raw := []byte(`{"model":"gpt-5.4","input":[` +
+		`{"type":"message","role":"user","content":[{"type":"input_image","image_url":"` + bigImage + `"},{"type":"input_text","text":"img 1"}]},` +
+		`{"type":"message","role":"user","content":[{"type":"input_image","image_url":"` + bigImage + `"},{"type":"input_text","text":"img 2"}]},` +
+		`{"type":"message","role":"user","content":[{"type":"input_image","image_url":"` + bigImage + `"},{"type":"input_text","text":"img 3"}]}` +
+		`]}`)
+
+	var reqMap map[string]any
+	if err := common.Unmarshal(raw, &reqMap); err != nil {
+		t.Fatal(err)
+	}
+	input := reqMap["input"].([]any)
+	if !stripOldImageParts(input, []string{"content", "output"}, "input_text") {
+		t.Fatal("expected changed=true")
+	}
+	reqMap["input"] = input
+	newBody, err := common.Marshal(reqMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(newBody) >= len(raw)/2 {
+		t.Fatalf("expected body shrunk significantly, before=%d after=%d", len(raw), len(newBody))
+	}
+	if !strings.Contains(string(newBody), omittedImagePlaceholder) {
+		t.Fatal("expected placeholder in new body")
+	}
+	// 最新图片应保留完整 data url
+	if !strings.Contains(string(newBody), bigImage) {
+		t.Fatal("expected latest image data url kept")
+	}
+}
+
+func TestParseContextOverflowMaxTokens(t *testing.T) {
+	cases := []struct {
+		name    string
+		message string
+		want    int
+		ok      bool
+	}{
+		{
+			name:    "openai",
+			message: "This model's maximum context length is 128000 tokens. However, your messages resulted in 130000 tokens. Please reduce the length of the messages or completion.",
+			want:    128000,
+			ok:      true,
+		},
+		{
+			name:    "deepseek",
+			message: "This model's maximum context length is 1048565 tokens. However, you requested 3220751 tokens",
+			want:    1048565,
+			ok:      true,
+		},
+		{
+			name:    "oc configured limit",
+			message: "Input tokens exceed the configured limit of 922000 tokens. Your messages resulted in 1055751 tokens. Please reduce the length of the messages.",
+			want:    922000,
+			ok:      true,
+		},
+		{
+			name:    "kimi model token limit",
+			message: "Invalid request: Your request exceeded model token limit: 262144 (requested: 1055340)",
+			want:    262144,
+			ok:      true,
+		},
+		{
+			name:    "not a context overflow",
+			message: "insufficient quota",
+			ok:      false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseContextOverflowMaxTokens(tc.message)
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("parseContextOverflowMaxTokens(%q) = (%d, %v), want (%d, %v)", tc.message, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestIsImageUnsupportedError(t *testing.T) {
+	cases := []struct {
+		name    string
+		message string
+		want    bool
+	}{
+		{
+			name:    "does not support images",
+			message: "Invalid request: This model does not support images in the conversation.",
+			want:    true,
+		},
+		{
+			name:    "unknown variant image_url (deepseek-v4-flash)",
+			message: "Failed to deserialize the JSON body into the target type: messages[7]: unknown variant `image_url`, expected `text` at line 1 column 1626970",
+			want:    true,
+		},
+		{
+			name:    "unknown variant image (double-quoted)",
+			message: `Failed to deserialize: unknown variant "image_url", expected text`,
+			want:    true,
+		},
+		{
+			name:    "image input not supported",
+			message: "Image input is not supported for this model.",
+			want:    true,
+		},
+		{
+			name:    "unsupported image",
+			message: "Unsupported image content type.",
+			want:    true,
+		},
+		{
+			name:    "no vision support",
+			message: "The model does not support vision inputs.",
+			want:    true,
+		},
+		{
+			name:    "unrelated error",
+			message: "Insufficient quota for the request.",
+			want:    false,
+		},
+		{
+			name:    "context overflow",
+			message: "Your request exceeded model token limit: 262144 (requested: 1055340)",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isImageUnsupportedError(tc.message); got != tc.want {
+				t.Fatalf("isImageUnsupportedError(%q) = %v, want %v", tc.message, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStripAllImagePartsChatMessages(t *testing.T) {
+	img := func() map[string]any {
+		return map[string]any{"type": "image_url", "image_url": map[string]any{"url": "data:image/png;base64,AAAA"}}
+	}
+	messages := []any{
+		map[string]any{"role": "user", "content": []any{img(), map[string]any{"type": "text", "text": "看图"}}},
+		map[string]any{"role": "assistant", "content": "ok"},
+		map[string]any{"role": "user", "content": []any{img(), img()}},
+	}
+	removed, changed := stripAllImageParts(messages, []string{"content"}, "text")
+	if !changed || removed != 3 {
+		t.Fatalf("expected changed=true removed=3, got changed=%v removed=%d", changed, removed)
+	}
+	placeholderSeen := false
+	for i, m := range messages {
+		mm := m.(map[string]any)
+		content, ok := mm["content"].([]any)
+		if !ok {
+			continue
+		}
+		for _, p := range content {
+			pm := p.(map[string]any)
+			if pm["type"] == "text" && pm["text"] == imageRemovedPlaceholder {
+				placeholderSeen = true
+				continue
+			}
+			if pm["type"] == "image_url" {
+				t.Fatalf("message %d: image part should have been removed, got %v", i, p)
+			}
+		}
+	}
+	if !placeholderSeen {
+		t.Fatal("expected at least one imageRemovedPlaceholder in messages")
+	}
+}
+
+func TestStripAllImagePartsResponsesInput(t *testing.T) {
+	imgPart := func() map[string]any {
+		return map[string]any{"type": "input_image", "image_url": "data:image/png;base64,BBBB"}
+	}
+	input := []any{
+		map[string]any{"type": "message", "role": "user", "content": []any{imgPart()}},
+		map[string]any{"type": "function_call_output", "call_id": "fc_1", "output": []any{imgPart()}},
+	}
+	removed, changed := stripAllImageParts(input, []string{"content", "output"}, "input_text")
+	if !changed || removed != 2 {
+		t.Fatalf("expected changed=true removed=2, got changed=%v removed=%d", changed, removed)
+	}
+	first := input[0].(map[string]any)["content"].([]any)[0].(map[string]any)
+	if first["type"] != "input_text" || first["text"] != imageRemovedPlaceholder {
+		t.Fatalf("expected input_text placeholder, got %v", first)
+	}
+	fco := input[1].(map[string]any)["output"].([]any)[0].(map[string]any)
+	if fco["type"] != "input_text" || fco["text"] != imageRemovedPlaceholder {
+		t.Fatalf("expected function_call_output placeholder, got %v", fco)
+	}
+}
+
+func TestIsToolPairingErrorNoToolOutputFound(t *testing.T) {
+	cases := []struct {
+		name    string
+		message string
+		want    bool
+	}{
+		{
+			name:    "cooai no tool output found",
+			message: "No tool output found for tool call call_02_9r7hnOiZfy9N67N7azD82137.",
+			want:    true,
+		},
+		{
+			name:    "no output found for function call",
+			message: "No output found for function call call_abc123",
+			want:    true,
+		},
+		{
+			name:    "must be followed by tool messages",
+			message: "assistant message with 'tool_calls' must be followed by tool messages",
+			want:    true,
+		},
+		{
+			name:    "unrelated error",
+			message: "The server had an error while processing your request.",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		if got := isToolPairingError(tc.message); got != tc.want {
+			t.Fatalf("%s: isToolPairingError(%q) = %v, want %v", tc.name, tc.message, got, tc.want)
+		}
+	}
+}
+
+func TestCompressImagesInBodyChatMessages(t *testing.T) {
+	imgPart := func() map[string]any {
+		// 大尺寸 base64 PNG，压缩后必然变小
+		dataURL := testCompressPNGDataURL(t, 1600, 1200)
+		return map[string]any{"type": "image_url", "image_url": map[string]any{"url": dataURL}}
+	}
+	reqMap := map[string]any{
+		"model": "chatgpt-5.4",
+		"messages": []any{
+			map[string]any{"role": "user", "content": []any{imgPart(), map[string]any{"type": "text", "text": "用这张参考图做海报"}}},
+		},
+	}
+	raw, err := common.Marshal(reqMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compressImagesInBody(reqMap) {
+		t.Fatal("expected compressImagesInBody changed=true")
+	}
+	newBody, err := common.Marshal(reqMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(newBody) >= len(raw) {
+		t.Fatalf("expected body shrunk: before=%d after=%d", len(raw), len(newBody))
+	}
+	var parsed map[string]any
+	if err := common.Unmarshal(newBody, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	content := parsed["messages"].([]any)[0].(map[string]any)["content"].([]any)
+	url := content[0].(map[string]any)["image_url"].(map[string]any)["url"].(string)
+	if !strings.HasPrefix(url, "data:image/jpeg;base64,") {
+		t.Fatalf("expected compressed jpeg data url, got prefix: %s", url[:40])
+	}
+}
+
+func TestCompressImagesInBodyResponsesInput(t *testing.T) {
+	dataURL := testCompressPNGDataURL(t, 1600, 1200)
+	reqMap := map[string]any{
+		"model": "chatgpt-5.4",
+		"input": []any{
+			map[string]any{"type": "message", "role": "user", "content": []any{
+				map[string]any{"type": "input_image", "image_url": dataURL},
+			}},
+		},
+	}
+	raw, err := common.Marshal(reqMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compressImagesInBody(reqMap) {
+		t.Fatal("expected compressImagesInBody changed=true")
+	}
+	newBody, err := common.Marshal(reqMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(newBody) >= len(raw) {
+		t.Fatalf("expected body shrunk: before=%d after=%d", len(raw), len(newBody))
+	}
+	var parsed map[string]any
+	if err := common.Unmarshal(newBody, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	content := parsed["input"].([]any)[0].(map[string]any)["content"].([]any)
+	url := content[0].(map[string]any)["image_url"].(string)
+	if !strings.HasPrefix(url, "data:image/jpeg;base64,") {
+		t.Fatalf("expected compressed jpeg data url, got prefix: %s", url[:40])
+	}
+}
+
+func TestCompressImagesInBodyNoChangeWhenSmallOrAbsent(t *testing.T) {
+	reqMap := map[string]any{
+		"model": "chatgpt-5.4",
+		"input": []any{
+			map[string]any{"type": "message", "role": "user", "content": "没有图片"},
+		},
+	}
+	if compressImagesInBody(reqMap) {
+		t.Fatal("expected no change for text-only body")
+	}
+}
+
+func testCompressPNGDataURL(t *testing.T, w, h int) string {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	rnd := rand.New(rand.NewSource(42))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(rnd.Intn(256)), G: uint8(rnd.Intn(256)), B: uint8(rnd.Intn(256)), A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(buf.Bytes())
+}

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -217,6 +217,12 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 		}
 		c.Request.Body = io.NopCloser(bodyStorage)
 
+		// 请求预清洗：修复客户端上下文压缩等原因产生的 tool/tool_calls 配对问题
+		//（孤儿 tool 删除、缺失响应补占位），仅在发现问题时改写请求
+		if relayFormat == types.RelayFormatOpenAI && relayInfo.RelayMode == relayconstant.RelayModeChatCompletions {
+			sanitizeChatToolPairing(c, relayInfo)
+		}
+
 		switch relayFormat {
 		case types.RelayFormatOpenAIRealtime:
 			newAPIError = relay.WssHelper(c, relayInfo)
@@ -225,6 +231,55 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 		case types.RelayFormatGemini:
 			newAPIError = geminiRelayHandler(c, relayInfo)
 		default:
+			newAPIError = relayHandler(c, relayInfo)
+		}
+
+		// context 超长自动恢复：裁剪历史消息后用同一渠道原地重试一次，实现用户无感知
+		if newAPIError != nil && relayFormat == types.RelayFormatOpenAI &&
+			relayInfo.RelayMode == relayconstant.RelayModeChatCompletions &&
+			tryContextOverflowRecovery(c, relayInfo, newAPIError) {
+			newAPIError = relayHandler(c, relayInfo)
+		}
+
+		// 上游 413（请求体字节超限，常见于会话累积大量 base64 图片）自动恢复：
+		// 剥离历史图片后用同一渠道原地重试一次
+		if newAPIError != nil && relayFormat == types.RelayFormatOpenAI &&
+			(relayInfo.RelayMode == relayconstant.RelayModeChatCompletions ||
+				relayInfo.RelayMode == relayconstant.RelayModeResponses ||
+				relayInfo.RelayMode == relayconstant.RelayModeResponsesCompact) &&
+			tryPayloadTooLargeRecovery(c, relayInfo, newAPIError) {
+			newAPIError = relayHandler(c, relayInfo)
+		}
+
+		// 剥离历史图片后仍 413（如单张超大参考图）时，压缩请求内图片后原地重试一次
+		if newAPIError != nil && relayFormat == types.RelayFormatOpenAI &&
+			(relayInfo.RelayMode == relayconstant.RelayModeChatCompletions ||
+				relayInfo.RelayMode == relayconstant.RelayModeResponses ||
+				relayInfo.RelayMode == relayconstant.RelayModeResponsesCompact) &&
+			tryPayloadTooLargeCompressRecovery(c, relayInfo, newAPIError) {
+			newAPIError = relayHandler(c, relayInfo)
+		}
+
+		// 上游"模型不支持图片输入"自动恢复：剥离请求中所有图片后原地重试，
+		// 用户无感，并通过占位文本与 X-Images-Removed 响应头提示
+		if newAPIError != nil && relayFormat == types.RelayFormatOpenAI &&
+			(relayInfo.RelayMode == relayconstant.RelayModeChatCompletions ||
+				relayInfo.RelayMode == relayconstant.RelayModeResponses ||
+				relayInfo.RelayMode == relayconstant.RelayModeResponsesCompact) &&
+			tryImageUnsupportedRecovery(c, relayInfo, newAPIError) {
+			newAPIError = relayHandler(c, relayInfo)
+			// 剥离图片后重试仍可能超长（图片 token 大，剔除后上下文仍超），
+			// 再尝试一次上下文裁剪恢复
+			if newAPIError != nil && relayInfo.RelayMode == relayconstant.RelayModeChatCompletions &&
+				tryContextOverflowRecovery(c, relayInfo, newAPIError) {
+				newAPIError = relayHandler(c, relayInfo)
+			}
+		}
+
+		// tool 配对错误兜底恢复：强制清洗后原地重试一次
+		if newAPIError != nil && relayFormat == types.RelayFormatOpenAI &&
+			relayInfo.RelayMode == relayconstant.RelayModeChatCompletions &&
+			tryToolPairingRecovery(c, relayInfo, newAPIError) {
 			newAPIError = relayHandler(c, relayInfo)
 		}
 

--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -1,13 +1,18 @@
 package relay
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
+	appconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/logger"
+	"github.com/QuantumNous/new-api/relay/channel"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/relay/helper"
@@ -15,9 +20,567 @@ import (
 	"github.com/QuantumNous/new-api/relaykit/types"
 	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting/model_setting"
-
 	"github.com/gin-gonic/gin"
 )
+
+func isResponsesContentArrayErrorMessage(msg string) bool {
+	msg = strings.ToLower(msg)
+	return strings.Contains(msg, "invalid 'input[") &&
+		strings.Contains(msg, ".content'") &&
+		strings.Contains(msg, "array too long")
+}
+
+func isResponsesReasoningSummaryErrorMessage(msg string) bool {
+	msg = strings.ToLower(msg)
+	return strings.Contains(msg, "missing required parameter") &&
+		strings.Contains(msg, "input[") &&
+		strings.Contains(msg, ".summary'")
+}
+
+func isResponsesEncryptedContentErrorMessage(msg string) bool {
+	msg = strings.ToLower(msg)
+	return strings.Contains(msg, "encrypted content") &&
+		(strings.Contains(msg, "could not be verified") ||
+			strings.Contains(msg, "could not be decrypted") ||
+			strings.Contains(msg, "could not be parsed"))
+}
+
+var responsesContextOverflowPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)maximum context length is (\d+) tokens`),
+	regexp.MustCompile(`(?i)configured limit of (\d+) tokens`),
+	regexp.MustCompile(`(?i)model token limit: (\d+)`),
+}
+
+var responsesImageUnsupportedPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)not support.{0,40}(?:image|vision)`),
+	regexp.MustCompile(`(?i)(?:image|vision).{0,40}(?:not support|unsupported)`),
+	regexp.MustCompile(`(?i)unsupported.{0,40}(?:image|vision)`),
+	regexp.MustCompile(`(?i)unknown variant\s+` + "`" + `image`),
+	regexp.MustCompile(`(?i)unknown variant\s+"image`),
+}
+
+const responsesImageRemovedPlaceholder = "[图片已移除：当前模型不支持图片输入]"
+
+func parseResponsesContextOverflowMaxTokens(msg string) (int, bool) {
+	for _, pattern := range responsesContextOverflowPatterns {
+		m := pattern.FindStringSubmatch(msg)
+		if m == nil {
+			continue
+		}
+		maxTokens, err := strconv.Atoi(m[1])
+		if err != nil || maxTokens <= 0 {
+			return 0, false
+		}
+		return maxTokens, true
+	}
+	return 0, false
+}
+
+func isResponsesImageUnsupportedError(msg string) bool {
+	for _, pattern := range responsesImageUnsupportedPatterns {
+		if pattern.MatchString(msg) {
+			return true
+		}
+	}
+	return false
+}
+
+func flattenResponsesContentArraysForRetry(body []byte) ([]byte, bool) {
+	return rewriteResponsesInputForRetry(body, false, false)
+}
+
+func summarizeResponsesReasoningItemsForRetry(body []byte) ([]byte, bool) {
+	return rewriteResponsesInputForRetry(body, false, true)
+}
+
+func stripResponsesReasoningItemsForRetry(body []byte) ([]byte, bool) {
+	return rewriteResponsesInputForRetry(body, true, false)
+}
+
+func hasResponsesReasoningItems(body []byte) bool {
+	var reqMap map[string]any
+	if err := common.Unmarshal(body, &reqMap); err != nil {
+		return false
+	}
+	input, ok := reqMap["input"].([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range input {
+		if mm, ok := item.(map[string]any); ok {
+			if itemType, _ := mm["type"].(string); itemType == "reasoning" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func summarizeResponsesInputTypes(body []byte) string {
+	var reqMap map[string]any
+	if err := common.Unmarshal(body, &reqMap); err != nil {
+		return "unmarshal_failed"
+	}
+	input, ok := reqMap["input"].([]any)
+	if !ok {
+		return "no_input_array"
+	}
+	typesSeen := make([]string, 0, len(input))
+	for _, item := range input {
+		if mm, ok := item.(map[string]any); ok {
+			itemType, _ := mm["type"].(string)
+			if itemType == "" {
+				if role, _ := mm["role"].(string); role != "" {
+					itemType = "role:" + role
+				} else {
+					itemType = "unknown"
+				}
+			}
+			typesSeen = append(typesSeen, itemType)
+		}
+	}
+	return strings.Join(typesSeen, ",")
+}
+
+func responsesIsImagePart(pm map[string]any) bool {
+	partType, _ := pm["type"].(string)
+	switch partType {
+	case "image_url", "input_image", "image":
+		return true
+	}
+	return false
+}
+
+func stripAllResponsesImageParts(items []any, fields []string, textPartType string) (int, bool) {
+	removed := 0
+	changed := false
+	for _, item := range items {
+		mm, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, field := range fields {
+			parts, ok := mm[field].([]any)
+			if !ok {
+				continue
+			}
+			itemRemoved := 0
+			newParts := make([]any, 0, len(parts))
+			for _, p := range parts {
+				pm, ok := p.(map[string]any)
+				if !ok || !responsesIsImagePart(pm) {
+					newParts = append(newParts, p)
+					continue
+				}
+				newParts = append(newParts, map[string]any{"type": textPartType, "text": responsesImageRemovedPlaceholder})
+				itemRemoved++
+			}
+			if itemRemoved > 0 {
+				mm[field] = newParts
+				removed += itemRemoved
+				changed = true
+			}
+		}
+	}
+	return removed, changed
+}
+
+func stripResponsesImagesForUnsupportedRetry(body []byte) ([]byte, int, bool) {
+	var reqMap map[string]any
+	if err := common.Unmarshal(body, &reqMap); err != nil {
+		return body, 0, false
+	}
+	removed := 0
+	if input, ok := reqMap["input"].([]any); ok && len(input) > 0 {
+		if n, ch := stripAllResponsesImageParts(input, []string{"content", "output"}, "input_text"); ch {
+			reqMap["input"] = input
+			removed += n
+		}
+	}
+	if removed == 0 {
+		return body, 0, false
+	}
+	out, err := common.Marshal(reqMap)
+	if err != nil {
+		return body, 0, false
+	}
+	return out, removed, true
+}
+
+func truncateResponsesMessageString(input []any, maxTokens int, model string) bool {
+	if len(input) == 0 || maxTokens <= 0 {
+		return false
+	}
+	targetChars := maxTokens * 3
+	changed := false
+	for i := 0; i < len(input)-1; i++ {
+		item, ok := input[i].(map[string]any)
+		if !ok {
+			continue
+		}
+		if item["type"] != "message" {
+			continue
+		}
+		content, ok := item["content"].(string)
+		if !ok || len(content) <= targetChars || targetChars <= 64 {
+			continue
+		}
+		keep := targetChars / 2
+		item["content"] = content[:keep] + "\n...[历史内容已截断]...\n" + content[len(content)-keep:]
+		changed = true
+	}
+	return changed
+}
+
+func truncateResponsesInputForContextRetry(body []byte, maxTokens int, model string) ([]byte, bool) {
+	var reqMap map[string]any
+	if err := common.Unmarshal(body, &reqMap); err != nil {
+		return body, false
+	}
+	input, ok := reqMap["input"].([]any)
+	if !ok || len(input) == 0 {
+		return body, false
+	}
+	changed := false
+	if truncateResponsesMessageString(input, maxTokens, model) {
+		changed = true
+	}
+	targetItems := int(float64(maxTokens) * 0.7)
+	for len(input) > 1 && len(input)*12000 > targetItems {
+		input = input[1:]
+		changed = true
+	}
+	if !changed {
+		return body, false
+	}
+	reqMap["input"] = input
+	out, err := common.Marshal(reqMap)
+	if err != nil {
+		return body, false
+	}
+	return out, true
+}
+
+const responsesOmittedToolOutputPlaceholder = "[工具调用结果已省略]"
+
+// isResponsesToolPairingError 匹配上游 function_call / function_call_output
+// 配对缺失类错误，例如：
+// cooai/deepseek: "No tool output found for tool call call_02_..."
+// openai:         "No function call found for function_call_output item with call_id ..."
+func isResponsesToolPairingError(msg string) bool {
+	lower := strings.ToLower(msg)
+	return strings.Contains(lower, "no tool output found for tool call") ||
+		strings.Contains(lower, "no output found for function call") ||
+		strings.Contains(lower, "no function call found") ||
+		(strings.Contains(lower, "tool output") && strings.Contains(lower, "missing"))
+}
+
+// sanitizeResponsesToolCallPairing 修复 responses input 中 function_call /
+// function_call_output 配对问题：
+//  1. dropOrphanOutputs 为 true 时，删除孤儿 function_call_output
+//     （前面没有携带对应 call_id 的 function_call）
+//  2. 为缺失响应的 function_call 补充占位 function_call_output，避免
+//     "No tool output found for tool call ..." 错误
+//
+// 与 chat 侧 sanitizeToolCallPairing 语义一致，但允许连续的 function_call
+// 同时挂起（responses 中并行工具调用是多个独立 item）。
+// dropOrphanOutputs 为 false 时（请求携带 previous_response_id），
+// 未匹配的 function_call_output 会被保留：其 function_call 可能位于
+// 上游服务端会话中，删除会破坏正常工具调用续跑流程。
+func sanitizeResponsesToolCallPairing(input []any, dropOrphanOutputs bool) ([]any, int) {
+	changed := 0
+	out := make([]any, 0, len(input)+2)
+	answerable := map[string]bool{}
+	var unanswered []string
+
+	fabricateMissing := func() {
+		for _, id := range unanswered {
+			out = append(out, map[string]any{
+				"type":    "function_call_output",
+				"call_id": id,
+				"output":  responsesOmittedToolOutputPlaceholder,
+			})
+			changed++
+		}
+		unanswered = nil
+	}
+
+	for _, item := range input {
+		mm, ok := item.(map[string]any)
+		if !ok {
+			out = append(out, item)
+			continue
+		}
+		itemType, _ := mm["type"].(string)
+		switch itemType {
+		case "function_call":
+			out = append(out, item)
+			if id, _ := mm["call_id"].(string); id != "" && !answerable[id] {
+				answerable[id] = true
+				unanswered = append(unanswered, id)
+			}
+		case "function_call_output":
+			id, _ := mm["call_id"].(string)
+			pending := false
+			for i, u := range unanswered {
+				if u == id {
+					pending = true
+					unanswered = append(unanswered[:i], unanswered[i+1:]...)
+					break
+				}
+			}
+			if id != "" && pending {
+				out = append(out, item)
+			} else if dropOrphanOutputs {
+				// 孤儿/重复 function_call_output（其 function_call 已被压缩/剥离或已响应），删除
+				changed++
+			} else {
+				// previous_response_id 场景：保留可能与服务端会话配对的输出
+				out = append(out, item)
+			}
+		case "message":
+			// 边界消息：function_call 响应无法跨消息，先补齐再追加
+			fabricateMissing()
+			answerable = map[string]bool{}
+			out = append(out, item)
+		default:
+			// reasoning / item_reference 等不打断配对
+			out = append(out, item)
+		}
+	}
+	// 末尾仍有未响应的 function_call，补占位
+	fabricateMissing()
+	return out, changed
+}
+
+// sanitizeResponsesToolPairingForRetry 在请求体上执行 function_call 配对清洗，
+// 返回清洗后的请求体与是否有修改。
+func sanitizeResponsesToolPairingForRetry(body []byte) ([]byte, bool) {
+	var reqMap map[string]any
+	if err := common.Unmarshal(body, &reqMap); err != nil {
+		return body, false
+	}
+	input, ok := reqMap["input"].([]any)
+	if !ok || len(input) == 0 {
+		return body, false
+	}
+	// previous_response_id 时，input 中可能只包含 function_call_output，
+	// 其 function_call 位于上游服务端会话中，不能按孤儿输出删除
+	previousID, _ := reqMap["previous_response_id"].(string)
+	sanitized, changed := sanitizeResponsesToolCallPairing(input, previousID == "")
+	if changed == 0 {
+		return body, false
+	}
+	reqMap["input"] = sanitized
+	out, err := common.Marshal(reqMap)
+	if err != nil {
+		return body, false
+	}
+	return out, true
+}
+
+// tryResponsesToolPairingRecovery 修复 responses input 中 function_call /
+// function_call_output 配对问题后用同一渠道重试一次，返回重试结果；
+// 无需修改时不重试（返回 nil, nil）。
+func tryResponsesToolPairingRecovery(c *gin.Context, info *relaycommon.RelayInfo, adaptor channel.Adaptor, body []byte, logMessage string) (*http.Response, *types.NewAPIError) {
+	if !appconstant.ContextOverflowAutoRecovery {
+		return nil, nil
+	}
+	newBody, changed := sanitizeResponsesToolPairingForRetry(body)
+	if !changed {
+		return nil, nil
+	}
+	return retryResponsesRequest(c, info, adaptor, newBody, logMessage)
+}
+
+func extractReasoningSummaryText(summary any) string {
+	summaryParts, ok := summary.([]any)
+	if !ok {
+		return ""
+	}
+	texts := make([]string, 0, len(summaryParts))
+	for _, partAny := range summaryParts {
+		part, ok := partAny.(map[string]any)
+		if !ok {
+			continue
+		}
+		partType, _ := part["type"].(string)
+		if partType != "summary_text" && partType != "text" {
+			continue
+		}
+		text, _ := part["text"].(string)
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		texts = append(texts, text)
+	}
+	return strings.TrimSpace(strings.Join(texts, "\n\n"))
+}
+
+func rewriteResponsesInputForRetry(body []byte, dropReasoning bool, summarizeReasoning bool) ([]byte, bool) {
+	var reqMap map[string]any
+	if err := common.Unmarshal(body, &reqMap); err != nil {
+		return body, false
+	}
+	inputVal, ok := reqMap["input"]
+	if !ok {
+		return body, false
+	}
+	inputBytes, err := common.Marshal(inputVal)
+	if err != nil {
+		return body, false
+	}
+	var input []map[string]any
+	if err := common.Unmarshal(inputBytes, &input); err != nil {
+		return body, false
+	}
+	changed := false
+	filtered := make([]map[string]any, 0, len(input))
+	for _, item := range input {
+		itemType, _ := item["type"].(string)
+		if itemType == "reasoning" {
+			if dropReasoning {
+				changed = true
+				continue
+			}
+			_, hasEncrypted := item["encrypted_content"]
+			if hasEncrypted {
+				delete(item, "encrypted_content")
+				changed = true
+			}
+			if summarizeReasoning {
+				summaryText := extractReasoningSummaryText(item["summary"])
+				if summaryText != "" {
+					filtered = append(filtered, map[string]any{
+						"type":    "message",
+						"role":    "assistant",
+						"content": "[Context Summary]\n" + summaryText,
+					})
+					changed = true
+					continue
+				}
+				// 带 encrypted_content 但无法提炼摘要的 reasoning 条目：
+				// 上游无法解密该内容，直接剥离整个条目，避免恢复链被卡住。
+				if hasEncrypted {
+					changed = true
+					continue
+				}
+			}
+			if _, exists := item["content"]; exists {
+				delete(item, "content")
+				changed = true
+			}
+			if _, exists := item["summary"]; !exists {
+				item["summary"] = []any{}
+				changed = true
+			}
+			filtered = append(filtered, item)
+			continue
+		}
+		if itemType == "message" {
+			content, ok := item["content"].([]any)
+			if ok {
+				texts := make([]string, 0, len(content))
+				convertible := true
+				for _, partAny := range content {
+					part, ok := partAny.(map[string]any)
+					if !ok {
+						convertible = false
+						break
+					}
+					partType, _ := part["type"].(string)
+					switch partType {
+					case "input_text", "output_text", "text":
+						if s, _ := part["text"].(string); s != "" {
+							texts = append(texts, s)
+						}
+					default:
+						convertible = false
+					}
+				}
+				if convertible {
+					item["content"] = strings.Join(texts, "\n")
+					changed = true
+				}
+			}
+		}
+		filtered = append(filtered, item)
+	}
+	if !changed {
+		return body, false
+	}
+	reqMap["input"] = filtered
+	out, err := common.Marshal(reqMap)
+	if err != nil {
+		return body, false
+	}
+	return out, true
+}
+
+func retryResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, adaptor channel.Adaptor, body []byte, logMessage string) (*http.Response, *types.NewAPIError) {
+	storage, createErr := common.CreateBodyStorage(body)
+	if createErr != nil {
+		return nil, nil
+	}
+	c.Set(common.KeyBodyStorage, storage)
+	c.Request.Body = io.NopCloser(storage)
+	if info.Request != nil {
+		_ = common.Unmarshal(body, info.Request)
+	}
+	logger.LogWarn(c, logMessage)
+	requestBody := bytes.NewBuffer(body)
+	resp, err := adaptor.DoRequest(c, info, requestBody)
+	if err != nil || resp == nil {
+		return nil, nil
+	}
+	httpResp := resp.(*http.Response)
+	if httpResp.StatusCode == http.StatusOK {
+		return httpResp, nil
+	}
+	return httpResp, service.RelayErrorHandler(c.Request.Context(), httpResp, false)
+}
+
+// tryResponsesReasoningDowngrade 处理 responses 输入中历史 reasoning 条目
+// 无法被上游消费（encrypted_content 解密失败、summary 缺失等）的场景：
+// 先尝试 summarize 转成带摘要的 assistant 消息，无改动或重试失败时再整体
+// 剥离 reasoning 条目，每次改动后原地重试一次。返回重试响应；
+// 无 reasoning 条目或无需改动时返回 nil。
+func tryResponsesReasoningDowngrade(c *gin.Context, info *relaycommon.RelayInfo, adaptor channel.Adaptor, body []byte) (*http.Response, *types.NewAPIError) {
+	if !hasResponsesReasoningItems(body) {
+		return nil, nil
+	}
+	logger.LogWarn(c, "responses handler detected reasoning items; attempting proactive reasoning downgrade")
+	if newBody, changed := summarizeResponsesReasoningItemsForRetry(body); changed {
+		retryResp, retryErr := retryResponsesRequest(c, info, adaptor, newBody, "responses handler auto-recovery: proactively summarized reasoning items and retried upstream once")
+		if retryResp != nil && retryErr == nil {
+			return retryResp, nil
+		}
+		if retryErr != nil {
+			if newBody2, changed2 := stripResponsesReasoningItemsForRetry(newBody); changed2 {
+				retryResp2, retryErr2 := retryResponsesRequest(c, info, adaptor, newBody2, "responses handler auto-recovery: proactively stripped reasoning items and retried upstream once")
+				if retryResp2 != nil && retryErr2 == nil {
+					return retryResp2, nil
+				}
+				if retryErr2 != nil {
+					return nil, retryErr2
+				}
+			}
+			return nil, retryErr
+		}
+	}
+	// summarize 无改动（如 reasoning 条目只有 encrypted_content 且无摘要）时，
+	// 兜底整体剥离 reasoning 条目后再重试一次，避免恢复链被 changed=false 卡住。
+	if newBody2, changed2 := stripResponsesReasoningItemsForRetry(body); changed2 {
+		retryResp2, retryErr2 := retryResponsesRequest(c, info, adaptor, newBody2, "responses handler auto-recovery: proactively stripped reasoning items and retried upstream once")
+		if retryResp2 != nil && retryErr2 == nil {
+			return retryResp2, nil
+		}
+		if retryErr2 != nil {
+			return nil, retryErr2
+		}
+	}
+	return nil, nil
+}
 
 func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
 	info.InitChannelMeta(c)
@@ -36,11 +599,6 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 	case *dto.OpenAIResponsesRequest:
 		responsesReq = req
 	case *dto.OpenAIResponsesCompactionRequest:
-		// Only fields documented for POST /v1/responses/compact are forwarded:
-		// model, input, instructions, previous_response_id, prompt_cache_key,
-		// prompt_cache_options, prompt_cache_retention, service_tier.
-		// Undocumented Codex-parity fields (tools, reasoning, text) are parsed
-		// for client compatibility but intentionally not sent upstream.
 		responsesReq = &dto.OpenAIResponsesRequest{
 			Model:                req.Model,
 			Input:                req.Input,
@@ -93,21 +651,16 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 		if err != nil {
 			return types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
 		}
-
-		// remove disabled fields for OpenAI Responses API
 		jsonData, err = relaycommon.RemoveDisabledFields(jsonData, info.ChannelOtherSettings, info.ChannelSetting.PassThroughBodyEnabled)
 		if err != nil {
 			return types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
 		}
-
-		// apply param override
 		if len(info.ParamOverride) > 0 {
 			jsonData, err = relaycommon.ApplyParamOverrideWithRelayInfo(jsonData, info)
 			if err != nil {
 				return newAPIErrorFromParamOverride(err)
 			}
 		}
-
 		logger.LogDebug(c, "requestBody: %s", jsonData)
 		body, closer, err := relaycommon.NewOutboundJSONBody(jsonData)
 		if err != nil {
@@ -118,28 +671,170 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 		requestBody = body
 	}
 
-	var httpResp *http.Response
 	resp, err := adaptor.DoRequest(c, info, requestBody)
 	if err != nil {
 		return types.NewOpenAIError(err, types.ErrorCodeDoRequestFailed, http.StatusInternalServerError)
 	}
 
 	statusCodeMappingStr := c.GetString("status_code_mapping")
-
+	var httpResp *http.Response
 	if resp != nil {
 		httpResp = resp.(*http.Response)
-
 		if httpResp.StatusCode != http.StatusOK {
 			newAPIError = service.RelayErrorHandler(c.Request.Context(), httpResp, false)
-			// reset status code 重置状态码
+			storage, storageErr := common.GetBodyStorage(c)
+			if storageErr == nil {
+				rawBody, readErr := storage.Bytes()
+				if readErr == nil {
+					if isResponsesEncryptedContentErrorMessage(newAPIError.Error()) {
+						if retryResp, retryErr := tryResponsesReasoningDowngrade(c, info, adaptor, rawBody); retryResp != nil && retryErr == nil {
+							httpResp = retryResp
+							goto RESPONSE_OK
+						} else if retryErr != nil {
+							newAPIError = retryErr
+						}
+					}
+					if isResponsesContentArrayErrorMessage(newAPIError.Error()) {
+						if newBody, changed := flattenResponsesContentArraysForRetry(rawBody); changed {
+							logger.LogWarn(c, "responses handler flatten input types: "+summarizeResponsesInputTypes(newBody))
+							retryResp, retryErr := retryResponsesRequest(c, info, adaptor, newBody, "responses handler auto-recovery: flattened input content arrays and retrying upstream once")
+							if retryResp != nil && retryErr == nil {
+								httpResp = retryResp
+								goto RESPONSE_OK
+							}
+							if retryErr != nil {
+								newAPIError = retryErr
+								// flatten 后即使上游先返回其他 400，也可能在下一步被旧
+								// reasoning.encrypted_content 卡住；只要输入里仍含 reasoning item，
+								// 主动尝试 summary/strip，避免依赖特定错误文案才能进入恢复链。
+								reasoningDowngradeTried := false
+								if hasResponsesReasoningItems(newBody) {
+									reasoningDowngradeTried = true
+									logger.LogWarn(c, "responses handler detected reasoning items after flatten; attempting proactive reasoning downgrade")
+									if retryResp2, retryErr2 := tryResponsesReasoningDowngrade(c, info, adaptor, newBody); retryResp2 != nil && retryErr2 == nil {
+										httpResp = retryResp2
+										goto RESPONSE_OK
+									} else if retryErr2 != nil {
+										newAPIError = retryErr2
+									}
+								}
+								if !reasoningDowngradeTried && isResponsesEncryptedContentErrorMessage(newAPIError.Error()) {
+									if newBody2, changed2 := summarizeResponsesReasoningItemsForRetry(newBody); changed2 {
+										retryResp2, retryErr2 := retryResponsesRequest(c, info, adaptor, newBody2, "responses handler auto-recovery: flattened input, then summarized unverifiable encrypted reasoning items and retried upstream once")
+										if retryResp2 != nil && retryErr2 == nil {
+											httpResp = retryResp2
+											goto RESPONSE_OK
+										}
+										if retryErr2 != nil {
+											newAPIError = retryErr2
+											if isResponsesEncryptedContentErrorMessage(newAPIError.Error()) || isResponsesReasoningSummaryErrorMessage(newAPIError.Error()) {
+												if newBody3, changed3 := stripResponsesReasoningItemsForRetry(newBody2); changed3 {
+													retryResp3, retryErr3 := retryResponsesRequest(c, info, adaptor, newBody3, "responses handler auto-recovery: flattened input, then stripped unverifiable reasoning items and retried upstream once")
+													if retryResp3 != nil && retryErr3 == nil {
+														httpResp = retryResp3
+														goto RESPONSE_OK
+													}
+													if retryErr3 != nil {
+														newAPIError = retryErr3
+													}
+												}
+											}
+										}
+									}
+								}
+								if !reasoningDowngradeTried && isResponsesReasoningSummaryErrorMessage(newAPIError.Error()) {
+									if newBody2, changed2 := summarizeResponsesReasoningItemsForRetry(newBody); changed2 {
+										retryResp2, retryErr2 := retryResponsesRequest(c, info, adaptor, newBody2, "responses handler auto-recovery: summarized incompatible reasoning items and retrying upstream once")
+										if retryResp2 != nil && retryErr2 == nil {
+											httpResp = retryResp2
+											goto RESPONSE_OK
+										}
+										if retryErr2 != nil {
+											newAPIError = retryErr2
+											if isResponsesReasoningSummaryErrorMessage(newAPIError.Error()) {
+												if newBody3, changed3 := stripResponsesReasoningItemsForRetry(newBody2); changed3 {
+													retryResp3, retryErr3 := retryResponsesRequest(c, info, adaptor, newBody3, "responses handler auto-recovery: stripped incompatible reasoning items and retrying upstream once")
+													if retryResp3 != nil && retryErr3 == nil {
+														httpResp = retryResp3
+														goto RESPONSE_OK
+													}
+													if retryErr3 != nil {
+														newAPIError = retryErr3
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					// function_call/function_call_output 配对缺失自动恢复：
+					// 删除孤儿输出、为缺失响应的调用补占位后原地重试一次。
+					// 注意需在图片剥离前先处理：若清洗后重试仍报图片不支持，
+					// 会落到下方的图片剥离分支继续恢复。
+					if isResponsesToolPairingError(newAPIError.Error()) {
+						retryResp, retryErr := tryResponsesToolPairingRecovery(c, info, adaptor, rawBody, "responses handler auto-recovery: sanitized function_call/function_call_output pairing and retrying upstream once")
+						if retryResp != nil && retryErr == nil {
+							httpResp = retryResp
+							goto RESPONSE_OK
+						}
+						if retryErr != nil {
+							newAPIError = retryErr
+						}
+					}
+					if isResponsesImageUnsupportedError(newAPIError.Error()) {
+						if newBody, removed, changed := stripResponsesImagesForUnsupportedRetry(rawBody); changed {
+							c.Header("X-Images-Removed", strconv.Itoa(removed))
+							retryResp, retryErr := retryResponsesRequest(c, info, adaptor, newBody, fmt.Sprintf("responses handler auto-recovery: removed %d unsupported images and retrying upstream once", removed))
+							if retryResp != nil && retryErr == nil {
+								httpResp = retryResp
+								goto RESPONSE_OK
+							}
+							if retryErr != nil {
+								newAPIError = retryErr
+								model := info.UpstreamModelName
+								if model == "" {
+									model = info.OriginModelName
+								}
+								if maxTokens, ok := parseResponsesContextOverflowMaxTokens(newAPIError.Error()); ok {
+									if newBody2, changed2 := truncateResponsesInputForContextRetry(newBody, maxTokens, model); changed2 {
+										c.Header("X-Context-Truncated", "responses")
+										retryResp2, retryErr2 := retryResponsesRequest(c, info, adaptor, newBody2, "responses handler auto-recovery: removed unsupported images, then truncated input context and retried upstream once")
+										if retryResp2 != nil && retryErr2 == nil {
+											httpResp = retryResp2
+											goto RESPONSE_OK
+										}
+										if retryErr2 != nil {
+											newAPIError = retryErr2
+										}
+									}
+								}
+								// 图片剥离后重试仍可能报 tool 配对缺失，
+								// 再清洗一次 function_call/function_call_output 配对
+								if isResponsesToolPairingError(newAPIError.Error()) {
+									retryResp3, retryErr3 := tryResponsesToolPairingRecovery(c, info, adaptor, newBody, "responses handler auto-recovery: removed unsupported images, then sanitized tool pairing and retried upstream once")
+									if retryResp3 != nil && retryErr3 == nil {
+										httpResp = retryResp3
+										goto RESPONSE_OK
+									}
+									if retryErr3 != nil {
+										newAPIError = retryErr3
+									}
+								}
+							}
+						}
+					}
+				}
+			}
 			service.ResetStatusCode(newAPIError, statusCodeMappingStr)
 			return newAPIError
 		}
 	}
 
+RESPONSE_OK:
 	usage, newAPIError := adaptor.DoResponse(c, httpResp, info)
 	if newAPIError != nil {
-		// reset status code 重置状态码
 		service.ResetStatusCode(newAPIError, statusCodeMappingStr)
 		return newAPIError
 	}
@@ -148,7 +843,6 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 	if info.RelayMode == relayconstant.RelayModeResponsesCompact {
 		originModelName := info.OriginModelName
 		originPriceData := info.PriceData
-
 		_, err := helper.ModelPriceHelper(c, info, info.GetEstimatePromptTokens(), &types.TokenCountMeta{})
 		if err != nil {
 			info.OriginModelName = originModelName
@@ -156,7 +850,6 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 			return types.NewError(err, types.ErrorCodeModelPriceError, types.ErrOptionWithSkipRetry(), types.ErrOptionWithStatusCode(http.StatusBadRequest))
 		}
 		service.PostTextConsumeQuota(c, info, usageDto, nil)
-
 		info.OriginModelName = originModelName
 		info.PriceData = originPriceData
 		return nil

--- a/relay/responses_handler_test.go
+++ b/relay/responses_handler_test.go
@@ -1,0 +1,390 @@
+package relay
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+func TestFlattenResponsesContentArraysForRetry_NoChange(t *testing.T) {
+	raw := []byte(`{"model":"gpt-5.4","input":[{"type":"message","role":"user","content":"你好"}]}`)
+	out, changed := flattenResponsesContentArraysForRetry(raw)
+	if changed {
+		t.Fatalf("expected unchanged, got changed=true body=%s", string(out))
+	}
+	if string(out) != string(raw) {
+		t.Fatalf("expected identical body when unchanged")
+	}
+}
+
+func TestFlattenResponsesContentArraysForRetry_FlattensMessageTextParts(t *testing.T) {
+	raw := []byte(`{"input":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hello"},{"type":"output_text","text":"World"}]}]}`)
+	out, changed := flattenResponsesContentArraysForRetry(raw)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	var req map[string]any
+	if err := common.Unmarshal(out, &req); err != nil {
+		t.Fatal(err)
+	}
+	input := req["input"].([]any)
+	item := input[0].(map[string]any)
+	content, ok := item["content"].(string)
+	if !ok {
+		t.Fatalf("expected flattened string content, got %#v", item["content"])
+	}
+	if content != "Hello\nWorld" {
+		t.Fatalf("unexpected flattened content: %q", content)
+	}
+}
+
+func TestFlattenResponsesContentArraysForRetry_StripsReasoningContentKeepsSummary(t *testing.T) {
+	raw := []byte(`{"input":[{"type":"reasoning","content":[{"type":"reasoning_text","text":"internal"}],"encrypted_content":null}]}`)
+	out, changed := flattenResponsesContentArraysForRetry(raw)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	var req map[string]any
+	if err := common.Unmarshal(out, &req); err != nil {
+		t.Fatal(err)
+	}
+	input := req["input"].([]any)
+	item := input[0].(map[string]any)
+	if _, exists := item["content"]; exists {
+		t.Fatalf("expected reasoning.content removed, got %#v", item["content"])
+	}
+	summary, exists := item["summary"]
+	if !exists {
+		t.Fatal("expected reasoning.summary to exist")
+	}
+	summaryArr, ok := summary.([]any)
+	if !ok || len(summaryArr) != 0 {
+		t.Fatalf("expected empty summary array, got %#v", summary)
+	}
+}
+
+func TestSummarizeResponsesReasoningItemsForRetry_ConvertsSummaryToAssistantMessage(t *testing.T) {
+	raw := []byte(`{"input":[{"type":"reasoning","summary":[{"type":"summary_text","text":"first"},{"type":"summary_text","text":"second"}]}]}`)
+	out, changed := summarizeResponsesReasoningItemsForRetry(raw)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	var req map[string]any
+	if err := common.Unmarshal(out, &req); err != nil {
+		t.Fatal(err)
+	}
+	input := req["input"].([]any)
+	if len(input) != 1 {
+		t.Fatalf("expected one converted input item, got %d", len(input))
+	}
+	item := input[0].(map[string]any)
+	if item["type"] != "message" {
+		t.Fatalf("expected converted item type=message, got %#v", item["type"])
+	}
+	if item["role"] != "assistant" {
+		t.Fatalf("expected converted role=assistant, got %#v", item["role"])
+	}
+	content, _ := item["content"].(string)
+	if content != "[Context Summary]\nfirst\n\nsecond" {
+		t.Fatalf("unexpected summarized content: %q", content)
+	}
+}
+
+func TestStripResponsesReasoningItemsForRetry_RemovesReasoningItems(t *testing.T) {
+	raw := []byte(`{"input":[{"type":"reasoning","summary":[{"type":"summary_text","text":"first"}]},{"type":"message","role":"user","content":"hello"}]}`)
+	out, changed := stripResponsesReasoningItemsForRetry(raw)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	var req map[string]any
+	if err := common.Unmarshal(out, &req); err != nil {
+		t.Fatal(err)
+	}
+	input := req["input"].([]any)
+	if len(input) != 1 {
+		t.Fatalf("expected one remaining input item, got %d", len(input))
+	}
+	item := input[0].(map[string]any)
+	if item["type"] != "message" {
+		t.Fatalf("expected remaining item type=message, got %#v", item["type"])
+	}
+}
+
+func TestIsResponsesToolPairingError(t *testing.T) {
+	cases := []struct {
+		name    string
+		message string
+		want    bool
+	}{
+		{
+			name:    "cooai no tool output found",
+			message: "No tool output found for tool call call_02_9r7hnOiZfy9N67N7azD82137.",
+			want:    true,
+		},
+		{
+			name:    "no output found for function call",
+			message: "No output found for function call call_abc123",
+			want:    true,
+		},
+		{
+			name:    "no function call found",
+			message: "No function call found for function_call_output item with call_id fc_123",
+			want:    true,
+		},
+		{
+			name:    "missing tool output",
+			message: "tool output missing for call call_abc123",
+			want:    true,
+		},
+		{
+			name:    "unrelated error",
+			message: "The server had an error while processing your request.",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		if got := isResponsesToolPairingError(tc.message); got != tc.want {
+			t.Fatalf("%s: isResponsesToolPairingError(%q) = %v, want %v", tc.name, tc.message, got, tc.want)
+		}
+	}
+}
+
+func TestSanitizeResponsesToolPairingForRetry_FabricatesMissingOutput(t *testing.T) {
+	raw := []byte(`{"input":[` +
+		`{"type":"message","role":"user","content":"分析这张图"},` +
+		`{"type":"function_call","call_id":"call_02_9r7hnOiZfy9N67N7azD82137","name":"analyze","arguments":"{}"},` +
+		`{"type":"message","role":"user","content":"继续"}]}`)
+	out, changed := sanitizeResponsesToolPairingForRetry(raw)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	var req map[string]any
+	if err := common.Unmarshal(out, &req); err != nil {
+		t.Fatal(err)
+	}
+	input := req["input"].([]any)
+	if len(input) != 4 {
+		t.Fatalf("expected 4 input items, got %d", len(input))
+	}
+	fabricated := input[2].(map[string]any)
+	if fabricated["type"] != "function_call_output" {
+		t.Fatalf("expected fabricated function_call_output at index 2, got %#v", fabricated)
+	}
+	if fabricated["call_id"] != "call_02_9r7hnOiZfy9N67N7azD82137" {
+		t.Fatalf("unexpected fabricated call_id: %v", fabricated["call_id"])
+	}
+	if fabricated["output"] != responsesOmittedToolOutputPlaceholder {
+		t.Fatalf("unexpected placeholder output: %v", fabricated["output"])
+	}
+}
+
+func TestSanitizeResponsesToolPairingForRetry_DropsOrphanOutput(t *testing.T) {
+	raw := []byte(`{"input":[` +
+		`{"type":"function_call_output","call_id":"call_01","output":"orphan"},` +
+		`{"type":"message","role":"user","content":"hello"}]}`)
+	out, changed := sanitizeResponsesToolPairingForRetry(raw)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	var req map[string]any
+	if err := common.Unmarshal(out, &req); err != nil {
+		t.Fatal(err)
+	}
+	input := req["input"].([]any)
+	if len(input) != 1 {
+		t.Fatalf("expected orphan output dropped, got %d items: %#v", len(input), input)
+	}
+	item := input[0].(map[string]any)
+	if item["type"] != "message" {
+		t.Fatalf("expected remaining message item, got %#v", item)
+	}
+}
+
+func TestSanitizeResponsesToolPairingForRetry_KeepsParallelCalls(t *testing.T) {
+	raw := []byte(`{"input":[` +
+		`{"type":"message","role":"user","content":"hello"},` +
+		`{"type":"function_call","call_id":"call_01","name":"a","arguments":"{}"},` +
+		`{"type":"function_call","call_id":"call_02","name":"b","arguments":"{}"},` +
+		`{"type":"function_call_output","call_id":"call_01","output":"out1"},` +
+		`{"type":"function_call_output","call_id":"call_02","output":"out2"},` +
+		`{"type":"message","role":"user","content":"继续"}]}`)
+	out, changed := sanitizeResponsesToolPairingForRetry(raw)
+	if changed {
+		t.Fatalf("expected no change for well-paired parallel calls, body=%s", string(out))
+	}
+	if string(out) != string(raw) {
+		t.Fatalf("expected identical body when unchanged")
+	}
+}
+
+func TestSanitizeResponsesToolPairingForRetry_NoChangeWhenPaired(t *testing.T) {
+	raw := []byte(`{"input":[` +
+		`{"type":"message","role":"user","content":"hello"},` +
+		`{"type":"function_call","call_id":"call_01","name":"a","arguments":"{}"},` +
+		`{"type":"function_call_output","call_id":"call_01","output":"out1"}]}`)
+	out, changed := sanitizeResponsesToolPairingForRetry(raw)
+	if changed {
+		t.Fatalf("expected no change for well-paired conversation, body=%s", string(out))
+	}
+	if string(out) != string(raw) {
+		t.Fatalf("expected identical body when unchanged")
+	}
+}
+
+func TestSanitizeResponsesToolPairingForRetry_KeepsOutputWithPreviousResponseID(t *testing.T) {
+	// previous_response_id 续跑场景：input 中只有 function_call_output，
+	// 其 function_call 位于上游服务端会话中，必须保留，不能当作孤儿输出删除
+	raw := []byte(`{"previous_response_id":"resp_123","input":[` +
+		`{"type":"function_call_output","call_id":"call_02_9r7hnOiZfy9N67N7azD82137","output":"real tool result"}]}`)
+	out, changed := sanitizeResponsesToolPairingForRetry(raw)
+	if changed {
+		t.Fatalf("expected no change with previous_response_id, body=%s", string(out))
+	}
+	if string(out) != string(raw) {
+		t.Fatalf("expected identical body when unchanged")
+	}
+}
+
+func TestSanitizeResponsesToolPairingForRetry_StillFabricatesWithPreviousResponseID(t *testing.T) {
+	// previous_response_id 场景下仍为当前 input 中缺失响应的 function_call 补占位
+	raw := []byte(`{"previous_response_id":"resp_123","input":[` +
+		`{"type":"function_call","call_id":"call_09","name":"a","arguments":"{}"},` +
+		`{"type":"message","role":"user","content":"继续"}]}`)
+	out, changed := sanitizeResponsesToolPairingForRetry(raw)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	var req map[string]any
+	if err := common.Unmarshal(out, &req); err != nil {
+		t.Fatal(err)
+	}
+	input := req["input"].([]any)
+	if len(input) != 3 {
+		t.Fatalf("expected 3 input items, got %d", len(input))
+	}
+	fabricated := input[1].(map[string]any)
+	if fabricated["type"] != "function_call_output" || fabricated["call_id"] != "call_09" {
+		t.Fatalf("expected fabricated output for call_09, got %#v", fabricated)
+	}
+}
+
+func TestIsResponsesEncryptedContentErrorMessage(t *testing.T) {
+	cases := []struct {
+		name    string
+		message string
+		want    bool
+	}{
+		{
+			name:    "openai encrypted content unverifiable",
+			message: "The encrypted content 7ea0...4c-0 could not be verified. Reason: Encrypted content could not be decrypted or parsed.",
+			want:    true,
+		},
+		{
+			name:    "decrypted only",
+			message: "Encrypted content could not be decrypted.",
+			want:    true,
+		},
+		{
+			name:    "unrelated",
+			message: "This model's maximum context length is 128000 tokens.",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		if got := isResponsesEncryptedContentErrorMessage(tc.message); got != tc.want {
+			t.Fatalf("%s: got=%v want=%v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestSummarizeResponsesReasoningItemsForRetry_RemovesEncryptedContentByReplacement(t *testing.T) {
+	raw := []byte(`{"input":[{"type":"reasoning","id":"rs_1","encrypted_content":"abc","summary":[{"type":"summary_text","text":"safe summary"}]}]}`)
+	out, changed := summarizeResponsesReasoningItemsForRetry(raw)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	var req map[string]any
+	if err := common.Unmarshal(out, &req); err != nil {
+		t.Fatal(err)
+	}
+	input := req["input"].([]any)
+	if len(input) != 1 {
+		t.Fatalf("expected one converted item, got %d", len(input))
+	}
+	item := input[0].(map[string]any)
+	if item["type"] != "message" || item["role"] != "assistant" {
+		t.Fatalf("expected assistant summary message, got %#v", item)
+	}
+}
+
+func TestStripResponsesReasoningItemsForRetry_RemovesEncryptedContentReasoning(t *testing.T) {
+	raw := []byte(`{"input":[{"type":"reasoning","id":"rs_1","encrypted_content":"abc","summary":[]},{"type":"message","role":"user","content":"hello"}]}`)
+	out, changed := stripResponsesReasoningItemsForRetry(raw)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	var req map[string]any
+	if err := common.Unmarshal(out, &req); err != nil {
+		t.Fatal(err)
+	}
+	input := req["input"].([]any)
+	if len(input) != 1 {
+		t.Fatalf("expected reasoning removed, got %d items", len(input))
+	}
+	if input[0].(map[string]any)["type"] != "message" {
+		t.Fatalf("expected remaining message, got %#v", input[0])
+	}
+}
+
+func TestSummarizeResponsesReasoningItemsForRetry_DropsEncryptedContentWithoutSummary(t *testing.T) {
+	raw := []byte(`{"input":[{"type":"reasoning","id":"rs_1","encrypted_content":"abc","summary":[]},{"type":"message","role":"user","content":"hello"}]}`)
+	out, changed := summarizeResponsesReasoningItemsForRetry(raw)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	var req map[string]any
+	if err := common.Unmarshal(out, &req); err != nil {
+		t.Fatal(err)
+	}
+	input := req["input"].([]any)
+	if len(input) != 1 {
+		t.Fatalf("expected encrypted reasoning dropped, got %d items", len(input))
+	}
+	if input[0].(map[string]any)["type"] != "message" {
+		t.Fatalf("expected remaining message, got %#v", input[0])
+	}
+}
+
+func TestFlattenResponsesContentArraysForRetry_RemovesEncryptedContent(t *testing.T) {
+	raw := []byte(`{"input":[{"type":"reasoning","id":"rs_1","encrypted_content":"abc"},{"type":"message","role":"user","content":"hello"}]}`)
+	out, changed := flattenResponsesContentArraysForRetry(raw)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	var req map[string]any
+	if err := common.Unmarshal(out, &req); err != nil {
+		t.Fatal(err)
+	}
+	input := req["input"].([]any)
+	if len(input) != 2 {
+		t.Fatalf("expected two items, got %d", len(input))
+	}
+	item := input[0].(map[string]any)
+	if _, exists := item["encrypted_content"]; exists {
+		t.Fatalf("expected encrypted_content removed, got %#v", item["encrypted_content"])
+	}
+	if _, exists := item["summary"]; !exists {
+		t.Fatal("expected reasoning.summary to exist after encrypted_content removal")
+	}
+}
+
+func TestHasResponsesReasoningItems(t *testing.T) {
+	withReasoning := []byte(`{"input":[{"type":"message","role":"user","content":"hi"},{"type":"reasoning","encrypted_content":"abc"}]}`)
+	if !hasResponsesReasoningItems(withReasoning) {
+		t.Fatal("expected reasoning items detected")
+	}
+	withoutReasoning := []byte(`{"input":[{"type":"message","role":"user","content":"hi"}]}`)
+	if hasResponsesReasoningItems(withoutReasoning) {
+		t.Fatal("expected no reasoning items")
+	}
+}

--- a/service/image.go
+++ b/service/image.go
@@ -6,6 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"image/color"
+	"image/draw"
+	_ "image/gif"
+	"image/jpeg"
+	_ "image/png"
 	"io"
 	"net/http"
 	"strings"
@@ -13,6 +18,7 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
 
+	ximagedraw "golang.org/x/image/draw"
 	"golang.org/x/image/webp"
 )
 
@@ -191,4 +197,105 @@ func getImageConfig(reader io.Reader) (image.Config, string, error) {
 	}
 
 	return image.Config{}, "", err
+}
+
+// 413 Payload Too Large 恢复时对 base64 图片的压缩档位（降采样边长 + JPEG 质量）
+var bodyImageCompressSteps = []struct {
+	maxDim  int
+	quality int
+}{
+	{1536, 80},
+	{1024, 70},
+	{768, 65},
+	{512, 60},
+}
+
+// 超大图片解码会占用大量内存，超过该像素数（约 40MP）时跳过压缩
+const maxCompressImagePixels = 40_000_000
+
+// CompressImageDataURL 将 base64 data URL 图片降采样并重编码为 JPEG，
+// 用于上游 413 Payload Too Large 时缩减请求体体积。
+// 依次尝试多档压缩并返回体积最小的一档；解码失败、GIF 动画或
+// 压缩后没有变小则返回错误。
+func CompressImageDataURL(dataURL string) (string, error) {
+	idx := strings.Index(dataURL, ",")
+	if idx == -1 {
+		return "", errors.New("invalid data url")
+	}
+	raw, err := base64.StdEncoding.DecodeString(dataURL[idx+1:])
+	if err != nil {
+		return "", fmt.Errorf("failed to decode base64 image: %w", err)
+	}
+
+	img, format, err := image.Decode(bytes.NewReader(raw))
+	if err != nil {
+		// webp 需要显式解码
+		img, err = webp.Decode(bytes.NewReader(raw))
+		if err != nil {
+			return "", fmt.Errorf("failed to decode image: %w", err)
+		}
+		format = "webp"
+	}
+	if format == "gif" {
+		// 动图跳过压缩，避免丢失动画
+		return "", errors.New("gif animation is not compressed")
+	}
+
+	bounds := img.Bounds()
+	if int64(bounds.Dx())*int64(bounds.Dy()) > maxCompressImagePixels {
+		return "", fmt.Errorf("image too large to compress safely (%dx%d)", bounds.Dx(), bounds.Dy())
+	}
+
+	var best string
+	var bestLen int
+	for _, step := range bodyImageCompressSteps {
+		scaled := scaleImageToMaxDim(img, step.maxDim)
+		flat := flattenToWhite(scaled)
+		var buf bytes.Buffer
+		if err := jpeg.Encode(&buf, flat, &jpeg.Options{Quality: step.quality}); err != nil {
+			continue
+		}
+		newDataURL := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(buf.Bytes())
+		if best == "" || len(newDataURL) < bestLen {
+			best = newDataURL
+			bestLen = len(newDataURL)
+		}
+	}
+	if best == "" || bestLen >= len(dataURL) {
+		return "", errors.New("compressed image is not smaller")
+	}
+	return best, nil
+}
+
+// scaleImageToMaxDim 等比缩放到最长边不超过 maxDim（未超限时原样返回）
+func scaleImageToMaxDim(img image.Image, maxDim int) image.Image {
+	bounds := img.Bounds()
+	w, h := bounds.Dx(), bounds.Dy()
+	if w <= maxDim && h <= maxDim {
+		return img
+	}
+	if w <= 0 || h <= 0 {
+		return img
+	}
+	ratio := float64(maxDim) / float64(max(w, h))
+	nw := int(float64(w) * ratio)
+	nh := int(float64(h) * ratio)
+	if nw < 1 {
+		nw = 1
+	}
+	if nh < 1 {
+		nh = 1
+	}
+	dst := image.NewRGBA(image.Rect(0, 0, nw, nh))
+	ximagedraw.BiLinear.Scale(dst, dst.Bounds(), img, bounds, ximagedraw.Over, nil)
+	return dst
+}
+
+// flattenToWhite 将透明背景合成到白色底上，避免 PNG 透明区域转 JPEG 后变黑
+func flattenToWhite(img image.Image) image.Image {
+	bounds := img.Bounds()
+	dst := image.NewRGBA(bounds)
+	draw.Draw(dst, bounds, image.NewUniform(color.White), image.Point{}, draw.Src)
+	draw.Draw(dst, bounds, img, bounds.Min, draw.Over)
+	return dst
 }

--- a/service/image_compress_test.go
+++ b/service/image_compress_test.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"bytes"
+	"encoding/base64"
+	"image"
+	"image/color"
+	"image/png"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func noisyPNGDataURL(t *testing.T, w, h int, alpha uint8) string {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	rnd := rand.New(rand.NewSource(42))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(rnd.Intn(256)), G: uint8(rnd.Intn(256)), B: uint8(rnd.Intn(256)), A: alpha})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(buf.Bytes())
+}
+
+func TestCompressImageDataURL(t *testing.T) {
+	dataURL := noisyPNGDataURL(t, 2000, 1500, 255)
+	compressed, err := CompressImageDataURL(dataURL)
+	if err != nil {
+		t.Fatalf("CompressImageDataURL error: %v", err)
+	}
+	if !strings.HasPrefix(compressed, "data:image/jpeg;base64,") {
+		t.Fatalf("expected jpeg data url, got prefix: %s", compressed[:40])
+	}
+	if len(compressed) >= len(dataURL) {
+		t.Fatalf("expected compressed smaller: before=%d after=%d", len(dataURL), len(compressed))
+	}
+}
+
+func TestCompressImageDataURLSmallImageSkipped(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 64, 64))
+	for y := 0; y < 64; y++ {
+		for x := 0; x < 64; x++ {
+			img.Set(x, y, color.RGBA{R: 200, G: 100, B: 50, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	dataURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(buf.Bytes())
+	if _, err := CompressImageDataURL(dataURL); err == nil {
+		t.Fatal("expected error for image that cannot be made smaller")
+	}
+}
+
+func TestCompressImageDataURLTransparentPNG(t *testing.T) {
+	dataURL := noisyPNGDataURL(t, 1200, 800, 200)
+	compressed, err := CompressImageDataURL(dataURL)
+	if err != nil {
+		t.Fatalf("CompressImageDataURL error: %v", err)
+	}
+	if len(compressed) >= len(dataURL) {
+		t.Fatalf("expected compressed smaller: before=%d after=%d", len(dataURL), len(compressed))
+	}
+}


### PR DESCRIPTION
## Summary
Adds transparent auto-recovery on the relay layer for several failures seen on long-running conversations, especially with gpt-5.x Responses models and image-heavy chats:

- **Encrypted reasoning items (Responses)**: when upstream rejects input with `encrypted content could not be verified`, strip the `encrypted_content` field; if no summary can be extracted, drop the reasoning item entirely, then retry once on the same channel. Also adds a proactive fallback that downgrades leftover reasoning items when summarize yields no change.
- **Oversized content arrays / tool pairing (Responses)**: flatten oversized `input[*].content` arrays, sanitize `function_call`/`function_call_output` pairing (remove orphan outputs, backfill missing outputs), retry once.
- **Context overflow**: on token-limit errors, trim historical images first, then drop oldest message blocks and retry on the same channel.
- **413 Payload Too Large**: strip historical images first; if still over the limit, downscale and JPEG-re-encode remaining base64 images (`service.CompressImageDataURL`) and retry.
- **Unsupported image input**: strip images (with placeholder text and `X-Images-Removed` header) and retry.

All recovery paths are gated behind `CONTEXT_OVERFLOW_AUTO_RECOVERY` (env, default on) and rewrite the request in place before a single same-channel retry, so unaffected requests pass through untouched.

## Files
- `controller/context_recovery.go` (new): chat-completions recovery (context overflow, 413, image unsupported, tool pairing)
- `controller/relay.go`: recovery hooks wired into the relay loop
- `relay/responses_handler.go`: Responses recovery chain + helpers
- `service/image.go`: base64 image compression for 413 recovery
- `constant/env.go`, `common/init.go`: `CONTEXT_OVERFLOW_AUTO_RECOVERY` setting
- Tests for all of the above

## Testing
- `go test ./controller/ ./relay/ ./service/` passes
- Deployed and verified against production traffic (oc + zh environments)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic recovery for context limits, oversized requests or images, unsupported image inputs, and tool-call errors.
  - Requests may be retried after trimming older content, simplifying reasoning data, repairing tool-call pairings, or removing unsupported images.
  - Added automatic compression of large images to reduce request size.
  - Recovery is enabled by default and can be controlled with `CONTEXT_OVERFLOW_AUTO_RECOVERY`.
- **Bug Fixes**
  - Improved handling of Responses API errors and malformed request content.
  - Fixed quota handling for compact responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->