### PR TITLE
feat: support Gemini Omni Flash video tasks via Interactions API

### DIFF
--- a/controller/video_proxy.go
+++ b/controller/video_proxy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/logger"
 	"github.com/QuantumNous/new-api/model"
+	vertexcore "github.com/QuantumNous/new-api/relay/channel/vertex"
 	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting/system_setting"
 
@@ -110,6 +111,20 @@ func VideoProxy(c *gin.Context) {
 			logger.LogError(c.Request.Context(), fmt.Sprintf("Failed to resolve Vertex video URL for task %s: %s", taskID, err.Error()))
 			videoProxyError(c, http.StatusBadGateway, "server_error", "Failed to resolve Vertex video URL")
 			return
+		}
+		if strings.HasPrefix(videoURL, "http://") || strings.HasPrefix(videoURL, "https://") {
+			credentials := &vertexcore.Credentials{}
+			if decodeErr := common.Unmarshal([]byte(getVertexTaskKey(channel, task)), credentials); decodeErr != nil {
+				videoProxyError(c, http.StatusInternalServerError, "server_error", "Failed to decode Vertex credentials")
+				return
+			}
+			accessToken, tokenErr := vertexcore.AcquireAccessToken(*credentials, proxy)
+			if tokenErr != nil {
+				videoProxyError(c, http.StatusBadGateway, "server_error", "Failed to authenticate Vertex video download")
+				return
+			}
+			req.Header.Set("Authorization", "Bearer "+accessToken)
+			req.Header.Set("x-goog-user-project", credentials.ProjectID)
 		}
 	case constant.ChannelTypeOpenAI, constant.ChannelTypeSora:
 		videoURL = fmt.Sprintf("%s/v1/videos/%s/content", baseURL, task.GetUpstreamTaskID())

--- a/controller/video_proxy_gemini.go
+++ b/controller/video_proxy_gemini.go
@@ -51,8 +51,13 @@ func getGeminiVideoURL(channel *model.Channel, task *model.Task, apiKey string) 
 	}
 
 	taskInfo, parseErr := adaptor.ParseTaskResult(body)
-	if parseErr == nil && taskInfo != nil && taskInfo.RemoteUrl != "" {
-		return ensureAPIKey(taskInfo.RemoteUrl, apiKey), nil
+	if parseErr == nil && taskInfo != nil {
+		if taskInfo.Url != "" {
+			return taskInfo.Url, nil
+		}
+		if taskInfo.RemoteUrl != "" {
+			return ensureAPIKey(taskInfo.RemoteUrl, apiKey), nil
+		}
 	}
 
 	if url := extractGeminiVideoURLFromPayload(body); url != "" {

--- a/controller/video_proxy_gemini.go
+++ b/controller/video_proxy_gemini.go
@@ -18,7 +18,7 @@ func getGeminiVideoURL(channel *model.Channel, task *model.Task, apiKey string) 
 	}
 
 	if url := extractGeminiVideoURLFromTaskData(task); url != "" {
-		return ensureAPIKey(url, apiKey), nil
+		return ensureGeminiVideoAccess(url, apiKey), nil
 	}
 
 	baseURL := constant.ChannelBaseURLs[channel.Type]
@@ -61,7 +61,7 @@ func getGeminiVideoURL(channel *model.Channel, task *model.Task, apiKey string) 
 	}
 
 	if url := extractGeminiVideoURLFromPayload(body); url != "" {
-		return ensureAPIKey(url, apiKey), nil
+		return ensureGeminiVideoAccess(url, apiKey), nil
 	}
 
 	if parseErr != nil {

--- a/controller/video_proxy_gemini.go
+++ b/controller/video_proxy_gemini.go
@@ -53,10 +53,10 @@ func getGeminiVideoURL(channel *model.Channel, task *model.Task, apiKey string) 
 	taskInfo, parseErr := adaptor.ParseTaskResult(body)
 	if parseErr == nil && taskInfo != nil {
 		if taskInfo.Url != "" {
-			return ensureAPIKey(taskInfo.Url, apiKey), nil
+			return ensureGeminiVideoAccess(taskInfo.Url, apiKey), nil
 		}
 		if taskInfo.RemoteUrl != "" {
-			return ensureAPIKey(taskInfo.RemoteUrl, apiKey), nil
+			return ensureGeminiVideoAccess(taskInfo.RemoteUrl, apiKey), nil
 		}
 	}
 
@@ -69,6 +69,13 @@ func getGeminiVideoURL(channel *model.Channel, task *model.Task, apiKey string) 
 	}
 
 	return "", fmt.Errorf("gemini video url not found")
+}
+
+func ensureGeminiVideoAccess(videoURL string, apiKey string) string {
+	if strings.HasPrefix(strings.TrimSpace(videoURL), "data:") {
+		return videoURL
+	}
+	return ensureAPIKey(videoURL, apiKey)
 }
 
 func extractGeminiVideoURLFromTaskData(task *model.Task) string {

--- a/controller/video_proxy_gemini.go
+++ b/controller/video_proxy_gemini.go
@@ -53,7 +53,7 @@ func getGeminiVideoURL(channel *model.Channel, task *model.Task, apiKey string) 
 	taskInfo, parseErr := adaptor.ParseTaskResult(body)
 	if parseErr == nil && taskInfo != nil {
 		if taskInfo.Url != "" {
-			return taskInfo.Url, nil
+			return ensureAPIKey(taskInfo.Url, apiKey), nil
 		}
 		if taskInfo.RemoteUrl != "" {
 			return ensureAPIKey(taskInfo.RemoteUrl, apiKey), nil

--- a/controller/video_proxy_gemini_test.go
+++ b/controller/video_proxy_gemini_test.go
@@ -1,0 +1,14 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnsureGeminiVideoAccessPreservesInlineVideo(t *testing.T) {
+	inline := "data:video/mp4;base64,dmlkZW8="
+
+	assert.Equal(t, inline, ensureGeminiVideoAccess(inline, "secret-key"))
+	assert.Equal(t, "https://example.com/video.mp4?key=secret-key", ensureGeminiVideoAccess("https://example.com/video.mp4", "secret-key"))
+}

--- a/controller/video_proxy_gemini_test.go
+++ b/controller/video_proxy_gemini_test.go
@@ -3,7 +3,9 @@ package controller
 import (
 	"testing"
 
+	"github.com/QuantumNous/new-api/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnsureGeminiVideoAccessPreservesInlineVideo(t *testing.T) {
@@ -11,4 +13,14 @@ func TestEnsureGeminiVideoAccessPreservesInlineVideo(t *testing.T) {
 
 	assert.Equal(t, inline, ensureGeminiVideoAccess(inline, "secret-key"))
 	assert.Equal(t, "https://example.com/video.mp4?key=secret-key", ensureGeminiVideoAccess("https://example.com/video.mp4", "secret-key"))
+}
+
+func TestStoredGeminiInlineVideoUsesUnifiedAccessHandler(t *testing.T) {
+	inline := "data:video/mp4;base64,dmlkZW8="
+	task := &model.Task{}
+	task.SetData(map[string]any{"response": map[string]any{"video": inline}})
+
+	extracted := extractGeminiVideoURLFromTaskData(task)
+	require.Equal(t, inline, extracted)
+	assert.Equal(t, inline, ensureGeminiVideoAccess(extracted, "secret-key"))
 }

--- a/docs/openapi/relay.json
+++ b/docs/openapi/relay.json
@@ -555,6 +555,59 @@
         "parameters": [],
         "requestBody": {
           "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "model",
+                  "prompt"
+                ],
+                "properties": {
+                  "model": {
+                    "description": "模型名称",
+                    "example": "gemini-omni-flash-preview",
+                    "type": "string"
+                  },
+                  "prompt": {
+                    "description": "提示词",
+                    "example": "Change the sphere to green. Keep everything else the same.",
+                    "type": "string"
+                  },
+                  "duration": {
+                    "description": "输出视频秒数；Gemini Omni Flash 支持 3 至 10 秒",
+                    "example": 3,
+                    "oneOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "size": {
+                    "description": "输出尺寸",
+                    "example": "1280x720",
+                    "type": "string"
+                  },
+                  "video": {
+                    "description": "单个参考视频；支持原始 Base64、Data URI 或经过 SSRF 防护的 HTTP(S) URL。最长 10 秒，最大 64 MiB，支持 MP4 或 QuickTime",
+                    "example": "data:video/mp4;base64,...",
+                    "type": "string"
+                  },
+                  "videos": {
+                    "description": "参考视频数组；Gemini Omni Flash 当前最多允许一个",
+                    "maxItems": 1,
+                    "type": "array",
+                    "items": {
+                      "description": "原始 Base64、Data URI 或经过 SSRF 防护的 HTTP(S) URL",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "examples": {}
+            },
             "multipart/form-data": {
               "schema": {
                 "type": "object",

--- a/docs/openapi/relay.json
+++ b/docs/openapi/relay.json
@@ -579,6 +579,12 @@
                     "type": "string",
                     "description": "参考图片文件",
                     "example": ""
+                  },
+                  "video": {
+                    "format": "binary",
+                    "type": "string",
+                    "description": "Gemini Omni Flash 参考视频文件；仅允许一个，最长 10 秒，最大 64 MiB，支持 MP4 或 QuickTime",
+                    "example": ""
                   }
                 }
               },

--- a/i18n/keys.go
+++ b/i18n/keys.go
@@ -241,6 +241,11 @@ const (
 	MsgRateLimitTotalReached = "rate_limit.total_reached"
 )
 
+// Video task validation messages
+const (
+	MsgOmniReferenceVideoDurationExceeded = "video.omni.reference_duration_exceeded"
+)
+
 // Setting related messages
 const (
 	MsgSettingInvalidType      = "setting.invalid_type"

--- a/i18n/locales/en.yaml
+++ b/i18n/locales/en.yaml
@@ -203,6 +203,7 @@ twofa.code_invalid: "Verification code or backup code is incorrect"
 # Rate limit messages
 rate_limit.reached: "You have reached the request limit: maximum {{.Max}} requests in {{.Minutes}} minutes"
 rate_limit.total_reached: "You have reached the total request limit: maximum {{.Max}} requests in {{.Minutes}} minutes, including failed attempts"
+video.omni.reference_duration_exceeded: "Reference video duration is {{.Duration}} seconds, which exceeds the {{.Max}}-second limit for {{.Model}}."
 
 # Setting messages
 setting.invalid_type: "Invalid warning type"

--- a/i18n/locales/zh-CN.yaml
+++ b/i18n/locales/zh-CN.yaml
@@ -204,6 +204,7 @@ twofa.code_invalid: "验证码或备用码不正确"
 # Rate limit messages
 rate_limit.reached: "您已达到请求数限制：{{.Minutes}}分钟内最多请求{{.Max}}次"
 rate_limit.total_reached: "您已达到总请求数限制：{{.Minutes}}分钟内最多请求{{.Max}}次，包括失败次数"
+video.omni.reference_duration_exceeded: "参考视频时长为 {{.Duration}} 秒，超过 {{.Model}} 的 {{.Max}} 秒上限。"
 
 # Setting messages
 setting.invalid_type: "无效的预警类型"

--- a/i18n/locales/zh-CN.yaml
+++ b/i18n/locales/zh-CN.yaml
@@ -204,7 +204,7 @@ twofa.code_invalid: "验证码或备用码不正确"
 # Rate limit messages
 rate_limit.reached: "您已达到请求数限制：{{.Minutes}}分钟内最多请求{{.Max}}次"
 rate_limit.total_reached: "您已达到总请求数限制：{{.Minutes}}分钟内最多请求{{.Max}}次，包括失败次数"
-video.omni.reference_duration_exceeded: "参考视频时长为 {{.Duration}} 秒，超过 {{.Model}} 的 {{.Max}} 秒上限。"
+video.omni.reference_duration_exceeded: "参考视频时长超过10 秒上限。"
 
 # Setting messages
 setting.invalid_type: "无效的预警类型"

--- a/i18n/locales/zh-TW.yaml
+++ b/i18n/locales/zh-TW.yaml
@@ -204,7 +204,7 @@ twofa.code_invalid: "驗證碼或備用碼不正確"
 # Rate limit messages
 rate_limit.reached: "您已達到請求數限制：{{.Minutes}}分鐘內最多請求{{.Max}}次"
 rate_limit.total_reached: "您已達到總請求數限制：{{.Minutes}}分鐘內最多請求{{.Max}}次，包括失敗次數"
-video.omni.reference_duration_exceeded: "參考影片時長為 {{.Duration}} 秒，超過 {{.Model}} 的 {{.Max}} 秒上限。"
+video.omni.reference_duration_exceeded: "參考影片時長超過 10 秒上限。"
 
 # Setting messages
 setting.invalid_type: "無效的預警類型"

--- a/i18n/locales/zh-TW.yaml
+++ b/i18n/locales/zh-TW.yaml
@@ -204,6 +204,7 @@ twofa.code_invalid: "驗證碼或備用碼不正確"
 # Rate limit messages
 rate_limit.reached: "您已達到請求數限制：{{.Minutes}}分鐘內最多請求{{.Max}}次"
 rate_limit.total_reached: "您已達到總請求數限制：{{.Minutes}}分鐘內最多請求{{.Max}}次，包括失敗次數"
+video.omni.reference_duration_exceeded: "參考影片時長為 {{.Duration}} 秒，超過 {{.Model}} 的 {{.Max}} 秒上限。"
 
 # Setting messages
 setting.invalid_type: "無效的預警類型"

--- a/relay/channel/gemini/constant.go
+++ b/relay/channel/gemini/constant.go
@@ -18,6 +18,7 @@ var ModelList = []string{
 	"gemini-3.1-flash-image-preview", "gemini-robotics-er-1.5-preview",
 	"gemini-2.5-computer-use-preview-10-2025", "deep-research-pro-preview-12-2025",
 	"gemini-2.5-flash-native-audio-preview-09-2025", "gemini-2.5-flash-native-audio-preview-12-2025",
+	"gemini-omni-flash-preview",
 	// gemma models
 	"gemma-3-1b-it", "gemma-3-4b-it", "gemma-3-12b-it",
 	"gemma-3-27b-it", "gemma-3n-e4b-it", "gemma-3n-e2b-it",

--- a/relay/channel/task/gemini/adaptor.go
+++ b/relay/channel/task/gemini/adaptor.go
@@ -14,6 +14,7 @@ import (
 	taskdto "github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/relay/channel"
+	omnitask "github.com/QuantumNous/new-api/relay/channel/task/omni"
 	taskcommon "github.com/QuantumNous/new-api/relay/channel/task/taskcommon"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relaykit/dto"
@@ -42,12 +43,23 @@ func (a *TaskAdaptor) Init(info *relaycommon.RelayInfo) {
 
 // ValidateRequestAndSetAction parses body, validates fields and sets default action.
 func (a *TaskAdaptor) ValidateRequestAndSetAction(c *gin.Context, info *relaycommon.RelayInfo) (taskErr *taskdto.TaskError) {
-	return relaycommon.ValidateBasicTaskRequest(c, info, constant.TaskActionTextGenerate)
+	if taskErr := relaycommon.ValidateBasicTaskRequest(c, info, constant.TaskActionTextGenerate); taskErr != nil {
+		return taskErr
+	}
+	if omnitask.IsModel(info.OriginModelName) {
+		if err := omnitask.ValidateRequest(c, info); err != nil {
+			return service.TaskErrorWrapperLocal(err, "invalid_omni_request", http.StatusBadRequest)
+		}
+	}
+	return nil
 }
 
 // BuildRequestURL constructs the Gemini API predictLongRunning endpoint for Veo.
 func (a *TaskAdaptor) BuildRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	modelName := info.UpstreamModelName
+	if omnitask.IsModel(modelName) {
+		return fmt.Sprintf("%s/%s/interactions", strings.TrimRight(a.baseURL, "/"), omnitask.GeminiAPIVersion), nil
+	}
 	version := model_setting.GetGeminiVersionSetting(modelName)
 
 	return fmt.Sprintf(
@@ -68,6 +80,12 @@ func (a *TaskAdaptor) BuildRequestHeader(c *gin.Context, req *http.Request, info
 
 // BuildRequestBody converts request into the Veo predictLongRunning format.
 func (a *TaskAdaptor) BuildRequestBody(c *gin.Context, info *relaycommon.RelayInfo) (io.Reader, error) {
+	if omnitask.IsModel(info.UpstreamModelName) {
+		if err := omnitask.ValidateRequest(c, info); err != nil {
+			return nil, err
+		}
+		return omnitask.BuildRequestBody(c, info)
+	}
 	v, ok := c.Get("task_request")
 	if !ok {
 		return nil, fmt.Errorf("request not found in context")
@@ -127,6 +145,20 @@ func (a *TaskAdaptor) DoResponse(c *gin.Context, resp *http.Response, info *rela
 		return "", nil, service.TaskErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError)
 	}
 	_ = resp.Body.Close()
+	if omnitask.IsModel(info.UpstreamModelName) {
+		upstreamName, err := omnitask.ParseSubmitResponse(responseBody)
+		if err != nil {
+			return "", nil, service.TaskErrorWrapper(err, "invalid_interaction_response", http.StatusInternalServerError)
+		}
+		localID := taskcommon.EncodeLocalTaskID(upstreamName)
+		ov := dto.NewOpenAIVideo()
+		ov.ID = info.PublicTaskID
+		ov.TaskID = info.PublicTaskID
+		ov.CreatedAt = time.Now().Unix()
+		ov.Model = info.OriginModelName
+		c.JSON(http.StatusOK, ov)
+		return localID, responseBody, nil
+	}
 
 	var s submitResponse
 	if err := common.Unmarshal(responseBody, &s); err != nil {
@@ -147,6 +179,7 @@ func (a *TaskAdaptor) DoResponse(c *gin.Context, resp *http.Response, info *rela
 
 func (a *TaskAdaptor) GetModelList() []string {
 	return []string{
+		omnitask.ModelGeminiOmniFlashPreview,
 		"veo-3.0-generate-001",
 		"veo-3.0-fast-generate-001",
 		"veo-3.1-generate-preview",
@@ -167,6 +200,9 @@ func (a *TaskAdaptor) EstimateBilling(c *gin.Context, info *relaycommon.RelayInf
 	req, ok := v.(relaycommon.TaskSubmitReq)
 	if !ok {
 		return nil
+	}
+	if omnitask.IsModel(info.UpstreamModelName) {
+		return map[string]float64{"seconds": float64(omnitask.ResolveDuration(req))}
 	}
 
 	seconds := ResolveVeoDuration(req.Metadata, req.Duration, req.Seconds)
@@ -190,6 +226,24 @@ func (a *TaskAdaptor) FetchTask(baseUrl, key string, body map[string]any, proxy 
 	if err != nil {
 		return nil, fmt.Errorf("decode task_id failed: %w", err)
 	}
+	if omnitask.IsInteractionTaskName(upstreamName) {
+		interactionID, err := omnitask.InteractionIDFromTaskName(upstreamName)
+		if err != nil {
+			return nil, err
+		}
+		url := fmt.Sprintf("%s/%s/interactions/%s", strings.TrimRight(baseUrl, "/"), omnitask.GeminiAPIVersion, interactionID)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("x-goog-api-key", key)
+		client, err := service.GetHttpClientWithProxy(proxy)
+		if err != nil {
+			return nil, fmt.Errorf("new proxy http client failed: %w", err)
+		}
+		return client.Do(req)
+	}
 
 	version := model_setting.GetGeminiVersionSetting("default")
 	url := fmt.Sprintf("%s/%s/%s", baseUrl, version, upstreamName)
@@ -210,6 +264,9 @@ func (a *TaskAdaptor) FetchTask(baseUrl, key string, body map[string]any, proxy 
 }
 
 func (a *TaskAdaptor) ParseTaskResult(respBody []byte) (*relaycommon.TaskInfo, error) {
+	if omnitask.IsInteractionResponse(respBody) {
+		return omnitask.ParseTaskResult(respBody)
+	}
 	var op operationResponse
 	if err := common.Unmarshal(respBody, &op); err != nil {
 		return nil, fmt.Errorf("unmarshal operation response failed: %w", err)
@@ -251,6 +308,9 @@ func (a *TaskAdaptor) ConvertToOpenAIVideo(task *model.Task) ([]byte, error) {
 		upstreamName = ""
 	}
 	modelName := extractModelFromOperationName(upstreamName)
+	if omnitask.IsInteractionTaskName(upstreamName) {
+		modelName = omnitask.ModelGeminiOmniFlashPreview
+	}
 	if strings.TrimSpace(modelName) == "" {
 		modelName = "veo-3.0-generate-001"
 	}

--- a/relay/channel/task/gemini/adaptor.go
+++ b/relay/channel/task/gemini/adaptor.go
@@ -17,6 +17,7 @@ import (
 	omnitask "github.com/QuantumNous/new-api/relay/channel/task/omni"
 	taskcommon "github.com/QuantumNous/new-api/relay/channel/task/taskcommon"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting/model_setting"
@@ -46,7 +47,11 @@ func (a *TaskAdaptor) ValidateRequestAndSetAction(c *gin.Context, info *relaycom
 	if taskErr := relaycommon.ValidateBasicTaskRequest(c, info, constant.TaskActionTextGenerate); taskErr != nil {
 		return taskErr
 	}
-	if omnitask.IsModel(info.OriginModelName) {
+	info.UpstreamModelName = info.OriginModelName
+	if err := helper.ModelMappedHelper(c, info, nil); err != nil {
+		return service.TaskErrorWrapperLocal(err, "model_mapping_failed", http.StatusBadRequest)
+	}
+	if omnitask.IsModel(info.UpstreamModelName) {
 		if err := omnitask.ValidateRequest(c, info); err != nil {
 			return service.TaskErrorWrapperLocal(err, "invalid_omni_request", http.StatusBadRequest)
 		}

--- a/relay/channel/task/gemini/adaptor_test.go
+++ b/relay/channel/task/gemini/adaptor_test.go
@@ -1,10 +1,14 @@
 package gemini
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	omnitask "github.com/QuantumNous/new-api/relay/channel/task/omni"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,4 +27,30 @@ func TestOmniBuildRequestURL(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https://generativelanguage.googleapis.com/v1beta/interactions", requestURL)
 	assert.Contains(t, adaptor.GetModelList(), omnitask.ModelGeminiOmniFlashPreview)
+}
+
+func TestOmniMappedAliasRunsReferenceVideoValidation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	request := httptest.NewRequest(http.MethodPost, "/v1/videos", strings.NewReader(`{
+		"model":"gemini-omni-flash",
+		"prompt":"edit this video",
+		"duration":3,
+		"video":"not-valid-base64"
+	}`))
+	request.Header.Set("Content-Type", "application/json")
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = request
+	context.Set("model_mapping", `{"gemini-omni-flash":"gemini-omni-flash-preview"}`)
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "gemini-omni-flash",
+		ChannelMeta:     &relaycommon.ChannelMeta{},
+		TaskRelayInfo:   &relaycommon.TaskRelayInfo{},
+	}
+
+	taskErr := (&TaskAdaptor{}).ValidateRequestAndSetAction(context, info)
+
+	require.NotNil(t, taskErr)
+	assert.Equal(t, "invalid_omni_request", taskErr.Code)
+	assert.Contains(t, taskErr.Message, "invalid base64 video data")
+	assert.Equal(t, omnitask.ModelGeminiOmniFlashPreview, info.UpstreamModelName)
 }

--- a/relay/channel/task/gemini/adaptor_test.go
+++ b/relay/channel/task/gemini/adaptor_test.go
@@ -1,0 +1,26 @@
+package gemini
+
+import (
+	"testing"
+
+	omnitask "github.com/QuantumNous/new-api/relay/channel/task/omni"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOmniBuildRequestURL(t *testing.T) {
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelBaseUrl:    "https://generativelanguage.googleapis.com/",
+			UpstreamModelName: omnitask.ModelGeminiOmniFlashPreview,
+		},
+	}
+	adaptor := &TaskAdaptor{}
+	adaptor.Init(info)
+
+	requestURL, err := adaptor.BuildRequestURL(info)
+	require.NoError(t, err)
+	assert.Equal(t, "https://generativelanguage.googleapis.com/v1beta/interactions", requestURL)
+	assert.Contains(t, adaptor.GetModelList(), omnitask.ModelGeminiOmniFlashPreview)
+}

--- a/relay/channel/task/gemini/adaptor_test.go
+++ b/relay/channel/task/gemini/adaptor_test.go
@@ -1,6 +1,7 @@
 package gemini
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -31,7 +32,7 @@ func TestOmniBuildRequestURL(t *testing.T) {
 
 func TestOmniMappedAliasRunsReferenceVideoValidation(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	request := httptest.NewRequest(http.MethodPost, "/v1/videos", strings.NewReader(`{
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/videos", strings.NewReader(`{
 		"model":"gemini-omni-flash",
 		"prompt":"edit this video",
 		"duration":3,

--- a/relay/channel/task/omni/image.go
+++ b/relay/channel/task/omni/image.go
@@ -1,0 +1,137 @@
+package omni
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+
+	"github.com/QuantumNous/new-api/service"
+	"github.com/gin-gonic/gin"
+)
+
+const maxInlineImageBytes = 20 * 1024 * 1024
+
+var supportedImageMimeTypes = map[string]struct{}{
+	"image/heic": {},
+	"image/heif": {},
+	"image/jpeg": {},
+	"image/png":  {},
+	"image/webp": {},
+}
+
+func multipartImageCount(c *gin.Context) int {
+	form, err := c.MultipartForm()
+	if err != nil || form == nil {
+		return 0
+	}
+	count := 0
+	for _, field := range []string{"input_reference", "image", "images"} {
+		count += len(form.File[field])
+	}
+	return count
+}
+
+func collectImageParts(c *gin.Context, images []string) ([]inputPart, error) {
+	parts := make([]inputPart, 0, len(images)+multipartImageCount(c))
+	form, err := c.MultipartForm()
+	if err == nil && form != nil {
+		for _, field := range []string{"input_reference", "image", "images"} {
+			for _, fileHeader := range form.File[field] {
+				part, err := imagePartFromMultipart(fileHeader)
+				if err != nil {
+					return nil, fmt.Errorf("invalid %s image: %w", field, err)
+				}
+				parts = append(parts, part)
+			}
+		}
+	}
+	for index, image := range images {
+		part, err := imagePartFromString(image)
+		if err != nil {
+			return nil, fmt.Errorf("invalid image %d: %w", index, err)
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) > MaxImages {
+		return nil, fmt.Errorf("images must contain at most %d items", MaxImages)
+	}
+	return parts, nil
+}
+
+func imagePartFromMultipart(fileHeader *multipart.FileHeader) (inputPart, error) {
+	if fileHeader == nil {
+		return inputPart{}, fmt.Errorf("file is required")
+	}
+	if fileHeader.Size <= 0 || fileHeader.Size > maxInlineImageBytes {
+		return inputPart{}, fmt.Errorf("file size must be between 1 and %d bytes", maxInlineImageBytes)
+	}
+	file, err := fileHeader.Open()
+	if err != nil {
+		return inputPart{}, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maxInlineImageBytes+1))
+	if err != nil {
+		return inputPart{}, err
+	}
+	if len(data) == 0 || len(data) > maxInlineImageBytes {
+		return inputPart{}, fmt.Errorf("file size must be between 1 and %d bytes", maxInlineImageBytes)
+	}
+	mimeType := strings.TrimSpace(fileHeader.Header.Get("Content-Type"))
+	if mimeType == "" || mimeType == "application/octet-stream" {
+		mimeType = http.DetectContentType(data)
+	}
+	return newInlineImagePart(mimeType, base64.StdEncoding.EncodeToString(data))
+}
+
+func imagePartFromString(value string) (inputPart, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return inputPart{}, fmt.Errorf("image is required")
+	}
+	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+		mimeType, data, err := service.GetImageFromUrl(value)
+		if err != nil {
+			return inputPart{}, err
+		}
+		return newInlineImagePart(mimeType, data)
+	}
+	if strings.HasPrefix(value, "data:") {
+		comma := strings.Index(value, ",")
+		if comma < 0 {
+			return inputPart{}, fmt.Errorf("invalid data URI")
+		}
+		metadata := value[len("data:"):comma]
+		if !strings.HasSuffix(metadata, ";base64") {
+			return inputPart{}, fmt.Errorf("image data URI must use base64 encoding")
+		}
+		return newInlineImagePart(strings.TrimSuffix(metadata, ";base64"), value[comma+1:])
+	}
+	decoded, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return inputPart{}, fmt.Errorf("image must be an HTTP URL, data URI, or raw base64")
+	}
+	return newInlineImagePart(http.DetectContentType(decoded), value)
+}
+
+func newInlineImagePart(mimeType string, data string) (inputPart, error) {
+	mimeType = strings.TrimSpace(strings.SplitN(mimeType, ";", 2)[0])
+	if _, ok := supportedImageMimeTypes[mimeType]; !ok {
+		return inputPart{}, fmt.Errorf("unsupported image MIME type %q", mimeType)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(data))
+	if err != nil {
+		return inputPart{}, fmt.Errorf("invalid base64 image data")
+	}
+	if len(decoded) == 0 || len(decoded) > maxInlineImageBytes {
+		return inputPart{}, fmt.Errorf("decoded image size must be between 1 and %d bytes", maxInlineImageBytes)
+	}
+	return inputPart{
+		Type:     "image",
+		MimeType: mimeType,
+		Data:     strings.TrimSpace(data),
+	}, nil
+}

--- a/relay/channel/task/omni/omni.go
+++ b/relay/channel/task/omni/omni.go
@@ -186,7 +186,7 @@ func ValidateRequest(c *gin.Context, info *relaycommon.RelayInfo) error {
 	}
 	referenceVideo, err := prepareReferenceVideo(c, req)
 	if err != nil {
-		return err
+		return localizeReferenceVideoError(c, err)
 	}
 	if (imageCount > 0 || referenceVideo.Part != nil) && info != nil {
 		info.Action = constant.TaskActionGenerate
@@ -215,7 +215,7 @@ func BuildRequestBody(c *gin.Context, info *relaycommon.RelayInfo) (io.Reader, e
 	}
 	referenceVideo, err := prepareReferenceVideo(c, req)
 	if err != nil {
-		return nil, err
+		return nil, localizeReferenceVideoError(c, err)
 	}
 	if referenceVideo.Part != nil {
 		content := []inputPart{*referenceVideo.Part}

--- a/relay/channel/task/omni/omni.go
+++ b/relay/channel/task/omni/omni.go
@@ -1,0 +1,330 @@
+package omni
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/model"
+	taskcommon "github.com/QuantumNous/new-api/relay/channel/task/taskcommon"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	ModelGeminiOmniFlashPreview = "gemini-omni-flash-preview"
+	GeminiAPIVersion            = "v1beta"
+	VertexAPIVersion            = "v1beta1"
+	APIRevision                 = "2026-05-20"
+	MaxImages                   = 10
+	MinDurationSeconds          = 3
+	MaxDurationSeconds          = 10
+
+	interactionTaskPrefix = "interactions/"
+)
+
+type inputPart struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	MimeType string `json:"mime_type,omitempty"`
+	Data     string `json:"data,omitempty"`
+	URI      string `json:"uri,omitempty"`
+}
+
+type responseFormat struct {
+	Type        string `json:"type"`
+	AspectRatio string `json:"aspect_ratio,omitempty"`
+}
+
+type interactionRequest struct {
+	Model                 string         `json:"model"`
+	Input                 []inputPart    `json:"input"`
+	ResponseFormat        responseFormat `json:"response_format"`
+	PreviousInteractionID string         `json:"previous_interaction_id,omitempty"`
+	Background            bool           `json:"background"`
+	Store                 bool           `json:"store"`
+}
+
+type interactionStep struct {
+	Type     string      `json:"type"`
+	Text     string      `json:"text,omitempty"`
+	MimeType string      `json:"mime_type,omitempty"`
+	Data     string      `json:"data,omitempty"`
+	URI      string      `json:"uri,omitempty"`
+	Content  []inputPart `json:"content"`
+}
+
+type interactionResponse struct {
+	ID      string            `json:"id"`
+	Model   string            `json:"model"`
+	Status  string            `json:"status"`
+	Steps   []interactionStep `json:"steps"`
+	Outputs []interactionStep `json:"outputs"`
+	Usage   struct {
+		TotalTokens  int `json:"total_tokens"`
+		OutputTokens int `json:"total_output_tokens"`
+	} `json:"usage"`
+	Error struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func IsModel(modelName string) bool {
+	return strings.TrimSpace(modelName) == ModelGeminiOmniFlashPreview
+}
+
+func IsInteractionTaskName(name string) bool {
+	return strings.HasPrefix(strings.TrimSpace(name), interactionTaskPrefix)
+}
+
+func InteractionIDFromTaskName(name string) (string, error) {
+	id, ok := strings.CutPrefix(strings.TrimSpace(name), interactionTaskPrefix)
+	if !ok || strings.TrimSpace(id) == "" || strings.Contains(id, "/") {
+		return "", fmt.Errorf("invalid interaction task name")
+	}
+	return id, nil
+}
+
+func TaskName(interactionID string) (string, error) {
+	id := strings.TrimSpace(interactionID)
+	if id == "" || strings.Contains(id, "/") {
+		return "", fmt.Errorf("invalid interaction id")
+	}
+	return interactionTaskPrefix + id, nil
+}
+
+func ResolveDuration(req relaycommon.TaskSubmitReq) int {
+	if req.Metadata != nil {
+		for _, key := range []string{"duration_seconds", "durationSeconds"} {
+			if raw, ok := req.Metadata[key]; ok {
+				switch value := raw.(type) {
+				case float64:
+					if value == math.Trunc(value) && value <= float64(MaxDurationSeconds) {
+						return int(value)
+					}
+					return -1
+				case int:
+					return value
+				default:
+					return -1
+				}
+			}
+		}
+	}
+	if req.Duration > 0 {
+		return req.Duration
+	}
+	if strings.TrimSpace(req.Seconds) != "" {
+		seconds, err := strconv.Atoi(req.Seconds)
+		if err != nil {
+			return -1
+		}
+		return seconds
+	}
+	return MinDurationSeconds
+}
+
+func ResolveAspectRatio(req relaycommon.TaskSubmitReq) string {
+	if req.Metadata != nil {
+		for _, key := range []string{"aspect_ratio", "aspectRatio"} {
+			if value, ok := req.Metadata[key].(string); ok && strings.TrimSpace(value) != "" {
+				return strings.TrimSpace(value)
+			}
+		}
+	}
+	if strings.TrimSpace(req.Size) == "" {
+		return "16:9"
+	}
+	parts := strings.SplitN(strings.ToLower(strings.TrimSpace(req.Size)), "x", 2)
+	if len(parts) != 2 {
+		return req.Size
+	}
+	width, widthErr := strconv.Atoi(parts[0])
+	height, heightErr := strconv.Atoi(parts[1])
+	if widthErr != nil || heightErr != nil || width <= 0 || height <= 0 {
+		return req.Size
+	}
+	if width*9 == height*16 {
+		return "16:9"
+	}
+	if width*16 == height*9 {
+		return "9:16"
+	}
+	return req.Size
+}
+
+func ValidateRequest(c *gin.Context, info *relaycommon.RelayInfo) error {
+	req, err := relaycommon.GetTaskRequest(c)
+	if err != nil {
+		return err
+	}
+	duration := ResolveDuration(req)
+	if duration < MinDurationSeconds || duration > MaxDurationSeconds {
+		return fmt.Errorf("duration must be between %d and %d seconds for %s", MinDurationSeconds, MaxDurationSeconds, ModelGeminiOmniFlashPreview)
+	}
+	aspectRatio := ResolveAspectRatio(req)
+	if aspectRatio != "16:9" && aspectRatio != "9:16" {
+		return fmt.Errorf("aspect_ratio must be 16:9 or 9:16 for %s", ModelGeminiOmniFlashPreview)
+	}
+	imageCount := len(req.Images) + multipartImageCount(c)
+	if imageCount > MaxImages {
+		return fmt.Errorf("images must contain at most %d items for %s", MaxImages, ModelGeminiOmniFlashPreview)
+	}
+	if imageCount > 0 && info != nil {
+		info.Action = constant.TaskActionGenerate
+	}
+	return nil
+}
+
+func BuildRequestBody(c *gin.Context, info *relaycommon.RelayInfo) (io.Reader, error) {
+	req, err := relaycommon.GetTaskRequest(c)
+	if err != nil {
+		return nil, err
+	}
+	duration := ResolveDuration(req)
+	prompt := strings.TrimSpace(req.Prompt)
+	prompt += fmt.Sprintf("\n\nGenerate exactly a %d-second video.", duration)
+
+	parts := []inputPart{{Type: "text", Text: prompt}}
+	images, err := collectImageParts(c, req.Images)
+	if err != nil {
+		return nil, err
+	}
+	parts = append(parts, images...)
+	if len(images) > 0 && info != nil {
+		info.Action = constant.TaskActionGenerate
+	}
+
+	previousInteractionID := ""
+	if req.Metadata != nil {
+		if value, ok := req.Metadata["previous_interaction_id"].(string); ok {
+			previousInteractionID = strings.TrimSpace(value)
+		}
+	}
+	body := interactionRequest{
+		Model:                 info.UpstreamModelName,
+		Input:                 parts,
+		ResponseFormat:        responseFormat{Type: "video", AspectRatio: ResolveAspectRatio(req)},
+		PreviousInteractionID: previousInteractionID,
+		Background:            true,
+		Store:                 true,
+	}
+	data, err := common.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(data), nil
+}
+
+func ParseSubmitResponse(body []byte) (string, error) {
+	var interaction interactionResponse
+	if err := common.Unmarshal(body, &interaction); err != nil {
+		return "", fmt.Errorf("unmarshal interaction response failed: %w", err)
+	}
+	if interaction.Error.Message != "" {
+		return "", fmt.Errorf("interaction request failed: %s", interaction.Error.Message)
+	}
+	return TaskName(interaction.ID)
+}
+
+func IsInteractionResponse(body []byte) bool {
+	var interaction struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}
+	if err := common.Unmarshal(body, &interaction); err != nil {
+		return false
+	}
+	return strings.TrimSpace(interaction.ID) != "" || strings.TrimSpace(interaction.Status) != ""
+}
+
+func ParseTaskResult(body []byte) (*relaycommon.TaskInfo, error) {
+	var interaction interactionResponse
+	if err := common.Unmarshal(body, &interaction); err != nil {
+		return nil, fmt.Errorf("unmarshal interaction response failed: %w", err)
+	}
+	result := &relaycommon.TaskInfo{}
+	if interaction.Error.Message != "" {
+		result.Status = model.TaskStatusFailure
+		result.Progress = taskcommon.ProgressComplete
+		result.Reason = interaction.Error.Message
+		return result, nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(interaction.Status)) {
+	case "queued":
+		result.Status = model.TaskStatusQueued
+		result.Progress = taskcommon.ProgressQueued
+		return result, nil
+	case "in_progress", "requires_action":
+		result.Status = model.TaskStatusInProgress
+		result.Progress = taskcommon.ProgressInProgress
+		return result, nil
+	case "failed", "cancelled", "incomplete", "budget_exceeded":
+		result.Status = model.TaskStatusFailure
+		result.Progress = taskcommon.ProgressComplete
+		result.Reason = strings.TrimSpace(interaction.Error.Message)
+		if result.Reason == "" {
+			result.Reason = "interaction ended with status " + interaction.Status
+		}
+		return result, nil
+	case "completed":
+		steps := interaction.Steps
+		if len(steps) == 0 {
+			steps = interaction.Outputs
+		}
+		for _, step := range steps {
+			if step.Type != "model_output" {
+				if partURL := videoPartURL(inputPart{Type: step.Type, MimeType: step.MimeType, Data: step.Data, URI: step.URI}); partURL != "" {
+					setCompletedResult(result, partURL, interaction)
+					return result, nil
+				}
+				continue
+			}
+			for _, part := range step.Content {
+				if partURL := videoPartURL(part); partURL != "" {
+					setCompletedResult(result, partURL, interaction)
+					return result, nil
+				}
+			}
+		}
+		result.Status = model.TaskStatusFailure
+		result.Progress = taskcommon.ProgressComplete
+		result.Reason = "completed interaction did not contain video output"
+		return result, nil
+	default:
+		result.Status = model.TaskStatusInProgress
+		result.Progress = taskcommon.ProgressInProgress
+		return result, nil
+	}
+}
+
+func videoPartURL(part inputPart) string {
+	if part.Type != "video" && !strings.HasPrefix(part.MimeType, "video/") {
+		return ""
+	}
+	if strings.TrimSpace(part.Data) != "" {
+		mimeType := strings.TrimSpace(part.MimeType)
+		if mimeType == "" {
+			mimeType = "video/mp4"
+		}
+		return "data:" + mimeType + ";base64," + part.Data
+	}
+	if strings.HasPrefix(part.URI, "http://") || strings.HasPrefix(part.URI, "https://") {
+		return part.URI
+	}
+	return ""
+}
+
+func setCompletedResult(result *relaycommon.TaskInfo, videoURL string, interaction interactionResponse) {
+	result.Url = videoURL
+	result.Status = model.TaskStatusSuccess
+	result.Progress = taskcommon.ProgressComplete
+	result.CompletionTokens = interaction.Usage.OutputTokens
+	result.TotalTokens = interaction.Usage.TotalTokens
+}

--- a/relay/channel/task/omni/omni.go
+++ b/relay/channel/task/omni/omni.go
@@ -39,6 +39,7 @@ type inputPart struct {
 type responseFormat struct {
 	Type        string  `json:"type"`
 	AspectRatio *string `json:"aspect_ratio,omitempty"`
+	Duration    *string `json:"duration,omitempty"`
 }
 
 type interactionRequest struct {
@@ -218,10 +219,11 @@ func BuildRequestBody(c *gin.Context, info *relaycommon.RelayInfo) (io.Reader, e
 		}
 	}
 	aspectRatio := ResolveAspectRatio(req)
+	durationOption := fmt.Sprintf("%ds", duration)
 	body := interactionRequest{
 		Model:                 info.UpstreamModelName,
 		Input:                 parts,
-		ResponseFormat:        responseFormat{Type: "video", AspectRatio: &aspectRatio},
+		ResponseFormat:        responseFormat{Type: "video", AspectRatio: &aspectRatio, Duration: &durationOption},
 		PreviousInteractionID: previousInteractionID,
 		Background:            true,
 		Store:                 true,

--- a/relay/channel/task/omni/omni.go
+++ b/relay/channel/task/omni/omni.go
@@ -37,15 +37,15 @@ type inputPart struct {
 }
 
 type responseFormat struct {
-	Type        string `json:"type"`
-	AspectRatio string `json:"aspect_ratio,omitempty"`
+	Type        string  `json:"type"`
+	AspectRatio *string `json:"aspect_ratio,omitempty"`
 }
 
 type interactionRequest struct {
 	Model                 string         `json:"model"`
 	Input                 []inputPart    `json:"input"`
 	ResponseFormat        responseFormat `json:"response_format"`
-	PreviousInteractionID string         `json:"previous_interaction_id,omitempty"`
+	PreviousInteractionID *string        `json:"previous_interaction_id,omitempty"`
 	Background            bool           `json:"background"`
 	Store                 bool           `json:"store"`
 }
@@ -74,14 +74,17 @@ type interactionResponse struct {
 	} `json:"error"`
 }
 
+// IsModel reports whether modelName uses the Omni Interactions protocol.
 func IsModel(modelName string) bool {
 	return strings.TrimSpace(modelName) == ModelGeminiOmniFlashPreview
 }
 
+// IsInteractionTaskName reports whether a stored upstream task name is an interaction.
 func IsInteractionTaskName(name string) bool {
 	return strings.HasPrefix(strings.TrimSpace(name), interactionTaskPrefix)
 }
 
+// InteractionIDFromTaskName extracts and validates an interaction ID from task storage.
 func InteractionIDFromTaskName(name string) (string, error) {
 	id, ok := strings.CutPrefix(strings.TrimSpace(name), interactionTaskPrefix)
 	if !ok || strings.TrimSpace(id) == "" || strings.Contains(id, "/") {
@@ -90,6 +93,7 @@ func InteractionIDFromTaskName(name string) (string, error) {
 	return id, nil
 }
 
+// TaskName encodes an interaction ID into the provider-neutral task name format.
 func TaskName(interactionID string) (string, error) {
 	id := strings.TrimSpace(interactionID)
 	if id == "" || strings.Contains(id, "/") {
@@ -98,6 +102,7 @@ func TaskName(interactionID string) (string, error) {
 	return interactionTaskPrefix + id, nil
 }
 
+// ResolveDuration returns the requested Omni duration, defaulting to three seconds.
 func ResolveDuration(req relaycommon.TaskSubmitReq) int {
 	if req.Metadata != nil {
 		for _, key := range []string{"duration_seconds", "durationSeconds"} {
@@ -129,6 +134,7 @@ func ResolveDuration(req relaycommon.TaskSubmitReq) int {
 	return MinDurationSeconds
 }
 
+// ResolveAspectRatio normalizes task metadata or dimensions to an Omni ratio.
 func ResolveAspectRatio(req relaycommon.TaskSubmitReq) string {
 	if req.Metadata != nil {
 		for _, key := range []string{"aspect_ratio", "aspectRatio"} {
@@ -158,6 +164,7 @@ func ResolveAspectRatio(req relaycommon.TaskSubmitReq) string {
 	return req.Size
 }
 
+// ValidateRequest enforces Omni duration, aspect-ratio, and image-count limits.
 func ValidateRequest(c *gin.Context, info *relaycommon.RelayInfo) error {
 	req, err := relaycommon.GetTaskRequest(c)
 	if err != nil {
@@ -181,6 +188,7 @@ func ValidateRequest(c *gin.Context, info *relaycommon.RelayInfo) error {
 	return nil
 }
 
+// BuildRequestBody maps a New API video task to a background Interactions request.
 func BuildRequestBody(c *gin.Context, info *relaycommon.RelayInfo) (io.Reader, error) {
 	req, err := relaycommon.GetTaskRequest(c)
 	if err != nil {
@@ -200,16 +208,20 @@ func BuildRequestBody(c *gin.Context, info *relaycommon.RelayInfo) (io.Reader, e
 		info.Action = constant.TaskActionGenerate
 	}
 
-	previousInteractionID := ""
+	var previousInteractionID *string
 	if req.Metadata != nil {
 		if value, ok := req.Metadata["previous_interaction_id"].(string); ok {
-			previousInteractionID = strings.TrimSpace(value)
+			value = strings.TrimSpace(value)
+			if value != "" {
+				previousInteractionID = &value
+			}
 		}
 	}
+	aspectRatio := ResolveAspectRatio(req)
 	body := interactionRequest{
 		Model:                 info.UpstreamModelName,
 		Input:                 parts,
-		ResponseFormat:        responseFormat{Type: "video", AspectRatio: ResolveAspectRatio(req)},
+		ResponseFormat:        responseFormat{Type: "video", AspectRatio: &aspectRatio},
 		PreviousInteractionID: previousInteractionID,
 		Background:            true,
 		Store:                 true,
@@ -221,6 +233,7 @@ func BuildRequestBody(c *gin.Context, info *relaycommon.RelayInfo) (io.Reader, e
 	return bytes.NewReader(data), nil
 }
 
+// ParseSubmitResponse validates an interaction submission and returns its task name.
 func ParseSubmitResponse(body []byte) (string, error) {
 	var interaction interactionResponse
 	if err := common.Unmarshal(body, &interaction); err != nil {
@@ -232,6 +245,7 @@ func ParseSubmitResponse(body []byte) (string, error) {
 	return TaskName(interaction.ID)
 }
 
+// IsInteractionResponse distinguishes Interactions payloads from Veo operations.
 func IsInteractionResponse(body []byte) bool {
 	var interaction struct {
 		ID     string `json:"id"`
@@ -243,6 +257,7 @@ func IsInteractionResponse(body []byte) bool {
 	return strings.TrimSpace(interaction.ID) != "" || strings.TrimSpace(interaction.Status) != ""
 }
 
+// ParseTaskResult maps an Interactions lifecycle response to New API task state.
 func ParseTaskResult(body []byte) (*relaycommon.TaskInfo, error) {
 	var interaction interactionResponse
 	if err := common.Unmarshal(body, &interaction); err != nil {
@@ -274,22 +289,20 @@ func ParseTaskResult(body []byte) (*relaycommon.TaskInfo, error) {
 		}
 		return result, nil
 	case "completed":
-		steps := interaction.Steps
-		if len(steps) == 0 {
-			steps = interaction.Outputs
-		}
-		for _, step := range steps {
-			if step.Type != "model_output" {
-				if partURL := videoPartURL(inputPart{Type: step.Type, MimeType: step.MimeType, Data: step.Data, URI: step.URI}); partURL != "" {
-					setCompletedResult(result, partURL, interaction)
-					return result, nil
+		for _, steps := range [][]interactionStep{interaction.Steps, interaction.Outputs} {
+			for _, step := range steps {
+				if step.Type != "model_output" {
+					if partURL := videoPartURL(inputPart{Type: step.Type, MimeType: step.MimeType, Data: step.Data, URI: step.URI}); partURL != "" {
+						setCompletedResult(result, partURL, interaction)
+						return result, nil
+					}
+					continue
 				}
-				continue
-			}
-			for _, part := range step.Content {
-				if partURL := videoPartURL(part); partURL != "" {
-					setCompletedResult(result, partURL, interaction)
-					return result, nil
+				for _, part := range step.Content {
+					if partURL := videoPartURL(part); partURL != "" {
+						setCompletedResult(result, partURL, interaction)
+						return result, nil
+					}
 				}
 			}
 		}

--- a/relay/channel/task/omni/omni.go
+++ b/relay/channel/task/omni/omni.go
@@ -29,11 +29,12 @@ const (
 )
 
 type inputPart struct {
-	Type     string `json:"type"`
-	Text     string `json:"text,omitempty"`
-	MimeType string `json:"mime_type,omitempty"`
-	Data     string `json:"data,omitempty"`
-	URI      string `json:"uri,omitempty"`
+	Type     string      `json:"type"`
+	Text     string      `json:"text,omitempty"`
+	MimeType string      `json:"mime_type,omitempty"`
+	Data     string      `json:"data,omitempty"`
+	URI      string      `json:"uri,omitempty"`
+	Content  []inputPart `json:"content,omitempty"`
 }
 
 type responseFormat struct {
@@ -165,7 +166,7 @@ func ResolveAspectRatio(req relaycommon.TaskSubmitReq) string {
 	return req.Size
 }
 
-// ValidateRequest enforces Omni duration, aspect-ratio, and image-count limits.
+// ValidateRequest enforces Omni output options and reference-media limits.
 func ValidateRequest(c *gin.Context, info *relaycommon.RelayInfo) error {
 	req, err := relaycommon.GetTaskRequest(c)
 	if err != nil {
@@ -183,7 +184,11 @@ func ValidateRequest(c *gin.Context, info *relaycommon.RelayInfo) error {
 	if imageCount > MaxImages {
 		return fmt.Errorf("images must contain at most %d items for %s", MaxImages, ModelGeminiOmniFlashPreview)
 	}
-	if imageCount > 0 && info != nil {
+	referenceVideo, err := prepareReferenceVideo(c, req)
+	if err != nil {
+		return err
+	}
+	if (imageCount > 0 || referenceVideo.Part != nil) && info != nil {
 		info.Action = constant.TaskActionGenerate
 	}
 	return nil
@@ -207,6 +212,19 @@ func BuildRequestBody(c *gin.Context, info *relaycommon.RelayInfo) (io.Reader, e
 	parts = append(parts, images...)
 	if len(images) > 0 && info != nil {
 		info.Action = constant.TaskActionGenerate
+	}
+	referenceVideo, err := prepareReferenceVideo(c, req)
+	if err != nil {
+		return nil, err
+	}
+	if referenceVideo.Part != nil {
+		content := []inputPart{*referenceVideo.Part}
+		content = append(content, images...)
+		content = append(content, inputPart{Type: "text", Text: prompt})
+		parts = []inputPart{{Type: "user_input", Content: content}}
+		if info != nil {
+			info.Action = constant.TaskActionGenerate
+		}
 	}
 
 	var previousInteractionID *string

--- a/relay/channel/task/omni/omni_test.go
+++ b/relay/channel/task/omni/omni_test.go
@@ -54,6 +54,8 @@ func TestBuildRequestBodyIncludesPromptReferenceImagesAndAsyncState(t *testing.T
 	assert.Equal(t, "interaction_previous", *request.PreviousInteractionID)
 	require.NotNil(t, request.ResponseFormat.AspectRatio)
 	assert.Equal(t, "9:16", *request.ResponseFormat.AspectRatio)
+	require.NotNil(t, request.ResponseFormat.Duration)
+	assert.Equal(t, "5s", *request.ResponseFormat.Duration)
 	require.Len(t, request.Input, 3)
 	assert.Contains(t, request.Input[0].Text, "Generate exactly a 5-second video.")
 	assert.Equal(t, inputPart{Type: "image", MimeType: "image/png", Data: imageOne}, request.Input[1])

--- a/relay/channel/task/omni/omni_test.go
+++ b/relay/channel/task/omni/omni_test.go
@@ -2,6 +2,7 @@ package omni
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"io"
@@ -180,7 +181,7 @@ func TestValidateMultipartReferenceVideoDurationBeforeSubmission(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())
 
-	request := httptest.NewRequest(http.MethodPost, "/v1/videos", &body)
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/videos", &body)
 	request.Header.Set("Content-Type", writer.FormDataContentType())
 	context, _ := gin.CreateTestContext(httptest.NewRecorder())
 	context.Request = request

--- a/relay/channel/task/omni/omni_test.go
+++ b/relay/channel/task/omni/omni_test.go
@@ -1,0 +1,127 @@
+package omni
+
+import (
+	"encoding/base64"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/model"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTaskContext(t *testing.T, req relaycommon.TaskSubmitReq) *gin.Context {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = httptest.NewRequest("POST", "/v1/videos", nil)
+	context.Set("task_request", req)
+	return context
+}
+
+func TestBuildRequestBodyIncludesPromptReferenceImagesAndAsyncState(t *testing.T) {
+	imageOne := base64.StdEncoding.EncodeToString([]byte("image-one"))
+	imageTwo := base64.StdEncoding.EncodeToString([]byte("image-two"))
+	req := relaycommon.TaskSubmitReq{
+		Prompt:   "A product rotates on a pedestal.",
+		Images:   []string{"data:image/png;base64," + imageOne, "data:image/jpeg;base64," + imageTwo},
+		Duration: 5,
+		Size:     "720x1280",
+		Metadata: map[string]any{"previous_interaction_id": "interaction_previous"},
+	}
+	context := newTaskContext(t, req)
+	info := &relaycommon.RelayInfo{
+		ChannelMeta:   &relaycommon.ChannelMeta{UpstreamModelName: ModelGeminiOmniFlashPreview},
+		TaskRelayInfo: &relaycommon.TaskRelayInfo{},
+	}
+
+	body, err := BuildRequestBody(context, info)
+	require.NoError(t, err)
+	raw, err := io.ReadAll(body)
+	require.NoError(t, err)
+	var request interactionRequest
+	require.NoError(t, common.Unmarshal(raw, &request))
+
+	assert.Equal(t, ModelGeminiOmniFlashPreview, request.Model)
+	assert.True(t, request.Background)
+	assert.True(t, request.Store)
+	assert.Equal(t, "interaction_previous", request.PreviousInteractionID)
+	assert.Equal(t, responseFormat{Type: "video", AspectRatio: "9:16"}, request.ResponseFormat)
+	require.Len(t, request.Input, 3)
+	assert.Contains(t, request.Input[0].Text, "Generate exactly a 5-second video.")
+	assert.Equal(t, inputPart{Type: "image", MimeType: "image/png", Data: imageOne}, request.Input[1])
+	assert.Equal(t, inputPart{Type: "image", MimeType: "image/jpeg", Data: imageTwo}, request.Input[2])
+	assert.Equal(t, constant.TaskActionGenerate, info.Action)
+}
+
+func TestValidateRequestEnforcesOmniBounds(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     relaycommon.TaskSubmitReq
+		wantErr string
+	}{
+		{
+			name:    "duration below minimum",
+			req:     relaycommon.TaskSubmitReq{Prompt: "test", Duration: 2},
+			wantErr: "duration must be between 3 and 10 seconds",
+		},
+		{
+			name:    "duration above maximum",
+			req:     relaycommon.TaskSubmitReq{Prompt: "test", Duration: 11},
+			wantErr: "duration must be between 3 and 10 seconds",
+		},
+		{
+			name:    "unsupported aspect ratio",
+			req:     relaycommon.TaskSubmitReq{Prompt: "test", Duration: 3, Metadata: map[string]any{"aspect_ratio": "1:1"}},
+			wantErr: "aspect_ratio must be 16:9 or 9:16",
+		},
+		{
+			name:    "too many images",
+			req:     relaycommon.TaskSubmitReq{Prompt: "test", Duration: 3, Images: make([]string, MaxImages+1)},
+			wantErr: "images must contain at most 10 items",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			context := newTaskContext(t, tt.req)
+			err := ValidateRequest(context, &relaycommon.RelayInfo{TaskRelayInfo: &relaycommon.TaskRelayInfo{}})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestParseInteractionLifecycle(t *testing.T) {
+	upstreamName, err := ParseSubmitResponse([]byte(`{"id":"interaction_123","status":"in_progress","model":"gemini-omni-flash-preview"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "interactions/interaction_123", upstreamName)
+
+	inProgress, err := ParseTaskResult([]byte(`{"id":"interaction_123","status":"in_progress"}`))
+	require.NoError(t, err)
+	assert.Equal(t, string(model.TaskStatusInProgress), inProgress.Status)
+
+	completed, err := ParseTaskResult([]byte(`{
+		"id":"interaction_123",
+		"status":"completed",
+		"steps":[{"type":"model_output","content":[{"type":"video","mime_type":"video/mp4","data":"dmlkZW8="}]}],
+		"usage":{"total_tokens":17682,"total_output_tokens":17376}
+	}`))
+	require.NoError(t, err)
+	assert.Equal(t, string(model.TaskStatusSuccess), completed.Status)
+	assert.Equal(t, "data:video/mp4;base64,dmlkZW8=", completed.Url)
+	assert.Equal(t, 17682, completed.TotalTokens)
+	assert.Equal(t, 17376, completed.CompletionTokens)
+}
+
+func TestParseCompletedInteractionWithoutVideoFails(t *testing.T) {
+	result, err := ParseTaskResult([]byte(`{"id":"interaction_123","status":"completed","steps":[]}`))
+	require.NoError(t, err)
+	assert.Equal(t, string(model.TaskStatusFailure), result.Status)
+	assert.Contains(t, result.Reason, "did not contain video")
+}

--- a/relay/channel/task/omni/omni_test.go
+++ b/relay/channel/task/omni/omni_test.go
@@ -182,12 +182,12 @@ func TestReferenceVideoDurationErrorUsesRequestLanguage(t *testing.T) {
 		{
 			name:     "simplified Chinese",
 			language: "zh-CN",
-			expected: "参考视频时长为 10.056 秒，超过 gemini-omni-flash-preview 的 10 秒上限。",
+			expected: "参考视频时长超过10 秒上限。",
 		},
 		{
 			name:     "traditional Chinese",
 			language: "zh-TW",
-			expected: "參考影片時長為 10.056 秒，超過 gemini-omni-flash-preview 的 10 秒上限。",
+			expected: "參考影片時長超過 10 秒上限。",
 		},
 		{
 			name:     "English",

--- a/relay/channel/task/omni/omni_test.go
+++ b/relay/channel/task/omni/omni_test.go
@@ -1,9 +1,14 @@
 package omni
 
 import (
+	"bytes"
 	"encoding/base64"
+	"encoding/binary"
 	"io"
+	"mime/multipart"
+	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"testing"
 
 	"github.com/QuantumNous/new-api/common"
@@ -14,6 +19,35 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func testMP4(durationMilliseconds uint32) []byte {
+	writeBox := func(boxType string, payload []byte) []byte {
+		box := make([]byte, 8+len(payload))
+		binary.BigEndian.PutUint32(box[:4], uint32(len(box)))
+		copy(box[4:8], boxType)
+		copy(box[8:], payload)
+		return box
+	}
+
+	ftyp := make([]byte, 16)
+	copy(ftyp[:4], "isom")
+	copy(ftyp[8:12], "isom")
+	copy(ftyp[12:16], "mp42")
+	mvhd := make([]byte, 100)
+	binary.BigEndian.PutUint32(mvhd[12:16], 1000)
+	binary.BigEndian.PutUint32(mvhd[16:20], durationMilliseconds)
+	binary.BigEndian.PutUint32(mvhd[20:24], 0x00010000)
+	binary.BigEndian.PutUint16(mvhd[24:26], 0x0100)
+	binary.BigEndian.PutUint32(mvhd[36:40], 0x00010000)
+	binary.BigEndian.PutUint32(mvhd[52:56], 0x00010000)
+	binary.BigEndian.PutUint32(mvhd[68:72], 0x40000000)
+	binary.BigEndian.PutUint32(mvhd[96:100], 1)
+
+	return bytes.Join([][]byte{
+		writeBox("ftyp", ftyp),
+		writeBox("moov", writeBox("mvhd", mvhd)),
+	}, nil)
+}
 
 func newTaskContext(t *testing.T, req relaycommon.TaskSubmitReq) *gin.Context {
 	t.Helper()
@@ -61,6 +95,101 @@ func TestBuildRequestBodyIncludesPromptReferenceImagesAndAsyncState(t *testing.T
 	assert.Equal(t, inputPart{Type: "image", MimeType: "image/png", Data: imageOne}, request.Input[1])
 	assert.Equal(t, inputPart{Type: "image", MimeType: "image/jpeg", Data: imageTwo}, request.Input[2])
 	assert.Equal(t, constant.TaskActionGenerate, info.Action)
+}
+
+func TestBuildRequestBodyUsesNestedUserInputForReferenceVideo(t *testing.T) {
+	videoData := base64.StdEncoding.EncodeToString(testMP4(3000))
+	imageData := base64.StdEncoding.EncodeToString([]byte("image"))
+	req := relaycommon.TaskSubmitReq{
+		Prompt:   "Change the sphere to green. Keep everything else the same.",
+		Video:    "data:video/mp4;base64," + videoData,
+		Images:   []string{"data:image/png;base64," + imageData},
+		Duration: 3,
+	}
+	context := newTaskContext(t, req)
+	info := &relaycommon.RelayInfo{
+		ChannelMeta:   &relaycommon.ChannelMeta{UpstreamModelName: ModelGeminiOmniFlashPreview},
+		TaskRelayInfo: &relaycommon.TaskRelayInfo{},
+	}
+
+	require.NoError(t, ValidateRequest(context, info))
+	body, err := BuildRequestBody(context, info)
+	require.NoError(t, err)
+	raw, err := io.ReadAll(body)
+	require.NoError(t, err)
+	var request interactionRequest
+	require.NoError(t, common.Unmarshal(raw, &request))
+
+	require.Len(t, request.Input, 1)
+	assert.Equal(t, "user_input", request.Input[0].Type)
+	require.Len(t, request.Input[0].Content, 3)
+	assert.Equal(t, inputPart{Type: "video", MimeType: "video/mp4", Data: videoData}, request.Input[0].Content[0])
+	assert.Equal(t, "image", request.Input[0].Content[1].Type)
+	assert.Contains(t, request.Input[0].Content[2].Text, "Change the sphere to green")
+	assert.Equal(t, constant.TaskActionGenerate, info.Action)
+}
+
+func TestValidateReferenceVideoDurationBeforeSubmission(t *testing.T) {
+	tests := []struct {
+		name    string
+		videos  []string
+		wantErr string
+	}{
+		{
+			name:   "exactly ten seconds is accepted",
+			videos: []string{"data:video/mp4;base64," + base64.StdEncoding.EncodeToString(testMP4(10000))},
+		},
+		{
+			name:    "thirty seconds is rejected",
+			videos:  []string{"data:video/mp4;base64," + base64.StdEncoding.EncodeToString(testMP4(30000))},
+			wantErr: "reference video duration 30.000 seconds exceeds the 10-second maximum",
+		},
+		{
+			name: "multiple videos are rejected",
+			videos: []string{
+				"data:video/mp4;base64," + base64.StdEncoding.EncodeToString(testMP4(3000)),
+				"data:video/mp4;base64," + base64.StdEncoding.EncodeToString(testMP4(3000)),
+			},
+			wantErr: "videos must contain at most 1 item",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			context := newTaskContext(t, relaycommon.TaskSubmitReq{Prompt: "edit", Videos: tt.videos, Duration: 3})
+			err := ValidateRequest(context, &relaycommon.RelayInfo{TaskRelayInfo: &relaycommon.TaskRelayInfo{}})
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestValidateMultipartReferenceVideoDurationBeforeSubmission(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", `form-data; name="video"; filename="reference.mp4"`)
+	header.Set("Content-Type", "video/mp4")
+	part, err := writer.CreatePart(header)
+	require.NoError(t, err)
+	_, err = part.Write(testMP4(30000))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/videos", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = request
+	context.Set("task_request", relaycommon.TaskSubmitReq{Prompt: "edit", Duration: 3})
+
+	err = ValidateRequest(context, &relaycommon.RelayInfo{TaskRelayInfo: &relaycommon.TaskRelayInfo{}})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reference video duration 30.000 seconds exceeds the 10-second maximum")
 }
 
 func TestValidateRequestEnforcesOmniBounds(t *testing.T) {

--- a/relay/channel/task/omni/omni_test.go
+++ b/relay/channel/task/omni/omni_test.go
@@ -50,8 +50,10 @@ func TestBuildRequestBodyIncludesPromptReferenceImagesAndAsyncState(t *testing.T
 	assert.Equal(t, ModelGeminiOmniFlashPreview, request.Model)
 	assert.True(t, request.Background)
 	assert.True(t, request.Store)
-	assert.Equal(t, "interaction_previous", request.PreviousInteractionID)
-	assert.Equal(t, responseFormat{Type: "video", AspectRatio: "9:16"}, request.ResponseFormat)
+	require.NotNil(t, request.PreviousInteractionID)
+	assert.Equal(t, "interaction_previous", *request.PreviousInteractionID)
+	require.NotNil(t, request.ResponseFormat.AspectRatio)
+	assert.Equal(t, "9:16", *request.ResponseFormat.AspectRatio)
 	require.Len(t, request.Input, 3)
 	assert.Contains(t, request.Input[0].Text, "Generate exactly a 5-second video.")
 	assert.Equal(t, inputPart{Type: "image", MimeType: "image/png", Data: imageOne}, request.Input[1])
@@ -124,4 +126,17 @@ func TestParseCompletedInteractionWithoutVideoFails(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, string(model.TaskStatusFailure), result.Status)
 	assert.Contains(t, result.Reason, "did not contain video")
+}
+
+func TestParseInteractionChecksOutputsWhenStepsArePresent(t *testing.T) {
+	result, err := ParseTaskResult([]byte(`{
+		"id":"interaction_123",
+		"status":"completed",
+		"steps":[{"type":"thought","content":[]}],
+		"outputs":[{"type":"model_output","content":[{"type":"video","mime_type":"video/mp4","data":"dmlkZW8="}]}]
+	}`))
+
+	require.NoError(t, err)
+	assert.Equal(t, string(model.TaskStatusSuccess), result.Status)
+	assert.Equal(t, "data:video/mp4;base64,dmlkZW8=", result.Url)
 }

--- a/relay/channel/task/omni/omni_test.go
+++ b/relay/channel/task/omni/omni_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
+	appI18n "github.com/QuantumNous/new-api/i18n"
 	"github.com/QuantumNous/new-api/model"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/gin-gonic/gin"
@@ -131,6 +132,7 @@ func TestBuildRequestBodyUsesNestedUserInputForReferenceVideo(t *testing.T) {
 }
 
 func TestValidateReferenceVideoDurationBeforeSubmission(t *testing.T) {
+	require.NoError(t, appI18n.Init())
 	tests := []struct {
 		name    string
 		videos  []string
@@ -143,7 +145,7 @@ func TestValidateReferenceVideoDurationBeforeSubmission(t *testing.T) {
 		{
 			name:    "thirty seconds is rejected",
 			videos:  []string{"data:video/mp4;base64," + base64.StdEncoding.EncodeToString(testMP4(30000))},
-			wantErr: "reference video duration 30.000 seconds exceeds the 10-second maximum",
+			wantErr: "Reference video duration is 30.000 seconds, which exceeds the 10-second limit",
 		},
 		{
 			name: "multiple videos are rejected",
@@ -169,7 +171,45 @@ func TestValidateReferenceVideoDurationBeforeSubmission(t *testing.T) {
 	}
 }
 
+func TestReferenceVideoDurationErrorUsesRequestLanguage(t *testing.T) {
+	require.NoError(t, appI18n.Init())
+	video := "data:video/mp4;base64," + base64.StdEncoding.EncodeToString(testMP4(10056))
+	tests := []struct {
+		name     string
+		language string
+		expected string
+	}{
+		{
+			name:     "simplified Chinese",
+			language: "zh-CN",
+			expected: "参考视频时长为 10.056 秒，超过 gemini-omni-flash-preview 的 10 秒上限。",
+		},
+		{
+			name:     "traditional Chinese",
+			language: "zh-TW",
+			expected: "參考影片時長為 10.056 秒，超過 gemini-omni-flash-preview 的 10 秒上限。",
+		},
+		{
+			name:     "English",
+			language: "en",
+			expected: "Reference video duration is 10.056 seconds, which exceeds the 10-second limit for gemini-omni-flash-preview.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			context := newTaskContext(t, relaycommon.TaskSubmitReq{Prompt: "edit", Video: video, Duration: 3})
+			context.Request.Header.Set("Accept-Language", tt.language)
+
+			err := ValidateRequest(context, &relaycommon.RelayInfo{TaskRelayInfo: &relaycommon.TaskRelayInfo{}})
+
+			require.EqualError(t, err, tt.expected)
+		})
+	}
+}
+
 func TestValidateMultipartReferenceVideoDurationBeforeSubmission(t *testing.T) {
+	require.NoError(t, appI18n.Init())
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 	header := make(textproto.MIMEHeader)
@@ -190,7 +230,7 @@ func TestValidateMultipartReferenceVideoDurationBeforeSubmission(t *testing.T) {
 	err = ValidateRequest(context, &relaycommon.RelayInfo{TaskRelayInfo: &relaycommon.TaskRelayInfo{}})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "reference video duration 30.000 seconds exceeds the 10-second maximum")
+	assert.Contains(t, err.Error(), "Reference video duration is 30.000 seconds, which exceeds the 10-second limit")
 }
 
 func TestValidateRequestEnforcesOmniBounds(t *testing.T) {

--- a/relay/channel/task/omni/video.go
+++ b/relay/channel/task/omni/video.go
@@ -3,13 +3,16 @@ package omni
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"strings"
 
-	"github.com/QuantumNous/new-api/relay/common"
+	rootcommon "github.com/QuantumNous/new-api/common"
+	appI18n "github.com/QuantumNous/new-api/i18n"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/service"
 	"github.com/abema/go-mp4"
 	"github.com/gin-gonic/gin"
@@ -27,12 +30,38 @@ type preparedReferenceVideo struct {
 	DurationSeconds float64
 }
 
+type referenceVideoDurationError struct {
+	DurationSeconds float64
+	MaxSeconds      int
+	Model           string
+}
+
+func (e *referenceVideoDurationError) Error() string {
+	return fmt.Sprintf("reference video duration %.3f seconds exceeds the %d-second maximum for %s", e.DurationSeconds, e.MaxSeconds, e.Model)
+}
+
+func localizeReferenceVideoError(c *gin.Context, err error) error {
+	var durationErr *referenceVideoDurationError
+	if !errors.As(err, &durationErr) {
+		return err
+	}
+	message := rootcommon.TranslateMessage(c, appI18n.MsgOmniReferenceVideoDurationExceeded, map[string]any{
+		"Duration": fmt.Sprintf("%.3f", durationErr.DurationSeconds),
+		"Max":      durationErr.MaxSeconds,
+		"Model":    durationErr.Model,
+	})
+	if message == appI18n.MsgOmniReferenceVideoDurationExceeded {
+		return err
+	}
+	return errors.New(message)
+}
+
 var supportedVideoMimeTypes = map[string]struct{}{
 	"video/mp4":       {},
 	"video/quicktime": {},
 }
 
-func prepareReferenceVideo(c *gin.Context, req common.TaskSubmitReq) (*preparedReferenceVideo, error) {
+func prepareReferenceVideo(c *gin.Context, req relaycommon.TaskSubmitReq) (*preparedReferenceVideo, error) {
 	if cached, ok := c.Get(preparedReferenceVideoKey); ok {
 		if prepared, ok := cached.(*preparedReferenceVideo); ok {
 			return prepared, nil
@@ -181,7 +210,11 @@ func newVideoPart(mimeType string, data []byte, encoded string) (inputPart, floa
 	}
 	duration := float64(probe.Duration) / float64(probe.Timescale)
 	if duration > MaxDurationSeconds {
-		return inputPart{}, 0, fmt.Errorf("reference video duration %.3f seconds exceeds the %d-second maximum for %s", duration, MaxDurationSeconds, ModelGeminiOmniFlashPreview)
+		return inputPart{}, 0, &referenceVideoDurationError{
+			DurationSeconds: duration,
+			MaxSeconds:      MaxDurationSeconds,
+			Model:           ModelGeminiOmniFlashPreview,
+		}
 	}
 	if encoded == "" {
 		encoded = base64.StdEncoding.EncodeToString(data)

--- a/relay/channel/task/omni/video.go
+++ b/relay/channel/task/omni/video.go
@@ -1,0 +1,209 @@
+package omni
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+
+	"github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/abema/go-mp4"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	MaxReferenceVideos  = 1
+	MaxInlineVideoBytes = 64 * 1024 * 1024
+
+	preparedReferenceVideoKey = "omni_prepared_reference_video"
+)
+
+type preparedReferenceVideo struct {
+	Part            *inputPart
+	DurationSeconds float64
+}
+
+var supportedVideoMimeTypes = map[string]struct{}{
+	"video/mp4":       {},
+	"video/quicktime": {},
+}
+
+func prepareReferenceVideo(c *gin.Context, req common.TaskSubmitReq) (*preparedReferenceVideo, error) {
+	if cached, ok := c.Get(preparedReferenceVideoKey); ok {
+		if prepared, ok := cached.(*preparedReferenceVideo); ok {
+			return prepared, nil
+		}
+	}
+
+	values := make([]string, 0, len(req.Videos)+1)
+	if value := strings.TrimSpace(req.Video); value != "" {
+		values = append(values, value)
+	}
+	for _, value := range req.Videos {
+		if value = strings.TrimSpace(value); value != "" {
+			values = append(values, value)
+		}
+	}
+	files := multipartVideoFiles(c)
+	if len(values)+len(files) > MaxReferenceVideos {
+		return nil, fmt.Errorf("videos must contain at most %d item for %s", MaxReferenceVideos, ModelGeminiOmniFlashPreview)
+	}
+
+	prepared := &preparedReferenceVideo{}
+	if len(files) == 1 {
+		part, duration, err := videoPartFromMultipart(files[0])
+		if err != nil {
+			return nil, fmt.Errorf("invalid reference video: %w", err)
+		}
+		prepared.Part = &part
+		prepared.DurationSeconds = duration
+	} else if len(values) == 1 {
+		part, duration, err := videoPartFromString(values[0])
+		if err != nil {
+			return nil, fmt.Errorf("invalid reference video: %w", err)
+		}
+		prepared.Part = &part
+		prepared.DurationSeconds = duration
+	}
+	c.Set(preparedReferenceVideoKey, prepared)
+	return prepared, nil
+}
+
+func multipartVideoFiles(c *gin.Context) []*multipart.FileHeader {
+	form, err := c.MultipartForm()
+	if err != nil || form == nil {
+		return nil
+	}
+	var files []*multipart.FileHeader
+	for _, field := range []string{"video", "videos"} {
+		files = append(files, form.File[field]...)
+	}
+	return files
+}
+
+func videoPartFromMultipart(fileHeader *multipart.FileHeader) (inputPart, float64, error) {
+	if fileHeader == nil {
+		return inputPart{}, 0, fmt.Errorf("file is required")
+	}
+	if fileHeader.Size <= 0 || fileHeader.Size > MaxInlineVideoBytes {
+		return inputPart{}, 0, fmt.Errorf("file size must be between 1 and %d bytes", MaxInlineVideoBytes)
+	}
+	file, err := fileHeader.Open()
+	if err != nil {
+		return inputPart{}, 0, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, MaxInlineVideoBytes+1))
+	if err != nil {
+		return inputPart{}, 0, err
+	}
+	if len(data) == 0 || len(data) > MaxInlineVideoBytes {
+		return inputPart{}, 0, fmt.Errorf("file size must be between 1 and %d bytes", MaxInlineVideoBytes)
+	}
+	mimeType := strings.TrimSpace(fileHeader.Header.Get("Content-Type"))
+	return newVideoPart(mimeType, data, "")
+}
+
+func videoPartFromString(value string) (inputPart, float64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return inputPart{}, 0, fmt.Errorf("video is required")
+	}
+	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+		return videoPartFromURL(value)
+	}
+	if strings.HasPrefix(value, "data:") {
+		comma := strings.Index(value, ",")
+		if comma < 0 {
+			return inputPart{}, 0, fmt.Errorf("invalid data URI")
+		}
+		metadata := value[len("data:"):comma]
+		if !strings.HasSuffix(metadata, ";base64") {
+			return inputPart{}, 0, fmt.Errorf("video data URI must use base64 encoding")
+		}
+		return newInlineVideoPart(strings.TrimSuffix(metadata, ";base64"), value[comma+1:])
+	}
+	return newInlineVideoPart("", value)
+}
+
+func videoPartFromURL(value string) (inputPart, float64, error) {
+	response, err := service.DoDownloadRequest(value, "gemini_omni_reference_video")
+	if err != nil {
+		return inputPart{}, 0, fmt.Errorf("failed to download video: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return inputPart{}, 0, fmt.Errorf("failed to download video: HTTP %d", response.StatusCode)
+	}
+	if response.ContentLength > MaxInlineVideoBytes {
+		return inputPart{}, 0, fmt.Errorf("file size exceeds maximum allowed size of %d bytes", MaxInlineVideoBytes)
+	}
+	data, err := io.ReadAll(io.LimitReader(response.Body, MaxInlineVideoBytes+1))
+	if err != nil {
+		return inputPart{}, 0, fmt.Errorf("failed to read video data: %w", err)
+	}
+	if len(data) == 0 || len(data) > MaxInlineVideoBytes {
+		return inputPart{}, 0, fmt.Errorf("file size must be between 1 and %d bytes", MaxInlineVideoBytes)
+	}
+	return newVideoPart(response.Header.Get("Content-Type"), data, "")
+}
+
+func newInlineVideoPart(mimeType string, encoded string) (inputPart, float64, error) {
+	encoded = strings.TrimSpace(encoded)
+	if encoded == "" || base64.StdEncoding.DecodedLen(len(encoded)) > MaxInlineVideoBytes+2 {
+		return inputPart{}, 0, fmt.Errorf("decoded video size must be between 1 and %d bytes", MaxInlineVideoBytes)
+	}
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return inputPart{}, 0, fmt.Errorf("invalid base64 video data")
+	}
+	if len(data) == 0 || len(data) > MaxInlineVideoBytes {
+		return inputPart{}, 0, fmt.Errorf("decoded video size must be between 1 and %d bytes", MaxInlineVideoBytes)
+	}
+	return newVideoPart(mimeType, data, encoded)
+}
+
+func newVideoPart(mimeType string, data []byte, encoded string) (inputPart, float64, error) {
+	mimeType = normalizeVideoMimeType(mimeType, data)
+	if _, ok := supportedVideoMimeTypes[mimeType]; !ok {
+		return inputPart{}, 0, fmt.Errorf("unsupported video MIME type %q; use MP4 or QuickTime", mimeType)
+	}
+	probe, err := mp4.Probe(bytes.NewReader(data))
+	if err != nil {
+		return inputPart{}, 0, fmt.Errorf("failed to read video duration: %w", err)
+	}
+	if probe.Timescale == 0 || probe.Duration == 0 {
+		return inputPart{}, 0, fmt.Errorf("video duration is missing or invalid")
+	}
+	duration := float64(probe.Duration) / float64(probe.Timescale)
+	if duration > MaxDurationSeconds {
+		return inputPart{}, 0, fmt.Errorf("reference video duration %.3f seconds exceeds the %d-second maximum for %s", duration, MaxDurationSeconds, ModelGeminiOmniFlashPreview)
+	}
+	if encoded == "" {
+		encoded = base64.StdEncoding.EncodeToString(data)
+	}
+
+	return inputPart{
+		Type:     "video",
+		MimeType: mimeType,
+		Data:     encoded,
+	}, duration, nil
+}
+
+func normalizeVideoMimeType(mimeType string, data []byte) string {
+	mimeType = strings.ToLower(strings.TrimSpace(strings.SplitN(mimeType, ";", 2)[0]))
+	switch mimeType {
+	case "video/mov":
+		return "video/quicktime"
+	case "video/x-m4v":
+		return "video/mp4"
+	case "", "application/octet-stream":
+		return http.DetectContentType(data)
+	default:
+		return mimeType
+	}
+}

--- a/relay/channel/task/vertex/adaptor.go
+++ b/relay/channel/task/vertex/adaptor.go
@@ -17,6 +17,7 @@ import (
 	taskdto "github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/relay/channel"
 	geminitask "github.com/QuantumNous/new-api/relay/channel/task/gemini"
+	omnitask "github.com/QuantumNous/new-api/relay/channel/task/omni"
 	taskcommon "github.com/QuantumNous/new-api/relay/channel/task/taskcommon"
 	vertexcore "github.com/QuantumNous/new-api/relay/channel/vertex"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
@@ -77,8 +78,15 @@ func (a *TaskAdaptor) Init(info *relaycommon.RelayInfo) {
 
 // ValidateRequestAndSetAction parses body, validates fields and sets default action.
 func (a *TaskAdaptor) ValidateRequestAndSetAction(c *gin.Context, info *relaycommon.RelayInfo) (taskErr *taskdto.TaskError) {
-	// Use the standard validation method for TaskSubmitReq
-	return relaycommon.ValidateBasicTaskRequest(c, info, constant.TaskActionTextGenerate)
+	if taskErr := relaycommon.ValidateBasicTaskRequest(c, info, constant.TaskActionTextGenerate); taskErr != nil {
+		return taskErr
+	}
+	if omnitask.IsModel(info.OriginModelName) {
+		if err := omnitask.ValidateRequest(c, info); err != nil {
+			return service.TaskErrorWrapperLocal(err, "invalid_omni_request", http.StatusBadRequest)
+		}
+	}
+	return nil
 }
 
 // BuildRequestURL constructs the upstream URL.
@@ -90,6 +98,9 @@ func (a *TaskAdaptor) BuildRequestURL(info *relaycommon.RelayInfo) (string, erro
 	modelName := info.UpstreamModelName
 	if modelName == "" {
 		modelName = "veo-3.0-generate-001"
+	}
+	if omnitask.IsModel(modelName) {
+		return vertexcore.BuildAPIBaseURL(a.baseURL, omnitask.VertexAPIVersion, adc.ProjectID, "global") + "/interactions", nil
 	}
 
 	region := vertexcore.GetModelRegion(info.ApiVersion, modelName)
@@ -119,6 +130,9 @@ func (a *TaskAdaptor) BuildRequestHeader(c *gin.Context, req *http.Request, info
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("x-goog-user-project", adc.ProjectID)
+	if info != nil && omnitask.IsModel(info.UpstreamModelName) {
+		req.Header.Set("Api-Revision", omnitask.APIRevision)
+	}
 	return nil
 }
 
@@ -129,6 +143,9 @@ func (a *TaskAdaptor) EstimateBilling(c *gin.Context, info *relaycommon.RelayInf
 		return nil
 	}
 	req := v.(relaycommon.TaskSubmitReq)
+	if omnitask.IsModel(info.UpstreamModelName) {
+		return map[string]float64{"seconds": float64(omnitask.ResolveDuration(req))}
+	}
 
 	seconds := geminitask.ResolveVeoDuration(req.Metadata, req.Duration, req.Seconds)
 	resolution := geminitask.ResolveVeoResolution(req.Metadata, req.Size)
@@ -142,6 +159,12 @@ func (a *TaskAdaptor) EstimateBilling(c *gin.Context, info *relaycommon.RelayInf
 
 // BuildRequestBody converts request into Vertex specific format.
 func (a *TaskAdaptor) BuildRequestBody(c *gin.Context, info *relaycommon.RelayInfo) (io.Reader, error) {
+	if omnitask.IsModel(info.UpstreamModelName) {
+		if err := omnitask.ValidateRequest(c, info); err != nil {
+			return nil, err
+		}
+		return omnitask.BuildRequestBody(c, info)
+	}
 	v, ok := c.Get("task_request")
 	if !ok {
 		return nil, fmt.Errorf("request not found in context")
@@ -198,6 +221,20 @@ func (a *TaskAdaptor) DoResponse(c *gin.Context, resp *http.Response, info *rela
 		return "", nil, service.TaskErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError)
 	}
 	_ = resp.Body.Close()
+	if omnitask.IsModel(info.UpstreamModelName) {
+		upstreamName, err := omnitask.ParseSubmitResponse(responseBody)
+		if err != nil {
+			return "", nil, service.TaskErrorWrapper(err, "invalid_interaction_response", http.StatusInternalServerError)
+		}
+		localID := taskcommon.EncodeLocalTaskID(upstreamName)
+		ov := dto.NewOpenAIVideo()
+		ov.ID = info.PublicTaskID
+		ov.TaskID = info.PublicTaskID
+		ov.CreatedAt = time.Now().Unix()
+		ov.Model = info.OriginModelName
+		c.JSON(http.StatusOK, ov)
+		return localID, responseBody, nil
+	}
 
 	var s submitResponse
 	if err := common.Unmarshal(responseBody, &s); err != nil {
@@ -218,6 +255,7 @@ func (a *TaskAdaptor) DoResponse(c *gin.Context, resp *http.Response, info *rela
 
 func (a *TaskAdaptor) GetModelList() []string {
 	return []string{
+		omnitask.ModelGeminiOmniFlashPreview,
 		"veo-3.0-generate-001",
 		"veo-3.0-fast-generate-001",
 		"veo-3.1-generate-preview",
@@ -252,15 +290,6 @@ func (a *TaskAdaptor) FetchTask(baseUrl, key string, body map[string]any, proxy 
 	if err != nil {
 		return nil, fmt.Errorf("decode task_id failed: %w", err)
 	}
-	url, err := buildFetchOperationURL(baseUrl, upstreamName)
-	if err != nil {
-		return nil, err
-	}
-	payload := fetchOperationPayload{OperationName: upstreamName}
-	data, err := common.Marshal(payload)
-	if err != nil {
-		return nil, err
-	}
 	adc := &vertexcore.Credentials{}
 	if err := common.Unmarshal([]byte(key), adc); err != nil {
 		return nil, fmt.Errorf("failed to decode credentials: %w", err)
@@ -269,7 +298,29 @@ func (a *TaskAdaptor) FetchTask(baseUrl, key string, body map[string]any, proxy 
 	if err != nil {
 		return nil, fmt.Errorf("failed to acquire access token: %w", err)
 	}
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(data))
+	method := http.MethodPost
+	url := ""
+	var requestBody io.Reader
+	if omnitask.IsInteractionTaskName(upstreamName) {
+		interactionID, err := omnitask.InteractionIDFromTaskName(upstreamName)
+		if err != nil {
+			return nil, err
+		}
+		method = http.MethodGet
+		url = vertexcore.BuildAPIBaseURL(baseUrl, omnitask.VertexAPIVersion, adc.ProjectID, "global") + "/interactions/" + interactionID
+	} else {
+		url, err = buildFetchOperationURL(baseUrl, upstreamName)
+		if err != nil {
+			return nil, err
+		}
+		payload := fetchOperationPayload{OperationName: upstreamName}
+		data, err := common.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		requestBody = bytes.NewReader(data)
+	}
+	req, err := http.NewRequest(method, url, requestBody)
 	if err != nil {
 		return nil, err
 	}
@@ -277,6 +328,9 @@ func (a *TaskAdaptor) FetchTask(baseUrl, key string, body map[string]any, proxy 
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("x-goog-user-project", adc.ProjectID)
+	if omnitask.IsInteractionTaskName(upstreamName) {
+		req.Header.Set("Api-Revision", omnitask.APIRevision)
+	}
 	client, err := service.GetHttpClientWithProxy(proxy)
 	if err != nil {
 		return nil, fmt.Errorf("new proxy http client failed: %w", err)
@@ -285,6 +339,9 @@ func (a *TaskAdaptor) FetchTask(baseUrl, key string, body map[string]any, proxy 
 }
 
 func (a *TaskAdaptor) ParseTaskResult(respBody []byte) (*relaycommon.TaskInfo, error) {
+	if omnitask.IsInteractionResponse(respBody) {
+		return omnitask.ParseTaskResult(respBody)
+	}
 	var op operationResponse
 	if err := common.Unmarshal(respBody, &op); err != nil {
 		return nil, fmt.Errorf("unmarshal operation response failed: %w", err)
@@ -358,6 +415,9 @@ func (a *TaskAdaptor) ConvertToOpenAIVideo(task *model.Task) ([]byte, error) {
 		upstreamName = ""
 	}
 	modelName := extractModelFromOperationName(upstreamName)
+	if omnitask.IsInteractionTaskName(upstreamName) {
+		modelName = omnitask.ModelGeminiOmniFlashPreview
+	}
 	if strings.TrimSpace(modelName) == "" {
 		modelName = "veo-3.0-generate-001"
 	}

--- a/relay/channel/task/vertex/adaptor.go
+++ b/relay/channel/task/vertex/adaptor.go
@@ -21,6 +21,7 @@ import (
 	taskcommon "github.com/QuantumNous/new-api/relay/channel/task/taskcommon"
 	vertexcore "github.com/QuantumNous/new-api/relay/channel/vertex"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/QuantumNous/new-api/service"
 )
@@ -81,7 +82,11 @@ func (a *TaskAdaptor) ValidateRequestAndSetAction(c *gin.Context, info *relaycom
 	if taskErr := relaycommon.ValidateBasicTaskRequest(c, info, constant.TaskActionTextGenerate); taskErr != nil {
 		return taskErr
 	}
-	if omnitask.IsModel(info.OriginModelName) {
+	info.UpstreamModelName = info.OriginModelName
+	if err := helper.ModelMappedHelper(c, info, nil); err != nil {
+		return service.TaskErrorWrapperLocal(err, "model_mapping_failed", http.StatusBadRequest)
+	}
+	if omnitask.IsModel(info.UpstreamModelName) {
 		if err := omnitask.ValidateRequest(c, info); err != nil {
 			return service.TaskErrorWrapperLocal(err, "invalid_omni_request", http.StatusBadRequest)
 		}

--- a/relay/channel/task/vertex/adaptor_test.go
+++ b/relay/channel/task/vertex/adaptor_test.go
@@ -1,6 +1,7 @@
 package vertex
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -31,7 +32,7 @@ func TestOmniBuildRequestURL(t *testing.T) {
 
 func TestOmniMappedAliasRunsReferenceVideoValidation(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	request := httptest.NewRequest(http.MethodPost, "/v1/videos", strings.NewReader(`{
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/videos", strings.NewReader(`{
 		"model":"gemini-omni-flash",
 		"prompt":"edit this video",
 		"duration":3,

--- a/relay/channel/task/vertex/adaptor_test.go
+++ b/relay/channel/task/vertex/adaptor_test.go
@@ -1,10 +1,14 @@
 package vertex
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	omnitask "github.com/QuantumNous/new-api/relay/channel/task/omni"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,4 +27,30 @@ func TestOmniBuildRequestURL(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https://aiplatform.googleapis.com/v1beta1/projects/vertex-project/locations/global/interactions", requestURL)
 	assert.Contains(t, adaptor.GetModelList(), omnitask.ModelGeminiOmniFlashPreview)
+}
+
+func TestOmniMappedAliasRunsReferenceVideoValidation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	request := httptest.NewRequest(http.MethodPost, "/v1/videos", strings.NewReader(`{
+		"model":"gemini-omni-flash",
+		"prompt":"edit this video",
+		"duration":3,
+		"video":"not-valid-base64"
+	}`))
+	request.Header.Set("Content-Type", "application/json")
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = request
+	context.Set("model_mapping", `{"gemini-omni-flash":"gemini-omni-flash-preview"}`)
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "gemini-omni-flash",
+		ChannelMeta:     &relaycommon.ChannelMeta{},
+		TaskRelayInfo:   &relaycommon.TaskRelayInfo{},
+	}
+
+	taskErr := (&TaskAdaptor{}).ValidateRequestAndSetAction(context, info)
+
+	require.NotNil(t, taskErr)
+	assert.Equal(t, "invalid_omni_request", taskErr.Code)
+	assert.Contains(t, taskErr.Message, "invalid base64 video data")
+	assert.Equal(t, omnitask.ModelGeminiOmniFlashPreview, info.UpstreamModelName)
 }

--- a/relay/channel/task/vertex/adaptor_test.go
+++ b/relay/channel/task/vertex/adaptor_test.go
@@ -1,0 +1,26 @@
+package vertex
+
+import (
+	"testing"
+
+	omnitask "github.com/QuantumNous/new-api/relay/channel/task/omni"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOmniBuildRequestURL(t *testing.T) {
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ApiKey:            `{"project_id":"vertex-project"}`,
+			UpstreamModelName: omnitask.ModelGeminiOmniFlashPreview,
+		},
+	}
+	adaptor := &TaskAdaptor{}
+	adaptor.Init(info)
+
+	requestURL, err := adaptor.BuildRequestURL(info)
+	require.NoError(t, err)
+	assert.Equal(t, "https://aiplatform.googleapis.com/v1beta1/projects/vertex-project/locations/global/interactions", requestURL)
+	assert.Contains(t, adaptor.GetModelList(), omnitask.ModelGeminiOmniFlashPreview)
+}

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -871,6 +871,8 @@ type TaskSubmitReq struct {
 	Mode           string                 `json:"mode,omitempty"`
 	Image          string                 `json:"image,omitempty"`
 	Images         []string               `json:"images,omitempty"`
+	Video          string                 `json:"video,omitempty"`
+	Videos         []string               `json:"videos,omitempty"`
 	Size           string                 `json:"size,omitempty"`
 	Duration       int                    `json:"duration,omitempty"`
 	Seconds        string                 `json:"seconds,omitempty"`
@@ -884,6 +886,10 @@ func (t *TaskSubmitReq) GetPrompt() string {
 
 func (t *TaskSubmitReq) HasImage() bool {
 	return len(t.Images) > 0
+}
+
+func (t *TaskSubmitReq) HasVideo() bool {
+	return strings.TrimSpace(t.Video) != "" || len(t.Videos) > 0
 }
 
 func (t *TaskSubmitReq) UnmarshalJSON(data []byte) error {

--- a/relay/common/relay_utils.go
+++ b/relay/common/relay_utils.go
@@ -168,6 +168,7 @@ func validateMultipartTaskRequest(c *gin.Context, info *RelayInfo, action string
 		Model:    formData.Get("model"),
 		Mode:     formData.Get("mode"),
 		Image:    formData.Get("image"),
+		Video:    formData.Get("video"),
 		Size:     formData.Get("size"),
 		Metadata: make(map[string]interface{}),
 	}
@@ -180,6 +181,9 @@ func validateMultipartTaskRequest(c *gin.Context, info *RelayInfo, action string
 
 	if images := formData["images"]; len(images) > 0 {
 		req.Images = images
+	}
+	if videos := formData["videos"]; len(videos) > 0 {
+		req.Videos = videos
 	}
 
 	for key, values := range formData {
@@ -273,6 +277,8 @@ func isKnownTaskField(field string) bool {
 		"mode":            true,
 		"image":           true,
 		"images":          true,
+		"video":           true,
+		"videos":          true,
 		"size":            true,
 		"duration":        true,
 		"input_reference": true, // Sora 特有字段

--- a/relay/common/relay_utils_test.go
+++ b/relay/common/relay_utils_test.go
@@ -77,6 +77,23 @@ func TestValidateMultipartDirectNormalizesImageField(t *testing.T) {
 	require.Equal(t, constant.TaskActionGenerate, info.Action)
 }
 
+func TestValidateBasicTaskRequestStoresReferenceVideo(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := strings.NewReader(`{"model":"gemini-omni-flash-preview","prompt":"edit","video":"data:video/mp4;base64,AAAA"}`)
+	request := httptest.NewRequest(http.MethodPost, "/v1/videos", body)
+	request.Header.Set("Content-Type", "application/json")
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = request
+	info := &RelayInfo{TaskRelayInfo: &TaskRelayInfo{}}
+
+	taskErr := ValidateBasicTaskRequest(context, info, constant.TaskActionTextGenerate)
+
+	require.Nil(t, taskErr)
+	storedReq, err := GetTaskRequest(context)
+	require.NoError(t, err)
+	assert.Equal(t, "data:video/mp4;base64,AAAA", storedReq.Video)
+}
+
 // TestTaskDurationBounds guards the billing invariant that user-supplied
 // video duration (a quota multiplier via OtherRatio "seconds") is bounded, so
 // it can never overflow quota calculation into a negative charge.

--- a/service/task_polling.go
+++ b/service/task_polling.go
@@ -620,6 +620,26 @@ func redactVideoResponseBody(body []byte) []byte {
 			}
 		}
 	}
+	for _, field := range []string{"steps", "outputs"} {
+		items, _ := m[field].([]any)
+		for _, item := range items {
+			step, _ := item.(map[string]any)
+			stepType, _ := step["type"].(string)
+			stepMimeType, _ := step["mime_type"].(string)
+			if stepType == "video" || strings.HasPrefix(stepMimeType, "video/") {
+				delete(step, "data")
+			}
+			contents, _ := step["content"].([]any)
+			for _, content := range contents {
+				part, _ := content.(map[string]any)
+				partType, _ := part["type"].(string)
+				mimeType, _ := part["mime_type"].(string)
+				if partType == "video" || strings.HasPrefix(mimeType, "video/") {
+					delete(part, "data")
+				}
+			}
+		}
+	}
 	b, err := common.Marshal(m)
 	if err != nil {
 		return body

--- a/service/task_polling_test.go
+++ b/service/task_polling_test.go
@@ -130,6 +130,21 @@ func (a *taskPollingFetchAdaptor) fetchedTaskIDs() []string {
 	return append([]string(nil), a.taskIDs...)
 }
 
+func TestRedactVideoResponseBodyRemovesInteractionVideoData(t *testing.T) {
+	body := []byte(`{
+		"id":"interaction_123",
+		"status":"completed",
+		"steps":[{"type":"model_output","content":[
+			{"type":"video","mime_type":"video/mp4","data":"large-base64-video"},
+			{"type":"text","text":"done"}
+		]}]
+	}`)
+
+	redacted := redactVideoResponseBody(body)
+	assert.NotContains(t, string(redacted), "large-base64-video")
+	assert.Contains(t, string(redacted), `"text":"done"`)
+}
+
 func seedTaskPollingChannel(t *testing.T, id int, disableSleep bool) {
 	t.Helper()
 	ch := &model.Channel{

--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -301,6 +301,7 @@ var defaultModelPrice = map[string]float64{
 	"veo-3.0-fast-generate-001":      0.15,
 	"veo-3.1-generate-preview":       0.4,
 	"veo-3.1-fast-generate-preview":  0.15,
+	"gemini-omni-flash-preview":      0.10,
 }
 
 var defaultAudioRatio = map[string]float64{


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
为 Gemini API 与 Vertex AI 的异步视频任务增加 `gemini-omni-flash-preview` 支持。该模型只接受 Interactions API，不能复用 Veo 的 `predictLongRunning`，因此新增共享 Omni 任务协议层，并让现有 Gemini/Vertex 任务适配器按模型选择对应协议。

主要行为：
- 使用后台 Interactions 请求提交任务，并通过 Interaction ID 轮询状态；
- 支持文本提示词及最多 10 张参考图，图片来源包括 Base64、Data URI、multipart 和经过 SSRF 防护的 HTTP(S) URL；
- 校验 3–10 秒时长、16:9/9:16 比例、图片 MIME 与大小；
- 解析 `steps[]`/`outputs[]` 中的内联 MP4 或 HTTPS 视频地址；
- 从任务持久化数据中移除视频 Base64，但保留按需获取 `/content` 的能力；
- 按官方约 $0.10/秒的价格加入默认模型价格。

本实现经 AI 辅助完成；提交者不是 QuantumNous/new-api 的历史核心维护者。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5835

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。（AI-assisted，等待人工复核）
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- `go test ./relay/channel/task/omni ./relay/channel/task/gemini ./relay/channel/task/vertex`
- `go test ./service -run TestRedactVideoResponseBodyRemovesInteractionVideoData -count=1`
- `go vet ./...`
- `go build ./...`
- 前端 `bun install --frozen-lockfile && bun run build`
- 使用真实 Vertex 服务账号验证：后台提交 HTTP 200，`0.72s` 返回 `in_progress`；轮询 6 次、约 `28.48s` 后返回 `completed`，取得 `video/mp4`，约 763 KB，输出 17,376 video tokens。凭据、项目 ID 与视频正文均未写入仓库或 PR。

全仓 `go test -p 1 ./...` 的本次相关包均通过；`service` 整包仍有既有的 ChannelAffinity usage-cache 测试隔离失败，该失败已在未修改的 `upstream/main@2d8e50bf3` 独立工作树复现，两个相关测试单独运行通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Gemini Omni Flash Preview video generation through Gemini and Vertex AI.
  - Supports image and reference-video inputs via uploads, URLs, data URIs, and Base64, with validation and size limits.
  - Added duration, aspect-ratio, asynchronous task tracking, video result handling, model availability, and pricing configuration.
  - Documented optional reference-video uploads for the video API.

- **Bug Fixes**
  - Improved video URL handling and authenticated Vertex AI downloads.
  - Prevented embedded video data from appearing in task responses while preserving text.

- **Tests**
  - Added coverage for Omni requests, validation, task processing, and response redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->