### PR TITLE
fix(auth): evict oldest active sessions instead of hard-blocking login at the session limit

### DIFF
--- a/controller/auth_session_test.go
+++ b/controller/auth_session_test.go
@@ -107,7 +107,10 @@ func TestWriteAuthSessionErrorMapsSessionGrowthLimits(t *testing.T) {
 	}
 }
 
-func TestSessionLimitDoesNotRecordRejectedLoginAsSuccessful(t *testing.T) {
+// A login rejected by the issuance limit (the active session limit now evicts
+// the oldest session instead of rejecting) must not record the login as
+// successful on the user row.
+func TestIssuanceLimitDoesNotRecordRejectedLoginAsSuccessful(t *testing.T) {
 	previousDB := model.DB
 	previousRedis := common.RedisEnabled
 	previousActiveLimit := common.UserSessionActiveLimit
@@ -118,8 +121,8 @@ func TestSessionLimitDoesNotRecordRejectedLoginAsSuccessful(t *testing.T) {
 	require.NoError(t, db.AutoMigrate(&model.User{}, &model.UserSession{}))
 	model.DB = db
 	common.RedisEnabled = false
-	common.UserSessionActiveLimit = 1
-	common.UserSessionIssuanceLimit = 100
+	common.UserSessionActiveLimit = 10
+	common.UserSessionIssuanceLimit = 1
 	common.UserSessionIssuanceWindowSeconds = int64(common.DefaultUserSessionIssuanceWindowSeconds)
 	t.Cleanup(func() {
 		model.DB = previousDB
@@ -148,7 +151,7 @@ func TestSessionLimitDoesNotRecordRejectedLoginAsSuccessful(t *testing.T) {
 	c.Request = httptest.NewRequest(http.MethodPost, "/api/user/login", nil)
 	setupLogin(user, c)
 
-	assert.Equal(t, http.StatusConflict, recorder.Code)
+	assert.Equal(t, http.StatusTooManyRequests, recorder.Code)
 	var stored model.User
 	require.NoError(t, db.First(&stored, user.Id).Error)
 	assert.Equal(t, previousLastLoginAt, stored.LastLoginAt)

--- a/model/user_session.go
+++ b/model/user_session.go
@@ -822,6 +822,22 @@ func revokeUserSessions(userID int, excludedSID, reason string) (int64, error) {
 	}
 }
 
+// DeleteUserSession permanently removes one session row. It exists for
+// compensation on the login-issuance path: when enforcement fails after a new
+// session row was stored but before any token is issued, the row must not
+// linger: stored rows count toward the issuance-limit window regardless of
+// status — and RevokeUserSession cannot be relied on there because its
+// deny-fence write is likely the very component that is failing. Only use it
+// for sessions that were never issued: a deleted row leaves no tombstone, so
+// tokens handed out for a live session would keep authorizing until their
+// cache entries expire.
+func DeleteUserSession(userID int, sid string) error {
+	if userID <= 0 || sid == "" {
+		return ErrUserSessionInvalid
+	}
+	return DB.Where("sid = ? AND user_id = ?", sid, userID).Delete(&UserSession{}).Error
+}
+
 func DeleteExpiredUserSessions(now int64) error {
 	if now <= 0 {
 		now = time.Now().Unix()

--- a/model/user_session.go
+++ b/model/user_session.go
@@ -709,6 +709,47 @@ func RevokeAllUserSessions(userID int, reason string) (int64, error) {
 	return revokeUserSessions(userID, "", reason)
 }
 
+// RevokeOldestActiveUserSessions revokes the oldest active sessions of a user
+// so that the number of active sessions does not exceed limit. It is a no-op
+// when the active count is already at or below limit, and returns the number
+// of sessions actually revoked. It is used at login time to make room for a
+// new session instead of hard-blocking once the active session limit is
+// reached, so a full session table can never lock the user out.
+func RevokeOldestActiveUserSessions(userID int, limit int64, now int64, reason string) (int64, error) {
+	if userID <= 0 || limit <= 0 {
+		return 0, ErrUserSessionInvalid
+	}
+	if now <= 0 {
+		now = time.Now().Unix()
+	}
+	activeCount, err := CountActiveUserSessions(userID, now)
+	if err != nil {
+		return 0, err
+	}
+	toEvict := activeCount - limit
+	if toEvict <= 0 {
+		return 0, nil
+	}
+	var sids []string
+	if err := DB.Model(&UserSession{}).
+		Where("user_id = ? AND status = ? AND expires_at > ?", userID, UserSessionStatusActive, now).
+		Order("last_active_at ASC").Order("created_at ASC").
+		Limit(int(toEvict)).Pluck("sid", &sids).Error; err != nil {
+		return 0, err
+	}
+	var revoked int64
+	for _, sid := range sids {
+		ok, err := RevokeUserSession(userID, sid, reason)
+		if err != nil {
+			return revoked, err
+		}
+		if ok {
+			revoked++
+		}
+	}
+	return revoked, nil
+}
+
 func revokeUserSessions(userID int, excludedSID, reason string) (int64, error) {
 	if userID <= 0 {
 		return 0, ErrUserSessionInvalid

--- a/model/user_session.go
+++ b/model/user_session.go
@@ -714,8 +714,12 @@ func RevokeAllUserSessions(userID int, reason string) (int64, error) {
 // when the active count is already at or below limit, and returns the number
 // of sessions actually revoked. It is used at login time to make room for a
 // new session instead of hard-blocking once the active session limit is
-// reached, so a full session table can never lock the user out.
-func RevokeOldestActiveUserSessions(userID int, limit int64, now int64, reason string) (int64, error) {
+// reached, so a full session table can never lock the user out. excludedSID
+// (typically the just-created session) is never considered for eviction:
+// last_active_at and created_at can tie for sessions created within the same
+// second, and without the exclusion the undefined tie order could revoke the
+// new session while its tokens are being issued.
+func RevokeOldestActiveUserSessions(userID int, limit int64, now int64, reason, excludedSID string) (int64, error) {
 	if userID <= 0 || limit <= 0 {
 		return 0, ErrUserSessionInvalid
 	}
@@ -730,9 +734,13 @@ func RevokeOldestActiveUserSessions(userID int, limit int64, now int64, reason s
 	if toEvict <= 0 {
 		return 0, nil
 	}
+	evictQuery := DB.Model(&UserSession{}).
+		Where("user_id = ? AND status = ? AND expires_at > ?", userID, UserSessionStatusActive, now)
+	if excludedSID != "" {
+		evictQuery = evictQuery.Where("sid <> ?", excludedSID)
+	}
 	var sids []string
-	if err := DB.Model(&UserSession{}).
-		Where("user_id = ? AND status = ? AND expires_at > ?", userID, UserSessionStatusActive, now).
+	if err := evictQuery.
 		Order("last_active_at ASC").Order("created_at ASC").
 		Limit(int(toEvict)).Pluck("sid", &sids).Error; err != nil {
 		return 0, err

--- a/model/user_session_test.go
+++ b/model/user_session_test.go
@@ -678,7 +678,7 @@ func TestRevokeOldestActiveUserSessionsEvictsOldestFirst(t *testing.T) {
 
 	// limit=2 with 4 active sessions: only the 2 with the oldest last_active_at
 	// should be revoked.
-	revokedCount, err := RevokeOldestActiveUserSessions(7, 2, now, "test_evict")
+	revokedCount, err := RevokeOldestActiveUserSessions(7, 2, now, "test_evict", "")
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), revokedCount)
 
@@ -706,7 +706,37 @@ func TestRevokeOldestActiveUserSessionsNoOpUnderLimit(t *testing.T) {
 	now := time.Now().Unix()
 	require.NoError(t, DB.Create(newTestUserSession("under-limit", 8, now)).Error)
 
-	revoked, err := RevokeOldestActiveUserSessions(8, 10, now, "test_evict")
+	revoked, err := RevokeOldestActiveUserSessions(8, 10, now, "test_evict", "")
 	require.NoError(t, err)
 	assert.Zero(t, revoked)
+}
+
+func TestRevokeOldestActiveUserSessionsExcludesSpecifiedSession(t *testing.T) {
+	setupUserSessionTest(t)
+	createUserSessionTestUser(t, 9, 1)
+	now := time.Now().Unix()
+	// All sessions share the same created_at and last_active_at, so the
+	// eviction order among them is undefined. The excluded session (the one
+	// just created at login) must never be revoked regardless of that order.
+	sessions := []*UserSession{
+		newTestUserSession("evict-tie-a", 9, now),
+		newTestUserSession("evict-tie-b", 9, now),
+		newTestUserSession("evict-tie-new", 9, now),
+	}
+	require.NoError(t, DB.Create(&sessions).Error)
+
+	// limit=2 with 3 tied active sessions: exactly one must be revoked, and
+	// it must never be the excluded "evict-tie-new" session.
+	revokedCount, err := RevokeOldestActiveUserSessions(9, 2, now, "test_evict", "evict-tie-new")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), revokedCount)
+
+	var excluded UserSession
+	require.NoError(t, DB.Where("sid = ?", "evict-tie-new").First(&excluded).Error)
+	assert.Equal(t, UserSessionStatusActive, excluded.Status)
+	var activeLeft int64
+	require.NoError(t, DB.Model(&UserSession{}).
+		Where("user_id = ? AND status = ?", 9, UserSessionStatusActive).
+		Count(&activeLeft).Error)
+	assert.Equal(t, int64(2), activeLeft)
 }

--- a/model/user_session_test.go
+++ b/model/user_session_test.go
@@ -653,3 +653,60 @@ func TestPasswordResetBumpsAuthVersionAndRevokesSessions(t *testing.T) {
 	assert.Equal(t, UserSessionStatusRevoked, storedSession.Status)
 	assert.Equal(t, "password_reset", storedSession.RevokedReason)
 }
+
+func TestRevokeOldestActiveUserSessionsEvictsOldestFirst(t *testing.T) {
+	setupUserSessionTest(t)
+	createUserSessionTestUser(t, 7, 1)
+	now := time.Now().Unix()
+	sessions := []*UserSession{
+		newTestUserSession("evict-oldest", 7, now),
+		newTestUserSession("evict-older", 7, now),
+		newTestUserSession("evict-newer", 7, now),
+		newTestUserSession("evict-newest", 7, now),
+	}
+	sessions[0].LastActiveAt = now - 100
+	sessions[1].LastActiveAt = now - 60
+	sessions[2].LastActiveAt = now - 30
+	sessions[3].LastActiveAt = now
+	expired := newTestUserSession("evict-expired", 7, now)
+	expired.ExpiresAt = now - 1
+	revoked := newTestUserSession("evict-revoked", 7, now)
+	revoked.Status = UserSessionStatusRevoked
+	revoked.RevokedAt = now - 1
+	all := append(sessions, expired, revoked)
+	require.NoError(t, DB.Create(&all).Error)
+
+	// limit=2 with 4 active sessions: only the 2 with the oldest last_active_at
+	// should be revoked.
+	revokedCount, err := RevokeOldestActiveUserSessions(7, 2, now, "test_evict")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), revokedCount)
+
+	var oldest UserSession
+	require.NoError(t, DB.Where("sid = ?", "evict-oldest").First(&oldest).Error)
+	assert.Equal(t, UserSessionStatusRevoked, oldest.Status)
+	var older UserSession
+	require.NoError(t, DB.Where("sid = ?", "evict-older").First(&older).Error)
+	assert.Equal(t, UserSessionStatusRevoked, older.Status)
+	var newer UserSession
+	require.NoError(t, DB.Where("sid = ?", "evict-newer").First(&newer).Error)
+	assert.Equal(t, UserSessionStatusActive, newer.Status)
+	var newest UserSession
+	require.NoError(t, DB.Where("sid = ?", "evict-newest").First(&newest).Error)
+	assert.Equal(t, UserSessionStatusActive, newest.Status)
+	// Expired/revoked sessions are outside the eviction scope and keep their state.
+	var expiredRow UserSession
+	require.NoError(t, DB.Where("sid = ?", "evict-expired").First(&expiredRow).Error)
+	assert.Equal(t, UserSessionStatusActive, expiredRow.Status)
+}
+
+func TestRevokeOldestActiveUserSessionsNoOpUnderLimit(t *testing.T) {
+	setupUserSessionTest(t)
+	createUserSessionTestUser(t, 8, 1)
+	now := time.Now().Unix()
+	require.NoError(t, DB.Create(newTestUserSession("under-limit", 8, now)).Error)
+
+	revoked, err := RevokeOldestActiveUserSessions(8, 10, now, "test_evict")
+	require.NoError(t, err)
+	assert.Zero(t, revoked)
+}

--- a/service/auth_session.go
+++ b/service/auth_session.go
@@ -102,7 +102,7 @@ func createLoginSession(userID int, expectedAuthVersion int64, loginMethod, ip, 
 	// session is already created and stays valid, and the limit converges on
 	// subsequent logins.
 	if _, err := model.RevokeOldestActiveUserSessions(
-		userID, int64(common.UserSessionActiveLimit), now, "active_limit_evicted",
+		userID, int64(common.UserSessionActiveLimit), now, "active_limit_evicted", session.SID,
 	); err != nil {
 		common.SysError(fmt.Sprintf("failed to evict oldest user sessions for user %d: %s", userID, err.Error()))
 	}

--- a/service/auth_session.go
+++ b/service/auth_session.go
@@ -100,13 +100,18 @@ func createLoginSession(userID int, expectedAuthVersion int64, loginMethod, ip, 
 	// session limit: revoke the oldest active sessions so a full session table
 	// can never lock the user out. Enforcement fails closed: if eviction
 	// errors out (e.g. a Redis deny-fence write fails), the just-created
-	// session is revoked and the login fails, so the active-session limit can
-	// never be bypassed by repeated logins while enforcement is failing.
+	// session is removed and the login fails, so the active-session limit can
+	// never be bypassed by repeated logins while enforcement is failing. The
+	// row is deleted outright instead of revoked: no token was issued for it,
+	// revocation depends on the same deny-fence write that is likely failing,
+	// and every stored row counts toward the issuance-limit window.
 	if _, err := model.RevokeOldestActiveUserSessions(
 		userID, int64(common.UserSessionActiveLimit), now, "active_limit_evicted", session.SID,
 	); err != nil {
-		_, _ = model.RevokeUserSession(userID, session.SID, "active_limit_enforcement_failed")
-		common.SysError(fmt.Sprintf("failed to evict oldest user sessions for user %d, revoking the new session: %s", userID, err.Error()))
+		if delErr := model.DeleteUserSession(userID, session.SID); delErr != nil {
+			common.SysError(fmt.Sprintf("failed to remove unissued session %s for user %d after eviction failure: %s", session.SID, userID, delErr.Error()))
+		}
+		common.SysError(fmt.Sprintf("failed to evict oldest user sessions for user %d, removing the new session: %s", userID, err.Error()))
 		return nil, fmt.Errorf("failed to enforce active session limit for user %d: %s", userID, err.Error())
 	}
 	bundle, err := issueAuthBundle(session, session.SID+"."+refreshSecret, true)

--- a/service/auth_session.go
+++ b/service/auth_session.go
@@ -98,13 +98,16 @@ func createLoginSession(userID int, expectedAuthVersion int64, loginMethod, ip, 
 	}
 	// Make room for the new session instead of hard-blocking at the active
 	// session limit: revoke the oldest active sessions so a full session table
-	// can never lock the user out. Eviction failure is only logged; the new
-	// session is already created and stays valid, and the limit converges on
-	// subsequent logins.
+	// can never lock the user out. Enforcement fails closed: if eviction
+	// errors out (e.g. a Redis deny-fence write fails), the just-created
+	// session is revoked and the login fails, so the active-session limit can
+	// never be bypassed by repeated logins while enforcement is failing.
 	if _, err := model.RevokeOldestActiveUserSessions(
 		userID, int64(common.UserSessionActiveLimit), now, "active_limit_evicted", session.SID,
 	); err != nil {
-		common.SysError(fmt.Sprintf("failed to evict oldest user sessions for user %d: %s", userID, err.Error()))
+		_, _ = model.RevokeUserSession(userID, session.SID, "active_limit_enforcement_failed")
+		common.SysError(fmt.Sprintf("failed to evict oldest user sessions for user %d, revoking the new session: %s", userID, err.Error()))
+		return nil, fmt.Errorf("failed to enforce active session limit for user %d: %s", userID, err.Error())
 	}
 	bundle, err := issueAuthBundle(session, session.SID+"."+refreshSecret, true)
 	if err != nil {

--- a/service/auth_session.go
+++ b/service/auth_session.go
@@ -65,13 +65,6 @@ func createLoginSession(userID int, expectedAuthVersion int64, loginMethod, ip, 
 		return nil, ErrLoginSessionRevoked
 	}
 	now := time.Now().Unix()
-	activeCount, err := model.CountActiveUserSessions(userID, now)
-	if err != nil {
-		return nil, err
-	}
-	if activeCount >= int64(common.UserSessionActiveLimit) {
-		return nil, model.ErrUserSessionLimit
-	}
 	issuanceCount, err := model.CountUserSessionsCreatedSince(userID, now-common.UserSessionIssuanceWindowSeconds)
 	if err != nil {
 		return nil, err
@@ -102,6 +95,16 @@ func createLoginSession(userID int, expectedAuthVersion int64, loginMethod, ip, 
 	}
 	if err := model.CreateUserSession(session); err != nil {
 		return nil, err
+	}
+	// Make room for the new session instead of hard-blocking at the active
+	// session limit: revoke the oldest active sessions so a full session table
+	// can never lock the user out. Eviction failure is only logged; the new
+	// session is already created and stays valid, and the limit converges on
+	// subsequent logins.
+	if _, err := model.RevokeOldestActiveUserSessions(
+		userID, int64(common.UserSessionActiveLimit), now, "active_limit_evicted",
+	); err != nil {
+		common.SysError(fmt.Sprintf("failed to evict oldest user sessions for user %d: %s", userID, err.Error()))
 	}
 	bundle, err := issueAuthBundle(session, session.SID+"."+refreshSecret, true)
 	if err != nil {

--- a/service/auth_session_test.go
+++ b/service/auth_session_test.go
@@ -196,7 +196,7 @@ func TestCreateLoginSessionFailsClosedWhenEvictionFails(t *testing.T) {
 	// out even after Redis recovers.
 	var leftover int64
 	require.NoError(t, model.DB.Model(&model.UserSession{}).
-		Where("user_id = ? AND login_method = ?", user.Id, "fail-closed-agent").
+		Where("user_id = ? AND user_agent = ?", user.Id, "fail-closed-agent").
 		Count(&leftover).Error)
 	assert.Zero(t, leftover, "the unissued session row must be removed after the failed login")
 	var activeCount int64

--- a/service/auth_session_test.go
+++ b/service/auth_session_test.go
@@ -126,10 +126,22 @@ func TestCreateLoginSessionEnforcesActiveLimitAcrossAuthVersions(t *testing.T) {
 	require.NoError(t, err, "49 active sessions must allow creation of the 50th")
 
 	_, err = CreateLoginSession(user.Id, "password", "127.0.0.1", "test-agent")
-	assert.ErrorIs(t, err, model.ErrUserSessionLimit)
-	var count int64
-	require.NoError(t, model.DB.Model(&model.UserSession{}).Count(&count).Error)
-	assert.Equal(t, int64(50), count)
+	require.NoError(t, err, "at the active limit the oldest session is evicted to make room")
+
+	var oldest model.UserSession
+	require.NoError(t, model.DB.Where("sid = ?", "active-limit-48").First(&oldest).Error)
+	assert.Equal(t, model.UserSessionStatusRevoked, oldest.Status)
+
+	// The 51st login inserts a new row, so the total row count is 51 (the
+	// evicted row stays revoked and is reclaimed by the periodic cleanup);
+	// the key invariant is that the active count returns to the limit of 50.
+	var activeCount int64
+	require.NoError(t, model.DB.Model(&model.UserSession{}).
+		Where("status = ?", model.UserSessionStatusActive).Count(&activeCount).Error)
+	assert.Equal(t, int64(50), activeCount)
+	var total int64
+	require.NoError(t, model.DB.Model(&model.UserSession{}).Count(&total).Error)
+	assert.Equal(t, int64(51), total)
 }
 
 func TestCreateLoginSessionEnforcesIssuanceLimitAcrossAllStatuses(t *testing.T) {

--- a/service/auth_session_test.go
+++ b/service/auth_session_test.go
@@ -183,14 +183,27 @@ func TestCreateLoginSessionFailsClosedWhenEvictionFails(t *testing.T) {
 	// creating the new session row still succeeds (cache write failures are
 	// tolerated there), but evicting the oldest active session errors out.
 	// Login must fail closed instead of issuing tokens that would leave the
-	// user above the active-session limit. The compensation revoke of the
-	// just-created row may also fail for the same reason; the row carries no
-	// issued tokens and is reclaimed by the periodic revoked-session cleanup.
+	// user above the active-session limit.
 	serverA.Close()
 
 	bundle, err := CreateLoginSession(user.Id, "password", "127.0.0.1", "fail-closed-agent")
 	require.Error(t, err, "eviction failure must fail the login")
 	assert.Nil(t, bundle, "no auth bundle may be issued when eviction fails")
+
+	// The unissued session must not linger: stored rows count toward the
+	// issuance-limit window regardless of status, so leftover rows from a
+	// Redis outage would burn through that window and keep the user locked
+	// out even after Redis recovers.
+	var leftover int64
+	require.NoError(t, model.DB.Model(&model.UserSession{}).
+		Where("user_id = ? AND login_method = ?", user.Id, "fail-closed-agent").
+		Count(&leftover).Error)
+	assert.Zero(t, leftover, "the unissued session row must be removed after the failed login")
+	var activeCount int64
+	require.NoError(t, model.DB.Model(&model.UserSession{}).
+		Where("user_id = ? AND status = ?", user.Id, model.UserSessionStatusActive).
+		Count(&activeCount).Error)
+	assert.Equal(t, int64(2), activeCount, "the pre-existing sessions stay untouched")
 }
 
 func TestCreateLoginSessionEnforcesIssuanceLimitAcrossAllStatuses(t *testing.T) {

--- a/service/auth_session_test.go
+++ b/service/auth_session_test.go
@@ -144,6 +144,55 @@ func TestCreateLoginSessionEnforcesActiveLimitAcrossAuthVersions(t *testing.T) {
 	assert.Equal(t, int64(51), total)
 }
 
+func TestCreateLoginSessionFailsClosedWhenEvictionFails(t *testing.T) {
+	useTestSessionSecret(t)
+	user := setupAuthSessionTestDB(t)
+	serverA, _, _, _ := useIndependentAuthSessionRedis(t)
+	common.UserSessionActiveLimit = 2
+	common.UserSessionIssuanceLimit = 100
+	now := time.Now().Unix()
+	rows := []model.UserSession{
+		{
+			SID:             "fail-closed-old-a",
+			UserID:          user.Id,
+			Version:         1,
+			UserAuthVersion: user.AuthVersion,
+			Status:          model.UserSessionStatusActive,
+			RefreshHash:     "hash-old-a",
+			LoginMethod:     "password",
+			CreatedAt:       now - 10,
+			LastActiveAt:    now - 10,
+			ExpiresAt:       now + 3600,
+		},
+		{
+			SID:             "fail-closed-old-b",
+			UserID:          user.Id,
+			Version:         1,
+			UserAuthVersion: user.AuthVersion,
+			Status:          model.UserSessionStatusActive,
+			RefreshHash:     "hash-old-b",
+			LoginMethod:     "password",
+			CreatedAt:       now - 5,
+			LastActiveAt:    now - 5,
+			ExpiresAt:       now + 3600,
+		},
+	}
+	require.NoError(t, model.DB.Create(&rows).Error)
+
+	// Kill Redis so the deny-fence write inside session revocation fails:
+	// creating the new session row still succeeds (cache write failures are
+	// tolerated there), but evicting the oldest active session errors out.
+	// Login must fail closed instead of issuing tokens that would leave the
+	// user above the active-session limit. The compensation revoke of the
+	// just-created row may also fail for the same reason; the row carries no
+	// issued tokens and is reclaimed by the periodic revoked-session cleanup.
+	serverA.Close()
+
+	bundle, err := CreateLoginSession(user.Id, "password", "127.0.0.1", "fail-closed-agent")
+	require.Error(t, err, "eviction failure must fail the login")
+	assert.Nil(t, bundle, "no auth bundle may be issued when eviction fails")
+}
+
 func TestCreateLoginSessionEnforcesIssuanceLimitAcrossAllStatuses(t *testing.T) {
 	useTestSessionSecret(t)
 	user := setupAuthSessionTestDB(t)


### PR DESCRIPTION
## 📝 变更描述 / Description

当用户的活跃会话数达到上限时，原逻辑直接以 `AUTH_SESSION_LIMIT` 拒绝登录。一旦到达上限，用户将无法在任何设备上登录去撤销自己的会话，账号会被锁死直到某个会话自然过期（即 #6972 描述的现象）。

本 PR 把"硬拒绝"改为"淘汰最老会话"：创建新会话后，撤销最老的活跃会话使活跃数回到上限。会话表打满永远不会再锁死账号；24h 窗口的签发限流（issuance limit）仍硬性约束会话创建速率。

改动：
- `model/user_session.go`：新增 `RevokeOldestActiveUserSessions`
- `service/auth_session.go`：建会话后淘汰最老会话，替代硬拒绝
- 测试：覆盖淘汰顺序、低于上限时 no-op、以及签发限流拒绝路径（原"活跃上限拒绝"测试改测签发限流，因活跃上限不再拒绝）

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - 关联 Issue #6972
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #6972

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 已搜索现有 Issues/PRs。
- [x] **Bug fix 说明:** 关联 Issue #6972。
- [x] **变更理解:** 已理解改动原理与影响。
- [x] **范围聚焦:** 仅含会话淘汰修复相关 5 个文件。
- [x] **本地验证:** `go build ./...` 通过；model/service/controller 会话相关测试全部通过。
- [x] **安全合规:** 无敏感凭据。

## 📸 运行证明 / Proof of Work

go1.26.1，本地：
- `go build ./...` ✅
- `go test ./model/ -run 'RevokeOldestActiveUserSessions|SessionLimit|ActiveLimit|LoginSession'` ✅
- `go test ./service/ -run 'TestCreateLoginSession|TestPasswordResetDoesNotClearSessionIssuanceHistory|TestCreateLoginSessionFailsClosed'` ✅
- `go test ./controller/ -run 'TestIssuanceLimitDoesNotRecord|TestWriteAuthSessionError|TestSession|TestLogout'` ✅

> 说明：本 PR 由 AI 辅助生成/整理（git 用户非项目核心维护者）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can sign in successfully when the active-session limit is reached.
  * The oldest active sessions are automatically revoked while the new session remains valid.
  * Session cleanup removes excess active sessions without affecting expired or already revoked sessions.

* **Bug Fixes**
  * Login attempts exceeding the session issuance allowance now return the correct rate-limit response.
  * Rejected logins no longer alter existing activity timestamps or leave unused session records.
  * Login fails safely when required session cleanup cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->