### PR TITLE
fix(dev): stabilize Docker startup

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,6 +12,9 @@ ENV GOEXPERIMENT=greenteagc
 WORKDIR /build
 
 ADD go.mod go.sum ./
+# relaykit is a local submodule referenced via replace; its go.mod must be
+# present for go mod download to resolve the main module graph.
+ADD relaykit/go.mod ./relaykit/go.mod
 RUN go mod download
 
 COPY . .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -48,6 +48,8 @@ services:
     image: redis:7-alpine
     container_name: new-api-dev-redis
     restart: unless-stopped
+    volumes:
+      - dev_redis_data:/data
     networks:
       - dev-network
 
@@ -72,6 +74,7 @@ services:
 volumes:
   dev_data:
   dev_pg_data:
+  dev_redis_data:
 
 networks:
   dev-network:


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
开发镜像在执行 `go mod download` 时只复制了根模块的 `go.mod` 和 `go.sum`，但根模块通过本地 `replace` 引用了 `./relaykit`，导致首次构建因缺少 `relaykit/go.mod` 而失败。本变更在下载依赖前复制该模块文件，使依赖图可以正常解析。

同时为开发环境 Redis 显式配置独立命名卷，避免复用宿主机上其他部署的 Redis 数据。这样不会因其他环境使用不同 Redis 大版本生成不兼容的 RDB 文件而导致 Redis 和 API 循环重启。

本次代码与 PR 描述由 AI 辅助生成。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无关联 Issue；问题通过本地 `make dev` 复现。

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- `docker build --progress=plain -f Dockerfile.dev -t new-api-dev:local .`：通过。
- `docker compose -f docker-compose.dev.yml config --quiet`：通过。
- 开发 Redis 实际挂载为 Docker 命名卷 `new-api_dev_redis_data`。
- 通过前端开发代理访问 `/api/status` 返回 HTTP 200。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development environment setup so local builds resolve module dependencies correctly.
  * Redis data now persists across development container restarts.

* **Chores**
  * Updated development container configuration for more reliable local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->