### PR TITLE
fix(ali): honor image response format (#5513)

### DIFF
--- a/relay/channel/ali/adaptor_test.go
+++ b/relay/channel/ali/adaptor_test.go
@@ -1,16 +1,25 @@
 package ali
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/QuantumNous/new-api/common"
+	rootconstant "github.com/QuantumNous/new-api/constant"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/constant"
 	relayhelper "github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/setting/system_setting"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -158,4 +167,82 @@ func TestMappedAliImageModelUsesUpstreamProtocol(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, adaptor.IsSyncImageModel)
 	assert.IsType(t, &AliImageRequest{}, converted)
+}
+
+func TestAliImageHandlerHonorsRequestResponseFormat(t *testing.T) {
+	imageBytes := []byte("ali-image")
+	var downloads atomic.Int32
+	imageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		downloads.Add(1)
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(imageBytes)
+	}))
+	t.Cleanup(imageServer.Close)
+
+	fetchSetting := system_setting.GetFetchSetting()
+	require.NotNil(t, fetchSetting)
+	originalFetchSetting := *fetchSetting
+	fetchSetting.EnableSSRFProtection = false
+	t.Cleanup(func() {
+		*fetchSetting = originalFetchSetting
+	})
+	originalMaxFileDownloadMB := rootconstant.MaxFileDownloadMB
+	rootconstant.MaxFileDownloadMB = 1
+	t.Cleanup(func() {
+		rootconstant.MaxFileDownloadMB = originalMaxFileDownloadMB
+	})
+	service.InitHttpClient()
+
+	tests := []struct {
+		name           string
+		responseFormat string
+		wantBase64     string
+		wantDownloads  int32
+	}{
+		{
+			name:           "base64",
+			responseFormat: "b64_json",
+			wantBase64:     base64.StdEncoding.EncodeToString(imageBytes),
+			wantDownloads:  1,
+		},
+		{
+			name:           "url",
+			responseFormat: "url",
+		},
+		{
+			name: "default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			downloads.Store(0)
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			info := &relaycommon.RelayInfo{
+				RelayMode: constant.RelayModeImagesGenerations,
+				StartTime: time.Unix(1, 0),
+				Request: &dto.ImageRequest{
+					ResponseFormat: tt.responseFormat,
+				},
+			}
+			responseBody := fmt.Sprintf(`{"output":{"results":[{"url":%q}]}}`, imageServer.URL)
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader(responseBody)),
+			}
+
+			newAPIError, usage := aliImageHandler(&Adaptor{IsSyncImageModel: true}, c, resp, info)
+			require.Nil(t, newAPIError)
+			require.NotNil(t, usage)
+
+			var imageResponse dto.ImageResponse
+			require.NoError(t, common.Unmarshal(recorder.Body.Bytes(), &imageResponse))
+			require.Len(t, imageResponse.Data, 1)
+			assert.Equal(t, imageServer.URL, imageResponse.Data[0].Url)
+			assert.Equal(t, tt.wantBase64, imageResponse.Data[0].B64Json)
+			assert.Equal(t, tt.wantDownloads, downloads.Load())
+		})
+	}
 }

--- a/relay/channel/ali/image.go
+++ b/relay/channel/ali/image.go
@@ -284,7 +284,10 @@ func responseAli2OpenAIImage(c *gin.Context, response *AliResponse, originBody [
 }
 
 func aliImageHandler(a *Adaptor, c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (*types.NewAPIError, *dto.Usage) {
-	responseFormat := c.GetString("response_format")
+	responseFormat := ""
+	if imageReq, ok := info.Request.(*dto.ImageRequest); ok {
+		responseFormat = imageReq.ResponseFormat
+	}
 
 	var aliTaskResponse AliResponse
 	responseBody, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
百炼图片响应处理此前只从 Gin context 读取 `response_format`，但图片请求链路并未写入该值，导致客户端请求 `b64_json` 时不会执行已有的 URL→base64 转换。

现在 `aliImageHandler` 直接从 `RelayInfo.Request` 中的 `dto.ImageRequest.ResponseFormat` 读取客户端请求格式，复用现有响应转换逻辑；`url` 和未指定格式继续保持原有行为。新增回归测试覆盖 `b64_json`、`url` 和默认格式，并验证是否发生图片下载。

> **AI-assisted disclosure:** 本次代码、测试与 PR 描述由 AI 辅助完成，提交者已复核改动逻辑与验证结果。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #5513

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
以下验证已通过：

- `go test ./relay/channel/ali -run '^TestAliImageHandlerHonorsRequestResponseFormat$' -count=1`
- `go test ./relay/channel/ali ./relay -count=1`
- `go vet ./relay/channel/ali ./relay`
- `go build ./relay ./relay/channel/ali`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image generation requests now correctly honor the requested response format.
  * Base64 image data is returned only when explicitly requested.
  * URL-based responses avoid unnecessary image downloads, improving efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->