### PR TITLE
docs: add cross-protocol repair plans

### DIFF
--- a/计划文档/Claude到Gemini思维预算与等级投影修复计划.md
+++ b/计划文档/Claude到Gemini思维预算与等级投影修复计划.md
@@ -1,0 +1,843 @@
+# Claude 到 Gemini 思维预算与等级投影修复计划
+
+## 1. 文档信息
+
+- 状态：已确认，待实施
+- 问题类型：跨协议请求转换语义错误
+- 影响路径：Claude Messages → Gemini `generateContent`
+- 主要影响模型：使用 `thinkingLevel` 的 Gemini 3.x/4.x 文本模型
+- 典型复现模型：`gemini-3.7-flash`
+- 调查依据：
+  - `C:\Users\31290\Desktop\程序\shanghua-api\测试\TEST_REPORT.md`
+  - `C:\Users\31290\Desktop\程序\shanghua-api\测试\test_results.json`
+  - `C:\Users\31290\Desktop\程序\shanghua-api\测试\run_api_tests.py`
+- 本文只制定修复计划，不包含代码修改。
+
+## 2. 问题结论
+
+Claude Messages 请求明确开启思维并提供数值预算时：
+
+```json
+{
+  "thinking": {
+    "type": "enabled",
+    "budget_tokens": 2048
+  }
+}
+```
+
+当前公共 Gemini 思维投影会优先保留数值预算，并向 Gemini 3.7 下发类似配置：
+
+```json
+{
+  "generationConfig": {
+    "thinkingConfig": {
+      "includeThoughts": true,
+      "thinkingBudget": 2048
+    }
+  }
+}
+```
+
+但项目已经将 Gemini 3.x/4.x 识别为使用 `thinkingLevel` 的 Level 模式模型。对这类模型，正确的原生控制应为：
+
+```json
+{
+  "generationConfig": {
+    "thinkingConfig": {
+      "includeThoughts": true,
+      "thinkingLevel": "HIGH"
+    }
+  }
+}
+```
+
+实测表明，在报告使用的系统提示、工具定义和任务下：
+
+- `thinkingBudget=2048`：连续请求均未产生 Gemini thought，`thoughtsTokenCount=0`；
+- `thinkingLevel=HIGH`：连续请求均产生 Gemini thought；
+- Gemini thought 一旦存在，当前 Gemini → Claude 非流式和流式响应投影都能正确生成 Claude thinking block/delta。
+
+因此，本问题不是 `includeThoughts` 丢失，也不是 Gemini thought 到 Claude 响应的转换丢失，而是：
+
+> 公共投影错误地让源协议的数值预算优先于目标模型的原生能力类型，向 Level 模式 Gemini 模型发送了 `thinkingBudget`。
+
+## 3. 复现与证据
+
+### 3.1 Claude 原始场景
+
+请求条件：
+
+- 客户端协议：Claude Messages
+- 目标模型：`gemini-3.7-flash`
+- `thinking.type=enabled`
+- `thinking.budget_tokens=2048`
+- 带工具调用
+- 非流式
+
+连续 5 次结果：
+
+| 次数 | Claude thinking 字符数 | 工具调用数 |
+| --- | ---: | ---: |
+| 1 | 0 | 1 |
+| 2 | 0 | 1 |
+| 3 | 0 | 1 |
+| 4 | 0 | 1 |
+| 5 | 0 | 1 |
+
+该结果与测试报告中的 Claude Messages → Gemini 无思维现象一致。
+
+### 3.2 直接 Gemini 对照
+
+使用相同提示和工具，直接调用 Gemini 原生接口。
+
+#### 使用数值预算
+
+```json
+{
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingBudget": 2048
+  }
+}
+```
+
+连续 5 次均为：
+
+- thought 文本长度：0
+- `thoughtsTokenCount`：0
+- 工具调用正常生成
+
+#### 使用原生等级
+
+```json
+{
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingLevel": "HIGH"
+  }
+}
+```
+
+连续 5 次 thought 文本长度分别为：
+
+```text
+1454、1262、1821、1834、984
+```
+
+说明相同模型、提示和工具下，思维是否产生与下发的原生思维控制字段直接相关。
+
+### 3.3 响应投影对照
+
+Claude 改用可映射为等级的配置：
+
+```json
+{
+  "thinking": {
+    "type": "adaptive",
+    "display": "summarized"
+  },
+  "output_config": {
+    "effort": "high"
+  }
+}
+```
+
+实测结果：
+
+- 非流式连续请求均返回 Claude `content[].type=thinking`；
+- 流式连续请求均返回：
+  - `content_block_start(type=thinking)`；
+  - `thinking_delta`；
+  - 后续 `tool_use`。
+
+这证明 Gemini thought → Claude thinking 的响应转换链路正常，修复范围应集中在请求侧公共思维投影。
+
+## 4. 当前代码根因
+
+### 4.1 Claude 入站同时保留预算和等级
+
+涉及文件：
+
+- `relaykit/ir/project/claude/request.go`
+
+Claude `thinking.budget_tokens` 被保存在公共 IR：
+
+```go
+cfg.Budget = req.Thinking.BudgetTokens
+```
+
+Claude `output_config.effort` 也可以被规范化后保存在公共 IR：
+
+```go
+cfg.Level = effort
+```
+
+这一阶段保留源信息是合理的，问题不应通过丢弃 Claude 入站字段解决。
+
+### 4.2 Gemini 投影无条件优先预算
+
+涉及文件：
+
+- `relaykit/relayconvert/reasoning/gemini.go`
+
+当前 `ProjectGeminiThinking` 虽然先计算了目标模型能力：
+
+```go
+control := GeminiThinkingControlForModel(model)
+```
+
+但后续只要存在预算，就直接输出 `thinkingBudget` 并返回：
+
+```go
+if budget != nil {
+    value := *budget
+    projection.ThinkingBudget = &value
+    return projection
+}
+```
+
+该分支没有检查 `control` 是否为 `GeminiControlLevel`，导致：
+
+1. Gemini 3.x 已被识别为 Level 模式；
+2. Claude 预算仍被原样输出为 `thinkingBudget`；
+3. 即使同时存在 `output_config.effort`，等级也会被预算分支覆盖；
+4. Gemini 接受请求但未按预期产生 thought；
+5. 下游 Claude 没有 thinking 内容可投影。
+
+### 4.3 现有测试固化了错误语义
+
+涉及文件：
+
+- `relaykit/relayconvert/reasoning/gemini_test.go`
+
+当前测试明确要求 Gemini 3 Level 模型保留显式预算：
+
+```go
+preserved := ProjectGeminiThinking(
+    "gemini-3.7-pro",
+    false,
+    &explicit,
+    LevelHigh,
+    &include,
+    DisplayAuto,
+)
+```
+
+并断言应输出数值预算而不是等级。该预期与真实 Gemini 3.7 行为不符，实施时必须修改测试语义，不能只改生产代码。
+
+### 4.4 路由级测试缺少思维配置断言
+
+涉及文件：
+
+- `relay/request_adapt_test.go`
+
+现有 Claude → Gemini 路由测试只验证消息内容和最终协议格式，没有验证：
+
+- `includeThoughts`；
+- `thinkingLevel`；
+- `thinkingBudget` 是否错误存在；
+- Claude effort 与 budget 同时存在时的优先级。
+
+这使错误可以通过所有现有测试。
+
+## 5. 已协商的目标语义
+
+### 5.1 核心原则
+
+思维控制投影必须遵循：
+
+> 目标模型能力优先，源协议信息完整保留在 IR，最终在线协议字段由目标模型支持的控制方式决定。
+
+不得继续采用“只要源请求有数值预算，就无条件输出 `thinkingBudget`”的规则。
+
+### 5.2 Level 模式 Gemini 模型
+
+适用范围：已知使用 `thinkingLevel` 的 Gemini 3.x/4.x 文本模型。
+
+| 源 IR 状态 | Gemini 原生输出 |
+| --- | --- |
+| 明确关闭思维 | `thinkingLevel=MINIMAL`，`includeThoughts=false`，记录能力降级 |
+| 存在明确 effort/level | 使用对应原生 `MINIMAL/LOW/MEDIUM/HIGH` |
+| level 与正数 budget 同时存在 | level 优先；不输出 budget；记录预算丢失/量化损失 |
+| 只有正数 budget | 降级为 `thinkingLevel=HIGH`；记录 `budget_to_level` 损失 |
+| 只请求可见思维，无 level/budget | 保留 `includeThoughts=true`，由模型默认思维策略决定 |
+
+等级映射继续使用既有规则：
+
+| IR 等级 | Gemini Level |
+| --- | --- |
+| `minimal` | `MINIMAL` |
+| `low` | `LOW` |
+| `medium` | `MEDIUM` |
+| `high` | `HIGH` |
+| `xhigh` | `HIGH` |
+| `max` | `HIGH` |
+
+`xhigh/max → HIGH` 必须继续记录等级能力降级。
+
+### 5.3 Budget 模式 Gemini 模型
+
+适用范围：Gemini 2.5 和已知只支持数值预算的 thinking 模型。
+
+| 源 IR 状态 | Gemini 原生输出 |
+| --- | --- |
+| 明确关闭思维 | `thinkingBudget=0`，`includeThoughts=false` |
+| 存在明确 budget | 原样保留 `thinkingBudget` |
+| budget 与 level 同时存在 | budget 优先；必要时记录 level 无法精确保留 |
+| 只有 level | 使用动态预算 `thinkingBudget=-1`，记录 effort 到预算的量化损失 |
+| 只请求可见思维 | 设置 `includeThoughts=true`，不伪造固定预算 |
+
+### 5.4 Unknown 模式
+
+未知 Gemini 模型不能被强行套入未经确认的能力规则。
+
+计划采用保守策略：
+
+1. 显式关闭请求继续使用当前安全关闭策略；
+2. 显式数值预算可按既有兼容策略保留；
+3. 显式等级只在当前兼容策略允许时输出；
+4. 不同时发送 `thinkingBudget` 和 `thinkingLevel`；
+5. 记录目标模型能力未知的审计信息或转换损失。
+
+### 5.5 不采用预算阈值猜测等级
+
+本次不采用类似以下未经协议定义的规则：
+
+```text
+1～2048 → LOW
+2049～8192 → MEDIUM
+8193 以上 → HIGH
+```
+
+原因：
+
+- Gemini 没有公开保证数值预算与 Level 枚举之间存在固定阈值关系；
+- 任意阈值会形成新的隐式兼容规则；
+- 不同模型代际的 token 行为可能不同；
+- 难以稳定测试和长期维护。
+
+对于 Level 模型，只有正数预算而没有 level 时统一降级为 `HIGH`，并通过损失报告明确其非精确转换。
+
+## 6. 实施计划
+
+### 阶段一：重构公共 Gemini 思维投影决策顺序
+
+#### 目标
+
+让 `ProjectGeminiThinking` 真正以 `GeminiThinkingControlForModel` 的结果决定目标线格式。
+
+#### 计划修改
+
+1. 先处理明确关闭语义；
+2. 独立计算 `includeThoughts`，使可见性与思维强度继续解耦；
+3. 根据 `GeminiThinkingControl` 分支投影：
+   - Level 分支只允许输出 `thinkingLevel`；
+   - Budget 分支只允许输出 `thinkingBudget`；
+   - Unknown 分支采用保守兼容策略；
+4. Level 分支中：
+   - 明确 level 优先于 budget；
+   - 只有正数 budget 时输出 `HIGH`；
+5. Budget 分支中：
+   - 显式 budget 优先；
+   - 只有 level 时输出动态预算 `-1`；
+6. 所有分支保证 `thinkingLevel` 与 `thinkingBudget` 互斥；
+7. 更新函数注释，删除“显式预算无条件保留”的错误描述。
+
+#### 重点文件
+
+- `relaykit/relayconvert/reasoning/gemini.go`
+- `relaykit/relayconvert/reasoning/gemini_test.go`
+
+### 阶段二：补齐转换损失报告
+
+#### 目标
+
+所有无法精确保留的思维控制都必须可审计，不能静默发生。
+
+#### 新增或调整的损失类型
+
+1. `thinking.budget_to_level`
+   - 场景：正数数值预算投影到 Gemini Level 模型；
+   - 结果：`thinkingLevel=HIGH`。
+2. `thinking.budget`
+   - 场景：源预算因 Level 目标不支持而无法原样保留；
+   - level 已明确时记录预算被丢弃。
+3. 继续保留：
+   - `thinking.level`：`xhigh/max → HIGH`；
+   - `thinking.effort_to_budget`：离散 effort → 动态预算 `-1`；
+   - `thinking.mode`：Level 模型无法完全关闭，只能 `MINIMAL + hidden`。
+
+#### 重点文件
+
+- `relaykit/relayconvert/ir_hub.go`
+- `relaykit/ir/loss.go`
+- 对应 `*_test.go`
+
+### 阶段三：增加 Claude → Gemini 精确请求回归
+
+#### 目标
+
+直接覆盖本次报告中的真实请求语义，避免只测试通用 projector。
+
+#### 测试一：Claude enabled + budget → Gemini 3
+
+输入：
+
+```json
+{
+  "thinking": {
+    "type": "enabled",
+    "budget_tokens": 2048
+  }
+}
+```
+
+目标模型：
+
+```text
+gemini-3.7-flash
+```
+
+期望：
+
+```json
+{
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingLevel": "HIGH"
+  }
+}
+```
+
+并断言：
+
+```text
+thinkingBudget == nil
+```
+
+#### 测试二：Claude budget + explicit effort → effort 优先
+
+输入：
+
+```json
+{
+  "thinking": {
+    "type": "enabled",
+    "budget_tokens": 2048
+  },
+  "output_config": {
+    "effort": "medium"
+  }
+}
+```
+
+期望：
+
+```json
+{
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingLevel": "MEDIUM"
+  }
+}
+```
+
+并记录预算无法原样表达的损失。
+
+#### 测试三：Claude budget → Gemini 2.5
+
+相同 Claude 输入，目标模型：
+
+```text
+gemini-2.5-flash
+```
+
+期望：
+
+```json
+{
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingBudget": 2048
+  }
+}
+```
+
+并断言 `thinkingLevel` 为空。
+
+#### 测试四：Claude adaptive summarized + xhigh
+
+输入：
+
+```json
+{
+  "thinking": {
+    "type": "adaptive",
+    "display": "summarized"
+  },
+  "output_config": {
+    "effort": "xhigh"
+  }
+}
+```
+
+Gemini 3 期望：
+
+```json
+{
+  "thinkingConfig": {
+    "includeThoughts": true,
+    "thinkingLevel": "HIGH"
+  }
+}
+```
+
+#### 重点文件
+
+- `relaykit/relayconvert/request_registry_test.go`
+- `relaykit/relayconvert/reasoning/gemini_test.go`
+- `relay/request_adapt_test.go`
+
+### 阶段四：补齐路由和模型别名测试
+
+#### 目标
+
+保证生产路由使用的上游模型名、思维后缀和最终原生格式不会绕过新规则。
+
+#### 覆盖场景
+
+1. Claude 客户端 + Gemini 渠道；
+2. Claude 客户端 + Vertex Gemini 渠道；
+3. 上游模型名为 `gemini-3.7-flash`；
+4. 上游模型名带 provider/publisher 前缀；
+5. 上游模型名带 `-high/-xhigh` 思维适配后缀；
+6. URL 构造剥离思维后缀后，思维等级仍保留在请求体；
+7. `FinalRequestRelayFormat` 保持 Gemini；
+8. 最终请求体不能同时存在 `thinkingLevel` 和 `thinkingBudget`。
+
+#### 重点文件
+
+- `relay/request_adapt_test.go`
+- `relay/common/native_format_test.go`
+- `relay/channel/gemini/upstream_model_test.go`
+- `relay/channel/vertex/adaptor_url_test.go`
+- 必要时增加 Gemini/Vertex 请求转换测试
+
+### 阶段五：确认响应转换不回归
+
+#### 目标
+
+虽然本次根因位于请求侧，但必须锁定已验证正常的 Gemini → Claude 响应能力。
+
+#### 非流式测试
+
+Gemini 响应：
+
+```json
+{
+  "parts": [
+    {
+      "thought": true,
+      "text": "visible thought"
+    },
+    {
+      "text": "final answer"
+    }
+  ]
+}
+```
+
+Claude 期望：
+
+```json
+{
+  "content": [
+    {
+      "type": "thinking",
+      "thinking": "visible thought"
+    },
+    {
+      "type": "text",
+      "text": "final answer"
+    }
+  ]
+}
+```
+
+#### 流式测试
+
+Gemini thought part 期望产生：
+
+```text
+content_block_start(type=thinking)
+thinking_delta
+content_block_stop
+```
+
+思维后出现工具调用时，还必须保证：
+
+```text
+thinking block 完整关闭
+tool_use 使用独立 index
+工具参数完整
+最终 stop_reason=tool_use
+```
+
+#### 重点文件
+
+- `relaykit/ir/project/gemini/stream.go`
+- `relaykit/ir/project/claude/stream.go`
+- `relaykit/relayconvert/format_matrix_test.go`
+- `relaykit/relayconvert/response_registry_test.go`
+- `relay/channel/gemini/relay_gemini_usage_test.go`
+
+除非新增测试发现独立缺陷，否则本阶段不应修改已正常工作的响应投影逻辑。
+
+### 阶段六：真实接口回归
+
+使用报告中的原始 Claude 场景进行回归，至少覆盖：
+
+1. 非流式、带工具、`enabled + budget_tokens=2048`；
+2. 流式、带工具、`enabled + budget_tokens=2048`；
+3. 非流式、不带工具；
+4. 流式、不带工具；
+5. `adaptive + summarized + effort=high/xhigh`；
+6. Gemini 3 Level 模型；
+7. Gemini 2.5 Budget 模型。
+
+回归时同时记录：
+
+- 最终转换后的脱敏 Gemini 请求体；
+- 是否下发 `includeThoughts`；
+- 实际下发的是 level 还是 budget；
+- Gemini `thoughtsTokenCount`；
+- Gemini 是否返回 thought part；
+- Claude 是否返回 thinking block/delta；
+- 工具调用是否正常。
+
+真实模型输出存在一定非确定性，因此验收必须以“请求字段正确 + 固定响应 fixture 投影正确”为确定性基础，真实 E2E 用于验证供应商行为，不单独承担协议转换正确性证明。
+
+## 7. 测试计划
+
+### 7.1 公共 projector 单元测试矩阵
+
+| 模型 | disabled | budget | level | 期望控制 |
+| --- | ---: | ---: | --- | --- |
+| Gemini 3.7 | false | 2048 | 空 | `HIGH` |
+| Gemini 3.7 | false | 2048 | medium | `MEDIUM` |
+| Gemini 3.7 | false | nil | xhigh | `HIGH` |
+| Gemini 3.7 | true | nil | 空 | `MINIMAL + hidden` |
+| Gemini 2.5 | false | 2048 | 空 | budget 2048 |
+| Gemini 2.5 | false | nil | high | budget -1 |
+| Gemini 2.5 | true | nil | 空 | budget 0 |
+| Unknown | false | 2048 | 空 | 保守兼容结果，且 level/budget 不冲突 |
+
+每个用例同时断言：
+
+- `IncludeThoughts`；
+- `ThinkingBudget`；
+- `ThinkingLevel`；
+- 两种控制字段互斥。
+
+### 7.2 请求转换测试
+
+覆盖：
+
+- Claude → Gemini；
+- Claude → Vertex Gemini；
+- Chat → Gemini，确保既有 `reasoning_effort` 不回归；
+- Responses → Gemini，确保既有 `reasoning.summary/effort` 不回归；
+- Gemini 原生请求在同协议转发时不被错误重写。
+
+### 7.3 响应转换测试
+
+覆盖：
+
+- Gemini thought → Claude thinking；
+- thought + text；
+- thought + tool call；
+- 多个流式 thought 分片；
+- usage 中 `thoughtsTokenCount`；
+- 没有 thought part 时不伪造 thinking 文本。
+
+### 7.4 损失报告测试
+
+覆盖：
+
+- Claude budget → Gemini Level `HIGH`；
+- budget 与 explicit level 同时存在；
+- `xhigh/max → HIGH`；
+- effort → Gemini Budget 动态预算；
+- 明确关闭 → Level `MINIMAL + hidden`。
+
+## 8. 验收标准
+
+### 请求侧
+
+1. Claude `enabled + budget_tokens=2048` 转 Gemini 3.7 后必须包含：
+   - `includeThoughts=true`；
+   - `thinkingLevel=HIGH`；
+   - 不包含 `thinkingBudget`。
+2. Claude 同时提供 effort 和 budget 时，Gemini Level 模型使用 effort 对应等级。
+3. Gemini 2.5 继续保留显式数值预算。
+4. 任意最终 Gemini 请求都不能同时包含 level 和 budget。
+5. 模型思维后缀、provider 前缀和 Vertex publisher 前缀不能改变以上语义。
+
+### 响应侧
+
+1. 固定 Gemini thought fixture 能转换为 Claude thinking block。
+2. 流式 thought 能转换为标准 Claude thinking 事件序列。
+3. thought 与工具调用同时存在时顺序和 index 正确。
+4. 上游没有 thought part 时不得伪造模型思维内容。
+
+### 兼容性
+
+1. Chat → Gemini 和 Responses → Gemini 已有思维转换测试继续通过。
+2. Gemini 2.5 Budget 模式不回归。
+3. Claude → Responses、Gemini → Chat 等其他协议路径不受影响。
+4. 不新增前端设置，不改变现有前端 API 合同。
+
+## 9. 风险与控制
+
+### 9.1 正数预算统一降级为 HIGH 可能增加推理量
+
+Level 模型无法精确表达数值 token 预算。选择 `HIGH` 的目的是避免“客户端明确开启思维但实际不思考”的静默失效。
+
+控制措施：
+
+- 有明确 effort 时始终使用 effort；
+- 只有预算时才降级为 HIGH；
+- 记录转换损失；
+- 不设计无协议依据的预算阈值。
+
+### 9.2 某些兼容代理可能接受 Gemini 3 的 thinkingBudget
+
+部分代理可能宽松接受该字段，但本项目目标是按目标模型原生能力生成请求，不能依赖代理的偶然兼容行为。
+
+控制措施：
+
+- 已知 Level 模型统一输出原生 Level；
+- Budget 模型继续输出 Budget；
+- Unknown 模型保留兼容策略。
+
+### 9.3 模型名识别错误
+
+如果模型别名、provider 前缀或自定义映射未正确归一化，可能错误进入 Unknown 分支。
+
+控制措施：
+
+- 使用现有模型名归一化入口；
+- 补充带前缀、publisher 和思维后缀测试；
+- 能力判断继续集中在 `GeminiThinkingControlForModel`，禁止在多个转换器散落模型名判断。
+
+### 9.4 真实模型 thought 输出仍可能存在非确定性
+
+即使请求字段正确，供应商也可能在个别响应中不返回可见 thought 摘要。
+
+控制措施：
+
+- 确定性验收使用转换后请求断言和固定响应 fixture；
+- E2E 将“上游未返回 thought”与“网关请求/响应映射失败”分开记录；
+- 不通过重试或伪造文本强制制造思维链。
+
+## 10. 非目标范围
+
+本次不处理：
+
+1. Chat → Gemini、Responses → Gemini 单次无可见 thought 的探针误报；
+2. 强制 Gemini 每次都返回可见思维摘要；
+3. 在无上游 thought 文本时伪造 Claude thinking；
+4. 自动重试已经开始输出或已经生成工具调用的请求；
+5. 暴露供应商不允许返回的私有完整思维链；
+6. 新增前端开关或修改前端文案；
+7. 为预算到等级设计任意 token 阈值。
+
+## 11. 前后端一致性说明
+
+本问题属于后端协议转换语义，不改变客户端请求格式、响应格式或现有系统设置：
+
+- Claude 客户端继续使用原有 `thinking` 和 `output_config`；
+- Gemini 上游请求仍使用原生 `generationConfig.thinkingConfig`；
+- Claude 响应仍使用标准 thinking block/delta；
+- 前端无需新增字段、开关或 i18n 文案；
+- 若实施中决定将转换损失展示到前端，应另行设计后端字段、前端类型和所有语言翻译，不在本次默认范围内。
+
+## 12. 实施后检查命令
+
+按照项目 `AGENTS.md` 要求，实施完成后必须执行完整检查，而不是只运行局部测试。
+
+```bash
+# Go 格式化
+gofmt -w <本次修改的 Go 文件>
+
+# 根模块测试
+go test ./...
+
+# relaykit 独立模块测试
+cd relaykit
+go test ./...
+cd ..
+
+# Go lint
+golangci-lint run ./...
+cd relaykit
+golangci-lint run ./...
+cd ..
+
+# 前端 OXLint、Vitest 和编译检查
+cd web
+bun run lint
+bun run test
+bun run build:check
+cd ..
+
+# 后端编译
+go build ./...
+go build -o bin/new-api.exe .
+
+# 构建来源校验
+go version -m bin/new-api.exe
+git rev-parse HEAD
+```
+
+若项目实际脚本名称与上述命令存在差异，应使用 `package.json`、`makefile` 中的现有命令完成等价检查，但不得省略：
+
+- go test；
+- go fmt；
+- golangci-lint；
+- OXLint；
+- Vitest；
+- 前端编译；
+- 后端编译。
+
+## 13. 预期结果
+
+修复后，报告中的 Claude 场景应从：
+
+```text
+Claude enabled + budget_tokens=2048
+  → Gemini includeThoughts=true + thinkingBudget=2048
+  → Gemini 未产生 thought
+  → Claude 无 thinking
+```
+
+变为：
+
+```text
+Claude enabled + budget_tokens=2048
+  → 识别目标 Gemini 3 为 Level 模式
+  → Gemini includeThoughts=true + thinkingLevel=HIGH
+  → Gemini 返回可见 thought 时
+  → Claude thinking block / thinking_delta 正常下发
+```
+
+同时保持：
+
+```text
+Claude enabled + budget_tokens=2048
+  → Gemini 2.5 Budget 模式
+  → includeThoughts=true + thinkingBudget=2048
+```
+
+最终实现应修正公共能力投影，而不是在 Claude → Gemini 单一路径上增加局部特判。

--- a/计划文档/Gemini到Chat流式工具调用生命周期修复计划.md
+++ b/计划文档/Gemini到Chat流式工具调用生命周期修复计划.md
@@ -1,0 +1,826 @@
+# Gemini 到 Chat 流式工具调用生命周期修复计划
+
+## 1. 文档信息
+
+- 状态：根因已确认，待实施第二轮修复
+- 问题类型：OpenAI Chat 上游流投影入口的协议判断与流生命周期管理错误
+- 客户端协议：Gemini `generateContent` / `streamGenerateContent`
+- 上游协议：OpenAI Chat Completions
+- 目标协议：Gemini `functionCall`
+- 原始问题：Gemini 工具调用参数已经从 Chat SSE 接收并进入 IR 缓冲，但 EOF 时没有完成最终提交
+- 新回归：修复后使用 `RelayMode` 判断上游协议，导致合法的 Gemini → Chat 流在读取 SSE 前被拒绝
+- 原始调查版本：`0180c3eb771a939311bb76ab3c6c2d8498475800`
+- 引入回归的提交：`a6d2b3e218ae98d416f7f8543c30526636da4b7d`
+- 本计划范围：修正 OpenAI Chat 上游流处理器的职责边界、协议判断、统计和测试
+- 本计划不包含：本轮只写计划，不修改代码
+
+## 2. 最终问题结论
+
+前一轮分析需要缩小范围。
+
+### 2.1 仍然成立的核心问题
+
+Gemini → OpenAI Chat 的跨格式流投影确实存在生命周期缺口：
+
+```text
+Gemini streamGenerateContent
+        ↓
+Gemini 请求转换为 Chat Completions 请求
+        ↓
+OpenAI Chat 上游返回 tool_calls 参数分片
+        ↓
+Chat 流解析器将工具名称、ID、arguments 写入 IR 状态
+        ↓
+Gemini 投影器等待 block stop 或 Finalize 再输出 functionCall
+        ↓
+旧的 OaiStreamHandler 在 EOF 没有调用 FinalizeStreamResponse
+        ↓
+Gemini 客户端收不到 functionCall
+```
+
+因此，原始故障不是：
+
+- Gemini 工具声明转换失败；
+- JSON Schema 丢失；
+- Chat 上游没有生成工具调用；
+- Chat chunk 解析失败。
+
+而是：
+
+> 旧的 `OaiStreamHandler` 使用逐块兼容入口处理 Chat → Gemini 流，却没有在 HTTP/SSE EOF 处提交 IR 中尚未关闭的工具 block。
+
+### 2.2 前一轮分析中需要修正的部分
+
+不能将 Claude、Responses 和 Gemini 简单归类为同一个未接入生命周期的问题。
+
+在 `a6d2b3e` 之前，下列处理器已经具备独立的状态式生命周期：
+
+- `OaiChatToResponsesStreamHandler`
+- `OaiResponsesToChatStreamHandler`
+- `ClaudeStreamHandler`
+- Gemini 原生流处理器
+
+这些处理器已经使用：
+
+```text
+NewResponseStreamState
+        ↓
+ConvertStreamResponseChunk
+        ↓
+FinalizeStreamResponse
+```
+
+因此，本次修复不应重新改造这些已经正常工作的处理器。
+
+### 2.3 当前回归的独立原因
+
+`a6d2b3e` 新增了类似以下判断：
+
+```go
+projected := info.RelayFormat != "" &&
+    info.RelayFormat != types.RelayFormatOpenAI
+
+if projected && info.RelayMode != relayconstant.RelayModeChatCompletions {
+    return error
+}
+```
+
+该判断混淆了两个不同概念：
+
+- `RelayMode`：客户端入口路径或业务模式；
+- `TextPlan.Native`：上游实际使用的原生文本协议。
+
+真实 Gemini 请求的状态是：
+
+```text
+RelayMode   = RelayModeGemini
+RelayFormat = RelayFormatGemini
+TextPlan.Client = RelayFormatGemini
+TextPlan.Native = RelayFormatOpenAI
+```
+
+因此，Gemini 请求经过转换后接收 OpenAI Chat SSE 是合法行为，不应因为 `RelayModeGemini != RelayModeChatCompletions` 被拒绝。
+
+当前报错：
+
+```text
+cannot project OpenAI completions stream to gemini
+```
+
+发生在读取上游 SSE 之前，是新增加的前置协议判断造成的回归，不是上游返回了错误的 legacy Completions 响应。
+
+## 3. 处理器与协议边界
+
+### 3.1 协议字段职责
+
+后续实现必须严格区分以下字段：
+
+| 字段 | 职责 | 是否用于判断上游响应 DTO |
+|---|---|---|
+| `RelayMode` | 客户端入口路径、业务类型 | 否 |
+| `RelayFormat` | 客户端目标响应协议 | 是，用于决定目标投影格式 |
+| `TextPlan.Client` | 客户端文本协议 | 否，主要用于记录规划结果 |
+| `TextPlan.Native` | 上游实际文本协议 | 是 |
+| 处理器入口 | 当前函数被调用时承诺的上游协议 | 是 |
+
+禁止继续使用 `RelayMode` 推断上游响应是 Chat、Responses、Claude 或 Gemini。
+
+### 3.2 OpenAI Chat 上游的正确入口
+
+`DoPlannedTextResponse` 已经根据 `TextPlan.Native` 选择响应处理器：
+
+```text
+Native = OpenAI Responses
+        → OaiResponsesStreamHandler 或 OaiResponsesToChatStreamHandler
+
+Native = OpenAI Chat
+        → OaiStreamHandler
+```
+
+因此，`OaiStreamHandler` 的职责应明确为：
+
+> 处理已经确认是 OpenAI Chat Completions 的上游流，并根据客户端目标格式选择原样透传或跨格式投影。
+
+它不应再要求客户端入口 `RelayMode` 必须是 `RelayModeChatCompletions`。
+
+### 3.3 Legacy Completions 的边界
+
+OpenAI `/v1/completions` 属于另一种上游响应格式，不能与 Chat Completions 混用。
+
+计划中需要明确：
+
+1. TextPlan 选择 `RelayFormatOpenAI` 时，`OaiStreamHandler` 接收的是 Chat Completions SSE；
+2. 未经过 TextPlan 的 legacy Completions 请求继续保留原有 Completions 处理行为；
+3. legacy Completions 不得被误判为 Chat，也不得被直接投影到 Gemini、Claude 或 Responses；
+4. 如果现有调用结构无法从入口区分两种上游响应，应拆分 Chat 和 Completions 流处理入口，或在进入处理器时显式传递 source format；
+5. 不能通过再次读取 `RelayMode` 来补充上游响应格式判断。
+
+## 4. 受影响路径矩阵
+
+| 客户端 | 上游原生协议 | 修复前处理器 | 修复前状态 | 本次计划 |
+|---|---|---|---|---|
+| Gemini | OpenAI Chat | `OaiStreamHandler` | 旧逐块入口，EOF 未 Finalize | 修复 |
+| Claude | OpenAI Chat | `OaiStreamHandler` | 可能缺少尾部终止，但工具 JSON 可增量输出 | 纳入回归验证，统一修复入口 |
+| OpenAI Chat | OpenAI Chat | `OaiStreamHandler` | 原样透传 | 保持原样透传 |
+| OpenAI | OpenAI Responses | `OaiChatToResponsesStreamHandler` | 已状态式 | 不重构 |
+| Responses | OpenAI Chat | `OaiResponsesToChatStreamHandler` | 已状态式 | 不重构 |
+| Gemini | OpenAI Responses | `OaiResponsesToChatStreamHandler` | 已状态式 | 不重构，仅回归验证 |
+| Claude | OpenAI Responses | `OaiResponsesToChatStreamHandler` | 已状态式 | 不重构，仅回归验证 |
+| Claude | Claude | `ClaudeStreamHandler` | 已状态式 | 不重构 |
+| Gemini | Gemini | Gemini 原生处理器 | 同格式或已有专用转换 | 不重构 |
+| OpenAI Completions | Legacy Completions | Legacy 处理入口 | 非 Chat 流 | 保持兼容并增加边界测试 |
+
+说明：Claude → OpenAI Chat 在技术上也经过 `OaiStreamHandler`，因此需要验证其终止事件；但它与 Gemini 的可见故障不同。Claude 投影器可以在参数分片阶段输出 `input_json_delta`，而 Gemini 只有在 block stop 或 Finalize 时才生成最终 `functionCall`。
+
+## 5. 修复目标
+
+本次修复需要同时满足以下目标：
+
+1. Gemini → OpenAI Chat 的合法流不再触发 `cannot project ...`；
+2. OpenAI Chat 上游跨格式流使用一个明确的 `ResponseStreamState`；
+3. 每个上游 Chat chunk 只解析和转换一次；
+4. EOF 时恰好调用一次 `FinalizeStreamResponse`；
+5. Gemini 工具参数在 EOF 时生成一个完整且稳定的 `functionCall`；
+6. Claude、Responses 的既有状态式处理器不被重复改造或破坏；
+7. token、工具调用计费和 usage 统计基于实际解析出的 Chat chunk，而不是基于客户端 `RelayMode`；
+8. Chat 原样透传、legacy Completions 和跨格式投影之间的职责边界清晰；
+9. 前端入口协议和 API 响应协议保持不变。
+
+## 6. 实施计划
+
+### 阶段一：先修正处理器入口判断
+
+#### 目标
+
+移除错误的客户端模式限制，使合法的 Gemini/Claude → OpenAI Chat 流能够进入投影处理。
+
+#### 计划内容
+
+1. 检查并移除 `OaiStreamHandler` 中基于以下条件的拒绝逻辑：
+
+   ```go
+   projected && info.RelayMode != relayconstant.RelayModeChatCompletions
+   ```
+
+2. 以处理器职责或 `info.TextNative()` 确认源格式为 OpenAI Chat，而不是使用客户端 `RelayMode`。
+3. 保留目标格式判断：
+
+   ```go
+   projected := info.RelayFormat != "" &&
+       info.RelayFormat != types.RelayFormatOpenAI
+   ```
+
+4. 如果源格式不是 OpenAI Chat，必须在更早的路由层进入对应处理器，而不是让 `OaiStreamHandler` 猜测响应 DTO。
+5. 对 legacy Completions 保留独立处理路径，避免为了放开 Gemini 投影而错误地允许 Completions → Gemini。
+6. 错误信息应反映真实的 source/target 协议，例如：
+
+   ```text
+   OpenAI Chat stream handler received unexpected source format
+   ```
+
+   不再使用“客户端不是 Chat 所以拒绝”的错误语义。
+
+#### 重点文件
+
+- `relay/channel/openai/relay-openai.go`
+- `relay/channel/openai/text_plan_response.go`
+- `relay/channel/openai/adaptor.go`
+- `relay/common/text_plan.go`
+
+### 阶段二：完善 OpenAI Chat 跨格式流状态
+
+#### 目标
+
+确保 `OaiStreamHandler` 对 Chat → Gemini、Chat → Claude 等目标协议使用单一状态对象。
+
+#### 计划内容
+
+1. 仅在目标协议与 OpenAI Chat 不同的情况下创建：
+
+   ```go
+   relayconvert.NewResponseStreamState(
+       types.RelayFormatOpenAI,
+       info.RelayFormat,
+       options,
+   )
+   ```
+
+2. 状态对象的生命周期覆盖整个 HTTP/SSE 响应流：
+
+   ```text
+   创建一次
+   每个 chunk 使用一次
+   EOF Finalize 一次
+   ```
+
+3. 每个 Chat chunk 的处理顺序固定为：
+
+   ```text
+   JSON 解析
+       ↓
+   metadata / usage / 统计信息更新
+       ↓
+   ConvertStreamResponseChunk
+       ↓
+   WriteProjectedStreamResults
+   ```
+
+4. 不得在 chunk 之间重新创建 state。
+5. 不得在 EOF 再次把最后一个原始 chunk 传给 `ConvertStreamResponse` 或 `ConvertStreamResponseChunk`。
+6. Chat → Chat 继续使用原样透传，不经过跨格式 IR 投影。
+7. 如果一个源 chunk 产生多个目标事件，必须全部写出。
+8. 上游响应解析失败时，区分：
+   - 尚未写出响应时的结构化错误返回；
+   - 已经开始流式响应后的终止和记录策略。
+
+#### 重点文件
+
+- `relay/channel/openai/relay-openai.go`
+- `relay/channel/openai/helper.go`
+- `relay/helper/text_project.go`
+- `relaykit/relayconvert/response_registry.go`
+
+### 阶段三：将 token、文本和工具统计与客户端模式解耦
+
+#### 目标
+
+修复当前 `switch info.RelayMode` 导致 Gemini/Claude 跨格式路径不执行 Chat chunk 统计的问题。
+
+#### 现状问题
+
+当前响应已经被解析为：
+
+```go
+dto.ChatCompletionsStreamResponse
+```
+
+但统计逻辑仍然类似：
+
+```go
+switch info.RelayMode {
+case RelayModeChatCompletions:
+    ProcessStreamResponse(...)
+case RelayModeCompletions:
+    processTokenData(...)
+}
+```
+
+真实 Gemini 请求的 `RelayMode` 是 `RelayModeGemini`，因此即使上游实际返回 Chat chunk，也会跳过：
+
+- 文本统计；
+- reasoning 统计；
+- 工具名称统计；
+- 工具参数统计；
+- 无 usage 时的 completion token 估算。
+
+#### 计划内容
+
+1. 对已经确认的 OpenAI Chat source，直接基于解析出的 `ChatCompletionsStreamResponse` 调用 Chat 统计逻辑。
+2. 统计逻辑使用 source format 或处理器职责，而不是客户端 `RelayMode`。
+3. 保证跨格式 Gemini 和 Claude 流也会执行：
+   - `ProcessStreamResponse`；
+   - 工具调用名称收集；
+   - 文本和 reasoning 累计；
+   - 无上游 usage 时的 token 估算。
+4. legacy Completions 使用独立的 `CompletionsStreamResponse` 统计逻辑。
+5. 工具调用数量按稳定的 choice/index 和 call ID 统计，避免：
+   - 同一工具名称的多个参数 chunk 被重复计费；
+   - 并行工具调用被合并；
+   - 当前 chunk 的数组长度被错误地当作全局工具数量。
+6. usage 估算只在上游没有有效 usage 时执行。
+7. usage 后处理和工具计费不应影响 stream state 的终止顺序。
+
+#### 重点文件
+
+- `relay/channel/openai/relay-openai.go`
+- `relay/channel/openai/helper.go`
+- `relay/channel/openai/usage.go`
+- `relay/common/tool_usage.go`
+- `service/usage_helpr.go`
+
+### 阶段四：在 EOF 统一完成 Finalize
+
+#### 目标
+
+把 HTTP/SSE EOF 作为正式终止边界，确保所有尚未结束的工具 block 和文本 block 都能提交。
+
+#### 计划内容
+
+1. SSE 扫描结束后确定最终 usage：
+   - 优先使用上游有效 usage；
+   - 没有有效 usage 时使用当前文本、reasoning 和工具统计估算；
+   - 保持现有 usage 后处理逻辑。
+2. 将最终 usage 写入 state：
+
+   ```go
+   streamState.SetUsage(usage)
+   ```
+
+3. Claude 目标继续向 `ClaudeConvertInfo` 同步 usage，但不改变公共 state 的终止流程。
+4. 调用一次：
+
+   ```go
+   relayconvert.FinalizeStreamResponse(...)
+   ```
+
+5. 将 Finalize 返回的所有结果完整写出。
+6. Finalize 成功后禁止：
+   - 再次转换最后一个 chunk；
+   - 再次调用 Finalize；
+   - 重复发送工具调用；
+   - 重复发送终止事件。
+7. 上游有 `finish_reason` 时，finish chunk 只负责更新 IR 状态；最终 block stop、工具提交和目标协议终止由统一 Finalize 完成。
+8. 上游没有 `finish_reason` 但正常 EOF 时，仍然必须：
+   - 关闭打开的文本 block；
+   - 刷新工具参数；
+   - 生成目标协议终止事件；
+   - 完成 usage。
+9. 上游出现错误或异常 EOF 时，遵循现有错误响应策略，不把不完整工具参数伪装成成功的完整调用。
+
+#### 重点文件
+
+- `relay/channel/openai/relay-openai.go`
+- `relaykit/relayconvert/response_registry.go`
+- `relaykit/relayconvert/ir_hub.go`
+- `relay/helper/stream_result.go`
+
+### 阶段五：保持工具调用投影语义不变
+
+#### 目标
+
+只修复生命周期，不通过提前输出或局部 Gemini 分支补丁规避问题。
+
+#### 计划内容
+
+1. 工具名称、ID、arguments 按 source index 隔离。
+2. arguments 分片阶段不提前生成 Gemini `functionCall`。
+3. 工具调用只在 block stop 或 Finalize 阶段提交。
+4. `{}` 快照不能覆盖后续完整参数。
+5. 已提交的工具索引不能重复输出。
+6. 并行工具调用需要保持：
+   - name 不串线；
+   - ID 不串线；
+   - arguments 不串线；
+   - 输出顺序稳定。
+7. Claude 的 `input_json_delta` 增量输出行为保持不变。
+8. Responses 的既有事件转换和终止事件保持不变。
+9. 只有在现有 projector 测试暴露实际缺陷时，才调整 `relaykit` 的 IR 状态实现；不因为本次入口回归而重新改写已验证的 Gemini/Claude/Responses projector。
+
+#### 重点文件
+
+- `relaykit/ir/stream.go`
+- `relaykit/ir/project/chat/stream.go`
+- `relaykit/ir/project/gemini/stream.go`
+- `relaykit/ir/project/claude/stream.go`
+
+### 阶段六：隔离并验证已有状态式处理器
+
+#### 目标
+
+证明本次修复不会将已经正常的 Claude、Responses 路径重新纳入不必要的重构。
+
+#### 计划内容
+
+1. 不修改以下处理器的生命周期实现，除非回归测试证明存在独立缺陷：
+   - `OaiChatToResponsesStreamHandler`；
+   - `OaiResponsesToChatStreamHandler`；
+   - `ClaudeStreamHandler`；
+   - Gemini 原生流处理器。
+2. 对这些处理器补充或保留回归测试，确认：
+   - state 创建一次；
+   - chunk 转换一次；
+   - EOF Finalize 一次；
+   - 终止事件只发送一次。
+3. 不使用 `RelayMode` 改写或覆盖上游协议。
+4. 不让 OpenAI Chat 处理器接管 Responses 或 Claude 原生 SSE。
+5. 不将 Gemini 的特殊工具提交时机复制到 Claude 或 Responses 投影器。
+
+## 7. 测试计划
+
+### 7.1 真实 Gemini 元数据处理器测试
+
+修正现有处理器测试中失真的上下文，不能手工把 Gemini 请求设置成 `RelayModeChatCompletions`。
+
+测试上下文应至少包含：
+
+```text
+RelayMode          = RelayModeGemini
+RelayFormat        = RelayFormatGemini
+TextPlan.Client    = RelayFormatGemini
+TextPlan.Native    = RelayFormatOpenAI
+```
+
+验证：
+
+1. 不再返回 `cannot project OpenAI completions stream to gemini`；
+2. 能够读取完整 Chat SSE；
+3. 普通文本能够投影到 Gemini；
+4. 工具调用能够在 EOF 生成 `functionCall`。
+
+建议位置：
+
+```text
+relay/channel/openai/relay_openai_stream_projection_test.go
+```
+
+### 7.2 Gemini Chat 工具流
+
+输入：
+
+```text
+chunk 1: tool id + name + {"code":
+chunk 2: "1+1"}
+chunk 3: finish_reason=tool_calls
+EOF
+```
+
+期望：
+
+1. 参数分片阶段不提前输出 `functionCall`；
+2. EOF Finalize 输出一个完整 `functionCall`；
+3. 名称为 `eval_javascript`；
+4. 参数为 `{"code":"1+1"}`；
+5. 工具调用不重复；
+6. Gemini 响应包含正确的终止语义。
+
+### 7.3 Gemini 无 finish_reason
+
+输入有效工具参数后直接 EOF。
+
+期望：
+
+- EOF 自动关闭工具 block；
+- 输出一次完整 `functionCall`；
+- 使用公共默认终止语义；
+- 不静默丢弃工具调用。
+
+### 7.4 finish 后独立 usage chunk
+
+输入：
+
+```text
+1. 工具参数 chunk
+2. finish_reason=tool_calls
+3. choices 为空、仅包含 usage 的 chunk
+4. EOF
+```
+
+期望：
+
+- 工具调用只输出一次；
+- usage 不丢失；
+- usage-only chunk 不重复触发 finish；
+- EOF Finalize 幂等完成。
+
+### 7.5 `{}` 快照与完整参数
+
+输入：
+
+```text
+{}
+{"code":"1+1"}
+finish
+EOF
+```
+
+期望只得到：
+
+```json
+{
+  "functionCall": {
+    "name": "eval_javascript",
+    "args": {
+      "code": "1+1"
+    }
+  }
+}
+```
+
+不得先提交空参数调用。
+
+### 7.6 并行工具调用
+
+至少两个不同 index 的工具调用交错返回 arguments。
+
+期望：
+
+- 工具 ID、名称、参数不串线；
+- 输出顺序稳定；
+- 每个工具只输出一次；
+- 一个工具的空快照不覆盖另一个工具的完整参数。
+
+### 7.7 文本、reasoning 和 usage 统计
+
+使用真实 Gemini、Claude 元数据验证：
+
+1. Chat chunk 中的文本会参与 completion token 估算；
+2. reasoning 会参与既有统计；
+3. 工具名称和参数会参与工具 token 估算；
+4. 上游有效 usage 优先于估算 usage；
+5. Gemini/Claude 的 `RelayMode` 不会导致 Chat 统计逻辑被跳过；
+6. 工具计费不会因多个 arguments chunk 重复发生。
+
+### 7.8 最后一块只处理一次
+
+对最后一个 chunk 同时包含 arguments、finish 或 usage 的场景增加断言：
+
+- 源 chunk 只进入转换器一次；
+- 文本不重复；
+- arguments 不重复拼接；
+- `functionCall` 不重复；
+- 终止事件不重复；
+- usage 不重复累计。
+
+### 7.9 Claude → Chat 回归
+
+使用真实 Claude 入口模式：
+
+```text
+RelayMode       = RelayModeUnknown
+RelayFormat     = RelayFormatClaude
+TextPlan.Native = RelayFormatOpenAI
+```
+
+验证：
+
+- Claude `tool_use` 输入增量保持正常；
+- `content_block_stop`、`message_delta`、`message_stop` 完整；
+- 无 finish 的 EOF 仍能生成终止事件；
+- usage 正确；
+- 不因 `RelayModeUnknown` 被拒绝。
+
+### 7.10 Responses 专用处理器回归
+
+确认以下路径不受本次改动影响：
+
+- OpenAI Chat → OpenAI Responses；
+- OpenAI Responses → Chat；
+- Gemini → OpenAI Responses；
+- Claude → OpenAI Responses。
+
+验证 Responses 事件顺序、工具调用、usage 和终止事件保持原有行为。
+
+### 7.11 原样 Chat 透传
+
+使用：
+
+```text
+RelayFormat = RelayFormatOpenAI
+TextPlan.Native = RelayFormatOpenAI
+```
+
+验证：
+
+- 不创建跨格式 state；
+- 不执行 IR 二次投影；
+- 每个 Chat chunk 只发送一次；
+- usage-only chunk 的隐藏规则保持不变；
+- 最终 `data: [DONE]` 只发送一次。
+
+### 7.12 Legacy Completions 边界测试
+
+验证 legacy Completions：
+
+1. 仍然使用 `CompletionsStreamResponse` 解析；
+2. 不被错误当成 Chat Completions；
+3. 不因为移除 Gemini/Chat 模式限制而被错误投影到 Gemini；
+4. 原有 OpenAI Completions 客户端行为不回退。
+
+### 7.13 处理器级完整 SSE 集成测试
+
+必须覆盖真实调用链：
+
+```text
+HTTP response body
+  → StreamScannerHandler
+  → OaiStreamHandler
+  → ChatCompletionsStreamResponse
+  → ConvertStreamResponseChunk
+  → FinalizeStreamResponse
+  → Gemini SSE writer
+```
+
+测试不应只调用 relaykit projector，还必须断言最终写出的 SSE：
+
+- 包含一个完整 `functionCall`；
+- 不包含错误 `cannot project ...`；
+- 工具调用和终止事件不重复；
+- usage 或估算 usage 存在。
+
+## 8. 验收标准
+
+### 8.1 Gemini 功能验收
+
+1. 真实 `RelayModeGemini` 请求能够进入 OpenAI Chat 流投影。
+2. 原始 Gemini 请求中的 5 个工具声明仍完整转换为 Chat 工具。
+3. Chat 上游工具参数最终能够生成 Gemini `functionCall`。
+4. `functionCall.args` 是完整 JSON，而不是 `{}` 或单个参数分片。
+5. 上游没有 `finish_reason` 时，EOF 仍能提交工具调用。
+6. finish 后独立 usage chunk 不丢失 usage、不重复工具调用。
+7. 并行工具调用互不串线。
+8. 当前错误 `cannot project OpenAI completions stream to gemini` 不再出现于合法 Gemini → Chat 请求。
+
+### 8.2 生命周期验收
+
+每个跨格式 Chat 流会话必须满足：
+
+```text
+创建 state 一次
+每个 chunk 转换一次
+最终 usage 设置至多一次
+Finalize 一次
+终止事件发送一次
+```
+
+### 8.3 协议边界验收
+
+1. 不使用 `RelayMode` 判断 OpenAI 上游响应 DTO。
+2. `TextPlan.Native` 或处理器入口负责描述上游协议。
+3. Chat、Responses、Claude、Gemini 原生处理器职责不混用。
+4. Legacy Completions 不与 Chat Completions 共用错误的解析路径。
+5. 客户端入口协议、上游实际协议和响应目标协议不互相覆盖。
+
+### 8.4 回归验收
+
+1. Claude 原有工具调用行为保持正常。
+2. Responses 原有流式事件顺序保持正常。
+3. OpenAI Chat 原样透传不重复、不延迟异常。
+4. 非流式 Chat、Claude、Gemini 请求不受影响。
+5. 前端 API、页面和国际化资源无需修改。
+
+## 9. 预计涉及文件
+
+重点运行层文件：
+
+```text
+relay/channel/openai/relay-openai.go
+relay/channel/openai/helper.go
+relay/channel/openai/text_plan_response.go
+relay/channel/openai/adaptor.go
+relay/common/text_plan.go
+relay/helper/text_project.go
+```
+
+统计和 usage 相关文件：
+
+```text
+relay/channel/openai/usage.go
+relay/common/tool_usage.go
+service/usage_helpr.go
+```
+
+测试文件：
+
+```text
+relay/channel/openai/relay_openai_stream_projection_test.go
+relay/channel/openai/stream_tool_billing_test.go
+relay/channel/openai/chat_via_responses_test.go
+relaykit/relayconvert/terminal_stream_test.go
+relaykit/relayconvert/request_registry_test.go
+relay/request_adapt_test.go
+```
+
+只有在测试证明 IR projector 本身存在独立缺陷时，才修改：
+
+```text
+relaykit/ir/stream.go
+relaykit/ir/project/chat/stream.go
+relaykit/ir/project/gemini/stream.go
+relaykit/ir/project/claude/stream.go
+relaykit/relayconvert/response_registry.go
+```
+
+## 10. 非目标
+
+本次不计划：
+
+1. 修改 Gemini 客户端请求协议；
+2. 修改 Gemini 工具声明和 JSON Schema 的公共定义；
+3. 修改 `thinkingBudget → reasoning_effort` 的既定映射；
+4. 让工具调用在 arguments 尚未稳定时提前输出；
+5. 重构已经正常的 Responses 专用流处理器；
+6. 重构已经正常的 Claude 原生流处理器；
+7. 将 Gemini 的工具提交策略复制到 Claude 或 Responses；
+8. 通过删除流式工具调用能力规避问题；
+9. 通过把所有客户端 `RelayMode` 强行改成 Chat 来绕过判断；
+10. 修改前端页面、前端 API 或国际化资源；
+11. 为单个模型增加供应商专用分支。
+
+## 11. 实施顺序
+
+1. 先修正处理器级测试上下文，使用真实的 Gemini、Claude 元数据。
+2. 增加当前回归的失败测试，确认 `RelayModeGemini` 不应被拒绝。
+3. 移除或重构 `RelayMode` 上游协议判断。
+4. 明确 Chat 与 legacy Completions 的源协议入口。
+5. 保留并检查 OpenAI Chat 跨格式 state 的单次创建。
+6. 将 Chat chunk 统计改为依据实际 source，而不是客户端 `RelayMode`。
+7. 删除跨格式路径对最后一个原始 chunk 的重复转换。
+8. 确认 EOF 只执行一次 `FinalizeStreamResponse`。
+9. 补齐 Gemini 工具流、无 finish、usage、并行工具和重复处理测试。
+10. 补齐 Claude、Responses、原样 Chat 和 legacy Completions 回归测试。
+11. 执行完整静态检查、测试、编译和构建验证。
+12. 提交并推送修复，重新构建正式二进制并确认构建版本一致。
+
+## 12. 验证命令
+
+实施完成后按照项目要求执行以下检查。
+
+### 12.1 Go 格式与差异检查
+
+```bash
+gofmt -w <本次修改的所有 Go 文件>
+git diff --check
+```
+
+### 12.2 Go 测试
+
+```bash
+make test
+```
+
+根模块和 relaykit 关键模块分别验证：
+
+```bash
+go test ./... -count=1
+cd relaykit
+go test ./... -count=1
+```
+
+### 12.3 golangci-lint
+
+```bash
+golangci-lint run ./...
+cd relaykit
+golangci-lint run ./...
+```
+
+### 12.4 OXLint、Vitest 和前端构建检查
+
+```bash
+cd web
+bun run lint
+bun run test
+bun run build:check
+```
+
+### 12.5 后端编译
+
+```bash
+go build ./...
+go build -o bin/new-api.exe .
+```
+
+### 12.6 提交和构建产物校验
+
+```bash
+git status --short
+git rev-parse HEAD
+go version -m bin/new-api.exe
+```
+
+正式构建验收要求：
+
+- `vcs.revision` 与最终提交一致；
+- `vcs.modified=false`；
+- 二进制包含最新修复；
+- 不使用旧提交或 dirty 工作区构建正式产物。


### PR DESCRIPTION
## Agent

- Tool: pi
- Tool version: 0.84.3
- Model (full id): sh-openai-responses/gpt-5.6-sol
- Host (CLI / IDE / GitHub coding agent / other): CLI
- Date (UTC): 2026-08-27

## Links

- Closes: 不适用（仅文档变更，不对应 issue）
- Related: https://github.com/QuantumNous/new-api/pull/6707（相关的跨协议工作，但不是本 PR 的重复项）

## User request

用户原话（按澄清后的含义）：为本项目创建一个分支，然后在 GitHub 上给本项目所 fork 的源头项目 `QuantumNous/new-api` 提交 PR。

## Out of scope — refuse

- Matched: no
- This is a documentation-only change. It does not add a coding plan to the product, reverse-engineer a channel, add a third-party wrapper, change Codex compatibility, add pass-through-only forwarding, add third-party hosting, or answer a usage/configuration/integration question.

## Kind

- [ ] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [x] Docs
- [ ] Other:

## Issue facts

- Actual behavior: 不适用；本 PR 不修改运行时行为。
- Impact: 不适用；本 PR 仅新增和修订修复计划文档。
- Frequency: 不适用；未在本 PR 中引入或验证运行时回归。
- Evidence that the problem is in new-api rather than the client or upstream: 不适用；文档记录的是仓库代码路径和已有调查结论，不在本 PR 中声称完成新的运行时归因。
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): relay 文档分析；不涉及 billing、frontend 或 deployment 字段。

## Change

本 PR 将当前 fork 中已经整理的跨协议问题分析提交为两个独立的中文计划文档：

1. 新增 Claude Messages → Gemini `generateContent` 的思维预算与等级投影修复计划，记录目标模型能力优先、预算与等级冲突处理、请求/响应投影回归场景以及后续测试矩阵。
2. 修订 Gemini → OpenAI Chat 的流式工具调用生命周期修复计划，明确 `RelayMode`、`RelayFormat`、`TextPlan.Native` 与处理器入口的职责边界，并记录 EOF 时 `FinalizeStreamResponse` 生命周期缺口及回归测试范围。

文档明确说明本次提交只制定实施计划，不修改生产代码。

## Research

### Duplicate / prior art

- Search queries (issues, PRs):
  - `repo:QuantumNous/new-api Gemini Chat stream tool`
  - `repo:QuantumNous/new-api Claude Gemini thinking`
  - `repo:QuantumNous/new-api cross protocol stream`
  - 检查了本 PR head `zhaibingye:docs/cross-protocol-repair-plans` 的已有 PR。
- What already existed and why this is not a duplicate: 仓库已有 RelayKit 的跨协议转换实现、流式状态测试，以及相关的跨协议 PR（例如 #6707）。#6707 的标题和范围是 Claude 上游通道的 OpenAI Responses API 支持；本 PR 不修改该功能，而是补充两个面向维护者的故障分析与实施计划文档，因此不是重复实现。

### Docs and code

- https://docs.newapi.ai/ : 官方文档首页将项目定位为统一的 AI 基础设施/API 网关，并列出多上游 AI 提供商的统一接入范围；这与本 PR 记录跨协议 relay 维护计划的范围一致。
- https://deepwiki.com/QuantumNous/new-api : DeepWiki 的仓库页面将 `QuantumNous/new-api` 作为 Go AI gateway 代码库进行索引；本 PR 使用它确认源头仓库范围，具体行为依据仍以仓库代码和 RelayKit 文档为准。
- README / repo docs: `README.md` 和 `relaykit/README.md` 记录 OpenAI Chat、OpenAI Responses、Claude Messages 与 Gemini 格式支持；`relaykit/README.md` 还说明跨事件需要持有 `ResponseStreamState`，并在上游结束后调用 `FinalizeStreamResponse`。
- Code paths and what they imply for this change:
  - `relaykit/relayconvert/reasoning/gemini.go` 与 `relaykit/relayconvert/reasoning/gemini_test.go` 定义 Gemini thinking 能力识别、投影与能力矩阵。
  - `relaykit/ir/project/claude/request.go` 保存 Claude thinking 的 budget/level 信息。
  - `relaykit/relayconvert/ir_hub.go` 组装跨格式 reasoning 投影。
  - `relaykit/relayconvert/response_registry.go` 提供 `FinalizeStreamResponse`。
  - `relay/channel/openai/relay-openai.go`、`relay/channel/openai/helper.go` 与 `relay/channel/openai/relay_openai_stream_projection_test.go` 体现 Chat 上游流处理与最终化生命周期。
  - `relay/common/text_plan.go`、`relay/common/relay_info.go` 区分文本规划和上游 native 格式。

### Alternatives considered

- Option A: 直接在本 PR 修改 reasoning projector、Chat 流处理器和回归测试。这样会把尚未完成的实施设计与运行时代码混在同一提交中。
- Option B: 先提交独立的调查/实施计划文档，再由后续代码 PR 按计划逐项实现并验证。
- Why this approach: 当前变更本身是文档内容，且文档明确标注不包含代码修改；保持文档 PR 单一职责，便于源头项目维护者先审阅根因、协议边界和测试标准。

## Files

| Path | Why |
| --- | --- |
| `计划文档/Claude到Gemini思维预算与等级投影修复计划.md` | 新增 Claude → Gemini thinking budget/level 投影问题的证据、目标语义、实施阶段和测试计划。 |
| `计划文档/Gemini到Chat流式工具调用生命周期修复计划.md` | 修订 Gemini → Chat 流式工具调用生命周期的根因、协议边界、修复步骤和回归场景。 |

## Behavior

- Before: 源头仓库没有这两份针对上述跨协议问题的集中式中文计划文档；本 PR 之前的运行时代码行为不因本 PR 改变。
- After: 源头项目可在 PR 中审阅完整的故障证据、代码路径、目标语义、实现阶段和验证标准；运行时代码行为保持不变。
- Explicit non-goals / leftover work: 不实现文档中列出的代码修复，不新增测试，不改变 relay、billing、auth、frontend、数据库或 provider 行为；后续需要独立代码提交完成实施和回归验证。

## Verification

- Commands and results:
  - `git diff --check upstream/main...HEAD` — passed。
  - changed Go files 检查 — 无 Go 文件变更，gofmt 不适用。
  - `GOWORK=off go build ./...` — passed。
  - `cd relaykit && GOWORK=off go build ./...` — passed；验证 RelayKit 独立可构建。
  - `cd web && bun run test` — passed（35 个 test files，179 个 tests）。
  - `cd web && bun run build:check` — passed（typecheck 与 Rsbuild build）。
  - `make test` — 未执行成功，环境中没有 `make`；随后执行了等价的根模块测试命令。
  - 等价根模块测试 — 失败于已有的 `service/TestObserveChannelAffinityUsageCacheByRelayFormat_MixedMode`（expected 2, actual 3）；本 PR 未修改该测试或相关生产代码。
  - `golangci-lint run` — 失败于仓库现有 153 个 lint issues；本 PR 没有 Go 代码变更。
  - `cd web && bun run format:check` — 失败于现有 6 个受保护头部格式检查文件；本 PR 没有 frontend 文件变更。
  - `cd web && bun run lint` — 失败于现有 frontend lint errors；本 PR 没有 frontend 文件变更。
- Manual steps and observed result: 无；本 PR 是文档变更。
- UI: 无截图或录屏；没有 UI 变更。
- Tests added or updated, or why none: 未新增或更新测试；没有运行时代码变更。
- Databases / providers / platforms exercised: 不适用。
- Not verified: 文档中规划的真实 provider E2E 行为和后续代码修复未在本 PR 中验证。

## Risks

- Failure modes: 计划文档中的模型能力、上游协议行为或代码路径可能随后续实现变化而过时；本 PR 不会引入新的运行时失败路径。
- Billing / quota / auth impact: 无；未修改 billing、quota、auth 或相关数据结构。
- Follow-ups: 按文档中的阶段拆分后续 reasoning projector、stream lifecycle 和回归测试代码 PR，并在实现后重新运行完整验证。

## Scope check

- Single focused change: yes；仅提交两份跨协议修复计划文档。
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a plan to correct Claude-to-Gemini thinking budget and thinking-level conversion across model capabilities.
  * Added a plan to fix Gemini-to-Chat streaming tool-call lifecycle handling, including end-of-stream finalization.
  * Documented affected scenarios, conversion rules, regression test coverage, acceptance criteria, risks, and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->