### PR TITLE
feat : forward attestation headers in SSE responses

### DIFF
--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -46,13 +46,16 @@ func NewStreamScanner(reader io.Reader) *bufio.Scanner {
 	return scanner
 }
 
-func copyCodexSSEHeaders(c *gin.Context, resp *http.Response) {
+func copyAllowedSSEHeaders(c *gin.Context, resp *http.Response) {
 	if c == nil || c.Writer == nil || resp == nil {
 		return
 	}
-	// codex
-	for _, name := range []string{"X-Reasoning-Included", "X-Codex-Turn-State"} {
-		values := resp.Header.Values(name)
+	for name, values := range resp.Header {
+		isCodexHeader := strings.EqualFold(name, "X-Reasoning-Included") ||
+			strings.EqualFold(name, "X-Codex-Turn-State")
+		if !isCodexHeader && !strings.HasPrefix(strings.ToLower(name), "x-attestation-") {
+			continue
+		}
 		if !service.ShouldCopyUpstreamHeader(c, name, values) {
 			continue
 		}
@@ -141,7 +144,7 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	defer cleanup()
 
 	scanner.Split(bufio.ScanLines)
-	copyCodexSSEHeaders(c, resp)
+	copyAllowedSSEHeaders(c, resp)
 	SetEventStreamHeaders(c)
 
 	ctx = context.WithValue(ctx, "stop_chan", stopChan)

--- a/relay/helper/stream_scanner_test.go
+++ b/relay/helper/stream_scanner_test.go
@@ -211,6 +211,41 @@ func TestStreamScannerHandler_DataWithExtraSpaces(t *testing.T) {
 	assert.Equal(t, "{\"trimmed\":true}", got)
 }
 
+func TestStreamScannerHandler_ForwardsAllowlistedUpstreamResponseHeaders(t *testing.T) {
+	t.Parallel()
+
+	allowedHeaders := []string{
+		"X-Reasoning-Included",
+		"X-Codex-Turn-State",
+		"X-Attestation-Profile",
+		"X-Attestation-Future-Field",
+	}
+	upstreamHeaders := make(http.Header, len(allowedHeaders)+1)
+	for _, name := range allowedHeaders {
+		upstreamHeaders.Set(name, "allowed")
+	}
+	upstreamHeaders.Set("X-Unrelated-Upstream", "must-not-forward")
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	resp := &http.Response{
+		Body:   io.NopCloser(strings.NewReader("data: chunk\ndata: [DONE]\n")),
+		Header: upstreamHeaders,
+	}
+	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{}}
+
+	StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {
+		_ = StringData(c, data)
+	})
+
+	response := recorder.Result()
+	for _, name := range allowedHeaders {
+		assert.Equal(t, "allowed", response.Header.Get(name), name)
+	}
+	assert.Empty(t, response.Header.Get("X-Unrelated-Upstream"))
+}
+
 // TestStreamScannerHandler_ClientCancelAbortsUpstreamAndReturns pins the
 // disconnect contract: when the client goes away, the handler must return
 // promptly (all goroutines joined, so the gin.Context can never leak into a


### PR DESCRIPTION
<!--
If you are an AI coding agent (Claude Code, Codex, Cursor, Copilot, OpenCode, Paseo, Grok, or similar): do not fill this human template. Read `.agents/github/PR.md` and use the filled file as the entire PR body.
-->
# ⚠️ 提交说明 / PR Notice

English template: `.github/PULL_REQUEST_TEMPLATE/en.md`

> [!IMPORTANT]
>
> - 描述可用 AI 辅助。提交前请审阅全文，并**声明对其负责**，避免未经核对的直接粘贴。
> - 请按本模板填写后再提交。

## 🔗 关联任务 / Related Issue
- 新功能请填写下方 Issue 编号；若还没有对应 Issue，请先自行创建。功能讨论请放在 Issue 中进行。
- 改动较大或方向性变更，请先在关联 Issue 中与维护者达成一致，再提交 PR。
- Bug 修复请关联对应 Issue。设计取舍、理解偏差或预期不一致，更适合作为讨论或功能请求。

- Closes #7067

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description
我目前正在开发一个使用HTTPS MITM Proxy 和 Google Confidential Space 技术，用来对中转到官方平台的请求进行签名，这样通过中转站调用的用户就能对来源进行校验，确认模型是否被掺假或者上游资源被掉包。

项目地址：https://github.com/tokenevol/TrustedAIProxy

在调试接入newapi的过程中，当前非流式请求已经能够实现。但流式请求在newapi转发的过程中会把大部分请求header都过滤掉，因此我希望在当前的过滤函数中，增加允许： X-Attestation-* headers，还请作者评估是否可行？

## 📸 运行证明 / Proof of Work

增加testcase

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 无论描述是否由 AI 生成，我已审阅全部内容，并声明对其准确性与完整性负责。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **新功能关联 Issue:** 若此 PR 标记为 `New feature`，我已关联对应 Issue；若尚无 Issue，我已先自行创建。
- [x] **事前沟通:** 若改动较大或涉及方向性变更，已在关联 Issue 中与维护者沟通并达成一致。
- [x] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口，也不是对 Codex 渠道类型的改动。
- [x] **范围聚焦:** 本 PR 为一项聚焦改动，未包含无关代码。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - SSE responses now forward additional approved upstream headers, including reasoning, turn-state, and attestation metadata.
  - Unapproved headers continue to be excluded, preserving response filtering and handling of empty values.

- **Tests**
  - Added coverage confirming approved headers are forwarded and unrelated headers are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->