### PR TITLE
fix(docker): add relaykit go.mod to dev build context

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,6 +12,9 @@ ENV GOEXPERIMENT=greenteagc
 WORKDIR /build
 
 ADD go.mod go.sum ./
+# relaykit is a local submodule referenced via replace; its go.mod must be
+# present for go mod download to resolve the main module graph.
+ADD relaykit/go.mod ./relaykit/go.mod
 RUN go mod download
 
 COPY . .


### PR DESCRIPTION
## Related Issue
- Closes #

Follow-up to #6369, which extracted `relaykit` into a standalone module.

## Type of change
- [x] Bug fix

## Description
`go.mod` has `replace github.com/QuantumNous/new-api/relaykit => ./relaykit`, so
`go mod download` needs `relaykit/go.mod` present in the build context to resolve
the module graph. `Dockerfile` was updated for this in #6369, `Dockerfile.dev` was missed.

This adds the same `ADD relaykit/go.mod ./relaykit/go.mod` line that `Dockerfile`
already carries (lines 21-23), with the same comment.

## Proof of Work
On current `main`, `docker build -f Dockerfile.dev .`:

```text
Step 9/19 : RUN go mod download
 ---> Running in 5c51c0a80d78
go: github.com/QuantumNous/new-api/relaykit@v0.0.0 (replaced by ./relaykit): reading relaykit/go.mod: open /build/relaykit/go.mod: no such file or directory
The command '/bin/sh -c go mod download' returned a non-zero code: 1
```

With this change, the same command succeeds:

```text
Successfully built 590010e35f8e
```

## Checklist
- [x] **Human review**
- [x] **Not a duplicate**
- [x] **Feature issue:** n/a — bug fix
- [x] **Prior discussion:** n/a — one-line fix
- [x] **Scope**
- [x] **Focused change**
- [x] **Local verification**
- [x] **Security**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development environment setup by ensuring local module dependencies resolve correctly during container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->