### PR TITLE
fix: honor disabled metrics and record async video outcomes

### DIFF
--- a/pkg/perf_metrics/flush.go
+++ b/pkg/perf_metrics/flush.go
@@ -15,9 +15,9 @@ func flushLoop() {
 		interval := perf_metrics_setting.GetFlushIntervalMinutes()
 		time.Sleep(time.Duration(interval) * time.Minute)
 		setting := perf_metrics_setting.GetSetting()
-		if !setting.Enabled {
-			continue
-		}
+		// Collection stops at Record when metrics are disabled. Flush samples
+		// that were already accepted before the toggle, and keep retention
+		// cleanup independent from collection state.
 		flushCompletedBuckets()
 		cleanupExpiredMetrics(setting.RetentionDays)
 	}

--- a/pkg/perf_metrics/metrics.go
+++ b/pkg/perf_metrics/metrics.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/model"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/setting/perf_metrics_setting"
@@ -26,6 +27,9 @@ func Init() {
 
 func RecordRelaySample(info *relaycommon.RelayInfo, success bool, outputTokens int64) {
 	if info == nil {
+		return
+	}
+	if relayTargetsOnlyAsyncVideo(info) {
 		return
 	}
 	now := time.Now()
@@ -54,6 +58,81 @@ func RecordRelaySample(info *relaycommon.RelayInfo, success bool, outputTokens i
 	})
 }
 
+// RecordTaskTerminalSample records one terminal sample for an asynchronous
+// video task. The caller must invoke it only after winning the terminal status
+// transition, so overlapping pollers cannot count the same task twice.
+func RecordTaskTerminalSample(task *model.Task) {
+	sample, ok := taskTerminalSample(task, time.Now().Unix())
+	if !ok {
+		return
+	}
+	Record(sample)
+}
+
+func taskTerminalSample(task *model.Task, now int64) (Sample, bool) {
+	if task == nil || task.Platform == constant.TaskPlatformSuno || task.Platform == constant.TaskPlatformMidjourney {
+		return Sample{}, false
+	}
+	if task.Status != model.TaskStatusSuccess && task.Status != model.TaskStatusFailure {
+		return Sample{}, false
+	}
+
+	modelName := task.Properties.OriginModelName
+	if modelName == "" && task.PrivateData.BillingContext != nil {
+		modelName = task.PrivateData.BillingContext.OriginModelName
+	}
+	if modelName == "" {
+		modelName = task.Properties.UpstreamModelName
+	}
+	if modelName == "" {
+		return Sample{}, false
+	}
+
+	startedAt := task.SubmitTime
+	if startedAt <= 0 {
+		startedAt = task.CreatedAt
+	}
+	finishedAt := task.FinishTime
+	if finishedAt <= 0 {
+		finishedAt = now
+	}
+	latencyMs := int64(0)
+	if startedAt > 0 && finishedAt > startedAt {
+		latencyMs = (finishedAt - startedAt) * 1000
+	}
+
+	return Sample{
+		Model:        modelName,
+		Group:        task.Group,
+		LatencyMs:    latencyMs,
+		Success:      task.Status == model.TaskStatusSuccess,
+		GenerationMs: latencyMs,
+	}, true
+}
+
+func relayTargetsOnlyAsyncVideo(info *relaycommon.RelayInfo) bool {
+	endpoints := model.GetModelSupportEndpointTypes(info.OriginModelName)
+	if len(endpoints) == 0 && info.ChannelMeta != nil {
+		endpoints = common.GetEndpointTypesByChannelType(info.ChannelMeta.ChannelType, info.OriginModelName)
+	}
+	return supportsOnlyAsyncVideo(endpoints)
+}
+
+func supportsOnlyAsyncVideo(endpoints []constant.EndpointType) bool {
+	if len(endpoints) == 0 {
+		return false
+	}
+	hasVideo := false
+	for _, endpoint := range endpoints {
+		if endpoint == constant.EndpointTypeOpenAIVideo {
+			hasVideo = true
+			continue
+		}
+		return false
+	}
+	return hasVideo
+}
+
 func Record(sample Sample) {
 	setting := perf_metrics_setting.GetSetting()
 	if !setting.Enabled || sample.Model == "" {
@@ -77,6 +156,14 @@ func Record(sample Sample) {
 }
 
 func Query(params QueryParams) (QueryResult, error) {
+	if !perf_metrics_setting.GetSetting().Enabled {
+		return QueryResult{
+			Enabled:      false,
+			ModelName:    params.Model,
+			SeriesSchema: seriesSchema,
+			Groups:       make([]GroupResult, 0),
+		}, nil
+	}
 	if params.Hours <= 0 {
 		params.Hours = 24
 	}
@@ -123,6 +210,9 @@ func Query(params QueryParams) (QueryResult, error) {
 }
 
 func QuerySummaryAll(hours int, groups []string) (SummaryAllResult, error) {
+	if !perf_metrics_setting.GetSetting().Enabled {
+		return SummaryAllResult{Enabled: false, Models: make([]ModelSummary, 0)}, nil
+	}
 	if hours <= 0 {
 		hours = 24
 	}
@@ -195,7 +285,7 @@ func QuerySummaryAll(hours int, groups []string) (SummaryAllResult, error) {
 		return models[i].RequestCount > models[j].RequestCount
 	})
 
-	return SummaryAllResult{Models: models}, nil
+	return SummaryAllResult{Enabled: true, Models: models}, nil
 }
 
 func mergeModelTotals(totals map[string]counters, modelName string, value counters) {
@@ -340,6 +430,7 @@ func buildQueryResult(modelName string, merged map[bucketKey]counters) QueryResu
 	}
 
 	return QueryResult{
+		Enabled:      true,
 		ModelName:    modelName,
 		SeriesSchema: seriesSchema,
 		Groups:       results,

--- a/pkg/perf_metrics/metrics_test.go
+++ b/pkg/perf_metrics/metrics_test.go
@@ -1,0 +1,147 @@
+package perfmetrics
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/model"
+	settingconfig "github.com/QuantumNous/new-api/setting/config"
+	"github.com/QuantumNous/new-api/setting/perf_metrics_setting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setMetricsEnabled(t *testing.T, enabled bool) {
+	t.Helper()
+	previous := perf_metrics_setting.GetSetting().Enabled
+	require.NoError(t, settingconfig.GlobalConfig.LoadFromDB(map[string]string{
+		"perf_metrics_setting.enabled": boolString(enabled),
+	}))
+	t.Cleanup(func() {
+		require.NoError(t, settingconfig.GlobalConfig.LoadFromDB(map[string]string{
+			"perf_metrics_setting.enabled": boolString(previous),
+		}))
+	})
+}
+
+func boolString(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+func TestQueriesHideHistoricalMetricsWhenDisabled(t *testing.T) {
+	setMetricsEnabled(t, false)
+
+	result, err := Query(QueryParams{Model: "video-model", Hours: 24})
+	require.NoError(t, err)
+	assert.False(t, result.Enabled)
+	assert.Equal(t, "video-model", result.ModelName)
+	assert.Empty(t, result.Groups)
+
+	summary, err := QuerySummaryAll(24, nil)
+	require.NoError(t, err)
+	assert.False(t, summary.Enabled)
+	assert.Empty(t, summary.Models)
+}
+
+func TestTaskTerminalSample(t *testing.T) {
+	tests := []struct {
+		name        string
+		task        *model.Task
+		now         int64
+		wantOK      bool
+		wantModel   string
+		wantGroup   string
+		wantMs      int64
+		wantSuccess bool
+	}{
+		{
+			name: "successful video task",
+			task: &model.Task{
+				Platform:   constant.TaskPlatform("kling"),
+				Status:     model.TaskStatusSuccess,
+				Group:      "video",
+				SubmitTime: 100,
+				FinishTime: 112,
+				Properties: model.Properties{OriginModelName: "video-public"},
+			},
+			now:         120,
+			wantOK:      true,
+			wantModel:   "video-public",
+			wantGroup:   "video",
+			wantMs:      12_000,
+			wantSuccess: true,
+		},
+		{
+			name: "failed task uses billing model and current finish time",
+			task: &model.Task{
+				Platform:  constant.TaskPlatform("kling"),
+				Status:    model.TaskStatusFailure,
+				CreatedAt: 200,
+				PrivateData: model.TaskPrivateData{BillingContext: &model.TaskBillingContext{
+					OriginModelName: "billing-model",
+				}},
+			},
+			now:       209,
+			wantOK:    true,
+			wantModel: "billing-model",
+			wantMs:    9_000,
+		},
+		{
+			name: "upstream model fallback",
+			task: &model.Task{
+				Platform:   constant.TaskPlatform("kling"),
+				Status:     model.TaskStatusSuccess,
+				SubmitTime: 300,
+				FinishTime: 304,
+				Properties: model.Properties{UpstreamModelName: "upstream-model"},
+			},
+			now:         310,
+			wantOK:      true,
+			wantModel:   "upstream-model",
+			wantMs:      4_000,
+			wantSuccess: true,
+		},
+		{
+			name:   "non-terminal task",
+			task:   &model.Task{Platform: constant.TaskPlatform("kling"), Status: model.TaskStatusInProgress},
+			now:    100,
+			wantOK: false,
+		},
+		{
+			name:   "suno is not a video task",
+			task:   &model.Task{Platform: constant.TaskPlatformSuno, Status: model.TaskStatusSuccess, Properties: model.Properties{OriginModelName: "suno"}},
+			now:    100,
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sample, ok := taskTerminalSample(tt.task, tt.now)
+			assert.Equal(t, tt.wantOK, ok)
+			if !tt.wantOK {
+				return
+			}
+			assert.Equal(t, tt.wantModel, sample.Model)
+			assert.Equal(t, tt.wantGroup, sample.Group)
+			assert.Equal(t, tt.wantMs, sample.LatencyMs)
+			assert.Equal(t, tt.wantMs, sample.GenerationMs)
+			assert.Equal(t, tt.wantSuccess, sample.Success)
+			assert.False(t, sample.HasTtft)
+			assert.Zero(t, sample.OutputTokens)
+		})
+	}
+}
+
+func TestSupportsOnlyAsyncVideo(t *testing.T) {
+	assert.False(t, supportsOnlyAsyncVideo(nil))
+	assert.True(t, supportsOnlyAsyncVideo([]constant.EndpointType{constant.EndpointTypeOpenAIVideo}))
+	assert.False(t, supportsOnlyAsyncVideo([]constant.EndpointType{
+		constant.EndpointTypeOpenAIVideo,
+		constant.EndpointTypeOpenAI,
+	}))
+	assert.False(t, supportsOnlyAsyncVideo([]constant.EndpointType{constant.EndpointTypeOpenAI}))
+}

--- a/pkg/perf_metrics/types.go
+++ b/pkg/perf_metrics/types.go
@@ -42,6 +42,7 @@ type GroupResult struct {
 }
 
 type QueryResult struct {
+	Enabled      bool          `json:"enabled"`
 	ModelName    string        `json:"model_name"`
 	SeriesSchema string        `json:"series_schema"`
 	Groups       []GroupResult `json:"groups"`
@@ -57,7 +58,8 @@ type ModelSummary struct {
 }
 
 type SummaryAllResult struct {
-	Models []ModelSummary `json:"models"`
+	Enabled bool           `json:"enabled"`
+	Models  []ModelSummary `json:"models"`
 }
 
 type bucketKey struct {

--- a/relay/relay_task.go
+++ b/relay/relay_task.go
@@ -13,12 +13,14 @@ import (
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/model"
+	perfmetrics "github.com/QuantumNous/new-api/pkg/perf_metrics"
 	"github.com/QuantumNous/new-api/relay/channel"
 	"github.com/QuantumNous/new-api/relay/channel/task/taskcommon"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/service"
+	"github.com/bytedance/gopkg/util/gopool"
 	"github.com/gin-gonic/gin"
 )
 
@@ -483,7 +485,13 @@ func tryRealtimeFetch(task *model.Task, isOpenAIVideoAPI bool) []byte {
 	}
 
 	if !snap.Equal(task.Snapshot()) {
-		_, _ = task.UpdateWithStatus(snap.Status)
+		won, _ := task.UpdateWithStatus(snap.Status)
+		if won && (task.Status == model.TaskStatusSuccess || task.Status == model.TaskStatusFailure) {
+			taskSnapshot := *task
+			gopool.Go(func() {
+				perfmetrics.RecordTaskTerminalSample(&taskSnapshot)
+			})
+		}
 	}
 
 	// OpenAI Video API 由调用者的 ConvertToOpenAIVideo 分支处理

--- a/service/task_billing_test.go
+++ b/service/task_billing_test.go
@@ -50,6 +50,7 @@ func TestMain(m *testing.M) {
 		&model.UserSubscription{},
 		&model.SystemTask{},
 		&model.SystemTaskLock{},
+		&model.PerfMetric{},
 	); err != nil {
 		panic("failed to migrate: " + err.Error())
 	}
@@ -74,6 +75,7 @@ func truncate(t *testing.T) {
 		model.DB.Exec("DELETE FROM user_subscriptions")
 		model.DB.Exec("DELETE FROM system_task_locks")
 		model.DB.Exec("DELETE FROM system_tasks")
+		model.DB.Exec("DELETE FROM perf_metrics")
 	})
 }
 

--- a/service/task_polling.go
+++ b/service/task_polling.go
@@ -16,6 +16,7 @@ import (
 	taskdto "github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/logger"
 	"github.com/QuantumNous/new-api/model"
+	perfmetrics "github.com/QuantumNous/new-api/pkg/perf_metrics"
 	"github.com/QuantumNous/new-api/relay/channel/task/taskcommon"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relaykit/dto"
@@ -37,6 +38,16 @@ type TaskPollingAdaptor interface {
 // GetTaskAdaptorFunc 由 main 包注入，用于获取指定平台的任务适配器。
 // 打破 service -> relay -> relay/channel -> service 的循环依赖。
 var GetTaskAdaptorFunc func(platform constant.TaskPlatform) TaskPollingAdaptor
+
+func recordTaskTerminalSampleAsync(task *model.Task) {
+	if task == nil {
+		return
+	}
+	snapshot := *task
+	gopool.Go(func() {
+		perfmetrics.RecordTaskTerminalSample(&snapshot)
+	})
+}
 
 // sweepTimedOutTasks 在主轮询之前独立清理超时任务。
 // 每次最多处理 100 条，剩余的下个周期继续处理。
@@ -82,6 +93,7 @@ func sweepTimedOutTasks(ctx context.Context) {
 			continue
 		}
 		timedOutCount++
+		recordTaskTerminalSampleAsync(task)
 		if !isLegacy && task.Quota != 0 {
 			RefundTaskQuota(ctx, task, reason)
 		}
@@ -571,6 +583,7 @@ func updateVideoSingleTask(ctx context.Context, adaptor TaskPollingAdaptor, ch *
 	}
 
 	isDone := task.Status == model.TaskStatusSuccess || task.Status == model.TaskStatusFailure
+	terminalTransitionWon := false
 	if isDone && snap.Status != task.Status {
 		won, err := task.UpdateWithStatus(snap.Status)
 		if err != nil {
@@ -581,6 +594,8 @@ func updateVideoSingleTask(ctx context.Context, adaptor TaskPollingAdaptor, ch *
 			logger.LogWarn(ctx, fmt.Sprintf("Task %s CAS lost or no-op update, skip billing", task.TaskID))
 			shouldRefund = false
 			shouldSettle = false
+		} else {
+			terminalTransitionWon = true
 		}
 	} else if !snap.Equal(task.Snapshot()) {
 		if _, err := task.UpdateWithStatus(snap.Status); err != nil {
@@ -596,6 +611,9 @@ func updateVideoSingleTask(ctx context.Context, adaptor TaskPollingAdaptor, ch *
 	}
 	if shouldRefund {
 		RefundTaskQuota(ctx, task, task.FailReason)
+	}
+	if terminalTransitionWon {
+		recordTaskTerminalSampleAsync(task)
 	}
 
 	return nil

--- a/service/task_polling_test.go
+++ b/service/task_polling_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/QuantumNous/new-api/constant"
 	taskdto "github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/model"
+	perfmetrics "github.com/QuantumNous/new-api/pkg/perf_metrics"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/bytedance/gopkg/util/gopool"
@@ -28,6 +29,44 @@ type taskPollingFetchAdaptor struct {
 	blockStarted chan struct{}
 	releaseBlock chan struct{}
 	blockOnce    sync.Once
+}
+
+type terminalVideoPollingAdaptor struct {
+	statuses map[string]model.TaskStatus
+}
+
+func (a *terminalVideoPollingAdaptor) Init(_ *relaycommon.RelayInfo) {}
+
+func (a *terminalVideoPollingAdaptor) FetchTask(_ string, _ string, body map[string]any, _ string) (*http.Response, error) {
+	taskID, _ := body["task_id"].(string)
+	status := a.statuses[taskID]
+	response := taskdto.TaskResponse[model.Task]{
+		Code: taskdto.TaskSuccessCode,
+		Data: model.Task{
+			TaskID:   taskID,
+			Status:   status,
+			Progress: "100%",
+		},
+	}
+	if status == model.TaskStatusFailure {
+		response.Data.FailReason = "upstream failed"
+	}
+	responseBody, err := common.Marshal(response)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(responseBody)),
+	}, nil
+}
+
+func (a *terminalVideoPollingAdaptor) ParseTaskResult([]byte) (*relaycommon.TaskInfo, error) {
+	return nil, nil
+}
+
+func (a *terminalVideoPollingAdaptor) AdjustBillingOnComplete(_ *model.Task, _ *relaycommon.TaskInfo) int {
+	return 0
 }
 
 type sunoFailurePollingAdaptor struct {
@@ -370,6 +409,61 @@ func TestUpdateVideoTasksMixedChannelSleepSettings(t *testing.T) {
 
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.ElementsMatch(t, []string{"upstream_sleepy_1", "upstream_fast_1", "upstream_fast_2"}, adaptor.fetchedTaskIDs())
+}
+
+func TestUpdateVideoSingleTaskRecordsTerminalMetrics(t *testing.T) {
+	truncate(t)
+
+	const channelID = 105
+	const modelName = "video-terminal-metrics-test"
+	const groupName = "video-test"
+	seedTaskPollingChannel(t, channelID, true)
+
+	successTask := seedPollingTask(t, channelID, "task_metric_success", "upstream_metric_success")
+	failureTask := seedPollingTask(t, channelID, "task_metric_failure", "upstream_metric_failure")
+	for _, task := range []*model.Task{successTask, failureTask} {
+		task.Group = groupName
+		task.SubmitTime = time.Now().Add(-10 * time.Second).Unix()
+		task.Properties = model.Properties{OriginModelName: modelName}
+		require.NoError(t, model.DB.Save(task).Error)
+	}
+	staleSuccessTask := *successTask
+
+	var channel model.Channel
+	require.NoError(t, model.DB.First(&channel, channelID).Error)
+	adaptor := &terminalVideoPollingAdaptor{statuses: map[string]model.TaskStatus{
+		successTask.GetUpstreamTaskID(): model.TaskStatusSuccess,
+		failureTask.GetUpstreamTaskID(): model.TaskStatusFailure,
+	}}
+
+	require.NoError(t, updateVideoSingleTask(context.Background(), adaptor, &channel,
+		successTask.GetUpstreamTaskID(), map[string]*model.Task{successTask.GetUpstreamTaskID(): successTask}))
+	require.NoError(t, updateVideoSingleTask(context.Background(), adaptor, &channel,
+		failureTask.GetUpstreamTaskID(), map[string]*model.Task{failureTask.GetUpstreamTaskID(): failureTask}))
+	// A stale overlapping poller loses the terminal CAS and must not record a
+	// duplicate success sample.
+	require.NoError(t, updateVideoSingleTask(context.Background(), adaptor, &channel,
+		staleSuccessTask.GetUpstreamTaskID(), map[string]*model.Task{staleSuccessTask.GetUpstreamTaskID(): &staleSuccessTask}))
+
+	require.Eventually(t, func() bool {
+		result, err := perfmetrics.Query(perfmetrics.QueryParams{Model: modelName, Hours: 1})
+		return err == nil && len(result.Groups) == 1 && result.Groups[0].SuccessRate == 50
+	}, time.Second, 10*time.Millisecond)
+
+	result, err := perfmetrics.Query(perfmetrics.QueryParams{Model: modelName, Hours: 1})
+	require.NoError(t, err)
+	require.True(t, result.Enabled)
+	require.Len(t, result.Groups, 1)
+	assert.Equal(t, groupName, result.Groups[0].Group)
+	assert.Equal(t, 50.0, result.Groups[0].SuccessRate)
+	assert.GreaterOrEqual(t, result.Groups[0].AvgLatencyMs, int64(10_000))
+
+	var reloadedSuccess model.Task
+	var reloadedFailure model.Task
+	require.NoError(t, model.DB.First(&reloadedSuccess, successTask.ID).Error)
+	require.NoError(t, model.DB.First(&reloadedFailure, failureTask.ID).Error)
+	assert.EqualValues(t, model.TaskStatusSuccess, reloadedSuccess.Status)
+	assert.EqualValues(t, model.TaskStatusFailure, reloadedFailure.Status)
 }
 
 func TestUpdateSunoTasksStalePollsRefundExactlyOnce(t *testing.T) {

--- a/web/src/features/performance-metrics/types.ts
+++ b/web/src/features/performance-metrics/types.ts
@@ -37,6 +37,7 @@ export type PerformanceMetricsData = {
   success: boolean
   message?: string
   data: {
+    enabled?: boolean
     model_name: string
     series_schema?: string
     groups: PerformanceGroup[]
@@ -56,6 +57,7 @@ export type PerfSummaryAllData = {
   success: boolean
   message?: string
   data: {
+    enabled?: boolean
     models: PerfModelSummary[]
   }
 }

--- a/web/src/features/pricing/components/model-details-performance.tsx
+++ b/web/src/features/pricing/components/model-details-performance.tsx
@@ -36,7 +36,7 @@ import {
 import type { PerformanceGroup } from '@/features/performance-metrics/types'
 import { cn } from '@/lib/utils'
 
-import { type UptimeDayPoint } from '../lib/mock-stats'
+import type { UptimeDayPoint } from '../lib/mock-stats'
 import type { PricingModel } from '../types'
 import { LatencyTrendChart, UptimeTrendChart } from './model-details-charts'
 import { UptimeSparkline } from './model-details-uptime-sparkline'
@@ -97,7 +97,7 @@ function toLatencySeries(groups: PerformanceGroup[]) {
     }
   }
 
-  return Array.from(byTs.entries())
+  return [...byTs.entries()]
     .sort(([a], [b]) => a - b)
     .map(([ts, values]) => ({
       timestamp: new Date(ts * 1000).toISOString(),
@@ -121,7 +121,7 @@ function toUptimeSeries(groups: PerformanceGroup[]): UptimeDayPoint[] {
       byTs.set(point.ts, current)
     }
   }
-  return Array.from(byTs.entries())
+  return [...byTs.entries()]
     .sort(([a], [b]) => a - b)
     .map(([ts, value]) => {
       const uptime =
@@ -172,6 +172,7 @@ export function ModelDetailsPerformance(props: { model: PricingModel }) {
     () => metricsQuery.data?.data.groups ?? [],
     [metricsQuery.data]
   )
+  const metricsEnabled = metricsQuery.data?.data.enabled ?? true
   const performances = useMemo<PerformanceRow[]>(
     () =>
       groups.map((group) => ({
@@ -192,6 +193,14 @@ export function ModelDetailsPerformance(props: { model: PricingModel }) {
     }
     return map
   }, [groups])
+
+  if (!metricsQuery.isLoading && !metricsEnabled) {
+    return (
+      <div className='text-muted-foreground rounded-lg border p-6 text-center text-sm'>
+        {t('Model performance metrics are disabled.')}
+      </div>
+    )
+  }
 
   if (metricsQuery.isLoading || performances.length === 0) {
     return (

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -3395,6 +3395,7 @@
     "Percentage:": "Percentage:",
     "Performance": "Performance",
     "Performance data is not yet available for this model.": "Performance data is not yet available for this model.",
+    "Model performance metrics are disabled.": "Model performance metrics are disabled.",
     "Performance health": "Performance health",
     "Performance metrics for the last 24 hours": "Performance metrics for the last 24 hours",
     "Performance metrics shown here are simulated for preview purposes and will be replaced with live observability data once the backend integration is complete.": "Performance metrics shown here are simulated for preview purposes and will be replaced with live observability data once the backend integration is complete.",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -3395,6 +3395,7 @@
     "Percentage:": "Pourcentage :",
     "Performance": "Performances",
     "Performance data is not yet available for this model.": "Aucune donnée de performance n'est encore disponible pour ce modèle.",
+    "Model performance metrics are disabled.": "Les indicateurs de performance des modèles sont désactivés.",
     "Performance health": "Santé des performances",
     "Performance metrics for the last 24 hours": "Indicateurs de performance des dernières 24 heures",
     "Performance metrics shown here are simulated for preview purposes and will be replaced with live observability data once the backend integration is complete.": "Les indicateurs de performance présentés ici sont simulés à des fins de prévisualisation et seront remplacés par des données d'observabilité réelles une fois l'intégration du backend terminée.",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -3395,6 +3395,7 @@
     "Percentage:": "パーセンテージ:",
     "Performance": "パフォーマンス",
     "Performance data is not yet available for this model.": "このモデルのパフォーマンスデータはまだ利用できません。",
+    "Model performance metrics are disabled.": "モデル性能メトリクスは無効です。",
     "Performance health": "パフォーマンス状態",
     "Performance metrics for the last 24 hours": "直近24時間のパフォーマンス指標",
     "Performance metrics shown here are simulated for preview purposes and will be replaced with live observability data once the backend integration is complete.": "ここに表示されているパフォーマンス指標はプレビュー用のシミュレーションデータです。バックエンド連携の完了後、実データに置き換えられます。",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -3395,6 +3395,7 @@
     "Percentage:": "Процент:",
     "Performance": "Производительность",
     "Performance data is not yet available for this model.": "Данные о производительности этой модели пока недоступны.",
+    "Model performance metrics are disabled.": "Метрики производительности моделей отключены.",
     "Performance health": "Состояние производительности",
     "Performance metrics for the last 24 hours": "Метрики производительности за последние 24 часа",
     "Performance metrics shown here are simulated for preview purposes and will be replaced with live observability data once the backend integration is complete.": "Показанные метрики производительности сгенерированы для предпросмотра и будут заменены реальными данными наблюдаемости после интеграции бэкенда.",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -3395,6 +3395,7 @@
     "Percentage:": "Phần trăm:",
     "Performance": "Hiệu suất",
     "Performance data is not yet available for this model.": "Chưa có dữ liệu hiệu năng cho mô hình này.",
+    "Model performance metrics are disabled.": "Chỉ số hiệu năng mô hình đã bị tắt.",
     "Performance health": "Tình trạng hiệu suất",
     "Performance metrics for the last 24 hours": "Chỉ số hiệu năng trong 24 giờ qua",
     "Performance metrics shown here are simulated for preview purposes and will be replaced with live observability data once the backend integration is complete.": "Các chỉ số hiệu năng hiển thị tại đây là dữ liệu mô phỏng để xem trước và sẽ được thay thế bằng dữ liệu thực sau khi tích hợp backend.",

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -3395,6 +3395,7 @@
     "Percentage:": "百分比：",
     "Performance": "效能",
     "Performance data is not yet available for this model.": "該模型暫無效能數據。",
+    "Model performance metrics are disabled.": "模型效能指標已關閉。",
     "Performance health": "效能健康",
     "Performance metrics for the last 24 hours": "最近 24 小時的效能指標",
     "Performance metrics shown here are simulated for preview purposes and will be replaced with live observability data once the backend integration is complete.": "此處展示的效能指標為預覽模擬數據，待後端對接完成後將替換為真實可觀測數據。",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -3395,6 +3395,7 @@
     "Percentage:": "百分比：",
     "Performance": "性能",
     "Performance data is not yet available for this model.": "该模型暂无性能数据。",
+    "Model performance metrics are disabled.": "模型性能指标已关闭。",
     "Performance health": "性能健康",
     "Performance metrics for the last 24 hours": "最近 24 小时的性能指标",
     "Performance metrics shown here are simulated for preview purposes and will be replaced with live observability data once the backend integration is complete.": "此处展示的性能指标为预览模拟数据，待后端对接完成后将替换为真实可观测数据。",


### PR DESCRIPTION
## Description

Fix two correctness gaps in model performance metrics:

1. When collection is disabled, the public performance APIs now return `enabled: false` with empty results, and Model Square shows an explicit disabled state instead of historical failure rates. Retention cleanup continues independently from collection.
2. Asynchronous video tasks now record one terminal sample after the caller wins the status CAS. Success/failure comes from the terminal task state and latency uses submit-to-finish time. Realtime terminal fetches and timed-out tasks use the same recorder. Sync Relay samples are skipped for models that only support the async video endpoint, so wrong-endpoint Relay failures cannot pollute video task success rates.

The response field is additive and the web type keeps it optional for compatibility with older backends.

## Why

Previously, sync Relay failures were sampled while successful `/v1/videos` tasks were not. A single invalid Chat Completions request for a video-only model could therefore show 0% success even when real video tasks succeeded. Disabling collection also stopped new samples but left Model Square querying and displaying existing rows.

## Validation

- `go test ./pkg/perf_metrics -count=1`
- `go test ./relay -count=1`
- `go test ./service -run '^(TestUpdateVideoSingleTaskRecordsTerminalMetrics|TestObserveChannelAffinityUsageCacheByRelayFormat_ClaudeMode|TestObserveChannelAffinityUsageCacheByRelayFormat_MixedMode|TestObserveChannelAffinityUsageCacheByRelayFormat_UnsupportedModeKeepsEmpty)$' -count=1`
- `go test ./controller ./model -count=1`
- `go vet ./...`
- `go build ./...`
- `cd web && bun run typecheck`
- `cd web && bunx oxlint -c .oxlintrc.json src/features/performance-metrics/types.ts src/features/pricing/components/model-details-performance.tsx`
- `cd web && bun run test` (35 files, 179 tests)
- `cd web && bun run build`
- `git diff --check`

## Notes

- Duplicate task samples are prevented by recording only after a successful terminal CAS.
- Suno and Midjourney tasks are intentionally excluded; this change targets the existing asynchronous video task pipeline.
- Historical metrics are retained according to the configured retention period and become visible again if collection is re-enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added performance tracking for completed asynchronous video tasks, including success, failure, latency, and generation time.
  * Performance metric responses now indicate whether metrics are enabled.
  * Added localized messaging when model performance metrics are disabled.

* **Bug Fixes**
  * Historical metrics are no longer displayed when performance tracking is disabled.
  * Metrics cleanup and processing continue reliably when tracking is turned off.
  * Prevented duplicate terminal performance records for task status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->