### PR TITLE
feat(chat): 将 AQBot 加入第三方聊天默认列表

### DIFF
--- a/setting/chat.go
+++ b/setting/chat.go
@@ -26,6 +26,9 @@ var Chats = []map[string]string{
 		"DeepChat": "deepchat://provider/install?v=1&data={deepchatConfig}",
 	},
 	{
+		"AQBot": "aqbot://providers?{aqbotConfig}",
+	},
+	{
 		"Lobe Chat 官方示例": "https://chat-preview.lobehub.com/?settings={\"keyVaults\":{\"openai\":{\"apiKey\":\"{key}\",\"baseURL\":\"{address}/v1\"}}}",
 	},
 	{

--- a/web/src/features/chat/lib/chat-links.ts
+++ b/web/src/features/chat/lib/chat-links.ts
@@ -89,7 +89,8 @@ export function chatLinkRequiresApiKey(url: string): boolean {
     url.includes('{key}') ||
     url.includes('{cherryConfig}') ||
     url.includes('{aionuiConfig}') ||
-    url.includes('{deepchatConfig}')
+    url.includes('{deepchatConfig}') ||
+    url.includes('{aqbotConfig}')
   )
 }
 
@@ -187,6 +188,16 @@ export function resolveChatUrl({
     }
     const encoded = encodeURIComponent(toBase64(JSON.stringify(payload)))
     return replaceToken(url, '{deepchatConfig}', encoded)
+  }
+
+  if (url.includes('{aqbotConfig}')) {
+    const query = [
+      `name=${encodeURIComponent('New API')}`,
+      `baseurl=${encodeURIComponent(safeServerAddress)}`,
+      `apikey=${encodeURIComponent(safeApiKey)}`,
+      'type=openai',
+    ].join('&')
+    return replaceToken(url, '{aqbotConfig}', query)
   }
 
   if (safeServerAddress) {


### PR DESCRIPTION
## Agent

- Tool: Grok
- Tool version: Grok Build
- Model (full id): grok-4.6
- Host (CLI / IDE / GitHub coding agent / other): CLI
- Date (UTC): 2026-08-29

## Links

- Closes #7078
- Related: https://github.com/AQBot-Desktop/AQBot ；PR #4668

## User request

将 https://github.com/AQBot-Desktop/AQBot 集成到 newapi 当前这个项目的第三方聊天的默认列表里面去，给一个完整的方案

## Out of scope — refuse

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR):

## Kind

- [ ] Bug fix
- [x] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: 默认第三方聊天列表没有 AQBot，也无法生成 `aqbot://providers` 导入链接。
- Impact: 用户无法从控制台一键把当前站点地址和 API Key 导入 AQBot。
- Frequency: 所有未自定义 `Chats` 的部署。
- Evidence that the problem is in new-api rather than the client or upstream: AQBot 已支持 `aqbot://providers`；缺口在 new-api 默认 `Chats` 和 `resolveChatUrl`。
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): frontend（聊天预设）；relay / billing / deployment not applicable

## Change

默认 `Chats` 在 DeepChat 后增加 AQBot 条目，模板为 `aqbot://providers?{aqbotConfig}`。`chatLinkRequiresApiKey` 识别 `{aqbotConfig}`；`resolveChatUrl` 按 AQBot 协议用 `encodeURIComponent` 拼 `name=New API`、`baseurl`（站点根地址，不带 `/v1`）、`apikey`、`type=openai`。侧边栏、API 密钥行操作、聊天页已走同一解析函数，不用再改组件。已保存过 `Chats` 的站点不自动合并。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `AQBot`；`DeepChat`；`聊天预设`；`Cherry Studio`
- What already existed and why this is not a duplicate: 无 AQBot issue/PR。#4668 是 DeepChat 同类 deeplink，模式可复用但客户端不同。

### Docs and code

- https://docs.newapi.ai/ : 未覆盖默认聊天客户端列表或 AQBot。
- https://deepwiki.com/QuantumNous/new-api : 本次抓取失败。
- README / repo docs: README 合作伙伴区没有 AQBot；默认列表以 `setting/chat.go` 为准。
- Code paths and what they imply for this change: `setting/chat.go` 默认列表；`web/src/features/chat/lib/chat-links.ts` 已有 `{cherryConfig}` `{aionuiConfig}` `{deepchatConfig}`。AQBot 源码要求 `aqbot://providers?name&baseurl&apikey&type`。

### Alternatives considered

- Option A: `{aqbotConfig}` 专用占位符，JS 编码 query。
- Option B: 只用现有 `{address}` `{key}` 拼 URL。
- Why this approach: `{key}` 当前不编码，密钥里的 `&` 会截断 query；A 与 Cherry/DeepChat 一致。

## Files

| Path | Why |
| --- | --- |
| `setting/chat.go` | 默认聊天预设增加 AQBot |
| `web/src/features/chat/lib/chat-links.ts` | 解析 `{aqbotConfig}` 并编码导入链接 |

## Behavior

- Before: 默认列表无 AQBot，无法一键导入。
- After: 新部署默认列表有 AQBot；点击后打开 `aqbot://providers?name=New%20API&baseurl=...&apikey=...&type=openai`。
- Explicit non-goals / leftover work: 不改落地页/README logo；不自动改已保存的 `Chats`。

## Verification

- Commands and results: `cd web && bun run test src/features/chat/lib/chat-links.test.ts` 4 passed（测试文件未纳入本次提交）；`cd web && bun run typecheck` 通过；`cd web && bunx oxlint -c .oxlintrc.json src/features/chat/lib/chat-links.ts` 0 error；`gofmt -e -l setting/chat.go` 无输出。
- Manual steps and observed result: 本地 SQLite 启动后 `GET /api/status` 的 `chats` 含 AQBot，位于 DeepChat 与 Lobe Chat 之间。
- UI: screenshot or recording (or why none): 本地控制台可看到预设；未上传截图。
- Tests added or updated, or why none: 本地写了 `chat-links.test.ts`，按要求未提交。
- Databases / providers / platforms exercised: sqlite；前端 dev server。
- Not verified: 未在已安装 AQBot 的机器上完成客户端确认导入；未跑 MySQL/PostgreSQL（无表结构变更）。

## Risks

- Failure modes: 未安装 AQBot 时系统打不开 `aqbot://`，与 Cherry Studio 相同；已保存自定义 `Chats` 的站点升级后不会自动出现 AQBot。
- Billing / quota / auth impact: 无。导入仍用用户自己的 API Key，AQBot 侧会再确认。
- Follow-ups: 管理员若需要，可在系统设置手动添加 `{"AQBot":"aqbot://providers?{aqbotConfig}"}`。

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AQBot as a supported chat provider.
  * AQBot connections now generate configuration links using the provider name, endpoint, API key, and OpenAI-compatible type.

* **Bug Fixes**
  * AQBot configuration links are now correctly recognized as requiring an API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->