### PR TITLE
fix(subscription): 无有效订阅时前端如实显示「仅用订阅」偏好 (#6222)

### DIFF
--- a/web/src/features/wallet/components/subscription-plans-card.tsx
+++ b/web/src/features/wallet/components/subscription-plans-card.tsx
@@ -194,8 +194,6 @@ export function SubscriptionPlansCard({
   const isSubPref =
     billingPreference === 'subscription_first' ||
     billingPreference === 'subscription_only'
-  const displayPref =
-    disablePref && isSubPref ? 'wallet_first' : billingPreference
 
   const planPurchaseCountMap = useMemo(() => {
     const map = new Map<number, number>()
@@ -332,12 +330,12 @@ export function SubscriptionPlansCard({
                     label: getBillingPreferenceLabel('wallet_only', t),
                   },
                 ]}
-                value={displayPref}
+                value={billingPreference}
                 onValueChange={(v) => v !== null && handlePreferenceChange(v)}
               >
                 <SelectTrigger className='h-8 flex-1 text-xs sm:w-[140px] sm:flex-none'>
                   <SelectValue>
-                    {getBillingPreferenceLabel(displayPref, t)}
+                    {getBillingPreferenceLabel(billingPreference, t)}
                   </SelectValue>
                 </SelectTrigger>
                 <SelectContent alignItemWithTrigger={false}>
@@ -381,15 +379,15 @@ export function SubscriptionPlansCard({
 
           {disablePref && isSubPref && (
             <p className='text-muted-foreground mt-2 text-xs'>
-              {t(
-                'Preference saved as {{pref}}, but no active subscription. Wallet will be used automatically.',
-                {
-                  pref:
-                    billingPreference === 'subscription_only'
-                      ? t('Subscription Only')
-                      : t('Subscription First'),
-                }
-              )}
+              {billingPreference === 'subscription_only'
+                ? t(
+                    'Preference saved as {{pref}}, but no active subscription. Requests will be rejected.',
+                    { pref: t('Subscription Only') }
+                  )
+                : t(
+                    'Preference saved as {{pref}}, but no active subscription. Wallet will be used automatically.',
+                    { pref: t('Subscription First') }
+                  )}
             </p>
           )}
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -3638,6 +3638,7 @@
     "Pre-consumed": "Pre-consumed",
     "Pre-Consumed Quota": "Pre-Consumed Quota",
     "Preference saved as {{pref}}, but no active subscription. Wallet will be used automatically.": "Preference saved as {{pref}}, but no active subscription. Wallet will be used automatically.",
+    "Preference saved as {{pref}}, but no active subscription. Requests will be rejected.": "Preference saved as {{pref}}, but no active subscription. Requests will be rejected.",
     "Preferences": "Preferences",
     "Prefill Group Management": "Prefill Group Management",
     "Prefill Groups": "Prefill Groups",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -3638,6 +3638,7 @@
     "Pre-consumed": "Pré-consommé",
     "Pre-Consumed Quota": "Quota pré-consommé",
     "Preference saved as {{pref}}, but no active subscription. Wallet will be used automatically.": "Préférence enregistrée comme {{pref}}, mais aucun abonnement actif. Le portefeuille sera utilisé automatiquement.",
+    "Preference saved as {{pref}}, but no active subscription. Requests will be rejected.": "Préférence enregistrée comme {{pref}}, mais aucun abonnement actif. Les demandes seront rejetées.",
     "Preferences": "Préférences",
     "Prefill Group Management": "Gestion des groupes de préremplissage",
     "Prefill Groups": "Groupes de préremplissage",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -3638,6 +3638,7 @@
     "Pre-consumed": "事前消費",
     "Pre-Consumed Quota": "事前消費クォータ",
     "Preference saved as {{pref}}, but no active subscription. Wallet will be used automatically.": "設定は{{pref}}として保存されましたが、アクティブなサブスクリプションがありません。ウォレットが自動的に使用されます。",
+    "Preference saved as {{pref}}, but no active subscription. Requests will be rejected.": "設定は{{pref}}として保存されましたが、アクティブなサブスクリプションがありません。リクエストは拒否されます。",
     "Preferences": "環境設定",
     "Prefill Group Management": "プリフィルグループ管理",
     "Prefill Groups": "プリフィルグループ",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -3638,6 +3638,7 @@
     "Pre-consumed": "Предоплата",
     "Pre-Consumed Quota": "Предварительно потребленная квота",
     "Preference saved as {{pref}}, but no active subscription. Wallet will be used automatically.": "Настройка сохранена как {{pref}}, но нет активной подписки. Кошелёк будет использоваться автоматически.",
+    "Preference saved as {{pref}}, but no active subscription. Requests will be rejected.": "Настройка сохранена как {{pref}}, но нет активной подписки. Запросы будут отклонены.",
     "Preferences": "Настройки",
     "Prefill Group Management": "Управление группами автозаполнения",
     "Prefill Groups": "Группы автозаполнения",

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -3638,6 +3638,7 @@
     "Pre-consumed": "Khấu trừ trước",
     "Pre-Consumed Quota": "Hạn mức đã tiêu thụ trước",
     "Preference saved as {{pref}}, but no active subscription. Wallet will be used automatically.": "Tùy chọn đã lưu là {{pref}}, nhưng không có gói đăng ký đang hoạt động. Ví sẽ được sử dụng tự động.",
+    "Preference saved as {{pref}}, but no active subscription. Requests will be rejected.": "Tùy chọn đã lưu là {{pref}}, nhưng không có gói đăng ký đang hoạt động. Các yêu cầu sẽ bị từ chối.",
     "Preferences": "Tùy chọn",
     "Prefill Group Management": "Quản lý Nhóm Điền sẵn",
     "Prefill Groups": "Điền sẵn các nhóm",

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -3638,6 +3638,7 @@
     "Pre-consumed": "預扣費",
     "Pre-Consumed Quota": "預消耗配額",
     "Preference saved as {{pref}}, but no active subscription. Wallet will be used automatically.": "已儲存偏好為{{pref}}，目前無生效訂閱，將自動使用錢包",
+    "Preference saved as {{pref}}, but no active subscription. Requests will be rejected.": "已儲存偏好為{{pref}}，目前無生效訂閱，請求將被拒絕",
     "Preferences": "偏好設定",
     "Prefill Group Management": "預填充分組管理",
     "Prefill Groups": "預填充分組",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -3638,6 +3638,7 @@
     "Pre-consumed": "预扣费",
     "Pre-Consumed Quota": "预消耗配额",
     "Preference saved as {{pref}}, but no active subscription. Wallet will be used automatically.": "已保存偏好为{{pref}}，当前无生效订阅，将自动使用钱包",
+    "Preference saved as {{pref}}, but no active subscription. Requests will be rejected.": "已保存偏好为{{pref}}，当前无生效订阅，请求将被拒绝",
     "Preferences": "偏好设置",
     "Prefill Group Management": "预填充分组管理",
     "Prefill Groups": "预填充分组",


### PR DESCRIPTION
Closes #6222

问题
用户偏好为「仅用订阅」(subscription_only)、无生效订阅时，前端把保存的偏好伪装显示为「优先钱包」，并提示「将自动使用钱包」。但后端对 subscription_only 绝不回退钱包而是直接拦截，导致前端显示与后端行为不一致。

修改方案：在仅用订阅，订阅过期时不应自动回退钱包。

改动
- web/src/features/wallet/components/subscription-plans-card.tsx：移除 displayPref 对 subscription_only 的伪装，下拉框如实显示保存的 billingPreference；无生效订阅时的提示按偏好拆分——
  - subscription_only → 提示「请求将被拒绝」
  - subscription_first → 保留「将自动使用钱包」
- web/src/i18n/locales/{en,zh,zh-TW,fr,ru,ja,vi}.json：新增对应翻译键。

后端计费语义（service/billing_session.go）不变，本次仅修复前端展示与后端行为的矛盾。

验证
- bun run typecheck ✅、改动文件 lint ✅、bun run build ✅
- 本地 SQLite 复现：yun 用户偏好 subscription_only、订阅过期，刷新钱包页后下拉框显示「仅用订阅」并提示「请求将被拒绝」，不再是「优先钱包」。


截图
修复前：<img width="2168" height="1397" alt="Ghostty 2026-08-30 11 06 41" src="https://github.com/user-attachments/assets/b0f12a4c-25f7-4871-8340-6bde67a0e529" />

修复后：<img width="1927" height="1214" alt="Google Chrome 2026-08-30 11 20 10" src="https://github.com/user-attachments/assets/c5a7785a-afab-4857-bb7e-dc3e6fe4a8ce" />

---

本 PR 代码由 AI 辅助生成（提交者为非项目历史核心开发者）。

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Billing preferences now accurately reflect the selected option, even when no active subscription exists.
  * Added distinct guidance for subscription-only preferences, clarifying that requests will be rejected without an active subscription.
  * Preserved wallet fallback guidance for subscription-first preferences.

* **Localization**
  * Added or updated the no-active-subscription warning across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->