### PR TITLE
fix: normalize missing Responses output item collections

### DIFF
--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -15,7 +15,30 @@ import (
 	"github.com/QuantumNous/new-api/service"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
+
+func normalizeResponsesOutputItemAdded(data string, event dto.ResponsesStreamResponse) (string, error) {
+	if event.Type != dto.ResponsesOutputTypeItemAdded || event.Item == nil {
+		return data, nil
+	}
+
+	var missingCollectionPath string
+	switch event.Item.Type {
+	case "reasoning":
+		missingCollectionPath = "item.summary"
+	case "message":
+		missingCollectionPath = "item.content"
+	default:
+		return data, nil
+	}
+	if gjson.Get(data, missingCollectionPath).Exists() {
+		return data, nil
+	}
+
+	return sjson.SetRaw(data, missingCollectionPath, "[]")
+}
 
 func OaiResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
 	defer service.CloseResponseBodyGracefully(resp)
@@ -94,7 +117,13 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 			sr.Error(err)
 			return
 		}
-		sendResponsesStreamData(c, streamResponse, data)
+		normalizedData, err := normalizeResponsesOutputItemAdded(data, streamResponse)
+		if err != nil {
+			logger.LogError(c, "failed to normalize responses output item: "+err.Error())
+			sr.Error(err)
+			return
+		}
+		sendResponsesStreamData(c, streamResponse, normalizedData)
 		switch streamResponse.Type {
 		case "response.completed", "response.done":
 			if streamResponse.Response != nil {

--- a/relay/channel/openai/relay_responses_compat_test.go
+++ b/relay/channel/openai/relay_responses_compat_test.go
@@ -1,0 +1,67 @@
+package openai
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOaiResponsesStreamHandlerAddsMissingItemCollections(t *testing.T) {
+	oldMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(oldMode) })
+
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	body := strings.Join([]string{
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_missing","type":"reasoning","status":"in_progress"},"sequence_number":2}`,
+		`data: {"type":"response.output_item.added","output_index":1,"item":{"id":"msg_missing","type":"message","role":"assistant","status":"in_progress"},"sequence_number":3}`,
+		`data: {"type":"response.output_item.added","output_index":2,"item":{"id":"rs_existing","type":"reasoning","summary":[{"type":"summary_text","text":"kept"}],"status":"in_progress"},"sequence_number":4}`,
+		`data: {"type":"response.output_item.added","output_index":3,"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"lookup"},"sequence_number":5}`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	c, recorder, resp, info := newResponsesChatTestContext(t, body, true)
+	usage, relayErr := OaiResponsesStreamHandler(c, info, resp)
+	require.Nil(t, relayErr)
+	require.NotNil(t, usage)
+	require.Equal(t, 2, usage.TotalTokens)
+
+	items := make(map[string]map[string]any)
+	sequences := make(map[string]any)
+	for _, line := range strings.Split(recorder.Body.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data: ") || line == "data: [DONE]" {
+			continue
+		}
+		var event map[string]any
+		require.NoError(t, common.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &event))
+		if event["type"] != dto.ResponsesOutputTypeItemAdded {
+			continue
+		}
+		item, ok := event["item"].(map[string]any)
+		require.True(t, ok)
+		id, ok := item["id"].(string)
+		require.True(t, ok)
+		items[id] = item
+		sequences[id] = event["sequence_number"]
+	}
+
+	require.Len(t, items, 4)
+	assert.Equal(t, []any{}, items["rs_missing"]["summary"])
+	assert.Equal(t, []any{}, items["msg_missing"]["content"])
+	assert.Equal(t, []any{map[string]any{"type": "summary_text", "text": "kept"}}, items["rs_existing"]["summary"])
+	assert.NotContains(t, items["fc_1"], "content")
+	assert.Equal(t, float64(2), sequences["rs_missing"])
+	assert.Equal(t, float64(5), sequences["fc_1"])
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

部分 Responses 上游在 `response.output_item.added` 阶段会省略尚为空的集合字段：reasoning item 缺少 `summary`，message item 缺少 `content`。严格按 OpenAI Responses item schema 反序列化的客户端会丢弃该 added item，后续 reasoning/text delta 因此无法关联 active item。

本 PR 在原生 Responses SSE 转发前做最小规范化：仅针对缺失字段补充 `summary: []` 或 `content: []`。已有字段、其他 item 类型及事件中的 `sequence_number` 等数据保持不变。

本 PR 的代码和测试由 AI 辅助生成；提交者已审阅实现、确认协议行为，并完成本地与生产环境验证。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #7087

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

修复前捕获到的上游事件：

```json
{"type":"response.output_item.added","output_index":0,"item":{"id":"rs_1","type":"reasoning","status":"in_progress"},"sequence_number":2}
{"type":"response.output_item.added","output_index":1,"item":{"id":"msg_1","type":"message","role":"assistant","status":"in_progress"},"sequence_number":3}
```

修复后使用 OpenAI Codex 验证，`ReasoningSummaryPartAdded/ReasoningSummaryDelta/OutputTextDelta without active item` 均消失，普通 streaming、reasoning 与 shell tool call 正常。

测试结果：

```text
go test ./relay/channel/openai ./relay/channel/advancedcustom
ok github.com/QuantumNous/new-api/relay/channel/openai
ok github.com/QuantumNous/new-api/relay/channel/advancedcustom

go test ./relay/channel/...
全部通过
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with streamed OpenAI Responses events by supplying missing empty collections for reasoning summaries and message content.
  * Preserved existing summaries, function-call payloads, and event sequence numbers.
  * Streams now stop safely if response normalization fails.

* **Tests**
  * Added coverage for mixed streamed response items and token usage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->