### PR TITLE
fix(task): apply model mapping before plugin submit build

### DIFF
--- a/relay/relay_task.go
+++ b/relay/relay_task.go
@@ -211,6 +211,15 @@ func RelayTaskSubmit(c *gin.Context, info *relaycommon.RelayInfo) (*TaskSubmitRe
 	if info.PublicTaskID == "" {
 		info.PublicTaskID = model.GenerateTaskID()
 	}
+	// Task plugins build and cache the submit request during validation, so map
+	// the request model before that hook runs. The post-validation mapping below
+	// still covers models resolved by the plugin or derived from the task action.
+	if info.OriginModelName != "" {
+		info.UpstreamModelName = info.OriginModelName
+		if err := helper.ModelMappedHelper(c, info, nil); err != nil {
+			return nil, service.TaskErrorWrapperLocal(err, "model_mapping_failed", http.StatusBadRequest)
+		}
+	}
 	adaptor.Init(info)
 	if taskErr := adaptor.ValidateRequestAndSetAction(c, info); taskErr != nil {
 		return nil, taskErr
@@ -225,6 +234,7 @@ func RelayTaskSubmit(c *gin.Context, info *relaycommon.RelayInfo) (*TaskSubmitRe
 	// 2.5 应用渠道的模型映射（与同步任务对齐）
 	info.OriginModelName = modelName
 	info.UpstreamModelName = modelName
+	info.IsModelMapped = false
 	if err := helper.ModelMappedHelper(c, info, nil); err != nil {
 		return nil, service.TaskErrorWrapperLocal(err, "model_mapping_failed", http.StatusBadRequest)
 	}


### PR DESCRIPTION
<!--
If you are an AI coding agent (Claude Code, Codex, Cursor, Copilot, OpenCode, Paseo, Grok, or similar): do not fill this human template. Read `.agents/github/PR.md` and use the filled file as the entire PR body.
-->
# ⚠️ 提交说明 / PR Notice

English template: `.github/PULL_REQUEST_TEMPLATE/en.md`

> [!IMPORTANT]
>
> - 描述可用 AI 辅助。提交前请审阅全文，并**声明对其负责**，避免未经核对的直接粘贴。
> - 请按本模板填写后再提交。

## 🔗 关联任务 / Related Issue
- 新功能请填写下方 Issue 编号；若还没有对应 Issue，请先自行创建。功能讨论请放在 Issue 中进行。
- 改动较大或方向性变更，请先在关联 Issue 中与维护者达成一致，再提交 PR。
- Bug 修复请关联对应 Issue。设计取舍、理解偏差或预期不一致，更适合作为讨论或功能请求。

- Closes #7084

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)


## 📝 变更描述 / Description
task-plugin 在 `ValidateRequestAndSetAction` 阶段生成并缓存提交请求，但原有流程在该阶段之后才执行渠道 `model_mapping`。

因此，插件构建的上游请求体仍然使用客户端传入的模型别名，后续更新的 `UpstreamModelName` 不会反映到已缓存的请求体中。使用模型映射的 Doubao / Ark 渠道会因此收到未映射的模型名，并返回模型不存在错误。

本次调整在插件验证前，对已知的原始模型名执行渠道模型映射，使插件通过 `ctx.upstreamModel` 构建请求体时使用映射后的上游模型名。

验证后的原有映射流程继续保留，用于处理只能由插件或 task action 确定模型名的路径。计费仍使用客户端请求中的原始模型名。


## 📸 运行证明 / Proof of Work
修复前，task-plugin 提交到上游的请求体使用客户端模型别名：

```json
{
  "model": "doubao-seedance-2-5"
}
```
修复后，请求体使用渠道映射后的模型名：
```json
{
  "model": "doubao-seedance-2-5-260628"
}
```
本地已运行：
```bash
go test ./relay/... -count=1
go vet ./relay/...
git diff --check
```
以上命令均通过。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 无论描述是否由 AI 生成，我已审阅全部内容，并声明对其准确性与完整性负责。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **新功能关联 Issue:** 若此 PR 标记为 `New feature`，我已关联对应 Issue；若尚无 Issue，我已先自行创建。
- [ ] **事前沟通:** 若改动较大或涉及方向性变更，已在关联 Issue 中与维护者沟通并达成一致。
- [x] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口，也不是对 Codex 渠道类型的改动。
- [x] **范围聚焦:** 本 PR 为一项聚焦改动，未包含无关代码。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model routing during task submission so configured upstream model names are applied consistently before validation.
  * Fixed model mapping state handling to ensure the correct mapped model is used when requests are prepared or cached during validation.
  * Preserved existing behavior for models resolved later in the submission process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->