### PR TITLE
fix(model): drop leftover prefill_groups unique constraints

### DIFF
--- a/model/main.go
+++ b/model/main.go
@@ -321,6 +321,9 @@ func migrateDB() error {
 	if err := migrateTokenModelLimitsToText(); err != nil {
 		return err
 	}
+	if err := migratePrefillGroupUniqueIndex(DB); err != nil {
+		return err
+	}
 
 	err := DB.AutoMigrate(
 		&Channel{},
@@ -381,6 +384,9 @@ func migrateDB() error {
 }
 
 func migrateDBFast() error {
+	if err := migratePrefillGroupUniqueIndex(DB); err != nil {
+		return err
+	}
 
 	var wg sync.WaitGroup
 

--- a/model/prefill_group_migration.go
+++ b/model/prefill_group_migration.go
@@ -1,0 +1,81 @@
+package model
+
+import (
+	"fmt"
+
+	"github.com/QuantumNous/new-api/common"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// migratePrefillGroupUniqueIndex drops leftover single-column UNIQUE
+// constraints on prefill_groups.name before AutoMigrate.
+//
+// GORM 1.25.x MigrateColumnUnique treats a catalog unique column as the
+// `unique` tag and issues DROP CONSTRAINT uni_<table>_<column>. Older
+// uniqueIndex migrations stored that uniqueness as idx_<table>_<column> or
+// PostgreSQL's <table>_<column>_key, so the uni_* constraint does not exist
+// and AutoMigrate aborts with SQLSTATE 42704. Removing the catalog unique
+// constraint first lets AutoMigrate create uk_prefill_name (partial unique
+// index) instead.
+func migratePrefillGroupUniqueIndex(db *gorm.DB) error {
+	if db == nil || db.Dialector == nil || db.Dialector.Name() != "postgres" {
+		return nil
+	}
+	if !db.Migrator().HasTable(&PrefillGroup{}) {
+		return nil
+	}
+	stmt := &gorm.Statement{DB: db}
+	if err := stmt.Parse(&PrefillGroup{}); err != nil {
+		return err
+	}
+	return dropPrefillGroupLegacyNameUniques(db, stmt.Schema.Table)
+}
+
+func dropPrefillGroupLegacyNameUniques(db *gorm.DB, table string) error {
+	if db == nil || table == "" {
+		return nil
+	}
+	column := "name"
+	var constraintNames []string
+	if err := db.Raw(`
+SELECT tc.constraint_name
+FROM information_schema.table_constraints AS tc
+INNER JOIN information_schema.key_column_usage AS kcu
+  ON tc.constraint_catalog = kcu.constraint_catalog
+ AND tc.constraint_schema = kcu.constraint_schema
+ AND tc.constraint_name = kcu.constraint_name
+ AND tc.table_name = kcu.table_name
+WHERE tc.constraint_schema = current_schema()
+  AND tc.table_name = ?
+  AND tc.constraint_type = 'UNIQUE'
+GROUP BY tc.constraint_name
+HAVING COUNT(*) = 1 AND MIN(kcu.column_name) = ?`, table, column).Scan(&constraintNames).Error; err != nil {
+		return fmt.Errorf("list unique constraints on %s.%s: %w", table, column, err)
+	}
+	for _, name := range constraintNames {
+		if name == "" {
+			continue
+		}
+		if err := db.Exec("ALTER TABLE ? DROP CONSTRAINT IF EXISTS ?",
+			clause.Table{Name: table}, clause.Column{Name: name}).Error; err != nil {
+			return fmt.Errorf("drop unique constraint %s on %s: %w", name, table, err)
+		}
+		common.SysLog(fmt.Sprintf("dropped leftover unique constraint %s on %s.%s", name, table, column))
+	}
+
+	legacyIndexNames := []string{
+		db.NamingStrategy.IndexName(table, column),
+		db.NamingStrategy.UniqueName(table, column),
+	}
+	for _, name := range legacyIndexNames {
+		if name == "" || name == "uk_prefill_name" {
+			continue
+		}
+		if err := db.Exec("DROP INDEX IF EXISTS ?", clause.Column{Name: name}).Error; err != nil {
+			return fmt.Errorf("drop leftover unique index %s on %s: %w", name, table, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!--
If you are an AI coding agent (Claude Code, Codex, Cursor, Copilot, OpenCode, Paseo, Grok, or similar): do not fill this human template. Read `.agents/github/PR.md` and use the filled file as the entire PR body.
-->
# ⚠️ 提交说明 / PR Notice

English template: `.github/PULL_REQUEST_TEMPLATE/en.md`

> [!IMPORTANT]
>
> - 描述可用 AI 辅助。提交前请审阅全文，并**声明对其负责**，避免未经核对的直接粘贴。
> - 请按本模板填写后再提交。

## 🔗 关联任务 / Related Issue
- 新功能请填写下方 Issue 编号；若还没有对应 Issue，请先自行创建。功能讨论请放在 Issue 中进行。
- 改动较大或方向性变更，请先在关联 Issue 中与维护者达成一致，再提交 PR。
- Bug 修复请关联对应 Issue。设计取舍、理解偏差或预期不一致，更适合作为讨论或功能请求。

- Closes #

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description
(简述做了什么、为什么生效。如果难以简述，建议先拆分范围，或在 Issue 中与维护者对齐。)

在gorm自动迁移前清理掉错误的index

## 📸 运行证明 / Proof of Work
(请写明如何验证：实际步骤与观察结果。UI 变更请附截图或录屏；Bug 修复请说明复现过程与修复后结果。)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 无论描述是否由 AI 生成，我已审阅全部内容，并声明对其准确性与完整性负责。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **新功能关联 Issue:** 若此 PR 标记为 `New feature`，我已关联对应 Issue；若尚无 Issue，我已先自行创建。
- [x] **事前沟通:** 若改动较大或涉及方向性变更，已在关联 Issue 中与维护者沟通并达成一致。
- [x] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口，也不是对 Codex 渠道类型的改动。
- [x] **范围聚焦:** 本 PR 为一项聚焦改动，未包含无关代码。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL database migrations by safely removing obsolete uniqueness rules from prefill group names.
  * Prevented migration failures caused by leftover legacy constraints or indexes.
  * Preserved the intended unique-name behavior during database upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->