### PR TITLE
fix(relayconvert): emit reasoning_text.delta instead of reasoning_summary_text.delta in chat→responses

### DIFF
--- a/relaykit/dto/openai_response.go
+++ b/relaykit/dto/openai_response.go
@@ -387,6 +387,7 @@ type ResponsesStreamResponse struct {
 	Type     string                   `json:"type"`
 	Response *OpenAIResponsesResponse `json:"response,omitempty"`
 	Delta    string                   `json:"delta,omitempty"`
+	Text     string                   `json:"text,omitempty"`
 	Item     *ResponsesOutput         `json:"item,omitempty"`
 	// - response.function_call_arguments.delta
 	// - response.function_call_arguments.done

--- a/relaykit/relayconvert/internal/oai_chat/to_oai_responses_resp.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_oai_responses_resp.go
@@ -22,6 +22,8 @@ const (
 	responsesEventOutputItemDone           = "response.output_item.done"
 	responsesEventFunctionArgsDelta        = "response.function_call_arguments.delta"
 	responsesEventFunctionArgsDone         = "response.function_call_arguments.done"
+	responsesEventReasoningTextDelta       = "response.reasoning_text.delta"
+	responsesEventReasoningTextDone        = "response.reasoning_text.done"
 	responsesEventReasoningSummaryDelta    = "response.reasoning_summary_text.delta"
 	responsesEventReasoningSummaryDone     = "response.reasoning_summary_text.done"
 	responsesOutputTypeFunctionCall        = "function_call"
@@ -79,7 +81,7 @@ func ChatCompletionsResponseToResponsesResponse(resp *dto.OpenAITextResponse, id
 			Status: responseOutputStatus(out),
 			Content: []dto.ResponsesOutputContent{
 				{
-					Type: "summary_text",
+					Type: "reasoning_text",
 					Text: reasoning,
 				},
 			},

--- a/relaykit/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
@@ -251,6 +251,7 @@ func (s *ChatToResponsesStreamState) doneDeltaEvents() []ChatToResponsesStreamEv
 			OutputIndex:  intPtr(s.textOutputIndex),
 			ContentIndex: intPtr(0),
 			ItemID:       s.messageID(),
+			Text:         s.text.String(),
 		}))
 		events = append(events, responsesStreamEvent(responsesEventOutputItemDone, dto.ResponsesStreamResponse{
 			Type:        responsesEventOutputItemDone,
@@ -265,6 +266,7 @@ func (s *ChatToResponsesStreamState) doneDeltaEvents() []ChatToResponsesStreamEv
 			OutputIndex:  intPtr(s.reasoningIndex),
 			ContentIndex: intPtr(0),
 			ItemID:       s.reasoningID(),
+			Text:         s.reasoning.String(),
 		}))
 		events = append(events, responsesStreamEvent(responsesEventOutputItemDone, dto.ResponsesStreamResponse{
 			Type:        responsesEventOutputItemDone,

--- a/relaykit/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
+++ b/relaykit/relayconvert/internal/oai_chat/to_oai_responses_stream_resp.go
@@ -181,10 +181,10 @@ func (s *ChatToResponsesStreamState) appendReasoningDelta(delta string) []ChatTo
 		}))
 	}
 	s.reasoning.WriteString(delta)
-	events = append(events, responsesStreamEvent(responsesEventReasoningSummaryDelta, dto.ResponsesStreamResponse{
-		Type:         responsesEventReasoningSummaryDelta,
+	events = append(events, responsesStreamEvent(responsesEventReasoningTextDelta, dto.ResponsesStreamResponse{
+		Type:         responsesEventReasoningTextDelta,
 		OutputIndex:  intPtr(s.reasoningIndex),
-		SummaryIndex: intPtr(0),
+		ContentIndex: intPtr(0),
 		Delta:        delta,
 		ItemID:       s.reasoningID(),
 	}))
@@ -260,15 +260,11 @@ func (s *ChatToResponsesStreamState) doneDeltaEvents() []ChatToResponsesStreamEv
 	}
 	if s.reasoningStarted && !s.reasoningDone {
 		s.reasoningDone = true
-		events = append(events, responsesStreamEvent(responsesEventReasoningSummaryDone, dto.ResponsesStreamResponse{
-			Type:         responsesEventReasoningSummaryDone,
+		events = append(events, responsesStreamEvent(responsesEventReasoningTextDone, dto.ResponsesStreamResponse{
+			Type:         responsesEventReasoningTextDone,
 			OutputIndex:  intPtr(s.reasoningIndex),
-			SummaryIndex: intPtr(0),
+			ContentIndex: intPtr(0),
 			ItemID:       s.reasoningID(),
-			Part: &dto.ResponsesReasoningSummaryPart{
-				Type: "summary_text",
-				Text: s.reasoning.String(),
-			},
 		}))
 		events = append(events, responsesStreamEvent(responsesEventOutputItemDone, dto.ResponsesStreamResponse{
 			Type:        responsesEventOutputItemDone,
@@ -398,7 +394,7 @@ func (s *ChatToResponsesStreamState) reasoningOutput(status string) *dto.Respons
 		Status: status,
 		Content: []dto.ResponsesOutputContent{
 			{
-				Type: "summary_text",
+				Type: "reasoning_text",
 				Text: s.reasoning.String(),
 			},
 		},

--- a/relaykit/relayconvert/testdata/golden/response/openai_to_openai_responses.golden.json
+++ b/relaykit/relayconvert/testdata/golden/response/openai_to_openai_responses.golden.json
@@ -29,7 +29,7 @@
       "role": "",
       "content": [
         {
-          "type": "summary_text",
+          "type": "reasoning_text",
           "text": "Deep thought.",
           "annotations": null
         }


### PR DESCRIPTION
### Problem

When converting from OpenAI Chat Completions format (with `reasoning_content`) to the Responses API format, the streaming output was emitting `response.reasoning_summary_text.delta` events instead of the correct `response.reasoning_text.delta` events.

This caused downstream consumers (e.g. AgentScope) that follow the Responses API spec to miss reasoning content entirely — they listen for `reasoning_text.delta` but only `reasoning_summary_text.delta` was being sent.

Per the OpenAI Responses API specification:
- `reasoning_text.delta` — carries the **full** reasoning process text
- `reasoning_summary_text.delta` — carries a **condensed summary** of the reasoning

Chat Completions `reasoning_content` represents the full reasoning text, so it should map to `reasoning_text`, not `reasoning_summary_text`.

### Changes

1. **Non-stream response** (`to_oai_responses_resp.go`): reasoning output content type changed from `summary_text` to `reasoning_text`
2. **Stream delta event**: event type changed from `response.reasoning_summary_text.delta` to `response.reasoning_text.delta`; `summary_index` changed to `content_index`
3. **Stream done event**: event type changed from `response.reasoning_summary_text.done` to `response.reasoning_text.done`; removed the `part` field (which is summary-specific)
4. **reasoningOutput helper**: content type changed from `summary_text` to `reasoning_text`
5. **Updated golden test snapshot** for the `openai → openai_responses` direction

### Notes

- The reverse direction (responses → chat) already handled **both** event types correctly, so no change is needed there.
- The old `reasoning_summary_text` constants are kept as unused constants in the package for reference.
- This is a **breaking change** for any downstream that was relying on the incorrect `reasoning_summary_text.delta` events to receive full reasoning content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming and non-streaming reasoning output compatibility by using the standardized `reasoning_text` content type.
  - Updated reasoning events to provide consistent text delta and completion notifications, including the accumulated text when streaming completes.
  - Corrected expected reasoning output in response conversion results.
  - Improved deserialization of streamed response text events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->