### PR TITLE
fix(docs): correct Video API links across localized READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -281,7 +281,7 @@ docker run --name new-api -d --restart always \
 - [Response Interface (Responses)](https://docs.newapi.pro/en/docs/api/ai-model/chat/openai/create-response)
 - [Image Interface (Image)](https://docs.newapi.pro/en/docs/api/ai-model/images/openai/v1-images-generations--post)
 - [Audio Interface (Audio)](https://docs.newapi.pro/en/docs/api/ai-model/audio/openai/create-transcription)
-- [Video Interface (Video)](https://docs.newapi.pro/en/docs/api/ai-model/videos/create-video-generation)
+- [Video Interface (Video)](https://docs.newapi.pro/en/docs/api/ai-model/videos/sora/createvideo)
 - [Embedding Interface (Embeddings)](https://docs.newapi.pro/en/docs/api/ai-model/embeddings/create-embedding)
 - [Rerank Interface (Rerank)](https://docs.newapi.pro/en/docs/api/ai-model/rerank/create-rerank)
 - [Realtime Conversation (Realtime)](https://docs.newapi.pro/en/docs/api/ai-model/realtime/create-realtime-session)

--- a/README.fr.md
+++ b/README.fr.md
@@ -282,7 +282,7 @@ docker run --name new-api -d --restart always \
 - [Interface de réponse (Responses)](https://docs.newapi.pro/en/docs/api/ai-model/chat/openai/createresponse)
 - [Interface d'image (Image)](https://docs.newapi.pro/en/docs/api/ai-model/images/openai/post-v1-images-generations)
 - [Interface audio (Audio)](https://docs.newapi.pro/en/docs/api/ai-model/audio/openai/create-transcription)
-- [Interface vidéo (Video)](https://docs.newapi.pro/en/docs/api/ai-model/audio/openai/createspeech)
+- [Interface vidéo (Video)](https://docs.newapi.pro/en/docs/api/ai-model/videos/sora/createvideo)
 - [Interface d'incorporation (Embeddings)](https://docs.newapi.pro/en/docs/api/ai-model/embeddings/createembedding)
 - [Interface de rerank (Rerank)](https://docs.newapi.pro/en/docs/api/ai-model/rerank/creatererank)
 - [Conversation en temps réel (Realtime)](https://docs.newapi.pro/en/docs/api/ai-model/realtime/createrealtimesession)

--- a/README.ja.md
+++ b/README.ja.md
@@ -284,7 +284,7 @@ docker run --name new-api -d --restart always \
 - [レスポンスインターフェース (Responses)](https://docs.newapi.pro/ja/docs/api/ai-model/chat/openai/createresponse)
 - [イメージインターフェース (Image)](https://docs.newapi.pro/ja/docs/api/ai-model/images/openai/post-v1-images-generations)
 - [オーディオインターフェース (Audio)](https://docs.newapi.pro/ja/docs/api/ai-model/audio/openai/create-transcription)
-- [ビデオインターフェース (Video)](https://docs.newapi.pro/ja/docs/api/ai-model/audio/openai/createspeech)
+- [ビデオインターフェース (Video)](https://docs.newapi.pro/ja/docs/api/ai-model/videos/sora/createvideo)
 - [エンベッドインターフェース (Embeddings)](https://docs.newapi.pro/ja/docs/api/ai-model/embeddings/createembedding)
 - [再ランク付けインターフェース (Rerank)](https://docs.newapi.pro/ja/docs/api/ai-model/rerank/creatererank)
 - [リアルタイム対話インターフェース (Realtime)](https://docs.newapi.pro/ja/docs/api/ai-model/realtime/createrealtimesession)

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ docker run --name new-api -d --restart always \
 - [Response Interface (Responses)](https://docs.newapi.pro/en/docs/api/ai-model/chat/openai/createresponse)
 - [Image Interface (Image)](https://docs.newapi.pro/en/docs/api/ai-model/images/openai/post-v1-images-generations)
 - [Audio Interface (Audio)](https://docs.newapi.pro/en/docs/api/ai-model/audio/openai/create-transcription)
-- [Video Interface (Video)](https://docs.newapi.pro/en/docs/api/ai-model/audio/openai/createspeech)
+- [Video Interface (Video)](https://docs.newapi.pro/en/docs/api/ai-model/videos/sora/createvideo)
 - [Embedding Interface (Embeddings)](https://docs.newapi.pro/en/docs/api/ai-model/embeddings/createembedding)
 - [Rerank Interface (Rerank)](https://docs.newapi.pro/en/docs/api/ai-model/rerank/creatererank)
 - [Realtime Conversation (Realtime)](https://docs.newapi.pro/en/docs/api/ai-model/realtime/createrealtimesession)

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -282,7 +282,7 @@ docker run --name new-api -d --restart always \
 - [响应接口 (Responses)](https://docs.newapi.pro/zh/docs/api/ai-model/chat/openai/createresponse)
 - [图像接口 (Image)](https://docs.newapi.pro/zh/docs/api/ai-model/images/openai/post-v1-images-generations)
 - [音频接口 (Audio)](https://docs.newapi.pro/zh/docs/api/ai-model/audio/openai/create-transcription)
-- [视频接口 (Video)](https://docs.newapi.pro/zh/docs/api/ai-model/audio/openai/createspeech)
+- [视频接口 (Video)](https://docs.newapi.pro/zh/docs/api/ai-model/videos/sora/createvideo)
 - [嵌入接口 (Embeddings)](https://docs.newapi.pro/zh/docs/api/ai-model/embeddings/createembedding)
 - [重排序接口 (Rerank)](https://docs.newapi.pro/zh/docs/api/ai-model/rerank/creatererank)
 - [实时对话 (Realtime)](https://docs.newapi.pro/zh/docs/api/ai-model/realtime/createrealtimesession)

--- a/README.zh_TW.md
+++ b/README.zh_TW.md
@@ -281,7 +281,7 @@ docker run --name new-api -d --restart always \
 - [響應接口 (Responses)](https://docs.newapi.pro/zh/docs/api/ai-model/chat/openai/createresponse)
 - [圖像接口 (Image)](https://docs.newapi.pro/zh/docs/api/ai-model/images/openai/post-v1-images-generations)
 - [音訊接口 (Audio)](https://docs.newapi.pro/zh/docs/api/ai-model/audio/openai/create-transcription)
-- [影片接口 (Video)](https://docs.newapi.pro/zh/docs/api/ai-model/audio/openai/createspeech)
+- [影片接口 (Video)](https://docs.newapi.pro/zh/docs/api/ai-model/videos/sora/createvideo)
 - [嵌入接口 (Embeddings)](https://docs.newapi.pro/zh/docs/api/ai-model/embeddings/createembedding)
 - [重排序接口 (Rerank)](https://docs.newapi.pro/zh/docs/api/ai-model/rerank/creatererank)
 - [即時對話 (Realtime)](https://docs.newapi.pro/zh/docs/api/ai-model/realtime/createrealtimesession)


### PR DESCRIPTION
## Agent

- Tool: OpenAI Codex
- Tool version: Codex desktop（运行时未暴露具体版本）
- Model (full id): 运行时未暴露
- Host (CLI / IDE / GitHub coding agent / other): IDE（Codex desktop）
- Date (UTC): 2026-08-31

## Links

- Closes #3186
- Related: https://docs.newapi.pro/en/docs/api/ai-model/videos/sora/createvideo

## User request

“修复 README 视频 API 链接，这个修复一下。”

## Out of scope — refuse

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): not applicable

## Kind

- [ ] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [x] Docs
- [ ] Other:

## Issue facts

- Actual behavior: 五份 README 的 Video 链接指向语音合成文档，`README.en.md` 的旧视频文档路径返回 404。
- Impact: 用户点击视频接口文档时会进入错误的语音页面或 404 页面。
- Frequency: 每次点击受影响链接都会发生。
- Evidence that the problem is in new-api rather than the client or upstream: 错误 URL 直接存在于当前 `main` 的六份 README 中；对应 en、zh、ja 视频文档页面均可正常访问。
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): not applicable（仅文档链接）

## Change

将六份 README 的 Video 链接更新为当前可用的 Sora 格式 Create Video 文档页，并保持各 README 原有语言前缀。未修改链接文案、代码、配置或其他文档链接。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `is:pr in:title "Video Interface URL"`、`is:pr "#3186" in:body`
- What already existed and why this is not a duplicate: Issue #3186 仍为 Open；未找到标题或正文直接关联该 Issue 的 PR。

### Docs and code

- https://docs.newapi.ai/ : 当前官方文档域名会路由至 New API 文档站；实际链接验证使用 `docs.newapi.pro`，与 README 现有链接域名一致。
- https://deepwiki.com/QuantumNous/new-api : 本次不涉及运行时行为，仅修复仓库 README 的静态链接。
- README / repo docs: `README.md`、`README.en.md`、`README.fr.md`、`README.ja.md`、`README.zh_CN.md`、`README.zh_TW.md`。
- Code paths and what they imply for this change: not applicable；未修改代码路径。

### Alternatives considered

- Option A: 链接到 Videos 分类页。
- Option B: 链接到已验证的 Sora `Create Video` 具体接口页。
- Why this approach: 具体接口页当前返回 HTTP 200，并明确记录 `POST /v1/videos`，与 README 的“Video Interface”条目直接对应。

## Files

| Path | Why |
| --- | --- |
| `README.md` | 修复默认英文 README 的 Video 链接 |
| `README.en.md` | 替换返回 404 的旧视频文档路径 |
| `README.fr.md` | 修复法文 README 使用的英文 Video 文档链接 |
| `README.ja.md` | 修复日文 Video 文档链接 |
| `README.zh_CN.md` | 修复简体中文 Video 文档链接 |
| `README.zh_TW.md` | 修复繁体中文 Video 文档链接 |

## Behavior

- Before: Video 链接进入 Text-to-Speech 页面或返回 404。
- After: en、zh、ja 链接进入对应语言的 `Create Video` 页面，并显示 `POST /v1/videos`。
- Explicit non-goals / leftover work: 不清理其他 README 失效链接，不修改文案或文档结构。

## Verification

- Commands and results: `git diff --check` 通过；最终差异为 6 files changed, 6 insertions(+), 6 deletions(-)。
- Manual steps and observed result: 对 en、zh、ja 三个目标 URL 执行 HTTP 请求，均返回 200，页面内容均包含 `/v1/videos`。
- UI: 无；仅静态 Markdown 链接修改。
- Tests added or updated, or why none: 未新增自动化测试；该改动不涉及可执行代码，使用链接可用性与差异范围检查验证。
- Databases / providers / platforms exercised: not applicable。
- Not verified: PR 创建后的 GitHub Actions CI 状态。

## Risks

- Failure modes: 官方文档未来再次调整路由时链接可能失效。
- Billing / quota / auth impact: none。
- Follow-ups: 可另行检查 README 中其他历史文档链接；不纳入本 PR。

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no

本次修改与 PR 描述由 OpenAI Codex 辅助生成。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Video interface links in all localized README files.
  * Links now direct readers to the Sora video-generation API documentation instead of audio speech-synthesis documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->