### PR TITLE
fix: forward reasoning_effort to zhipu upstream

### DIFF
--- a/relay/channel/zhipu_4v/relay-zhipu_v4.go
+++ b/relay/channel/zhipu_4v/relay-zhipu_v4.go
@@ -42,15 +42,16 @@ func requestOpenAI2Zhipu(request dto.GeneralOpenAIRequest) *dto.GeneralOpenAIReq
 		Stop, _ = request.Stop.([]string)
 	}
 	out := &dto.GeneralOpenAIRequest{
-		Model:       request.Model,
-		Stream:      request.Stream,
-		Messages:    messages,
-		Temperature: request.Temperature,
-		TopP:        request.TopP,
-		Stop:        Stop,
-		Tools:       request.Tools,
-		ToolChoice:  request.ToolChoice,
-		THINKING:    request.THINKING,
+		Model:           request.Model,
+		Stream:          request.Stream,
+		Messages:        messages,
+		Temperature:     request.Temperature,
+		TopP:            request.TopP,
+		Stop:            Stop,
+		Tools:           request.Tools,
+		ToolChoice:      request.ToolChoice,
+		THINKING:        request.THINKING,
+		ReasoningEffort: request.ReasoningEffort,
 	}
 	if request.MaxTokens != nil || request.MaxCompletionTokens != nil {
 		maxTokens := request.GetMaxTokens()


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description

`requestOpenAI2Zhipu` 用字段白名单重建上游请求,`reasoning_effort` 不在名单里,被静默丢弃。

按智谱文档,glm-5.3 / glm-5.3-flash 的 thinking 强制开启(`disabled` 无效),思考强度只能靠 `reasoning_effort` 控制,默认 `max`。参数被丢的结果是:客户端传 `low` 也按 `max` 思考,复杂 agent 请求动辄思考十几分钟,极端情况 `max_tokens` 全被 reasoning 吃掉,`finish_reason=length`,正文为空但照常计费。

修复就一行:白名单补 `ReasoningEffort`。

## 📸 运行证明 / Proof of Work

线上真实用户请求(12,653 prompt tokens + 22 个 function tools,`reasoning_effort: "low"`)修复前后 A/B:

| | 输出 tokens | 耗时 |
|---|---|---|
| 修复前(参数被丢,实际 max) | 5,050 | 2m4s |
| 修复后(low 生效) | 164 | 8s |

触发排查的原始案例:同场景请求思考 15 分钟,32,000 completion tokens 里 31,844 个是 reasoning,`finish_reason=length`,`content` 为空。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 无论描述是否由 AI 生成,我已审阅全部内容,并声明对其准确性与完整性负责。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls),确认不是重复提交。
- [x] **新功能关联 Issue:** 若此 PR 标记为 `New feature`,我已关联对应 Issue;若尚无 Issue,我已先自行创建。
- [x] **事前沟通:** 若改动较大或涉及方向性变更,已在关联 Issue 中与维护者沟通并达成一致。
- [x] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口,也不是对 Codex 渠道类型的改动。
- [x] **范围聚焦:** 本 PR 为一项聚焦改动,未包含无关代码。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证,维护者可以据此复核。
- [x] **安全合规:** 代码中无敏感凭据,且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the requested reasoning effort when converting requests for Zhipu 4V, ensuring model behavior aligns with the incoming configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->