### PR TITLE
fix: atomically reserve model success rate limit slots

### DIFF
--- a/common/rate-limit.go
+++ b/common/rate-limit.go
@@ -7,33 +7,51 @@ import (
 
 type InMemoryRateLimiter struct {
 	store              map[string]*[]int64
+	reservations       map[string]map[uint64]struct{}
 	mutex              sync.Mutex
 	expirationDuration time.Duration
+	nextReservationID  uint64
 }
 
 func (l *InMemoryRateLimiter) Init(expirationDuration time.Duration) {
-	if l.store == nil {
-		l.mutex.Lock()
-		if l.store == nil {
-			l.store = make(map[string]*[]int64)
-			l.expirationDuration = expirationDuration
-			if expirationDuration > 0 {
-				go l.clearExpiredItems()
-			}
-		}
+	l.mutex.Lock()
+	if l.store != nil && l.reservations != nil {
 		l.mutex.Unlock()
+		return
+	}
+	startCleanup := false
+	if l.store == nil {
+		l.store = make(map[string]*[]int64)
+		l.expirationDuration = expirationDuration
+		startCleanup = expirationDuration > 0
+	}
+	if l.reservations == nil {
+		l.reservations = make(map[string]map[uint64]struct{})
+	}
+	l.mutex.Unlock()
+	if startCleanup {
+		go l.clearExpiredItems()
 	}
 }
 
 func (l *InMemoryRateLimiter) clearExpiredItems() {
+	duration := l.expirationDuration
+	if duration <= 0 {
+		return
+	}
 	for {
-		time.Sleep(l.expirationDuration)
+		time.Sleep(duration)
 		l.mutex.Lock()
 		now := time.Now().Unix()
 		for key := range l.store {
 			queue := l.store[key]
+			if queue == nil {
+				delete(l.store, key)
+				continue
+			}
 			size := len(*queue)
-			if size == 0 || now-(*queue)[size-1] > int64(l.expirationDuration.Seconds()) {
+			if (size == 0 || now-(*queue)[size-1] > int64(duration.Seconds())) &&
+				len(l.reservations[key]) == 0 {
 				delete(l.store, key)
 			}
 		}
@@ -43,8 +61,13 @@ func (l *InMemoryRateLimiter) clearExpiredItems() {
 
 // Request parameter duration's unit is seconds
 func (l *InMemoryRateLimiter) Request(key string, maxRequestNum int, duration int64) bool {
+	if maxRequestNum <= 0 {
+		return true
+	}
+
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
+	l.ensureInitializedLocked()
 	// [old <-- new]
 	queue, ok := l.store[key]
 	now := time.Now().Unix()
@@ -67,4 +90,120 @@ func (l *InMemoryRateLimiter) Request(key string, maxRequestNum int, duration in
 		*(l.store[key]) = append(*(l.store[key]), now)
 	}
 	return true
+}
+
+// Reserve atomically reserves one success-rate slot for an in-flight request.
+// The reservation is counted together with completed successes until Commit or
+// Release is called. A zero reservation ID means the limit is unlimited.
+func (l *InMemoryRateLimiter) Reserve(key string, maxRequestNum int, duration int64) (uint64, bool) {
+	if maxRequestNum <= 0 {
+		return 0, true
+	}
+
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	l.ensureInitializedLocked()
+
+	now := time.Now().Unix()
+	l.pruneExpiredQueueLocked(key, now, duration)
+	queueLength := 0
+	if queue := l.store[key]; queue != nil {
+		queueLength = len(*queue)
+	}
+	if queueLength+len(l.reservations[key]) >= maxRequestNum {
+		return 0, false
+	}
+
+	l.nextReservationID++
+	if l.nextReservationID == 0 {
+		l.nextReservationID++
+	}
+	if l.reservations[key] == nil {
+		l.reservations[key] = make(map[uint64]struct{})
+	}
+	reservationID := l.nextReservationID
+	l.reservations[key][reservationID] = struct{}{}
+	return reservationID, true
+}
+
+// Commit converts a reservation into a completed success entry.
+func (l *InMemoryRateLimiter) Commit(key string, reservationID uint64, duration int64) bool {
+	if reservationID == 0 {
+		return true
+	}
+
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	l.ensureInitializedLocked()
+
+	pending := l.reservations[key]
+	if _, ok := pending[reservationID]; !ok {
+		return false
+	}
+	delete(pending, reservationID)
+	if len(pending) == 0 {
+		delete(l.reservations, key)
+	}
+
+	now := time.Now().Unix()
+	l.pruneExpiredQueueLocked(key, now, duration)
+	queue := l.store[key]
+	if queue == nil {
+		entries := make([]int64, 0, 1)
+		l.store[key] = &entries
+		queue = &entries
+	}
+	*queue = append(*queue, now)
+	return true
+}
+
+// Release returns a reservation without recording a successful request.
+func (l *InMemoryRateLimiter) Release(key string, reservationID uint64) bool {
+	if reservationID == 0 {
+		return true
+	}
+
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	if l.reservations == nil {
+		return false
+	}
+	pending := l.reservations[key]
+	if _, ok := pending[reservationID]; !ok {
+		return false
+	}
+	delete(pending, reservationID)
+	if len(pending) == 0 {
+		delete(l.reservations, key)
+	}
+	return true
+}
+
+func (l *InMemoryRateLimiter) ensureInitializedLocked() {
+	if l.store == nil {
+		l.store = make(map[string]*[]int64)
+	}
+	if l.reservations == nil {
+		l.reservations = make(map[string]map[uint64]struct{})
+	}
+}
+
+func (l *InMemoryRateLimiter) pruneExpiredQueueLocked(key string, now, duration int64) {
+	if duration < 0 {
+		return
+	}
+	queue := l.store[key]
+	if queue == nil {
+		return
+	}
+	first := 0
+	for first < len(*queue) && now-(*queue)[first] >= duration {
+		first++
+	}
+	if first > 0 {
+		*queue = (*queue)[first:]
+	}
+	if len(*queue) == 0 && len(l.reservations[key]) == 0 {
+		delete(l.store, key)
+	}
 }

--- a/common/rate-limit_test.go
+++ b/common/rate-limit_test.go
@@ -1,0 +1,68 @@
+package common
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestInMemoryRateLimiterReserveIsAtomicUnderConcurrency(t *testing.T) {
+	limiter := InMemoryRateLimiter{}
+	limiter.Init(0)
+
+	const (
+		requestCount = 50
+		maximumCount = 10
+		duration     = int64(60)
+	)
+
+	var allowedCount atomic.Int32
+	reservations := make(chan uint64, maximumCount)
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(requestCount)
+	for range requestCount {
+		go func() {
+			defer waitGroup.Done()
+			reservationID, allowed := limiter.Reserve("concurrent", maximumCount, duration)
+			if allowed {
+				allowedCount.Add(1)
+				reservations <- reservationID
+			}
+		}()
+	}
+	waitGroup.Wait()
+	close(reservations)
+
+	if got := allowedCount.Load(); got != maximumCount {
+		t.Fatalf("Reserve allowed %d requests, want %d", got, maximumCount)
+	}
+	for reservationID := range reservations {
+		if !limiter.Release("concurrent", reservationID) {
+			t.Fatalf("Release(%d) failed", reservationID)
+		}
+	}
+}
+
+func TestInMemoryRateLimiterFailedReservationCanBeReused(t *testing.T) {
+	limiter := InMemoryRateLimiter{}
+	limiter.Init(0)
+
+	reservationID, allowed := limiter.Reserve("failed", 1, 60)
+	if !allowed {
+		t.Fatal("first reservation should be allowed")
+	}
+	if !limiter.Release("failed", reservationID) {
+		t.Fatal("failed request reservation should be released")
+	}
+
+	reservationID, allowed = limiter.Reserve("failed", 1, 60)
+	if !allowed {
+		t.Fatal("released reservation should free the slot")
+	}
+	if !limiter.Commit("failed", reservationID, 60) {
+		t.Fatal("successful reservation should be committed")
+	}
+	if _, allowed = limiter.Reserve("failed", 1, 60); allowed {
+		t.Fatal("a committed success should consume the slot")
+	}
+}

--- a/middleware/model-rate-limit.go
+++ b/middleware/model-rate-limit.go
@@ -146,22 +146,33 @@ func memoryRateLimitHandler(duration int64, totalMaxCount, successMaxCount int) 
 			return
 		}
 
-		// 2. 检查成功请求数限制
-		// 使用一个临时key来检查限制，这样可以避免实际记录
-		checkKey := successKey + "_check"
-		if !inMemoryRateLimiter.Request(checkKey, successMaxCount, duration) {
+		// 2. 原子预占成功请求名额，避免高并发请求同时通过检查
+		reservationID, allowed := inMemoryRateLimiter.Reserve(successKey, successMaxCount, duration)
+		if !allowed {
 			c.Status(http.StatusTooManyRequests)
 			c.Abort()
 			return
 		}
+		settled := false
+		defer func() {
+			if !settled {
+				// 请求链发生 panic 或提前返回时，释放未完成的成功名额。
+				inMemoryRateLimiter.Release(successKey, reservationID)
+			}
+		}()
 
 		// 3. 处理请求
 		c.Next()
 
-		// 4. 如果请求成功，记录到实际的成功请求计数中
+		// 4. 成功提交名额，失败释放名额；总请求数仍已在入口处计数
 		if c.Writer.Status() < 400 {
-			inMemoryRateLimiter.Request(successKey, successMaxCount, duration)
+			if !inMemoryRateLimiter.Commit(successKey, reservationID, duration) {
+				fmt.Println("提交成功请求限流名额失败")
+			}
+		} else {
+			inMemoryRateLimiter.Release(successKey, reservationID)
 		}
+		settled = true
 	}
 }
 

--- a/middleware/model_rate_limit_test.go
+++ b/middleware/model_rate_limit_test.go
@@ -2,12 +2,23 @@ package middleware
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var memoryModelRateLimitTestID atomic.Int64
+
+func nextMemoryModelRateLimitTestID() int {
+	return int(1_000_000_000 + memoryModelRateLimitTestID.Add(1))
+}
 
 func TestModelRedisRateLimitUsesUTCRegardlessOfLocalTimezone(t *testing.T) {
 	redisServer, redisClient := useRateLimitMiniRedis(t)
@@ -31,4 +42,97 @@ func TestModelRedisRateLimitUsesUTCRegardlessOfLocalTimezone(t *testing.T) {
 	allowed, err := checkRedisRateLimit(ctx, redisClient, checkKey, 2, 60)
 	require.NoError(t, err)
 	assert.False(t, allowed, "an existing UTC timestamp inside the window must remain limited on a non-UTC host")
+}
+
+func TestMemoryModelRateLimitSuccessAdmissionIsAtomicUnderConcurrency(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const (
+		requestCount = 50
+		maximumCount = 10
+		duration     = int64(60)
+	)
+
+	id := nextMemoryModelRateLimitTestID()
+	entered := make(chan struct{}, requestCount)
+	release := make(chan struct{})
+	responses := make(chan int, requestCount)
+
+	router := gin.New()
+	router.GET(
+		"/limited",
+		func(c *gin.Context) { c.Set("id", id) },
+		memoryRateLimitHandler(duration, 0, maximumCount),
+		func(c *gin.Context) {
+			entered <- struct{}{}
+			<-release
+			c.Status(http.StatusNoContent)
+		},
+	)
+
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(requestCount)
+	for range requestCount {
+		go func() {
+			defer waitGroup.Done()
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/limited", nil)
+			router.ServeHTTP(recorder, request)
+			responses <- recorder.Code
+		}()
+	}
+
+	for range maximumCount {
+		select {
+		case <-entered:
+		case <-time.After(2 * time.Second):
+			close(release)
+			waitGroup.Wait()
+			t.Fatal("not all reserved requests reached the downstream handler")
+		}
+	}
+	close(release)
+	waitGroup.Wait()
+	close(responses)
+
+	var noContentCount, tooManyRequestsCount int
+	for status := range responses {
+		switch status {
+		case http.StatusNoContent:
+			noContentCount++
+		case http.StatusTooManyRequests:
+			tooManyRequestsCount++
+		default:
+			t.Fatalf("unexpected response status %d", status)
+		}
+	}
+	assert.Equal(t, maximumCount, noContentCount)
+	assert.Equal(t, requestCount-maximumCount, tooManyRequestsCount)
+}
+
+func TestMemoryModelRateLimitFailedRequestReleasesSuccessSlot(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	id := nextMemoryModelRateLimitTestID()
+	var calls atomic.Int32
+
+	router := gin.New()
+	router.GET(
+		"/limited",
+		func(c *gin.Context) { c.Set("id", id) },
+		memoryRateLimitHandler(60, 0, 1),
+		func(c *gin.Context) {
+			if calls.Add(1) == 1 {
+				c.Status(http.StatusBadGateway)
+				return
+			}
+			c.Status(http.StatusNoContent)
+		},
+	)
+
+	first := httptest.NewRecorder()
+	router.ServeHTTP(first, httptest.NewRequest(http.MethodGet, "/limited", nil))
+	assert.Equal(t, http.StatusBadGateway, first.Code)
+
+	second := httptest.NewRecorder()
+	router.ServeHTTP(second, httptest.NewRequest(http.MethodGet, "/limited", nil))
+	assert.Equal(t, http.StatusNoContent, second.Code)
 }


### PR DESCRIPTION
## Summary

- Atomically reserve a model success-rate slot before entering the downstream request.
- Commit the reservation only for a final response below HTTP 400; release it for failures, early exits, and panics.
- Keep the existing total-request counter semantics unchanged.
- Add regression coverage for failed requests and concurrent admission.

## Problem

The in-memory model success-rate limiter currently performs its pre-check through a mutating counter. A failed request can therefore consume success quota. Replacing that with a non-mutating check avoids the first problem, but leaves a time-of-check/time-of-use race: concurrent requests can all pass the check before any of them records a result, allowing successful completions to exceed `successMaxCount`.

For example, with a success limit of 10, a burst of 50 concurrent requests can admit more than 10 downstream requests.

This change gives each admitted request a temporary reservation. The reservation counts toward the limit while the request is in flight, then is committed or released exactly once.

Related upstream reports: [#5815](https://github.com/QuantumNous/new-api/issues/5815) and [#6528](https://github.com/QuantumNous/new-api/pull/6528).

## Tests

```text
go test ./common ./middleware -count=1
go test -race ./common ./middleware -run 'Test(InMemoryRateLimiterReserve|InMemoryRateLimiterFailedReservation|MemoryModelRateLimit)' -count=1
go vet ./common ./middleware
```

The full application test command also requires generated `web/dist` assets in a clean checkout; that is unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added atomic rate-limit reservations for in-flight requests.
  * Reservations can be committed after success or released when processing fails, allowing slots to be reused.
  * Improved rate-limiter initialization and expiration handling.

* **Bug Fixes**
  * Prevented concurrent requests from exceeding configured success limits.
  * Ensured failed or interrupted requests do not permanently consume rate-limit capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->