### PR TITLE
fix(web): use namespace imports for Zod schemas

### DIFF
--- a/web/src/features/auth/constants.ts
+++ b/web/src/features/auth/constants.ts
@@ -16,7 +16,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { z } from 'zod'
+import * as z from 'zod'
 
 // ============================================================================
 // Form Schemas

--- a/web/src/features/channels/lib/channel-form.ts
+++ b/web/src/features/channels/lib/channel-form.ts
@@ -16,7 +16,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { z } from 'zod'
+import * as z from 'zod'
 
 import {
   CLAUDE_FIELD_PASSTHROUGH_TYPES,

--- a/web/src/features/keys/lib/api-key-form.ts
+++ b/web/src/features/keys/lib/api-key-form.ts
@@ -17,7 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import type { TFunction } from 'i18next'
-import { z } from 'zod'
+import * as z from 'zod'
 
 import { parseQuotaFromDollars, quotaUnitsToDollars } from '@/lib/format'
 

--- a/web/src/features/keys/types.ts
+++ b/web/src/features/keys/types.ts
@@ -16,7 +16,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { z } from 'zod'
+import * as z from 'zod'
 
 // ============================================================================
 // API Key Schema & Types

--- a/web/src/features/playground/lib/storage/storage-schema.ts
+++ b/web/src/features/playground/lib/storage/storage-schema.ts
@@ -16,7 +16,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { z } from 'zod'
+import * as z from 'zod'
 
 export const STORAGE_VERSION = 1
 export const MAX_STORED_MESSAGES = 100

--- a/web/src/features/redemption-codes/lib/redemption-form.ts
+++ b/web/src/features/redemption-codes/lib/redemption-form.ts
@@ -17,7 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import type { TFunction } from 'i18next'
-import { z } from 'zod'
+import * as z from 'zod'
 
 import {
   parseQuotaFromDollars,

--- a/web/src/features/system-settings/utils/numeric-field.ts
+++ b/web/src/features/system-settings/utils/numeric-field.ts
@@ -22,7 +22,7 @@ import type {
   FieldPath,
   FieldValues,
 } from 'react-hook-form'
-import { z } from 'zod'
+import * as z from 'zod'
 
 export function positiveIntegerSchema(message: string) {
   return z.number().int(message).positive(message)


### PR DESCRIPTION
## Agent

- Tool: Multica OpenCode
- Tool version: v0.4.37
- Model (full id): f3000/gpt-5.6-sol
- Host (CLI / IDE / GitHub coding agent / other): Multica Windows desktop runtime with WSL ArchLinux toolchain
- Date (UTC): 2026-09-01

This PR was AI-assisted.

## Links

- Closes: not applicable; #7131 was automatically closed by the template bot
- Related: #7131; `v1.0.0-rc.30` (`27ff6a8767e728f879d52770c273d4f73214a430`)

## User request

Check whether an upstream Issue or PR already covers the Bun 1.4.0 + Vitest Zod import failure; if not, report and fix it upstream.

## Out of scope — refuse

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): not applicable

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: a clean `v1.0.0-rc.30` checkout with Bun 1.4.0 reports 8 failed frontend tests/suites. Runtime schema imports fail with `TypeError: undefined is not an object (evaluating 'z.object')` or `z.number`.
- Impact: the full repository frontend test command cannot pass under the Bun version introduced by rc.30.
- Frequency: reproducible on every tested clean WSL ArchLinux worktree.
- Evidence that the problem is in new-api rather than the client or upstream: reproduced directly on the unmodified QuantumNous/new-api tag. The seven import-only changes in this PR change the result from `370 passed / 8 failed` to `406 passed / 0 failed`.
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): frontend Zod runtime imports under Bun 1.4.0 + Vitest 4.1.10; relay, billing, and deployment are not applicable.

## Change

Use the Zod namespace import already used elsewhere in the frontend for the seven runtime schema modules proven to fail in Vitest. No schema definitions, validation rules, API payloads, or UI behavior change.

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `zod vitest`, `Bun 1.4.0 test`, `z.object undefined`, `undefined is not an object`, `import z from zod`, `zod test failure`, `Vitest frontend tests`, across open and closed Issues and PRs.
- What already existed and why this is not a duplicate: #6995 and #6444 concern Claude/Ollama client errors; PR #6317 and #4894 contain unrelated Zod usage. No thread covers this test-toolchain failure.

### Docs and code

- https://docs.newapi.ai/ : checked project and development entry points; no test-toolchain workaround is documented.
- https://deepwiki.com/QuantumNous/new-api : checked Web Frontend and Development Guide architecture; indexed content predates rc.30.
- README / repo docs: read `README.md`, `AGENTS.md`, `CLAUDE.md`, `web/AGENTS.md`, `web/package.json`, and `.agents/github/PR.md`.
- Code paths and what they imply for this change: the seven files define runtime schemas loaded by all eight failing test groups. Namespace imports avoid the undefined runtime binding in Vitest and match an established repository pattern.

### Alternatives considered

- Option A: change Bun, Vitest, or Zod versions. This modifies the dependency contract and lockfile for a seven-import compatibility issue.
- Option B: change only the affected runtime imports to the repository's existing namespace form.
- Why this approach: it is minimal, lockfile-free, behavior-preserving, and fully verified by the existing suite.

## Files

| Path | Why |
| --- | --- |
| `web/src/features/auth/constants.ts` | Restore login schema loading in OAuth tests |
| `web/src/features/channels/lib/channel-form.ts` | Restore channel schema loading |
| `web/src/features/keys/lib/api-key-form.ts` | Restore API key form schema loading |
| `web/src/features/keys/types.ts` | Restore API key data schema loading |
| `web/src/features/playground/lib/storage/storage-schema.ts` | Restore playground storage schema loading |
| `web/src/features/redemption-codes/lib/redemption-form.ts` | Restore redemption form schema loading |
| `web/src/features/system-settings/utils/numeric-field.ts` | Restore numeric schema loading |

## Behavior

- Before: `bun run test` reports `51 passed / 8 failed` files and `370 passed / 8 failed` tests.
- After: `bun run test` reports `59 passed` files and `406 passed` tests.
- Explicit non-goals / leftover work: no dependency updates, no schema changes, no product UI changes, and no fork-specific customization.

## Verification

- Commands and results: `bun install --frozen-lockfile` passed; `bun run test` passed (`59 files / 406 tests`); `bun run typecheck` passed; `bun run build` passed; targeted `bun x oxlint` passed with `0 warnings / 0 errors`; `git diff --check` passed.
- Manual steps and observed result: compared a clean unmodified rc.30 worktree (`370 / 8`) against this import-only branch (`406 / 0`).
- UI: no screenshot; this only changes module import syntax and the production build passes.
- Tests added or updated, or why none: no new tests; eight existing failing test groups directly cover the regression, and the full suite now passes.
- Databases / providers / platforms exercised: WSL ArchLinux x86_64, Bun 1.4.0, Vitest 4.1.10, jsdom 29.1.1, Zod 4.4.3.
- Not verified: native Windows Bun, macOS, other Bun versions, browser E2E.

## Risks

- Failure modes: low; namespace imports can affect bundler interop, so both typecheck and production build were run.
- Billing / quota / auth impact: no billing or quota behavior changes; auth validation schema content is unchanged.
- Follow-ups: if maintainers prefer a dependency-level solution, this PR can be superseded after an equivalent full-suite result is demonstrated.

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized validation library imports across authentication, channel, key, playground, redemption code, and system settings forms.
  * No changes to form behavior, validation rules, or user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->