### PR TITLE
fix(i18n): keep cached zhTW interface code stable across page loads

### DIFF
--- a/web/src/i18n/languages.test.ts
+++ b/web/src/i18n/languages.test.ts
@@ -1,0 +1,49 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { describe, expect, test } from 'vitest'
+
+import { convertDetectedLanguage } from './languages'
+
+describe('convertDetectedLanguage', () => {
+  test('maps browser BCP-47 Chinese tags onto interface codes', () => {
+    expect(convertDetectedLanguage('zh-TW')).toBe('zhTW')
+    expect(convertDetectedLanguage('zh-HK')).toBe('zhTW')
+    expect(convertDetectedLanguage('zh-MO')).toBe('zhTW')
+    expect(convertDetectedLanguage('zh-Hant-TW')).toBe('zhTW')
+    expect(convertDetectedLanguage('zh')).toBe('zhCN')
+    expect(convertDetectedLanguage('zh-CN')).toBe('zhCN')
+    expect(convertDetectedLanguage('zh-Hans')).toBe('zhCN')
+  })
+
+  test('keeps already-normalized interface codes stable (localStorage round-trip)', () => {
+    // i18next caches `zhTW`/`zhCN` (the supportedLngs codes) to localStorage,
+    // and the detector runs this converter on the cached value at every page
+    // load — if `zhTW` does not survive the round-trip, a user who picked
+    // Traditional Chinese is flipped to Simplified on the next load and the
+    // cache is overwritten, making the flip permanent.
+    expect(convertDetectedLanguage('zhTW')).toBe('zhTW')
+    expect(convertDetectedLanguage('zhCN')).toBe('zhCN')
+  })
+
+  test('passes non-Chinese values through unchanged', () => {
+    expect(convertDetectedLanguage('en')).toBe('en')
+    expect(convertDetectedLanguage('fr-FR')).toBe('fr-FR')
+    expect(convertDetectedLanguage('ja')).toBe('ja')
+  })
+})

--- a/web/src/i18n/languages.ts
+++ b/web/src/i18n/languages.ts
@@ -64,6 +64,7 @@ export function convertDetectedLanguage(value: string): string {
   const lower = value.trim().replaceAll('_', '-').toLowerCase()
   if (!lower.startsWith('zh')) return value
   if (
+    lower === 'zhtw' ||
     lower === 'zh-tw' ||
     lower === 'zh-hk' ||
     lower === 'zh-mo' ||


### PR DESCRIPTION
Fixes #7141.

`convertDetectedLanguage()` lowercases the detected value and only recognizes hyphenated BCP-47 tags — but i18next caches the interface language to localStorage as this project's own camelCase codes (`zhTW`/`zhCN`), and the detector runs the converter on that cached value at every page load. `'zhTW'` → `'zhtw'` has no hyphen, matches no Traditional branch, and falls through to `'zhCN'`; the detector then re-caches `zhCN`. Net effect: choosing 繁體中文 lasts exactly one page load, then the UI is permanently flipped to 简体中文. Browsers reporting `zh-TW` hit the same round-trip from their second visit.

**Fix:** recognize the already-normalized `zhtw` in the Traditional branch (one line). `zhCN` already survives via the fall-through.

**Tests:** added `web/src/i18n/languages.test.ts` covering the localStorage round-trip (`zhTW`→`zhTW`, `zhCN`→`zhCN`), the browser-tag mappings, and non-Chinese passthrough. The round-trip test fails on current `main` and passes with this change; full web suite: 60 files / 409 tests pass.

Verified on a live rc.30 deployment: before the fix, `localStorage.setItem('i18nextLng','zhTW')` + reload → UI renders Simplified and localStorage reads `zhCN`.

