### PR TITLE
fix: exclude inline media from token estimates

### DIFF
--- a/relaykit/dto/claude.go
+++ b/relaykit/dto/claude.go
@@ -330,9 +330,22 @@ func (c *ClaudeRequest) GetTokenCountMeta() *types.TokenCountMeta {
 					texts = append(texts, string(b))
 				}
 			case "tool_result":
-				if media.Content != nil {
-					b, _ := kitutil.Marshal(media.Content)
-					texts = append(texts, string(b))
+				if media.IsStringContent() {
+					texts = append(texts, media.GetStringContent())
+					continue
+				}
+				for _, result := range media.ParseMediaContent() {
+					switch result.Type {
+					case "text":
+						texts = append(texts, result.GetText())
+					case "image":
+						if source := result.ToFileSource(); source != nil {
+							fileMeta = append(fileMeta, &types.FileMeta{
+								FileType: types.FileTypeImage,
+								Source:   source,
+							})
+						}
+					}
 				}
 			}
 		}

--- a/relaykit/dto/openai_responses_compaction_request.go
+++ b/relaykit/dto/openai_responses_compaction_request.go
@@ -3,7 +3,6 @@ package dto
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
 
 	"github.com/QuantumNous/new-api/relaykit/types"
 )
@@ -27,16 +26,7 @@ type OpenAIResponsesCompactionRequest struct {
 }
 
 func (r *OpenAIResponsesCompactionRequest) GetTokenCountMeta() *types.TokenCountMeta {
-	var parts []string
-	if len(r.Instructions) > 0 {
-		parts = append(parts, string(r.Instructions))
-	}
-	if len(r.Input) > 0 {
-		parts = append(parts, string(r.Input))
-	}
-	return &types.TokenCountMeta{
-		CombineText: strings.Join(parts, "\n"),
-	}
+	return (&OpenAIResponsesRequest{Input: r.Input, Instructions: r.Instructions}).GetTokenCountMeta()
 }
 
 func (r *OpenAIResponsesCompactionRequest) IsStream(c *http.Request) bool {

--- a/relaykit/dto/token_count_meta_test.go
+++ b/relaykit/dto/token_count_meta_test.go
@@ -1,0 +1,89 @@
+package dto
+
+import (
+	"strings"
+	"testing"
+
+	kitutil "github.com/QuantumNous/new-api/relaykit/relayconvert/kitutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenCountMetaExcludesInlineMediaPayloads(t *testing.T) {
+	imageData := strings.Repeat("base64-image-data", 100)
+	toolText := "tool output"
+
+	t.Run("claude tool result", func(t *testing.T) {
+		request := ClaudeRequest{Messages: []ClaudeMessage{{
+			Role: "user",
+			Content: []ClaudeMediaMessage{{
+				Type: "tool_result",
+				Content: []ClaudeMediaMessage{
+					{Type: "text", Text: &toolText},
+					{Type: "image", Source: &ClaudeMessageSource{Type: "base64", MediaType: "image/png", Data: imageData}},
+				},
+			}, {
+				Type:    "tool_result",
+				Content: "string output",
+			}},
+		}}}
+
+		meta := request.GetTokenCountMeta()
+
+		assert.Contains(t, meta.CombineText, toolText)
+		assert.Contains(t, meta.CombineText, "string output")
+		assert.NotContains(t, meta.CombineText, imageData)
+		require.Len(t, meta.Files, 1)
+		assert.Equal(t, imageData, meta.Files[0].Source.GetRawData())
+	})
+
+	t.Run("openai message", func(t *testing.T) {
+		request := GeneralOpenAIRequest{Messages: []Message{{
+			Role: "user",
+			Content: []MediaContent{
+				{Type: ContentTypeText, Text: "message text"},
+				{Type: ContentTypeImageURL, ImageUrl: &MessageImageUrl{Url: "data:image/png;base64," + imageData}},
+			},
+		}}}
+
+		meta := request.GetTokenCountMeta()
+
+		assert.Contains(t, meta.CombineText, "message text")
+		assert.NotContains(t, meta.CombineText, imageData)
+		require.Len(t, meta.Files, 1)
+	})
+
+	t.Run("openai responses compaction", func(t *testing.T) {
+		input, err := kitutil.Marshal([]map[string]any{{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]any{
+				{"type": "input_text", "text": "message text"},
+				{"type": "input_image", "image_url": "data:image/png;base64," + imageData},
+			},
+		}})
+		require.NoError(t, err)
+
+		meta := (&OpenAIResponsesCompactionRequest{Input: input}).GetTokenCountMeta()
+
+		assert.Contains(t, meta.CombineText, "message text")
+		assert.NotContains(t, meta.CombineText, imageData)
+		require.Len(t, meta.Files, 1)
+	})
+
+	t.Run("gemini inline data", func(t *testing.T) {
+		request := GeminiChatRequest{Contents: []GeminiChatContent{{
+			Role: "user",
+			Parts: []GeminiPart{
+				{Text: "message text"},
+				{InlineData: &GeminiInlineData{MimeType: "image/png", Data: imageData}},
+			},
+		}}}
+
+		meta := request.GetTokenCountMeta()
+
+		assert.Contains(t, meta.CombineText, "message text")
+		assert.NotContains(t, meta.CombineText, imageData)
+		require.Len(t, meta.Files, 1)
+	})
+}


### PR DESCRIPTION
## Agent

- Tool: OpenAI Codex desktop
- Tool version: host did not expose it
- Model (full id): GPT-5 (host did not expose a more specific id)
- Host (CLI / IDE / GitHub coding agent / other): IDE
- Date (UTC): 2026-09-02

This PR was AI-assisted. The current git author is not a recurring upstream core developer.

## Links

- Closes #7148
- Related: #7147 (superseded issue with an unrecognized template)

## User request

Fix the upstream new-api bug that counts structured inline-image Base64 as text during local token estimation, keep the change minimal, cover other established media paths against regression, and submit it through the upstream process.

## Out of scope — refuse

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): not applicable. This fixes new-api's own pre-upstream token metadata generation for documented Claude Messages and OpenAI Responses inputs.

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: Claude `tool_result.content` and Responses compact input can place an inline-image Base64 payload in `CombineText` while leaving `Files` empty.
- Impact: local usage fallback can substantially inflate prompt tokens, quota reservation, and settlement. The redacted incident in #7148 observed 307,159 upstream input tokens versus about 5,419,180 locally estimated input tokens.
- Frequency: deterministic for both affected input shapes; the clean upstream/main reproducer failed in both subtests on two consecutive runs.
- Evidence that the problem is in new-api rather than the client or upstream: the failure is reproduced by calling upstream/main's `GetTokenCountMeta()` without a database, network, or provider. The same input passes after changing only the two DTO metadata paths.
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): relay/API — `POST /v1/messages` (Claude Messages) and `POST /v1/responses/compact` (OpenAI Responses compact), pass-through disabled, before channel dispatch; billing — affects the prompt-token base before model/group ratios when local usage fallback is used; frontend — not applicable; deployment — not applicable.

## Change

- Parse Claude string `tool_result` content as text, and parse block-array results by separating text blocks from image sources.
- Reuse the existing Responses request token-metadata parser for Responses compact instead of counting the raw input JSON as text.
- Add one table-like regression test with subtests for the two affected paths and the already-correct OpenAI message and Gemini inline-media paths.

This works because Base64 stays in `FileMeta` and no longer reaches the text tokenizer, while existing string/text content is still counted.

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `tool_result base64 token count`, `responses/compact base64`, `GetTokenCountMeta image`, and the exact affected DTO/function names across open and closed Issues and PRs.
- What already existed and why this is not a duplicate: #3376 concerns Playground storing generated images as Markdown text; #7019 concerns request recovery and image trimming; #4441 adds a Claude count-tokens endpoint but explicitly does not count images. None changes these DTO metadata paths.

### Docs and code

- https://docs.newapi.ai/ : the Claude-native endpoint is supported; no setting changes local media token extraction.
- https://deepwiki.com/QuantumNous/new-api : request token estimation precedes pricing and pre-consume billing.
- README / repo docs: Anthropic documents text/image blocks in `tool_result.content`; OpenAI documents text/image/file input for Responses compact.
- Code paths and what they imply for this change: `relaykit/dto/claude.go` serialized the whole nested result; `relaykit/dto/openai_responses_compaction_request.go` appended raw input JSON; `relaykit/dto/openai_request.go` and `relaykit/dto/gemini.go` already separate text and media.

### Alternatives considered

- Option A: remove Base64-looking substrings from serialized JSON.
- Option B: use the existing typed content and media parsers.
- Why this approach: Option B is smaller, preserves the structured request boundary, avoids a fragile Base64 heuristic, and introduces no dependency or new abstraction.

## Files

| Path | Why |
| --- | --- |
| `relaykit/dto/claude.go` | Separate nested tool-result text from images. |
| `relaykit/dto/openai_responses_compaction_request.go` | Reuse the normal Responses token-metadata parser. |
| `relaykit/dto/token_count_meta_test.go` | Protect affected and already-correct inline-media paths. |

## Behavior

- Before: inline image data can enter `CombineText`; affected requests report no corresponding file metadata.
- After: text remains in `CombineText`; inline images are represented in `Files` and use the existing media estimator.
- Explicit non-goals / leftover work: no historical billing adjustment, provider-exact tokenizer, request rewriting, Playground Markdown cleanup, or new document/search-result behavior.

## Verification

- Commands and results:
  - Clean upstream/main reproducer: `GOWORK=off go test ./dto -run TestInlineMediaPayloadIsNotCountedAsText -count=2` — failed twice before the fix in both affected subtests.
  - `cd relaykit && GOWORK=off go test ./dto -run TestTokenCountMetaExcludesInlineMediaPayloads -count=2` — passed.
  - `cd relaykit && GOWORK=off go test ./...` — passed.
  - `cd relaykit && GOWORK=off go build ./...` — passed, preserving relaykit's standalone build.
  - `gofmt -d` on all three changed files and `git diff --check upstream/main...HEAD` — no output.
  - Root `go test ./...` — not fully green on the clean Windows checkout: the root package lacks generated `web/dist`; an existing HTTP/2 retry test expects a different OS error string; two service cache-state tests failed in the full run and passed when rerun alone. None of these failures touches the changed relaykit files.
- Manual steps and observed result: inspected the generated metadata before and after the fix; Base64 moved out of `CombineText`, one image appeared in `Files`, and normal text remained countable.
- UI: not applicable; no frontend change.
- Tests added or updated, or why none: added deterministic regression coverage for Claude tool results, Responses compact, OpenAI messages, and Gemini inline data.
- Databases / providers / platforms exercised: Windows 11 amd64, Go 1.26.5; no database or live provider is required by this pure DTO path.
- Not verified: live Anthropic/OpenAI requests, Linux/macOS, URL images, documents, and search-result blocks.

## Risks

- Failure modes: malformed or unsupported nested content remains outside the verified scope; this focused parser preserves string/text results and extracts images rather than treating the whole block array as text.
- Billing / quota / auth impact: local image-heavy fallback estimates decrease to the intended media-based path; normal upstream usage settlement and auth are unchanged.
- Follow-ups: none required for this fix; provider-exact token counting can remain a separate proposal.

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved token counting for tool results containing text and media.
  - Inline image payloads are no longer included as text, improving token-count accuracy while preserving media file metadata.
  - OpenAI response compaction requests now calculate token-count metadata consistently with standard response requests.
  - Text content from mixed media messages is preserved correctly across supported providers.

- **Tests**
  - Added coverage for inline media handling across Claude, OpenAI, and Gemini token-counting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->