### PR TITLE
fix(relay): unify AWS Bedrock auth through SDK

### DIFF
--- a/relay/channel/aws/adaptor.go
+++ b/relay/channel/aws/adaptor.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
-	"github.com/QuantumNous/new-api/relay/channel"
 	"github.com/QuantumNous/new-api/relay/channel/claude"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relaykit/dto"
@@ -18,15 +16,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type ClientMode int
-
-const (
-	ClientModeApiKey ClientMode = iota + 1
-	ClientModeAKSK
-)
-
 type Adaptor struct {
-	ClientMode ClientMode
 	AwsClient  *bedrockruntime.Client
 	AwsModelId string
 	AwsReq     any
@@ -92,26 +82,14 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 func (a *Adaptor) Init(info *relaycommon.RelayInfo) {
 }
 
-func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
-	if info.ChannelOtherSettings.AwsKeyType == dto.AwsKeyTypeApiKey {
-		awsModelId := getAwsModelID(info.UpstreamModelName)
-		a.ClientMode = ClientModeApiKey
-		awsSecret := strings.Split(info.ApiKey, "|")
-		if len(awsSecret) != 2 {
-			return "", errors.New("invalid aws api key, should be in format of <api-key>|<region>")
-		}
-		return fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s/converse", awsModelId, awsSecret[1]), nil
-	} else {
-		a.ClientMode = ClientModeAKSK
-		return "", nil
-	}
+// GetRequestURL 保留通用适配器接口；AWS 端点由 SDK 根据渠道信息解析，因此返回空地址和空错误
+func (a *Adaptor) GetRequestURL(_ *relaycommon.RelayInfo) (string, error) {
+	return "", nil
 }
 
+// SetupRequestHeader 将请求上下文 c 与渠道信息 info 中的 Claude 扩展头写入 req，成功时返回 nil
 func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *relaycommon.RelayInfo) error {
 	claude.CommonClaudeHeadersOperation(c, req, info)
-	if a.ClientMode == ClientModeApiKey {
-		req.Set("Authorization", "Bearer "+info.ApiKey)
-	}
 	return nil
 }
 
@@ -153,29 +131,25 @@ func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommo
 	return nil, errors.New("not implemented")
 }
 
+// DoRequest 使用请求上下文 c、渠道信息 info 和请求体 requestBody 构造 AWS SDK 请求，返回构造结果或错误
 func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBody io.Reader) (any, error) {
-	if a.ClientMode == ClientModeApiKey {
-		return channel.DoApiRequest(a, c, info, requestBody)
-	} else {
-		return doAwsClientRequest(c, info, a, requestBody)
-	}
+	return doAwsClientRequest(c, info, a, requestBody)
 }
 
-func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
-	if a.ClientMode == ClientModeApiKey {
-		claudeAdaptor := claude.Adaptor{}
-		usage, err = claudeAdaptor.DoResponse(c, resp, info)
-	} else {
-		if a.IsNova {
-			err, usage = handleNovaRequest(c, info, a)
-		} else {
-			if info.IsStream {
-				err, usage = awsStreamHandler(c, info, a)
-			} else {
-				err, usage = awsHandler(c, info, a)
-			}
-		}
+// DoResponse 使用请求上下文 c 与渠道信息 info 执行并解析 AWS SDK 响应，返回用量和标准化错误
+func (a *Adaptor) DoResponse(c *gin.Context, _ *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
+	// 1. Nova 使用独立的请求与响应格式
+	if a.IsNova {
+		err, usage = handleNovaRequest(c, info, a)
+		return
 	}
+
+	// 2. Claude 根据流式标记选择现有 SDK 响应处理器
+	if info.IsStream {
+		err, usage = awsStreamHandler(c, info, a)
+		return
+	}
+	err, usage = awsHandler(c, info, a)
 	return
 }
 

--- a/relay/channel/aws/relay_aws_test.go
+++ b/relay/channel/aws/relay_aws_test.go
@@ -141,6 +141,130 @@ func newAwsStreamResponse(request *http.Request, body io.ReadCloser) *http.Respo
 	}
 }
 
+// TestNewAwsClientAuthentication 使用 t 验证两种凭据格式生成的 SDK 认证头及无效格式错误，函数无返回值
+func TestNewAwsClientAuthentication(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		apiKey           string
+		keyType          dto.AwsKeyType
+		wantAuth         string
+		wantAuthContains []string
+		wantErr          bool
+	}{
+		{
+			name:     "api key bearer",
+			apiKey:   "test-api-key|us-east-1",
+			keyType:  dto.AwsKeyTypeApiKey,
+			wantAuth: "Bearer test-api-key",
+		},
+		{
+			name:             "access key signature",
+			apiKey:           "access-key|secret-key|us-east-1",
+			keyType:          dto.AwsKeyTypeAKSK,
+			wantAuthContains: []string{"AWS4-HMAC-SHA256 ", "Credential=access-key/", "/us-east-1/bedrock/aws4_request"},
+		},
+		{name: "missing region", apiKey: "test-api-key", keyType: dto.AwsKeyTypeApiKey, wantErr: true},
+		{name: "too many parts", apiKey: "a|b|c|d", keyType: dto.AwsKeyTypeAKSK, wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := newAwsTestContext(httptest.NewRecorder(), context.Background())
+			info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{
+				ApiKey:               test.apiKey,
+				ChannelOtherSettings: dto.ChannelOtherSettings{AwsKeyType: test.keyType},
+			}}
+
+			client, err := newAwsClient(c, info)
+			if test.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, client)
+				return
+			}
+			require.NoError(t, err)
+
+			var authorization string
+			var requestHost string
+			var requestPath string
+			_, err = client.InvokeModel(context.Background(), newAwsInvokeModelInput(), func(options *bedrockruntime.Options) {
+				options.BaseEndpoint = aws.String("https://bedrock.test")
+				options.HTTPClient = awsHTTPClientFunc(func(request *http.Request) (*http.Response, error) {
+					authorization = request.Header.Get("Authorization")
+					requestHost = request.URL.Host
+					requestPath = request.URL.Path
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(bytes.NewBufferString(`{}`)),
+						Request:    request,
+					}, nil
+				})
+				options.Retryer = aws.NopRetryer{}
+			})
+			require.NoError(t, err)
+			assert.Equal(t, "bedrock.test", requestHost)
+			assert.Equal(t, "/model/"+awsTestModel+"/invoke", requestPath)
+			if test.wantAuth != "" {
+				assert.Equal(t, test.wantAuth, authorization)
+				assert.NotContains(t, authorization, "|us-east-1")
+			}
+			for _, expected := range test.wantAuthContains {
+				assert.Contains(t, authorization, expected)
+			}
+		})
+	}
+}
+
+// TestAdaptorDoRequestUsesSdk 使用 t 验证所有 AWS 密钥格式及流式模式均构造 SDK 请求，函数无返回值
+func TestAdaptorDoRequestUsesSdk(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		apiKey   string
+		keyType  dto.AwsKeyType
+		isStream bool
+	}{
+		{name: "api key non-stream", apiKey: "test-api-key|us-east-1", keyType: dto.AwsKeyTypeApiKey},
+		{name: "api key stream", apiKey: "test-api-key|us-east-1", keyType: dto.AwsKeyTypeApiKey, isStream: true},
+		{name: "access key non-stream", apiKey: "access-key|secret-key|us-east-1", keyType: dto.AwsKeyTypeAKSK},
+		{name: "access key stream", apiKey: "access-key|secret-key|us-east-1", keyType: dto.AwsKeyTypeAKSK, isStream: true},
+		{name: "legacy api key", apiKey: "test-api-key|us-east-1"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := newAwsTestContext(httptest.NewRecorder(), context.Background())
+			info := &relaycommon.RelayInfo{
+				IsStream:        test.isStream,
+				OriginModelName: awsTestModel,
+				ChannelMeta: &relaycommon.ChannelMeta{
+					ApiKey:               test.apiKey,
+					UpstreamModelName:    awsTestModel,
+					ChannelOtherSettings: dto.ChannelOtherSettings{AwsKeyType: test.keyType},
+				},
+			}
+			adaptor := &Adaptor{}
+			adaptor.Init(info)
+
+			result, err := adaptor.DoRequest(c, info, bytes.NewBufferString(`{"messages":[{"role":"user","content":"hello"}],"max_tokens":128}`))
+			require.NoError(t, err)
+			assert.Nil(t, result)
+			require.NotNil(t, adaptor.AwsClient)
+			if test.isStream {
+				_, ok := adaptor.AwsReq.(*bedrockruntime.InvokeModelWithResponseStreamInput)
+				assert.True(t, ok)
+			} else {
+				_, ok := adaptor.AwsReq.(*bedrockruntime.InvokeModelInput)
+				assert.True(t, ok)
+			}
+		})
+	}
+}
+
 func TestDoAwsClientRequest_AppliesRuntimeHeaderOverrideToAnthropicBeta(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Agent

- Tool: OpenAI Codex CLI
- Tool version: 0.152.1
- Model (full id): gpt-5
- Host (CLI / IDE / GitHub coding agent / other): CLI
- Date (UTC): 2026-09-02
- AI disclosure: 本变更由 OpenAI Codex 辅助生成，并由提交者复核。

## Links

- Closes #7023
- Related: #1508

## User request

“查明 #7023 的错误链路，给出修复方案；确认后实现，并按仓库规范提交 PR。”

## Out of scope — refuse

- Coding Plan
- Reverse-engineered channels
- Third-party API wrappers
- Codex channel-type changes, or compatibility from exposing Codex as a general-purpose API
- Codex API-specific protocol or behavior treated as standard OpenAI API behavior
- Pass-through-only forwarding
- Third-party hosting sites, relay services, or API services
- Usage, configuration, or integration

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): 不适用

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other: 不适用

## Issue facts

- Actual behavior: 新建 AWS adaptor 的 `ClientMode` 保持零值；`Init` 为空，而 `DoRequest` 在 `GetRequestURL` 之前按该字段分流，因此 direct API key REST 分支不可达，`aws_key_type: api_key` 实际仍落入 SDK 路径。
- Impact: API Key 渠道可能因 SDK 已支持两段式 bearer 凭据而继续工作，但配置意图与实际传输不一致；休眠 REST 路径中的错误 URL、认证头和协议处理也可能在未来被激活后造成回归。
- Frequency: 每个新建 AWS adaptor 请求都会遇到该分流条件，direct REST 分支始终不可达。
- Evidence that the problem is in new-api rather than the client or upstream: `GetAdaptor` 创建零值 adaptor，AWS `Init` 不赋值，`DoRequest` 先判断 `ClientMode`，而唯一赋值点 `GetRequestURL` 只能在已进入 REST 分支后调用；`newAwsClient` 已在 new-api 内支持 `APIKey|Region`。
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): relay：AWS `Adaptor.ClientMode`、`ChannelOtherSettings.AwsKeyType`、`ChannelMeta.ApiKey`；billing / frontend / deployment：not applicable。

## Change

删除不可达且重复的 direct REST / `ClientMode` 分支，使 API Key 与 AK/SK 凭据都明确通过现有 AWS SDK 路径构造和执行请求。认证继续由 SDK 的 Bearer 或 SigV4 signer 处理，现有密钥格式与渠道配置保持兼容。新增传输级回归测试，捕获 SDK 发出的认证头，并覆盖流式、非流式、旧配置和无效凭据格式。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `repo:QuantumNous/new-api is:pr AWS Bedrock ClientMode`、`repo:QuantumNous/new-api is:pr "direct REST" AWS`、`head:PuppetKL:fix/aws-bedrock-sdk-auth`。
- What already existed and why this is not a duplicate: 未发现对应现有 PR；#1508 已实现 AWS SDK bearer token 支持，本 PR 清理的是后续加入但不可达的重复 REST 分支。

### Docs and code

- https://docs.newapi.ai/ : 首页及站内检索没有 AWS Bedrock 传输实现的专项说明，不存在与本修复冲突的公开配置契约。
- https://deepwiki.com/QuantumNous/new-api : Provider / adaptor 文档说明渠道通过统一 adaptor 接口接入，但没有为该休眠 REST 分支定义独立契约。
- README / repo docs: README 说明项目用于合法授权的上游渠道与统一网关场景，没有规定 AWS 必须使用 direct REST。
- Code paths and what they imply for this change: `relay/relay_adaptor.go` 创建零值 AWS adaptor；`relay/compatible_handler.go` 先调用空 `Init` 再调用 `DoRequest`；`relay/channel/aws/relay-aws.go` 已通过 SDK 同时支持两段式 bearer 和三段式 AK/SK 凭据。

### Alternatives considered

- Option A: 初始化 `ClientMode` 并保留 direct REST，同时修复 URL、Bearer token、Converse 请求/响应转换和 ConverseStream event stream。
- Option B: 删除重复 REST 分支，统一复用已支持两种认证方式的 AWS SDK。
- Why this approach: Option B 保持当前实际可用路径和外部配置兼容，删除未使用代码，避免重复实现 AWS 认证、区域解析、流式协议和错误处理。

## Files

| Path | Why |
| --- | --- |
| `relay/channel/aws/adaptor.go` | 删除 `ClientMode` 与 direct REST 分流，使请求和响应统一走 SDK |
| `relay/channel/aws/relay_aws_test.go` | 验证 Bearer / SigV4 认证头、凭据格式及流式/非流式 SDK 请求选择 |

## Behavior

- Before: `aws_key_type` 看似选择 direct REST，但新 adaptor 始终因零值 `ClientMode` 进入 SDK；仓库保留一条不可达且不完整的 REST 实现。
- After: API Key 与 AK/SK 均明确走 AWS SDK，认证头由 SDK 正确生成，旧的空 `aws_key_type` 两段式 API Key 仍兼容。
- Explicit non-goals / leftover work: 不新增 Converse / ConverseStream 能力，不修改前端、渠道配置、SDK 版本、数据库或计费逻辑。

## Verification

- Commands and results: `go test ./relay/channel/aws` 通过；`go test ./relay/...` 通过；`go build ./relay/...` 通过；`go vet ./relay/channel/aws` 通过；`git diff --check` 通过。
- Manual steps and observed result: 未使用真实 AWS 凭据；通过假 AWS HTTP transport 捕获最终 SDK 请求，确认 API Key 生成 `Bearer test-api-key` 且不包含 `|Region`，AK/SK 生成包含正确 region scope 的 SigV4 认证头。
- UI: 无；本变更仅涉及后端 AWS relay。
- Tests added or updated, or why none: 新增两组表驱动测试，覆盖两种认证、无效凭据、旧配置以及流式/非流式 SDK 请求类型。
- Databases / providers / platforms exercised: 未涉及数据库；使用 AWS SDK 与假 HTTP transport；Windows / PowerShell 7.6.5。
- Not verified: 未执行真实 AWS Bedrock 请求；`go build ./...` 因缺少忽略提交的 `web/dist` 而失败，环境未安装 Bun，无法生成该前端构建产物。

## Risks

- Failure modes: 两种认证现在都明确依赖当前 AWS SDK；若 SDK 的认证选择发生回归，可能影响 Bedrock 请求。传输级测试已锁定当前 Bearer 与 SigV4 行为。
- Billing / quota / auth impact: 仅调整 AWS 认证传输选择；计费与配额不变。Bearer token 不再有进入错误手写 Header 路径的可能，SigV4 行为保持现状。
- Follow-ups: 若出现经验证的 Converse 专属需求，应另开议题并复用 SDK 的 `Converse` / `ConverseStream`，而不是恢复手写 REST 鉴权。

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized AWS request handling across credential formats.
  * Ensured both streaming and non-streaming requests use the AWS SDK request flow.
  * Improved authentication handling for API-key and access-key credentials.
* **Tests**
  * Added coverage for authentication headers, request endpoints, credential validation, and streaming modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->