### PR TITLE
fix(deepseek): 修复工具调用时缺失 reasoning_content 导致的 400 错误

### DIFF
--- a/relay/channel/deepseek/adaptor.go
+++ b/relay/channel/deepseek/adaptor.go
@@ -89,8 +89,26 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 	if err := applyDeepSeekV4OpenAIThinkingSuffix(info, request); err != nil {
 		return nil, err
 	}
-
+	ensureToolCallReasoningContent(request)
 	return request, nil
+}
+
+// ensureToolCallReasoningContent 保证所有携带 tool_calls 的 assistant 消息都带
+// reasoning_content 字段。DeepSeek 在开启思考模式时，如果历史消息里的工具调用轮次
+// 缺少 reasoning_content（例如客户端或中间路由裁剪上下文时丢弃了该字段），上游会
+// 直接返回 400 "reasoning_content must be passed back to the API"。空字符串即可
+// 通过该校验，已有的非空值则原样保留。
+func ensureToolCallReasoningContent(request *dto.GeneralOpenAIRequest) {
+	emptyReasoning := ""
+	for i := range request.Messages {
+		msg := &request.Messages[i]
+		if msg.Role != "assistant" || len(msg.ToolCalls) == 0 {
+			continue
+		}
+		if msg.ReasoningContent == nil {
+			msg.ReasoningContent = &emptyReasoning
+		}
+	}
 }
 
 func applyDeepSeekV4OpenAIThinkingSuffix(info *relaycommon.RelayInfo, request *dto.GeneralOpenAIRequest) error {

--- a/relay/channel/deepseek/adaptor_test.go
+++ b/relay/channel/deepseek/adaptor_test.go
@@ -1,0 +1,83 @@
+package deepseek
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnsureToolCallReasoningContent 覆盖 DeepSeek 400 报错的回归路径：开启思考模式时，
+// 历史消息中带 tool_calls 的 assistant 轮次必须回传 reasoning_content，否则上游直接返回
+// 400 "reasoning_content must be passed back to the API"。空字符串即可通过该校验，
+// 已有非空值应原样保留，非工具调用消息不得被改写。
+func TestEnsureToolCallReasoningContent(t *testing.T) {
+	toolCalls := json.RawMessage(`[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Paris\"}"}}]`)
+	keptReasoning := "Let me check the weather."
+
+	tests := []struct {
+		name     string
+		messages []dto.Message
+		// 期望每一条消息转换后的 reasoning_content："" 表示被补空串，
+		// "<unset>" 表示必须保持未设置（nil）。
+		want []string
+	}{
+		{
+			name: "带 tool_calls 且缺失 reasoning_content 时补空串",
+			messages: []dto.Message{
+				{Role: "assistant", ToolCalls: toolCalls},
+			},
+			want: []string{""},
+		},
+		{
+			name: "带 tool_calls 且已有 reasoning_content 时原样保留",
+			messages: []dto.Message{
+				{Role: "assistant", ReasoningContent: &keptReasoning, ToolCalls: toolCalls},
+			},
+			want: []string{keptReasoning},
+		},
+		{
+			name: "assistant 消息无 tool_calls 不被改写",
+			messages: []dto.Message{
+				{Role: "assistant"},
+			},
+			want: []string{"<unset>"},
+		},
+		{
+			name: "user 与 tool 消息不受影响",
+			messages: []dto.Message{
+				{Role: "user"},
+				{Role: "tool", ToolCallId: "call_1"},
+			},
+			want: []string{"<unset>", "<unset>"},
+		},
+		{
+			name: "混合消息只补全工具调用轮次",
+			messages: []dto.Message{
+				{Role: "user"},
+				{Role: "assistant", ToolCalls: toolCalls},
+				{Role: "tool", ToolCallId: "call_1"},
+				{Role: "assistant", ReasoningContent: &keptReasoning},
+			},
+			want: []string{"<unset>", "", "<unset>", keptReasoning},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := &dto.GeneralOpenAIRequest{Messages: tt.messages}
+			ensureToolCallReasoningContent(request)
+			require.Len(t, request.Messages, len(tt.want))
+			for i, want := range tt.want {
+				if want == "<unset>" {
+					assert.Nil(t, request.Messages[i].ReasoningContent, "消息 %d 不应被写入 reasoning_content", i)
+				} else {
+					require.NotNil(t, request.Messages[i].ReasoningContent, "消息 %d 缺少 reasoning_content", i)
+					assert.Equal(t, want, *request.Messages[i].ReasoningContent, "消息 %d 的 reasoning_content 不一致", i)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Agent

- Tool: TRAE (TraeCode)
- Tool version: latest
- Model (full id): DeepSeek-V4-Flash 正式版
- Host (CLI / IDE / GitHub coding agent / other): IDE
- Date (UTC): 2026-09-01

## Links

- Closes #6939
- Related: #4543, #4408, #6998, #6593, #6655, #4497

## User request

> API Error: 400 If thinking mode and tool_calls, `reasoning_content` must be passed back to the API. 这是为什么？Claude code 经常触发这个问题。
>
> （随后提供了自行调研的社区资料：DeepSeek 在思考模式下强制要求带 tool_calls 的 assistant 轮次原样回传 reasoning_content，而客户端或中转常在重组历史时裁剪该字段；社区方案包括让网关在收到 tool 结果回传时，检查上一条 assistant 消息——若含 tool_calls 但 reasoning_content 被删，强制注入空字符串，"DeepSeek 接受空字符串 reasoning_content 作为回传，只要该字段存在即可规避 400 报错"。）
>
> 用的是 new api，接的 DeepSeek（腾讯云接口），你看看社区里面有没有提到这个问题……看看这个问题怎么解决？

## Out of scope — refuse

- Matched: no

## Kind

- [x] Bug fix

## Issue facts

- Actual behavior: 使用 Claude Code 等依赖多轮工具调用的客户端，配合开启思考模式的 DeepSeek 系模型（官方接口、腾讯云兼容接口等）时，多轮对话报 HTTP 400 "If thinking mode and tool_calls, `reasoning_content` must be passed back to the API"。
- Impact: DeepSeek 官方文档要求历史中带 `tool_calls` 的 assistant 轮次必须原样回传 `reasoning_content`。但很多客户端（Cursor、Claude Code）或上下文压缩工具在回传历史时会自行裁剪掉该字段——#4543 中已实测确认（@Feliks151450）：即使走 DeepSeek 渠道类型，new-api 也不会补上，照样报错。用户侧无法规避。
- Frequency: 高频，每轮工具调用回传都可能触发（#4543 26 条评论、#6939、#4408、#4806、#4515 均为同一报错）。
- Evidence that the problem is in new-api rather than the client or upstream: 腾讯云 DeepSeek 接口实测复现；上游校验行为符合 DeepSeek 官方文档；DeepSeek 渠道类型正是为适配 DeepSeek 各种行为而存在（维护者在 #4543 中认可"可以考虑针对这个渠道类型补齐这个"），但当前适配器未做此补全。
- Applicable types and their fields: relay — `relay/channel/deepseek/adaptor.go`（DeepSeek 渠道类型请求出口）。

## Change

在 `relay/channel/deepseek/adaptor.go` 的 `ConvertOpenAIRequest` 出口处新增 `ensureToolCallReasoningContent`：

1. 遍历 `request.Messages`；
2. 凡 `role == "assistant"` 且携带 `tool_calls` 而 `reasoning_content` 为 `nil` 的消息，补全为空字符串 `""`；
3. 已有非空值原样保留，`user` / `tool` 等其他角色的消息不受影响。

**为什么补空字符串？** 上游校验仅要求字段存在（接受空串），补空串既能通过校验，又不伪造思考内容、不增加 Token 计费。

**为什么只在 DeepSeek 适配器改？** 影响面最小。通用转换层的映射（#6593 方向）无法覆盖字段已被客户端裁剪的场景——此时历史里已无 thinking 可映射，渠道出口是唯一有效层；且 DeepSeek 渠道专属兜底不触碰通用转换，与其他供应商零相互影响。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): "reasoning_content"、"thinking must be passed back"、"passed back to the API"
- What already existed and why this is not a duplicate: 现有 open PR 分两类——#6593/#6655/#4497 改通用转换层（维护者在 #4543/#6592 已明确通用转换不默认处理该字段）；#6998 修反方向（OpenAI 请求 → Claude 渠道）的 thinking signature 透传。没有任何 PR 在 DeepSeek 渠道适配器内做兜底，而这正是维护者在 #4543（2026-05-04）松口的方向："可以考虑针对这个渠道类型补齐这个，之后我看看"。本 PR 只做这一件事，与上述 PR 零文件冲突；即使后续通用层做了映射，本兜底仍能保证被客户端裁剪过的请求通过校验，两者互补。

### Docs and code

- https://docs.newapi.ai/ : 渠道文档未涉及该回传要求。
- https://deepwiki.com/QuantumNous/new-api : DeepSeek 渠道类型定位为 DeepSeek 专用适配。
- README / repo docs: 无相关说明。
- Code paths: `relay/channel/deepseek/adaptor.go` 的 `ConvertOpenAIRequest` 是 DeepSeek 渠道发上游前的最后出口，在此补全覆盖所有进入该渠道类型的请求，无论客户端什么协议、字段是否被中间环节裁剪。

### Alternatives considered

- Option A: 修通用转换层（Messages→Chat 映射 thinking→reasoning_content）。与 #6593 重复，且维护者已明确拒绝通用转换默认处理该字段（#6592 关闭理由）。
- Option B: 要求客户端自行适配。#4543 实测不可行——客户端裁剪行为不受 new-api 控制。
- Why this approach: 渠道内兜底是维护者认可的方向、影响面最小、对已裁剪历史是唯一有效层。

## Files

| Path | Why |
| --- | --- |
| `relay/channel/deepseek/adaptor.go` | `ensureToolCallReasoningContent` 兜底补全 |
| `relay/channel/deepseek/adaptor_test.go` | 5 个单测：补全缺失 / 保留非空值 / 无 tool_calls 不改写 / user·tool 不受影响 / 混合消息 |

## Behavior

- Before: DeepSeek 渠道收到缺 `reasoning_content` 的 tool_calls 轮次时原样转发，上游返回 400。
- After: 出口处自动补 `reasoning_content: ""`，请求通过校验；已有值不受影响。
- Explicit non-goals / leftover work: 不处理通用转换层的 thinking 映射（#6593 方向）；不处理 OpenAI→Claude 方向 signature 透传（#6998 方向）；不伪造非空思考内容。

## Verification

- Commands and results:
  - `go build ./relay/channel/deepseek/` — PASS
  - `go vet ./relay/channel/deepseek/` — PASS
  - `go test ./relay/channel/deepseek/` — PASS（新增 5 用例）
- Manual steps and observed result: 本地构建部署（DeepSeek 渠道类型，上游对接腾讯云 DeepSeek 接口），Claude Code 高频工具调用场景下稳定运行 15 小时、约 20,000 次调用。修复前每轮工具调用回传必现的 400 错误已彻底解决。
- UI: 无 UI 变化（纯 relay 路径改动）。
- Tests added or updated, or why none: 新增 `adaptor_test.go`（表驱动，require/assert）。
- Databases / providers / platforms exercised: 不涉及数据库；腾讯云 DeepSeek 兼容接口（DeepSeek 渠道类型）。
- Not verified: DeepSeek 官方接口直连（同一校验行为见 #6939/#4515）；MySQL/PostgreSQL（改动不涉及 DB）。

## Risks

- Failure modes: 仅 DeepSeek 渠道生效；若上游未来要求非空 `reasoning_content`，需改为注入占位文本（上游目前接受空串）。
- Billing / quota / auth impact: 无——空字符串不产生额外 Token，不触碰计费路径。
- Follow-ups: 若维护者后续接受通用转换方案，本兜底与之互补。

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no

---

*Note: 本 PR 的问题定位、代码实现与单测由 AI 辅助完成，提交者已审阅全部内容并对其准确性负责，在真实的腾讯云 DeepSeek 接口上通过了 15 小时 / 约 20,000 次调用的实测验证。*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DeepSeek requests with assistant tool calls being rejected when reasoning content was missing.
  * Missing reasoning content is now supplied automatically, while existing values remain unchanged.
  * Messages without tool calls are unaffected.

* **Tests**
  * Added coverage for tool-call requests, preserved reasoning content, and unaffected messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->