### PR TITLE
fix(web): count selected subRows in bulk actions toolbar

### DIFF
--- a/web/src/components/data-table/__tests__/bulk-actions.test.tsx
+++ b/web/src/components/data-table/__tests__/bulk-actions.test.tsx
@@ -1,0 +1,110 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import {
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+  type Row,
+  type RowSelectionState,
+} from '@tanstack/react-table'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+
+import { DataTableBulkActions } from '../toolbar/bulk-actions'
+
+// Regression tests for issue #6885: with tag mode + batch mode enabled on the
+// channels table, selecting channels never showed the bulk-actions toolbar.
+// Tag mode turns the data into a tree (tag rows on top, channels as subRows)
+// and tag rows are not selectable, so every selected row is a subRow. The
+// toolbar must count selected subRows too, not only selected top-level rows.
+
+type TreeRow = {
+  id: string
+  label: string
+  children?: TreeRow[]
+}
+
+const columns: ColumnDef<TreeRow>[] = [
+  { id: 'label', accessorFn: (row) => row.label },
+]
+
+function Harness({
+  data,
+  initialSelection,
+}: {
+  data: TreeRow[]
+  initialSelection: RowSelectionState
+}) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: (row) => row.id,
+    getSubRows: (row) => row.children,
+    // Mirrors the channels table in tag mode: aggregate (parent) rows are not
+    // selectable, leaf rows are. See channels-table.tsx enableRowSelection.
+    enableRowSelection: (row: Row<TreeRow>) =>
+      !Array.isArray(row.original.children),
+    initialState: { rowSelection: initialSelection },
+  })
+
+  return (
+    <DataTableBulkActions table={table} entityName='channel'>
+      <button type='button'>bulk action</button>
+    </DataTableBulkActions>
+  )
+}
+
+const treeData: TreeRow[] = [
+  {
+    id: 'tag:alpha',
+    label: 'alpha',
+    children: [
+      { id: 'channel:1', label: 'channel one' },
+      { id: 'channel:2', label: 'channel two' },
+    ],
+  },
+]
+
+const flatData: TreeRow[] = [
+  { id: 'channel:1', label: 'channel one' },
+  { id: 'channel:2', label: 'channel two' },
+]
+
+describe('DataTableBulkActions selection counting', () => {
+  test('shows the toolbar when only a subRow of a tree table is selected (issue #6885)', () => {
+    render(<Harness data={treeData} initialSelection={{ 'channel:1': true }} />)
+
+    const toolbar = screen.getByRole('toolbar')
+    expect(toolbar).toHaveAccessibleName('Bulk actions for 1 selected channel')
+  })
+
+  test('still shows the toolbar for a selected top-level row in a flat table', () => {
+    render(<Harness data={flatData} initialSelection={{ 'channel:1': true }} />)
+
+    const toolbar = screen.getByRole('toolbar')
+    expect(toolbar).toHaveAccessibleName('Bulk actions for 1 selected channel')
+  })
+
+  test('renders nothing when no row is selected', () => {
+    render(<Harness data={treeData} initialSelection={{}} />)
+
+    expect(screen.queryByRole('toolbar')).toBeNull()
+  })
+})

--- a/web/src/components/data-table/__tests__/bulk-actions.test.tsx
+++ b/web/src/components/data-table/__tests__/bulk-actions.test.tsx
@@ -24,6 +24,7 @@ import {
   type RowSelectionState,
 } from '@tanstack/react-table'
 import { render, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
 import { describe, expect, test } from 'vitest'
 
 import { DataTableBulkActions } from '../toolbar/bulk-actions'
@@ -50,7 +51,7 @@ function Harness({
 }: {
   data: TreeRow[]
   initialSelection: RowSelectionState
-}) {
+}): ReactElement {
   const table = useReactTable({
     data,
     columns,
@@ -92,14 +93,14 @@ describe('DataTableBulkActions selection counting', () => {
     render(<Harness data={treeData} initialSelection={{ 'channel:1': true }} />)
 
     const toolbar = screen.getByRole('toolbar')
-    expect(toolbar).toHaveAccessibleName('Bulk actions for 1 selected channel')
+    expect(toolbar).toHaveAccessibleName(/1 selected channel/)
   })
 
   test('still shows the toolbar for a selected top-level row in a flat table', () => {
     render(<Harness data={flatData} initialSelection={{ 'channel:1': true }} />)
 
     const toolbar = screen.getByRole('toolbar')
-    expect(toolbar).toHaveAccessibleName('Bulk actions for 1 selected channel')
+    expect(toolbar).toHaveAccessibleName(/1 selected channel/)
   })
 
   test('renders nothing when no row is selected', () => {

--- a/web/src/components/data-table/toolbar/bulk-actions.tsx
+++ b/web/src/components/data-table/toolbar/bulk-actions.tsx
@@ -53,7 +53,10 @@ export function DataTableBulkActions<TData>({
   children,
 }: DataTableBulkActionsProps<TData>): React.ReactNode | null {
   const { t } = useTranslation()
-  const selectedRows = table.getFilteredSelectedRowModel().rows
+  // Use flatRows instead of rows: rows only contains selected *top-level*
+  // rows, so in tree tables (e.g. the channels table in tag mode, where only
+  // subRows are selectable) the count would always be 0. See issue #6885.
+  const selectedRows = table.getFilteredSelectedRowModel().flatRows
   const selectedCount = selectedRows.length
   const toolbarRef = useRef<HTMLDivElement>(null)
   const buttonsRef = useRef<NodeListOf<HTMLButtonElement> | null>(null)

--- a/web/src/features/channels/components/__tests__/data-table-bulk-actions.test.tsx
+++ b/web/src/features/channels/components/__tests__/data-table-bulk-actions.test.tsx
@@ -1,0 +1,112 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+  type Row,
+  type RowSelectionState,
+} from '@tanstack/react-table'
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { handleBatchEnable } from '../../lib'
+import { DataTableBulkActions } from '../data-table-bulk-actions'
+
+vi.mock('../../lib', () => ({
+  handleBatchDelete: vi.fn(),
+  handleBatchDisable: vi.fn(),
+  handleBatchEnable: vi.fn(),
+  handleBatchSetTag: vi.fn(),
+}))
+
+// Regression test for issue #6885: in tag mode channels are subRows of tag
+// rows, so batch actions must collect ids from flatRows — a selected nested
+// channel id has to reach the batch handler, not just make the toolbar show.
+
+type ChannelRow = {
+  id?: number
+  name: string
+  children?: ChannelRow[]
+}
+
+const columns: ColumnDef<ChannelRow>[] = [
+  { id: 'name', accessorFn: (row) => row.name },
+]
+
+function Harness({
+  data,
+  initialSelection,
+}: {
+  data: ChannelRow[]
+  initialSelection: RowSelectionState
+}): ReactElement {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: (row) =>
+      row.children ? `tag:${row.name}` : `channel:${row.id}`,
+    getSubRows: (row) => row.children,
+    // Mirrors the channels table in tag mode: tag (parent) rows are not
+    // selectable, channel (leaf) rows are.
+    enableRowSelection: (row: Row<ChannelRow>) =>
+      !Array.isArray(row.original.children),
+    initialState: { rowSelection: initialSelection },
+  })
+
+  return <DataTableBulkActions table={table} />
+}
+
+const treeData: ChannelRow[] = [
+  {
+    name: 'alpha',
+    children: [
+      { id: 42, name: 'channel one' },
+      { id: 43, name: 'channel two' },
+    ],
+  },
+]
+
+describe('channels DataTableBulkActions', () => {
+  test('batch enable receives the id of a channel selected as a subRow (issue #6885)', () => {
+    const queryClient = new QueryClient()
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Harness
+          data={treeData}
+          initialSelection={{ 'channel:42': true }}
+        />
+      </QueryClientProvider>
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Enable selected channels' })
+    )
+
+    expect(handleBatchEnable).toHaveBeenCalledTimes(1)
+    expect(handleBatchEnable).toHaveBeenCalledWith(
+      [42],
+      queryClient,
+      expect.any(Function)
+    )
+  })
+})

--- a/web/src/features/channels/components/data-table-bulk-actions.tsx
+++ b/web/src/features/channels/components/data-table-bulk-actions.tsx
@@ -67,7 +67,9 @@ export function DataTableBulkActions<TData>({
     ADMIN_PERMISSION_ACTIONS.SENSITIVE_WRITE
   )
 
-  const selectedRows = table.getFilteredSelectedRowModel().rows
+  // flatRows, not rows: in tag mode channels are subRows of tag rows, and
+  // rows only lists selected top-level rows (issue #6885).
+  const selectedRows = table.getFilteredSelectedRowModel().flatRows
   const selectedIds = selectedRows.reduce<number[]>((ids, row) => {
     const id = (row.original as Channel).id
 


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

> [!IMPORTANT]
>
> 本 PR 的代码与描述为 AI 辅助生成（Claude），我已逐行审阅、在本地完整验证，并声明对其准确性与完整性负责。

## 🔗 关联任务 / Related Issue

- Closes #6885

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description

标签模式下渠道表是树形结构：标签行在顶层、真实渠道作为 subRows 挂在下面，且标签行不可勾选（`channels-table.tsx` 的 `enableRowSelection` 有意排除聚合行）。而批量操作工具栏用 `table.getFilteredSelectedRowModel().rows` 统计选中数——`.rows` 只包含**顶层**被选中的行，父行未选中时其已选子行会被一并过滤掉。于是标签模式 + 批量模式下：渠道勾得动、复选框也变色，但计数恒为 0，工具栏永远不渲染。

修法是把两处读法换成 `.flatRows`（包含被选中的子行）：

- `web/src/components/data-table/toolbar/bulk-actions.tsx`：工具栏显示与计数
- `web/src/features/channels/components/data-table-bulk-actions.tsx`：`selectedIds` 收集（只改第一处的话工具栏会出现，但操作会提示"未选择任何渠道"）

对其余使用该共用组件的表（models / users / keys / redemption-codes）行为无变化：`getSubRows` 在整个 `web/src` 只有渠道表一处，无子行时 `.rows` 与 `.flatRows` 内容相同。

非目标：移动端 / 卡片视图（`card-grid.tsx` 只渲染顶层行，标签模式下本就看不到子渠道卡片）是既有的另一个限制，不在本 PR 范围内。

## 📸 运行证明 / Proof of Work

补了回归测试 `web/src/components/data-table/__tests__/bulk-actions.test.tsx`（树形选子行 / 扁平选顶层 / 未选中三个场景），按"先失败后修复"流程验证：

- 修复前：树形场景恰好失败（工具栏不渲染，即本 issue 症状），扁平与未选中场景通过
- 修复后：3/3 通过
- `bun run typecheck` 通过
- `bun run test` 全量：373 通过、8 个失败文件与未修改的 main（2b6f1dfe）基线**完全一致**（oauth-bind-window / playground / keys 等，与本改动无关的既存环境性失败）

环境：Bun 1.4.0（与 CI 对齐），Linux 容器。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 无论描述是否由 AI 生成，我已审阅全部内容，并声明对其准确性与完整性负责。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **新功能关联 Issue:** 不适用（Bug 修复），已关联 #6885。
- [x] **事前沟通:** 改动为两行读法修正 + 回归测试，非方向性变更。
- [x] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口，也不是对 Codex 渠道类型的改动。
- [x] **范围聚焦:** 本 PR 为一项聚焦改动，未包含无关代码。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed bulk actions not appearing when selecting nested rows in tree-based tables.
  - Updated channel bulk actions in tag mode to correctly include selected channels nested under tags.
  - Bulk-action controls now accurately reflect selections in both flat and hierarchical tables.
  - Improved handling when no rows are selected so the toolbar remains hidden.

- **Tests**
  - Added regression coverage for nested, top-level, and empty selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->