### PR TITLE
fix: correct model vendor mapping

### DIFF
--- a/model/pricing_default.go
+++ b/model/pricing_default.go
@@ -4,38 +4,49 @@ import (
 	"strings"
 )
 
-// 简化的供应商映射规则
-var defaultVendorRules = map[string]string{
-	"gpt":      "OpenAI",
-	"dall-e":   "OpenAI",
-	"whisper":  "OpenAI",
-	"o1":       "OpenAI",
-	"o3":       "OpenAI",
-	"claude":   "Anthropic",
-	"gemini":   "Google",
-	"moonshot": "Moonshot",
-	"kimi":     "Moonshot",
-	"chatglm":  "智谱",
-	"glm-":     "智谱",
-	"qwen":     "阿里巴巴",
-	"deepseek": "DeepSeek",
-	"abab":     "MiniMax",
-	"minimax":  "MiniMax",
-	"ernie":    "百度",
-	"spark":    "讯飞",
-	"hunyuan":  "腾讯",
-	"command":  "Cohere",
-	"@cf/":     "Cloudflare",
-	"360":      "360",
-	"yi":       "零一万物",
-	"jina":     "Jina",
-	"mistral":  "Mistral",
-	"grok":     "xAI",
-	"llama":    "Meta",
-	"doubao":   "字节跳动",
-	"kling":    "快手",
-	"jimeng":   "即梦",
-	"vidu":     "Vidu",
+// 简化的供应商映射规则。
+// 规则顺序有意固定：模型名可能同时命中多个关键词，先命中的规则优先。
+type defaultVendorRule struct {
+	pattern    string
+	vendorName string
+}
+
+var defaultVendorRules = []defaultVendorRule{
+	{pattern: "gpt", vendorName: "OpenAI"},
+	{pattern: "dall-e", vendorName: "OpenAI"},
+	{pattern: "whisper", vendorName: "OpenAI"},
+	{pattern: "o1", vendorName: "OpenAI"},
+	{pattern: "o3", vendorName: "OpenAI"},
+	{pattern: "codex", vendorName: "OpenAI"},
+	{pattern: "claude", vendorName: "Anthropic"},
+	{pattern: "gemini", vendorName: "Google"},
+	{pattern: "moonshot", vendorName: "Moonshot"},
+	{pattern: "kimi", vendorName: "Moonshot"},
+	{pattern: "chatglm", vendorName: "智谱"},
+	{pattern: "glm-", vendorName: "智谱"},
+	{pattern: "qwen", vendorName: "阿里巴巴"},
+	{pattern: "deepseek", vendorName: "DeepSeek"},
+	{pattern: "abab", vendorName: "MiniMax"},
+	{pattern: "minimax", vendorName: "MiniMax"},
+	{pattern: "ernie", vendorName: "百度"},
+	{pattern: "command", vendorName: "Cohere"},
+	{pattern: "@cf/", vendorName: "Cloudflare"},
+	{pattern: "360", vendorName: "360"},
+	{pattern: "yi", vendorName: "零一万物"},
+	{pattern: "jina", vendorName: "Jina"},
+	{pattern: "mistral", vendorName: "Mistral"},
+	{pattern: "grok", vendorName: "xAI"},
+	{pattern: "llama", vendorName: "Meta"},
+	{pattern: "muse", vendorName: "Meta"},
+	{pattern: "meta-", vendorName: "Meta"},
+	{pattern: "spark-", vendorName: "讯飞"},
+	{pattern: "xspark", vendorName: "讯飞"},
+	{pattern: "hunyuan", vendorName: "腾讯"},
+	{pattern: "hy", vendorName: "腾讯"},
+	{pattern: "doubao", vendorName: "字节跳动"},
+	{pattern: "kling", vendorName: "快手"},
+	{pattern: "jimeng", vendorName: "即梦"},
+	{pattern: "vidu", vendorName: "Vidu"},
 }
 
 // 供应商默认图标映射
@@ -58,7 +69,7 @@ var defaultVendorIcons = map[string]string{
 	"Jina":       "Jina",
 	"Mistral":    "Mistral.Color",
 	"xAI":        "XAI",
-	"Meta":       "Ollama",
+	"Meta":       "Meta.Color",
 	"字节跳动":       "Doubao.Color",
 	"快手":         "Kling.Color",
 	"即梦":         "Jimeng.Color",
@@ -79,9 +90,9 @@ func initDefaultVendorMapping(metaMap map[string]*Model, vendorMap map[int]*Vend
 		// 匹配供应商
 		vendorID := 0
 		modelLower := strings.ToLower(modelName)
-		for pattern, vendorName := range defaultVendorRules {
-			if strings.Contains(modelLower, pattern) {
-				vendorID = getOrCreateVendor(vendorName, vendorMap)
+		for _, rule := range defaultVendorRules {
+			if strings.Contains(modelLower, rule.pattern) {
+				vendorID = getOrCreateVendor(rule.vendorName, vendorMap)
 				break
 			}
 		}

--- a/model/pricing_default_test.go
+++ b/model/pricing_default_test.go
@@ -1,0 +1,55 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitDefaultVendorMappingPrefersOpenAIForCodexSpark(t *testing.T) {
+	metaMap := make(map[string]*Model)
+	vendorMap := map[int]*Vendor{
+		1: {Id: 1, Name: "OpenAI"},
+		2: {Id: 2, Name: "讯飞"},
+		3: {Id: 3, Name: "Meta"},
+	}
+
+	initDefaultVendorMapping(metaMap, vendorMap, []AbilityWithChannel{
+		{Ability: Ability{Model: "gpt-5.3-codex-spark"}},
+	})
+
+	meta, ok := metaMap["gpt-5.3-codex-spark"]
+	require.True(t, ok)
+	require.Equal(t, 1, meta.VendorID)
+}
+
+func TestInitDefaultVendorMappingDistinguishesMuseAndXunfeiModels(t *testing.T) {
+	metaMap := make(map[string]*Model)
+	vendorMap := map[int]*Vendor{
+		1: {Id: 1, Name: "讯飞"},
+		2: {Id: 2, Name: "Meta"},
+		3: {Id: 3, Name: "腾讯"},
+	}
+
+	initDefaultVendorMapping(metaMap, vendorMap, []AbilityWithChannel{
+		{Ability: Ability{Model: "muse"}},
+		{Ability: Ability{Model: "muse-spark-1.2"}},
+		{Ability: Ability{Model: "meta-llama-3"}},
+		{Ability: Ability{Model: "spark-x"}},
+		{Ability: Ability{Model: "xsparkx2"}},
+		{Ability: Ability{Model: "hunyuan-t1"}},
+		{Ability: Ability{Model: "hy-2"}},
+	})
+
+	require.Equal(t, 2, metaMap["muse"].VendorID)
+	require.Equal(t, 2, metaMap["muse-spark-1.2"].VendorID)
+	require.Equal(t, 2, metaMap["meta-llama-3"].VendorID)
+	require.Equal(t, 1, metaMap["spark-x"].VendorID)
+	require.Equal(t, 1, metaMap["xsparkx2"].VendorID)
+	require.Equal(t, 3, metaMap["hunyuan-t1"].VendorID)
+	require.Equal(t, 3, metaMap["hy-2"].VendorID)
+}
+
+func TestGetDefaultVendorIconUsesMetaIcon(t *testing.T) {
+	require.Equal(t, "Meta.Color", getDefaultVendorIcon("Meta"))
+}

--- a/web/src/features/channels/lib/model-categories.ts
+++ b/web/src/features/channels/lib/model-categories.ts
@@ -112,7 +112,7 @@ const MODEL_CATEGORY_RULES: readonly ModelCategoryRule[] = [
       'magistral',
     ],
   },
-  { name: 'Meta', keywords: ['meta-llama', 'llama-', 'llama2', 'llama3'] },
+  { name: 'Meta', keywords: ['meta-llama', 'llama-', 'llama2', 'llama3', 'muse'] },
   {
     name: 'Cohere',
     keywords: ['cohere', 'command-', 'c4ai-aya', 'aya-'],

--- a/web/src/features/usage-logs/components/model-badge.tsx
+++ b/web/src/features/usage-logs/components/model-badge.tsx
@@ -91,10 +91,13 @@ function resolveModelProvider(modelName: string): ModelProvider | null {
   if (hasAny(['ernie'])) {
     return { icon: 'Wenxin.Color', label: 'Baidu' }
   }
-  if (hasAny(['spark'])) {
+  if (hasAny(['llama-', 'meta-', 'muse'])) {
+    return { icon: 'Meta.Color', label: 'Meta' }
+  }
+  if (hasAny(['spark-', 'xspark'])) {
     return { icon: 'Spark.Color', label: 'iFlyTek' }
   }
-  if (hasAny(['hunyuan'])) {
+  if (hasAny(['hunyuan', 'hy'])) {
     return { icon: 'Hunyuan.Color', label: 'Tencent' }
   }
   if (hasAny(['baichuan'])) {
@@ -111,9 +114,6 @@ function resolveModelProvider(modelName: string): ModelProvider | null {
   }
   if (hasAny(['mistral-', 'mixtral-'])) {
     return { icon: 'Mistral.Color', label: 'Mistral' }
-  }
-  if (hasAny(['llama-', 'meta-'])) {
-    return { icon: 'Meta.Color', label: 'Meta' }
   }
   if (hasAny(['command-', 'cohere-'])) {
     return { icon: 'Cohere.Color', label: 'Cohere' }


### PR DESCRIPTION
## Agent

- Tool: GitHub CLI (`gh`)
- Tool version: gh version 2.97.0
- Model (full id): Codex model id not exposed in task context
- Host (CLI / IDE / GitHub coding agent / other): Codex desktop
- Date (UTC): 2026-09-02

## Links

- Closes #6925
- Related: #6926

## User request

修复模型广场供应商自动归类错误，并修正 Meta 供应商图标及相关前端识别。

## Out of scope — refuse

- Matched: no
- If yes, what was told to the user: not applicable

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: `gpt-5.3-codex-spark` 和 `muse-spark-1.2` 可能被模型广场归到讯飞。
- Impact: 模型供应商筛选、展示和图标不准确，模型调用本身不受影响。
- Frequency: 按用户提供的步骤可复现。
- Evidence that the problem is in new-api rather than the client or upstream: 本地通过 `GET /api/pricing` 观察到错误 `vendor_id`；根因位于 `model/pricing_default.go` 的默认供应商匹配逻辑。
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): Relay/API、Billing、Deployment 不适用；Frontend 涉及模型广场、频道模型分类和使用日志徽标。

## Change

- 将默认供应商规则改为有序列表，保证规则优先级稳定。
- OpenAI 补充 `codex` 关键词，用于 `codex-auto-review`。
- Meta 补充 `muse` 关键词，用于 `muse-spark` 系列。
- 讯飞匹配 `spark-`、`xspark`。经查阅，现在讯飞星火模型主要是 `spark‑` 前缀，讯飞星辰中是 `xspark` 前缀。其他 `iFlytek` `sparkdesk` 大多都被弃用了。
- 腾讯补充 `hy` 关键词。
- 将 Meta 默认图标从 Ollama 修正为 `Meta.Color`。
- 同步修正频道模型分类中的 Meta 识别，以及使用日志中的 Meta/讯飞徽标识别。
- 增加供应商映射和 Meta 图标回归测试。

本代码由 AI 辅助完成，提交者已审阅并对改动负责。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `gpt-5.3-codex-spark`, `muse spark provider`, `vendor spark`, `provider detection`。
- What already existed and why this is not a duplicate: #6925 是原始误判 Issue，#6926 是最接近的开放 PR；本 PR 在同一根因上补充 OpenAI Codex Spark、Meta 图标、腾讯 `hy` 及前端徽标处理。

### Docs and code

- https://docs.newapi.ai/ : 未发现供应商自动识别关键词的用户配置入口。
- https://deepwiki.com/QuantumNous/new-api : 模型目录由模型管理、元信息和定价系统聚合生成。
- README / repo docs: new-api 支持多供应商模型管理。
- Code paths and what they imply for this change:
  - `model/pricing.go` 聚合模型广场数据。
  - `model/pricing_default.go` 生成默认供应商和图标。
  - `web/src/features/channels/lib/model-categories.ts` 负责频道管理中的模型分类。
  - `web/src/features/usage-logs/components/model-badge.tsx` 负责使用日志徽标识别。

### Alternatives considered

- Option A: 继续使用 map，依赖当前关键词不重叠。
- Option B: 使用有序规则列表并明确冲突优先级。
- Why this approach: 规则数量很少，有序列表直观解决 map 遍历顺序不确定问题，并能稳定保证 `muse`、`gpt` 等规则优先。

## Files

| Path | Why |
| --- | --- |
| `model/pricing_default.go` | 默认供应商映射和 Meta 图标 |
| `model/pricing_default_test.go` | 供应商映射与图标回归测试 |
| `web/src/features/channels/lib/model-categories.ts` | 频道模型分类补充 Meta/muse |
| `web/src/features/usage-logs/components/model-badge.tsx` | 使用日志徽标识别修正 |

## Behavior

- Before: 无序 map + 宽泛 `spark` 关键词可能把 OpenAI 或 Meta 模型归到讯飞；Meta 图标显示为 Ollama。
- After: `gpt-5.3-codex-spark` 显示为 OpenAI；`muse-spark-1.2` 显示为 Meta；`spark-*`/`xspark*` 显示为讯飞；Meta 图标为 `Meta.Color`。
- Explicit non-goals / leftover work: 未改变上游渠道协议或模型调用；由于按要求使用包含匹配，其他名称若包含 `spark-` 或 `hy` 仍可能被识别为对应供应商。

## Verification

- Commands and results:
  - `GOWORK=off go test ./model` — passed。
  - `cd web && bun run typecheck` — passed。
- Manual steps and observed result: 本地启动服务，添加目标模型并请求 `GET /api/pricing`；目标模型供应商映射正确。
- Tests added or updated, or why none: 新增 `model/pricing_default_test.go`，覆盖 Codex Spark、Muse、Meta、讯飞、腾讯模型和 Meta 图标。
- Databases / providers / platforms exercised: 本地 SQLite、macOS arm64；未连接真实上游供应商。
- Not verified: MySQL/PostgreSQL、其他操作系统和浏览器版本。

修复前
<img width="1912" height="966" alt="image" src="https://github.com/user-attachments/assets/bee8e7b9-61dc-472c-a501-280a3e15b838" />
<img width="1912" height="966" alt="image-1" src="https://github.com/user-attachments/assets/e88596cb-11d3-4552-a682-94a20dfbf0e6" />

修复后
<img width="1912" height="966" alt="image-3" src="https://github.com/user-attachments/assets/b965ed1a-5de2-4237-81fc-43b8cdc6ac3d" />

## Risks

- Failure modes: 关键词规则仍是启发式匹配，新增厂商模型名可能需要补充规则。
- Billing / quota / auth impact: 不影响计费、配额或认证，仅影响供应商元信息和展示。
- Follow-ups: 如需保留或清理频道管理中的历史 `iflytek`/`sparkdesk` 分类，可另行处理。

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved automatic vendor recognition for Codex, Muse, Meta, iFlyTek, and Tencent models.
  - Added more accurate handling for similarly named model families, including Spark variants.
  - Updated Meta model categorization and vendor icon display.
- **Bug Fixes**
  - Corrected provider badges and default vendor assignments for affected models.
  - Ensured matching follows a consistent priority order for overlapping model names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->