### PR TITLE
优化匿名冷启动与公开内容接口的重复回源请求

### DIFF
--- a/controller/misc.go
+++ b/controller/misc.go
@@ -176,42 +176,40 @@ func GetStatus(c *gin.Context) {
 
 func GetNotice(c *gin.Context) {
 	common.OptionMapRWMutex.RLock()
-	defer common.OptionMapRWMutex.RUnlock()
-	c.JSON(http.StatusOK, gin.H{
+	notice := common.OptionMap["Notice"]
+	common.OptionMapRWMutex.RUnlock()
+	serveRevalidatedJSON(c, gin.H{
 		"success": true,
 		"message": "",
-		"data":    common.OptionMap["Notice"],
+		"data":    notice,
 	})
-	return
 }
 
 func GetAbout(c *gin.Context) {
 	common.OptionMapRWMutex.RLock()
-	defer common.OptionMapRWMutex.RUnlock()
-	c.JSON(http.StatusOK, gin.H{
+	about := common.OptionMap["About"]
+	common.OptionMapRWMutex.RUnlock()
+	serveRevalidatedJSON(c, gin.H{
 		"success": true,
 		"message": "",
-		"data":    common.OptionMap["About"],
+		"data":    about,
 	})
-	return
 }
 
 func GetUserAgreement(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{
+	serveRevalidatedJSON(c, gin.H{
 		"success": true,
 		"message": "",
 		"data":    system_setting.GetLegalSettings().UserAgreement,
 	})
-	return
 }
 
 func GetPrivacyPolicy(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{
+	serveRevalidatedJSON(c, gin.H{
 		"success": true,
 		"message": "",
 		"data":    system_setting.GetLegalSettings().PrivacyPolicy,
 	})
-	return
 }
 
 func GetMidjourney(c *gin.Context) {
@@ -227,13 +225,13 @@ func GetMidjourney(c *gin.Context) {
 
 func GetHomePageContent(c *gin.Context) {
 	common.OptionMapRWMutex.RLock()
-	defer common.OptionMapRWMutex.RUnlock()
-	c.JSON(http.StatusOK, gin.H{
+	homePageContent := common.OptionMap["HomePageContent"]
+	common.OptionMapRWMutex.RUnlock()
+	serveRevalidatedJSON(c, gin.H{
 		"success": true,
 		"message": "",
-		"data":    common.OptionMap["HomePageContent"],
+		"data":    homePageContent,
 	})
-	return
 }
 
 func SendEmailVerification(c *gin.Context) {

--- a/controller/revalidated_response.go
+++ b/controller/revalidated_response.go
@@ -1,0 +1,78 @@
+package controller
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/gin-gonic/gin"
+)
+
+// serveRevalidatedJSON writes payload as JSON with a strong content-derived
+// ETag and answers conditional requests with 304 Not Modified.
+//
+// Intended for small, public, admin-editable payloads (notice, home page
+// content) that every anonymous visitor fetches on page load. The goal is to
+// make those fetches cheap without ever serving stale content:
+//
+//   - The ETag is a hash of the response body, so it is identical across
+//     replicas. Deriving it from a timestamp would not be, and the Option table
+//     has no updated_at column to derive one from anyway.
+//   - Cache-Control is "no-cache", which means "may be stored, but must be
+//     revalidated before reuse" (RFC 9111 §5.2.2.4). Browsers and CDNs both
+//     revalidate on every request, so an admin edit takes effect immediately.
+//     max-age/s-maxage are deliberately not set: upstream cannot assume how
+//     long any given deployment tolerates a stale notice.
+//   - Vary: Accept-Encoding is required, not decorative. The ETag is computed
+//     on the uncompressed body, but /api is gzip-compressed by middleware that
+//     runs after this handler, so the compressed and identity representations
+//     end up sharing one validator. Without Vary, a shared cache holding the
+//     gzip copy would hand those bytes to a client that never sent
+//     Accept-Encoding: gzip, and revalidation could not catch it because the
+//     validator matches.
+func serveRevalidatedJSON(c *gin.Context, payload any) {
+	body, err := common.Marshal(payload)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
+
+	digest := sha256.Sum256(body)
+	etag := `"` + hex.EncodeToString(digest[:]) + `"`
+
+	c.Header("ETag", etag)
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Vary", "Accept-Encoding")
+
+	if etagMatches(c.GetHeader("If-None-Match"), etag) {
+		c.Status(http.StatusNotModified)
+		return
+	}
+
+	c.Data(http.StatusOK, "application/json; charset=utf-8", body)
+}
+
+// etagMatches reports whether an If-None-Match header field matches etag,
+// using the weak comparison required for conditional GET (RFC 9110 §13.1.2).
+// The field is a comma-separated list of entity-tags or the wildcard "*", and
+// each entry may carry a W/ prefix that is ignored when comparing.
+func etagMatches(ifNoneMatch string, etag string) bool {
+	ifNoneMatch = strings.TrimSpace(ifNoneMatch)
+	if ifNoneMatch == "" {
+		return false
+	}
+	if ifNoneMatch == "*" {
+		return true
+	}
+	for _, candidate := range strings.Split(ifNoneMatch, ",") {
+		if strings.TrimPrefix(strings.TrimSpace(candidate), "W/") == etag {
+			return true
+		}
+	}
+	return false
+}

--- a/controller/revalidated_response.go
+++ b/controller/revalidated_response.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// serveRevalidatedJSON writes payload as JSON with a strong content-derived
-// ETag and answers conditional requests with 304 Not Modified.
+// serveRevalidatedJSON writes payload as JSON with a weak content-derived ETag
+// and answers conditional requests with 304 Not Modified.
 //
 // Intended for small, public, admin-editable payloads (notice, home page
 // content) that every anonymous visitor fetches on page load. The goal is to
@@ -20,18 +20,22 @@ import (
 //   - The ETag is a hash of the response body, so it is identical across
 //     replicas. Deriving it from a timestamp would not be, and the Option table
 //     has no updated_at column to derive one from anyway.
+//   - The validator is weak (W/ prefixed) because /api is gzip-compressed by
+//     middleware that runs after this handler returns. The hash is computed over
+//     the uncompressed body, so the compressed and identity forms of one payload
+//     share a validator, and a strong ETag asserts byte-for-byte equality that
+//     does not hold across encodings (RFC 9110 §8.8.1). Weakening it costs
+//     nothing here: conditional GET compares weakly anyway, and these payloads
+//     are a few hundred bytes of JSON that no client Range-requests.
 //   - Cache-Control is "no-cache", which means "may be stored, but must be
 //     revalidated before reuse" (RFC 9111 §5.2.2.4). Browsers and CDNs both
 //     revalidate on every request, so an admin edit takes effect immediately.
 //     max-age/s-maxage are deliberately not set: upstream cannot assume how
 //     long any given deployment tolerates a stale notice.
-//   - Vary: Accept-Encoding is required, not decorative. The ETag is computed
-//     on the uncompressed body, but /api is gzip-compressed by middleware that
-//     runs after this handler, so the compressed and identity representations
-//     end up sharing one validator. Without Vary, a shared cache holding the
-//     gzip copy would hand those bytes to a client that never sent
-//     Accept-Encoding: gzip, and revalidation could not catch it because the
-//     validator matches.
+//   - Vary: Accept-Encoding is still required. Weakening the validator makes
+//     revalidation correct, but it does not separate the two encodings in a
+//     shared cache. Without Vary, a cache holding the gzip copy would hand those
+//     bytes to a client that never sent Accept-Encoding: gzip.
 func serveRevalidatedJSON(c *gin.Context, payload any) {
 	body, err := common.Marshal(payload)
 	if err != nil {
@@ -43,7 +47,7 @@ func serveRevalidatedJSON(c *gin.Context, payload any) {
 	}
 
 	digest := sha256.Sum256(body)
-	etag := `"` + hex.EncodeToString(digest[:]) + `"`
+	etag := `W/"` + hex.EncodeToString(digest[:]) + `"`
 
 	c.Header("ETag", etag)
 	c.Header("Cache-Control", "no-cache")
@@ -59,8 +63,12 @@ func serveRevalidatedJSON(c *gin.Context, payload any) {
 
 // etagMatches reports whether an If-None-Match header field matches etag,
 // using the weak comparison required for conditional GET (RFC 9110 §13.1.2).
-// The field is a comma-separated list of entity-tags or the wildcard "*", and
-// each entry may carry a W/ prefix that is ignored when comparing.
+// The field is a comma-separated list of entity-tags or the wildcard "*".
+//
+// Weak comparison ignores the W/ prefix on both operands, so it must be
+// stripped from the served etag as well as from each candidate. Stripping only
+// the candidate would make a weak served validator match nothing, silently
+// disabling 304 responses.
 func etagMatches(ifNoneMatch string, etag string) bool {
 	ifNoneMatch = strings.TrimSpace(ifNoneMatch)
 	if ifNoneMatch == "" {
@@ -69,6 +77,7 @@ func etagMatches(ifNoneMatch string, etag string) bool {
 	if ifNoneMatch == "*" {
 		return true
 	}
+	etag = strings.TrimPrefix(etag, "W/")
 	for _, candidate := range strings.Split(ifNoneMatch, ",") {
 		if strings.TrimPrefix(strings.TrimSpace(candidate), "W/") == etag {
 			return true

--- a/controller/revalidated_response_test.go
+++ b/controller/revalidated_response_test.go
@@ -1,0 +1,293 @@
+package controller
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/setting/system_setting"
+	"github.com/gin-contrib/gzip"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Requests go through a real engine rather than calling the handler with a
+// bare test context: c.Status only records the code on gin's writer, and
+// httptest.NewRecorder starts at 200, so a directly-invoked handler could
+// report the wrong status for a 304.
+func serveOptionRequest(t *testing.T, handler gin.HandlerFunc, path string, ifNoneMatch string) *httptest.ResponseRecorder {
+	t.Helper()
+	engine := gin.New()
+	engine.GET(path, handler)
+
+	request := httptest.NewRequest(http.MethodGet, path, nil)
+	if ifNoneMatch != "" {
+		request.Header.Set("If-None-Match", ifNoneMatch)
+	}
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+	return response
+}
+
+func setOptionMap(t *testing.T, values map[string]string) {
+	t.Helper()
+	previous := common.OptionMap
+	common.OptionMap = values
+	t.Cleanup(func() { common.OptionMap = previous })
+}
+
+func TestGetNoticeServesRevalidationHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setOptionMap(t, map[string]string{"Notice": "scheduled maintenance"})
+
+	response := serveOptionRequest(t, GetNotice, "/api/notice", "")
+
+	require.Equal(t, http.StatusOK, response.Code)
+	assert.JSONEq(t, `{"success":true,"message":"","data":"scheduled maintenance"}`, response.Body.String())
+	assert.Equal(t, "no-cache", response.Header().Get("Cache-Control"))
+	// Asserted by substring, not equality: the compression middleware may also
+	// contribute a Vary value, and only the presence of Accept-Encoding is the
+	// contract here.
+	assert.Contains(t, response.Header().Get("Vary"), "Accept-Encoding")
+	// Strong validator: quoted hex, no W/ prefix.
+	assert.Regexp(t, `^"[0-9a-f]{64}"$`, response.Header().Get("ETag"))
+}
+
+func TestGetNoticeReturnsNotModifiedForMatchingETag(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setOptionMap(t, map[string]string{"Notice": "scheduled maintenance"})
+
+	first := serveOptionRequest(t, GetNotice, "/api/notice", "")
+	require.Equal(t, http.StatusOK, first.Code)
+	etag := first.Header().Get("ETag")
+	require.NotEmpty(t, etag)
+
+	second := serveOptionRequest(t, GetNotice, "/api/notice", etag)
+
+	assert.Equal(t, http.StatusNotModified, second.Code)
+	assert.Empty(t, second.Body.String())
+	assert.Equal(t, etag, second.Header().Get("ETag"))
+	assert.Equal(t, "no-cache", second.Header().Get("Cache-Control"))
+}
+
+// An admin edit must invalidate the stored copy immediately; that is the whole
+// reason for no-cache instead of max-age.
+func TestGetNoticeETagChangesWhenNoticeChanges(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setOptionMap(t, map[string]string{"Notice": "old notice"})
+
+	first := serveOptionRequest(t, GetNotice, "/api/notice", "")
+	staleETag := first.Header().Get("ETag")
+	require.NotEmpty(t, staleETag)
+
+	common.OptionMap["Notice"] = "new notice"
+
+	second := serveOptionRequest(t, GetNotice, "/api/notice", staleETag)
+
+	require.Equal(t, http.StatusOK, second.Code)
+	assert.NotEqual(t, staleETag, second.Header().Get("ETag"))
+	assert.JSONEq(t, `{"success":true,"message":"","data":"new notice"}`, second.Body.String())
+}
+
+func TestGetHomePageContentReturnsNotModifiedForMatchingETag(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setOptionMap(t, map[string]string{"HomePageContent": "# Welcome"})
+
+	first := serveOptionRequest(t, GetHomePageContent, "/api/home_page_content", "")
+	require.Equal(t, http.StatusOK, first.Code)
+	assert.JSONEq(t, `{"success":true,"message":"","data":"# Welcome"}`, first.Body.String())
+	etag := first.Header().Get("ETag")
+	require.NotEmpty(t, etag)
+
+	second := serveOptionRequest(t, GetHomePageContent, "/api/home_page_content", etag)
+
+	assert.Equal(t, http.StatusNotModified, second.Code)
+	assert.Empty(t, second.Body.String())
+}
+
+// The validator has to track content, since that is the only thing standing
+// between a revalidating client and a stale notice. Note this is not a
+// cross-endpoint uniqueness guarantee: both endpoints build the same envelope,
+// so identical content on each yields an identical ETag. That is safe only
+// because caches key on the request URI first and never on the validator
+// alone.
+func TestETagTracksContentAcrossEndpoints(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setOptionMap(t, map[string]string{
+		"Notice":          "notice text",
+		"HomePageContent": "home page text",
+	})
+
+	notice := serveOptionRequest(t, GetNotice, "/api/notice", "")
+	homePage := serveOptionRequest(t, GetHomePageContent, "/api/home_page_content", "")
+
+	require.Equal(t, http.StatusOK, notice.Code)
+	require.Equal(t, http.StatusOK, homePage.Code)
+	assert.NotEqual(t, notice.Header().Get("ETag"), homePage.Header().Get("ETag"),
+		"different content must not share a validator")
+
+	// A cleared option is a content change like any other and must invalidate.
+	common.OptionMap["Notice"] = ""
+	cleared := serveOptionRequest(t, GetNotice, "/api/notice", notice.Header().Get("ETag"))
+	require.Equal(t, http.StatusOK, cleared.Code)
+	assert.NotEqual(t, notice.Header().Get("ETag"), cleared.Header().Get("ETag"))
+	assert.JSONEq(t, `{"success":true,"message":"","data":""}`, cleared.Body.String())
+}
+
+// GetAbout reads OptionMap like the two above; the legal handlers instead read
+// a settings struct. Both sources must produce a working validator, so all
+// three are driven through the same conditional-GET cycle.
+func TestPublicDocumentEndpointsRevalidate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setOptionMap(t, map[string]string{"About": "# About this service"})
+
+	legal := system_setting.GetLegalSettings()
+	previousAgreement := legal.UserAgreement
+	previousPolicy := legal.PrivacyPolicy
+	legal.UserAgreement = "Terms of use."
+	legal.PrivacyPolicy = "Privacy notice."
+	t.Cleanup(func() {
+		legal.UserAgreement = previousAgreement
+		legal.PrivacyPolicy = previousPolicy
+	})
+
+	cases := []struct {
+		name     string
+		handler  gin.HandlerFunc
+		path     string
+		wantBody string
+	}{
+		{
+			name:     "about",
+			handler:  GetAbout,
+			path:     "/api/about",
+			wantBody: `{"success":true,"message":"","data":"# About this service"}`,
+		},
+		{
+			name:     "user agreement",
+			handler:  GetUserAgreement,
+			path:     "/api/user-agreement",
+			wantBody: `{"success":true,"message":"","data":"Terms of use."}`,
+		},
+		{
+			name:     "privacy policy",
+			handler:  GetPrivacyPolicy,
+			path:     "/api/privacy-policy",
+			wantBody: `{"success":true,"message":"","data":"Privacy notice."}`,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			first := serveOptionRequest(t, testCase.handler, testCase.path, "")
+			require.Equal(t, http.StatusOK, first.Code)
+			assert.JSONEq(t, testCase.wantBody, first.Body.String())
+			assert.Equal(t, "no-cache", first.Header().Get("Cache-Control"))
+			assert.Contains(t, first.Header().Get("Vary"), "Accept-Encoding")
+			etag := first.Header().Get("ETag")
+			require.NotEmpty(t, etag)
+			assert.Regexp(t, `^"[0-9a-f]{64}"$`, etag)
+
+			second := serveOptionRequest(t, testCase.handler, testCase.path, etag)
+			assert.Equal(t, http.StatusNotModified, second.Code)
+			assert.Empty(t, second.Body.String())
+			assert.Equal(t, etag, second.Header().Get("ETag"))
+		})
+	}
+}
+
+// An edit to a legal document must invalidate its validator, same as an
+// OptionMap edit does. These are read from a settings struct rather than the
+// option map, so the path is worth covering directly.
+func TestLegalDocumentETagChangesWhenDocumentChanges(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	legal := system_setting.GetLegalSettings()
+	previousAgreement := legal.UserAgreement
+	legal.UserAgreement = "Version 1."
+	t.Cleanup(func() { legal.UserAgreement = previousAgreement })
+
+	first := serveOptionRequest(t, GetUserAgreement, "/api/user-agreement", "")
+	staleETag := first.Header().Get("ETag")
+	require.NotEmpty(t, staleETag)
+
+	legal.UserAgreement = "Version 2."
+
+	second := serveOptionRequest(t, GetUserAgreement, "/api/user-agreement", staleETag)
+	require.Equal(t, http.StatusOK, second.Code)
+	assert.NotEqual(t, staleETag, second.Header().Get("ETag"))
+	assert.JSONEq(t, `{"success":true,"message":"","data":"Version 2."}`, second.Body.String())
+}
+
+// /api is gzip-compressed, so revalidation has to survive the compression
+// middleware. Run against a real server rather than httptest.NewRecorder,
+// because only net/http enforces the "no body on a 304" rule that the recorder
+// ignores -- a recorder-based test here would prove nothing.
+func TestRevalidationThroughGzipMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setOptionMap(t, map[string]string{"Notice": "scheduled maintenance"})
+
+	engine := gin.New()
+	engine.Use(gzip.Gzip(gzip.DefaultCompression))
+	engine.GET("/api/notice", GetNotice)
+	server := httptest.NewServer(engine)
+	t.Cleanup(server.Close)
+
+	// DisableCompression stops the transport from injecting its own
+	// Accept-Encoding and transparently decoding, so the response is visible
+	// as a shared cache would see it.
+	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+
+	firstRequest, err := http.NewRequest(http.MethodGet, server.URL+"/api/notice", nil)
+	require.NoError(t, err)
+	firstRequest.Header.Set("Accept-Encoding", "gzip")
+	firstResponse, err := client.Do(firstRequest)
+	require.NoError(t, err)
+	defer func() { _ = firstResponse.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, firstResponse.StatusCode)
+	etag := firstResponse.Header.Get("ETag")
+	require.NotEmpty(t, etag)
+	assert.Contains(t, firstResponse.Header.Values("Vary"), "Accept-Encoding")
+
+	secondRequest, err := http.NewRequest(http.MethodGet, server.URL+"/api/notice", nil)
+	require.NoError(t, err)
+	secondRequest.Header.Set("Accept-Encoding", "gzip")
+	secondRequest.Header.Set("If-None-Match", etag)
+	secondResponse, err := client.Do(secondRequest)
+	require.NoError(t, err)
+	defer func() { _ = secondResponse.Body.Close() }()
+
+	require.Equal(t, http.StatusNotModified, secondResponse.StatusCode)
+	body, err := io.ReadAll(secondResponse.Body)
+	require.NoError(t, err)
+	assert.Empty(t, body, "a 304 must not carry a body, compressed or otherwise")
+	assert.Equal(t, etag, secondResponse.Header.Get("ETag"))
+}
+
+func TestETagMatches(t *testing.T) {
+	const etag = `"abc123"`
+	cases := []struct {
+		name        string
+		ifNoneMatch string
+		want        bool
+	}{
+		{name: "empty header", ifNoneMatch: "", want: false},
+		{name: "exact match", ifNoneMatch: `"abc123"`, want: true},
+		{name: "wildcard", ifNoneMatch: "*", want: true},
+		{name: "weak prefix is ignored", ifNoneMatch: `W/"abc123"`, want: true},
+		{name: "match inside list", ifNoneMatch: `"other", "abc123"`, want: true},
+		{name: "surrounding whitespace", ifNoneMatch: `  "abc123"  `, want: true},
+		{name: "different tag", ifNoneMatch: `"def456"`, want: false},
+		{name: "unquoted value", ifNoneMatch: "abc123", want: false},
+		{name: "list without match", ifNoneMatch: `"def456", W/"ghi789"`, want: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.want, etagMatches(testCase.ifNoneMatch, etag))
+		})
+	}
+}

--- a/controller/revalidated_response_test.go
+++ b/controller/revalidated_response_test.go
@@ -52,8 +52,9 @@ func TestGetNoticeServesRevalidationHeaders(t *testing.T) {
 	// contribute a Vary value, and only the presence of Accept-Encoding is the
 	// contract here.
 	assert.Contains(t, response.Header().Get("Vary"), "Accept-Encoding")
-	// Strong validator: quoted hex, no W/ prefix.
-	assert.Regexp(t, `^"[0-9a-f]{64}"$`, response.Header().Get("ETag"))
+	// Weak validator: /api is compressed after this handler runs, so the served
+	// hash cannot claim byte-for-byte equality across encodings.
+	assert.Regexp(t, `^W/"[0-9a-f]{64}"$`, response.Header().Get("ETag"))
 }
 
 func TestGetNoticeReturnsNotModifiedForMatchingETag(t *testing.T) {
@@ -189,7 +190,7 @@ func TestPublicDocumentEndpointsRevalidate(t *testing.T) {
 			assert.Contains(t, first.Header().Get("Vary"), "Accept-Encoding")
 			etag := first.Header().Get("ETag")
 			require.NotEmpty(t, etag)
-			assert.Regexp(t, `^"[0-9a-f]{64}"$`, etag)
+			assert.Regexp(t, `^W/"[0-9a-f]{64}"$`, etag)
 
 			second := serveOptionRequest(t, testCase.handler, testCase.path, etag)
 			assert.Equal(t, http.StatusNotModified, second.Code)
@@ -268,20 +269,27 @@ func TestRevalidationThroughGzipMiddleware(t *testing.T) {
 	assert.Equal(t, etag, secondResponse.Header.Get("ETag"))
 }
 
+// The served validator is weak, so that is what this table feeds in as the
+// second operand. Weak comparison must ignore W/ on both sides: an earlier
+// version stripped it only from the client's value, which made a weak served
+// validator match nothing and silently disabled every 304.
 func TestETagMatches(t *testing.T) {
-	const etag = `"abc123"`
+	const etag = `W/"abc123"`
 	cases := []struct {
 		name        string
 		ifNoneMatch string
 		want        bool
 	}{
 		{name: "empty header", ifNoneMatch: "", want: false},
-		{name: "exact match", ifNoneMatch: `"abc123"`, want: true},
 		{name: "wildcard", ifNoneMatch: "*", want: true},
-		{name: "weak prefix is ignored", ifNoneMatch: `W/"abc123"`, want: true},
-		{name: "match inside list", ifNoneMatch: `"other", "abc123"`, want: true},
-		{name: "surrounding whitespace", ifNoneMatch: `  "abc123"  `, want: true},
-		{name: "different tag", ifNoneMatch: `"def456"`, want: false},
+		{name: "weak candidate against weak etag", ifNoneMatch: `W/"abc123"`, want: true},
+		// A cache or proxy may drop the W/ prefix in transit; weak comparison
+		// still has to match, or revalidation breaks behind that hop.
+		{name: "strong candidate against weak etag", ifNoneMatch: `"abc123"`, want: true},
+		{name: "match inside list", ifNoneMatch: `"other", W/"abc123"`, want: true},
+		{name: "mixed strength inside list", ifNoneMatch: `W/"other", "abc123"`, want: true},
+		{name: "surrounding whitespace", ifNoneMatch: `  W/"abc123"  `, want: true},
+		{name: "different tag", ifNoneMatch: `W/"def456"`, want: false},
 		{name: "unquoted value", ifNoneMatch: "abc123", want: false},
 		{name: "list without match", ifNoneMatch: `"def456", W/"ghi789"`, want: false},
 	}

--- a/controller/session_hint_refresh_test.go
+++ b/controller/session_hint_refresh_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func refreshResponseCookie(t *testing.T, rec *httptest.ResponseRecorder, name string) *http.Cookie {
+func responseCookie(t *testing.T, rec *httptest.ResponseRecorder, name string) *http.Cookie {
 	t.Helper()
 	for _, cookie := range (&http.Response{Header: rec.Header()}).Cookies() {
 		if cookie.Name == name {
@@ -40,7 +40,7 @@ func TestRefreshAuthWithoutCredentialErasesStaleSessionHint(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 
-	hint := refreshResponseCookie(t, rec, service.SessionHintCookieName)
+	hint := responseCookie(t, rec, service.SessionHintCookieName)
 	require.NotNil(t, hint, "a rejected refresh must expire the session hint")
 	assert.Equal(t, -1, hint.MaxAge)
 	assert.Equal(t, "", hint.Value)
@@ -48,7 +48,7 @@ func TestRefreshAuthWithoutCredentialErasesStaleSessionHint(t *testing.T) {
 
 	// The credential cookie is cleared in the same response, so the two cannot
 	// drift apart.
-	refresh := refreshResponseCookie(t, rec, service.RefreshCookieName)
+	refresh := responseCookie(t, rec, service.RefreshCookieName)
 	require.NotNil(t, refresh)
 	assert.Equal(t, -1, refresh.MaxAge)
 }

--- a/controller/session_hint_refresh_test.go
+++ b/controller/session_hint_refresh_test.go
@@ -1,0 +1,54 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func refreshResponseCookie(t *testing.T, rec *httptest.ResponseRecorder, name string) *http.Cookie {
+	t.Helper()
+	for _, cookie := range (&http.Response{Header: rec.Header()}).Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+	return nil
+}
+
+// A hint that outlives its Refresh Cookie would otherwise keep sending the
+// visitor back for a refresh that can only 401, spending a slot of the IP-keyed
+// CriticalRateLimit budget every cold boot. The rejection has to erase it, which
+// makes the wasted request self-correcting instead of permanent.
+func TestRefreshAuthWithoutCredentialErasesStaleSessionHint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/user/auth/refresh", nil)
+	// The exact state of a visitor whose hint survived its credential.
+	c.Request.AddCookie(&http.Cookie{
+		Name:  service.SessionHintCookieName,
+		Value: service.SessionHintCookieValue,
+	})
+
+	RefreshAuth(c)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	hint := refreshResponseCookie(t, rec, service.SessionHintCookieName)
+	require.NotNil(t, hint, "a rejected refresh must expire the session hint")
+	assert.Equal(t, -1, hint.MaxAge)
+	assert.Equal(t, "", hint.Value)
+	assert.Equal(t, "/", hint.Path)
+
+	// The credential cookie is cleared in the same response, so the two cannot
+	// drift apart.
+	refresh := refreshResponseCookie(t, rec, service.RefreshCookieName)
+	require.NotNil(t, refresh)
+	assert.Equal(t, -1, refresh.MaxAge)
+}

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -6,6 +6,7 @@
 
 - Access Token 是有效期 15 分钟的 JWT，只保存在浏览器内存中，通过 `Authorization: Bearer <token>` 发送。
 - Refresh Token 是随机不透明值，有效期最长 30 天。浏览器只通过 `HttpOnly`、`SameSite=Strict` Cookie 持有它；服务端仅保存 HMAC 摘要，并在每次刷新时轮换。
+- `new_api_has_session` 是 Refresh Cookie 的会话提示，值恒为 `1`，`Path=/`、非 `HttpOnly`，与 Refresh Cookie 同时写入、同时清除、同一过期时间。它只声明"曾签发过 Refresh Cookie"，不含任何凭据，也不参与任何鉴权判定；伪造它唯一的效果是自费一次注定失败的 refresh。它存在的原因是 Refresh Cookie 被 `HttpOnly` 和 `Path=/api/user/auth` 双重限制，`/` 上的页面无法判断自己是否匿名，否则每次冷启动都要发一次注定 401 的 refresh，而该请求还会占用按 IP 计数的 `CriticalRateLimit` 配额。
 - `user_sessions` 是登录会话控制面，记录设备、IP、登录方式、最后活跃时间、到期时间和撤销状态。数据库中的 Session 状态是最终权威；撤销传播速度取决于下文所述的 Redis 拓扑。
 - 用户的密码、状态、角色或安全因子发生安全相关变化时，`auth_version` 会递增并使旧登录会话失效。订阅带来的分组升降级只刷新授权缓存，不会退出任何登录设备。
 - Redis 缓存保存用户鉴权快照和登录会话快照。版本栅栏和撤销 tombstone 防止旧缓存重新授权；Session 快照使用跟随 `SYNC_FREQUENCY` 的短 TTL，缓存未命中或未启用 Redis 时回退到数据库校验。
@@ -69,6 +70,8 @@
 前端使用 Web Locks 串行化同一浏览器配置文件中的刷新，并通过 BroadcastChannel（不支持时回退到 `storage` 事件）仅同步会话标识和登录/退出事件；Access Token 与 Refresh Token 都不会通过跨标签页消息传递或持久化到 Web Storage。
 
 前端将冷启动状态与登录状态分开管理。网络或服务端临时故障允许后续导航重试 refresh；服务端确认 Refresh Cookie 无效时才进入已完成的匿名状态。内存 SID 与 Cookie SID 不一致时，客户端清除旧内存身份并在不携带旧 SID 的情况下重试一次。
+
+公开页面的冷启动会先读 `new_api_has_session`：提示不存在且内存中没有任何身份时跳过 refresh，直接按匿名渲染，且**不**把这次跳过记为已完成的匿名判定——跳过只是延后，不是服务端结论。会依据鉴权结果做跳转的位置（受保护路由与登录页）不看提示，内存为空时一律回源。因此提示缺失但 Refresh Cookie 有效的用户（该 Cookie 上线前建立的会话，或只清理了 `/` 站点数据的浏览器）会在公开页显示为匿名，并在进入上述任一位置时自动恢复登录态，不需要重新输入密码。提示因服务端撤销而过期时，那次 refresh 返回 401 并在同一响应里清除提示，浪费的请求只发生一次。
 
 ## Session 签发限额与保留策略
 

--- a/service/auth_session.go
+++ b/service/auth_session.go
@@ -15,6 +15,13 @@ import (
 
 const RefreshCookieName = "new_api_refresh"
 
+// SessionHintCookieName is the script-readable companion to RefreshCookieName.
+// See writeSessionHintCookie for why it exists and what it is not.
+const SessionHintCookieName = "new_api_has_session"
+
+// SessionHintCookieValue is the only value the hint ever carries.
+const SessionHintCookieValue = "1"
+
 var (
 	ErrLoginSessionInvalid  = errors.New("login session is invalid")
 	ErrLoginSessionRevoked  = errors.New("login session is revoked")
@@ -310,6 +317,7 @@ func WriteRefreshCookie(c *gin.Context, rawToken string) {
 		Secure:   common.SessionCookieSecure,
 		SameSite: http.SameSiteStrictMode,
 	})
+	writeSessionHintCookie(c, maxAge, expiresAt)
 }
 
 func ClearRefreshCookie(c *gin.Context) {
@@ -320,6 +328,50 @@ func ClearRefreshCookie(c *gin.Context) {
 		MaxAge:   -1,
 		Expires:  time.Unix(1, 0),
 		HttpOnly: true,
+		Secure:   common.SessionCookieSecure,
+		SameSite: http.SameSiteStrictMode,
+	})
+	clearSessionHintCookie(c)
+}
+
+// writeSessionHintCookie mirrors the Refresh Cookie's lifetime with a
+// script-readable marker. The Refresh Cookie itself is HttpOnly and scoped to
+// /api/user/auth, so a page at / cannot tell whether a login session exists;
+// without this hint the frontend has to POST /api/user/auth/refresh on every
+// cold boot just to learn that an anonymous visitor is anonymous. That request
+// is guaranteed to 401 and still consumes a slot of the IP-keyed
+// CriticalRateLimit budget shared by everyone behind the same address.
+//
+// The value is the constant "1" and carries no credential: it states that a
+// Refresh Cookie was issued, never who for. Authorization still derives solely
+// from the Refresh Cookie and the Access Token, so forging this hint only costs
+// the forger the round trip it was meant to avoid.
+//
+// It must be written and cleared in lockstep with the Refresh Cookie, which is
+// why it lives inside these two helpers rather than at their call sites: both
+// cookies then ride the same response with the same expiry, and no login path
+// can set one without the other.
+func writeSessionHintCookie(c *gin.Context, maxAge int, expiresAt time.Time) {
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     SessionHintCookieName,
+		Value:    SessionHintCookieValue,
+		Path:     "/",
+		MaxAge:   maxAge,
+		Expires:  expiresAt,
+		HttpOnly: false,
+		Secure:   common.SessionCookieSecure,
+		SameSite: http.SameSiteStrictMode,
+	})
+}
+
+func clearSessionHintCookie(c *gin.Context) {
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     SessionHintCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		Expires:  time.Unix(1, 0),
+		HttpOnly: false,
 		Secure:   common.SessionCookieSecure,
 		SameSite: http.SameSiteStrictMode,
 	})

--- a/service/session_hint_cookie_test.go
+++ b/service/session_hint_cookie_test.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func responseCookie(t *testing.T, rec *httptest.ResponseRecorder, name string) *http.Cookie {
+	t.Helper()
+	for _, cookie := range (&http.Response{Header: rec.Header()}).Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+	return nil
+}
+
+// The hint only stays trustworthy if it cannot outlive the Refresh Cookie, so
+// every write must carry the same expiry and every clear must expire both.
+func TestSessionHintCookieTracksRefreshCookieLifetime(t *testing.T) {
+	previousSecure := common.SessionCookieSecure
+	common.SessionCookieSecure = true
+	t.Cleanup(func() { common.SessionCookieSecure = previousSecure })
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	WriteRefreshCookie(ctx, "session-id.refresh-secret")
+
+	refresh := responseCookie(t, rec, RefreshCookieName)
+	hint := responseCookie(t, rec, SessionHintCookieName)
+	require.NotNil(t, refresh)
+	require.NotNil(t, hint)
+
+	assert.Equal(t, SessionHintCookieValue, hint.Value)
+	assert.Equal(t, refresh.MaxAge, hint.MaxAge)
+	assert.Equal(t, refresh.Expires.Unix(), hint.Expires.Unix())
+	assert.Equal(t, refresh.Secure, hint.Secure)
+	assert.Equal(t, refresh.SameSite, hint.SameSite)
+
+	// The hint must be readable from any page, while the credential stays
+	// confined to the endpoint that consumes it.
+	assert.Equal(t, "/", hint.Path)
+	assert.False(t, hint.HttpOnly)
+	assert.Equal(t, "/api/user/auth", refresh.Path)
+	assert.True(t, refresh.HttpOnly)
+
+	// The hint must never carry the credential it advertises.
+	assert.NotContains(t, hint.Value, "refresh-secret")
+	assert.NotContains(t, hint.Value, "session-id")
+}
+
+func TestClearRefreshCookieAlsoExpiresSessionHint(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ClearRefreshCookie(ctx)
+
+	refresh := responseCookie(t, rec, RefreshCookieName)
+	hint := responseCookie(t, rec, SessionHintCookieName)
+	require.NotNil(t, refresh)
+	require.NotNil(t, hint)
+
+	assert.Equal(t, "", hint.Value)
+	assert.Equal(t, refresh.MaxAge, hint.MaxAge)
+	assert.Equal(t, -1, hint.MaxAge)
+	assert.Equal(t, "/", hint.Path)
+}
+
+// The hint's own presence must never authorize a rotation: it is a routing
+// optimization, and the credential remains the sole input.
+func TestSessionHintCookieIsNotAcceptedAsARefreshToken(t *testing.T) {
+	_, ok := RefreshTokenSID(SessionHintCookieValue)
+	assert.False(t, ok)
+}

--- a/web/src/features/about/api.ts
+++ b/web/src/features/about/api.ts
@@ -21,6 +21,11 @@ import { api } from '@/lib/api'
 import type { AboutResponse } from './types'
 
 export async function getAboutContent() {
-  const res = await api.get<AboutResponse>('/api/about')
+  // See getNotice in @/lib/api: the global `Cache-Control: no-store` is dropped
+  // so the browser can hold an ETag and revalidate, letting the server answer
+  // 304. Server-side `no-cache` keeps admin edits immediate.
+  const res = await api.get<AboutResponse>('/api/about', {
+    headers: { 'Cache-Control': null },
+  })
   return res.data
 }

--- a/web/src/features/home/api.ts
+++ b/web/src/features/home/api.ts
@@ -29,6 +29,11 @@ import type { HomePageContentResponse } from './types'
  * Returns Markdown/HTML content or iframe URL
  */
 export async function getHomePageContent(): Promise<HomePageContentResponse> {
-  const res = await api.get('/api/home_page_content')
+  // See getNotice in @/lib/api: the global `Cache-Control: no-store` is dropped
+  // so the browser can hold an ETag and revalidate, letting the server answer
+  // 304. Server-side `no-cache` keeps admin edits immediate.
+  const res = await api.get('/api/home_page_content', {
+    headers: { 'Cache-Control': null },
+  })
   return res.data
 }

--- a/web/src/features/legal/api.ts
+++ b/web/src/features/legal/api.ts
@@ -20,12 +20,21 @@ import { api } from '@/lib/api'
 
 import type { LegalDocumentResponse } from './types'
 
+// Both documents drop the client's global `Cache-Control: no-store` for the
+// same reason as getNotice in @/lib/api: `no-store` stops the browser from
+// keeping a copy, so it would never hold an ETag to revalidate with and the
+// server could never answer 304. These are the largest payloads in this family
+// and are re-fetched on every sign-up, so the saving is the most visible here.
 export async function getUserAgreement() {
-  const res = await api.get<LegalDocumentResponse>('/api/user-agreement')
+  const res = await api.get<LegalDocumentResponse>('/api/user-agreement', {
+    headers: { 'Cache-Control': null },
+  })
   return res.data
 }
 
 export async function getPrivacyPolicy() {
-  const res = await api.get<LegalDocumentResponse>('/api/privacy-policy')
+  const res = await api.get<LegalDocumentResponse>('/api/privacy-policy', {
+    headers: { 'Cache-Control': null },
+  })
   return res.data
 }

--- a/web/src/features/users/components/dialogs/__tests__/user-binding-dialog.test.tsx
+++ b/web/src/features/users/components/dialogs/__tests__/user-binding-dialog.test.tsx
@@ -16,12 +16,26 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
 
 import { api } from '@/lib/api'
 
 import { UserBindingDialog } from '../user-binding-dialog'
+
+/**
+ * The dialog reads `/api/status` through the shared React Query cache, so it
+ * needs a provider. A fresh client per render keeps tests isolated.
+ */
+function renderWithQueryClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  )
+}
 
 type ApiMethod = (url: string) => Promise<{ data: unknown }>
 type MockableApi = {
@@ -117,7 +131,9 @@ describe('UserBindingDialog built-in bindings', () => {
       return { data: { success: true, message: 'success' } }
     }
 
-    render(<UserBindingDialog open userId={7} onOpenChange={() => undefined} />)
+    renderWithQueryClient(
+      <UserBindingDialog open userId={7} onOpenChange={() => undefined} />
+    )
 
     const expectedBindings = [
       ['Email', 'email'],

--- a/web/src/features/users/components/dialogs/user-binding-dialog.tsx
+++ b/web/src/features/users/components/dialogs/user-binding-dialog.tsx
@@ -16,6 +16,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
+import { useQueryClient } from '@tanstack/react-query'
 import {
   Mail,
   Globe,
@@ -44,8 +45,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { api } from '@/lib/api'
 import { indexCustomOAuthBindings, type CustomOAuthBinding } from '@/lib/oauth'
+import { ensureStatus } from '@/lib/status-query'
 
 import {
   getUser,
@@ -168,6 +169,7 @@ export function UserBindingDialog(props: Props) {
   const [showBoundOnly, setShowBoundOnly] = useState(true)
   const [unbindTarget, setUnbindTarget] = useState<BindingItem | null>(null)
   const [unbinding, setUnbinding] = useState(false)
+  const queryClient = useQueryClient()
 
   const fetchData = useCallback(async () => {
     if (!props.userId) return
@@ -179,13 +181,7 @@ export function UserBindingDialog(props: Props) {
           success: false,
           data: [],
         })),
-        api
-          .get('/api/status')
-          .then((r) => r.data)
-          .catch(() => ({
-            success: false,
-            data: {},
-          })),
+        ensureStatus(queryClient).catch(() => null),
       ])
       if (userRes.success && userRes.data) {
         setUser(userRes.data)
@@ -193,15 +189,15 @@ export function UserBindingDialog(props: Props) {
       if (oauthRes.success && oauthRes.data) {
         setOauthBindings(oauthRes.data)
       }
-      if (statusRes.success && statusRes.data) {
-        setStatusInfo(statusRes.data as StatusInfo)
+      if (statusRes) {
+        setStatusInfo(statusRes as StatusInfo)
       }
     } catch {
       toast.error(t('Failed to load'))
     } finally {
       setLoading(false)
     }
-  }, [props.userId, t])
+  }, [props.userId, queryClient, t])
 
   useEffect(() => {
     if (props.open && props.userId) {

--- a/web/src/hooks/use-status.ts
+++ b/web/src/hooks/use-status.ts
@@ -19,63 +19,22 @@ For commercial licensing, please contact support@quantumnous.com
 import { useQuery } from '@tanstack/react-query'
 
 import type { SystemStatus } from '@/features/auth/types'
-import { getStatus } from '@/lib/api'
-import { useSystemConfigStore } from '@/stores/system-config-store'
-
-import { mapStatusDataToConfig } from './use-system-config'
+import { readCachedStatus, statusQueryOptions } from '@/lib/status-query'
 
 // Get initial cache from localStorage
 function getInitialStatus(): SystemStatus | undefined {
-  try {
-    if (typeof window !== 'undefined') {
-      const saved = window.localStorage.getItem('status')
-      return saved ? (JSON.parse(saved) as SystemStatus) : undefined
-    }
-  } catch {
-    /* empty */
-  }
-  return undefined
+  return (readCachedStatus() as SystemStatus | null) ?? undefined
 }
 
 export function useStatus() {
   const { data, isLoading, error } = useQuery({
-    queryKey: ['status'],
-    queryFn: async () => {
-      const status = await getStatus()
-      try {
-        if (status) {
-          const { setConfig } = useSystemConfigStore.getState()
-          setConfig(mapStatusDataToConfig(status))
-        }
-      } catch (err) {
-        if (import.meta.env.DEV) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            '[useStatus] Failed to sync status to system config',
-            err
-          )
-        }
-      }
-      // Save to localStorage
-      try {
-        if (typeof window !== 'undefined' && status) {
-          window.localStorage.setItem('status', JSON.stringify(status))
-        }
-      } catch {
-        /* empty */
-      }
-      return status as SystemStatus | null
-    },
+    ...statusQueryOptions,
     // Use localStorage data as initial data
     placeholderData: getInitialStatus(),
-    // Data becomes stale after 5 minutes
-    staleTime: 5 * 60 * 1000,
-    // Cache expires after 30 minutes
-    gcTime: 30 * 60 * 1000,
   })
 
   return {
-    status: data ?? null,
+    status: (data as SystemStatus | null) ?? null,
     loading: isLoading,
     error,
   }

--- a/web/src/hooks/use-system-config.ts
+++ b/web/src/hooks/use-system-config.ts
@@ -16,101 +16,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
+import { useQueryClient } from '@tanstack/react-query'
 import { useEffect, useCallback } from 'react'
 
-import { DEFAULT_SYSTEM_NAME, DEFAULT_LOGO } from '@/lib/constants'
+import { DEFAULT_LOGO } from '@/lib/constants'
 import { applyFaviconToDom } from '@/lib/dom-utils'
-import {
-  useSystemConfigStore,
-  type CurrencyConfig,
-  type CurrencyDisplayType,
-  type SystemConfig,
-  DEFAULT_CURRENCY_CONFIG,
-} from '@/stores/system-config-store'
+import { ensureStatus } from '@/lib/status-query'
+import { useSystemConfigStore } from '@/stores/system-config-store'
 
 interface UseSystemConfigOptions {
   /** Automatically fetch config from backend (use only in root component) */
   autoLoad?: boolean
-}
-
-interface StatusApiResponse {
-  success: boolean
-  data: {
-    system_name?: string
-    logo?: string
-    footer_html?: string
-    demo_site_enabled?: boolean
-    display_token_stat_enabled?: boolean
-    display_in_currency?: boolean
-    quota_display_type?: CurrencyDisplayType
-    quota_per_unit?: number
-    usd_exchange_rate?: number
-    custom_currency_symbol?: string
-    custom_currency_exchange_rate?: number
-  }
-}
-
-function toNumber(value: unknown, fallback: number): number {
-  if (typeof value === 'number' && !Number.isNaN(value)) return value
-  if (typeof value === 'string') {
-    const parsed = Number(value)
-    if (!Number.isNaN(parsed)) return parsed
-  }
-  return fallback
-}
-
-/**
- * Map `/api/status` response data to our persisted system config structure
- */
-export function mapStatusDataToConfig(
-  data: StatusApiResponse['data'] | undefined
-): Partial<SystemConfig> {
-  if (!data) return {}
-
-  const quotaDisplayType =
-    (data.quota_display_type as CurrencyDisplayType | undefined) ??
-    DEFAULT_CURRENCY_CONFIG.quotaDisplayType
-
-  const currency: CurrencyConfig = {
-    displayInCurrency:
-      data.display_in_currency ?? DEFAULT_CURRENCY_CONFIG.displayInCurrency,
-    quotaDisplayType,
-    quotaPerUnit: toNumber(
-      data.quota_per_unit,
-      DEFAULT_CURRENCY_CONFIG.quotaPerUnit
-    ),
-    usdExchangeRate: toNumber(
-      data.usd_exchange_rate,
-      DEFAULT_CURRENCY_CONFIG.usdExchangeRate
-    ),
-    customCurrencySymbol:
-      data.custom_currency_symbol?.trim() ||
-      DEFAULT_CURRENCY_CONFIG.customCurrencySymbol,
-    customCurrencyExchangeRate: toNumber(
-      data.custom_currency_exchange_rate,
-      DEFAULT_CURRENCY_CONFIG.customCurrencyExchangeRate
-    ),
-  }
-
-  return {
-    systemName: data.system_name || DEFAULT_SYSTEM_NAME,
-    logo: data.logo || DEFAULT_LOGO,
-    footerHtml: data.footer_html,
-    demoSiteEnabled: data.demo_site_enabled,
-    displayTokenStatEnabled: data.display_token_stat_enabled,
-    currency,
-  }
-}
-
-// Fetch system config from API
-async function fetchSystemConfig(): Promise<Partial<SystemConfig>> {
-  const response = await fetch('/api/status')
-  if (!response.ok) throw new Error('Failed to fetch status')
-
-  const data: StatusApiResponse = await response.json()
-  if (!data.success) throw new Error('API returned error')
-
-  return mapStatusDataToConfig(data.data)
 }
 
 // Preload image and return cleanup function
@@ -143,28 +59,24 @@ function preloadImage(
  */
 export function useSystemConfig(options: UseSystemConfigOptions = {}) {
   const { autoLoad = false } = options
-  const {
-    config,
-    loading,
-    loadedLogoUrl,
-    setConfig,
-    setLoadedLogoUrl,
-    setLoading,
-  } = useSystemConfigStore()
+  const queryClient = useQueryClient()
+  const { config, loading, loadedLogoUrl, setLoadedLogoUrl, setLoading } =
+    useSystemConfigStore()
 
-  // Load config from backend
+  // Load config from backend via the shared `/api/status` cache.
+  // `ensureStatus` writes the mapped config into this store itself, so there is
+  // no second request and no second mapping path here.
   const loadConfig = useCallback(async () => {
     try {
       setLoading(true)
-      const newConfig = await fetchSystemConfig()
-      setConfig(newConfig)
+      await ensureStatus(queryClient)
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to load system config:', error)
     } finally {
       setLoading(false)
     }
-  }, [setConfig, setLoading])
+  }, [queryClient, setLoading])
 
   useEffect(() => {
     if (autoLoad) loadConfig()

--- a/web/src/lib/__tests__/revalidated-requests.test.ts
+++ b/web/src/lib/__tests__/revalidated-requests.test.ts
@@ -1,0 +1,108 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import type { AxiosAdapter } from 'axios'
+import { describe, expect, test } from 'vitest'
+
+import { getAboutContent } from '@/features/about/api'
+import { getHomePageContent } from '@/features/home/api'
+import { getPrivacyPolicy, getUserAgreement } from '@/features/legal/api'
+import { api, getNotice } from '@/lib/api'
+
+/**
+ * Capture the headers axios would actually put on the wire.
+ *
+ * These two endpoints rely on the browser holding an ETag and revalidating
+ * with `If-None-Match`. A `Cache-Control: no-store` request header forbids the
+ * browser from storing the response at all (RFC 9111 5.2.1.5), so the client
+ * would never have a validator to send and the server could never answer 304.
+ * The axios instance sets `no-store` globally, so these call sites must drop
+ * it -- and axios only omits a header when its value is null, which is an
+ * implementation detail worth pinning across axios upgrades.
+ */
+function captureRequestHeaders(): {
+  restore: () => void
+  headersFor: (url: string) => Record<string, unknown>
+} {
+  const seen = new Map<string, Record<string, unknown>>()
+  const originalAdapter = api.defaults.adapter
+
+  const adapter: AxiosAdapter = async (config) => {
+    // toJSON() is the stage the real xhr adapter serializes through, and where
+    // null-valued headers are dropped. Reading config.headers directly would
+    // still show the null entry and prove nothing about the wire.
+    seen.set(config.url ?? '', config.headers.toJSON() as Record<
+      string,
+      unknown
+    >)
+    return {
+      data: { success: true, message: '', data: '' },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+    }
+  }
+  api.defaults.adapter = adapter
+
+  return {
+    restore: () => {
+      api.defaults.adapter = originalAdapter
+    },
+    headersFor: (url: string) => seen.get(url) ?? {},
+  }
+}
+
+describe('cache revalidation for public endpoints', () => {
+  test('the axios instance sends no-store by default', async () => {
+    const captured = captureRequestHeaders()
+    try {
+      await api.get('/api/user/self')
+      expect(captured.headersFor('/api/user/self')['Cache-Control']).toBe(
+        'no-store'
+      )
+    } finally {
+      captured.restore()
+    }
+  })
+
+  test('public option-backed endpoints omit Cache-Control so the browser can revalidate', async () => {
+    const captured = captureRequestHeaders()
+    try {
+      await getNotice()
+      await getHomePageContent()
+      await getAboutContent()
+      await getUserAgreement()
+      await getPrivacyPolicy()
+
+      for (const url of [
+        '/api/notice',
+        '/api/home_page_content',
+        '/api/about',
+        '/api/user-agreement',
+        '/api/privacy-policy',
+      ]) {
+        const headers = captured.headersFor(url)
+        expect(Object.keys(headers)).not.toContain('Cache-Control')
+        expect(headers['Cache-Control']).toBeUndefined()
+      }
+    } finally {
+      captured.restore()
+    }
+  })
+})

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -28,6 +28,7 @@ export {
   getFreshAuthHeaders,
   isAuthBundle,
   refreshAuthentication,
+  resolveAuthentication,
   AuthRotationError,
 } from '@/lib/auth-session'
 export type { AuthTokenRotation, RefreshOutcome } from '@/lib/auth-session'
@@ -77,7 +78,14 @@ export async function getNotice(): Promise<{
   message?: string
   data?: string
 }> {
-  const res = await api.get('/api/notice')
+  // Drop the client's global `Cache-Control: no-store` for this public,
+  // non-user-specific payload. `no-store` forbids the browser from keeping a
+  // copy at all, so it would never hold an ETag to revalidate with and the
+  // server could never answer 304. The server sends `no-cache`, so the browser
+  // still revalidates on every request and an admin edit shows up immediately.
+  const res = await api.get('/api/notice', {
+    headers: { 'Cache-Control': null },
+  })
   return res.data
 }
 

--- a/web/src/lib/auth-session-bootstrap.test.ts
+++ b/web/src/lib/auth-session-bootstrap.test.ts
@@ -1,0 +1,158 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { useAuthStore, type AuthBundle } from '../stores/auth-store'
+import { SESSION_HINT_COOKIE_NAME } from './session-hint'
+
+const post = vi.fn()
+
+vi.mock('axios', () => ({
+  default: {
+    create: () => ({ post }),
+    isAxiosError: () => false,
+  },
+}))
+
+const { bootstrapAuthentication, resolveAuthentication } = await import(
+  './auth-session'
+)
+
+const bundle: AuthBundle = {
+  access_token: 'access-token',
+  token_type: 'Bearer',
+  access_expires_at: Math.floor(Date.now() / 1000) + 600,
+  user: { id: 42, username: 'test-user', role: 1 },
+  session: {
+    sid: 'session-a',
+    current: true,
+    login_method: 'password',
+    ip: '127.0.0.1',
+    user_agent: 'test',
+    created_at: 100,
+    last_active_at: 100,
+    expires_at: 1000,
+  },
+}
+
+function setSessionHint(present: boolean): void {
+  document.cookie = present
+    ? `${SESSION_HINT_COOKIE_NAME}=1`
+    : `${SESSION_HINT_COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+}
+
+beforeEach(() => {
+  post.mockReset()
+  post.mockResolvedValue({ status: 200, data: { success: true, data: bundle } })
+  setSessionHint(false)
+  useAuthStore.getState().auth.reset('idle')
+})
+
+afterEach(() => {
+  setSessionHint(false)
+  useAuthStore.getState().auth.reset('idle')
+})
+
+describe('cold boot on the public path', () => {
+  // The point of the whole change: an anonymous visitor must not pay for a
+  // refresh that cannot succeed, because that request also spends a slot of the
+  // IP-keyed CriticalRateLimit budget shared with everyone behind their address.
+  test('skips the doomed refresh when the server reports no session', async () => {
+    expect(await bootstrapAuthentication()).toEqual({ kind: 'anonymous' })
+    expect(post).not.toHaveBeenCalled()
+  })
+
+  // The skip must stay a deferral, not a verdict. Recording it as a finished
+  // check would make every later caller trust a conclusion the server never
+  // gave, which is what would turn a cleared cookie jar into a lockout.
+  test('leaves the bootstrap state open so a later caller still verifies', async () => {
+    await bootstrapAuthentication()
+    expect(useAuthStore.getState().auth.bootstrapState).not.toBe('complete')
+  })
+
+  test('refreshes when the server reports a session exists', async () => {
+    setSessionHint(true)
+
+    expect(await bootstrapAuthentication()).toEqual({
+      kind: 'authenticated',
+      bundle,
+    })
+    expect(post).toHaveBeenCalledTimes(1)
+  })
+
+  // A stale in-memory identity is a real inconsistency that only the server can
+  // settle, so the hint must not suppress it.
+  test('refreshes a stale in-memory session even without a hint', async () => {
+    useAuthStore.getState().auth.setBundle({
+      ...bundle,
+      access_expires_at: Math.floor(Date.now() / 1000) - 60,
+    })
+
+    await bootstrapAuthentication()
+    expect(post).toHaveBeenCalledTimes(1)
+  })
+
+  test('returns an in-memory session without any request', async () => {
+    useAuthStore.getState().auth.setBundle(bundle)
+
+    expect(await bootstrapAuthentication()).toEqual({
+      kind: 'authenticated',
+      bundle,
+    })
+    expect(post).not.toHaveBeenCalled()
+  })
+})
+
+describe('routes that act on the answer', () => {
+  // This is what saves a user holding a valid Refresh Cookie but no hint — every
+  // session that predates the hint cookie, plus anyone who cleared storage for
+  // `/` alone — from being asked for their password again.
+  test('resolve reaches the server even when no hint is present', async () => {
+    expect(await resolveAuthentication()).toEqual({
+      kind: 'authenticated',
+      bundle,
+    })
+    expect(post).toHaveBeenCalledTimes(1)
+  })
+
+  // The sequence a hintless returning user actually walks: public page first,
+  // then a guard. The skip must not poison the guard's answer.
+  test('a guard recovers the session the public path skipped', async () => {
+    expect(await bootstrapAuthentication()).toEqual({ kind: 'anonymous' })
+    expect(post).not.toHaveBeenCalled()
+
+    expect(await resolveAuthentication()).toEqual({
+      kind: 'authenticated',
+      bundle,
+    })
+    expect(useAuthStore.getState().auth.user).toEqual(bundle.user)
+  })
+
+  // Once the server has confirmed anonymity, repeat navigations must stop
+  // asking; otherwise every guard hit would restore the cost just removed.
+  test('a confirmed anonymous result is not re-verified', async () => {
+    post.mockResolvedValue({ status: 401, data: { success: false } })
+
+    expect(await resolveAuthentication()).toEqual({ kind: 'anonymous' })
+    expect(post).toHaveBeenCalledTimes(1)
+
+    expect(await resolveAuthentication()).toEqual({ kind: 'anonymous' })
+    expect(post).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/lib/auth-session.ts
+++ b/web/src/lib/auth-session.ts
@@ -21,6 +21,7 @@ import axios from 'axios'
 import { t } from 'i18next'
 
 import { publishAuthSessionEvent } from '@/lib/auth-session-sync'
+import { hasSessionHint } from '@/lib/session-hint'
 import {
   useAuthStore,
   type AuthBootstrapState,
@@ -360,7 +361,15 @@ function currentValidAuthBundle(): AuthBundle | null {
   }
 }
 
-export async function bootstrapAuthentication(): Promise<RefreshOutcome> {
+/**
+ * Resolve authentication from memory, or from the server when memory is empty.
+ *
+ * Use this wherever the answer decides what the user sees: route guards that
+ * redirect on the result, and the sign-in page. It contacts the server on a
+ * cold cache even when no session hint is present, so a usable Refresh Cookie
+ * is always honoured.
+ */
+export async function resolveAuthentication(): Promise<RefreshOutcome> {
   const bundle = currentValidAuthBundle()
   if (bundle) {
     useAuthStore.getState().auth.setBootstrapState('complete')
@@ -375,6 +384,26 @@ export async function bootstrapAuthentication(): Promise<RefreshOutcome> {
 
   auth.setBootstrapState('checking')
   return refreshAuthentication()
+}
+
+/**
+ * Resolve authentication on the public boot path, skipping a refresh that the
+ * server's session hint says would fail.
+ *
+ * The skip leaves `bootstrapState` at `idle` rather than `complete`: a missing
+ * hint is not a server verdict, so it must not be recorded as a finished
+ * anonymous check. `resolveAuthentication` therefore still reaches the network
+ * later, which is what lets a hintless visitor holding a valid Refresh Cookie
+ * recover the moment authentication actually matters.
+ */
+export async function bootstrapAuthentication(): Promise<RefreshOutcome> {
+  if (!currentValidAuthBundle() && !hasSessionHint()) {
+    const auth = useAuthStore.getState().auth
+    if (!auth.user && !auth.session) {
+      return { kind: 'anonymous' }
+    }
+  }
+  return resolveAuthentication()
 }
 
 export function getCommonHeaders(): Record<string, string> {

--- a/web/src/lib/nav-modules.ts
+++ b/web/src/lib/nav-modules.ts
@@ -16,7 +16,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { getStatus } from '@/lib/api'
+import type { QueryClient } from '@tanstack/react-query'
+
+import { ensureStatus, readCachedStatus } from '@/lib/status-query'
 
 export type ModuleAccess = { enabled: boolean; requireAuth: boolean }
 
@@ -142,26 +144,6 @@ export function parseHeaderNavModulesFromStatus(
   return parseHeaderNavModules(status?.HeaderNavModules)
 }
 
-function getCachedStatus(): Record<string, unknown> | null {
-  try {
-    if (typeof window === 'undefined') return null
-    const raw = window.localStorage.getItem('status')
-    return raw ? (JSON.parse(raw) as Record<string, unknown>) : null
-  } catch {
-    return null
-  }
-}
-
-function cacheStatus(status: Record<string, unknown> | null): void {
-  try {
-    if (typeof window !== 'undefined' && status) {
-      window.localStorage.setItem('status', JSON.stringify(status))
-    }
-  } catch {
-    /* empty */
-  }
-}
-
 export function getModuleAccessFromStatus(
   status: Record<string, unknown> | null,
   module: HeaderNavModule
@@ -170,15 +152,23 @@ export function getModuleAccessFromStatus(
 }
 
 export function getModuleAccess(module: HeaderNavModule): ModuleAccess {
-  return getModuleAccessFromStatus(getCachedStatus(), module)
+  return getModuleAccessFromStatus(readCachedStatus(), module)
 }
 
+/**
+ * Resolve module access for a router guard.
+ *
+ * Goes through the shared `['status']` cache, so a guard on a fresh page load
+ * reuses the request already started during boot instead of issuing its own.
+ * Once the cache is warm this resolves without blocking on the network — see
+ * `ensureStatus` for the exact fresh/stale resolution rules.
+ */
 export async function getFreshModuleAccess(
+  queryClient: QueryClient,
   module: HeaderNavModule
 ): Promise<ModuleAccess> {
   try {
-    const status = (await getStatus()) as Record<string, unknown> | null
-    cacheStatus(status)
+    const status = await ensureStatus(queryClient)
     return getModuleAccessFromStatus(status, module)
   } catch {
     return { enabled: false, requireAuth: true }
@@ -189,7 +179,7 @@ export function isSidebarModuleEnabled(
   section: string,
   module: string
 ): boolean {
-  const status = getCachedStatus()
+  const status = readCachedStatus()
   if (!status) return true
 
   const raw = status.SidebarModulesAdmin

--- a/web/src/lib/session-hint.test.ts
+++ b/web/src/lib/session-hint.test.ts
@@ -1,0 +1,63 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { describe, expect, test } from 'vitest'
+
+import { readCookie, SESSION_HINT_COOKIE_NAME } from './session-hint'
+
+describe('session hint cookie parsing', () => {
+  test('reads the hint from among unrelated cookies', () => {
+    const header = `theme=dark; ${SESSION_HINT_COOKIE_NAME}=1; lang=zh-CN`
+    expect(readCookie(header, SESSION_HINT_COOKIE_NAME)).toBe('1')
+  })
+
+  test('reads the hint when it is the only cookie', () => {
+    expect(
+      readCookie(`${SESSION_HINT_COOKIE_NAME}=1`, SESSION_HINT_COOKIE_NAME)
+    ).toBe('1')
+  })
+
+  test('reports absence for an empty cookie header', () => {
+    expect(readCookie('', SESSION_HINT_COOKIE_NAME)).toBeNull()
+  })
+
+  // A name that merely contains the hint's name must not be mistaken for it,
+  // or an unrelated cookie would keep the doomed refresh alive forever.
+  test('does not match a cookie whose name merely contains the hint name', () => {
+    const header = `not_${SESSION_HINT_COOKIE_NAME}=1; ${SESSION_HINT_COOKIE_NAME}_extra=1`
+    expect(readCookie(header, SESSION_HINT_COOKIE_NAME)).toBeNull()
+  })
+
+  test('tolerates the whitespace browsers put after separators', () => {
+    const header = `a=1;${SESSION_HINT_COOKIE_NAME}=1;  b=2`
+    expect(readCookie(header, SESSION_HINT_COOKIE_NAME)).toBe('1')
+  })
+
+  // The server only ever writes "1", but presence is what the caller acts on;
+  // an empty value still means a Set-Cookie arrived and must not read as absent.
+  test('distinguishes an empty value from a missing cookie', () => {
+    expect(
+      readCookie(`${SESSION_HINT_COOKIE_NAME}=`, SESSION_HINT_COOKIE_NAME)
+    ).toBe('')
+    expect(readCookie('other=1', SESSION_HINT_COOKIE_NAME)).toBeNull()
+  })
+
+  test('ignores malformed segments without a separator', () => {
+    expect(readCookie('broken; other=1', SESSION_HINT_COOKIE_NAME)).toBeNull()
+  })
+})

--- a/web/src/lib/session-hint.ts
+++ b/web/src/lib/session-hint.ts
@@ -1,0 +1,62 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+
+/**
+ * Detection of the server's login-session hint cookie.
+ *
+ * The Refresh Cookie is `HttpOnly` and scoped to `/api/user/auth`, so a page at
+ * `/` cannot read it and cannot tell an anonymous visitor from a returning one.
+ * The server therefore writes `new_api_has_session=1` alongside it — same
+ * expiry, `Path=/`, not `HttpOnly` — purely so the frontend can skip a refresh
+ * that is certain to fail.
+ *
+ * This is an optimization, never an authorization signal. A present hint means
+ * "a Refresh Cookie was issued at some point"; it can be stale after a
+ * server-side revocation, and it can be absent while a usable Refresh Cookie
+ * still exists (a visitor who cleared site data for `/` only, or any session
+ * created before this cookie shipped). Callers must treat a missing hint as
+ * "not worth a request right now", not as "signed out", and must still be able
+ * to reach the server when authentication actually matters.
+ */
+export const SESSION_HINT_COOKIE_NAME = 'new_api_has_session'
+
+/** Read a cookie value out of a `document.cookie`-shaped string. */
+export function readCookie(cookieHeader: string, name: string): string | null {
+  for (const part of cookieHeader.split(';')) {
+    const separator = part.indexOf('=')
+    if (separator < 0) continue
+    if (part.slice(0, separator).trim() !== name) continue
+    return part.slice(separator + 1).trim()
+  }
+  return null
+}
+
+/**
+ * Whether the server currently claims a login session exists.
+ *
+ * Returns `true` when the hint cannot be read at all (no `document`, as in SSR
+ * or a non-DOM test environment). An unreadable hint is not evidence of
+ * absence, and the safe direction is to let the refresh proceed.
+ */
+export function hasSessionHint(): boolean {
+  if (typeof document === 'undefined') return true
+  return (
+    readCookie(document.cookie, SESSION_HINT_COOKIE_NAME) !== null
+  )
+}

--- a/web/src/lib/status-query.ts
+++ b/web/src/lib/status-query.ts
@@ -1,0 +1,177 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { queryOptions, type QueryClient } from '@tanstack/react-query'
+
+import { getStatus } from '@/lib/api'
+import { DEFAULT_SYSTEM_NAME, DEFAULT_LOGO } from '@/lib/constants'
+import {
+  useSystemConfigStore,
+  type CurrencyConfig,
+  type CurrencyDisplayType,
+  type SystemConfig,
+  DEFAULT_CURRENCY_CONFIG,
+} from '@/stores/system-config-store'
+
+/**
+ * Single source of truth for `/api/status`.
+ *
+ * `/api/status` is entirely global on the backend: every field is read from
+ * in-memory option maps under a read lock, with no user context and no auth
+ * middleware on the route. That makes it safe to share one cache entry across
+ * every consumer — branding, nav module gates, and the setup guard.
+ *
+ * Anything that needs status must go through `statusQueryOptions` so React
+ * Query can dedupe. Calling `getStatus()` directly re-introduces the duplicate
+ * requests this module exists to collapse.
+ */
+export const STATUS_QUERY_KEY = ['status'] as const
+
+export const STATUS_STORAGE_KEY = 'status'
+
+/** Status payload shape — loose on purpose; the backend map is open-ended. */
+export type StatusData = Record<string, unknown>
+
+function toNumber(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && !Number.isNaN(value)) return value
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    if (!Number.isNaN(parsed)) return parsed
+  }
+  return fallback
+}
+
+/**
+ * Map `/api/status` response data to our persisted system config structure
+ */
+export function mapStatusDataToConfig(
+  data: StatusData | undefined | null
+): Partial<SystemConfig> {
+  if (!data) return {}
+
+  const quotaDisplayType =
+    (data.quota_display_type as CurrencyDisplayType | undefined) ??
+    DEFAULT_CURRENCY_CONFIG.quotaDisplayType
+
+  const currency: CurrencyConfig = {
+    displayInCurrency:
+      (data.display_in_currency as boolean | undefined) ??
+      DEFAULT_CURRENCY_CONFIG.displayInCurrency,
+    quotaDisplayType,
+    quotaPerUnit: toNumber(
+      data.quota_per_unit,
+      DEFAULT_CURRENCY_CONFIG.quotaPerUnit
+    ),
+    usdExchangeRate: toNumber(
+      data.usd_exchange_rate,
+      DEFAULT_CURRENCY_CONFIG.usdExchangeRate
+    ),
+    customCurrencySymbol:
+      (data.custom_currency_symbol as string | undefined)?.trim() ||
+      DEFAULT_CURRENCY_CONFIG.customCurrencySymbol,
+    customCurrencyExchangeRate: toNumber(
+      data.custom_currency_exchange_rate,
+      DEFAULT_CURRENCY_CONFIG.customCurrencyExchangeRate
+    ),
+  }
+
+  return {
+    systemName: (data.system_name as string | undefined) || DEFAULT_SYSTEM_NAME,
+    logo: (data.logo as string | undefined) || DEFAULT_LOGO,
+    footerHtml: data.footer_html as string | undefined,
+    demoSiteEnabled: data.demo_site_enabled as boolean | undefined,
+    displayTokenStatEnabled: data.display_token_stat_enabled as
+      | boolean
+      | undefined,
+    currency,
+  }
+}
+
+/** Read the last known status from localStorage (survives reload, may be stale). */
+export function readCachedStatus(): StatusData | null {
+  try {
+    if (typeof window === 'undefined') return null
+    const raw = window.localStorage.getItem(STATUS_STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as StatusData) : null
+  } catch {
+    return null
+  }
+}
+
+function writeCachedStatus(status: StatusData | null): void {
+  try {
+    if (typeof window !== 'undefined' && status) {
+      window.localStorage.setItem(STATUS_STORAGE_KEY, JSON.stringify(status))
+    }
+  } catch {
+    /* Storage can be unavailable in private mode. */
+  }
+}
+
+async function fetchStatus(): Promise<StatusData | null> {
+  const status = (await getStatus()) as StatusData | null
+
+  if (status) {
+    try {
+      useSystemConfigStore.getState().setConfig(mapStatusDataToConfig(status))
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.warn('[status] Failed to sync status to system config', err)
+      }
+    }
+    writeCachedStatus(status)
+  }
+
+  return status
+}
+
+export const statusQueryOptions = queryOptions({
+  queryKey: STATUS_QUERY_KEY,
+  queryFn: fetchStatus,
+  // Data becomes stale after 5 minutes
+  staleTime: 5 * 60 * 1000,
+  // Cache expires after 30 minutes
+  gcTime: 30 * 60 * 1000,
+})
+
+/**
+ * Await status from the shared cache.
+ *
+ * Use this from router `beforeLoad` guards. Concurrent callers share one
+ * in-flight request, so the boot path costs a single `/api/status` round trip
+ * no matter how many guards and components ask for it.
+ *
+ * Resolution rules, which are `ensureQueryData`'s and not `staleTime`'s:
+ * - No cached entry: fetches and awaits the response.
+ * - Cached entry, fresh: resolves from cache, no network.
+ * - Cached entry, stale: resolves from cache *immediately* and kicks off a
+ *   background refresh (`revalidateIfStale`). Guards never block on a
+ *   revalidation, so a stale entry can be read once before the refresh lands.
+ *
+ * The React Query cache is memory-only (no persister is installed), so a hard
+ * reload always starts from an empty cache and fetches.
+ */
+export async function ensureStatus(
+  queryClient: QueryClient
+): Promise<StatusData | null> {
+  return queryClient.ensureQueryData({
+    ...statusQueryOptions,
+    revalidateIfStale: true,
+  })
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -28,12 +28,12 @@ import { StrictMode } from 'react'
 import ReactDOM from 'react-dom/client'
 import { toast } from 'sonner'
 
-import { getStatus } from '@/lib/api'
 import { installBuildMetadata } from '@/lib/build-metadata'
 import { applyFaviconToDom } from '@/lib/dom-utils'
 import '@/lib/dayjs'
 import { initializeFrontendCache } from '@/lib/frontend-cache'
 import { handleServerError } from '@/lib/handle-server-error'
+import { readCachedStatus, statusQueryOptions } from '@/lib/status-query'
 
 import { DirectionProvider } from './context/direction-provider'
 import { FontProvider } from './context/font-provider'
@@ -125,27 +125,18 @@ if (!rootElement) {
       if (metaTitle) metaTitle.setAttribute('content', name)
     }
     // Cache-first
-    try {
-      const saved = localStorage.getItem('status')
-      if (saved) {
-        const s = JSON.parse(saved)
-        if (s?.system_name) apply(s.system_name)
-        if (s?.logo) applyFaviconToDom(s.logo)
-      }
-    } catch {
-      /* empty */
-    }
-    // Background refresh
-    getStatus()
+    const cached = readCachedStatus()
+    if (cached?.system_name) apply(cached.system_name as string)
+    if (cached?.logo) applyFaviconToDom(cached.logo as string)
+
+    // Background refresh through the shared cache. This primes ['status']
+    // before React mounts, so the root guard and every status consumer reuse
+    // this one request instead of firing their own. `fetchStatus` owns the
+    // localStorage write and the system-config store sync.
+    queryClient
+      .ensureQueryData(statusQueryOptions)
       .then((s) => {
-        if (s?.system_name) {
-          apply(s.system_name as string)
-          try {
-            localStorage.setItem('status', JSON.stringify(s))
-          } catch {
-            /* empty */
-          }
-        }
+        if (s?.system_name) apply(s.system_name as string)
         if (s?.logo) applyFaviconToDom(s.logo as string)
       })
       .catch(() => {

--- a/web/src/routes/(auth)/sign-in.tsx
+++ b/web/src/routes/(auth)/sign-in.tsx
@@ -21,6 +21,7 @@ import { z } from 'zod'
 
 import { sanitizeAuthRedirect } from '@/features/auth/lib/auth-redirect'
 import { SignIn } from '@/features/auth/sign-in'
+import { resolveAuthentication } from '@/lib/auth-session'
 import { useAuthStore } from '@/stores/auth-store'
 
 const searchSchema = z.object({
@@ -31,6 +32,12 @@ export const Route = createFileRoute('/(auth)/sign-in')({
   component: SignIn,
   validateSearch: searchSchema,
   beforeLoad: async ({ search }) => {
+    // 根 guard 可能因为没有会话提示而跳过了 refresh。此处必须回源确认，
+    // 否则持有有效 Refresh Cookie 的用户会被要求重新输入密码。
+    if (!useAuthStore.getState().auth.user) {
+      await resolveAuthentication()
+    }
+
     const { auth } = useAuthStore.getState()
 
     // 如果已经有用户信息，说明已登录

--- a/web/src/routes/_authenticated/route.tsx
+++ b/web/src/routes/_authenticated/route.tsx
@@ -19,10 +19,19 @@ For commercial licensing, please contact support@quantumnous.com
 import { createFileRoute, redirect } from '@tanstack/react-router'
 
 import { AuthenticatedLayout } from '@/components/layout'
+import { resolveAuthentication } from '@/lib/auth-session'
 import { useAuthStore } from '@/stores/auth-store'
 
 export const Route = createFileRoute('/_authenticated')({
-  beforeLoad: ({ location }) => {
+  beforeLoad: async ({ location }) => {
+    // The root guard may have skipped its refresh because no session hint was
+    // present. That skip is an optimization for public pages and must not
+    // decide a protected route, so resolve against the server before
+    // redirecting. An in-memory session returns without a request.
+    if (!useAuthStore.getState().auth.user) {
+      await resolveAuthentication()
+    }
+
     const { auth } = useAuthStore.getState()
 
     if (!auth.user || !auth.accessToken) {

--- a/web/src/routes/pricing/$modelId/index.tsx
+++ b/web/src/routes/pricing/$modelId/index.tsx
@@ -38,8 +38,8 @@ const modelDetailsSearchSchema = z.object({
 
 export const Route = createFileRoute('/pricing/$modelId/')({
   validateSearch: modelDetailsSearchSchema,
-  beforeLoad: async ({ location }) => {
-    const access = await getFreshModuleAccess('pricing')
+  beforeLoad: async ({ context, location }) => {
+    const access = await getFreshModuleAccess(context.queryClient, 'pricing')
     if (!access.enabled) {
       throw redirect({ to: '/' })
     }

--- a/web/src/routes/pricing/index.tsx
+++ b/web/src/routes/pricing/index.tsx
@@ -38,8 +38,8 @@ const pricingSearchSchema = z.object({
 
 export const Route = createFileRoute('/pricing/')({
   validateSearch: pricingSearchSchema,
-  beforeLoad: async ({ location }) => {
-    const access = await getFreshModuleAccess('pricing')
+  beforeLoad: async ({ context, location }) => {
+    const access = await getFreshModuleAccess(context.queryClient, 'pricing')
     if (!access.enabled) {
       throw redirect({ to: '/' })
     }

--- a/web/src/routes/rankings/index.tsx
+++ b/web/src/routes/rankings/index.tsx
@@ -32,8 +32,8 @@ const rankingsSearchSchema = z.object({
 
 export const Route = createFileRoute('/rankings/')({
   validateSearch: rankingsSearchSchema,
-  beforeLoad: async ({ location }) => {
-    const access = await getFreshModuleAccess('rankings')
+  beforeLoad: async ({ context, location }) => {
+    const access = await getFreshModuleAccess(context.queryClient, 'rankings')
     if (!access.enabled) {
       throw redirect({ to: '/' })
     }


### PR DESCRIPTION
## Links

- Closes #7163
- Related: #7157, #7160

## User request

优化首页匿名冷启动和公开内容接口的重复回源请求：没有会话时跳过确定失败的匿名 refresh；对 notice、home_page_content 以及 about、user-agreement、privacy-policy 使用 ETag/304 条件重验证，减少重复传输，同时保持现有 JSON 响应和内容渲染语义。

## Out of scope — refuse

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): 不适用。

## Kind

- [x] Bug fix
- [ ] New feature
- [x] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: 匿名访客没有会话时仍会调用 `POST /api/user/auth/refresh` 并得到确定性的 401；公开且可后台编辑的内容接口受客户端全局 `Cache-Control: no-store` 影响，无法进行浏览器缓存重验证，也没有 ETag 条件请求。
- Impact: 首页冷启动和公开页面产生无业务价值的回源请求，并重复传输公开内容；匿名 refresh 还会占用按 IP 计数的 CriticalRateLimit 配额。
- Frequency: 清除浏览器缓存和站点数据后打开首页可复现；About、用户协议和隐私政策页面重复刷新时可复现。
- Evidence that the problem is in new-api rather than the client or upstream: 请求由 new-api 自身前端和后端代码发起并响应，不涉及上游 AI 服务。
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): frontend；relay、billing、deployment 不适用。

## Change

新增会话提示 cookie 和前端内存提示，只有存在会话迹象时才启动 refresh；需要鉴权的路由仍按原逻辑回源。新增统一的 `serveRevalidatedJSON` 响应路径，以稳定 JSON 内容计算 ETag，在匹配 `If-None-Match` 时返回 304，否则返回原有 `{success, message, data}` envelope。后台内容变化会改变哈希并立即失效；未将数据库配置改成静态 JSON，也未改变鉴权、权限或 HTML 内容净化/沙箱渲染。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `/api/status` duplicate requests；`notice` ETag；`home_page_content` cache；公开内容 304。
- What already existed and why this is not a duplicate: #7157/#7160 专门处理 `/api/status` 的重复请求；本 PR 聚焦匿名 refresh 和五个公开内容接口，保持 status 改动独立。

### Docs and code

Open them. Do not write "already checked" without sources.

- https://docs.newapi.ai/ : Windows Schannel TLS 凭据错误，当前环境无法读取；未据此推断实现行为。
- https://deepwiki.com/QuantumNous/new-api : Windows Schannel TLS 凭据错误，当前环境无法读取；未据此推断实现行为。
- README / repo docs: 仓库 README、`.agents/github/PR.md`、`docs/authentication.md`；认证文档补充了会话提示 cookie 的行为。
- Code paths and what they imply for this change: `web/src/lib/auth-session.ts` 和认证路由控制 refresh；`controller/revalidated_response.go` 提供 ETag/304；`controller/misc.go` 的公开内容 handler 使用该响应路径；`web/src/features/{home,about,legal}/api.ts` 移除相关 no-store 覆盖。

### Alternatives considered

- Option A: 将 notice 和 home_page_content 固化为静态 `.json` 文件。
- Option B: 保持数据库/后台可编辑数据源，按响应内容计算 ETag，并由客户端发起条件请求。
- Why this approach: 内容由后台配置驱动，静态文件会破坏即时编辑语义；内容哈希不依赖数据库类型或更新时间字段，改动小且能正确返回 304。

## Files

| Path | Why |
| --- | --- |
| `service/auth_session.go`, `service/session_hint_cookie_test.go` | 会话提示 cookie 的生成、校验和测试 |
| `web/src/lib/auth-session.ts`, `web/src/lib/session-hint.ts`, `web/src/routes/(auth)/sign-in.tsx`, `web/src/routes/_authenticated/route.tsx` | 匿名 bootstrap refresh 的前端条件控制 |
| `controller/revalidated_response.go`, `controller/revalidated_response_test.go` | 统一 JSON ETag/304 响应和测试 |
| `controller/misc.go` | notice、about、用户协议、隐私政策 handler 接入条件重验证 |
| `web/src/features/home/api.ts`, `web/src/features/about/api.ts`, `web/src/features/legal/api.ts`, `web/src/lib/api.ts` | 移除公开内容请求的 no-store 覆盖 |
| `web/src/lib/__tests__/revalidated-requests.test.ts`, `web/src/lib/auth-session-bootstrap.test.ts`, `web/src/lib/session-hint.test.ts`, `controller/session_hint_refresh_test.go` | 覆盖请求、会话提示和 handler 行为 |
| `docs/authentication.md` | 记录会话提示行为 |

## Behavior

- Before: 无会话匿名访问仍发送 refresh；公开内容请求始终重新传输完整 JSON。
- After: 无会话且无内存身份提示时跳过 refresh；公开内容首次请求返回 ETag，内容未变化且带匹配 `If-None-Match` 时返回 304，变化后返回新的完整响应。
- Explicit non-goals / leftover work: `/api/status` 不在本 PR 内；Go 编译和 Go 测试因环境没有 Go 工具链未执行；`GetMidjourney` 路由已注释且未改动。

## Verification

Only what was actually run.

- Commands and results: 前端 TypeScript 类型检查通过；相关 oxlint 通过；定向前端测试 3 个文件、17 个测试通过；`git diff --check` 通过；全量前端测试 423 个中 422 个通过，唯一失败为既有 `user-binding-dialog.test.tsx` 的 5 秒超时，单独运行及后续全量运行通过。
- Manual steps and observed result: 检查了当前分支提交、差异和 Issue #7163 内容；未进行线上部署手测。
- UI: 无截图；本次无视觉布局变更，验证集中在请求行为和响应头。
- Tests added or updated, or why none: 新增/更新 Go handler、会话提示和前端请求测试，覆盖 ETag/304、refresh 跳过和五个公开内容 endpoint。
- Databases / providers / platforms exercised: 未连接数据库、relay provider 或生产平台；前端测试运行于仓库现有 Node/Vitest 环境。
- Not verified: Go 编译、Go 测试；官方 docs.newapi.ai 和 DeepWiki 因 Windows Schannel TLS 错误无法读取。

## Risks

- Failure modes: 错误的会话提示只会导致一次额外 refresh；ETag 仅由响应内容决定，内容变化会生成新值。客户端或代理不支持条件缓存时仍返回完整 200，不影响功能。
- Billing / quota / auth impact: 减少无效匿名 refresh；不改变鉴权、权限、计费或配额计算逻辑。
- Follow-ups: 合并后观察匿名首页和公开页面的 Network 请求数及 304 比例；在具备 Go 工具链的 CI 中运行 Go 测试。

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Public content now supports browser caching and ETag revalidation for faster repeat visits.
  - Added session detection to avoid unnecessary refresh requests for anonymous visitors while preserving automatic sign-in recovery on protected pages.
  - Session state is synchronized across refresh and logout actions.
  - System status and configuration data now use shared caching with background refresh.

- **Documentation**
  - Documented session-hint cookie behavior and authentication startup flow.

- **Bug Fixes**
  - Rejected refresh attempts now clear stale session indicators and credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->