### PR TITLE
fix(plugin): bill MiniMax-H3 input media usage

### DIFF
--- a/plugins/hailuo_responses_test.go
+++ b/plugins/hailuo_responses_test.go
@@ -37,7 +37,7 @@ func TestHailuoResponsesProtocol(t *testing.T) {
 			"size":     "1920x1080",
 			"metadata": map[string]any{"first_frame_image": "https://cdn.example/frame.png"},
 		},
-		wantUsageKeys:  []string{"resolution", "seconds"},
+		wantUsageKeys:  []string{"input_images", "input_video_seconds", "resolution", "seconds"},
 		wantVendorName: "hailuo",
 	})
 }
@@ -368,15 +368,35 @@ func TestHailuoParseTaskResult(t *testing.T) {
 
 func TestHailuoExtractUsageFacts(t *testing.T) {
 	plugin := loadHailuoPlugin(t)
+	nineReferenceImages := make([]any, 0, 9)
+	for i := 0; i < 9; i++ {
+		nineReferenceImages = append(nineReferenceImages, map[string]any{
+			"type": "image_url", "role": "reference_image", "image_url": map[string]any{"url": "image"},
+		})
+	}
 	testCases := []struct {
 		name    string
 		model   string
 		request map[string]any
 		want    map[string]any
 	}{
-		{"H3 defaults", "MiniMax-H3", map[string]any{"prompt": "p"}, map[string]any{"seconds": float64(5), "resolution": "768P"}},
-		{"H3 2K", "MiniMax-H3", map[string]any{"prompt": "p", "duration": 12, "size": "2K"}, map[string]any{"seconds": float64(12), "resolution": "2K"}},
-		{"legacy model", "MiniMax-Hailuo-2.3", map[string]any{"prompt": "p", "duration": 10}, map[string]any{"seconds": float64(10), "resolution": "768P"}},
+		{"H3 defaults", "MiniMax-H3", map[string]any{"prompt": "p"}, map[string]any{
+			"seconds": float64(5), "resolution": "768P", "input_images": float64(0), "input_video_seconds": float64(0),
+		}},
+		{"H3 2K", "MiniMax-H3", map[string]any{"prompt": "p", "duration": 12, "size": "2K"}, map[string]any{
+			"seconds": float64(12), "resolution": "2K", "input_images": float64(0), "input_video_seconds": float64(0),
+		}},
+		{"H3 reference images", "MiniMax-H3", map[string]any{"prompt": "p", "metadata": map[string]any{"content": nineReferenceImages}}, map[string]any{
+			"seconds": float64(5), "resolution": "768P", "input_images": float64(9), "input_video_seconds": float64(0),
+		}},
+		{"H3 reference video reserves total duration limit", "MiniMax-H3", map[string]any{"prompt": "p", "metadata": map[string]any{
+			"reference_video": []any{"one.mp4", "two.mp4", "three.mp4"},
+		}}, map[string]any{
+			"seconds": float64(5), "resolution": "768P", "input_images": float64(0), "input_video_seconds": float64(15),
+		}},
+		{"legacy model", "MiniMax-Hailuo-2.3", map[string]any{"prompt": "p", "duration": 10}, map[string]any{
+			"seconds": float64(10), "resolution": "768P", "input_images": float64(0), "input_video_seconds": float64(0),
+		}},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -386,6 +406,59 @@ func TestHailuoExtractUsageFacts(t *testing.T) {
 			assert.Equal(t, testCase.want, callHailuoHook(t, plugin, "extractUsage", ctx))
 		})
 	}
+}
+
+func TestHailuoH3CompletionUsageFacts(t *testing.T) {
+	plugin := loadHailuoPlugin(t)
+	testCases := []struct {
+		name string
+		body string
+		want map[string]any
+	}{
+		{
+			name: "actual usage replaces submission estimates",
+			body: `{"task":{"id":"1","status":"succeeded","resolution":"2K","usage":{"output_seconds":5,"input_seconds":7.5,"input_image_count":6}}}`,
+			want: map[string]any{"seconds": float64(5), "resolution": "2K", "input_images": float64(6), "input_video_seconds": float64(7.5)},
+		},
+		{
+			name: "zero actual usage is retained for settlement",
+			body: `{"task":{"id":"1","status":"succeeded","resolution":"768P","usage":{"output_seconds":4,"input_seconds":0,"input_image_count":0}}}`,
+			want: map[string]any{"seconds": float64(4), "resolution": "768P", "input_images": float64(0), "input_video_seconds": float64(0)},
+		},
+		{
+			name: "zero output cannot erase the submission reservation",
+			body: `{"task":{"id":"1","status":"succeeded","resolution":"768P","usage":{"output_seconds":0,"input_seconds":0,"input_image_count":0}}}`,
+			want: map[string]any{"resolution": "768P", "input_images": float64(0), "input_video_seconds": float64(0)},
+		},
+		{
+			name: "missing usage leaves submission estimates untouched",
+			body: `{"task":{"id":"1","status":"succeeded","resolution":"768P"}}`,
+			want: map[string]any{"resolution": "768P"},
+		},
+		{
+			name: "out of contract usage cannot become a billing multiplier",
+			body: `{"task":{"id":"1","status":"succeeded","resolution":"2K","usage":{"output_seconds":16,"input_seconds":16,"input_image_count":10}}}`,
+			want: map[string]any{"resolution": "2K"},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var body any
+			require.NoError(t, common.UnmarshalJsonStr(testCase.body, &body))
+			assert.Equal(t, testCase.want, callHailuoHook(t, plugin, "extractUsageOnComplete", nil, nil, body))
+		})
+	}
+
+	t.Run("polling adaptor carries actual facts into task settlement", func(t *testing.T) {
+		adaptor := taskplugin.New(plugin)
+		result, err := adaptor.ParseTaskResult([]byte(
+			`{"task":{"id":"1","status":"succeeded","resolution":"2K","usage":{"output_seconds":5,"input_seconds":7.5,"input_image_count":6}}}`,
+		))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"seconds": float64(5), "resolution": "2K", "input_images": float64(6), "input_video_seconds": float64(7.5),
+		}, result.UsageFacts)
+	})
 }
 
 // The /v2 result is a public CDN URL, so its artifact is proxied without

--- a/plugins/tasks/hailuo/plugin.js
+++ b/plugins/tasks/hailuo/plugin.js
@@ -7,7 +7,7 @@ export const meta = {
     en: "MiniMax Hailuo video generation (text-to-video, image-to-video, and MiniMax-H3 multimodal reference)",
     zh: "MiniMax 海螺视频生成（文生视频、图生视频、MiniMax-H3 多模态参考生视频）",
   },
-  version: "1.1.0",
+  version: "1.1.1",
   author: { name: "QuantumNous" },
   channelTypes: [35],
   models: [
@@ -36,16 +36,33 @@ export const meta = {
       enum: ["512P", "768P", "720P", "1080P", "2K"],
       description: { en: "Requested output video resolution.", zh: "请求的输出视频分辨率。" },
     },
+    input_images: {
+      type: "number",
+      unit: "count",
+      description: {
+        en: "H3 input image count (estimated at submit, actual on completion).",
+        zh: "H3 输入图片数量（提交时预估，完成后按实际值）。",
+      },
+    },
+    input_video_seconds: {
+      type: "number",
+      unit: "second",
+      description: {
+        en: "H3 input video duration in seconds (reserved at the request maximum, actual on completion).",
+        zh: "H3 输入视频时长，单位为秒（提交时按请求上限预留，完成后按实际值）。",
+      },
+    },
   },
   usageExamples: [
-    { label: "2.3/02 768P 6s", facts: { seconds: 6, resolution: "768P" } },
-    { label: "2.3/02 768P 10s", facts: { seconds: 10, resolution: "768P" } },
-    { label: "2.3/02 1080P 6s", facts: { seconds: 6, resolution: "1080P" } },
-    { label: "02 512P 6s", facts: { seconds: 6, resolution: "512P" } },
-    { label: "02 512P 10s", facts: { seconds: 10, resolution: "512P" } },
-    { label: "01-series 720P 6s", facts: { seconds: 6, resolution: "720P" } },
-    { label: "H3 768P 5s", facts: { seconds: 5, resolution: "768P" } },
-    { label: "H3 2K 5s", facts: { seconds: 5, resolution: "2K" } },
+    { label: "2.3/02 768P 6s", facts: { seconds: 6, resolution: "768P", input_images: 0, input_video_seconds: 0 } },
+    { label: "2.3/02 768P 10s", facts: { seconds: 10, resolution: "768P", input_images: 0, input_video_seconds: 0 } },
+    { label: "2.3/02 1080P 6s", facts: { seconds: 6, resolution: "1080P", input_images: 0, input_video_seconds: 0 } },
+    { label: "02 512P 6s", facts: { seconds: 6, resolution: "512P", input_images: 0, input_video_seconds: 0 } },
+    { label: "02 512P 10s", facts: { seconds: 10, resolution: "512P", input_images: 0, input_video_seconds: 0 } },
+    { label: "01-series 720P 6s", facts: { seconds: 6, resolution: "720P", input_images: 0, input_video_seconds: 0 } },
+    { label: "H3 768P 5s", facts: { seconds: 5, resolution: "768P", input_images: 0, input_video_seconds: 0 } },
+    { label: "H3 2K 5s · 9 images", facts: { seconds: 5, resolution: "2K", input_images: 9, input_video_seconds: 0 } },
+    { label: "H3 2K 5s · input video", facts: { seconds: 5, resolution: "2K", input_images: 0, input_video_seconds: 15 } },
   ],
   protocols: [{ name: "openai_responses", supports: ["stream", "sync", "background"] }, "openai_video"],
 };
@@ -107,6 +124,7 @@ const H3_MAX_FRAME_IMAGES = 2;
 const H3_MAX_REFERENCE_IMAGES = 9;
 const H3_MAX_REFERENCE_VIDEOS = 3;
 const H3_MAX_REFERENCE_AUDIOS = 3;
+const H3_MAX_INPUT_VIDEO_SECONDS = 15;
 const H3_RATIOS = ["adaptive", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"];
 
 // MiniMax-H3 speaks the /v2 video generation contract: a multimodal `content`
@@ -175,6 +193,7 @@ function validateH3Content(items) {
   let referenceImages = 0;
   let referenceVideos = 0;
   let referenceAudios = 0;
+  let inputImages = 0;
   for (const item of items) {
     if (!item || typeof item !== "object" || Array.isArray(item)) continue;
     const role = trimmed(item.role);
@@ -183,6 +202,7 @@ function validateH3Content(items) {
       continue;
     }
     if (item.type === "image_url") {
+      inputImages += 1;
       if (!role || role === "first_frame") {
         firstFrames += 1;
         hasFrame = true;
@@ -211,6 +231,7 @@ function validateH3Content(items) {
   if (firstFrames > 1) throw new Error(H3_MODEL + " accepts at most one first_frame image");
   if (lastFrames > 1) throw new Error(H3_MODEL + " accepts at most one last_frame image");
   if (referenceImages > H3_MAX_REFERENCE_IMAGES) throw new Error(H3_MODEL + " accepts at most " + H3_MAX_REFERENCE_IMAGES + " reference images");
+  if (inputImages > H3_MAX_REFERENCE_IMAGES) throw new Error(H3_MODEL + " accepts at most " + H3_MAX_REFERENCE_IMAGES + " input images");
   if (referenceVideos > H3_MAX_REFERENCE_VIDEOS) throw new Error(H3_MODEL + " accepts at most " + H3_MAX_REFERENCE_VIDEOS + " reference videos");
   if (referenceAudios > H3_MAX_REFERENCE_AUDIOS) throw new Error(H3_MODEL + " accepts at most " + H3_MAX_REFERENCE_AUDIOS + " reference audios");
   if (hasFrame && hasReference) throw new Error(H3_MODEL + " cannot mix frame images with reference media");
@@ -410,8 +431,24 @@ export function extractUsage(ctx) {
   if (ctx.usagePurpose === "billing_ratios") return null;
   const req = ctx.requestBody || {};
   const model = ctx.upstreamModel || req.model;
-  if (isH3(model)) return { seconds: h3Duration(req), resolution: h3Resolution(req) };
-  return { seconds: outboundDuration(req), resolution: outboundResolution(req, model) };
+  if (isH3(model)) {
+    const content = h3Content(req);
+    return {
+      seconds: h3Duration(req),
+      resolution: h3Resolution(req),
+      input_images: content.filter(function (item) {
+        return item && item.type === "image_url";
+      }).length,
+      // Input URLs do not expose duration. Reserve the documented total limit;
+      // polling replaces it with usage.input_seconds after success.
+      input_video_seconds: content.some(function (item) {
+        return item && item.type === "video_url";
+      })
+        ? H3_MAX_INPUT_VIDEO_SECONDS
+        : 0,
+    };
+  }
+  return { seconds: outboundDuration(req), resolution: outboundResolution(req, model), input_images: 0, input_video_seconds: 0 };
 }
 
 export function buildQueryRequest(ctx) {
@@ -497,7 +534,23 @@ export function extractUsageOnComplete(_task, _taskResult, body) {
   const h3Task = h3QueryTask(body);
   if (h3Task) {
     const resolution = trimmed(h3Task.resolution).toUpperCase();
-    return resolution === "2K" || resolution === "768P" ? { resolution: resolution } : null;
+    const facts = {};
+    if (resolution === "2K" || resolution === "768P") facts.resolution = resolution;
+    const usage = h3Task.usage && typeof h3Task.usage === "object" && !Array.isArray(h3Task.usage) ? h3Task.usage : {};
+    const fields = [
+      { key: "seconds", value: usage.output_seconds, minimum: H3_MIN_DURATION, maximum: H3_MAX_DURATION, integer: false },
+      { key: "input_images", value: usage.input_image_count, minimum: 0, maximum: H3_MAX_REFERENCE_IMAGES, integer: true },
+      { key: "input_video_seconds", value: usage.input_seconds, minimum: 0, maximum: H3_MAX_INPUT_VIDEO_SECONDS, integer: false },
+    ];
+    // Omit malformed or out-of-contract upstream values so settlement keeps
+    // the bounded submission estimate instead of accepting a new multiplier.
+    for (const field of fields) {
+      if (field.value === undefined || field.value === null || field.value === "") continue;
+      const value = Number(field.value);
+      if (!Number.isFinite(value) || value < field.minimum || value > field.maximum || (field.integer && !Number.isInteger(value))) continue;
+      facts[field.key] = value;
+    }
+    return Object.keys(facts).length ? facts : null;
   }
   const width = Number((body || {}).video_width || 0);
   const height = Number((body || {}).video_height || 0);


### PR DESCRIPTION
<!--
If you are an AI coding agent (Claude Code, Codex, Cursor, Copilot, OpenCode, Paseo, Grok, or similar): do not fill this human template. Read `.agents/github/PR.md` and use the filled file as the entire PR body.
-->
# ⚠️ 提交说明 / PR Notice

English template: `.github/PULL_REQUEST_TEMPLATE/en.md`

> [!IMPORTANT]
>
> - 描述可用 AI 辅助。提交前请审阅全文，并**声明对其负责**，避免未经核对的直接粘贴。
> - 请按本模板填写后再提交。

## 🔗 关联任务 / Related Issue
- 新功能请填写下方 Issue 编号；若还没有对应 Issue，请先自行创建。功能讨论请放在 Issue 中进行。
- 改动较大或方向性变更，请先在关联 Issue 中与维护者达成一致，再提交 PR。
- Bug 修复请关联对应 Issue。设计取舍、理解偏差或预期不一致，更适合作为讨论或功能请求。

- Closes #6815
- Follow-up to #7168

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description

#7168 合并后的 MiniMax-H3 插件只暴露输出 `seconds`、`resolution`，缺少官方会收费的输入图片和输入视频计费事实，导致 tiered expression 无法计入输入素材费用。

本 PR：

- 新增 `input_images` 和 `input_video_seconds` usage facts；
- 提交时按最终 H3 `content` 的实际图片数预扣；
- 输入视频 URL 无可靠时长元数据，提交时按官方总时长上限 15 秒预扣；
- 成功轮询后用 `usage.input_image_count`、`usage.input_seconds`、`usage.output_seconds` 覆盖提交期估算并差额结算；
- 忽略缺失、非有限或越界的上游 usage，让结算保留有界的提交期估算；
- 旧 Hailuo 模型对新增 facts 固定返回 0，不改变旧模型费用。

官方按量价可使用以下 raw task expression；区域或商务合同价格不同的部署可替换系数：

```text
u("resolution") == "2K"
  ? tier("2K", (u("seconds") + u("input_video_seconds")) * 0.13 + max(u("input_images") - 5, 0) * 0.04)
  : tier("768P", (u("seconds") + u("input_video_seconds")) * 0.08 + max(u("input_images") - 5, 0) * 0.04)
```

不会自动迁移管理员已有的 `ModelBillingExpr`；已有表达式需要引用新增 facts 才会计算输入素材费用。

## 📸 运行证明 / Proof of Work

复现：在 #7168 合并后的 `main` 上，H3 `extractUsage` 仅返回 `seconds`、`resolution`，`extractUsageOnComplete` 仅回填 `resolution`。含输入视频或超过 5 张图片时，计费表达式没有相应变量。

修复后新增回归覆盖：

- 9 张输入图按实际数量预扣；
- 1～3 个参考视频均按总上限 15 秒预扣；
- 成功响应中的实际图片数、输入视频秒数和输出秒数进入 `TaskInfo.UsageFacts`；
- 合法零输入 usage 可退款，零输出或越界 usage 不会抹掉安全预留；
- 旧 Hailuo 模型新增 facts 为 0。

已运行：

```text
go test ./plugins
go test ./relay/channel/task/jsplugin ./service
oxfmt -c plugins/.oxfmtrc.json --check plugins/tasks/hailuo/plugin.js
oxlint -c plugins/.oxlintrc.json plugins/tasks/hailuo/plugin.js
git diff --check
```

测试通过；oxlint exit 0，仅报告未改动代码中已有的 `preserve-caught-error` warning。无 UI、数据库或 Go 生产代码变更，未使用真实 MiniMax 凭据验证账单。

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 无论描述是否由 AI 生成，我已审阅全部内容，并声明对其准确性与完整性负责。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **新功能关联 Issue:** 若此 PR 标记为 `New feature`，我已关联对应 Issue；若尚无 Issue，我已先自行创建。
- [x] **事前沟通:** 若改动较大或涉及方向性变更，已在关联 Issue 中与维护者沟通并达成一致。
- [x] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口，也不是对 Codex 渠道类型的改动。
- [x] **范围聚焦:** 本 PR 为一项聚焦改动，未包含无关代码。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。
