### PR TITLE
fix(logs): attach request diagnostics to error logs

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -412,12 +412,10 @@ func processChannelError(c *gin.Context, channelError types.ChannelError, err *t
 		tokenId := c.GetInt("token_id")
 		userGroup := c.GetString("group")
 		other := model.NewLogOther()
-		if c.Request != nil && c.Request.URL != nil {
-			other.SetPublic("request_path", c.Request.URL.Path)
-		}
 		other.SetPublic("error_type", err.GetErrorType())
 		other.SetPublic("error_code", err.GetErrorCode())
 		other.SetPublic("status_code", err.StatusCode)
+		service.AppendRelayLogRequestInfo(c, relayInfo, other)
 		service.AppendRelayLogAdminInfo(c, relayInfo, other)
 		service.AppendTaskPluginContextAuditInfo(c, other)
 		startTime := common.GetContextKeyTime(c, constant.ContextKeyRequestStartTime)

--- a/controller/relay_error_log_test.go
+++ b/controller/relay_error_log_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/model"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relaykit/types"
 
 	"github.com/gin-gonic/gin"
@@ -19,7 +20,8 @@ import (
 	"gorm.io/gorm"
 )
 
-func TestProcessChannelErrorUsesSnapshotWithoutLeakingChannelMetadata(t *testing.T) {
+func setupProcessChannelErrorLogDB(t *testing.T) *gorm.DB {
+	t.Helper()
 	gin.SetMode(gin.TestMode)
 	previousDB, previousLogDB := model.DB, model.LOG_DB
 	previousRedisEnabled := common.RedisEnabled
@@ -44,10 +46,12 @@ func TestProcessChannelErrorUsesSnapshotWithoutLeakingChannelMetadata(t *testing
 		constant.ErrorLogEnabled = previousErrorLogEnabled
 		require.NoError(t, sqlDB.Close())
 	})
-
 	require.NoError(t, database.Create(&model.User{Id: 7, Username: "log-owner", Group: "default"}).Error)
-	recorder := httptest.NewRecorder()
-	ctx, _ := gin.CreateTestContext(recorder)
+	return database
+}
+
+func newProcessChannelErrorContext() *gin.Context {
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	ctx.Set("id", 7)
 	ctx.Set("username", "log-owner")
@@ -60,6 +64,12 @@ func TestProcessChannelErrorUsesSnapshotWithoutLeakingChannelMetadata(t *testing
 	ctx.Set("channel_type", 9)
 	ctx.Set("use_channel", []string{"101"})
 	common.SetContextKey(ctx, constant.ContextKeyRequestStartTime, time.Now().Add(-time.Second))
+	return ctx
+}
+
+func TestProcessChannelErrorUsesSnapshotWithoutLeakingChannelMetadata(t *testing.T) {
+	database := setupProcessChannelErrorLogDB(t)
+	ctx := newProcessChannelErrorContext()
 
 	channelSnapshot := types.ChannelError{
 		ChannelId:   101,
@@ -77,6 +87,7 @@ func TestProcessChannelErrorUsesSnapshotWithoutLeakingChannelMetadata(t *testing
 	storedOther, err := common.StrToMap(stored.Other)
 	require.NoError(t, err)
 	assert.Equal(t, float64(http.StatusBadGateway), storedOther["status_code"])
+	assert.Equal(t, "/v1/chat/completions", storedOther["request_path"])
 	for _, key := range []string{"channel_id", "channel_name", "channel_type"} {
 		assert.NotContains(t, storedOther, key)
 	}
@@ -93,7 +104,71 @@ func TestProcessChannelErrorUsesSnapshotWithoutLeakingChannelMetadata(t *testing
 	userOther, err := common.StrToMap(logs[0].Other)
 	require.NoError(t, err)
 	assert.NotContains(t, userOther, "admin_info")
+	assert.Equal(t, "/v1/chat/completions", userOther["request_path"])
 	for _, key := range []string{"channel_id", "channel_name", "channel_type"} {
 		assert.NotContains(t, userOther, key)
 	}
+}
+
+func TestProcessChannelErrorRecordsModelMappingAndRequestDiagnostics(t *testing.T) {
+	database := setupProcessChannelErrorLogDB(t)
+	ctx := newProcessChannelErrorContext()
+	ctx.Set(string(constant.ContextKeySystemPromptOverride), true)
+
+	streamStatus := relaycommon.NewStreamStatus()
+	streamStatus.SetEndReason(relaycommon.StreamEndReasonTimeout, errors.New(`Get "https://api.openai.com/v1/chat/completions": upstream timeout`))
+	streamStatus.RecordError("chunk decode failed from 10.0.0.1")
+
+	relayInfo := &relaycommon.RelayInfo{
+		OriginModelName:         "gpt-test",
+		ReasoningEffort:         "high",
+		IsStream:                true,
+		RequestConversionChain:  []types.RelayFormat{types.RelayFormatOpenAI, types.RelayFormatClaude},
+		FinalRequestRelayFormat: types.RelayFormatClaude,
+		ParamOverrideAudit:      []string{"set temperature=0.2"},
+		StreamStatus:            streamStatus,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			IsModelMapped:     true,
+			UpstreamModelName: "claude-sonnet-4",
+		},
+	}
+	channelSnapshot := types.ChannelError{
+		ChannelId:   101,
+		ChannelType: 1,
+		ChannelName: "snapshot-channel",
+		AutoBan:     false,
+	}
+	apiErr := types.NewOpenAIError(errors.New("upstream failed"), types.ErrorCodeBadResponseStatusCode, http.StatusBadGateway)
+
+	processChannelError(ctx, channelSnapshot, apiErr, relayInfo)
+
+	var stored model.Log
+	require.NoError(t, database.First(&stored).Error)
+	storedOther, err := common.StrToMap(stored.Other)
+	require.NoError(t, err)
+	assert.Equal(t, true, storedOther["is_model_mapped"])
+	assert.Equal(t, "claude-sonnet-4", storedOther["upstream_model_name"])
+	assert.Equal(t, true, storedOther["is_system_prompt_overwritten"])
+	assert.Equal(t, "high", storedOther["reasoning_effort"])
+	assert.Equal(t, []interface{}{"OpenAI Compatible", "Claude Messages"}, storedOther["request_conversion"])
+	assert.Equal(t, true, storedOther["claude"])
+	assert.Equal(t, []interface{}{"set temperature=0.2"}, storedOther["po"])
+	assert.Equal(t, "/v1/chat/completions", storedOther["request_path"])
+	streamInfo, ok := storedOther["stream_status"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "error", streamInfo["status"])
+	assert.Equal(t, "timeout", streamInfo["end_reason"])
+	assert.Equal(t, common.MaskSensitiveInfo(`Get "https://api.openai.com/v1/chat/completions": upstream timeout`), streamInfo["end_error"])
+	assert.NotContains(t, streamInfo["end_error"], "api.openai.com")
+	require.Equal(t, []interface{}{common.MaskSensitiveInfo("chunk decode failed from 10.0.0.1")}, streamInfo["errors"])
+
+	logs, total, err := model.GetUserLogs(7, model.LogTypeError, 0, 0, "", "", 0, 10, "", "", "")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	userOther, err := common.StrToMap(logs[0].Other)
+	require.NoError(t, err)
+	assert.NotContains(t, userOther, "admin_info")
+	assert.Equal(t, true, userOther["is_model_mapped"])
+	assert.Equal(t, "claude-sonnet-4", userOther["upstream_model_name"])
+	assert.Equal(t, []interface{}{"OpenAI Compatible", "Claude Messages"}, userOther["request_conversion"])
 }

--- a/service/log_info_generate.go
+++ b/service/log_info_generate.go
@@ -65,6 +65,33 @@ func appendRequestPath(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, other
 	}
 }
 
+// AppendRelayLogRequestInfo records request-side diagnostics shared by
+// successful consume logs and failed error logs: model mapping, conversion
+// chain, param override, stream status, and related public metadata.
+func AppendRelayLogRequestInfo(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, other *model.LogOther) {
+	if other == nil {
+		return
+	}
+	appendRequestPath(ctx, relayInfo, other)
+	if ctx != nil && common.GetContextKeyBool(ctx, constant.ContextKeySystemPromptOverride) {
+		other.SetPublic("is_system_prompt_overwritten", true)
+	}
+	if relayInfo == nil {
+		return
+	}
+	if relayInfo.ReasoningEffort != "" {
+		other.SetPublic("reasoning_effort", relayInfo.ReasoningEffort)
+	}
+	if relayInfo.HasChannelMeta() && relayInfo.IsModelMapped {
+		other.SetPublic("is_model_mapped", true)
+		other.SetPublic("upstream_model_name", relayInfo.UpstreamModelName)
+	}
+	appendRequestConversionChain(relayInfo, other)
+	appendFinalRequestFormat(relayInfo, other)
+	appendParamOverrideInfo(relayInfo, other)
+	appendStreamStatus(relayInfo, other)
+}
+
 // AppendRelayLogAdminInfo records relay routing and conversion diagnostics in
 // the admin-only scope shared by successful and failed request logs.
 func AppendRelayLogAdminInfo(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, other *model.LogOther) {
@@ -105,26 +132,9 @@ func GenerateTextOtherInfo(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, m
 	other.SetPublic("model_price", modelPrice)
 	other.SetPublic("user_group_ratio", userGroupRatio)
 	other.SetPublic("frt", float64(relayInfo.FirstResponseTime.UnixMilli()-relayInfo.StartTime.UnixMilli()))
-	if relayInfo.ReasoningEffort != "" {
-		other.SetPublic("reasoning_effort", relayInfo.ReasoningEffort)
-	}
-	if relayInfo.IsModelMapped {
-		other.SetPublic("is_model_mapped", true)
-		other.SetPublic("upstream_model_name", relayInfo.UpstreamModelName)
-	}
-
-	isSystemPromptOverwritten := common.GetContextKeyBool(ctx, constant.ContextKeySystemPromptOverride)
-	if isSystemPromptOverwritten {
-		other.SetPublic("is_system_prompt_overwritten", true)
-	}
-
+	AppendRelayLogRequestInfo(ctx, relayInfo, other)
 	AppendRelayLogAdminInfo(ctx, relayInfo, other)
-	appendRequestPath(ctx, relayInfo, other)
-	appendRequestConversionChain(relayInfo, other)
-	appendFinalRequestFormat(relayInfo, other)
 	appendBillingInfo(relayInfo, other)
-	appendParamOverrideInfo(relayInfo, other)
-	appendStreamStatus(relayInfo, other)
 	return other
 }
 
@@ -149,13 +159,13 @@ func appendStreamStatus(relayInfo *relaycommon.RelayInfo, other *model.LogOther)
 		"end_reason": string(ss.EndReason),
 	}
 	if ss.EndError != nil {
-		streamInfo["end_error"] = ss.EndError.Error()
+		streamInfo["end_error"] = common.MaskSensitiveInfo(ss.EndError.Error())
 	}
 	if ss.ErrorCount > 0 {
 		streamInfo["error_count"] = ss.ErrorCount
 		messages := make([]string, 0, len(ss.Errors))
 		for _, e := range ss.Errors {
-			messages = append(messages, e.Message)
+			messages = append(messages, common.MaskSensitiveInfo(e.Message))
 		}
 		streamInfo["errors"] = messages
 	}


### PR DESCRIPTION
<!--
If you are an AI coding agent (Claude Code, Codex, Cursor, Copilot, OpenCode, Paseo, Grok, or similar): do not fill this human template. Read `.agents/github/PR.md` and use the filled file as the entire PR body.
-->
# ⚠️ 提交说明 / PR Notice

English template: `.github/PULL_REQUEST_TEMPLATE/en.md`

> [!IMPORTANT]
>
> - 描述可用 AI 辅助。提交前请审阅全文，并**声明对其负责**，避免未经核对的直接粘贴。
> - 请按本模板填写后再提交。

## 🔗 关联任务 / Related Issue
- 新功能请填写下方 Issue 编号；若还没有对应 Issue，请先自行创建。功能讨论请放在 Issue 中进行。
- 改动较大或方向性变更，请先在关联 Issue 中与维护者达成一致，再提交 PR。
- Bug 修复请关联对应 Issue。设计取舍、理解偏差或预期不一致，更适合作为讨论或功能请求。

- Closes #

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description
(简述做了什么、为什么生效。如果难以简述，建议先拆分范围，或在 Issue 中与维护者对齐。)

错误日志中补齐缺少的消费日志中有的内容


## 📸 运行证明 / Proof of Work
(请写明如何验证：实际步骤与观察结果。UI 变更请附截图或录屏；Bug 修复请说明复现过程与修复后结果。)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 无论描述是否由 AI 生成，我已审阅全部内容，并声明对其准确性与完整性负责。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **新功能关联 Issue:** 若此 PR 标记为 `New feature`，我已关联对应 Issue；若尚无 Issue，我已先自行创建。
- [x] **事前沟通:** 若改动较大或涉及方向性变更，已在关联 Issue 中与维护者沟通并达成一致。
- [x] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口，也不是对 Codex 渠道类型的改动。
- [x] **范围聚焦:** 本 PR 为一项聚焦改动，未包含无关代码。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay error logs with more complete request diagnostics, including model mapping, conversion details, parameter overrides, and stream status.
  * Ensured request paths and related troubleshooting information are recorded consistently in applicable logs.
  * Sensitive stream error details are now masked to reduce exposure of confidential information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->