### PR TITLE
fix(relay): drain upstream after client_gone to collect final usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,8 @@
 # RELAY_RESPONSE_HEADER_TIMEOUT=1800
 # 流模式无响应超时时间，单位秒，如果出现空补全可以尝试改为更大值
 # STREAMING_TIMEOUT=300
+# 客户端断开后继续读取上游 usage 的最长等待时间，单位秒，0 表示立即关闭上游
+# CLIENT_GONE_DRAIN_TIMEOUT=60
 
 # TLS / HTTP 跳过验证设置
 # TLS_INSECURE_SKIP_VERIFY=false

--- a/common/init.go
+++ b/common/init.go
@@ -177,6 +177,7 @@ func positiveUserSessionEnv(name string, fallback int) int {
 
 func initConstantEnv() {
 	constant.StreamingTimeout = GetEnvOrDefault("STREAMING_TIMEOUT", 300)
+	constant.ClientGoneDrainTimeout = GetEnvOrDefault("CLIENT_GONE_DRAIN_TIMEOUT", 60)
 	constant.DifyDebug = GetEnvOrDefaultBool("DIFY_DEBUG", true)
 	constant.MaxFileDownloadMB = GetEnvOrDefault("MAX_FILE_DOWNLOAD_MB", 64)
 	constant.StreamScannerMaxBufferMB = GetEnvOrDefault("STREAM_SCANNER_MAX_BUFFER_MB", 128)

--- a/constant/env.go
+++ b/constant/env.go
@@ -1,6 +1,7 @@
 package constant
 
 var StreamingTimeout int
+var ClientGoneDrainTimeout int
 var DifyDebug bool
 var MaxFileDownloadMB int
 var StreamScannerMaxBufferMB int

--- a/relay/helper/common.go
+++ b/relay/helper/common.go
@@ -86,7 +86,8 @@ func ClaudeChunkData(c *gin.Context, resp dto.ClaudeResponse, data string) {
 
 func ResponseChunkData(c *gin.Context, resp dto.ResponsesStreamResponse, data string) error {
 	if requestContextDone(c) {
-		return fmt.Errorf("request context done: %w", c.Request.Context().Err())
+		// 客户端断开后进入 drain 阶段：写失败不应中断上游 usage 读取。
+		return nil
 	}
 
 	c.Render(-1, common.CustomEvent{Data: fmt.Sprintf("event: %s\n", resp.Type)})
@@ -100,7 +101,8 @@ func StringData(c *gin.Context, str string) error {
 	}
 
 	if requestContextDone(c) {
-		return fmt.Errorf("request context done: %w", c.Request.Context().Err())
+		// 客户端断开后进入 drain 阶段：写失败不应中断上游 usage 读取。
+		return nil
 	}
 
 	c.Render(-1, common.CustomEvent{Data: "data: " + str})

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -290,15 +290,27 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	})
 
 	// 主循环等待完成或超时
+	clientGoneDrainTimeout := time.Duration(constant.ClientGoneDrainTimeout) * time.Second
 	select {
 	case <-ticker.C:
 		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonTimeout, nil)
 	case <-stopChan:
 		// EndReason already set by the goroutine that triggered stopChan
 	case <-c.Request.Context().Done():
-		// 客户端断开：立即 cleanup 关闭上游 resp.Body，解除 scanner 阻塞并让上游停止生成，
-		// 避免为已放弃的请求继续消费上游 token。
-		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, c.Request.Context().Err())
+		// 客户端断开。不要立即关闭上游 body：先继续消费上游一段时间，尽可能拿到最终
+		// usage，避免后续只能用本地估算 token 结算导致多扣/少扣。
+		if clientGoneDrainTimeout <= 0 {
+			info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, c.Request.Context().Err())
+			break
+		}
+		logger.LogInfo(c, fmt.Sprintf("client gone, draining upstream for %.0fs to collect final usage", clientGoneDrainTimeout.Seconds()))
+		select {
+		case <-stopChan:
+			// 上游已正常结束/出错，scanner 会设置对应的 EndReason。
+		case <-time.After(clientGoneDrainTimeout):
+			info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonClientGone, c.Request.Context().Err())
+			logger.LogWarn(c, fmt.Sprintf("client gone drain timeout after %.0fs, force closing upstream", clientGoneDrainTimeout.Seconds()))
+		}
 	}
 
 	cleanup()

--- a/relay/helper/stream_scanner_test.go
+++ b/relay/helper/stream_scanner_test.go
@@ -283,6 +283,132 @@ func TestStreamScannerHandler_ClientCancelAbortsUpstreamAndReturns(t *testing.T)
 	assert.NotContains(t, body, "second")
 }
 
+// TestStreamScannerHandler_ClientGoneDrainsUntilFinalUsage pins the new
+// disconnect contract when CLIENT_GONE_DRAIN_TIMEOUT > 0: after the client
+// disconnects, the scanner keeps reading upstream until [DONE]/EOF so the
+// final usage can be collected instead of falling back to local estimates.
+func TestStreamScannerHandler_ClientGoneDrainsUntilFinalUsage(t *testing.T) {
+	oldDrain := constant.ClientGoneDrainTimeout
+	constant.ClientGoneDrainTimeout = 1
+	t.Cleanup(func() { constant.ClientGoneDrainTimeout = oldDrain })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pr, pw := io.Pipe()
+	t.Cleanup(func() {
+		_ = pr.Close()
+		_ = pw.Close()
+	})
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+
+	resp := &http.Response{Body: pr}
+	info := &relaycommon.RelayInfo{
+		DisablePing: true,
+		ChannelMeta: &relaycommon.ChannelMeta{},
+	}
+
+	var count atomic.Int64
+	firstHandled := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {
+			count.Add(1)
+			if data == "first" {
+				close(firstHandled)
+			}
+		})
+		close(done)
+	}()
+
+	_, err := fmt.Fprint(pw, "data: first\n")
+	require.NoError(t, err)
+
+	select {
+	case <-firstHandled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first chunk")
+	}
+
+	cancel()
+
+	// Upstream is allowed to finish after the disconnect; the scanner should
+	// still consume the terminal event so the caller can settle with real usage.
+	_, err = fmt.Fprint(pw, "data: final-usage\n")
+	require.NoError(t, err)
+	_, err = fmt.Fprint(pw, "data: [DONE]\n")
+	require.NoError(t, err)
+	_ = pw.Close()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler did not finish after drain reached [DONE]")
+	}
+
+	assert.Equal(t, int64(2), count.Load(), "data after disconnect should be drained until [DONE]")
+	require.NotNil(t, info.StreamStatus)
+	assert.Equal(t, relaycommon.StreamEndReasonDone, info.StreamStatus.EndReason)
+}
+
+// TestStreamScannerHandler_ClientGoneDrainTimeoutClosesUpstream ensures the
+// drain is bounded: if the upstream never terminates, the handler still returns
+// after the configured drain timeout and closes the upstream body.
+func TestStreamScannerHandler_ClientGoneDrainTimeoutClosesUpstream(t *testing.T) {
+	oldDrain := constant.ClientGoneDrainTimeout
+	constant.ClientGoneDrainTimeout = 1
+	t.Cleanup(func() { constant.ClientGoneDrainTimeout = oldDrain })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pr, pw := io.Pipe()
+	t.Cleanup(func() {
+		_ = pr.Close()
+		_ = pw.Close()
+	})
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+
+	resp := &http.Response{Body: pr}
+	info := &relaycommon.RelayInfo{
+		DisablePing: true,
+		ChannelMeta: &relaycommon.ChannelMeta{},
+	}
+
+	var count atomic.Int64
+	done := make(chan struct{})
+	go func() {
+		StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {
+			count.Add(1)
+		})
+		close(done)
+	}()
+
+	_, err := fmt.Fprint(pw, "data: first\n")
+	require.NoError(t, err)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler did not return after drain timeout")
+	}
+
+	require.NotNil(t, info.StreamStatus)
+	assert.Equal(t, relaycommon.StreamEndReasonClientGone, info.StreamStatus.EndReason)
+
+	// The upstream body must be closed once the drain timeout fires.
+	_, err = fmt.Fprint(pw, "data: second\n")
+	require.ErrorIs(t, err, io.ErrClosedPipe, "upstream body should be closed after drain timeout")
+	assert.Equal(t, int64(1), count.Load(), "no chunk after drain timeout should be processed")
+}
+
 // ---------- Ping tests ----------
 
 func TestStreamScannerHandler_PingSentDuringSlowUpstream(t *testing.T) {


### PR DESCRIPTION
## Problem

When a streaming client disconnects (`client_gone`), `StreamScannerHandler` immediately closes the upstream HTTP body. The upstream's final usage block is often still in flight, so the relay never sees it.

After the stream ends, Claude/OpenAI/Gemini handlers fall back to locally estimated prompt tokens. For large cached/context-heavy Claude requests this can charge far more than the upstream actually billed.

Related: #4168

## Change

- Add `CLIENT_GONE_DRAIN_TIMEOUT` (default 60s, `0` preserves old behavior).
- After the client disconnects, keep reading the upstream body for that bounded window so terminal usage can be collected when the upstream still finishes.
- Make `StringData` / `ResponseChunkData` no-ops once the client context is done, so write failures do not abort the drain.

## Tests

- `TestStreamScannerHandler_ClientGoneDrainsUntilFinalUsage`
- `TestStreamScannerHandler_ClientGoneDrainTimeoutClosesUpstream`
- Existing immediate-close test is preserved when drain is disabled.

Ran:
- `go test ./relay/...`
- `go test ./service/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable handling for upstream data when a client disconnects.
  * The server can continue collecting final usage data for up to 60 seconds by default.
  * Set the timeout to zero to close the upstream connection immediately.

* **Bug Fixes**
  * Improved usage tracking after client disconnections while ensuring stalled streams stop within the configured timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->