### PR TITLE
fix(task): fall back to unique mapped plugin

### DIFF
--- a/middleware/task_plugin.go
+++ b/middleware/task_plugin.go
@@ -342,7 +342,9 @@ func PinTaskPluginEndpoint() gin.HandlerFunc {
 		pinModel := claimedModel
 		mappedModel := ""
 		rewriteTo := ""
+		directlyDeclared := false
 		if declared, ok := generation.CanonicalModel(claimedModel); ok {
+			directlyDeclared = true
 			lookupModel = declared
 			pinModel = declared
 			if claimedModel != declared {
@@ -415,6 +417,13 @@ func PinTaskPluginEndpoint() gin.HandlerFunc {
 			candidates = filtered
 			binding = candidates[0]
 		}
+		if directlyDeclared && !hasTaskPluginChannel(c, generation, pinModel, binding.Plugin, candidates) {
+			if fallback, fallbackCandidates, ok := mappedTaskPluginFallback(c, generation, pinModel); ok {
+				binding = fallback
+				candidates = fallbackCandidates
+				mappedModel = fallback.Model
+			}
+		}
 
 		pin := pluginruntime.PinnedPlugin{Generation: generation, Plugin: binding.Plugin}
 		pinnedEndpoint := pluginruntime.PinnedEndpoint{
@@ -440,6 +449,127 @@ func PinTaskPluginEndpoint() gin.HandlerFunc {
 		)
 		c.Next()
 	}
+}
+
+func hasTaskPluginChannel(c *gin.Context, generation *pluginruntime.RoutingGeneration, modelName string, plugin *pluginruntime.LoadedPlugin, candidates []pluginruntime.ProtocolBinding) bool {
+	groups := taskPluginRequestGroups(c)
+	if len(groups) == 0 || plugin == nil {
+		return false
+	}
+	channelTypes := make([]int, 0)
+	for _, candidate := range candidates {
+		if candidate.Plugin == nil {
+			continue
+		}
+		for _, channelType := range candidate.Plugin.Meta.ChannelTypes {
+			if channelType != 0 && channelType != constant.ChannelTypeTaskPlugin && generation != nil {
+				if owner, ok := generation.GetByChannelType(channelType); ok && owner == candidate.Plugin {
+					channelTypes = append(channelTypes, channelType)
+				}
+			}
+		}
+	}
+	filters := append([]dto.ChannelFilter(nil), service.GetChannelConstraints(c).Filters...)
+	filters = append(filters,
+		dto.ChannelFilter{Kind: dto.FilterRequestPath, RequestPath: c.Request.URL.Path},
+		dto.ChannelFilter{Kind: dto.FilterTaskPluginIdentity, TaskPluginKey: plugin.Meta.Key, TaskPluginChannelTypes: channelTypes},
+	)
+	if pin, found, _ := service.GetChannelConstraints(c).ResolvedPin(); found {
+		channel, err := model.CacheGetChannel(pin.ChannelId)
+		if err != nil || channel.Status != common.ChannelStatusEnabled || !model.IsChannelEnabledForAnyGroupModel(groups, modelName, channel.Id) {
+			return false
+		}
+		ok, _ := model.ChannelSatisfiesFilters(channel, modelName, filters)
+		return ok
+	}
+	for _, group := range groups {
+		channel, err := model.GetRandomSatisfiedChannel(group, modelName, 0, filters)
+		if err != nil {
+			return true
+		}
+		if channel != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func mappedTaskPluginFallback(c *gin.Context, generation *pluginruntime.RoutingGeneration, modelName string) (pluginruntime.ProtocolBinding, []pluginruntime.ProtocolBinding, bool) {
+	groups := taskPluginRequestGroups(c)
+	if len(groups) == 0 {
+		return pluginruntime.ProtocolBinding{}, nil, false
+	}
+	pin, pinned, _ := service.GetChannelConstraints(c).ResolvedPin()
+	type fallbackChoice struct {
+		binding pluginruntime.ProtocolBinding
+	}
+	choices := make(map[string]fallbackChoice)
+	for _, candidate := range model.ResolveTaskModelFallbackCandidates(generation, modelName) {
+		channel, err := model.CacheGetChannel(candidate.ChannelID)
+		if err != nil || channel.Status != common.ChannelStatusEnabled || pinned && pin.ChannelId != channel.Id {
+			continue
+		}
+		if channel.Type != constant.ChannelTypeTaskPlugin {
+			continue
+		}
+		if !model.IsChannelEnabledForAnyGroupModel(groups, modelName, channel.Id) {
+			continue
+		}
+		filters := append([]dto.ChannelFilter(nil), service.GetChannelConstraints(c).Filters...)
+		filters = append(filters,
+			dto.ChannelFilter{Kind: dto.FilterRequestPath, RequestPath: c.Request.URL.Path},
+			dto.ChannelFilter{Kind: dto.FilterTaskPluginIdentity, TaskPluginKey: candidate.PluginKey},
+		)
+		if ok, _ := model.ChannelSatisfiesFilters(channel, modelName, filters); !ok {
+			continue
+		}
+		endpointCandidates := generation.LookupEndpointCandidates(c.Request.Method, c.Request.URL.Path, candidate.Declared)
+		var binding pluginruntime.ProtocolBinding
+		for _, endpointCandidate := range endpointCandidates {
+			supported := endpointCandidate.Plugin != nil && taskPluginBindingSupportsRequest(c, endpointCandidate)
+			if supported && endpointCandidate.Plugin.Meta.Key == candidate.PluginKey {
+				binding = endpointCandidate
+			}
+		}
+		if binding.Plugin == nil {
+			continue
+		}
+		key := candidate.PluginKey + "\x00" + candidate.Declared
+		choices[key] = fallbackChoice{binding: binding}
+	}
+	if len(choices) != 1 {
+		return pluginruntime.ProtocolBinding{}, nil, false
+	}
+	for _, choice := range choices {
+		return choice.binding, []pluginruntime.ProtocolBinding{choice.binding}, true
+	}
+	return pluginruntime.ProtocolBinding{}, nil, false
+}
+
+func taskPluginRequestGroups(c *gin.Context) []string {
+	usingGroup := common.GetContextKeyString(c, constant.ContextKeyUsingGroup)
+	if usingGroup == "auto" {
+		return service.GetRequestAutoGroups(c, common.GetContextKeyString(c, constant.ContextKeyUserGroup))
+	}
+	if usingGroup == "" {
+		return nil
+	}
+	return []string{usingGroup}
+}
+
+func taskPluginBindingSupportsRequest(c *gin.Context, binding pluginruntime.ProtocolBinding) bool {
+	definition, known := pluginruntime.HostProtocol(binding.Protocol)
+	if !known || len(definition.DefinedModes()) == 0 {
+		return true
+	}
+	stream, background := jsonBodyBoolFlags(c)
+	mode := "sync"
+	if stream {
+		mode = "stream"
+	} else if background {
+		mode = "background"
+	}
+	return binding.Plugin.Meta.ProtocolSupports(binding.Protocol, mode)
 }
 
 func jsonBodyBoolFlags(c *gin.Context) (stream, background bool) {

--- a/middleware/task_plugin_test.go
+++ b/middleware/task_plugin_test.go
@@ -19,6 +19,9 @@ import (
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/pkg/jsplugin"
 	builtinplugins "github.com/QuantumNous/new-api/plugins"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/setting"
+	"github.com/QuantumNous/new-api/setting/ratio_setting"
 	"github.com/gin-gonic/gin"
 	"github.com/glebarez/sqlite"
 	"github.com/stretchr/testify/assert"
@@ -1582,6 +1585,275 @@ func TestPinTaskPluginEndpointMovesParserToSurvivingSharedCandidate(t *testing.T
 		assert.Same(t, streamOnly, pinned.Candidates[0].Plugin)
 		assert.Equal(t, "stream-parser", action)
 	})
+}
+
+func TestPinTaskPluginEndpointFallsBackToUniqueMappedPlugin(t *testing.T) {
+	tests := []struct {
+		name           string
+		channels       []taskPluginFallbackTestChannel
+		targetModels   map[string][]string
+		targetProtocol map[string]string
+		pinChannel     int
+		wantPlugin     string
+		wantMapped     string
+		usingGroup     string
+		autoGroups     []string
+	}{
+		{
+			name: "direct owner channel keeps direct plugin",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "direct", models: "client-model"},
+				{plugin: "target", models: "client-model", mapping: `{"client-model":"target-model"}`},
+			},
+			wantPlugin: "direct",
+		},
+		{
+			name: "unique mapping falls back",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "target", models: "client-model", mapping: `{"client-model":"target-model"}`},
+			},
+			wantPlugin: "target", wantMapped: "target-model",
+		},
+		{
+			name: "duplicate channels with same pair fall back",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "target", models: "client-model", mapping: `{"client-model":"target-model"}`},
+				{plugin: "target", models: "client-model", mapping: `{"client-model":"target-model"}`},
+			},
+			wantPlugin: "target", wantMapped: "target-model",
+		},
+		{
+			name: "different plugins are ambiguous",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "target", models: "client-model", mapping: `{"client-model":"target-model"}`},
+				{plugin: "other", models: "client-model", mapping: `{"client-model":"other-model"}`},
+			},
+			targetModels: map[string][]string{"other": {"other-model"}},
+			wantPlugin:   "direct",
+		},
+		{
+			name: "different target models in one plugin are ambiguous",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "target", models: "client-model", mapping: `{"client-model":"target-model"}`},
+				{plugin: "target", models: "client-model", mapping: `{"client-model":"target-model-2"}`},
+			},
+			targetModels: map[string][]string{"target": {"target-model", "target-model-2"}},
+			wantPlugin:   "direct",
+		},
+		{
+			name: "disabled mapping is ignored",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "target", models: "client-model", mapping: `{"client-model":"target-model"}`, disabled: true},
+			},
+			wantPlugin: "direct",
+		},
+		{
+			name: "mapping outside request group is ignored",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "target", models: "client-model", group: "other", mapping: `{"client-model":"target-model"}`},
+			},
+			wantPlugin: "direct",
+		},
+		{
+			name: "mapping in auto request group falls back",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "target", models: "client-model", group: "other", mapping: `{"client-model":"target-model"}`},
+			},
+			usingGroup: "auto", autoGroups: []string{"other"},
+			wantPlugin: "target", wantMapped: "target-model",
+		},
+		{
+			name: "mapping outside auto request groups is ignored",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "target", models: "client-model", group: "other", mapping: `{"client-model":"target-model"}`},
+			},
+			usingGroup: "auto", autoGroups: []string{"default"},
+			wantPlugin: "direct",
+		},
+		{
+			name: "mapping source must be publicly exposed",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "target", models: "another-model", mapping: `{"client-model":"target-model"}`},
+			},
+			wantPlugin: "direct",
+		},
+		{
+			name: "cyclic mapping is ignored",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "target", models: "client-model", mapping: `{"client-model":"middle-model","middle-model":"client-model"}`},
+			},
+			wantPlugin: "direct",
+		},
+		{
+			name: "undeclared mapping target is ignored",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "target", models: "client-model", mapping: `{"client-model":"missing-model"}`},
+			},
+			wantPlugin: "direct",
+		},
+		{
+			name: "malformed mapping is ignored",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "target", models: "client-model", mapping: `{"client-model":`},
+			},
+			wantPlugin: "direct",
+		},
+		{
+			name: "channel plugin identity must match target owner",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "other", models: "client-model", mapping: `{"client-model":"target-model"}`},
+			},
+			targetModels: map[string][]string{"other": {"other-model"}},
+			wantPlugin:   "direct",
+		},
+		{
+			name: "target must support request path",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "target", models: "client-model", mapping: `{"client-model":"target-model"}`},
+			},
+			targetProtocol: map[string]string{"target": "/v1/responses"},
+			wantPlugin:     "direct",
+		},
+		{
+			name: "channel pin restricts fallback candidates",
+			channels: []taskPluginFallbackTestChannel{
+				{plugin: "target", models: "client-model", mapping: `{"client-model":"target-model"}`},
+				{plugin: "other", models: "client-model", mapping: `{"client-model":"other-model"}`},
+			},
+			targetModels: map[string][]string{"other": {"other-model"}},
+			pinChannel:   1,
+			wantPlugin:   "target", wantMapped: "target-model",
+		},
+	}
+
+	for index, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			previousDB := model.DB
+			previousMemoryCache := common.MemoryCacheEnabled
+			database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+			require.NoError(t, err)
+			require.NoError(t, database.AutoMigrate(&model.Channel{}, &model.Ability{}))
+			model.DB = database
+			common.MemoryCacheEnabled = true
+			if testCase.usingGroup == "auto" {
+				originalMax := setting.GetMaxTokenAutoGroups()
+				originalUsableGroups := setting.UserUsableGroups2JSONString()
+				originalRatios := ratio_setting.GroupRatio2JSONString()
+				require.NoError(t, setting.UpdateMaxTokenAutoGroups("10"))
+				require.NoError(t, setting.UpdateUserUsableGroupsByJSONString(`{"default":"Default","other":"Other"}`))
+				require.NoError(t, ratio_setting.UpdateGroupRatioByJSONString(`{"default":1,"other":1}`))
+				t.Cleanup(func() {
+					require.NoError(t, setting.UpdateMaxTokenAutoGroups(fmt.Sprintf("%d", originalMax)))
+					require.NoError(t, setting.UpdateUserUsableGroupsByJSONString(originalUsableGroups))
+					require.NoError(t, ratio_setting.UpdateGroupRatioByJSONString(originalRatios))
+				})
+			}
+			t.Cleanup(func() {
+				model.DB = previousDB
+				common.MemoryCacheEnabled = previousMemoryCache
+				if previousDB != nil {
+					model.InitChannelCache()
+				}
+			})
+
+			prefix := fmt.Sprintf("fallback-%d-", index)
+			directKey := prefix + "direct"
+			pluginKeys := map[string]string{"direct": directKey, "target": prefix + "target", "other": prefix + "other"}
+			modelsByPlugin := map[string][]string{"direct": {prefix + "client-model"}, "target": {prefix + "target-model"}}
+			for plugin, models := range testCase.targetModels {
+				prefixed := make([]string, len(models))
+				for i, modelName := range models {
+					prefixed[i] = prefix + modelName
+				}
+				modelsByPlugin[plugin] = prefixed
+			}
+			for plugin, models := range modelsByPlugin {
+				endpoint := "/v1/videos"
+				if configured := testCase.targetProtocol[plugin]; configured != "" {
+					endpoint = configured
+				}
+				modelJSON, marshalErr := common.Marshal(models)
+				require.NoError(t, marshalErr)
+				_, err = jsplugin.DefaultRegistry.Register(taskProtocolPluginSource(
+					pluginKeys[plugin], "1.0.0", string(modelJSON), endpoint,
+					fmt.Sprintf(`return {model: ctx.model, action: %q};`, plugin),
+				), jsplugin.Options{})
+				require.NoError(t, err)
+				key := pluginKeys[plugin]
+				t.Cleanup(func() { require.NoError(t, jsplugin.DefaultRegistry.Unregister(key)) })
+			}
+
+			insertedIDs := make([]int, 0, len(testCase.channels))
+			for _, fixture := range testCase.channels {
+				status := common.ChannelStatusEnabled
+				if fixture.disabled {
+					status = common.ChannelStatusManuallyDisabled
+				}
+				group := fixture.group
+				if group == "" {
+					group = "default"
+				}
+				mapping := strings.ReplaceAll(fixture.mapping, "client-model", prefix+"client-model")
+				mapping = strings.ReplaceAll(mapping, "other-model", prefix+"other-model")
+				mapping = strings.ReplaceAll(mapping, "target-model", prefix+"target-model")
+				setting := fmt.Sprintf(`{"task_plugin_key":%q}`, pluginKeys[fixture.plugin])
+				baseURL := "https://example.com"
+				priority := int64(0)
+				weight := uint(1)
+				channel := model.Channel{
+					Type: constant.ChannelTypeTaskPlugin, Status: status, Name: fixture.plugin,
+					Key: "sk", Models: prefix + fixture.models, Group: group, BaseURL: &baseURL,
+					Setting: &setting, ModelMapping: &mapping, Priority: &priority, Weight: &weight,
+				}
+				require.NoError(t, channel.Insert())
+				insertedIDs = append(insertedIDs, channel.Id)
+			}
+			model.InitChannelCache()
+
+			var pinned jsplugin.PinnedEndpoint
+			var action string
+			router := gin.New()
+			router.POST("/v1/videos", func(c *gin.Context) {
+				usingGroup := testCase.usingGroup
+				if usingGroup == "" {
+					usingGroup = "default"
+				}
+				common.SetContextKey(c, constant.ContextKeyUsingGroup, usingGroup)
+				if usingGroup == "auto" {
+					common.SetContextKey(c, constant.ContextKeyTokenAutoGroups, testCase.autoGroups)
+				}
+				if testCase.pinChannel > 0 {
+					service.GetChannelConstraints(c).AddPin(dto.ChannelPin{ChannelId: insertedIDs[testCase.pinChannel-1], Source: dto.PinSourceToken, Rank: dto.PinRankToken})
+				}
+				c.Next()
+			}, PinTaskPluginEndpoint(), PrepareTaskPluginEndpoint(), func(c *gin.Context) {
+				pinned = c.MustGet(jsplugin.ContextKeyPinnedEndpoint).(jsplugin.PinnedEndpoint)
+				action = c.GetString("task_action")
+				c.Status(http.StatusNoContent)
+			})
+			request := httptest.NewRequest(http.MethodPost, "/v1/videos", strings.NewReader(fmt.Sprintf(`{"model":%q}`, prefix+"client-model")))
+			request.Header.Set("Content-Type", "application/json")
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, request)
+
+			require.Equal(t, http.StatusNoContent, recorder.Code, recorder.Body.String())
+			assert.Equal(t, pluginKeys[testCase.wantPlugin], pinned.Plugin.Meta.Key)
+			assert.Equal(t, testCase.wantPlugin, action)
+			mapped := testCase.wantMapped
+			if mapped != "" {
+				mapped = prefix + mapped
+			}
+			assert.Equal(t, mapped, pinned.MappedModel)
+		})
+	}
+}
+
+type taskPluginFallbackTestChannel struct {
+	plugin   string
+	models   string
+	group    string
+	mapping  string
+	disabled bool
 }
 
 func compileTaskRoutePlugin(t *testing.T, source string) *jsplugin.LoadedPlugin {

--- a/model/task_model_alias.go
+++ b/model/task_model_alias.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/pkg/jsplugin"
+	relaykitdto "github.com/QuantumNous/new-api/relaykit/dto"
 )
 
 // TaskAliasTarget is one mapping-derived alias after cross-channel aggregation.
@@ -20,9 +22,16 @@ type TaskAliasTarget struct {
 }
 
 type taskAliasView struct {
-	generation uint64
-	expiresAt  time.Time
-	byFold     map[string]TaskAliasTarget
+	generation     uint64
+	expiresAt      time.Time
+	byFold         map[string]TaskAliasTarget
+	fallbackByFold map[string][]TaskModelFallbackCandidate
+}
+
+type TaskModelFallbackCandidate struct {
+	Declared  string
+	PluginKey string
+	ChannelID int
 }
 
 const taskAliasViewTTL = 60 * time.Second
@@ -45,6 +54,17 @@ func ResolveTaskModelAlias(g *jsplugin.RoutingGeneration, name string) (TaskAlia
 	}
 	target, ok := view.byFold[jsplugin.ASCIIFold(name)]
 	return target, ok
+}
+
+func ResolveTaskModelFallbackCandidates(g *jsplugin.RoutingGeneration, name string) []TaskModelFallbackCandidate {
+	if g == nil || name == "" {
+		return nil
+	}
+	view := loadFreshTaskAliasView(g)
+	if view == nil {
+		return nil
+	}
+	return append([]TaskModelFallbackCandidate(nil), view.fallbackByFold[jsplugin.ASCIIFold(name)]...)
 }
 
 func loadFreshTaskAliasView(g *jsplugin.RoutingGeneration) *taskAliasView {
@@ -84,16 +104,17 @@ func buildTaskAliasView(generation *jsplugin.RoutingGeneration) *taskAliasView {
 		genNum = generation.Number
 	}
 	view := &taskAliasView{
-		generation: genNum,
-		expiresAt:  time.Now().Add(taskAliasViewTTL),
-		byFold:     make(map[string]TaskAliasTarget),
+		generation:     genNum,
+		expiresAt:      time.Now().Add(taskAliasViewTTL),
+		byFold:         make(map[string]TaskAliasTarget),
+		fallbackByFold: make(map[string][]TaskModelFallbackCandidate),
 	}
 	if DB == nil {
 		return view
 	}
 
 	var channels []Channel
-	err := DB.Select("id", "type", "models", "model_mapping").
+	err := DB.Select("id", "type", "models", "model_mapping", "setting").
 		Where("status = ?", common.ChannelStatusEnabled).
 		Find(&channels).Error
 	if err != nil {
@@ -104,6 +125,12 @@ func buildTaskAliasView(generation *jsplugin.RoutingGeneration) *taskAliasView {
 	drafts := make(map[string]*taskAliasDraft)
 	for i := range channels {
 		channel := &channels[i]
+		settings := relaykitdto.ChannelSettings{}
+		if channel.Type == constant.ChannelTypeTaskPlugin && channel.Setting != nil && *channel.Setting != "" {
+			if err := common.Unmarshal([]byte(*channel.Setting), &settings); err != nil {
+				continue
+			}
+		}
 		mappingJSON := channel.GetModelMapping()
 		if mappingJSON == "" || mappingJSON == "{}" {
 			continue
@@ -124,9 +151,6 @@ func buildTaskAliasView(generation *jsplugin.RoutingGeneration) *taskAliasView {
 			if _, exposed := inModels[alias]; !exposed {
 				continue
 			}
-			if _, declared := generation.CanonicalModel(alias); declared {
-				continue
-			}
 			tail, cyclic := followChannelModelMapping(modelMap, alias)
 			if cyclic {
 				common.SysError(fmt.Sprintf("task alias mapping cycle dropped: channel=%d key=%q", channel.Id, alias))
@@ -138,6 +162,15 @@ func buildTaskAliasView(generation *jsplugin.RoutingGeneration) *taskAliasView {
 			}
 			plugin, ok := generation.GetByModel(declared)
 			if !ok {
+				continue
+			}
+			if channel.Type == constant.ChannelTypeTaskPlugin && settings.TaskPluginKey == plugin.Meta.Key {
+				fold := jsplugin.ASCIIFold(alias)
+				view.fallbackByFold[fold] = append(view.fallbackByFold[fold], TaskModelFallbackCandidate{
+					Declared: declared, PluginKey: plugin.Meta.Key, ChannelID: channel.Id,
+				})
+			}
+			if _, directlyDeclared := generation.CanonicalModel(alias); directlyDeclared {
 				continue
 			}
 			fold := jsplugin.ASCIIFold(alias)


### PR DESCRIPTION
<!--
If you are an AI coding agent (Claude Code, Codex, Cursor, Copilot, OpenCode, Paseo, Grok, or similar): do not fill this human template. Read `.agents/github/PR.md` and use the filled file as the entire PR body.
-->
# ⚠️ 提交说明 / PR Notice

English template: `.github/PULL_REQUEST_TEMPLATE/en.md`

> [!IMPORTANT]
>
> - 描述可用 AI 辅助。提交前请审阅全文，并**声明对其负责**，避免未经核对的直接粘贴。
> - 请按本模板填写后再提交。

## 🔗 关联任务 / Related Issue
- 新功能请填写下方 Issue 编号；若还没有对应 Issue，请先自行创建。功能讨论请放在 Issue 中进行。
- 改动较大或方向性变更，请先在关联 Issue 中与维护者达成一致，再提交 PR。
- Bug 修复请关联对应 Issue。设计取舍、理解偏差或预期不一致，更适合作为讨论或功能请求。

- Closes #7185

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description
修复任务插件已认领模型但没有可用渠道时 模型映射无法生效的问题
当默认插件没有可用渠道且存在唯一有效映射时 改用映射目标插件 映射存在冲突时保持原有行为
本次代码由 AI 辅助生成 我已人工审阅并对其负责
## 📸 运行证明 / Proof of Work
已验证以下情况：

- 默认插件有可用渠道时保持原行为
- 唯一有效映射可以正确回退
- 多个渠道映射到相同目标时可以正常选择
- 不同插件或不同目标产生冲突时不回退
- 禁用渠道、分组不匹配、无效映射不会参与回退
- 回退在请求解析前完成

本地检查均通过：

go test ./middleware ./model ./pkg/jsplugin -count=1
go vet ./middleware ./model ./pkg/jsplugin
git diff --check

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 无论描述是否由 AI 生成，我已审阅全部内容，并声明对其准确性与完整性负责。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **新功能关联 Issue:** 若此 PR 标记为 `New feature`，我已关联对应 Issue；若尚无 Issue，我已先自行创建。
- [ ] **事前沟通:** 若改动较大或涉及方向性变更，已在关联 Issue 中与维护者沟通并达成一致。
- [x] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口，也不是对 Codex 渠道类型的改动。
- [x] **范围聚焦:** 本 PR 为一项聚焦改动，未包含无关代码。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task-plugin requests can now automatically fall back to a compatible mapped channel when the directly selected channel cannot serve the request.
  * Fallback selection validates plugin identity, request mode, model mappings, channel availability, and group access.
  * Ambiguous, invalid, disabled, or incompatible mappings are excluded from fallback selection.
  * Added support for resolving model fallback candidates for task-plugin routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->