### PR TITLE
fix(frontend): deduplicate /api/status requests (#7157) 

### DIFF
--- a/web/src/features/users/components/dialogs/__tests__/user-binding-dialog.test.tsx
+++ b/web/src/features/users/components/dialogs/__tests__/user-binding-dialog.test.tsx
@@ -28,7 +28,9 @@ import { UserBindingDialog } from '../user-binding-dialog'
  * The dialog reads `/api/status` through the shared React Query cache, so it
  * needs a provider. A fresh client per render keeps tests isolated.
  */
-function renderWithQueryClient(ui: React.ReactElement) {
+function renderWithQueryClient(
+  ui: React.ReactElement
+): ReturnType<typeof render> {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   })

--- a/web/src/features/users/components/dialogs/__tests__/user-binding-dialog.test.tsx
+++ b/web/src/features/users/components/dialogs/__tests__/user-binding-dialog.test.tsx
@@ -16,12 +16,26 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
 
 import { api } from '@/lib/api'
 
 import { UserBindingDialog } from '../user-binding-dialog'
+
+/**
+ * The dialog reads `/api/status` through the shared React Query cache, so it
+ * needs a provider. A fresh client per render keeps tests isolated.
+ */
+function renderWithQueryClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  )
+}
 
 type ApiMethod = (url: string) => Promise<{ data: unknown }>
 type MockableApi = {
@@ -117,7 +131,9 @@ describe('UserBindingDialog built-in bindings', () => {
       return { data: { success: true, message: 'success' } }
     }
 
-    render(<UserBindingDialog open userId={7} onOpenChange={() => undefined} />)
+    renderWithQueryClient(
+      <UserBindingDialog open userId={7} onOpenChange={() => undefined} />
+    )
 
     const expectedBindings = [
       ['Email', 'email'],

--- a/web/src/features/users/components/dialogs/__tests__/user-binding-dialog.test.tsx
+++ b/web/src/features/users/components/dialogs/__tests__/user-binding-dialog.test.tsx
@@ -17,10 +17,28 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest'
 
 import { api } from '@/lib/api'
+import { STATUS_QUERY_KEY } from '@/lib/status-query'
+import { useSystemConfigStore } from '@/stores/system-config-store'
 
 import { UserBindingDialog } from '../user-binding-dialog'
 
@@ -28,12 +46,20 @@ import { UserBindingDialog } from '../user-binding-dialog'
  * The dialog reads `/api/status` through the shared React Query cache, so it
  * needs a provider. A fresh client per render keeps tests isolated.
  */
-function renderWithQueryClient(
-  ui: React.ReactElement
-): ReturnType<typeof render> {
+const queryClients: QueryClient[] = []
+
+function createQueryClient(): QueryClient {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   })
+  queryClients.push(queryClient)
+  return queryClient
+}
+
+function renderWithQueryClient(
+  ui: React.ReactElement,
+  queryClient = createQueryClient()
+): ReturnType<typeof render> {
   return render(
     <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
   )
@@ -96,7 +122,16 @@ afterAll(() => {
   Reflect.deleteProperty(HTMLElement.prototype, 'getAnimations')
 })
 
+beforeEach(() => {
+  window.localStorage.clear()
+  useSystemConfigStore.setState(useSystemConfigStore.getInitialState(), true)
+})
+
 afterEach(() => {
+  cleanup()
+  queryClients.splice(0).forEach((client) => client.clear())
+  window.localStorage.clear()
+  useSystemConfigStore.setState(useSystemConfigStore.getInitialState(), true)
   apiClient.get = originalGet
   apiClient.delete = originalDelete
 })
@@ -163,4 +198,135 @@ describe('UserBindingDialog built-in bindings', () => {
 
     expect(deletedUrls).toHaveLength(expectedBindings.length)
   })
+})
+
+describe('UserBindingDialog shared status updates', () => {
+  test('updates provider availability and the provider list after a background refresh', async () => {
+    const queryClient = createQueryClient()
+    queryClient.setQueryData(
+      STATUS_QUERY_KEY,
+      { github_oauth: false },
+      { updatedAt: Date.now() - 600_000 }
+    )
+    let resolveStatus!: (value: { data: unknown }) => void
+    const response = new Promise<{ data: unknown }>((resolve) => {
+      resolveStatus = resolve
+    })
+    apiClient.get = async (url) => {
+      if (url === '/api/status') return response
+      if (url === '/api/user/7') return { data: { success: true, data: user } }
+      if (url === '/api/user/7/oauth/bindings') {
+        return { data: { success: true, data: [] } }
+      }
+      throw new Error(`Unexpected GET ${url}`)
+    }
+    renderWithQueryClient(
+      <UserBindingDialog open userId={7} onOpenChange={() => undefined} />,
+      queryClient
+    )
+    await screen.findByText('bound-user (ID: 7)')
+    expect(screen.getByText('GitHub').parentElement).toHaveTextContent(
+      'Disabled'
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Show All' }))
+    await act(async () => {
+      resolveStatus({
+        data: {
+          success: true,
+          data: {
+            github_oauth: true,
+            custom_oauth_providers: [{ id: 9, name: 'New provider' }],
+          },
+        },
+      })
+    })
+    await screen.findByText('New provider')
+    expect(screen.getByText('GitHub').parentElement).not.toHaveTextContent(
+      'Disabled'
+    )
+  })
+
+  test.each(['success', 'failure'] as const)(
+    'waits for the initial status request and shows user data on %s',
+    async (outcome) => {
+      let resolveStatus!: (value: { data: unknown }) => void
+      let rejectStatus!: (error: Error) => void
+      const response = new Promise<{ data: unknown }>((resolve, reject) => {
+        resolveStatus = resolve
+        rejectStatus = reject
+      })
+      const get = vi.fn(async (url: string) => {
+        if (url === '/api/status') return response
+        if (url === '/api/user/7') {
+          return { data: { success: true, data: user } }
+        }
+        if (url === '/api/user/7/oauth/bindings') {
+          return { data: { success: true, data: [] } }
+        }
+        throw new Error(`Unexpected GET ${url}`)
+      })
+      apiClient.get = get
+      renderWithQueryClient(
+        <UserBindingDialog open userId={7} onOpenChange={() => undefined} />
+      )
+      await waitFor(() => expect(get).toHaveBeenCalledWith('/api/status'))
+      expect(screen.queryByText('bound-user (ID: 7)')).not.toBeInTheDocument()
+      await act(async () => {
+        if (outcome === 'success') {
+          resolveStatus({
+            data: { success: true, data: { github_oauth: true } },
+          })
+        } else rejectStatus(new Error('Status unavailable'))
+      })
+      await screen.findByText('bound-user (ID: 7)')
+      expect(screen.getByText('github-user')).toBeInTheDocument()
+    }
+  )
+
+  test('retains cached provider state when background refresh fails', async () => {
+    const queryClient = createQueryClient()
+    queryClient.setQueryData(
+      STATUS_QUERY_KEY,
+      { github_oauth: true },
+      { updatedAt: Date.now() - 600_000 }
+    )
+    apiClient.get = async (url) => {
+      if (url === '/api/status') throw new Error('Status unavailable')
+      if (url === '/api/user/7') return { data: { success: true, data: user } }
+      if (url === '/api/user/7/oauth/bindings') {
+        return { data: { success: true, data: [] } }
+      }
+      throw new Error(`Unexpected GET ${url}`)
+    }
+    renderWithQueryClient(
+      <UserBindingDialog open userId={7} onOpenChange={() => undefined} />,
+      queryClient
+    )
+    await screen.findByText('bound-user (ID: 7)')
+    await waitFor(() =>
+      expect(queryClient.getQueryState(STATUS_QUERY_KEY)?.status).toBe('error')
+    )
+    expect(screen.getByText('GitHub').parentElement).not.toHaveTextContent(
+      'Disabled'
+    )
+  })
+
+  test.each([
+    { open: false, userId: 7 },
+    { open: true, userId: null },
+  ])(
+    'does not request status when open=$open and userId=$userId',
+    async (props) => {
+      const get = vi.fn(async () => {
+        throw new Error('Unexpected request')
+      })
+      apiClient.get = get
+      await act(async () => {
+        renderWithQueryClient(
+          <UserBindingDialog {...props} onOpenChange={() => undefined} />
+        )
+      })
+      expect(get).not.toHaveBeenCalled()
+    }
+  )
 })

--- a/web/src/features/users/components/dialogs/user-binding-dialog.tsx
+++ b/web/src/features/users/components/dialogs/user-binding-dialog.tsx
@@ -16,6 +16,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
+import { useQueryClient } from '@tanstack/react-query'
 import {
   Mail,
   Globe,
@@ -44,8 +45,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { api } from '@/lib/api'
 import { indexCustomOAuthBindings, type CustomOAuthBinding } from '@/lib/oauth'
+import { ensureStatus } from '@/lib/status-query'
 
 import {
   getUser,
@@ -168,6 +169,7 @@ export function UserBindingDialog(props: Props) {
   const [showBoundOnly, setShowBoundOnly] = useState(true)
   const [unbindTarget, setUnbindTarget] = useState<BindingItem | null>(null)
   const [unbinding, setUnbinding] = useState(false)
+  const queryClient = useQueryClient()
 
   const fetchData = useCallback(async () => {
     if (!props.userId) return
@@ -179,13 +181,7 @@ export function UserBindingDialog(props: Props) {
           success: false,
           data: [],
         })),
-        api
-          .get('/api/status')
-          .then((r) => r.data)
-          .catch(() => ({
-            success: false,
-            data: {},
-          })),
+        ensureStatus(queryClient).catch(() => null),
       ])
       if (userRes.success && userRes.data) {
         setUser(userRes.data)
@@ -193,15 +189,15 @@ export function UserBindingDialog(props: Props) {
       if (oauthRes.success && oauthRes.data) {
         setOauthBindings(oauthRes.data)
       }
-      if (statusRes.success && statusRes.data) {
-        setStatusInfo(statusRes.data as StatusInfo)
+      if (statusRes) {
+        setStatusInfo(statusRes as StatusInfo)
       }
     } catch {
       toast.error(t('Failed to load'))
     } finally {
       setLoading(false)
     }
-  }, [props.userId, t])
+  }, [props.userId, queryClient, t])
 
   useEffect(() => {
     if (props.open && props.userId) {

--- a/web/src/features/users/components/dialogs/user-binding-dialog.tsx
+++ b/web/src/features/users/components/dialogs/user-binding-dialog.tsx
@@ -16,7 +16,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import {
   Mail,
   Globe,
@@ -46,7 +46,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { indexCustomOAuthBindings, type CustomOAuthBinding } from '@/lib/oauth'
-import { ensureStatus } from '@/lib/status-query'
+import { statusQueryOptions } from '@/lib/status-query'
 
 import {
   getUser,
@@ -164,24 +164,25 @@ export function UserBindingDialog(props: Props) {
   const { t } = useTranslation()
   const [user, setUser] = useState<User | null>(null)
   const [oauthBindings, setOauthBindings] = useState<CustomOAuthBinding[]>([])
-  const [statusInfo, setStatusInfo] = useState<StatusInfo>({})
   const [loading, setLoading] = useState(false)
   const [showBoundOnly, setShowBoundOnly] = useState(true)
   const [unbindTarget, setUnbindTarget] = useState<BindingItem | null>(null)
   const [unbinding, setUnbinding] = useState(false)
-  const queryClient = useQueryClient()
+  const { data: statusInfo, isLoading: statusLoading } = useQuery({
+    ...statusQueryOptions,
+    enabled: props.open && !!props.userId,
+  })
 
   const fetchData = useCallback(async () => {
     if (!props.userId) return
     setLoading(true)
     try {
-      const [userRes, oauthRes, statusRes] = await Promise.all([
+      const [userRes, oauthRes] = await Promise.all([
         getUser(props.userId),
         getUserOAuthBindings(props.userId).catch(() => ({
           success: false,
           data: [],
         })),
-        ensureStatus(queryClient).catch(() => null),
       ])
       if (userRes.success && userRes.data) {
         setUser(userRes.data)
@@ -189,15 +190,12 @@ export function UserBindingDialog(props: Props) {
       if (oauthRes.success && oauthRes.data) {
         setOauthBindings(oauthRes.data)
       }
-      if (statusRes) {
-        setStatusInfo(statusRes as StatusInfo)
-      }
     } catch {
       toast.error(t('Failed to load'))
     } finally {
       setLoading(false)
     }
-  }, [props.userId, queryClient, t])
+  }, [props.userId, t])
 
   useEffect(() => {
     if (props.open && props.userId) {
@@ -206,12 +204,12 @@ export function UserBindingDialog(props: Props) {
     } else {
       setUser(null)
       setOauthBindings([])
-      setStatusInfo({})
     }
   }, [props.open, props.userId, fetchData])
 
   const allBindings = useMemo<BindingItem[]>(() => {
     const items: BindingItem[] = []
+    const status = statusInfo as StatusInfo | undefined
 
     for (const field of BUILTIN_BINDINGS) {
       const value = user
@@ -219,7 +217,7 @@ export function UserBindingDialog(props: Props) {
         : ''
       const isBound = !!value
       const isEnabled =
-        field.statusKey == null ? true : Boolean(statusInfo[field.statusKey])
+        field.statusKey == null ? true : Boolean(status?.[field.statusKey])
 
       items.push({
         key: field.key,
@@ -234,7 +232,7 @@ export function UserBindingDialog(props: Props) {
 
     const oauthBindingMap = indexCustomOAuthBindings(oauthBindings)
 
-    const customProviders = statusInfo.custom_oauth_providers || []
+    const customProviders = status?.custom_oauth_providers || []
     const seenProviderIds = new Set<number>()
 
     for (const provider of customProviders) {
@@ -324,7 +322,7 @@ export function UserBindingDialog(props: Props) {
         contentHeight='auto'
         bodyClassName='space-y-4'
       >
-        {loading ? (
+        {loading || statusLoading ? (
           <div className='flex items-center justify-center py-8'>
             <Loader2 className='text-muted-foreground h-6 w-6 animate-spin' />
           </div>

--- a/web/src/hooks/use-status.ts
+++ b/web/src/hooks/use-status.ts
@@ -21,11 +21,17 @@ import { useQuery } from '@tanstack/react-query'
 import type { SystemStatus } from '@/features/auth/types'
 import { readCachedStatus, statusQueryOptions } from '@/lib/status-query'
 
-// Get initial cache from localStorage
+/** Seed value from the persisted snapshot, so the first render is not empty. */
 function getInitialStatus(): SystemStatus | undefined {
   return (readCachedStatus() as SystemStatus | null) ?? undefined
 }
 
+/**
+ * Subscribe to the shared `/api/status` query.
+ *
+ * Every caller reads the same cache entry, so mounting this hook in several
+ * components costs one request. See `statusQueryOptions` for cache lifetimes.
+ */
 export function useStatus() {
   const { data, isLoading, error } = useQuery({
     ...statusQueryOptions,

--- a/web/src/hooks/use-status.ts
+++ b/web/src/hooks/use-status.ts
@@ -19,63 +19,22 @@ For commercial licensing, please contact support@quantumnous.com
 import { useQuery } from '@tanstack/react-query'
 
 import type { SystemStatus } from '@/features/auth/types'
-import { getStatus } from '@/lib/api'
-import { useSystemConfigStore } from '@/stores/system-config-store'
-
-import { mapStatusDataToConfig } from './use-system-config'
+import { readCachedStatus, statusQueryOptions } from '@/lib/status-query'
 
 // Get initial cache from localStorage
 function getInitialStatus(): SystemStatus | undefined {
-  try {
-    if (typeof window !== 'undefined') {
-      const saved = window.localStorage.getItem('status')
-      return saved ? (JSON.parse(saved) as SystemStatus) : undefined
-    }
-  } catch {
-    /* empty */
-  }
-  return undefined
+  return (readCachedStatus() as SystemStatus | null) ?? undefined
 }
 
 export function useStatus() {
   const { data, isLoading, error } = useQuery({
-    queryKey: ['status'],
-    queryFn: async () => {
-      const status = await getStatus()
-      try {
-        if (status) {
-          const { setConfig } = useSystemConfigStore.getState()
-          setConfig(mapStatusDataToConfig(status))
-        }
-      } catch (err) {
-        if (import.meta.env.DEV) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            '[useStatus] Failed to sync status to system config',
-            err
-          )
-        }
-      }
-      // Save to localStorage
-      try {
-        if (typeof window !== 'undefined' && status) {
-          window.localStorage.setItem('status', JSON.stringify(status))
-        }
-      } catch {
-        /* empty */
-      }
-      return status as SystemStatus | null
-    },
+    ...statusQueryOptions,
     // Use localStorage data as initial data
     placeholderData: getInitialStatus(),
-    // Data becomes stale after 5 minutes
-    staleTime: 5 * 60 * 1000,
-    // Cache expires after 30 minutes
-    gcTime: 30 * 60 * 1000,
   })
 
   return {
-    status: data ?? null,
+    status: (data as SystemStatus | null) ?? null,
     loading: isLoading,
     error,
   }

--- a/web/src/hooks/use-system-config.ts
+++ b/web/src/hooks/use-system-config.ts
@@ -16,101 +16,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
+import { useQueryClient } from '@tanstack/react-query'
 import { useEffect, useCallback } from 'react'
 
-import { DEFAULT_SYSTEM_NAME, DEFAULT_LOGO } from '@/lib/constants'
+import { DEFAULT_LOGO } from '@/lib/constants'
 import { applyFaviconToDom } from '@/lib/dom-utils'
-import {
-  useSystemConfigStore,
-  type CurrencyConfig,
-  type CurrencyDisplayType,
-  type SystemConfig,
-  DEFAULT_CURRENCY_CONFIG,
-} from '@/stores/system-config-store'
+import { ensureStatus } from '@/lib/status-query'
+import { useSystemConfigStore } from '@/stores/system-config-store'
 
 interface UseSystemConfigOptions {
   /** Automatically fetch config from backend (use only in root component) */
   autoLoad?: boolean
-}
-
-interface StatusApiResponse {
-  success: boolean
-  data: {
-    system_name?: string
-    logo?: string
-    footer_html?: string
-    demo_site_enabled?: boolean
-    display_token_stat_enabled?: boolean
-    display_in_currency?: boolean
-    quota_display_type?: CurrencyDisplayType
-    quota_per_unit?: number
-    usd_exchange_rate?: number
-    custom_currency_symbol?: string
-    custom_currency_exchange_rate?: number
-  }
-}
-
-function toNumber(value: unknown, fallback: number): number {
-  if (typeof value === 'number' && !Number.isNaN(value)) return value
-  if (typeof value === 'string') {
-    const parsed = Number(value)
-    if (!Number.isNaN(parsed)) return parsed
-  }
-  return fallback
-}
-
-/**
- * Map `/api/status` response data to our persisted system config structure
- */
-export function mapStatusDataToConfig(
-  data: StatusApiResponse['data'] | undefined
-): Partial<SystemConfig> {
-  if (!data) return {}
-
-  const quotaDisplayType =
-    (data.quota_display_type as CurrencyDisplayType | undefined) ??
-    DEFAULT_CURRENCY_CONFIG.quotaDisplayType
-
-  const currency: CurrencyConfig = {
-    displayInCurrency:
-      data.display_in_currency ?? DEFAULT_CURRENCY_CONFIG.displayInCurrency,
-    quotaDisplayType,
-    quotaPerUnit: toNumber(
-      data.quota_per_unit,
-      DEFAULT_CURRENCY_CONFIG.quotaPerUnit
-    ),
-    usdExchangeRate: toNumber(
-      data.usd_exchange_rate,
-      DEFAULT_CURRENCY_CONFIG.usdExchangeRate
-    ),
-    customCurrencySymbol:
-      data.custom_currency_symbol?.trim() ||
-      DEFAULT_CURRENCY_CONFIG.customCurrencySymbol,
-    customCurrencyExchangeRate: toNumber(
-      data.custom_currency_exchange_rate,
-      DEFAULT_CURRENCY_CONFIG.customCurrencyExchangeRate
-    ),
-  }
-
-  return {
-    systemName: data.system_name || DEFAULT_SYSTEM_NAME,
-    logo: data.logo || DEFAULT_LOGO,
-    footerHtml: data.footer_html,
-    demoSiteEnabled: data.demo_site_enabled,
-    displayTokenStatEnabled: data.display_token_stat_enabled,
-    currency,
-  }
-}
-
-// Fetch system config from API
-async function fetchSystemConfig(): Promise<Partial<SystemConfig>> {
-  const response = await fetch('/api/status')
-  if (!response.ok) throw new Error('Failed to fetch status')
-
-  const data: StatusApiResponse = await response.json()
-  if (!data.success) throw new Error('API returned error')
-
-  return mapStatusDataToConfig(data.data)
 }
 
 // Preload image and return cleanup function
@@ -143,28 +59,24 @@ function preloadImage(
  */
 export function useSystemConfig(options: UseSystemConfigOptions = {}) {
   const { autoLoad = false } = options
-  const {
-    config,
-    loading,
-    loadedLogoUrl,
-    setConfig,
-    setLoadedLogoUrl,
-    setLoading,
-  } = useSystemConfigStore()
+  const queryClient = useQueryClient()
+  const { config, loading, loadedLogoUrl, setLoadedLogoUrl, setLoading } =
+    useSystemConfigStore()
 
-  // Load config from backend
+  // Load config from backend via the shared `/api/status` cache.
+  // `ensureStatus` writes the mapped config into this store itself, so there is
+  // no second request and no second mapping path here.
   const loadConfig = useCallback(async () => {
     try {
       setLoading(true)
-      const newConfig = await fetchSystemConfig()
-      setConfig(newConfig)
+      await ensureStatus(queryClient)
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to load system config:', error)
     } finally {
       setLoading(false)
     }
-  }, [setConfig, setLoading])
+  }, [queryClient, setLoading])
 
   useEffect(() => {
     if (autoLoad) loadConfig()

--- a/web/src/hooks/use-system-config.ts
+++ b/web/src/hooks/use-system-config.ts
@@ -29,7 +29,7 @@ interface UseSystemConfigOptions {
   autoLoad?: boolean
 }
 
-// Preload image and return cleanup function
+/** Preload an image, returning a cleanup that detaches the pending handlers. */
 function preloadImage(
   src: string,
   onLoad: () => void,

--- a/web/src/lib/__tests__/status-query.test.tsx
+++ b/web/src/lib/__tests__/status-query.test.tsx
@@ -1,0 +1,142 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import { useStatus } from '@/hooks/use-status'
+import { api } from '@/lib/api'
+import {
+  STATUS_QUERY_KEY,
+  STATUS_STORAGE_KEY,
+  ensureStatus,
+  statusQueryOptions,
+} from '@/lib/status-query'
+
+/**
+ * Guards the deduplication contract of the shared `['status']` query: several
+ * independent consumers asking for status must cost one `/api/status` request.
+ */
+
+type ApiMethod = (url: string) => Promise<{ data: unknown }>
+type MockableApi = { get: ApiMethod }
+
+const apiClient = api as unknown as MockableApi
+const originalGet = apiClient.get
+
+let statusRequests: string[] = []
+
+/** Count `/api/status` calls at the network boundary and serve `system_name`. */
+function stubStatusEndpoint(systemName: string): void {
+  apiClient.get = async (url) => {
+    if (url !== '/api/status') throw new Error(`Unexpected GET ${url}`)
+    statusRequests.push(url)
+    return { data: { success: true, data: { system_name: systemName } } }
+  }
+}
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+}
+
+function wrapper(queryClient: QueryClient) {
+  return function QueryWrapper(props: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    )
+  }
+}
+
+beforeEach(() => {
+  statusRequests = []
+  window.localStorage.removeItem(STATUS_STORAGE_KEY)
+})
+
+afterEach(() => {
+  apiClient.get = originalGet
+  window.localStorage.removeItem(STATUS_STORAGE_KEY)
+})
+
+describe('shared status query deduplication', () => {
+  test('serves concurrent guard and hook consumers from one /api/status request', async () => {
+    stubStatusEndpoint('shared')
+    const queryClient = createQueryClient()
+
+    const guards = Promise.all([
+      ensureStatus(queryClient),
+      ensureStatus(queryClient),
+      ensureStatus(queryClient),
+    ])
+    const hook = renderHook(() => useStatus(), {
+      wrapper: wrapper(queryClient),
+    })
+
+    const guardResults = await guards
+    await waitFor(() => {
+      expect(hook.result.current.status?.system_name).toBe('shared')
+    })
+
+    expect(guardResults.map((status) => status?.system_name)).toEqual([
+      'shared',
+      'shared',
+      'shared',
+    ])
+    expect(statusRequests).toHaveLength(1)
+  })
+
+  test('resolves a later consumer from the warm cache without a second request', async () => {
+    stubStatusEndpoint('warm')
+    const queryClient = createQueryClient()
+
+    await ensureStatus(queryClient)
+    const second = await ensureStatus(queryClient)
+
+    expect(second?.system_name).toBe('warm')
+    expect(statusRequests).toHaveLength(1)
+  })
+
+  test('returns a stale entry immediately and refreshes it in the background', async () => {
+    stubStatusEndpoint('refreshed')
+    const queryClient = createQueryClient()
+    const staleTime = statusQueryOptions.staleTime as number
+    queryClient.setQueryData(
+      STATUS_QUERY_KEY,
+      { system_name: 'stale' },
+      {
+        updatedAt: Date.now() - staleTime - 1,
+      }
+    )
+
+    const resolved = await ensureStatus(queryClient)
+
+    expect(resolved?.system_name).toBe('stale')
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<Record<string, unknown>>(STATUS_QUERY_KEY)
+          ?.system_name
+      ).toBe('refreshed')
+    })
+    expect(statusRequests).toHaveLength(1)
+  })
+})

--- a/web/src/lib/__tests__/status-query.test.tsx
+++ b/web/src/lib/__tests__/status-query.test.tsx
@@ -17,18 +17,22 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { renderHook, waitFor } from '@testing-library/react'
+import { cleanup, renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
 import { useStatus } from '@/hooks/use-status'
 import { api } from '@/lib/api'
 import {
+  getModuleAccessForGuard,
+  type HeaderNavModule,
+} from '@/lib/nav-modules'
+import {
   STATUS_QUERY_KEY,
-  STATUS_STORAGE_KEY,
   ensureStatus,
   statusQueryOptions,
 } from '@/lib/status-query'
+import { useSystemConfigStore } from '@/stores/system-config-store'
 
 /**
  * Guards the deduplication contract of the shared `['status']` query: several
@@ -42,6 +46,7 @@ const apiClient = api as unknown as MockableApi
 const originalGet = apiClient.get
 
 let statusRequests: string[] = []
+const queryClients: QueryClient[] = []
 
 /** Count `/api/status` calls at the network boundary and serve `system_name`. */
 function stubStatusEndpoint(systemName: string): void {
@@ -53,9 +58,11 @@ function stubStatusEndpoint(systemName: string): void {
 }
 
 function createQueryClient(): QueryClient {
-  return new QueryClient({
+  const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
+  queryClients.push(queryClient)
+  return queryClient
 }
 
 function wrapper(queryClient: QueryClient) {
@@ -70,40 +77,72 @@ function wrapper(queryClient: QueryClient) {
 
 beforeEach(() => {
   statusRequests = []
-  window.localStorage.removeItem(STATUS_STORAGE_KEY)
+  window.localStorage.clear()
+  useSystemConfigStore.setState(useSystemConfigStore.getInitialState(), true)
 })
 
 afterEach(() => {
+  cleanup()
+  queryClients.splice(0).forEach((client) => client.clear())
   apiClient.get = originalGet
-  window.localStorage.removeItem(STATUS_STORAGE_KEY)
+  window.localStorage.clear()
+  useSystemConfigStore.setState(useSystemConfigStore.getInitialState(), true)
 })
 
 describe('shared status query deduplication', () => {
-  test('serves concurrent guard and hook consumers from one /api/status request', async () => {
-    stubStatusEndpoint('shared')
-    const queryClient = createQueryClient()
-
-    const guards = Promise.all([
-      ensureStatus(queryClient),
-      ensureStatus(queryClient),
-      ensureStatus(queryClient),
-    ])
-    const hook = renderHook(() => useStatus(), {
-      wrapper: wrapper(queryClient),
-    })
-
-    const guardResults = await guards
-    await waitFor(() => {
-      expect(hook.result.current.status?.system_name).toBe('shared')
-    })
-
-    expect(guardResults.map((status) => status?.system_name)).toEqual([
-      'shared',
-      'shared',
-      'shared',
-    ])
-    expect(statusRequests).toHaveLength(1)
-  })
+  test.each(['cold', 'stale'] as const)(
+    'deduplicates %s cache requests across guards and hook consumers',
+    async (cacheState) => {
+      const queryClient = createQueryClient()
+      if (cacheState === 'stale') {
+        queryClient.setQueryData(
+          STATUS_QUERY_KEY,
+          {
+            system_name: 'old',
+            HeaderNavModules: { pricing: false, rankings: false },
+          },
+          { updatedAt: Date.now() - 600_000 }
+        )
+      }
+      const status = {
+        system_name: 'shared',
+        HeaderNavModules: {
+          pricing: { enabled: true, requireAuth: true },
+          rankings: { enabled: true, requireAuth: false },
+        },
+      }
+      let resolveStatus!: (value: { data: unknown }) => void
+      const response = new Promise<{ data: unknown }>((resolve) => {
+        resolveStatus = resolve
+      })
+      apiClient.get = (url) => {
+        statusRequests.push(url)
+        return response
+      }
+      let guardsResolved = false
+      const guards = Promise.all([
+        getModuleAccessForGuard(queryClient, 'pricing'),
+        getModuleAccessForGuard(queryClient, 'rankings'),
+      ]).then((result) => {
+        guardsResolved = true
+        return result
+      })
+      const hook = renderHook(() => useStatus(), {
+        wrapper: wrapper(queryClient),
+      })
+      await waitFor(() => expect(statusRequests).toEqual(['/api/status']))
+      expect(guardsResolved).toBe(false)
+      resolveStatus({ data: { success: true, data: status } })
+      expect(await guards).toEqual([
+        { enabled: true, requireAuth: true },
+        { enabled: true, requireAuth: false },
+      ])
+      await waitFor(() =>
+        expect(hook.result.current.status?.system_name).toBe('shared')
+      )
+      expect(statusRequests).toHaveLength(1)
+    }
+  )
 
   test('resolves a later consumer from the warm cache without a second request', async () => {
     stubStatusEndpoint('warm')
@@ -139,4 +178,88 @@ describe('shared status query deduplication', () => {
     })
     expect(statusRequests).toHaveLength(1)
   })
+})
+
+describe('module guard status freshness', () => {
+  test.each([
+    {
+      module: 'pricing',
+      before: { enabled: false, requireAuth: false },
+      after: { enabled: true, requireAuth: false },
+    },
+    {
+      module: 'rankings',
+      before: { enabled: true, requireAuth: false },
+      after: { enabled: false, requireAuth: false },
+    },
+    {
+      module: 'pricing',
+      before: { enabled: true, requireAuth: false },
+      after: { enabled: true, requireAuth: true },
+    },
+    {
+      module: 'rankings',
+      before: { enabled: true, requireAuth: true },
+      after: { enabled: true, requireAuth: false },
+    },
+  ])('uses refreshed $module access: $before -> $after', async (scenario) => {
+    const queryClient = createQueryClient()
+    queryClient.setQueryData(
+      STATUS_QUERY_KEY,
+      { HeaderNavModules: { [scenario.module]: scenario.before } },
+      { updatedAt: Date.now() - 600_000 }
+    )
+    apiClient.get = async () => ({
+      data: {
+        success: true,
+        data: { HeaderNavModules: { [scenario.module]: scenario.after } },
+      },
+    })
+    expect(
+      await getModuleAccessForGuard(
+        queryClient,
+        scenario.module as HeaderNavModule
+      )
+    ).toEqual(scenario.after)
+  })
+
+  test('reuses fresh access but refreshes explicitly invalidated access', async () => {
+    const queryClient = createQueryClient()
+    queryClient.setQueryData(STATUS_QUERY_KEY, {
+      HeaderNavModules: { pricing: false },
+    })
+    stubStatusEndpoint('updated')
+    expect(await getModuleAccessForGuard(queryClient, 'pricing')).toEqual({
+      enabled: false,
+      requireAuth: false,
+    })
+    expect(statusRequests).toHaveLength(0)
+    await queryClient.invalidateQueries({ queryKey: STATUS_QUERY_KEY })
+    expect(await getModuleAccessForGuard(queryClient, 'pricing')).toEqual({
+      enabled: true,
+      requireAuth: false,
+    })
+    expect(statusRequests).toHaveLength(1)
+  })
+
+  test.each(['cold', 'stale'] as const)(
+    'fails closed when a %s cache request fails',
+    async (cacheState) => {
+      const queryClient = createQueryClient()
+      if (cacheState === 'stale') {
+        queryClient.setQueryData(
+          STATUS_QUERY_KEY,
+          { HeaderNavModules: { pricing: true } },
+          { updatedAt: Date.now() - 600_000 }
+        )
+      }
+      apiClient.get = async () => {
+        throw new Error('Status unavailable')
+      }
+      expect(await getModuleAccessForGuard(queryClient, 'pricing')).toEqual({
+        enabled: false,
+        requireAuth: true,
+      })
+    }
+  )
 })

--- a/web/src/lib/nav-modules.ts
+++ b/web/src/lib/nav-modules.ts
@@ -16,7 +16,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { getStatus } from '@/lib/api'
+import type { QueryClient } from '@tanstack/react-query'
+
+import { ensureStatus, readCachedStatus } from '@/lib/status-query'
 
 export type ModuleAccess = { enabled: boolean; requireAuth: boolean }
 
@@ -142,26 +144,6 @@ export function parseHeaderNavModulesFromStatus(
   return parseHeaderNavModules(status?.HeaderNavModules)
 }
 
-function getCachedStatus(): Record<string, unknown> | null {
-  try {
-    if (typeof window === 'undefined') return null
-    const raw = window.localStorage.getItem('status')
-    return raw ? (JSON.parse(raw) as Record<string, unknown>) : null
-  } catch {
-    return null
-  }
-}
-
-function cacheStatus(status: Record<string, unknown> | null): void {
-  try {
-    if (typeof window !== 'undefined' && status) {
-      window.localStorage.setItem('status', JSON.stringify(status))
-    }
-  } catch {
-    /* empty */
-  }
-}
-
 export function getModuleAccessFromStatus(
   status: Record<string, unknown> | null,
   module: HeaderNavModule
@@ -170,15 +152,23 @@ export function getModuleAccessFromStatus(
 }
 
 export function getModuleAccess(module: HeaderNavModule): ModuleAccess {
-  return getModuleAccessFromStatus(getCachedStatus(), module)
+  return getModuleAccessFromStatus(readCachedStatus(), module)
 }
 
+/**
+ * Resolve module access for a router guard.
+ *
+ * Goes through the shared `['status']` cache, so a guard on a fresh page load
+ * reuses the request already started during boot instead of issuing its own.
+ * Once the cache is warm this resolves without blocking on the network — see
+ * `ensureStatus` for the exact fresh/stale resolution rules.
+ */
 export async function getFreshModuleAccess(
+  queryClient: QueryClient,
   module: HeaderNavModule
 ): Promise<ModuleAccess> {
   try {
-    const status = (await getStatus()) as Record<string, unknown> | null
-    cacheStatus(status)
+    const status = await ensureStatus(queryClient)
     return getModuleAccessFromStatus(status, module)
   } catch {
     return { enabled: false, requireAuth: true }
@@ -189,7 +179,7 @@ export function isSidebarModuleEnabled(
   section: string,
   module: string
 ): boolean {
-  const status = getCachedStatus()
+  const status = readCachedStatus()
   if (!status) return true
 
   const raw = status.SidebarModulesAdmin

--- a/web/src/lib/nav-modules.ts
+++ b/web/src/lib/nav-modules.ts
@@ -144,6 +144,12 @@ export function parseHeaderNavModulesFromStatus(
   return parseHeaderNavModules(status?.HeaderNavModules)
 }
 
+/**
+ * Resolve one module's access flags from an already-loaded status payload.
+ *
+ * Falls back to the module's default when status is missing or does not carry
+ * a `HeaderNavModules` entry for it.
+ */
 export function getModuleAccessFromStatus(
   status: Record<string, unknown> | null,
   module: HeaderNavModule
@@ -151,19 +157,34 @@ export function getModuleAccessFromStatus(
   return parseHeaderNavModulesFromStatus(status)[module] ?? DEFAULTS[module]
 }
 
+/**
+ * Read module access synchronously from the persisted status snapshot.
+ *
+ * For render paths that cannot await, such as deciding whether to show a nav
+ * item. Never issues a request; use {@link getModuleAccessForGuard} when the
+ * caller can await.
+ */
 export function getModuleAccess(module: HeaderNavModule): ModuleAccess {
   return getModuleAccessFromStatus(readCachedStatus(), module)
 }
 
 /**
- * Resolve module access for a router guard.
+ * Resolve module access for a router `beforeLoad` guard.
  *
- * Goes through the shared `['status']` cache, so a guard on a fresh page load
+ * Reads through the shared `['status']` cache, so a guard on a fresh page load
  * reuses the request already started during boot instead of issuing its own.
- * Once the cache is warm this resolves without blocking on the network — see
- * `ensureStatus` for the exact fresh/stale resolution rules.
+ *
+ * This does not force a network round trip: a warm cache resolves immediately,
+ * and a stale entry resolves from cache while a refresh runs in the background.
+ * A guard can therefore act on status that is up to one `staleTime` old — see
+ * `ensureStatus` for the exact resolution rules. That is deliberate; these
+ * guards only decide navigation, and the backend still authorizes every
+ * request behind them.
+ *
+ * On failure this fails closed, reporting the module as disabled and
+ * auth-required.
  */
-export async function getFreshModuleAccess(
+export async function getModuleAccessForGuard(
   queryClient: QueryClient,
   module: HeaderNavModule
 ): Promise<ModuleAccess> {
@@ -175,6 +196,12 @@ export async function getFreshModuleAccess(
   }
 }
 
+/**
+ * Whether an admin sidebar entry is enabled by `SidebarModulesAdmin`.
+ *
+ * Fails open: an absent, blank, or unparsable configuration keeps every module
+ * visible, so a status read that has not landed yet cannot blank the sidebar.
+ */
 export function isSidebarModuleEnabled(
   section: string,
   module: string

--- a/web/src/lib/nav-modules.ts
+++ b/web/src/lib/nav-modules.ts
@@ -18,7 +18,7 @@ For commercial licensing, please contact support@quantumnous.com
 */
 import type { QueryClient } from '@tanstack/react-query'
 
-import { ensureStatus, readCachedStatus } from '@/lib/status-query'
+import { readCachedStatus, statusQueryOptions } from '@/lib/status-query'
 
 export type ModuleAccess = { enabled: boolean; requireAuth: boolean }
 
@@ -174,12 +174,9 @@ export function getModuleAccess(module: HeaderNavModule): ModuleAccess {
  * Reads through the shared `['status']` cache, so a guard on a fresh page load
  * reuses the request already started during boot instead of issuing its own.
  *
- * This does not force a network round trip: a warm cache resolves immediately,
- * and a stale entry resolves from cache while a refresh runs in the background.
- * A guard can therefore act on status that is up to one `staleTime` old — see
- * `ensureStatus` for the exact resolution rules. That is deliberate; these
- * guards only decide navigation, and the backend still authorizes every
- * request behind them.
+ * Fresh entries resolve immediately. Stale or invalidated entries await a
+ * shared refresh before deciding navigation; a background refresh cannot undo
+ * a redirect already made by a guard. The backend still authorizes requests.
  *
  * On failure this fails closed, reporting the module as disabled and
  * auth-required.
@@ -189,7 +186,7 @@ export async function getModuleAccessForGuard(
   module: HeaderNavModule
 ): Promise<ModuleAccess> {
   try {
-    const status = await ensureStatus(queryClient)
+    const status = await queryClient.fetchQuery(statusQueryOptions)
     return getModuleAccessFromStatus(status, module)
   } catch {
     return { enabled: false, requireAuth: true }

--- a/web/src/lib/status-query.ts
+++ b/web/src/lib/status-query.ts
@@ -1,0 +1,177 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { queryOptions, type QueryClient } from '@tanstack/react-query'
+
+import { getStatus } from '@/lib/api'
+import { DEFAULT_SYSTEM_NAME, DEFAULT_LOGO } from '@/lib/constants'
+import {
+  useSystemConfigStore,
+  type CurrencyConfig,
+  type CurrencyDisplayType,
+  type SystemConfig,
+  DEFAULT_CURRENCY_CONFIG,
+} from '@/stores/system-config-store'
+
+/**
+ * Single source of truth for `/api/status`.
+ *
+ * `/api/status` is entirely global on the backend: every field is read from
+ * in-memory option maps under a read lock, with no user context and no auth
+ * middleware on the route. That makes it safe to share one cache entry across
+ * every consumer — branding, nav module gates, and the setup guard.
+ *
+ * Anything that needs status must go through `statusQueryOptions` so React
+ * Query can dedupe. Calling `getStatus()` directly re-introduces the duplicate
+ * requests this module exists to collapse.
+ */
+export const STATUS_QUERY_KEY = ['status'] as const
+
+export const STATUS_STORAGE_KEY = 'status'
+
+/** Status payload shape — loose on purpose; the backend map is open-ended. */
+export type StatusData = Record<string, unknown>
+
+function toNumber(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && !Number.isNaN(value)) return value
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    if (!Number.isNaN(parsed)) return parsed
+  }
+  return fallback
+}
+
+/**
+ * Map `/api/status` response data to our persisted system config structure
+ */
+export function mapStatusDataToConfig(
+  data: StatusData | undefined | null
+): Partial<SystemConfig> {
+  if (!data) return {}
+
+  const quotaDisplayType =
+    (data.quota_display_type as CurrencyDisplayType | undefined) ??
+    DEFAULT_CURRENCY_CONFIG.quotaDisplayType
+
+  const currency: CurrencyConfig = {
+    displayInCurrency:
+      (data.display_in_currency as boolean | undefined) ??
+      DEFAULT_CURRENCY_CONFIG.displayInCurrency,
+    quotaDisplayType,
+    quotaPerUnit: toNumber(
+      data.quota_per_unit,
+      DEFAULT_CURRENCY_CONFIG.quotaPerUnit
+    ),
+    usdExchangeRate: toNumber(
+      data.usd_exchange_rate,
+      DEFAULT_CURRENCY_CONFIG.usdExchangeRate
+    ),
+    customCurrencySymbol:
+      (data.custom_currency_symbol as string | undefined)?.trim() ||
+      DEFAULT_CURRENCY_CONFIG.customCurrencySymbol,
+    customCurrencyExchangeRate: toNumber(
+      data.custom_currency_exchange_rate,
+      DEFAULT_CURRENCY_CONFIG.customCurrencyExchangeRate
+    ),
+  }
+
+  return {
+    systemName: (data.system_name as string | undefined) || DEFAULT_SYSTEM_NAME,
+    logo: (data.logo as string | undefined) || DEFAULT_LOGO,
+    footerHtml: data.footer_html as string | undefined,
+    demoSiteEnabled: data.demo_site_enabled as boolean | undefined,
+    displayTokenStatEnabled: data.display_token_stat_enabled as
+      | boolean
+      | undefined,
+    currency,
+  }
+}
+
+/** Read the last known status from localStorage (survives reload, may be stale). */
+export function readCachedStatus(): StatusData | null {
+  try {
+    if (typeof window === 'undefined') return null
+    const raw = window.localStorage.getItem(STATUS_STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as StatusData) : null
+  } catch {
+    return null
+  }
+}
+
+function writeCachedStatus(status: StatusData | null): void {
+  try {
+    if (typeof window !== 'undefined' && status) {
+      window.localStorage.setItem(STATUS_STORAGE_KEY, JSON.stringify(status))
+    }
+  } catch {
+    /* Storage can be unavailable in private mode. */
+  }
+}
+
+async function fetchStatus(): Promise<StatusData | null> {
+  const status = (await getStatus()) as StatusData | null
+
+  if (status) {
+    try {
+      useSystemConfigStore.getState().setConfig(mapStatusDataToConfig(status))
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.warn('[status] Failed to sync status to system config', err)
+      }
+    }
+    writeCachedStatus(status)
+  }
+
+  return status
+}
+
+export const statusQueryOptions = queryOptions({
+  queryKey: STATUS_QUERY_KEY,
+  queryFn: fetchStatus,
+  // Data becomes stale after 5 minutes
+  staleTime: 5 * 60 * 1000,
+  // Cache expires after 30 minutes
+  gcTime: 30 * 60 * 1000,
+})
+
+/**
+ * Await status from the shared cache.
+ *
+ * Use this from router `beforeLoad` guards. Concurrent callers share one
+ * in-flight request, so the boot path costs a single `/api/status` round trip
+ * no matter how many guards and components ask for it.
+ *
+ * Resolution rules, which are `ensureQueryData`'s and not `staleTime`'s:
+ * - No cached entry: fetches and awaits the response.
+ * - Cached entry, fresh: resolves from cache, no network.
+ * - Cached entry, stale: resolves from cache *immediately* and kicks off a
+ *   background refresh (`revalidateIfStale`). Guards never block on a
+ *   revalidation, so a stale entry can be read once before the refresh lands.
+ *
+ * The React Query cache is memory-only (no persister is installed), so a hard
+ * reload always starts from an empty cache and fetches.
+ */
+export async function ensureStatus(
+  queryClient: QueryClient
+): Promise<StatusData | null> {
+  return queryClient.ensureQueryData({
+    ...statusQueryOptions,
+    revalidateIfStale: true,
+  })
+}

--- a/web/src/lib/status-query.ts
+++ b/web/src/lib/status-query.ts
@@ -47,6 +47,7 @@ export const STATUS_STORAGE_KEY = 'status'
 /** Status payload shape — loose on purpose; the backend map is open-ended. */
 export type StatusData = Record<string, unknown>
 
+/** Coerce a status field to a number, keeping `fallback` for unusable values. */
 function toNumber(value: unknown, fallback: number): number {
   if (typeof value === 'number' && !Number.isNaN(value)) return value
   if (typeof value === 'string') {
@@ -113,6 +114,7 @@ export function readCachedStatus(): StatusData | null {
   }
 }
 
+/** Persist the latest status so the next cold start can render before fetching. */
 function writeCachedStatus(status: StatusData | null): void {
   try {
     if (typeof window !== 'undefined' && status) {
@@ -123,6 +125,12 @@ function writeCachedStatus(status: StatusData | null): void {
   }
 }
 
+/**
+ * The single `/api/status` request.
+ *
+ * Owns both side effects of a successful read — syncing the system-config store
+ * and writing the localStorage snapshot — so consumers never repeat either one.
+ */
 async function fetchStatus(): Promise<StatusData | null> {
   const status = (await getStatus()) as StatusData | null
 

--- a/web/src/lib/status-query.ts
+++ b/web/src/lib/status-query.ts
@@ -161,16 +161,17 @@ export const statusQueryOptions = queryOptions({
 /**
  * Await status from the shared cache.
  *
- * Use this from router `beforeLoad` guards. Concurrent callers share one
- * in-flight request, so the boot path costs a single `/api/status` round trip
- * no matter how many guards and components ask for it.
+ * Use this when a cached snapshot can be shown during a background refresh,
+ * such as system configuration loading. Concurrent callers share one request.
+ * Navigation guards use `fetchQuery(statusQueryOptions)` instead, because
+ * redirects must wait for stale or invalidated access flags to refresh.
  *
  * Resolution rules, which are `ensureQueryData`'s and not `staleTime`'s:
  * - No cached entry: fetches and awaits the response.
  * - Cached entry, fresh: resolves from cache, no network.
  * - Cached entry, stale: resolves from cache *immediately* and kicks off a
- *   background refresh (`revalidateIfStale`). Guards never block on a
- *   revalidation, so a stale entry can be read once before the refresh lands.
+ *   background refresh (`revalidateIfStale`). Consumers must subscribe to the
+ *   updated query or system-config store to observe the refreshed data.
  *
  * The React Query cache is memory-only (no persister is installed), so a hard
  * reload always starts from an empty cache and fetches.

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -28,12 +28,12 @@ import { StrictMode } from 'react'
 import ReactDOM from 'react-dom/client'
 import { toast } from 'sonner'
 
-import { getStatus } from '@/lib/api'
 import { installBuildMetadata } from '@/lib/build-metadata'
 import { applyFaviconToDom } from '@/lib/dom-utils'
 import '@/lib/dayjs'
 import { initializeFrontendCache } from '@/lib/frontend-cache'
 import { handleServerError } from '@/lib/handle-server-error'
+import { readCachedStatus, statusQueryOptions } from '@/lib/status-query'
 
 import { DirectionProvider } from './context/direction-provider'
 import { FontProvider } from './context/font-provider'
@@ -125,27 +125,18 @@ if (!rootElement) {
       if (metaTitle) metaTitle.setAttribute('content', name)
     }
     // Cache-first
-    try {
-      const saved = localStorage.getItem('status')
-      if (saved) {
-        const s = JSON.parse(saved)
-        if (s?.system_name) apply(s.system_name)
-        if (s?.logo) applyFaviconToDom(s.logo)
-      }
-    } catch {
-      /* empty */
-    }
-    // Background refresh
-    getStatus()
+    const cached = readCachedStatus()
+    if (cached?.system_name) apply(cached.system_name as string)
+    if (cached?.logo) applyFaviconToDom(cached.logo as string)
+
+    // Background refresh through the shared cache. This primes ['status']
+    // before React mounts, so the root guard and every status consumer reuse
+    // this one request instead of firing their own. `fetchStatus` owns the
+    // localStorage write and the system-config store sync.
+    queryClient
+      .ensureQueryData(statusQueryOptions)
       .then((s) => {
-        if (s?.system_name) {
-          apply(s.system_name as string)
-          try {
-            localStorage.setItem('status', JSON.stringify(s))
-          } catch {
-            /* empty */
-          }
-        }
+        if (s?.system_name) apply(s.system_name as string)
         if (s?.logo) applyFaviconToDom(s.logo as string)
       })
       .catch(() => {

--- a/web/src/routes/pricing/$modelId/index.tsx
+++ b/web/src/routes/pricing/$modelId/index.tsx
@@ -38,8 +38,8 @@ const modelDetailsSearchSchema = z.object({
 
 export const Route = createFileRoute('/pricing/$modelId/')({
   validateSearch: modelDetailsSearchSchema,
-  beforeLoad: async ({ location }) => {
-    const access = await getFreshModuleAccess('pricing')
+  beforeLoad: async ({ context, location }) => {
+    const access = await getFreshModuleAccess(context.queryClient, 'pricing')
     if (!access.enabled) {
       throw redirect({ to: '/' })
     }

--- a/web/src/routes/pricing/$modelId/index.tsx
+++ b/web/src/routes/pricing/$modelId/index.tsx
@@ -20,7 +20,7 @@ import { createFileRoute, redirect } from '@tanstack/react-router'
 import z from 'zod'
 
 import { ModelDetails } from '@/features/pricing/components/model-details'
-import { getFreshModuleAccess } from '@/lib/nav-modules'
+import { getModuleAccessForGuard } from '@/lib/nav-modules'
 import { useAuthStore } from '@/stores/auth-store'
 
 const modelDetailsSearchSchema = z.object({
@@ -39,7 +39,7 @@ const modelDetailsSearchSchema = z.object({
 export const Route = createFileRoute('/pricing/$modelId/')({
   validateSearch: modelDetailsSearchSchema,
   beforeLoad: async ({ context, location }) => {
-    const access = await getFreshModuleAccess(context.queryClient, 'pricing')
+    const access = await getModuleAccessForGuard(context.queryClient, 'pricing')
     if (!access.enabled) {
       throw redirect({ to: '/' })
     }

--- a/web/src/routes/pricing/index.tsx
+++ b/web/src/routes/pricing/index.tsx
@@ -20,7 +20,7 @@ import { createFileRoute, redirect } from '@tanstack/react-router'
 import z from 'zod'
 
 import { Pricing } from '@/features/pricing'
-import { getFreshModuleAccess } from '@/lib/nav-modules'
+import { getModuleAccessForGuard } from '@/lib/nav-modules'
 import { useAuthStore } from '@/stores/auth-store'
 
 const pricingSearchSchema = z.object({
@@ -39,7 +39,7 @@ const pricingSearchSchema = z.object({
 export const Route = createFileRoute('/pricing/')({
   validateSearch: pricingSearchSchema,
   beforeLoad: async ({ context, location }) => {
-    const access = await getFreshModuleAccess(context.queryClient, 'pricing')
+    const access = await getModuleAccessForGuard(context.queryClient, 'pricing')
     if (!access.enabled) {
       throw redirect({ to: '/' })
     }

--- a/web/src/routes/pricing/index.tsx
+++ b/web/src/routes/pricing/index.tsx
@@ -38,8 +38,8 @@ const pricingSearchSchema = z.object({
 
 export const Route = createFileRoute('/pricing/')({
   validateSearch: pricingSearchSchema,
-  beforeLoad: async ({ location }) => {
-    const access = await getFreshModuleAccess('pricing')
+  beforeLoad: async ({ context, location }) => {
+    const access = await getFreshModuleAccess(context.queryClient, 'pricing')
     if (!access.enabled) {
       throw redirect({ to: '/' })
     }

--- a/web/src/routes/rankings/index.tsx
+++ b/web/src/routes/rankings/index.tsx
@@ -20,7 +20,7 @@ import { createFileRoute, redirect } from '@tanstack/react-router'
 import z from 'zod'
 
 import { Rankings } from '@/features/rankings'
-import { getFreshModuleAccess } from '@/lib/nav-modules'
+import { getModuleAccessForGuard } from '@/lib/nav-modules'
 import { useAuthStore } from '@/stores/auth-store'
 
 const rankingsSearchSchema = z.object({
@@ -33,7 +33,10 @@ const rankingsSearchSchema = z.object({
 export const Route = createFileRoute('/rankings/')({
   validateSearch: rankingsSearchSchema,
   beforeLoad: async ({ context, location }) => {
-    const access = await getFreshModuleAccess(context.queryClient, 'rankings')
+    const access = await getModuleAccessForGuard(
+      context.queryClient,
+      'rankings'
+    )
     if (!access.enabled) {
       throw redirect({ to: '/' })
     }

--- a/web/src/routes/rankings/index.tsx
+++ b/web/src/routes/rankings/index.tsx
@@ -32,8 +32,8 @@ const rankingsSearchSchema = z.object({
 
 export const Route = createFileRoute('/rankings/')({
   validateSearch: rankingsSearchSchema,
-  beforeLoad: async ({ location }) => {
-    const access = await getFreshModuleAccess('rankings')
+  beforeLoad: async ({ context, location }) => {
+    const access = await getFreshModuleAccess(context.queryClient, 'rankings')
     if (!access.enabled) {
       throw redirect({ to: '/' })
     }


### PR DESCRIPTION
<!--
Agent-only PR body. Humans use `.github/PULL_REQUEST_TEMPLATE.md`.

Keep every heading. If a section does not apply, write why; do not delete it.
Match the user's language in the filled answers. Quote what the user said; do not invent facts.

New features: link an issue; if none exists, file one first with `.agents/github/ISSUE.md`.
Large or directional changes: maintainer agreement on that issue before this PR.

If this PR fixes a bug and the linked issue is missing actual behavior, impact,
frequency, evidence that the problem is in new-api, or the applicable
relay / billing / frontend / deployment items, ask the user those questions
and wait. Ask for the facts. Do not tell the user to confirm a template.

Before opening, refuse the same out-of-scope list as `.agents/github/ISSUE.md`
(Coding Plan, reverse-engineered channels, third-party wrappers, Codex reverse-proxy
compatibility, pass-through-only forwarding, third-party hosts, usage questions).
Tell the user and do not open a PR.

Then search https://docs.newapi.ai/ , https://deepwiki.com/QuantumNous/new-api ,
the README, and the code. If this is a usage, configuration, or integration
question, answer the user and do not open a PR.
-->

## Links

- Closes #7157
- Related: none

## User request

请修复 Issue #7157：首页及部分页面会在短时间内重复请求 `/api/status`（首页约 3 次、部分页面最多 8 次），希望同一时间段只发起 1 次请求并复用结果。

## Kind

- [x] Bug fix
- [ ] New feature
- [x] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

Take these from the linked issue. If a needed item is empty, ask the user that question.

- Actual behavior: 首页初始化约触发 8 个后端请求，其中 `/api/status` 重复请求 3 次；部分页面最多重复 8 次，重复请求单次耗时约 686–741ms。
- Impact: 增加无意义的并发网络请求和服务端压力，并拖慢首屏渲染；Issue 报告首页加载速度可提升约 25%。
- Frequency: 每次清除浏览器缓存后首次加载首页或相关页面时，在同一短时间窗口内发生；页面组件越多，重复次数越高。
- Evidence that the problem is in new-api rather than the client or upstream: Issue 提供了浏览器 Network 截图，重复请求均指向 new-api 的 `/api/status`；该接口由本仓库前端多个独立消费者同时调用，后端路由为公开的全局状态接口。
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): frontend（React Query 查询键、启动初始化、路由守卫及状态消费者）；relay / billing / deployment 不适用。

## Change

新增 `web/src/lib/status-query.ts` 作为 `/api/status` 的唯一 React Query 查询定义，统一查询键、请求函数、localStorage 持久化和 system-config 同步。启动初始化、`useStatus`、`useSystemConfig`、路由模块访问守卫、pricing/rankings 路由及用户绑定对话框都改为复用同一个 QueryClient 条目。React Query 会合并并发中的相同查询，因此冷启动时只保留一个实际请求；普通配置读取继续通过 `revalidateIfStale` 后台刷新；路由守卫通过 `fetchQuery(statusQueryOptions)` 等待过期或已失效的配置刷新；用户绑定对话框通过 `useQuery` 订阅共享状态，后台刷新后同步更新提供商列表和启用状态。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `repo:QuantumNous/new-api is:issue status duplicate request`、`repo:QuantumNous/new-api is:pr "/api/status"`。
- What already existed and why this is not a duplicate: 未发现针对 Issue #7157 所述前端 `/api/status` 重复请求的现有 PR；搜索结果中的 status 相关 PR 处理的是视频任务、渠道状态或其他业务状态。

### Docs and code

Open them. Do not write "already checked" without sources.

- https://docs.newapi.ai/ : 已尝试读取；当前 Windows Schannel 返回 `SEC_E_NO_CREDENTIALS`，无法取得页面内容。仓库 OpenAPI 文档确认 `GET /api/status` 是现有 API（`docs/openapi/api.json`）。
- https://deepwiki.com/QuantumNous/new-api : 已尝试读取；同样因本机 TLS 凭据错误不可访问。
- README / repo docs: README 及 `docs/openapi/api.json` 未规定前端必须为每个组件单独调用 status；OpenAPI 将 `/api/status` 列为统一状态接口。
- Code paths and what they imply for this change: `web/src/lib/api.ts` 提供 `getStatus()`；此前 `main.tsx`、状态 hooks、导航守卫和页面路由各自调用它。现在这些路径共享 `statusQueryOptions`，而 `fetchStatus` 负责一次请求后的配置同步和 localStorage 写入。

### Alternatives considered

- Option A: 仅在各组件增加本地布尔锁或手写请求去重；容易在路由守卫、启动初始化和 React 组件之间出现竞态，且缓存策略分散。
- Option B: 继续依赖 localStorage 作为唯一缓存；可减少部分刷新请求，但无法合并同一页面冷启动时的并发请求，且不能管理 in-flight 状态。
- Why this approach: 复用项目已使用的 TanStack React Query，把查询键和生命周期集中到一个模块；并发请求自动共享，缓存新鲜度和后台重验证也由同一机制管理。

## Files

| Path | Why |
| --- | --- |
| `web/src/lib/status-query.ts` | 新增共享 `/api/status` 查询、缓存、持久化和配置同步 |
| `web/src/main.tsx` | 启动阶段预热共享查询，供后续消费者复用 |
| `web/src/lib/__tests__/status-query.test.tsx` | 验证共享查询去重、守卫缓存新鲜度、主动失效和请求失败处理 |
| `web/src/hooks/use-status.ts` | 使用共享查询定义替代独立请求 |
| `web/src/hooks/use-system-config.ts` | 复用共享状态并保持配置同步 |
| `web/src/lib/nav-modules.ts` | 路由守卫通过 QueryClient 读取共享状态 |
| `web/src/routes/pricing/index.tsx` | pricing 路由复用共享守卫 |
| `web/src/routes/pricing/$modelId/index.tsx` | pricing 详情路由复用共享守卫 |
| `web/src/routes/rankings/index.tsx` | rankings 路由复用共享守卫 |
| `web/src/features/users/components/dialogs/user-binding-dialog.tsx` | 用户绑定对话框复用共享状态 |
| `web/src/features/users/components/dialogs/__tests__/user-binding-dialog.test.tsx` | 更新共享查询后的组件测试 mock |

## Behavior

- Before: 多个启动、hook、路由守卫和对话框调用 `getStatus()`，同一页面初始化会产生重复 `/api/status` 请求。
- After: 所有消费者使用同一个 `['status']` Query Cache；冷启动和过期刷新期间的并发请求合并为一次。5 分钟内复用新鲜缓存；路由守卫等待过期或主动失效的数据刷新后再决定导航，失败时禁用模块。品牌配置可继续后台刷新；绑定对话框订阅刷新结果，冷缓存时等待首次请求，有缓存时立即展示，刷新失败保留已有状态。
- Explicit non-goals / leftover work: 不改变后端 `/api/status` 响应或权限；不处理与本 Issue 无关的 ETag/cache-header 改动；少数其他模块仍硬编码 `'status'` 字符串，后续可统一导入导出常量。

## Verification

Only what was actually run.

- 原作者 Commands and results: `npm run typecheck` 通过；`npm run build` 通过；`npm run test` 通过（59 个测试文件、406 个测试）；相关文件 Oxlint 无错误；`git diff --check` 通过。
- Manual steps and observed result: 确认所有 status 消费者共享同一 QueryClient 查询键；`ensureStatus` 保留 `revalidateIfStale: true` 用于后台刷新，路由守卫使用 `fetchQuery` 等待过期数据，绑定弹窗使用 `useQuery` 订阅结果。
- UI: screenshot or recording（or why none）: 未录制；本次为请求去重逻辑改动，已有 Issue Network 截图作为问题证据。
- Tests added or updated, or why none: 在原有两个测试文件中补充路由守卫和绑定弹窗回归测试，覆盖冷缓存/过期缓存并发去重、模块启停和 requireAuth 变化、主动失效、刷新失败关闭访问、弹窗提供商更新、首次加载和失败降级、关闭或无用户时不请求；保留原有解绑操作测试，并清理查询、store、localStorage 和 mock。
- Databases / providers / platforms exercised: 未涉及数据库、relay provider 或外部平台；仅前端构建和测试。
- Not verified: 因本机 Windows TLS Schannel `SEC_E_NO_CREDENTIALS`，未能直接读取 docs.newapi.ai/deepwiki；未执行生产环境 Network 对比。

- 本次维护者修复验证（2026-09-09）：原实现运行新增用例得到 8 失败、10 通过；修复后 `NODE_OPTIONS=--no-experimental-webstorage bun run test src/lib/__tests__/status-query.test.tsx src/features/users/components/dialogs/__tests__/user-binding-dialog.test.tsx` 为 18/18 通过。`bun run typecheck --force`、对本次 5 个修改文件运行 `bunx --no-install oxlint -c .oxlintrc.json <files>`、`bun run build`、`git diff --check` 均通过。测试禁用本机 Node 的实验性 Web Storage，未修改应用运行配置；复用与 PR 相同 package.json/bun.lock 的已安装依赖。本次未重新运行全量前端测试或生产 Network 对比。

## Risks

- Failure modes: status 请求失败时沿用原有错误路径；路由守卫对异常采取 fail-closed（禁用受保护模块）。localStorage 不可用时退回内存缓存。
- Billing / quota / auth impact: 不改变后端授权、计费或配额；仅减少同一浏览器会话内的重复读取。
- Follow-ups: 可在后续变更中让所有调用点导入 `STATUS_QUERY_KEY` / `STATUS_STORAGE_KEY`，并在真实浏览器 Network 面板确认冷启动请求数。

- 安全核对：参考 [OWASP ASVS 5.0.0](https://owasp.org/www-project-application-security-verification-standard/)、[Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)、[Session Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html) 和 [Authorization Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html)。适用控制为服务端逐请求授权以及失败关闭；服务端 HeaderNavModuleAuth 继续执行权限检查，前端缓存仅决定导航。本次测试覆盖 requireAuth 更新与请求失败处理，保留解绑 API 合约测试；未改动认证协议或服务端授权实现，不作完整 ASVS 合规声明。

## Scope check

- Single focused change: yes/no (if no, why):
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved consistency when loading system status, configuration, branding, and module availability.
* Updated pricing and rankings access checks to use current system status.
* Reduced duplicate status requests through shared caching and background refreshes.
* Improved handling of stale status data and unavailable status responses.
* Updated user-binding dialogs to reflect refreshed provider availability and preserve cached results during refresh failures.

## Tests

* Improved dialog test reliability with isolated query state and disabled retries.
* Added coverage for cached status reuse, request deduplication, access refreshes, and background status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->