### PR TITLE
feat(relay): support Ali Bailian speech-to-text models

### DIFF
--- a/docs/openapi/relay.json
+++ b/docs/openapi/relay.json
@@ -1638,6 +1638,12 @@
                     "default": "json",
                     "example": "json"
                   },
+                  "stream": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "是否以 Server-Sent Events 流式返回转写结果",
+                    "example": false
+                  },
                   "temperature": {
                     "type": "number",
                     "example": 0

--- a/relay/channel/ali/adaptor.go
+++ b/relay/channel/ali/adaptor.go
@@ -125,6 +125,13 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 			}
 		case constant.RelayModeCompletions:
 			fullRequestURL = fmt.Sprintf("%s/compatible-mode/v1/completions", info.ChannelBaseUrl)
+		case constant.RelayModeAudioTranscription:
+			switch aliAudioTranscriptionProtocolFor(info.UpstreamModelName) {
+			case aliAudioTranscriptionProtocolLegacyMultimodal, aliAudioTranscriptionProtocolQwenASRMultimodal:
+				fullRequestURL = fmt.Sprintf("%s/api/v1/services/aigc/multimodal-generation/generation", info.ChannelBaseUrl)
+			default:
+				return "", fmt.Errorf("Ali audio transcription model %q is not supported", info.UpstreamModelName)
+			}
 		default:
 			fullRequestURL = fmt.Sprintf("%s/compatible-mode/v1/chat/completions", info.ChannelBaseUrl)
 		}
@@ -138,6 +145,19 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *rel
 	req.Set("Authorization", "Bearer "+info.ApiKey)
 	if info.IsStream {
 		req.Set("X-DashScope-SSE", "enable")
+	}
+	if info.RelayMode == constant.RelayModeAudioTranscription {
+		switch aliAudioTranscriptionProtocolFor(info.UpstreamModelName) {
+		case aliAudioTranscriptionProtocolLegacyMultimodal, aliAudioTranscriptionProtocolQwenASRMultimodal:
+			req.Set("Content-Type", "application/json")
+			req.Set("X-DashScope-SSE", "disable")
+			if info.IsStream {
+				req.Set("Accept", "text/event-stream")
+				req.Set("X-DashScope-SSE", "enable")
+			}
+		default:
+			return fmt.Errorf("Ali audio transcription model %q is not supported", info.UpstreamModelName)
+		}
 	}
 	if c.GetString("plugin") != "" {
 		req.Set("X-DashScope-Plugin", c.GetString("plugin"))
@@ -230,8 +250,14 @@ func (a *Adaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.Rela
 }
 
 func (a *Adaptor) ConvertAudioRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.AudioRequest) (io.Reader, error) {
-	//TODO implement me
-	return nil, errors.New("not implemented")
+	switch aliAudioTranscriptionProtocolFor(info.UpstreamModelName) {
+	case aliAudioTranscriptionProtocolLegacyMultimodal:
+		return convertAliAudioTranscriptionRequest(c, info, request)
+	case aliAudioTranscriptionProtocolQwenASRMultimodal:
+		return convertAliQwenASRTranscriptionRequest(c, info, request)
+	default:
+		return nil, fmt.Errorf("Ali audio transcription model %q is not supported", info.UpstreamModelName)
+	}
 }
 
 func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {
@@ -260,6 +286,15 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycom
 			err, usage = aliImageHandler(a, c, resp, info)
 		case constant.RelayModeRerank:
 			err, usage = RerankHandler(c, resp, info)
+		case constant.RelayModeAudioTranscription:
+			switch aliAudioTranscriptionProtocolFor(info.UpstreamModelName) {
+			case aliAudioTranscriptionProtocolLegacyMultimodal:
+				usage, err = aliAudioTranscriptionHandler(c, resp, info)
+			case aliAudioTranscriptionProtocolQwenASRMultimodal:
+				usage, err = aliQwenASRTranscriptionHandler(c, resp, info)
+			default:
+				err = types.NewError(fmt.Errorf("Ali audio transcription model %q is not supported", info.UpstreamModelName), types.ErrorCodeBadResponseBody)
+			}
 		default:
 			adaptor := openai.Adaptor{}
 			usage, err = adaptor.DoResponse(c, resp, info)

--- a/relay/channel/ali/audio.go
+++ b/relay/channel/ali/audio.go
@@ -1,0 +1,881 @@
+package ali
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/QuantumNous/new-api/common"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/relay/helper"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/types"
+	"github.com/QuantumNous/new-api/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+const aliAudioMaxDataURIBytes = 10 << 20
+const aliAudioPromptMaxRunes = 400
+
+type aliAudioTranscriptionRequest struct {
+	Model      string             `json:"model"`
+	Input      aliAudioInput      `json:"input"`
+	Parameters aliAudioParameters `json:"parameters"`
+}
+
+type aliAudioInput struct {
+	Messages []aliAudioMessage `json:"messages"`
+}
+
+type aliAudioMessage struct {
+	Role    string            `json:"role"`
+	Content []aliAudioContent `json:"content"`
+}
+
+type aliAudioContent struct {
+	Type       string         `json:"type"`
+	Text       string         `json:"text,omitempty"`
+	InputAudio *aliInputAudio `json:"input_audio,omitempty"`
+}
+
+type aliInputAudio struct {
+	Data string `json:"data"`
+}
+
+type aliAudioParameters struct {
+	Format        string   `json:"format"`
+	SampleRate    string   `json:"sample_rate,omitempty"`
+	LanguageHints []string `json:"language_hints,omitempty"`
+}
+
+type aliAudioTranscriptionResponse struct {
+	Output aliAudioOutput `json:"output"`
+	Usage  aliAudioUsage  `json:"usage"`
+}
+
+type aliQwenASRTranscriptionRequest struct {
+	Model      string                  `json:"model"`
+	Input      aliQwenASRInput         `json:"input"`
+	Parameters aliQwenASRRequestParams `json:"parameters"`
+}
+
+type aliQwenASRInput struct {
+	Messages []aliQwenASRMessage `json:"messages"`
+}
+
+type aliQwenASRMessage struct {
+	Role    string              `json:"role"`
+	Content []aliQwenASRContent `json:"content"`
+}
+
+type aliQwenASRContent struct {
+	Audio string `json:"audio"`
+}
+
+type aliQwenASRRequestParams struct {
+	ASROptions aliQwenASROptions `json:"asr_options,omitempty"`
+}
+
+type aliQwenASROptions struct {
+	Language string `json:"language,omitempty"`
+}
+
+type aliQwenASRTranscriptionResponse struct {
+	Output aliQwenASROutput `json:"output"`
+	Usage  aliQwenASRUsage  `json:"usage"`
+}
+
+type aliQwenASROutput struct {
+	Choices []aliQwenASRChoice `json:"choices"`
+}
+
+type aliQwenASRChoice struct {
+	Message aliQwenASRMessageResponse `json:"message"`
+}
+
+type aliQwenASRMessageResponse struct {
+	Content []aliQwenASRTextContent `json:"content"`
+}
+
+type aliQwenASRTextContent struct {
+	Text string `json:"text"`
+}
+
+type aliQwenASRUsage struct {
+	Seconds *float64 `json:"seconds,omitempty"`
+}
+
+type aliAudioOutput struct {
+	Text     string             `json:"text"`
+	Sentence *aliAudioSentence  `json:"sentence,omitempty"`
+	Output   *aliAudioOutput    `json:"output,omitempty"`
+	Choices  []aliQwenASRChoice `json:"choices,omitempty"`
+}
+
+type aliAudioSentence struct {
+	SentenceID  int            `json:"sentence_id"`
+	SentenceEnd bool           `json:"sentence_end"`
+	BeginTime   int            `json:"begin_time"`
+	EndTime     int            `json:"end_time"`
+	Text        string         `json:"text"`
+	ChannelID   int            `json:"channel_id"`
+	Words       []aliAudioWord `json:"words,omitempty"`
+}
+
+type aliAudioWord struct {
+	Text        string `json:"text"`
+	BeginTime   int    `json:"begin_time"`
+	EndTime     int    `json:"end_time"`
+	Punctuation string `json:"punctuation,omitempty"`
+}
+
+type aliAudioUsage struct {
+	Duration *float64 `json:"duration,omitempty"`
+}
+
+type aliVerboseAudioResponse struct {
+	Task     string                   `json:"task"`
+	Duration float64                  `json:"duration"`
+	Text     string                   `json:"text"`
+	Segments []aliVerboseAudioSegment `json:"segments,omitempty"`
+}
+
+type aliVerboseAudioSegment struct {
+	ID    int                   `json:"id"`
+	Start float64               `json:"start"`
+	End   float64               `json:"end"`
+	Text  string                `json:"text"`
+	Words []aliVerboseAudioWord `json:"words,omitempty"`
+}
+
+type aliVerboseAudioWord struct {
+	Word  string  `json:"word"`
+	Start float64 `json:"start"`
+	End   float64 `json:"end"`
+}
+
+type aliTranscriptDeltaEvent struct {
+	Type  string `json:"type"`
+	Delta string `json:"delta"`
+}
+
+type aliTranscriptDoneEvent struct {
+	Type  string                 `json:"type"`
+	Text  string                 `json:"text"`
+	Usage *aliTranscriptDuration `json:"usage,omitempty"`
+}
+
+type aliTranscriptDuration struct {
+	Type    string  `json:"type"`
+	Seconds float64 `json:"seconds"`
+}
+
+func convertAliAudioTranscriptionRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.AudioRequest) (io.Reader, error) {
+	if info.RelayMode != constant.RelayModeAudioTranscription {
+		return nil, errors.New("Ali audio adaptor supports transcription only")
+	}
+	if aliAudioTranscriptionProtocolFor(info.UpstreamModelName) != aliAudioTranscriptionProtocolLegacyMultimodal {
+		return nil, fmt.Errorf("Ali audio transcription model %q is not supported", info.UpstreamModelName)
+	}
+	if _, err := aliAudioResponseFormat(request); err != nil {
+		return nil, err
+	}
+
+	form := c.Request.MultipartForm
+	if form == nil {
+		var err error
+		form, err = common.ParseMultipartFormReusable(c)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse audio form request: %w", err)
+		}
+		c.Request.MultipartForm = form
+	}
+	fileHeaders := form.File["file"]
+	if len(fileHeaders) == 0 {
+		return nil, errors.New("file is required")
+	}
+
+	fileHeader := fileHeaders[0]
+	format, mediaType, err := aliAudioFormatAndMediaType(fileHeader)
+	if err != nil {
+		return nil, err
+	}
+	prefix := "data:" + mediaType + ";base64,"
+	maxRawBytes := ((aliAudioMaxDataURIBytes - len(prefix)) / 4) * 3
+	if fileHeader.Size > int64(maxRawBytes) {
+		return nil, fmt.Errorf("audio file is too large for Ali Base64 input (maximum %d bytes)", maxRawBytes)
+	}
+
+	file, err := fileHeader.Open()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open audio file: %w", err)
+	}
+	defer file.Close()
+
+	audioBytes, err := io.ReadAll(io.LimitReader(file, int64(maxRawBytes)+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read audio file: %w", err)
+	}
+	if len(audioBytes) > maxRawBytes {
+		return nil, fmt.Errorf("audio file is too large for Ali Base64 input (maximum %d bytes)", maxRawBytes)
+	}
+
+	dataURI := prefix + base64.StdEncoding.EncodeToString(audioBytes)
+	if len(dataURI) > aliAudioMaxDataURIBytes {
+		return nil, fmt.Errorf("audio file is too large for Ali Base64 input (maximum %d bytes)", maxRawBytes)
+	}
+
+	formData := url.Values(form.Value)
+	messages := make([]aliAudioMessage, 0, 2)
+	if prompt := truncateAliAudioPrompt(formData.Get("prompt")); prompt != "" {
+		messages = append(messages, aliAudioMessage{
+			Role: "user",
+			Content: []aliAudioContent{{
+				Type: "input_text",
+				Text: prompt,
+			}},
+		})
+	}
+	messages = append(messages, aliAudioMessage{
+		Role: "user",
+		Content: []aliAudioContent{{
+			Type:       "input_audio",
+			InputAudio: &aliInputAudio{Data: dataURI},
+		}},
+	})
+
+	aliRequest := aliAudioTranscriptionRequest{
+		Model: info.UpstreamModelName,
+		Input: aliAudioInput{Messages: messages},
+		Parameters: aliAudioParameters{
+			Format: format,
+		},
+	}
+	if sampleRate := aliWAVSampleRate(format, audioBytes); sampleRate != "" {
+		aliRequest.Parameters.SampleRate = sampleRate
+	}
+	if language := strings.TrimSpace(formData.Get("language")); language != "" {
+		aliRequest.Parameters.LanguageHints = []string{language}
+	}
+
+	jsonData, err := common.Marshal(aliRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Ali audio transcription request: %w", err)
+	}
+	return bytes.NewReader(jsonData), nil
+}
+
+func convertAliQwenASRTranscriptionRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.AudioRequest) (io.Reader, error) {
+	if info.RelayMode != constant.RelayModeAudioTranscription {
+		return nil, errors.New("Ali audio adaptor supports transcription only")
+	}
+	if aliAudioTranscriptionProtocolFor(info.UpstreamModelName) != aliAudioTranscriptionProtocolQwenASRMultimodal {
+		return nil, fmt.Errorf("Ali audio transcription model %q is not supported", info.UpstreamModelName)
+	}
+	if _, err := aliAudioResponseFormat(request); err != nil {
+		return nil, err
+	}
+
+	form := c.Request.MultipartForm
+	if form == nil {
+		var err error
+		form, err = common.ParseMultipartFormReusable(c)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse audio form request: %w", err)
+		}
+		c.Request.MultipartForm = form
+	}
+	fileHeaders := form.File["file"]
+	if len(fileHeaders) == 0 {
+		return nil, errors.New("file is required")
+	}
+
+	fileHeader := fileHeaders[0]
+	_, mediaType, err := aliAudioFormatAndMediaType(fileHeader)
+	if err != nil {
+		return nil, err
+	}
+	prefix := "data:" + mediaType + ";base64,"
+	maxRawBytes := ((aliAudioMaxDataURIBytes - len(prefix)) / 4) * 3
+	if fileHeader.Size > int64(maxRawBytes) {
+		return nil, fmt.Errorf("audio file is too large for Ali Base64 input (maximum %d bytes)", maxRawBytes)
+	}
+
+	file, err := fileHeader.Open()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open audio file: %w", err)
+	}
+	defer file.Close()
+
+	audioBytes, err := io.ReadAll(io.LimitReader(file, int64(maxRawBytes)+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read audio file: %w", err)
+	}
+	if len(audioBytes) > maxRawBytes {
+		return nil, fmt.Errorf("audio file is too large for Ali Base64 input (maximum %d bytes)", maxRawBytes)
+	}
+
+	dataURI := prefix + base64.StdEncoding.EncodeToString(audioBytes)
+	if len(dataURI) > aliAudioMaxDataURIBytes {
+		return nil, fmt.Errorf("audio file is too large for Ali Base64 input (maximum %d bytes)", maxRawBytes)
+	}
+
+	formData := url.Values(form.Value)
+	aliRequest := aliQwenASRTranscriptionRequest{
+		Model: info.UpstreamModelName,
+		Input: aliQwenASRInput{Messages: []aliQwenASRMessage{{
+			Role: "user",
+			Content: []aliQwenASRContent{{
+				Audio: dataURI,
+			}},
+		}}},
+	}
+	if language := strings.TrimSpace(formData.Get("language")); language != "" {
+		aliRequest.Parameters.ASROptions.Language = language
+	}
+
+	jsonData, err := common.Marshal(aliRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Ali Qwen ASR transcription request: %w", err)
+	}
+	return bytes.NewReader(jsonData), nil
+}
+
+func aliWAVSampleRate(format string, audioBytes []byte) string {
+	if format != "wav" || len(audioBytes) < 20 || string(audioBytes[:4]) != "RIFF" || string(audioBytes[8:12]) != "WAVE" {
+		return ""
+	}
+
+	for offset := 12; offset+8 <= len(audioBytes); {
+		chunkLength := int(binary.LittleEndian.Uint32(audioBytes[offset+4 : offset+8]))
+		chunkDataStart := offset + 8
+		if chunkLength < 0 || chunkLength > len(audioBytes)-chunkDataStart {
+			return ""
+		}
+		if string(audioBytes[offset:offset+4]) == "fmt " {
+			if chunkLength < 8 {
+				return ""
+			}
+			sampleRate := binary.LittleEndian.Uint32(audioBytes[chunkDataStart+4 : chunkDataStart+8])
+			if sampleRate == 0 {
+				return ""
+			}
+			return strconv.FormatUint(uint64(sampleRate), 10)
+		}
+		offset = chunkDataStart + chunkLength
+		if chunkLength%2 != 0 {
+			offset++
+		}
+	}
+	return ""
+}
+
+func aliAudioResponseFormat(request dto.AudioRequest) (string, error) {
+	responseFormat := strings.TrimSpace(request.ResponseFormat)
+	if responseFormat == "" {
+		responseFormat = "json"
+	}
+	switch responseFormat {
+	case "json", "text", "verbose_json":
+		return responseFormat, nil
+	default:
+		return "", fmt.Errorf("response_format %q is not supported by Ali audio transcription", responseFormat)
+	}
+}
+
+func aliAudioFormatAndMediaType(fileHeader *multipart.FileHeader) (string, string, error) {
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(fileHeader.Filename)), ".")
+	mediaTypes := map[string]string{
+		"aac":  "audio/aac",
+		"amr":  "audio/amr",
+		"avi":  "video/x-msvideo",
+		"flac": "audio/flac",
+		"flv":  "video/x-flv",
+		"m4a":  "audio/mp4",
+		"mkv":  "video/x-matroska",
+		"mov":  "video/quicktime",
+		"mp3":  "audio/mpeg",
+		"mp4":  "audio/mp4",
+		"mpeg": "audio/mpeg",
+		"ogg":  "audio/ogg",
+		"opus": "audio/opus",
+		"wav":  "audio/wav",
+		"webm": "audio/webm",
+		"wma":  "audio/x-ms-wma",
+		"wmv":  "video/x-ms-wmv",
+	}
+	mediaType, ok := mediaTypes[ext]
+	if !ok {
+		return "", "", fmt.Errorf("unsupported audio file format %q", ext)
+	}
+	return ext, mediaType, nil
+}
+
+func truncateAliAudioPrompt(prompt string) string {
+	if utf8.RuneCountInString(prompt) <= aliAudioPromptMaxRunes {
+		return prompt
+	}
+	return string([]rune(prompt)[:aliAudioPromptMaxRunes])
+}
+
+func aliAudioTranscriptionHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (any, *types.NewAPIError) {
+	request, ok := info.Request.(*dto.AudioRequest)
+	if !ok {
+		return nil, types.NewError(errors.New("invalid audio request type"), types.ErrorCodeBadResponseBody)
+	}
+	responseFormat, err := aliAudioResponseFormat(*request)
+	if err != nil {
+		return nil, types.NewError(err, types.ErrorCodeBadResponseBody)
+	}
+	if info.IsStream {
+		return aliAudioTranscriptionStreamHandler(c, resp, info)
+	}
+	return aliAudioTranscriptionResponseHandler(c, resp, info, responseFormat)
+}
+
+func aliAudioTranscriptionResponseHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo, responseFormat string) (any, *types.NewAPIError) {
+	defer service.CloseResponseBodyGracefully(resp)
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeReadResponseBodyFailed, http.StatusInternalServerError)
+	}
+	var aliResponse aliAudioTranscriptionResponse
+	if err := common.Unmarshal(responseBody, &aliResponse); err != nil {
+		return nil, types.NewError(err, types.ErrorCodeBadResponseBody)
+	}
+	info.SetFirstResponseTime()
+	usage := aliAudioUsageFromDuration(info, aliResponse.Usage.Duration)
+
+	switch responseFormat {
+	case "text":
+		c.Writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		c.Writer.WriteHeader(http.StatusOK)
+		if _, err := c.Writer.Write([]byte(aliResponse.Output.text())); err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+	case "verbose_json":
+		verboseResponse := aliVerboseAudioResponse{
+			Task: "transcribe",
+			Text: aliResponse.Output.text(),
+		}
+		if aliResponse.Usage.Duration != nil {
+			verboseResponse.Duration = nonNegativeDuration(*aliResponse.Usage.Duration)
+		}
+		if sentence := aliResponse.Output.sentence(); sentence != nil {
+			verboseResponse.Segments = []aliVerboseAudioSegment{{
+				ID:    sentence.SentenceID,
+				Start: float64(sentence.BeginTime) / 1000,
+				End:   float64(sentence.EndTime) / 1000,
+				Text:  sentence.Text,
+				Words: aliAudioWordsToVerbose(sentence.Words),
+			}}
+		}
+		jsonData, err := common.Marshal(verboseResponse)
+		if err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+		c.Writer.Header().Set("Content-Type", "application/json")
+		c.Writer.WriteHeader(http.StatusOK)
+		if _, err := c.Writer.Write(jsonData); err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+	default:
+		jsonData, err := common.Marshal(dto.AudioResponse{Text: aliResponse.Output.text()})
+		if err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+		c.Writer.Header().Set("Content-Type", "application/json")
+		c.Writer.WriteHeader(http.StatusOK)
+		if _, err := c.Writer.Write(jsonData); err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+	}
+
+	return usage, nil
+}
+
+func aliAudioTranscriptionStreamHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (any, *types.NewAPIError) {
+	defer service.CloseResponseBodyGracefully(resp)
+
+	helper.SetEventStreamHeaders(c)
+	scanner := helper.NewStreamScanner(resp.Body)
+	scanner.Split(bufio.ScanLines)
+	seenSentences := make(map[int]struct{})
+	var lastText string
+	var emittedText string
+	var duration *float64
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		var data string
+		switch {
+		case strings.HasPrefix(line, "data:"):
+			data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		case strings.HasPrefix(line, "{"):
+			// Some Bailian deployments return one complete JSON object even when
+			// X-DashScope-SSE is enabled. Preserve the streaming client contract by
+			// converting that object into a delta followed by a done event.
+			data = line
+		default:
+			continue
+		}
+		if data == "" {
+			continue
+		}
+		if data == "[DONE]" {
+			break
+		}
+
+		var aliResponse aliAudioTranscriptionResponse
+		if err := common.Unmarshal([]byte(data), &aliResponse); err != nil {
+			return nil, types.NewError(fmt.Errorf("failed to parse Ali audio stream event: %w", err), types.ErrorCodeBadResponseBody)
+		}
+		info.SetFirstResponseTime()
+		info.ReceivedResponseCount++
+		text := aliResponse.Output.text()
+		if text == "" {
+			text = aliAudioStreamText([]byte(data))
+		}
+		if aliResponse.Usage.Duration != nil {
+			duration = aliResponse.Usage.Duration
+		}
+		sentence := aliResponse.Output.sentence()
+		if sentence == nil {
+			if text == "" {
+				continue
+			}
+			delta := text
+			if strings.HasPrefix(text, emittedText) {
+				delta = strings.TrimPrefix(text, emittedText)
+				emittedText = text
+				lastText = text
+			} else {
+				emittedText += text
+				lastText += text
+			}
+			if delta == "" {
+				continue
+			}
+			if err := writeAliAudioSSEvent(c, "transcript.text.delta", aliTranscriptDeltaEvent{
+				Type:  "transcript.text.delta",
+				Delta: delta,
+			}); err != nil {
+				return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+			}
+			continue
+		}
+		if text != "" {
+			lastText = text
+		}
+		if !sentence.SentenceEnd || sentence.Text == "" {
+			continue
+		}
+		if _, exists := seenSentences[sentence.SentenceID]; exists {
+			continue
+		}
+		seenSentences[sentence.SentenceID] = struct{}{}
+		if err := writeAliAudioSSEvent(c, "transcript.text.delta", aliTranscriptDeltaEvent{
+			Type:  "transcript.text.delta",
+			Delta: sentence.Text,
+		}); err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeReadResponseBodyFailed, http.StatusInternalServerError)
+	}
+
+	usage := aliAudioUsageFromDuration(info, duration)
+	doneEvent := aliTranscriptDoneEvent{
+		Type: "transcript.text.done",
+		Text: lastText,
+	}
+	if duration != nil {
+		doneEvent.Usage = &aliTranscriptDuration{
+			Type:    "duration",
+			Seconds: nonNegativeDuration(*duration),
+		}
+	}
+	if err := writeAliAudioSSEvent(c, "transcript.text.done", doneEvent); err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+	return usage, nil
+}
+
+func (o aliAudioOutput) text() string {
+	if o.Text != "" {
+		return o.Text
+	}
+	if o.Output != nil {
+		return o.Output.text()
+	}
+	for _, choice := range o.Choices {
+		for _, content := range choice.Message.Content {
+			if content.Text != "" {
+				return content.Text
+			}
+		}
+	}
+	return ""
+}
+
+func (o aliAudioOutput) sentence() *aliAudioSentence {
+	if o.Sentence != nil {
+		return o.Sentence
+	}
+	if o.Output != nil {
+		return o.Output.sentence()
+	}
+	return nil
+}
+
+func aliAudioStreamText(data []byte) string {
+	var value any
+	if err := common.Unmarshal(data, &value); err != nil {
+		return ""
+	}
+	return findAliAudioText(value)
+}
+
+func findAliAudioText(value any) string {
+	switch typed := value.(type) {
+	case map[string]any:
+		for _, key := range []string{"text", "content"} {
+			if text, ok := typed[key].(string); ok && text != "" {
+				return text
+			}
+		}
+		for _, key := range []string{"output", "choices", "message", "delta", "content"} {
+			if child, ok := typed[key]; ok {
+				if text := findAliAudioText(child); text != "" {
+					return text
+				}
+			}
+		}
+	case []any:
+		for _, item := range typed {
+			if text := findAliAudioText(item); text != "" {
+				return text
+			}
+		}
+	}
+	return ""
+}
+
+func aliQwenASRTranscriptionHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (any, *types.NewAPIError) {
+	request, ok := info.Request.(*dto.AudioRequest)
+	if !ok {
+		return nil, types.NewError(errors.New("invalid audio request type"), types.ErrorCodeBadResponseBody)
+	}
+	responseFormat, err := aliAudioResponseFormat(*request)
+	if err != nil {
+		return nil, types.NewError(err, types.ErrorCodeBadResponseBody)
+	}
+	if info.IsStream {
+		return aliQwenASRTranscriptionStreamHandler(c, resp, info)
+	}
+	return aliQwenASRTranscriptionResponseHandler(c, resp, info, responseFormat)
+}
+
+func aliQwenASRTranscriptionResponseHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo, responseFormat string) (any, *types.NewAPIError) {
+	defer service.CloseResponseBodyGracefully(resp)
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeReadResponseBodyFailed, http.StatusInternalServerError)
+	}
+	var aliResponse aliQwenASRTranscriptionResponse
+	if err := common.Unmarshal(responseBody, &aliResponse); err != nil {
+		return nil, types.NewError(err, types.ErrorCodeBadResponseBody)
+	}
+	info.SetFirstResponseTime()
+	usage := aliAudioUsageFromDuration(info, aliResponse.Usage.Seconds)
+	text := aliResponse.text()
+
+	switch responseFormat {
+	case "text":
+		c.Writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		c.Writer.WriteHeader(http.StatusOK)
+		if _, err := c.Writer.Write([]byte(text)); err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+	case "verbose_json":
+		verboseResponse := aliVerboseAudioResponse{
+			Task: "transcribe",
+			Text: text,
+		}
+		if aliResponse.Usage.Seconds != nil {
+			verboseResponse.Duration = nonNegativeDuration(*aliResponse.Usage.Seconds)
+		}
+		jsonData, err := common.Marshal(verboseResponse)
+		if err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+		c.Writer.Header().Set("Content-Type", "application/json")
+		c.Writer.WriteHeader(http.StatusOK)
+		if _, err := c.Writer.Write(jsonData); err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+	default:
+		jsonData, err := common.Marshal(dto.AudioResponse{Text: text})
+		if err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+		c.Writer.Header().Set("Content-Type", "application/json")
+		c.Writer.WriteHeader(http.StatusOK)
+		if _, err := c.Writer.Write(jsonData); err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+	}
+
+	return usage, nil
+}
+
+func aliQwenASRTranscriptionStreamHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (any, *types.NewAPIError) {
+	defer service.CloseResponseBodyGracefully(resp)
+
+	helper.SetEventStreamHeaders(c)
+	scanner := helper.NewStreamScanner(resp.Body)
+	scanner.Split(bufio.ScanLines)
+	var text string
+	var duration *float64
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "" || data == "[DONE]" {
+			continue
+		}
+
+		var aliResponse aliQwenASRTranscriptionResponse
+		if err := common.Unmarshal([]byte(data), &aliResponse); err != nil {
+			return nil, types.NewError(fmt.Errorf("failed to parse Ali Qwen ASR stream event: %w", err), types.ErrorCodeBadResponseBody)
+		}
+		info.SetFirstResponseTime()
+		info.ReceivedResponseCount++
+		if aliResponse.Usage.Seconds != nil {
+			duration = aliResponse.Usage.Seconds
+		}
+		currentText := aliResponse.text()
+		if currentText == "" {
+			continue
+		}
+		delta := currentText
+		if strings.HasPrefix(currentText, text) {
+			delta = strings.TrimPrefix(currentText, text)
+			text = currentText
+		} else {
+			text += currentText
+		}
+		if delta == "" {
+			continue
+		}
+		if err := writeAliAudioSSEvent(c, "transcript.text.delta", aliTranscriptDeltaEvent{
+			Type:  "transcript.text.delta",
+			Delta: delta,
+		}); err != nil {
+			return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeReadResponseBodyFailed, http.StatusInternalServerError)
+	}
+
+	usage := aliAudioUsageFromDuration(info, duration)
+	doneEvent := aliTranscriptDoneEvent{
+		Type: "transcript.text.done",
+		Text: text,
+	}
+	if duration != nil {
+		doneEvent.Usage = &aliTranscriptDuration{
+			Type:    "duration",
+			Seconds: nonNegativeDuration(*duration),
+		}
+	}
+	if err := writeAliAudioSSEvent(c, "transcript.text.done", doneEvent); err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+	return usage, nil
+}
+
+func (r aliQwenASRTranscriptionResponse) text() string {
+	for _, choice := range r.Output.Choices {
+		for _, content := range choice.Message.Content {
+			if content.Text != "" {
+				return content.Text
+			}
+		}
+	}
+	return ""
+}
+
+func writeAliAudioSSEvent(c *gin.Context, event string, value any) error {
+	jsonData, err := common.Marshal(value)
+	if err != nil {
+		return err
+	}
+	helper.ExtendWriteDeadline(c)
+	c.Render(-1, common.CustomEvent{Data: "event: " + event + "\n"})
+	c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonData)})
+	return helper.FlushWriter(c)
+}
+
+func aliAudioUsageFromDuration(info *relaycommon.RelayInfo, duration *float64) *dto.Usage {
+	audioTokens := info.GetEstimatePromptTokens()
+	if duration != nil {
+		checkedTokens, clamp := common.QuotaRoundChecked(math.Ceil(nonNegativeDuration(*duration)) / 60 * 1000)
+		audioTokens = checkedTokens
+		if clamp != nil {
+			if info.QuotaClamp == nil {
+				info.QuotaClamp = clamp
+			}
+		}
+	}
+	return &dto.Usage{
+		PromptTokens: audioTokens,
+		TotalTokens:  audioTokens,
+		PromptTokensDetails: dto.InputTokenDetails{
+			AudioTokens: audioTokens,
+		},
+	}
+}
+
+func nonNegativeDuration(duration float64) float64 {
+	if math.IsNaN(duration) || duration < 0 {
+		return 0
+	}
+	return duration
+}
+
+func aliAudioWordsToVerbose(words []aliAudioWord) []aliVerboseAudioWord {
+	if len(words) == 0 {
+		return nil
+	}
+	result := make([]aliVerboseAudioWord, 0, len(words))
+	for _, word := range words {
+		result = append(result, aliVerboseAudioWord{
+			Word:  word.Text + word.Punctuation,
+			Start: float64(word.BeginTime) / 1000,
+			End:   float64(word.EndTime) / 1000,
+		})
+	}
+	return result
+}

--- a/relay/channel/ali/audio_test.go
+++ b/relay/channel/ali/audio_test.go
@@ -1,0 +1,428 @@
+package ali
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"math"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func newAliAudioRequestContext(t *testing.T, fields map[string]string, filename string, fileContent []byte) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for key, value := range fields {
+		require.NoError(t, writer.WriteField(key, value))
+	}
+	if filename != "" {
+		part, err := writer.CreateFormFile("file", filename)
+		require.NoError(t, err)
+		_, err = part.Write(fileContent)
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Close())
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", bytes.NewReader(body.Bytes()))
+	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	return c, recorder
+}
+
+func newAliAudioRelayInfo(request dto.AudioRequest) *relaycommon.RelayInfo {
+	return &relaycommon.RelayInfo{
+		Request:   &request,
+		RelayMode: constant.RelayModeAudioTranscription,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelBaseUrl:    "https://dashscope.aliyuncs.com",
+			UpstreamModelName: "qwen-audio-3.0-asr-flash",
+			ApiKey:            "test-key",
+		},
+		StartTime: time.Now(),
+	}
+}
+
+func TestAliAudioTranscriptionProtocolFor(t *testing.T) {
+	tests := []struct {
+		model    string
+		protocol aliAudioTranscriptionProtocol
+	}{
+		{"qwen-audio-3.0-asr-flash", aliAudioTranscriptionProtocolLegacyMultimodal},
+		{"fun-asr-flash-2026-06-15", aliAudioTranscriptionProtocolLegacyMultimodal},
+		{"qwen3-asr-flash", aliAudioTranscriptionProtocolQwenASRMultimodal},
+		{"qwen3-asr-flash-us", aliAudioTranscriptionProtocolQwenASRMultimodal},
+		{"fun-asr", aliAudioTranscriptionProtocolUnsupported},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			assert.Equal(t, tt.protocol, aliAudioTranscriptionProtocolFor(tt.model))
+		})
+	}
+}
+
+func TestConvertAliAudioTranscriptionRequest(t *testing.T) {
+	c, _ := newAliAudioRequestContext(t, map[string]string{
+		"model":           "customer-asr",
+		"language":        "zh",
+		"prompt":          "品牌名：百炼",
+		"response_format": "json",
+	}, "clip.mp3", []byte("audio-bytes"))
+	request := dto.AudioRequest{Model: "customer-asr", ResponseFormat: "json"}
+	info := newAliAudioRelayInfo(request)
+
+	converted, err := (&Adaptor{}).ConvertAudioRequest(c, info, request)
+	require.NoError(t, err)
+	body, err := io.ReadAll(converted)
+	require.NoError(t, err)
+
+	assert.Equal(t, "qwen-audio-3.0-asr-flash", gjson.GetBytes(body, "model").String())
+	assert.Equal(t, "mp3", gjson.GetBytes(body, "parameters.format").String())
+	assert.Equal(t, "zh", gjson.GetBytes(body, "parameters.language_hints.0").String())
+	assert.Equal(t, "input_text", gjson.GetBytes(body, "input.messages.0.content.0.type").String())
+	assert.Equal(t, "品牌名：百炼", gjson.GetBytes(body, "input.messages.0.content.0.text").String())
+	assert.Equal(t, "input_audio", gjson.GetBytes(body, "input.messages.1.content.0.type").String())
+	assert.Equal(t, "data:audio/mpeg;base64,YXVkaW8tYnl0ZXM=", gjson.GetBytes(body, "input.messages.1.content.0.input_audio.data").String())
+
+	header := http.Header{}
+	require.NoError(t, (&Adaptor{}).SetupRequestHeader(c, &header, info))
+	assert.Equal(t, "Bearer test-key", header.Get("Authorization"))
+	assert.Equal(t, "application/json", header.Get("Content-Type"))
+	assert.Equal(t, "disable", header.Get("X-DashScope-SSE"))
+	info.IsStream = true
+	streamHeader := http.Header{}
+	require.NoError(t, (&Adaptor{}).SetupRequestHeader(c, &streamHeader, info))
+	assert.Equal(t, "enable", streamHeader.Get("X-DashScope-SSE"))
+	assert.Equal(t, "text/event-stream", streamHeader.Get("Accept"))
+
+	requestURL, err := (&Adaptor{}).GetRequestURL(info)
+	require.NoError(t, err)
+	assert.Equal(t, "https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation", requestURL)
+}
+
+func TestConvertAliAudioTranscriptionRequestIncludesWAVSampleRate(t *testing.T) {
+	wav := make([]byte, 44)
+	copy(wav, "RIFF")
+	copy(wav[8:], "WAVEfmt ")
+	binary.LittleEndian.PutUint32(wav[16:20], 16)
+	binary.LittleEndian.PutUint32(wav[24:28], 16000)
+	copy(wav[36:], "data")
+
+	c, _ := newAliAudioRequestContext(t, map[string]string{
+		"model": "qwen-audio-3.0-asr-flash",
+	}, "asr_zh.wav", wav)
+	request := dto.AudioRequest{Model: "qwen-audio-3.0-asr-flash", ResponseFormat: "json"}
+	converted, err := (&Adaptor{}).ConvertAudioRequest(c, newAliAudioRelayInfo(request), request)
+	require.NoError(t, err)
+	body, err := io.ReadAll(converted)
+	require.NoError(t, err)
+
+	assert.Equal(t, "wav", gjson.GetBytes(body, "parameters.format").String())
+	assert.Equal(t, "16000", gjson.GetBytes(body, "parameters.sample_rate").String())
+}
+
+func TestConvertAliQwenASRTranscriptionRequest(t *testing.T) {
+	c, _ := newAliAudioRequestContext(t, map[string]string{
+		"model":    "qwen3-asr-flash",
+		"language": "zh",
+	}, "clip.mp3", []byte("audio-bytes"))
+	request := dto.AudioRequest{Model: "qwen3-asr-flash", ResponseFormat: "json"}
+	info := newAliAudioRelayInfo(request)
+	info.UpstreamModelName = "qwen3-asr-flash"
+
+	converted, err := (&Adaptor{}).ConvertAudioRequest(c, info, request)
+	require.NoError(t, err)
+	body, err := io.ReadAll(converted)
+	require.NoError(t, err)
+
+	assert.Equal(t, "qwen3-asr-flash", gjson.GetBytes(body, "model").String())
+	assert.Equal(t, "data:audio/mpeg;base64,YXVkaW8tYnl0ZXM=", gjson.GetBytes(body, "input.messages.0.content.0.audio").String())
+	assert.Equal(t, "zh", gjson.GetBytes(body, "parameters.asr_options.language").String())
+
+	requestURL, err := (&Adaptor{}).GetRequestURL(info)
+	require.NoError(t, err)
+	assert.Equal(t, "https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation", requestURL)
+}
+
+func TestConvertAliAudioTranscriptionRequestRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name           string
+		fields         map[string]string
+		filename       string
+		fileContent    []byte
+		responseFormat string
+		wantError      string
+	}{
+		{
+			name:           "missing file",
+			fields:         map[string]string{"model": "qwen-audio-3.0-asr-flash"},
+			responseFormat: "json",
+			wantError:      "file is required",
+		},
+		{
+			name:           "unsupported response format",
+			fields:         map[string]string{"model": "qwen-audio-3.0-asr-flash"},
+			filename:       "clip.mp3",
+			fileContent:    []byte("audio"),
+			responseFormat: "srt",
+			wantError:      "response_format",
+		},
+		{
+			name:           "data URI too large",
+			fields:         map[string]string{"model": "qwen-audio-3.0-asr-flash"},
+			filename:       "clip.wav",
+			fileContent:    bytes.Repeat([]byte("a"), 8<<20),
+			responseFormat: "json",
+			wantError:      "too large",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := newAliAudioRequestContext(t, tt.fields, tt.filename, tt.fileContent)
+			request := dto.AudioRequest{Model: "qwen-audio-3.0-asr-flash", ResponseFormat: tt.responseFormat}
+			_, err := (&Adaptor{}).ConvertAudioRequest(c, newAliAudioRelayInfo(request), request)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantError)
+		})
+	}
+
+	c, _ := newAliAudioRequestContext(t, map[string]string{"model": "qwen-audio-3.0-asr-flash"}, "clip.mp3", []byte("audio"))
+	request := dto.AudioRequest{Model: "qwen-audio-3.0-asr-flash", ResponseFormat: "json"}
+	info := newAliAudioRelayInfo(request)
+	info.RelayMode = constant.RelayModeAudioTranslation
+	_, err := (&Adaptor{}).ConvertAudioRequest(c, info, request)
+	require.EqualError(t, err, "Ali audio adaptor supports transcription only")
+}
+
+func TestAliAudioTranscriptionResponseHandler(t *testing.T) {
+	tests := []struct {
+		name            string
+		responseFormat  string
+		wantBody        string
+		wantContentType string
+	}{
+		{
+			name:            "json",
+			responseFormat:  "json",
+			wantBody:        `{"text":"你好，百炼。"}`,
+			wantContentType: "application/json",
+		},
+		{
+			name:            "text",
+			responseFormat:  "text",
+			wantBody:        "你好，百炼。",
+			wantContentType: "text/plain; charset=utf-8",
+		},
+		{
+			name:            "verbose json",
+			responseFormat:  "verbose_json",
+			wantBody:        `{"task":"transcribe","duration":60,"text":"你好，百炼。","segments":[{"id":1,"start":0,"end":1.2,"text":"你好，百炼。","words":[{"word":"你好","start":0,"end":0.5}]}]}`,
+			wantContentType: "application/json",
+		},
+	}
+	upstreamBody := `{"output":{"text":"你好，百炼。","sentence":{"sentence_id":1,"sentence_end":true,"begin_time":0,"end_time":1200,"text":"你好，百炼。","words":[{"text":"你好","begin_time":0,"end_time":500}]}},"usage":{"duration":60}}`
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", nil)
+			request := dto.AudioRequest{Model: "qwen-audio-3.0-asr-flash", ResponseFormat: tt.responseFormat}
+			info := newAliAudioRelayInfo(request)
+			response := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(upstreamBody))}
+
+			usage, apiErr := aliAudioTranscriptionHandler(c, response, info)
+			require.Nil(t, apiErr)
+			assert.Equal(t, http.StatusOK, recorder.Code)
+			assert.Equal(t, tt.wantContentType, recorder.Header().Get("Content-Type"))
+			if tt.responseFormat == "text" {
+				assert.Equal(t, tt.wantBody, recorder.Body.String())
+			} else {
+				assert.JSONEq(t, tt.wantBody, recorder.Body.String())
+			}
+			usageData, ok := usage.(*dto.Usage)
+			require.True(t, ok)
+			assert.Equal(t, 1000, usageData.PromptTokens)
+			assert.Equal(t, 1000, usageData.PromptTokensDetails.AudioTokens)
+		})
+	}
+}
+
+func TestAliAudioTranscriptionResponseHandlerAcceptsNestedSentence(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", nil)
+	request := dto.AudioRequest{Model: "fun-asr-flash-2026-06-15", ResponseFormat: "verbose_json"}
+	info := newAliAudioRelayInfo(request)
+	info.UpstreamModelName = "fun-asr-flash-2026-06-15"
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"output":{"text":"你好，百炼。","output":{"sentence":{"sentence_id":1,"sentence_end":true,"begin_time":0,"end_time":1200,"text":"你好，百炼。"}}},"usage":{"duration":2}}`)),
+	}
+
+	_, apiErr := aliAudioTranscriptionHandler(c, response, info)
+	require.Nil(t, apiErr)
+	assert.JSONEq(t, `{"task":"transcribe","duration":2,"text":"你好，百炼。","segments":[{"id":1,"start":0,"end":1.2,"text":"你好，百炼。"}]}`, recorder.Body.String())
+}
+
+func TestAliQwenASRTranscriptionResponseHandler(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", nil)
+	request := dto.AudioRequest{Model: "qwen3-asr-flash", ResponseFormat: "verbose_json"}
+	info := newAliAudioRelayInfo(request)
+	info.UpstreamModelName = "qwen3-asr-flash"
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"output":{"choices":[{"message":{"content":[{"text":"你好，百炼。"}]}}]},"usage":{"seconds":2}}`)),
+	}
+
+	usage, apiErr := aliQwenASRTranscriptionHandler(c, response, info)
+	require.Nil(t, apiErr)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.JSONEq(t, `{"task":"transcribe","duration":2,"text":"你好，百炼。"}`, recorder.Body.String())
+	usageData, ok := usage.(*dto.Usage)
+	require.True(t, ok)
+	assert.Equal(t, 33, usageData.PromptTokens)
+	assert.Equal(t, 33, usageData.PromptTokensDetails.AudioTokens)
+}
+
+func TestAliAudioTranscriptionStreamHandler(t *testing.T) {
+	streamBody := strings.Join([]string{
+		`event: result`,
+		`data: {"output":{"text":"你好","sentence":{"sentence_id":1,"sentence_end":true,"text":"你好"}},"usage":{"duration":1}}`,
+		``,
+		`data: {"output":{"text":"你好，百炼。","sentence":{"sentence_id":1,"sentence_end":true,"text":"你好"}},"usage":{"duration":2}}`,
+		``,
+		`data: {"output":{"text":"你好，百炼。","sentence":{"sentence_id":2,"sentence_end":true,"text":"，百炼。"}},"usage":{"duration":2}}`,
+		``,
+	}, "\n")
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", nil)
+	stream := true
+	request := dto.AudioRequest{Model: "qwen-audio-3.0-asr-flash", ResponseFormat: "json", Stream: &stream}
+	info := newAliAudioRelayInfo(request)
+	info.IsStream = true
+	response := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(streamBody))}
+
+	usage, apiErr := aliAudioTranscriptionHandler(c, response, info)
+	require.Nil(t, apiErr)
+	assert.Equal(t, "text/event-stream", recorder.Header().Get("Content-Type"))
+	assert.Equal(t, 1, strings.Count(recorder.Body.String(), `"delta":"你好"`))
+	assert.Equal(t, 1, strings.Count(recorder.Body.String(), `"delta":"，百炼。"`))
+	assert.Contains(t, recorder.Body.String(), `event: transcript.text.done`)
+	assert.Contains(t, recorder.Body.String(), `"text":"你好，百炼。"`)
+	assert.Contains(t, recorder.Body.String(), `"seconds":2`)
+	usageData, ok := usage.(*dto.Usage)
+	require.True(t, ok)
+	assert.Equal(t, 33, usageData.PromptTokens)
+	assert.Equal(t, 33, usageData.PromptTokensDetails.AudioTokens)
+}
+
+func TestAliAudioTranscriptionStreamHandlerAcceptsJSONFallback(t *testing.T) {
+	upstreamBody := `{"sentence":{"sentence_id":1,"begin_time":560,"end_time":3920,"text":"甚至出现交易几乎停滞的情况。","sentence_end":true},"text":"甚至出现交易几乎停滞的情况。","output":{"sentence":{"sentence_id":1,"begin_time":560,"end_time":3920,"text":"甚至出现交易几乎停滞的情况。","sentence_end":true},"text":"甚至出现交易几乎停滞的情况。"},"usage":{"duration":4}}`
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", nil)
+	stream := true
+	request := dto.AudioRequest{Model: "qwen-audio-3.0-asr-flash", ResponseFormat: "json", Stream: &stream}
+	info := newAliAudioRelayInfo(request)
+	info.IsStream = true
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}
+
+	usage, apiErr := aliAudioTranscriptionHandler(c, response, info)
+	require.Nil(t, apiErr)
+	assert.Contains(t, recorder.Body.String(), `event: transcript.text.delta`)
+	assert.Contains(t, recorder.Body.String(), `"delta":"甚至出现交易几乎停滞的情况。"`)
+	assert.Contains(t, recorder.Body.String(), `event: transcript.text.done`)
+	assert.Contains(t, recorder.Body.String(), `"text":"甚至出现交易几乎停滞的情况。"`)
+	assert.Contains(t, recorder.Body.String(), `"seconds":4`)
+	usageData, ok := usage.(*dto.Usage)
+	require.True(t, ok)
+	assert.Equal(t, 67, usageData.PromptTokensDetails.AudioTokens)
+}
+
+func TestAliAudioTranscriptionStreamHandlerUsesChoicesTextFallback(t *testing.T) {
+	streamBody := strings.Join([]string{
+		`data: {"output":{"choices":[{"message":{"content":[{"text":"甚至出现"}]}}]}}`,
+		``,
+		`data: {"output":{"choices":[{"message":{"content":[{"text":"甚至出现交易几乎停滞的情况。"}]}}]},"usage":{"duration":4}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", nil)
+	stream := true
+	request := dto.AudioRequest{Model: "qwen-audio-3.0-asr-flash", ResponseFormat: "json", Stream: &stream}
+	info := newAliAudioRelayInfo(request)
+	info.IsStream = true
+	response := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(streamBody))}
+
+	_, apiErr := aliAudioTranscriptionHandler(c, response, info)
+	require.Nil(t, apiErr)
+	assert.Contains(t, recorder.Body.String(), `"delta":"甚至出现"`)
+	assert.Contains(t, recorder.Body.String(), `"delta":"交易几乎停滞的情况。"`)
+	assert.Contains(t, recorder.Body.String(), `"text":"甚至出现交易几乎停滞的情况。"`)
+}
+
+func TestAliAudioTranscriptionStreamHandlerUsesOpenAIStyleDeltaFallback(t *testing.T) {
+	streamBody := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"甚至出现"}}]}`,
+		``,
+		`data: {"choices":[{"delta":{"content":"交易几乎停滞的情况。"}}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", nil)
+	stream := true
+	request := dto.AudioRequest{Model: "qwen-audio-3.0-asr-flash", ResponseFormat: "json", Stream: &stream}
+	info := newAliAudioRelayInfo(request)
+	info.IsStream = true
+	response := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(streamBody))}
+
+	_, apiErr := aliAudioTranscriptionHandler(c, response, info)
+	require.Nil(t, apiErr)
+	assert.Contains(t, recorder.Body.String(), `"delta":"甚至出现"`)
+	assert.Contains(t, recorder.Body.String(), `"delta":"交易几乎停滞的情况。"`)
+	assert.Contains(t, recorder.Body.String(), `"text":"甚至出现交易几乎停滞的情况。"`)
+}
+
+func TestAliAudioUsageFromDurationFallsBackAndAuditsSaturation(t *testing.T) {
+	request := dto.AudioRequest{Model: "qwen-audio-3.0-asr-flash"}
+	info := newAliAudioRelayInfo(request)
+	info.SetEstimatePromptTokens(123)
+
+	fallbackUsage := aliAudioUsageFromDuration(info, nil)
+	assert.Equal(t, 123, fallbackUsage.PromptTokensDetails.AudioTokens)
+
+	hugeDuration := math.MaxFloat64
+	saturatedUsage := aliAudioUsageFromDuration(info, &hugeDuration)
+	assert.Equal(t, math.MaxInt32, saturatedUsage.PromptTokensDetails.AudioTokens)
+	require.NotNil(t, info.QuotaClamp)
+}

--- a/relay/channel/ali/constants.go
+++ b/relay/channel/ali/constants.go
@@ -1,5 +1,26 @@
 package ali
 
+import "strings"
+
+type aliAudioTranscriptionProtocol int
+
+const (
+	aliAudioTranscriptionProtocolUnsupported aliAudioTranscriptionProtocol = iota
+	aliAudioTranscriptionProtocolLegacyMultimodal
+	aliAudioTranscriptionProtocolQwenASRMultimodal
+)
+
+var aliAudioTranscriptionProtocols = map[string]aliAudioTranscriptionProtocol{
+	"qwen-audio-3.0-asr-flash": aliAudioTranscriptionProtocolLegacyMultimodal,
+	"fun-asr-flash-2026-06-15": aliAudioTranscriptionProtocolLegacyMultimodal,
+	"qwen3-asr-flash":          aliAudioTranscriptionProtocolQwenASRMultimodal,
+	"qwen3-asr-flash-us":       aliAudioTranscriptionProtocolQwenASRMultimodal,
+}
+
+func aliAudioTranscriptionProtocolFor(modelName string) aliAudioTranscriptionProtocol {
+	return aliAudioTranscriptionProtocols[strings.ToLower(strings.TrimSpace(modelName))]
+}
+
 var ModelList = []string{
 	"qwen-turbo",
 	"qwen-plus",
@@ -7,6 +28,10 @@ var ModelList = []string{
 	"qwen-max-longcontext",
 	"qwq-32b",
 	"qwen3-235b-a22b",
+	"qwen-audio-3.0-asr-flash",
+	"fun-asr-flash-2026-06-15",
+	"qwen3-asr-flash",
+	"qwen3-asr-flash-us",
 	"text-embedding-v1",
 	"gte-rerank-v2",
 }

--- a/relay/helper/audio_request_test.go
+++ b/relay/helper/audio_request_test.go
@@ -1,0 +1,36 @@
+package helper
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/relay/constant"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAndValidAudioRequestParsesMultipartStream(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "qwen-audio-3.0-asr-flash"))
+	require.NoError(t, writer.WriteField("response_format", "json"))
+	require.NoError(t, writer.WriteField("stream", "true"))
+	part, err := writer.CreateFormFile("file", "clip.wav")
+	require.NoError(t, err)
+	_, err = part.Write([]byte("audio"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", bytes.NewReader(body.Bytes()))
+	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+
+	request, err := GetAndValidAudioRequest(c, constant.RelayModeAudioTranscription)
+	require.NoError(t, err)
+	require.NotNil(t, request.Stream)
+	require.True(t, *request.Stream)
+	require.True(t, request.IsStream(c.Request))
+}

--- a/relay/helper/valid_request.go
+++ b/relay/helper/valid_request.go
@@ -59,9 +59,29 @@ func GetAndValidateRequest(c *gin.Context, format types.RelayFormat) (request dt
 
 func GetAndValidAudioRequest(c *gin.Context, relayMode int) (*dto.AudioRequest, error) {
 	audioRequest := &dto.AudioRequest{}
-	err := common.UnmarshalBodyReusable(c, audioRequest)
-	if err != nil {
-		return nil, err
+	contentType := c.Request.Header.Get("Content-Type")
+	if strings.Contains(contentType, gin.MIMEMultipartPOSTForm) {
+		form, err := common.ParseMultipartFormReusable(c)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse audio form request: %w", err)
+		}
+		formData := url.Values(form.Value)
+		c.Request.MultipartForm = form
+		c.Request.PostForm = formData
+		audioRequest.Model = formData.Get("model")
+		audioRequest.ResponseFormat = formData.Get("response_format")
+		if streamValue := strings.TrimSpace(formData.Get("stream")); streamValue != "" {
+			stream, err := strconv.ParseBool(streamValue)
+			if err != nil {
+				return nil, fmt.Errorf("invalid stream value: %w", err)
+			}
+			audioRequest.Stream = &stream
+		}
+	} else {
+		err := common.UnmarshalBodyReusable(c, audioRequest)
+		if err != nil {
+			return nil, err
+		}
 	}
 	switch relayMode {
 	case relayconstant.RelayModeAudioSpeech:

--- a/relaykit/dto/audio.go
+++ b/relaykit/dto/audio.go
@@ -14,6 +14,7 @@ type AudioRequest struct {
 	Voice          string          `json:"voice"`
 	Instructions   string          `json:"instructions,omitempty"`
 	ResponseFormat string          `json:"response_format,omitempty"`
+	Stream         *bool           `json:"stream,omitempty"`
 	Speed          *float64        `json:"speed,omitempty"`
 	StreamFormat   string          `json:"stream_format,omitempty"`
 	Metadata       json.RawMessage `json:"metadata,omitempty"`
@@ -41,7 +42,7 @@ func (r *AudioRequest) GetTokenCountMeta() *types.TokenCountMeta {
 }
 
 func (r *AudioRequest) IsStream(c *http.Request) bool {
-	return r.StreamFormat == "sse"
+	return r.Stream != nil && *r.Stream || r.StreamFormat == "sse"
 }
 
 func (r *AudioRequest) SetModelName(modelName string) {


### PR DESCRIPTION

## 🔗 关联任务 / Related Issue
- Closes #7182

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [✅ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description
(简述做了什么、为什么生效。如果难以简述，建议先拆分范围，或在 Issue 中与维护者对齐。)
为 Ali 渠道实现 /v1/audio/transcriptions 请求转换与响应处理。
将 OpenAI multipart 音频读取为原始字节，并包装为百炼要求的 Base64 Data URI。
支持 json、text 和 verbose_json 响应格式。
支持客户端 multipart stream=true 参数。
支持标准百炼 SSE 响应，并兼容上游在启用 X-DashScope-SSE 后仍返回完整 JSON 对象的情况。
使用已验证模型白名单，并按协议类别选择转换器：
qwen-audio-3.0-asr-flash
fun-asr-flash-2026-06-15
qwen3-asr-flash
qwen3-asr-flash-us
qwen-audio-3.0-asr-flash 和 Fun-ASR 使用同一套百炼多模态 ASR 协议。
Qwen3-ASR 使用独立的协议类别，以适配其不同的请求和响应结构。
增加文件格式、Base64 请求大小、prompt 长度、响应格式及 usage 转换校验。
增加协议转换、模型白名单、multipart stream 解析、响应格式、流式响应和 quota 饱和保护测试。
该修改由 OpenAI Codex 辅助开发，提交者已审阅代码并对修改内容负责。

## 📸 运行证明 / Proof of Work

非流式：
<img width="1188" height="204" alt="image" src="https://github.com/user-attachments/assets/8b2a968d-7fe7-46bf-9745-9fb7d10ab3af" />
流式：
<img width="1644" height="392" alt="image" src="https://github.com/user-attachments/assets/874afb52-b7f6-4c85-97c4-733b2f915ab2" />


## ✅ 提交前检查项 / Checklist
- [✅ ] **人工确认:** 无论描述是否由 AI 生成，我已审阅全部内容，并声明对其准确性与完整性负责。
- [ ✅] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ✅] **新功能关联 Issue:** 若此 PR 标记为 `New feature`，我已关联对应 Issue；若尚无 Issue，我已先自行创建。
- [✅ ] **事前沟通:** 若改动较大或涉及方向性变更，已在关联 Issue 中与维护者沟通并达成一致。
- [✅ ] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口，也不是对 Codex 渠道类型的改动。
- [✅ ] **范围聚焦:** 本 PR 为一项聚焦改动，未包含无关代码。
- [ ✅] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核。
- [ ✅] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio transcription support for Alibaba Cloud legacy multimodal and Qwen ASR models.
  * Added multipart audio requests with optional streaming responses via Server-Sent Events.
  * Added support for text, verbose JSON, and standard JSON transcription formats.
  * Added validation for audio files, formats, and size limits.
  * Added usage estimation based on audio duration.

* **Documentation**
  * Updated the API specification to document the optional `stream` field for audio transcription requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->