### PR TITLE
fix(responses): preserve pre-consume when streamed output lacks usage

### DIFF
--- a/constant/context_key.go
+++ b/constant/context_key.go
@@ -65,6 +65,10 @@ const (
 	// It is not returned to end users, but can be persisted into consume/error logs for debugging.
 	ContextKeyAdminRejectReason ContextKey = "admin_reject_reason"
 
+	// ContextKeyResponsesBillableStreamOutput marks a Responses stream that emitted
+	// billable output before its terminal usage event was observed.
+	ContextKeyResponsesBillableStreamOutput ContextKey = "responses_billable_stream_output"
+
 	// ContextKeyLanguage stores the user's language preference for i18n
 	ContextKeyLanguage ContextKey = "language"
 	ContextKeyIsStream ContextKey = "is_stream"

--- a/relay/channel/openai/helper.go
+++ b/relay/channel/openai/helper.go
@@ -261,9 +261,9 @@ func HandleFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, lastStream
 	}
 }
 
-func sendResponsesStreamData(c *gin.Context, streamResponse dto.ResponsesStreamResponse, data string) {
+func sendResponsesStreamData(c *gin.Context, streamResponse dto.ResponsesStreamResponse, data string) error {
 	if data == "" {
-		return
+		return nil
 	}
-	_ = helper.ResponseChunkData(c, streamResponse, data)
+	return helper.ResponseChunkData(c, streamResponse, data)
 }

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/logger"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/helper"
@@ -71,6 +72,7 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 	}
 
 	defer service.CloseResponseBodyGracefully(resp)
+	common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, false)
 
 	var usage = &dto.Usage{}
 	var responseTextBuilder strings.Builder
@@ -86,10 +88,15 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 			sr.Error(err)
 			return
 		}
-		sendResponsesStreamData(c, streamResponse, data)
+		delivered := sendResponsesStreamData(c, streamResponse, data) == nil
 		switch streamResponse.Type {
 		case "response.completed", "response.done":
 			if streamResponse.Response != nil {
+				if relaycommon.IsNonBillableResponsesStatus(streamResponse.Response.Status) {
+					common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, false)
+				} else if delivered && len(streamResponse.Response.Output) > 0 {
+					common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, true)
+				}
 				if streamResponse.Response.Usage != nil {
 					incomingUsage := relayconvert.NormalizeResponsesUsage(streamResponse.Response.Usage)
 					usage = dto.MergeUsageNonZero(usage, incomingUsage)
@@ -113,26 +120,40 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 				imageCommitted = true
 			}
 		case "response.failed", "response.incomplete", "response.cancelled", "response.canceled":
+			common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, false)
 			if !imageCommitted {
 				imageCounter.Reset()
 				imageCounter.Commit(info)
 				imageCommitted = true
 			}
-		case "response.output_text.delta":
-			// 处理输出文本
-			responseTextBuilder.WriteString(streamResponse.Delta)
+		case "response.output_text.delta", "response.function_call_arguments.delta",
+			"response.reasoning_summary_text.delta", "response.refusal.delta":
+			// Track billable deltas; visible text is also retained for token estimation.
+			if delivered && streamResponse.Delta != "" {
+				common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, true)
+				if streamResponse.Type == "response.output_text.delta" {
+					responseTextBuilder.WriteString(streamResponse.Delta)
+				}
+			}
 		case dto.ResponsesOutputTypeItemDone:
-			if streamResponse.Item != nil {
+			if delivered && streamResponse.Item != nil {
 				switch streamResponse.Item.Type {
 				case dto.BuildInCallWebSearchCall:
+					common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, true)
 					info.CountBillableToolCall(dto.BuildInCallWebSearchCall, "")
 				case dto.BuildInCallFileSearchCall:
+					common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, true)
 					info.CountBillableToolCall(dto.BuildInCallFileSearchCall, "")
 				case dto.BuildInCallFunctionCall:
+					common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, true)
 					info.CountBillableToolCall(dto.BuildInCallFunctionCall, streamResponse.Item.Name)
 				case dto.ResponsesOutputTypeImageGenerationCall:
 					if !imageCommitted {
+						before := imageCounter.Count()
 						imageCounter.Observe(streamResponse.Item, streamResponse.OutputIndex)
+						if imageCounter.Count() > before {
+							common.SetContextKey(c, constant.ContextKeyResponsesBillableStreamOutput, true)
+						}
 					}
 				}
 			}

--- a/relay/channel/openai/relay_responses_billing_test.go
+++ b/relay/channel/openai/relay_responses_billing_test.go
@@ -265,3 +265,88 @@ func TestOaiResponsesStreamHandlerDoesNotCountPartialImageEvent(t *testing.T) {
 
 	assert.Equal(t, 0, info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolImageGeneration].CallCount)
 }
+
+func runResponsesBillableOutputMarkerStream(t *testing.T, events ...string) bool {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() {
+		constant.StreamingTimeout = oldTimeout
+	})
+
+	var body strings.Builder
+	for _, event := range events {
+		body.WriteString("data: ")
+		body.WriteString(event)
+		body.WriteString("\n\n")
+	}
+	body.WriteString("data: [DONE]\n\n")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	info := &relaycommon.RelayInfo{
+		IsStream:        true,
+		OriginModelName: "gpt-5.1",
+		DisablePing:     true,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "gpt-5.1",
+		},
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body.String())),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+
+	_, apiErr := OaiResponsesStreamHandler(c, info, resp)
+	require.Nil(t, apiErr)
+	return common.GetContextKeyBool(c, constant.ContextKeyResponsesBillableStreamOutput)
+}
+
+func TestOaiResponsesStreamHandlerMarksBillableDeltaOutput(t *testing.T) {
+	marked := runResponsesBillableOutputMarkerStream(
+		t,
+		`{"type":"response.function_call_arguments.delta","delta":"{\"query\":\"status\"}"}`,
+	)
+
+	assert.True(t, marked)
+}
+
+func TestOaiResponsesStreamHandlerMarksCompletedResponseOutput(t *testing.T) {
+	marked := runResponsesBillableOutputMarkerStream(
+		t,
+		`{"type":"response.completed","response":{"status":"completed","output":[{"type":"message","role":"assistant","content":[]}]}}`,
+	)
+
+	assert.True(t, marked)
+}
+
+func TestOaiResponsesStreamHandlerClearsBillableOutputOnFailedTerminalEvent(t *testing.T) {
+	marked := runResponsesBillableOutputMarkerStream(
+		t,
+		`{"type":"response.function_call_arguments.delta","delta":"{\"query\":\"partial\"}"}`,
+		`{"type":"response.failed","response":{"status":"failed"}}`,
+	)
+
+	assert.False(t, marked)
+}
+
+func TestOaiResponsesStreamHandlerDoesNotMarkIncompleteCompletedResponse(t *testing.T) {
+	marked := runResponsesBillableOutputMarkerStream(
+		t,
+		`{"type":"response.completed","response":{"status":"incomplete","output":[{"type":"message","role":"assistant","content":[]}]}}`,
+	)
+
+	assert.False(t, marked)
+}
+
+func TestOaiResponsesStreamHandlerDoesNotMarkMetadataOnlyStream(t *testing.T) {
+	marked := runResponsesBillableOutputMarkerStream(
+		t,
+		`{"type":"response.created","response":{"status":"in_progress"}}`,
+	)
+
+	assert.False(t, marked)
+}

--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -66,6 +66,7 @@ type textQuotaSummary struct {
 	AudioInputPrice        float64
 	ToolSurchargeItems     []ToolSurchargeItem
 	ToolCallSurchargeQuota decimal.Decimal
+	MissingUsageFallback   bool
 }
 
 // hasBillableUsage reports whether this request should incur any charge.
@@ -73,7 +74,42 @@ type textQuotaSummary struct {
 // surcharge (e.g. /v1/alpha/search returns no usage but bills one web_search
 // call), so token count alone is not sufficient to decide.
 func (s *textQuotaSummary) hasBillableUsage() bool {
-	return s.TotalTokens > 0 || !s.ToolCallSurchargeQuota.IsZero()
+	return s.MissingUsageFallback || s.TotalTokens > 0 || !s.ToolCallSurchargeQuota.IsZero()
+}
+
+func preConsumedQuotaForRelay(relayInfo *relaycommon.RelayInfo) int {
+	if relayInfo == nil {
+		return 0
+	}
+	if relayInfo.Billing != nil {
+		// BillingSession is authoritative even when a trusted request legitimately
+		// reserved zero quota.
+		return relayInfo.Billing.GetPreConsumedQuota()
+	}
+	return relayInfo.FinalPreConsumedQuota
+}
+
+func missingResponsesUsageFallbackQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, summary *textQuotaSummary) (int, bool) {
+	if relayInfo == nil || summary == nil || !relayInfo.IsStream || summary.TotalTokens != 0 {
+		return 0, false
+	}
+	if relayInfo.GetFinalRequestRelayFormat() != types.RelayFormatOpenAIResponses {
+		return 0, false
+	}
+	if !common.GetContextKeyBool(ctx, constant.ContextKeyResponsesBillableStreamOutput) {
+		return 0, false
+	}
+
+	preConsumed := preConsumedQuotaForRelay(relayInfo)
+	if preConsumed <= 0 {
+		return 0, false
+	}
+
+	quota, clamp := common.QuotaFromDecimalChecked(
+		decimal.NewFromInt(int64(preConsumed)).Add(summary.ToolCallSurchargeQuota),
+	)
+	noteQuotaClamp(relayInfo, clamp)
+	return quota, true
 }
 
 func cacheWriteTokensTotal(summary textQuotaSummary) int {
@@ -375,7 +411,10 @@ func calculateTextQuotaSummary(ctx *gin.Context, relayInfo *relaycommon.RelayInf
 		noteQuotaClamp(relayInfo, clamp)
 	}
 
-	if !summary.hasBillableUsage() {
+	if fallbackQuota, ok := missingResponsesUsageFallbackQuota(ctx, relayInfo, &summary); ok {
+		summary.Quota = fallbackQuota
+		summary.MissingUsageFallback = true
+	} else if !summary.hasBillableUsage() {
 		summary.Quota = 0
 	} else if !ratio.IsZero() && summary.Quota == 0 {
 		summary.Quota = 1
@@ -409,7 +448,7 @@ func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, us
 
 	var tieredResult *billingexpr.TieredResult
 	tieredBillingApplied := false
-	if originUsage != nil {
+	if originUsage != nil && !summary.MissingUsageFallback {
 		var tieredUsedVars map[string]bool
 		if snap := relayInfo.TieredBillingSnapshot; snap != nil {
 			tieredUsedVars = billingexpr.UsedVars(snap.ExprString)
@@ -442,8 +481,12 @@ func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, us
 
 	if !summary.hasBillableUsage() {
 		extraContent = append(extraContent, "上游没有返回计费信息，无法扣费（可能是上游超时）")
-		logger.LogError(ctx, fmt.Sprintf("total tokens is 0, cannot consume quota, userId %d, channelId %d, tokenId %d, model %s， pre-consumed quota %d", relayInfo.UserId, relayInfo.ChannelId, relayInfo.TokenId, summary.ModelName, relayInfo.FinalPreConsumedQuota))
+		logger.LogError(ctx, fmt.Sprintf("total tokens is 0, cannot consume quota, userId %d, channelId %d, tokenId %d, model %s， pre-consumed quota %d", relayInfo.UserId, relayInfo.ChannelId, relayInfo.TokenId, summary.ModelName, preConsumedQuotaForRelay(relayInfo)))
 	} else {
+		if summary.MissingUsageFallback {
+			extraContent = append(extraContent, "流式响应已产生可计费输出但缺少最终用量，按预扣额度结算")
+			logger.LogWarn(ctx, fmt.Sprintf("responses stream usage missing after billable output, settling pre-consumed quota, userId %d, channelId %d, tokenId %d, model %s, quota %d", relayInfo.UserId, relayInfo.ChannelId, relayInfo.TokenId, summary.ModelName, summary.Quota))
+		}
 		model.UpdateUserUsedQuotaAndRequestCount(relayInfo.UserId, summary.Quota)
 		model.UpdateChannelUsedQuota(relayInfo.ChannelId, summary.Quota)
 	}
@@ -479,6 +522,12 @@ func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, us
 	appendUsageBillingPathForLog(other, common.GetContextKeyBool(ctx, constant.ContextKeyLocalCountTokens), originUsage)
 	if adminRejectReason != "" {
 		other.SetAdmin("reject_reason", adminRejectReason)
+	}
+	if summary.MissingUsageFallback {
+		other.SetAdmin("missing_usage_fallback", map[string]any{
+			"policy": "pre_consumed_after_billable_output",
+			"quota":  summary.Quota,
+		})
 	}
 	if summary.ImageTokens != 0 {
 		other.SetPublic("image", true)
@@ -517,7 +566,7 @@ func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, us
 		// prompt/cache fields here, otherwise old upstream payloads may be double-counted.
 		other.SetPublic("input_tokens_total", billingUsage.InputTokens)
 	}
-	if tieredBillingApplied {
+	if tieredBillingApplied || summary.MissingUsageFallback {
 		InjectTieredBillingInfo(other, relayInfo, tieredResult)
 	}
 

--- a/service/text_quota_test.go
+++ b/service/text_quota_test.go
@@ -486,6 +486,111 @@ func TestCacheWriteTokensTotal(t *testing.T) {
 	})
 }
 
+func newMissingResponsesUsageContext(markBillableOutput bool) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	common.SetContextKey(ctx, constant.ContextKeyResponsesBillableStreamOutput, markBillableOutput)
+	return ctx
+}
+
+func newMissingResponsesUsageRelayInfo() *relaycommon.RelayInfo {
+	return &relaycommon.RelayInfo{
+		IsStream:              true,
+		RelayFormat:           types.RelayFormatOpenAIResponses,
+		OriginModelName:       "gpt-5.1",
+		FinalPreConsumedQuota: 5000,
+		PriceData: hosttypes.PriceData{
+			ModelRatio:      1,
+			CompletionRatio: 1,
+			GroupRatioInfo:  hosttypes.GroupRatioInfo{GroupRatio: 1},
+		},
+		StartTime: time.Now(),
+	}
+}
+
+func TestCalculateTextQuotaSummaryKeepsPreConsumedQuotaForBillableResponsesOutput(t *testing.T) {
+	ctx := newMissingResponsesUsageContext(true)
+	relayInfo := newMissingResponsesUsageRelayInfo()
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, &dto.Usage{})
+
+	assert.Zero(t, summary.TotalTokens)
+	assert.Equal(t, 5000, summary.Quota)
+	assert.True(t, summary.MissingUsageFallback)
+}
+
+func TestCalculateTextQuotaSummaryRefundsMissingUsageWithoutBillableOutput(t *testing.T) {
+	ctx := newMissingResponsesUsageContext(false)
+	relayInfo := newMissingResponsesUsageRelayInfo()
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, &dto.Usage{})
+
+	assert.Zero(t, summary.Quota)
+	assert.False(t, summary.MissingUsageFallback)
+}
+
+func TestCalculateTextQuotaSummaryActualUsageOverridesMissingUsageFallback(t *testing.T) {
+	ctx := newMissingResponsesUsageContext(true)
+	relayInfo := newMissingResponsesUsageRelayInfo()
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, &dto.Usage{
+		PromptTokens:     100,
+		CompletionTokens: 20,
+	})
+
+	assert.Equal(t, 120, summary.TotalTokens)
+	assert.Equal(t, 120, summary.Quota)
+	assert.False(t, summary.MissingUsageFallback)
+}
+
+func TestCalculateTextQuotaSummaryDoesNotApplyMissingUsageFallbackToOtherFormats(t *testing.T) {
+	ctx := newMissingResponsesUsageContext(true)
+	relayInfo := newMissingResponsesUsageRelayInfo()
+	relayInfo.RelayFormat = types.RelayFormatOpenAI
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, &dto.Usage{})
+
+	assert.Zero(t, summary.Quota)
+	assert.False(t, summary.MissingUsageFallback)
+}
+
+func TestCalculateTextQuotaSummaryUsesBillingSessionReservationAsAuthoritative(t *testing.T) {
+	ctx := newMissingResponsesUsageContext(true)
+	relayInfo := newMissingResponsesUsageRelayInfo()
+	relayInfo.Billing = &recordingBillingSettler{}
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, &dto.Usage{})
+
+	assert.Zero(t, summary.Quota)
+	assert.False(t, summary.MissingUsageFallback)
+}
+
+func TestCalculateTextQuotaSummaryAddsObservedToolSurchargeToMissingUsageFallback(t *testing.T) {
+	operation_setting.SetToolPriceForTest(dto.BuildInToolWebSearchPreview, 5)
+	t.Cleanup(func() {
+		operation_setting.DeleteToolPriceForTest(dto.BuildInToolWebSearchPreview)
+	})
+
+	ctx := newMissingResponsesUsageContext(true)
+	relayInfo := newMissingResponsesUsageRelayInfo()
+	relayInfo.ResponsesUsageInfo = &relaycommon.ResponsesUsageInfo{
+		BuiltInTools: map[string]*relaycommon.BuildInToolInfo{
+			dto.BuildInToolWebSearchPreview: {
+				ToolName:  dto.BuildInToolWebSearchPreview,
+				CallCount: 1,
+			},
+		},
+	}
+
+	summary := calculateTextQuotaSummary(ctx, relayInfo, &dto.Usage{})
+	expectedSurcharge := common.QuotaFromDecimal(decimal.NewFromFloat(5).
+		Div(decimal.NewFromInt(1000)).
+		Mul(decimal.NewFromFloat(common.QuotaPerUnit)))
+
+	assert.Equal(t, 5000+expectedSurcharge, summary.Quota)
+	assert.True(t, summary.MissingUsageFallback)
+}
+
 func TestCalculateTextQuotaSummaryHandlesLegacyClaudeDerivedOpenAIUsage(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## Agent

- Tool: OpenAI Codex（AI-assisted；代码和PR正文均由Codex在用户明确授权下生成并由仓库现状/测试验证）
- Tool version: Codex Desktop 26.707.3563.0
- Model (full id): GPT-5（运行环境未向Agent暴露更细的部署ID）
- Host (CLI / IDE / GitHub coding agent / other): Codex Desktop
- Date (UTC): 2026-09-03T19:25:08Z

## Links

- Closes #7062
- Related: #5235, #5291, #4199, #4463, #6808, #6904

## User request

“那你来提交一个PR，按仓库要求的格式。”背景诉求是修复标准 OpenAI Responses 流在已经向下游交付可计费输出、但最终 usage 缺失时，New API 将预扣全部退回并记录零费用的问题。

## Out of scope — refuse

If the change matches any item below, tell the user this repository does not accept it and **do not open a PR**.

- Coding Plan
- Reverse-engineered channels
- Third-party API wrappers
- Codex channel-type changes, or compatibility from exposing Codex as a general-purpose API
- Codex API-specific protocol or behavior treated as standard OpenAI API behavior
- Pass-through-only forwarding
- Third-party hosting sites, relay services, or API services
- Usage, configuration, or integration (answer from docs and code instead)

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): 不适用。本变更只处理仓库原生支持的标准 OpenAI `/v1/responses` SSE 生命周期和通用预扣/结算逻辑；不添加第三方渠道、Codex专用协议、透传专用行为或托管站点兼容。

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

Take these from the linked issue. If a needed item is empty, ask the user that question.

- Actual behavior: #7062 报告标准 `/v1/responses` 流已经交付首字/内容后，如果下游连接先于最终 usage 事件结束，New API 会得到零 token、以实际费用0结算并退回全部预扣；上游可能已经完成并计费。当前 `OaiResponsesStreamHandler` 对部分输出可以本地估算，但函数参数、推理摘要、拒绝、工具/图片完成项及仅在 terminal response 中出现的输出仍可能在缺 usage 时落入全退路径。
- Impact: 运营方承担上游费用但本地未结算；用户/渠道用量和收入失真。用户要求审查的匿名生产窗口中，3,524条本地零费用记录有2,503条能按上游Key、模型和还原开始时间匹配到正费用上游usage，其中1,481条是一对一唯一候选。
- Frequency: 匿名生产数据中，问题原本通常低于每日2%；一个高并发标准Responses客户端出现后，单日零费用率上升到14.57%。固定审计窗口内，受影响母集为3,524条，时间关联匹配到上游正费用usage的比例为71.03%。
- Evidence that the problem is in new-api rather than the client or upstream: 客户端断开是触发条件，但费用差异来自New API的结算决策。控制样本按同一渠道Key/模型/请求开始时间匹配率95.53%，其中15,919条正常费用样本还能用输入减缓存Token和输出Token精确复核，开始时间中位误差0.607秒；匹配到的2,503条零费用记录在上游均有正数钱包账单。代码侧 `calculateTextQuotaSummary` 在无billable usage时将 quota 置0，`SettleBilling(0)`随后退回预扣。
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): relay：标准 OpenAI Responses SSE事件、成功下游写入、最终usage；billing：`BillingSettler.GetPreConsumedQuota`、tiered snapshot、工具附加费、settle delta；frontend：不适用，沿用现有消费日志；deployment：官方main源码，无环境变量、数据库或部署格式变化。

## Change

- 为Responses流维护请求级“已经成功交付可计费输出”标记；覆盖文本、函数参数、推理摘要、拒绝、可计费工具/图片完成项及terminal response输出。
- 只有 `ResponseChunkData` 成功写给下游后才设置标记；显式 `failed/incomplete/cancelled` terminal事件会清除标记，避免向未获得有效结果的请求保留预扣。
- 当且仅当标准Responses流满足“最终usage为0 + 已成功交付billable output + 实际预扣大于0”时，以BillingSession的真实预扣值作为fallback；真实usage始终优先，无输出仍保持现有退款行为。
- fallback在预扣基础上加入已经观察到的工具附加费，并继续使用统一quota饱和保护；tiered billing保留原表达式快照，但不使用零usage重新执行表达式覆盖预扣。
- 消费日志写入admin-only结构化fallback原因，普通日志内容也说明按预扣结算，便于审计。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `client_gone missing usage billing`, `Responses stream pre-consume`, `stream disconnect quota=0`, `response.completed client_gone`, `stream abort prompt tokens`。
- What already existed and why this is not a duplicate: #5235描述同一风险但因复现资料未确认而closed as not planned；#5291实现过相近fallback，测试通过后因缺少current main实证而由作者主动关闭。本PR在最新main上重做并补充真实频率/上下游对账证据，同时只按成功下游写入标记、清除显式非计费terminal状态，并保留已观察工具附加费。#6904/#6808修复正常完成流误标client_gone，属于互补的生命周期分类，不处理真实usage缺失时的结算。

### Docs and code

Open them. Do not write "already checked" without sources.

- https://docs.newapi.ai/ : 检索streaming、usage、billing、disconnect与quota；未找到已有的missing-usage计费策略或可配置fallback。
- https://deepwiki.com/QuantumNous/new-api : `Request Lifecycle`和`Quota & Billing System`说明预扣→执行→settle/refund链路；失败/取消默认退款，成功结算依赖handler解析到的usage，没有覆盖“已交付输出但最终usage缺失”的政策。
- README / repo docs: 阅读仓库README、`AGENTS.md`和`pkg/billingexpr/expr.md`；`STREAMING_TIMEOUT`只控制流等待，不能恢复缺失usage；表达式文档要求预扣和实际结算使用同一冻结计价契约。
- Code paths and what they imply for this change: `relay/channel/openai/relay_responses.go`解析Responses SSE并收集usage/输出；`relay/channel/openai/helper.go`负责实际下游写入；`service/text_quota.go`计算实际quota、执行tiered settle及`SettleBilling`。fallback必须在summary计算完成后、tiered零usage结算前决定，并以BillingSession实际预扣为权威。

### Alternatives considered

- Option A: 客户端断开后继续读取完整上游流直到usage到达。优点是可能精确结算；缺点是会继续消耗上游资源、延长后台工作，并且上游不保证最终usage一定可得（#4463）。
- Option B: 所有缺usage的Responses流一律保留预扣。能最大限度防漏收，但会误扣从未获得输出或明确失败/取消的请求。
- Why this approach: 只在已经成功交付billable output时保留预扣，是当前可在单次请求内证明服务已交付的最窄边界；无输出和显式失败继续退款，真实usage优先。它与#5291/#4199讨论形成的保守政策一致，并保持改动集中。

## Files

| Path | Why |
| --- | --- |
| `constant/context_key.go` | 定义请求级Responses billable-output标记 |
| `relay/channel/openai/helper.go` | 返回真实下游写入结果，防止失败写入触发计费标记 |
| `relay/channel/openai/relay_responses.go` | 标记billable事件并在显式非计费terminal状态清除 |
| `relay/channel/openai/relay_responses_billing_test.go` | 覆盖delta、terminal输出、失败清除和metadata-only行为 |
| `service/text_quota.go` | 选择安全预扣fallback、加入工具附加费、记录审计信息 |
| `service/text_quota_test.go` | 覆盖fallback、退款、真实usage优先、格式边界、信任旁路和工具附加费 |

## Behavior

- Before: Responses流只要最终usage缺失且无法从可见文本估算token，就可能以0结算并退回预扣，即使已经向客户端交付函数参数、工具/图片结果或terminal输出。
- After: 已成功交付billable output且缺最终usage时保留真实预扣（加已观察工具附加费）；无输出、显式failed/incomplete/cancelled、非Responses、信任旁路预扣为0及已有真实usage均保持原语义。
- Explicit non-goals / leftover work: 不继续读取已断开的上游；不实现异步上游账单查询；不添加第三方request-id协议；不处理#6904的正常完成误标；不追溯补扣历史数据。

## Verification

Only what was actually run.

- Commands and results:
  - `go test ./service -run '^TestCalculateTextQuotaSummary' -count=1`：通过。
  - 新增6个missing-usage计费定向测试：通过。
  - `go test ./relay/channel/openai -count=1`：通过。
  - `go test ./relay/channel/openai ./relay/helper -count=1`：通过。
  - `go test ./relay/common ./relay/constant -count=1`：通过。
  - `go vet ./service ./relay/channel/openai ./relay/helper`：通过。
  - `bun install --frozen-lockfile`、`bun run build`：通过；仅为生成Go embed所需`web/dist`，无前端源码改动。
  - `go build ./...`：通过。
  - `git diff --check`：通过。
  - `go test ./service -count=1`：未全绿；两个未改动的channel-affinity测试在Windows同一进程用`time.Now().UnixNano()`生成相同键而互相污染，分别单独运行均通过。
  - `go test ./relay/... -count=1`：相关包通过；全量被未改动的Windows HTTP/2错误文案断言差异及本机分页文件不足导致的Go runtime内存错误打断。
- Manual steps and observed result: 对匿名生产日志进行只读上下游对账；未发付费请求。正常费用控制样本匹配率95.53%，零费用母集中71.03%存在上游正费用usage。
- UI: 无UI变更，因此无截图/录屏。
- Tests added or updated, or why none: 新增11个回归测试，覆盖billable marker和计费fallback的正反边界。
- Databases / providers / platforms exercised: 无数据库schema/query变更，数据库矩阵不适用；本地Windows Go工具链；标准OpenAI Responses测试夹具，不调用真实provider。
- Not verified: Linux完整CI、真实provider端到端调用、未来与#6904合并后的组合行为、异步上游账单精确对账。

## Risks

- Failure modes: 预扣是保守估算，可能与未知真实usage不同；该风险仅限已经成功交付billable output且上游未给usage的请求。显式失败/取消及无输出请求不会进入fallback。
- Billing / quota / auth impact: fallback会阻止已交付输出请求的预扣全退；真实usage仍优先；工具附加费使用现有统一计算和饱和保护；BillingSession预扣为0时不从旧字段补扣。无auth变更。
- Follow-ups: 若维护者希望精确账单，可另案增加标准化request-id贯通和异步usage reconciliation；#6904可独立修复正常完成流的状态竞态。

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved billing accuracy for OpenAI Responses streaming requests when final usage information is missing.
  - Preserved pre-consumed quota when billable streamed output was delivered, including tool calls and other response content.
  - Prevented quota charges for incomplete, failed, cancelled, or metadata-only streams without billable output.
  - Improved handling of streamed function-call arguments, reasoning summaries, refusal messages, and completed responses.
- **Tests**
  - Added coverage for missing-usage billing, refunds, tool-call surcharges, and terminal stream outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->