### PR TITLE
fix(relaykit): keep single-element stop_sequences as array in Claude->OpenAI conversion

### DIFF
--- a/relaykit/relayconvert/internal/claude_messages/to_oai_chat_req.go
+++ b/relaykit/relayconvert/internal/claude_messages/to_oai_chat_req.go
@@ -92,9 +92,7 @@ func ClaudeMessagesRequestToOpenAIChat(claudeRequest dto.ClaudeRequest, info con
 		info.SetReasoningEffort(string(effectiveEffort))
 	}
 
-	if len(claudeRequest.StopSequences) == 1 {
-		openAIRequest.Stop = claudeRequest.StopSequences[0]
-	} else if len(claudeRequest.StopSequences) > 1 {
+	if len(claudeRequest.StopSequences) > 0 {
 		openAIRequest.Stop = claudeRequest.StopSequences
 	}
 

--- a/relaykit/relayconvert/internal/claude_messages/to_oai_chat_req_stop_test.go
+++ b/relaykit/relayconvert/internal/claude_messages/to_oai_chat_req_stop_test.go
@@ -1,0 +1,36 @@
+package claudemessages
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/relayconvert/convmeta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaudeMessagesStopSequencesPreservesArray(t *testing.T) {
+	maxTokens := uint(16)
+	cases := []struct {
+		name string
+		stop []string
+		want any
+	}{
+		{name: "single element", stop: []string{"</block>"}, want: []string{"</block>"}},
+		{name: "multiple elements", stop: []string{"A", "B"}, want: []string{"A", "B"}},
+		{name: "empty", stop: nil, want: nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			openAIRequest, err := ClaudeMessagesRequestToOpenAIChat(dto.ClaudeRequest{
+				Model:         "claude-test",
+				MaxTokens:     &maxTokens,
+				StopSequences: tc.stop,
+			}, &convmeta.Values{})
+			require.NoError(t, err)
+			require.NotNil(t, openAIRequest)
+			assert.Equal(t, tc.want, openAIRequest.Stop)
+		})
+	}
+}


### PR DESCRIPTION
## Agent

- Tool: Hermes Agent (Nous Research)
- Tool version: n/a
- Model (full id): claude-opus-4-8
- Host (CLI / IDE / GitHub coding agent / other): CLI
- Date (UTC): 2026-09-04

## Links

- Closes #7175
- Related:

## User request

Fix the reported bug: when a Claude Messages request with a single-element `stop_sequences` is converted to an OpenAI Chat Completions request, `stop` is emitted as a bare string instead of an array, which some upstream providers reject with HTTP 400.

## Out of scope — refuse

- Matched: no
- If yes, what was told to the user: n/a

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: In `ClaudeMessagesRequestToOpenAIChat`, a `stop_sequences` slice of length 1 is assigned to `openAIRequest.Stop` as its single string element (`StopSequences[0]`), so the emitted request contains `"stop": "</block>"`. With 2+ elements the slice is kept as an array.
- Impact: Upstream providers that require `stop` to be an array (e.g. Jackson-based `ChatCompletionRequest` deserialization) return `400 JSON parse error: Cannot construct instance of ArrayList ... from String value`. The request fails whenever exactly one stop sequence is sent.
- Frequency: Intermittent — only when a request carries exactly one `stop_sequences` entry. Reporter reproduces it reliably via glm-5.3 through an OpenCode/Claude-Code path.
- Evidence that the problem is in new-api rather than the client or upstream: The Claude→OpenAI conversion code in this repo shapes the outgoing `stop`. OpenAI's Chat Completions spec accepts `stop` as either a string or an array, so emitting an array is always valid; the length-1 special-case is what produces the string form.
- Applicable types and their fields: relay (`relaykit/relayconvert/internal/claude_messages/to_oai_chat_req.go`).

## Change

Replace the length-based branch with an unconditional array assignment:

```go
if len(claudeRequest.StopSequences) > 0 {
    openAIRequest.Stop = claudeRequest.StopSequences
}
```

`GeneralOpenAIRequest.Stop` is typed `any`, so assigning `[]string` marshals to a JSON array, which is valid OpenAI Chat Completions and satisfies providers that require an array. The reverse converter (`oai_chat/to_claude_messages_req.go`) already normalizes a scalar `stop` string back into `[]string{stop}`, so an array on the outbound side round-trips cleanly.

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `gh pr list --repo QuantumNous/new-api --state all --search "7175 stop_sequences stop"` → none.
- What already existed and why this is not a duplicate: No open or merged PR references this issue or touches this branch.

### Docs and code

- Code paths and what they imply for this change: `relaykit/relayconvert/internal/claude_messages/to_oai_chat_req.go` (the length-1 special case); `relaykit/dto/openai_request.go` (`Stop any`); `relaykit/relayconvert/internal/oai_chat/to_claude_messages_req.go` (reverse direction already wraps a scalar `stop` into `[]string`).

### Alternatives considered

- Option A: Keep the scalar form for single-element and special-case per provider. Rejected — the array form is universally valid OpenAI and avoids provider-specific branching.
- Option B (chosen): Always emit the array when non-empty.
- Why this approach: Minimal, matches the OpenAI spec, and is the fix the reporter proposed.

## Files

| Path | Why |
| --- | --- |
| relaykit/relayconvert/internal/claude_messages/to_oai_chat_req.go | Emit `stop` as an array for any non-empty `stop_sequences` |
| relaykit/relayconvert/internal/claude_messages/to_oai_chat_req_stop_test.go | Regression test covering single, multiple, and empty cases |

## Behavior

- Before: single-element `stop_sequences` → `"stop": "</block>"`.
- After: single-element `stop_sequences` → `"stop": ["</block>"]`; multiple and empty cases unchanged.
- Explicit non-goals / leftover work: none.

## Verification

- Commands and results:
  - `go test ./relayconvert/internal/claude_messages/ -run TestClaudeMessagesStopSequencesPreservesArray -v` → PASS (single/multiple/empty). Verified RED→GREEN: on the original code the single-element subtest failed with `expected: []string{"</block>"}, actual: string("</block>")`; after the fix all subtests pass.
  - `go test ./relayconvert/...` → all packages ok.
  - `gofmt -l` on both files → clean.
- Manual steps and observed result: n/a (unit test covers the conversion).
- UI: none (backend conversion).
- Tests added or updated: added `to_oai_chat_req_stop_test.go`.
- Databases / providers / platforms exercised: Go 1.25.1 unit tests, Linux/amd64.
- Not verified: end-to-end request against a live upstream provider.

## Risks

- Failure modes: none identified — `stop` as an array is valid OpenAI; multi-element behavior is unchanged.
- Billing / quota / auth impact: none.
- Follow-ups: none.

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved conversion of Claude Messages requests to OpenAI Chat requests by consistently preserving all provided stop sequences.
  - Requests with one, multiple, or no stop sequences now retain the intended stop-sequence configuration during conversion.

- **Tests**
  - Added coverage for stop-sequence handling across single, multiple, and empty sequence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->