### PR TITLE
fix: 修正火山方舟(VolcEngine)渠道获取模型列表端点路径 404

### DIFF
--- a/controller/channel_upstream_update.go
+++ b/controller/channel_upstream_update.go
@@ -417,10 +417,13 @@ func fetchChannelUpstreamModelIDs(channel *model.Channel) ([]string, error) {
 			url = fmt.Sprintf("%s/api/paas/v4/models", baseURL)
 		}
 	case constant.ChannelTypeVolcEngine:
+		// 火山方舟 OpenAI 兼容 API 根路径是 /api/v3（chat/embeddings 均为
+		// {base}/api/v3/...，见 relay/channel/volcengine 的 GetRequestURL），
+		// 不存在 /v1/models 端点。原拼接会导致「获取模型列表」固定 404 失败。
 		if plan, ok := constant.ChannelSpecialBases[baseURL]; ok && plan.OpenAIBaseURL != "" {
 			url = fmt.Sprintf("%s/v1/models", plan.OpenAIBaseURL)
 		} else {
-			url = fmt.Sprintf("%s/v1/models", baseURL)
+			url = fmt.Sprintf("%s/api/v3/models", baseURL)
 		}
 	case constant.ChannelTypeMoonshot:
 		if plan, ok := constant.ChannelSpecialBases[baseURL]; ok && plan.OpenAIBaseURL != "" {


### PR DESCRIPTION
## 问题描述

火山方舟（VolcEngine, type=45）渠道点击「获取模型列表」（`GET /api/channel/fetch_models/:id` → `fetchChannelUpstreamModelIDs`）固定失败，前端报错 `获取模型列表失败: status code: 404`。

## 根因

`fetchChannelUpstreamModelIDs` 对 VolcEngine 拼接的模型列表 URL 是 `{baseURL}/v1/models`：

```go
case constant.ChannelTypeVolcEngine:
    ...
    url = fmt.Sprintf("%s/v1/models", baseURL)  // https://ark.cn-beijing.volces.com/v1/models
```

但火山方舟的 OpenAI 兼容 API 根路径是 **`/api/v3`**（同一仓库 `relay/channel/volcengine/adaptor.go` 的 `GetRequestURL` 中 chat/embeddings/images 均为 `{base}/api/v3/...`），上游**不存在 `/v1/models` 端点**，因此固定 404。

实测（真实渠道 API Key 直连上游）：

| URL | 结果 |
|---|---|
| `https://ark.cn-beijing.volces.com/v1/models` | 404 |
| `https://ark.cn-beijing.volces.com/api/v3/models` | 200，返回标准 OpenAI 格式 `{"data":[{"id":"..."}]}` |

## 修复

将 VolcEngine 分支的模型列表 URL 改为 `{baseURL}/api/v3/models`。上游 `/api/v3/models` 返回体与 `OpenAIModelsResponse`/`parseOpenAIModelIDs` 完全兼容，无需其他改动。

（`ChannelSpecialBases` 的自定义 OpenAIBaseURL 分支保持原样未动，避免引入未经验证的变更。）

## 验证

本地按此补丁构建镜像后，火山方舟渠道「获取模型列表」成功拉取到账号全部有权限的 doubao/seed 模型；推理链路（`/api/v3/chat/completions`）不受影响。

## 影响面

仅影响 VolcEngine 渠道的"获取模型列表/上游模型巡检"功能（该功能 404 失败本身无副作用，不会清空已配置模型）。其它渠道不受影响。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model-list retrieval for VolcEngine channels by using the correct API endpoint when no custom base URL is configured.
  * Prevented model-list requests from failing with a 404 error under the default configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->