### PR TITLE
fix(channel-test): route image generation model tests to /v1/images/generations

### DIFF
--- a/common/model.go
+++ b/common/model.go
@@ -12,7 +12,7 @@ var (
 	ImageGenerationModels = []string{
 		"dall-e-3",
 		"dall-e-2",
-		"gpt-image-1",
+		"gpt-image",
 		"prefix:imagen-",
 		"flux-",
 		"flux.1-",

--- a/common/model_test.go
+++ b/common/model_test.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsImageGenerationModel(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{name: "openai gpt-image-2", model: "gpt-image-2", want: true},
+		{name: "openai gpt-image-1", model: "gpt-image-1", want: true},
+		{name: "openai dall-e-3", model: "dall-e-3", want: true},
+		{name: "openai dall-e-2", model: "dall-e-2", want: true},
+		{name: "flux", model: "black-forest-labs/flux-1.1-pro", want: true},
+		{name: "imagen", model: "imagen-3.0-generate-002", want: true},
+		// 以下厂商图片模型不进入全局模型分类，仅由渠道测试本地识别
+		{name: "volc seedream not global", model: "seedream-3.0-250825", want: false},
+		{name: "doubao seedream not global", model: "doubao-seedream-1-0-250615", want: false},
+		{name: "zhipu cogview not global", model: "cogview-4-250304", want: false},
+		{name: "ali wanx not global", model: "wanx2.1-t2i-turbo", want: false},
+		{name: "stable diffusion not global", model: "stable-diffusion-xl-1024-v1-0", want: false},
+		{name: "ideogram not global", model: "ideogram-v2-turbo", want: false},
+		{name: "chat model", model: "gpt-5.4", want: false},
+		{name: "embedding model", model: "text-embedding-3-small", want: false},
+		{name: "rerank model", model: "bge-large-zh", want: false},
+		{name: "code model", model: "kimi-k2.7-code", want: false},
+		{name: "video model", model: "doubao-seedance-1-0-pro", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsImageGenerationModel(tt.model))
+		})
+	}
+
+	assert.False(t, IsImageGenerationModel(""))
+	assert.True(t, IsImageGenerationModel("GPT-IMAGE-2"))
+}

--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -118,31 +118,8 @@ func testChannel(ctx context.Context, channel *model.Channel, testUserID int, te
 			requestPath = endpointInfo.Path
 		}
 	} else {
-		// 如果没有指定端点类型，使用原有的自动检测逻辑
-
-		if strings.Contains(strings.ToLower(testModel), "rerank") {
-			requestPath = "/v1/rerank"
-		}
-
-		// 先判断是否为 Embedding 模型
-		if strings.Contains(strings.ToLower(testModel), "embedding") ||
-			strings.HasPrefix(testModel, "m3e") || // m3e 系列模型
-			strings.Contains(testModel, "bge-") || // bge 系列模型
-			strings.Contains(testModel, "embed") ||
-			channel.Type == constant.ChannelTypeMokaAI { // 其他 embedding 模型
-			requestPath = "/v1/embeddings" // 修改请求路径
-		}
-
-		// VolcEngine 图像生成模型
-		if channel.Type == constant.ChannelTypeVolcEngine && strings.Contains(testModel, "seedream") {
-			requestPath = "/v1/images/generations"
-		}
-
-		// responses-only models
-		if strings.Contains(strings.ToLower(testModel), "codex") {
-			requestPath = "/v1/responses"
-		}
-
+		// 如果没有指定端点类型，使用自动检测逻辑
+		requestPath = autoDetectChannelTestRequestPath(channel.Type, testModel)
 	}
 	// Gemini 原生流式通过 URL action（:streamGenerateContent）表达而非请求体字段，
 	// GeminiChatRequest.IsStream 依据请求 URL 判定，合成请求路径需与生产入口保持一致
@@ -515,7 +492,12 @@ func testChannel(ctx context.Context, channel *model.Channel, testUserID int, te
 		Group:            info.UsingGroup,
 		Other:            other,
 	})
-	common.SysLog(fmt.Sprintf("testing channel #%d, response: \n%s", channel.Id, string(respBody)))
+	// 图片生成等测试响应可能携带超大 base64 内容，仅记录前缀避免刷爆日志
+	logRespBody := respBody
+	if len(logRespBody) > 64<<10 {
+		logRespBody = logRespBody[:64<<10]
+	}
+	common.SysLog(fmt.Sprintf("testing channel #%d, response: \n%s", channel.Id, string(logRespBody)))
 	return testResult{
 		context:     c,
 		localErr:    nil,
@@ -711,13 +693,9 @@ func buildTestRequest(model string, endpointType string, channel *model.Channel,
 				Input: []any{"hello world"},
 			}
 		case constant.EndpointTypeImageGeneration:
-			// 返回 ImageRequest
-			return &dto.ImageRequest{
-				Model:  model,
-				Prompt: "a cute cat",
-				N:      lo.ToPtr(uint(1)),
-				Size:   "1024x1024",
-			}
+			// 图片生成连通性测试使用最小生成配置（n=1 + 最小可用尺寸/最低档），
+			// 验证渠道连通性的同时把每次测试的 token 消耗降到最低。
+			return buildImageGenerationTestRequest(model)
 		case constant.EndpointTypeJinaRerank:
 			// 返回 RerankRequest
 			return &dto.RerankRequest{
@@ -803,6 +781,11 @@ func buildTestRequest(model string, endpointType string, channel *model.Channel,
 		}
 	}
 
+	// 图片生成模型（OpenAI gpt-image/dall-e、flux、seedream、cogview、wanx 等）
+	if isImageGenerationTestModel(model) {
+		return buildImageGenerationTestRequest(model)
+	}
+
 	// Responses-only models (e.g. codex series)
 	if strings.Contains(strings.ToLower(model), "codex") {
 		return &dto.OpenAIResponsesRequest{
@@ -840,6 +823,84 @@ func buildTestRequest(model string, endpointType string, channel *model.Channel,
 	}
 
 	return testRequest
+}
+
+// autoDetectChannelTestRequestPath 根据渠道类型与模型名自动推断测试请求路径，
+// 与 buildTestRequest 的判断保持一致。
+func autoDetectChannelTestRequestPath(channelType int, model string) string {
+	requestPath := "/v1/chat/completions"
+
+	if strings.Contains(strings.ToLower(model), "rerank") {
+		requestPath = "/v1/rerank"
+	}
+
+	// 先判断是否为 Embedding 模型
+	if strings.Contains(strings.ToLower(model), "embedding") ||
+		strings.HasPrefix(model, "m3e") || // m3e 系列模型
+		strings.Contains(model, "bge-") || // bge 系列模型
+		strings.Contains(model, "embed") ||
+		channelType == constant.ChannelTypeMokaAI { // 其他 embedding 模型
+		requestPath = "/v1/embeddings"
+	}
+
+	// 图片生成模型统一走 /v1/images/generations（含 VolcEngine seedream 等各厂商模型）
+	if isImageGenerationTestModel(model) {
+		requestPath = "/v1/images/generations"
+	}
+
+	// responses-only models
+	if strings.Contains(strings.ToLower(model), "codex") {
+		requestPath = "/v1/responses"
+	}
+
+	return requestPath
+}
+
+// isImageGenerationTestModel 判断渠道测试是否应把该模型当作图片生成模型处理。
+// 除了复用全局 common.IsImageGenerationModel（OpenAI gpt-image/dall-e、imagen、flux），
+// 仅在此处补充其它走 OpenAI 兼容 /v1/images/generations 的厂商图片模型关键字，
+// 避免把这类识别逻辑泛化到模型目录/定价等其它功能。
+func isImageGenerationTestModel(model string) bool {
+	if common.IsImageGenerationModel(model) {
+		return true
+	}
+	lowerModel := strings.ToLower(model)
+	for _, keyword := range []string{"seedream", "cogview", "wanx", "stable-diffusion", "kolors", "ideogram"} {
+		if strings.Contains(lowerModel, keyword) {
+			return true
+		}
+	}
+	return false
+}
+
+// buildImageGenerationTestRequest 构造图片生成连通性测试请求，n 固定为 1 且
+// 使用各厂商允许的最小尺寸/最低质量档位，尽量降低每次测试消耗的 token：
+//   - OpenAI gpt-image 系列：最小尺寸 1024x1024 + quality=low（当前最小像素预算）
+//   - OpenAI dall-e-2/dall-e：支持 256x256，为最小尺寸
+//   - OpenAI dall-e-3：最小尺寸 1024x1024 + standard（hd 才加倍）
+//   - 其它厂商（flux/seedream/cogview/wanx 等）：默认 1024x1024，不传 quality
+func buildImageGenerationTestRequest(model string) *dto.ImageRequest {
+	lowerModel := strings.ToLower(model)
+	req := &dto.ImageRequest{
+		Model:  model,
+		Prompt: "a red dot on a plain white background",
+		N:      lo.ToPtr(uint(1)),
+	}
+
+	switch {
+	case strings.Contains(lowerModel, "gpt-image"):
+		req.Size = "1024x1024"
+		req.Quality = "low"
+	case strings.Contains(lowerModel, "dall-e-3"):
+		req.Size = "1024x1024"
+		req.Quality = "standard"
+	case strings.Contains(lowerModel, "dall-e"):
+		req.Size = "256x256"
+	default:
+		req.Size = "1024x1024"
+	}
+
+	return req
 }
 
 func TestChannel(c *gin.Context) {

--- a/controller/channel_test_internal_test.go
+++ b/controller/channel_test_internal_test.go
@@ -464,3 +464,107 @@ func TestTestAllChannelsRejectsExistingActiveTask(t *testing.T) {
 	require.Contains(t, recorder.Body.String(), existing.TaskID)
 	require.Contains(t, recorder.Body.String(), "已有通道测试任务正在运行或等待中")
 }
+
+func TestAutoDetectChannelTestRequestPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		channelType int
+		model       string
+		want        string
+	}{
+		{name: "chat model", channelType: constant.ChannelTypeOpenAI, model: "gpt-5.4", want: "/v1/chat/completions"},
+		{name: "rerank", channelType: constant.ChannelTypeJina, model: "jina-reranker", want: "/v1/rerank"},
+		{name: "embedding", channelType: constant.ChannelTypeOpenAI, model: "text-embedding-3-small", want: "/v1/embeddings"},
+		{name: "gpt-image-2", channelType: constant.ChannelTypeOpenAI, model: "gpt-image-2", want: "/v1/images/generations"},
+		{name: "dall-e-3", channelType: constant.ChannelTypeOpenAI, model: "dall-e-3", want: "/v1/images/generations"},
+		{name: "flux", channelType: constant.ChannelTypeOpenAI, model: "black-forest-labs/flux-1.1-pro", want: "/v1/images/generations"},
+		{name: "seedream on volcengine", channelType: constant.ChannelTypeVolcEngine, model: "seedream-3.0-250825", want: "/v1/images/generations"},
+		{name: "cogview", channelType: constant.ChannelTypeZhipu_v4, model: "cogview-4-250304", want: "/v1/images/generations"},
+		{name: "wanx", channelType: constant.ChannelTypeAli, model: "wanx2.1-t2i-turbo", want: "/v1/images/generations"},
+		{name: "responses model", channelType: constant.ChannelTypeOpenAI, model: "gpt-5.4-codex", want: "/v1/responses"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, autoDetectChannelTestRequestPath(tt.channelType, tt.model))
+		})
+	}
+}
+
+func TestIsImageGenerationTestModel(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		// 全局分类（OpenAI gpt-image / dall-e / imagen / flux）
+		{name: "gpt-image-2", model: "gpt-image-2", want: true},
+		{name: "dall-e-3", model: "dall-e-3", want: true},
+		{name: "imagen", model: "imagen-3.0-generate-002", want: true},
+		{name: "flux", model: "black-forest-labs/flux-1.1-pro", want: true},
+		// 渠道测试本地补充的厂商
+		{name: "seedream", model: "seedream-3.0-250825", want: true},
+		{name: "cogview", model: "cogview-4-250304", want: true},
+		{name: "wanx", model: "wanx2.1-t2i-turbo", want: true},
+		{name: "stable diffusion", model: "stable-diffusion-xl-1024-v1-0", want: true},
+		// 非图片模型保持不受影响
+		{name: "chat", model: "gpt-5.4", want: false},
+		{name: "embedding", model: "text-embedding-3-small", want: false},
+		{name: "video", model: "doubao-seedance-1-0-pro", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isImageGenerationTestModel(tt.model))
+		})
+	}
+}
+
+func TestBuildImageGenerationTestRequest(t *testing.T) {
+	tests := []struct {
+		name          string
+		model         string
+		wantSize      string
+		wantQuality   string
+		wantPromptLen int
+	}{
+		{name: "gpt-image-2 low cost", model: "gpt-image-2", wantSize: "1024x1024", wantQuality: "low"},
+		{name: "gpt-image-1 low cost", model: "gpt-image-1", wantSize: "1024x1024", wantQuality: "low"},
+		{name: "dall-e-3 standard", model: "dall-e-3", wantSize: "1024x1024", wantQuality: "standard"},
+		{name: "dall-e-2 small", model: "dall-e-2", wantSize: "256x256", wantQuality: ""},
+		{name: "flux default", model: "black-forest-labs/flux-1.1-pro", wantSize: "1024x1024", wantQuality: ""},
+		{name: "seedream default", model: "seedream-3.0-250825", wantSize: "1024x1024", wantQuality: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := buildImageGenerationTestRequest(tt.model)
+			require.NotNil(t, req)
+			require.Equal(t, tt.model, req.Model)
+			require.NotEmpty(t, req.Prompt)
+			require.NotNil(t, req.N)
+			require.Equal(t, uint(1), *req.N)
+			require.Equal(t, tt.wantSize, req.Size)
+			require.Equal(t, tt.wantQuality, req.Quality)
+		})
+	}
+}
+
+func TestBuildTestRequestAutoDetectsImageModel(t *testing.T) {
+	channel := &model.Channel{Type: constant.ChannelTypeOpenAI}
+	req := buildTestRequest("gpt-image-2", "", channel, false)
+
+	imageReq, ok := req.(*dto.ImageRequest)
+	require.True(t, ok)
+	require.Equal(t, "gpt-image-2", imageReq.Model)
+	require.Equal(t, "1024x1024", imageReq.Size)
+	require.Equal(t, "low", imageReq.Quality)
+	require.NotNil(t, imageReq.N)
+	require.Equal(t, uint(1), *imageReq.N)
+
+	explicit := buildTestRequest("gpt-image-2", string(constant.EndpointTypeImageGeneration), channel, false)
+	explicitImage, ok := explicit.(*dto.ImageRequest)
+	require.True(t, ok)
+	require.Equal(t, "1024x1024", explicitImage.Size)
+	require.Equal(t, "low", explicitImage.Quality)
+}


### PR DESCRIPTION
## 📝 变更描述 / Description

修复渠道「测试连接」把图片生成模型误当作对话模型调用的问题。

- **原因**：`controller/channel-test.go` 的测试请求默认走 `/v1/chat/completions`；OpenAI `gpt-image-2` 等图片模型在该端点会被上游拒绝（实测返回 HTTP 500 `server_error`）。图片模型应通过 `/v1/images/generations` 做连通性测试。
- **改动**：
  - `common/model.go`：图片模型全局分类由 `gpt-image-1` 收窄为 `gpt-image` 前缀，使 `gpt-image-2` 进入既有图片模型分类（不改动其它厂商分类，避免影响模型目录/定价）。
  - `controller/channel-test.go`：把端点类型未指定时的自动检测逻辑抽为 `autoDetectChannelTestRequestPath`（rerank → embedding → image → responses，行为与原来一致），并新增图片生成模型判定 `isImageGenerationTestModel`（在全局分类基础上，仅在渠道测试内识别 `seedream`/`cogview`/`wanx`/`stable-diffusion`/`kolors`/`ideogram` 等走 OpenAI 兼容图片接口的模型）。
  - `buildImageGenerationTestRequest`：图片测试固定 `n=1`，并选用各厂商**最小尺寸/最低质量档**（gpt-image：`1024x1024`+`quality=low`；dall-e-2：`256x256`；dall-e-3：`1024x1024`+`standard`；其余：`1024x1024`），把每次测试的 token 消耗降到最低。
  - 测试响应 SysLog 记录截断为 64KB，避免图片 base64 大响应刷爆日志。
  - 新增 `common/model_test.go` 与 `controller/channel_test_internal_test.go` 回归用例。
- **范围**：仅影响渠道「测试连接」路径选择与测试请求构造；正常转发链路、定价、模型目录不受影响；非图片模型路径与原有自动检测顺序无回归。

> 本 PR 由 AI 辅助生成与整理（AI-assisted）。此说明按仓库规则如实声明，改动内容与验证过程如下。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- `go test ./common/ -run TestIsImageGenerationModel -count=1` 通过
- `go test ./controller/ -run 'TestAutoDetectChannelTestRequestPath|TestIsImageGenerationTestModel|TestBuildImageGenerationTestRequest|TestBuildTestRequestAutoDetectsImageModel' -count=1` 通过
- `gofmt -l` 对改动文件无输出
- 实际部署验证：`gpt-image-2` 图片最小生成测试（`n=1`、`1024x1024`、`quality=low`）返回 HTTP 200；`gpt-5.4` chat 测试仍返回 200（无回归）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Channel testing now automatically detects image-generation models and uses the appropriate image-generation endpoint.
  - Image-generation checks use lightweight requests to reduce resource consumption.
  - Large test responses are truncated in logs for easier review.
  - Updated image model recognition to support the `gpt-image` identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->