### PR TITLE
fix(relay): 避免将 -max 产品档位误判为推理力度后缀

### DIFF
--- a/relay/helper/reasoning_suffix_test.go
+++ b/relay/helper/reasoning_suffix_test.go
@@ -159,6 +159,25 @@ func TestApplyReasoningModelSuffixPreservesEffortTailModelID(t *testing.T) {
 	assert.Nil(t, info.ReasoningConversion)
 }
 
+// qwen3.8-max is a real upstream model ID that is not on the effort-tail
+// preserve list; -max must not be trimmed into a non-existent qwen3.8.
+func TestApplyReasoningModelSuffixKeepsUnlistedMaxProductTier(t *testing.T) {
+	request := &dto.GeneralOpenAIRequest{Model: "qwen3.8-max"}
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "qwen3.8-max",
+		Request:         request,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelType:       constant.ChannelTypeOpenAI,
+			UpstreamModelName: "qwen3.8-max",
+		},
+	}
+
+	require.NoError(t, ApplyReasoningModelSuffix(info, request))
+	assert.Equal(t, "qwen3.8-max", info.UpstreamModelName)
+	assert.Equal(t, "qwen3.8-max", request.Model)
+	assert.Nil(t, info.ReasoningConversion)
+}
+
 func TestApplyReasoningModelSuffixLeavesDeepSeekV4SuffixForAdaptor(t *testing.T) {
 	info := &relaycommon.RelayInfo{
 		OriginModelName: "deepseek-v4-chat-max",

--- a/relaykit/relayconvert/reasoning/suffix.go
+++ b/relaykit/relayconvert/reasoning/suffix.go
@@ -10,7 +10,13 @@ import (
 
 var EffortSuffixes = []string{"-max", "-xhigh", "-high", "-medium", "-low", "-minimal"}
 
-var OpenAIEffortSuffixes = []string{"-max", "-xhigh", "-high", "-medium", "-low", "-minimal", "-none"}
+// OpenAIEffortSuffixes are the effort tails recognized on arbitrary
+// OpenAI-compatible model names. "-max" is deliberately absent: it is not an
+// OpenAI reasoning_effort value (see OpenAIEffort, which folds max into xhigh)
+// and it is a common product-tier token in real model IDs such as qwen3.8-max
+// or qwen-vl-max. Providers that do own a "-max" effort tail (Claude, Gemini,
+// DeepSeek V4) parse it through their own model-gated suffix lists.
+var OpenAIEffortSuffixes = []string{"-xhigh", "-high", "-medium", "-low", "-minimal", "-none"}
 
 var DeepSeekV4EffortSuffixes = []string{"-none", "-max"}
 

--- a/relaykit/relayconvert/reasoning/suffix_test.go
+++ b/relaykit/relayconvert/reasoning/suffix_test.go
@@ -120,6 +120,20 @@ func TestParseKnownProviderModelSuffix(t *testing.T) {
 		assert.Equal(t, "gpt-5.6-sol", base)
 	})
 
+	t.Run("xhigh effort tail wins over the high tail", func(t *testing.T) {
+		t.Parallel()
+		effort, base := ParseOpenAIReasoningEffortFromModelSuffix("gpt-5.6-sol-xhigh", nil)
+		assert.Equal(t, "xhigh", effort)
+		assert.Equal(t, "gpt-5.6-sol", base)
+	})
+
+	t.Run("max tail is a product tier, not an openai effort", func(t *testing.T) {
+		t.Parallel()
+		effort, base := ParseOpenAIReasoningEffortFromModelSuffix("qwen3.8-max", nil)
+		assert.Empty(t, effort)
+		assert.Equal(t, "qwen3.8-max", base)
+	})
+
 	t.Run("preserve effort tail on real model id", func(t *testing.T) {
 		t.Parallel()
 		effort, base := ParseOpenAIReasoningEffortFromModelSuffix("qwen-max", preserveQwenMax)


### PR DESCRIPTION
## 🔗 关联任务 / Related Issue

- Closes #7201

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description

rc.31 将 `-max` 加入 `OpenAIEffortSuffixes` 后，任意 OpenAI 兼容模型名只要以 `-max` 结尾，都会被当作推理力度后缀裁剪。

这会将 Alibaba TokenPlan 的真实模型 ID `qwen3.7-max`、`qwen3.8-max` 分别改写为不存在的 `qwen3.7`、`qwen3.8`，最终导致上游返回 404。

本次修改：

- 从通用 `OpenAIEffortSuffixes` 中移除 `-max`，保留真实模型 ID 中的产品档位标记。
- 保持 `-xhigh`、`-high`、`-medium`、`-low`、`-minimal` 和 `-none` 等现有推理力度别名行为不变。
- 保留 Claude、Gemini、DeepSeek V4 各自带模型判定的 `-max` 解析逻辑，不影响这些提供商的推理力度转换。
- 增加回归测试，验证 `qwen3.8-max` 不会被裁剪，同时确认 `-xhigh` 仍能正确解析。

`-max` 不是 OpenAI 的 `reasoning_effort` 取值；本项目在 OpenAI 协议边界也会将跨提供商的 `max` 映射为 `xhigh`。相比之下，`-max` 经常属于真实模型 ID，因此不适合作为面向任意 OpenAI 兼容模型的通用后缀。

## 📸 运行证明 / Proof of Work

Issue 中的失败路径：

```text
qwen3.8-max
    ↓ rc.31 错误裁剪
qwen3.8
    ↓ 请求不存在的上游模型
404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model names ending in `-max` are now preserved for OpenAI-compatible models instead of being incorrectly interpreted as reasoning-effort suffixes.
  * Valid OpenAI reasoning suffixes, including `-xhigh`, continue to be recognized and converted correctly.

* **Tests**
  * Added coverage confirming correct handling of `-max` product-tier model names and supported reasoning-effort suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->