### PR TITLE
fix(web): silence 403 toast from admin-only /api/option/ and lazy-load system options

### DIFF
--- a/web/src/features/models/components/drawers/model-mutate-drawer.tsx
+++ b/web/src/features/models/components/drawers/model-mutate-drawer.tsx
@@ -279,7 +279,7 @@ export function ModelMutateDrawer({
   })
 
   // Fetch system options for ratio configuration
-  const { data: systemOptionsData } = useSystemOptions()
+  const { data: systemOptionsData } = useSystemOptions({ enabled: open })
 
   const updateOption = useUpdateOption()
 

--- a/web/src/features/system-settings/api.ts
+++ b/web/src/features/system-settings/api.ts
@@ -32,7 +32,9 @@ import type {
 } from './types'
 
 export async function getSystemOptions() {
-  const res = await api.get<SystemOptionsResponse>('/api/option/')
+  const res = await api.get<SystemOptionsResponse>('/api/option/', {
+    skipErrorHandler: true,
+  })
   return res.data
 }
 

--- a/web/src/features/system-settings/hooks/use-system-options.ts
+++ b/web/src/features/system-settings/hooks/use-system-options.ts
@@ -20,11 +20,12 @@ import { useQuery } from '@tanstack/react-query'
 
 import { getSystemOptions } from '../api'
 
-export function useSystemOptions() {
+export function useSystemOptions(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: ['system-options'],
     queryFn: getSystemOptions,
     staleTime: 5 * 60 * 1000,
+    enabled: options?.enabled,
   })
 }
 


### PR DESCRIPTION
### Problem

Non-root admins (role=10) opening the models page and model mutate drawer get a spurious "no permission" toast, because `useSystemOptions()` unconditionally calls `GET /api/option/`, which is protected by `RootAuth` (router/api-router.go:193). The axios interceptor turns the resulting 403 into an error toast even though the page renders fine.

### Fix

- `getSystemOptions()`: pass `skipErrorHandler: true` so the 403 falls back silently instead of surfacing as a toast. This covers every caller (models, channels, users, subscriptions, system settings).
- `useSystemOptions()`: support an `{ enabled }` option so callers can defer the request.
- `model-mutate-drawer.tsx`: only fetch system options while the drawer is open.

### Notes

Related to #6799, but a different approach: #6799 gates the request on the user role in the hook (requires `useAuthStore`), while this change makes the request itself resilient (no auth-store dependency) and lazily loads it. Either approach fixes the toast; happy to adjust if maintainers prefer the role-gating version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - System options are now loaded only when the model settings drawer is opened, reducing unnecessary background requests.

- **Bug Fixes**
  - System option request failures no longer trigger the app-wide error handler, preventing unrelated global error messages when these settings cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->