### PR TITLE
fix(pricing): reset card grid page when filtered models change

### DIFF
--- a/web/src/features/pricing/components/__tests__/pagination.test.tsx
+++ b/web/src/features/pricing/components/__tests__/pagination.test.tsx
@@ -1,0 +1,132 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import i18next from 'i18next'
+import { useState } from 'react'
+import { beforeAll, describe, expect, test, vi } from 'vitest'
+
+import type { PerfSummaryAllData } from '@/features/performance-metrics/types'
+
+import type { PricingModel } from '../../types'
+import { ModelCardGrid } from '../model-card-grid'
+
+// @lobehub/icons transitively imports @emoji-mart JSON assets that vitest's
+// externalized ESM loader rejects. Icon rendering is irrelevant to the
+// pagination contracts under test, so the icon loader boundary is stubbed.
+vi.mock('@/lib/lobe-icon', () => ({
+  getLobeIcon: () => null,
+}))
+
+// The perf summary endpoint is a network boundary the grid queries on mount;
+// perf badges are irrelevant to pagination behavior.
+vi.mock('@/features/performance-metrics/api', () => ({
+  getPerfMetricsSummary: vi.fn(
+    async (): Promise<PerfSummaryAllData> => ({
+      success: true,
+      data: { models: [] },
+    })
+  ),
+}))
+
+beforeAll(() => {
+  i18next.addResourceBundle(
+    'en',
+    'translation',
+    {
+      'Page {{current}} of {{total}}': 'Page {{current}} of {{total}}',
+      'Previous page': 'Previous page',
+      'Next page': 'Next page',
+    },
+    true,
+    true
+  )
+})
+
+// The grid paginates 20 models per page (DEFAULT_PRICING_PAGE_SIZE).
+function makeModels(count: number): PricingModel[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+    model_name: `model-${String(index + 1).padStart(3, '0')}`,
+    quota_type: 0,
+    model_ratio: 1,
+    completion_ratio: 2,
+    enable_groups: ['default'],
+  }))
+}
+
+function GridHarness({ models }: { models: PricingModel[] }) {
+  const [queryClient] = useState(() => new QueryClient())
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ModelCardGrid models={models} onModelClick={() => {}} />
+    </QueryClientProvider>
+  )
+}
+
+describe('ModelCardGrid pagination', () => {
+  test('given the filtered list shrinks below the current page, the grid returns to page 1 of the new list', async () => {
+    const user = userEvent.setup()
+    const view = render(<GridHarness models={makeModels(100)} />)
+
+    const nextButton = await screen.findByRole('button', { name: 'Next page' })
+    for (let i = 0; i < 4; i += 1) {
+      await user.click(nextButton)
+    }
+    expect(screen.getByText('Page 5 of 5')).toBeInTheDocument()
+
+    view.rerender(<GridHarness models={makeModels(45)} />)
+
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument()
+    expect(screen.getByText('model-001')).toBeInTheDocument()
+    expect(screen.queryByText('model-021')).not.toBeInTheDocument()
+  })
+
+  test('given a shrunken list, previous and next navigate within the new page range', async () => {
+    const user = userEvent.setup()
+    const view = render(<GridHarness models={makeModels(100)} />)
+
+    const nextButton = await screen.findByRole('button', { name: 'Next page' })
+    for (let i = 0; i < 4; i += 1) {
+      await user.click(nextButton)
+    }
+    view.rerender(<GridHarness models={makeModels(45)} />)
+
+    expect(screen.getByRole('button', { name: 'Previous page' })).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: 'Next page' }))
+    expect(screen.getByText('Page 2 of 3')).toBeInTheDocument()
+    expect(screen.getByText('model-021')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Previous page' }))
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Previous page' })).toBeDisabled()
+  })
+
+  test('given a single-page list, the pagination footer is not rendered', () => {
+    render(<GridHarness models={makeModels(20)} />)
+
+    expect(screen.queryByText(/Page \d+ of \d+/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Next page' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('model-001')).toBeInTheDocument()
+  })
+})

--- a/web/src/features/pricing/components/__tests__/pagination.test.tsx
+++ b/web/src/features/pricing/components/__tests__/pagination.test.tsx
@@ -21,7 +21,8 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import i18next from 'i18next'
 import { useState } from 'react'
-import { beforeAll, describe, expect, test, vi } from 'vitest'
+import { I18nextProvider } from 'react-i18next'
+import { describe, expect, test, vi } from 'vitest'
 
 import type { PerfSummaryAllData } from '@/features/performance-metrics/types'
 
@@ -46,20 +47,6 @@ vi.mock('@/features/performance-metrics/api', () => ({
   ),
 }))
 
-beforeAll(() => {
-  i18next.addResourceBundle(
-    'en',
-    'translation',
-    {
-      'Page {{current}} of {{total}}': 'Page {{current}} of {{total}}',
-      'Previous page': 'Previous page',
-      'Next page': 'Next page',
-    },
-    true,
-    true
-  )
-})
-
 // The grid paginates 20 models per page (DEFAULT_PRICING_PAGE_SIZE).
 function makeModels(count: number): PricingModel[] {
   return Array.from({ length: count }, (_, index) => ({
@@ -72,12 +59,35 @@ function makeModels(count: number): PricingModel[] {
   }))
 }
 
+// A test-local i18next instance keeps the shared singleton untouched; the
+// three keys are the only copy the pagination assertions rely on.
+function createTestI18n() {
+  const instance = i18next.createInstance()
+  void instance.init({
+    lng: 'en',
+    fallbackLng: 'en',
+    resources: {
+      en: {
+        translation: {
+          'Page {{current}} of {{total}}': 'Page {{current}} of {{total}}',
+          'Previous page': 'Previous page',
+          'Next page': 'Next page',
+        },
+      },
+    },
+  })
+  return instance
+}
+
 function GridHarness({ models }: { models: PricingModel[] }) {
   const [queryClient] = useState(() => new QueryClient())
+  const [i18n] = useState(createTestI18n)
   return (
-    <QueryClientProvider client={queryClient}>
-      <ModelCardGrid models={models} onModelClick={() => {}} />
-    </QueryClientProvider>
+    <I18nextProvider i18n={i18n}>
+      <QueryClientProvider client={queryClient}>
+        <ModelCardGrid models={models} onModelClick={() => {}} />
+      </QueryClientProvider>
+    </I18nextProvider>
   )
 }
 

--- a/web/src/features/pricing/components/model-card-grid.tsx
+++ b/web/src/features/pricing/components/model-card-grid.tsx
@@ -42,6 +42,13 @@ export interface ModelCardGridProps {
 export function ModelCardGrid(props: ModelCardGridProps) {
   const { t } = useTranslation()
   const [page, setPage] = useState(1)
+  const [prevModels, setPrevModels] = useState(props.models)
+  if (props.models !== prevModels) {
+    // A new filtered list (group/search/sort change) invalidates the old page
+    // number; adjusting during render resets it in the same paint.
+    setPrevModels(props.models)
+    setPage(1)
+  }
   const pageSize = DEFAULT_PRICING_PAGE_SIZE
   const tokenUnit = props.tokenUnit ?? DEFAULT_TOKEN_UNIT
   const totalPages = Math.max(1, Math.ceil(props.models.length / pageSize))


### PR DESCRIPTION
## Agent

- Tool: ZCode
- Tool version: ZCode CLI
- Model (full id): builtin:zai-start-plan/GLM-5.3-Flash
- Host (CLI / IDE / GitHub coding agent / other): CLI
- Date (UTC): 2026-09-05
- 声明：本 PR 代码由 AI 生成/辅助完成，经 @mutuyihao 复核并提交。

## Links

- Closes #7222
- Related: 无

## User request

"模型广场里，分页，下一页点击了几次，比如来到第5页了，再点击其他分组，这个分组可能只有两页，此时分页会直接来到第二页，且无法点击回上一页了。"

## Out of scope — refuse

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): 不适用——本 PR 是 new-api 自身前端缺陷的修复，不属于任何拒绝项。

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

Take these from the linked issue. If a needed item is empty, ask the user that question.

- Actual behavior: 卡片视图翻到第 5 页后切换到仅两页模型的分组：分页条显示"第 2 页 / 共 2 页"，点"上一页"前 3 次无可见变化，第 4 次才回到第 1 页。
- Impact: 切换分组/筛选后分页导航失灵，视图停在最后一页，"上一页"看似不可用。
- Frequency: 必现。只要当前页码大于目标分组总页数即复现。
- Evidence that the problem is in new-api rather than the client or upstream: 模型广场数据为一次全量拉取后纯前端过滤分页，无后端分页请求参与；浏览器 Console 无报错；缺陷可在源码中精确定位。
- Applicable types and their fields: Frontend——/pricing 卡片视图；Chrome 152.0.7977.76（64 位）；默认主题；Console 无报错。Relay / Billing / Deployment：不适用。

## Change

`web/src/features/pricing/components/model-card-grid.tsx`：卡片视图分页的内部 `page` 状态与显示钳制值 `currentPage = Math.min(page, totalPages)` 是两个状态源——列表变少后内部 `page` 仍为 5，显示被钳制在最后一页，而翻页按钮操作内部 `page`、禁用状态依据 `currentPage`，导致"上一页"看似失灵。修复：检测 `props.models` 引用变化（`filteredModels` 为稳定 useMemo，仅在分组/搜索/排序/筛选或数据实际变化时更新）时在渲染期把 `page` 重置为 1（React 官方 state-adjust-during-render 模式，同步生效无闪烁），保留 `Math.min` 钳制作兜底。行为与表格视图的 TanStack `autoResetPageIndex` 对齐。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): 「模型广场 分页」「模型广场 翻页」「切换分组 分页」「上一页 分组」「pricing pagination」
- What already existed and why this is not a duplicate: 最接近的 #5624/#5627（钱包弹窗分页文字重叠）、#7144（排序下拉导航抖动）均为不同问题；无既有 issue/PR 修复此分页状态缺陷。

### Docs and code

Open them. Do not write "already checked" without sources.

- https://docs.newapi.ai/ : 模型广场为前端功能页，文档未涉及分页状态行为
- https://deepwiki.com/QuantumNous/new-api : 未检索到相关既有结论
- README / repo docs: 无相关内容
- Code paths and what they imply for this change: `model-card-grid.tsx`（缺陷所在，见 Change）；`hooks/use-filters.ts`（过滤结果为稳定 useMemo，可作为重置信号）；`pricing-table.tsx`（表格视图 autoResetPageIndex 自动回第 1 页，本修复使两视图行为一致）

### Alternatives considered

- Option A: 过滤列表变化时渲染期重置页码为 1（本 PR）——同时消除两个症状，与表格视图及常见筛选 UX 一致
- Option B: 仅让翻页按钮改用钳制后的 `currentPage`——只修"上一页失灵"，切分组后仍停留在最后一页且内部状态过期
- Why this approach: A 修复更完整且单一状态源，防止回归

## Files

| Path | Why |
| --- | --- |
| web/src/features/pricing/components/model-card-grid.tsx | 核心修复：过滤列表变化时渲染期重置页码（+7 行） |
| web/src/features/pricing/components/__tests__/pagination.test.tsx | 新增 RTL 回归测试（3 用例），修复前失败复现、修复后通过 |

## Behavior

- Before: 翻到第 5 页后切到两页分组 → 显示"Page 2 of 2"，上一页前 3 次点击无响应，第 4 次才回第 1 页
- After: 切换分组/搜索/排序/筛选 → 页码立即回到该列表第 1 页（如"Page 1 of 3"），上一页/下一页在新区间内正常工作
- Explicit non-goals / leftover work: 无后端改动（分页为纯前端实现）；表格视图行为不变（其本就自动重置）

## Verification

Only what was actually run.

- Commands and results:
  - `bun run test src/features/pricing/components/__tests__/pagination.test.tsx`：修复前 2 failed（复现 issue）→ 修复后 3 passed
  - `bun run typecheck`（tsgo -b）：通过
  - `bunx oxlint -c .oxlintrc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pagination now returns to the first page when filtering, searching, or sorting reduces available results.
  - Users can continue navigating through valid pages after the result list changes.
  - Pagination controls are hidden when all results fit on a single page.

- **Tests**
  - Added coverage for pagination behavior when result lists shrink, pages become invalid, or results fit on a single page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->