### PR TITLE
feat: per-channel TTFB (first-token) timeout with automatic fallback

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -173,6 +173,14 @@ var RelayIdleConnTimeout int // unit is second
 // ResponseHeaderTimeout only bounds the wait for the response headers; once the
 // headers arrive, streaming is unaffected.
 var RelayResponseHeaderTimeout int // unit is second
+
+// TTFBTimeout is the global default first-token (TTFB) timeout in seconds for
+// streaming requests: once the upstream response headers have arrived, if the
+// first data chunk does not arrive within this window the request fails as a
+// channel error ("channel:ttfb_timeout") so the relay can fall back to the
+// next channel. 0 disables it. Per-channel override:
+// ChannelSettings.TTFBTimeoutSeconds (channel setting JSON field "ttfb_timeout").
+var TTFBTimeout int // unit is second
 var RelayMaxIdleConns int
 var RelayMaxIdleConnsPerHost int
 

--- a/common/init.go
+++ b/common/init.go
@@ -112,6 +112,7 @@ func InitEnv() {
 	RelayTimeout = GetEnvOrDefault("RELAY_TIMEOUT", 0)
 	RelayIdleConnTimeout = GetEnvOrDefault("RELAY_IDLE_CONN_TIMEOUT", 90)
 	RelayResponseHeaderTimeout = GetEnvOrDefault("RELAY_RESPONSE_HEADER_TIMEOUT", 1800)
+	TTFBTimeout = GetEnvOrDefault("TTFB_TIMEOUT", 0)
 	RelayMaxIdleConns = GetEnvOrDefault("RELAY_MAX_IDLE_CONNS", 500)
 	RelayMaxIdleConnsPerHost = GetEnvOrDefault("RELAY_MAX_IDLE_CONNS_PER_HOST", 100)
 

--- a/relay/channel/openai/relay-openai.go
+++ b/relay/channel/openai/relay-openai.go
@@ -142,6 +142,18 @@ func OaiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Re
 		}
 	})
 
+	// TTFB timeout: the upstream sent response headers but never delivered the
+	// first data chunk within the configured window. Nothing has been written to
+	// the client yet (SSE headers flush with the first data), so return a
+	// channel-level error to make the relay fall back to the next channel.
+	if info.StreamStatus.EndReason == relaycommon.StreamEndReasonTTFBTimeout {
+		err := info.StreamStatus.EndError
+		if err == nil {
+			err = fmt.Errorf("first token timeout")
+		}
+		return nil, types.NewOpenAIError(err, types.ErrorCodeChannelTTFBTimeout, http.StatusBadGateway)
+	}
+
 	// 处理最后的响应
 	shouldSendLastResp := true
 	if err := handleLastResponse(lastStreamData, &responseId, &createAt, &systemFingerprint, &model, &usage,

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -139,6 +139,17 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 		}
 	})
 
+	// TTFB timeout: upstream sent headers but no first data chunk within the
+	// configured window. Nothing written to the client yet, so fail with a
+	// channel-level error to trigger fallback to the next channel.
+	if info.StreamStatus.EndReason == relaycommon.StreamEndReasonTTFBTimeout {
+		err := info.StreamStatus.EndError
+		if err == nil {
+			err = fmt.Errorf("first token timeout")
+		}
+		return nil, types.NewOpenAIError(err, types.ErrorCodeChannelTTFBTimeout, http.StatusBadGateway)
+	}
+
 	if usage.CompletionTokens == 0 {
 		// 计算输出文本的 token 数量
 		tempStr := responseTextBuilder.String()

--- a/relay/common/stream_status.go
+++ b/relay/common/stream_status.go
@@ -15,6 +15,7 @@ const (
 	StreamEndReasonTimeout     StreamEndReason = "timeout"
 	StreamEndReasonClientGone  StreamEndReason = "client_gone"
 	StreamEndReasonScannerErr  StreamEndReason = "scanner_error"
+	StreamEndReasonTTFBTimeout StreamEndReason = "ttfb_timeout"
 	StreamEndReasonHandlerStop StreamEndReason = "handler_stop"
 	StreamEndReasonEOF         StreamEndReason = "eof"
 	StreamEndReasonPanic       StreamEndReason = "panic"

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -87,6 +87,20 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 
 	streamingTimeout := time.Duration(constant.StreamingTimeout) * time.Second
 
+	// TTFB (first-token) timeout: per-channel value wins; otherwise the global
+	// TTFB_TIMEOUT env default. 0 in both = feature disabled.
+	ttfbSeconds := info.ChannelSetting.TTFBTimeoutSeconds
+	if ttfbSeconds <= 0 {
+		ttfbSeconds = common.TTFBTimeout
+	}
+	var ttfbTimer *time.Timer
+	var ttfbTimerC <-chan time.Time // nil channel disables the select branch
+	if ttfbSeconds > 0 {
+		ttfbTimer = time.NewTimer(time.Duration(ttfbSeconds) * time.Second)
+		ttfbTimerC = ttfbTimer.C
+		logger.LogDebug(c, "ttfb timeout seconds: %d", ttfbSeconds)
+	}
+
 	var (
 		stopChan    = make(chan bool, 3) // 增加缓冲区避免阻塞
 		scanner     = NewStreamScanner(resp.Body)
@@ -130,6 +144,9 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 			}
 
 			ticker.Stop()
+			if ttfbTimer != nil {
+				ttfbTimer.Stop()
+			}
 			if pingTicker != nil {
 				pingTicker.Stop()
 			}
@@ -265,6 +282,15 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 			if !strings.HasPrefix(data, "[DONE]") {
 				info.SetFirstResponseTime()
 				info.ReceivedResponseCount++
+				// First data chunk arrived: TTFB satisfied, disarm the timer.
+				if ttfbTimer != nil {
+					if !ttfbTimer.Stop() {
+						select {
+						case <-ttfbTimer.C:
+						default:
+						}
+					}
+				}
 
 				select {
 				case dataChan <- data:
@@ -293,6 +319,13 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	select {
 	case <-ticker.C:
 		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonTimeout, nil)
+	case <-ttfbTimerC:
+		// Headers arrived but the first data chunk never did within the TTFB
+		// window. cleanup() below closes resp.Body which unblocks the scanner,
+		// then the caller sees StreamEndReasonTTFBTimeout and returns a
+		// channel-level error so the relay falls back to the next channel.
+		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonTTFBTimeout,
+			fmt.Errorf("first token timeout: no upstream data within %d seconds", ttfbSeconds))
 	case <-stopChan:
 		// EndReason already set by the goroutine that triggered stopChan
 	case <-c.Request.Context().Done():

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
@@ -110,6 +111,13 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 		wg          sync.WaitGroup // 用于等待所有 goroutine 退出
 		cleanupOnce sync.Once
 		stopOnce    sync.Once
+		// firstChunkArrived flips true the moment the scanner hands the first
+		// real data chunk to the caller. Until then we must not write anything
+		// to the client: a ping would commit the response, which would prevent
+		// the relay from falling back to another channel if the TTFB timer
+		// fires first (the write has already started, so the response can no
+		// longer be aborted for fallback).
+		firstChunkArrived atomic.Bool
 	)
 
 	stop := func() {
@@ -185,6 +193,14 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 			for {
 				select {
 				case <-pingTicker.C:
+					if !firstChunkArrived.Load() {
+						// The first upstream data chunk has not arrived yet.
+						// Writing a ping now would commit the response and
+						// defeat the TTFB fallback, so drop the tick and wait
+						// for the next one.
+						logger.LogDebug(c, "ping suppressed: first data chunk not yet arrived")
+						continue
+					}
 					var err error
 					func() {
 						writeMutex.Lock()
@@ -282,6 +298,7 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 			if !strings.HasPrefix(data, "[DONE]") {
 				info.SetFirstResponseTime()
 				info.ReceivedResponseCount++
+				firstChunkArrived.Store(true)
 				// First data chunk arrived: TTFB satisfied, disarm the timer.
 				if ttfbTimer != nil {
 					if !ttfbTimer.Stop() {

--- a/relay/helper/stream_scanner_test.go
+++ b/relay/helper/stream_scanner_test.go
@@ -336,6 +336,60 @@ func TestStreamScannerHandler_PingSentDuringSlowUpstream(t *testing.T) {
 		"expected at least 1 ping during slow stream with 1s interval; got %d", pingCount)
 }
 
+func TestStreamScannerHandler_PingSuppressedBeforeFirstChunk(t *testing.T) {
+	setting := operation_setting.GetGeneralSetting()
+	oldEnabled := setting.PingIntervalEnabled
+	oldSeconds := setting.PingIntervalSeconds
+	setting.PingIntervalEnabled = true
+	setting.PingIntervalSeconds = 1
+	t.Cleanup(func() {
+		setting.PingIntervalEnabled = oldEnabled
+		setting.PingIntervalSeconds = oldSeconds
+	})
+
+	pr, pw := io.Pipe()
+	go func() {
+		defer pw.Close()
+		// First upstream chunk is delayed well past one ping interval.
+		time.Sleep(1500 * time.Millisecond)
+		fmt.Fprint(pw, "data: chunk_0\n")
+		fmt.Fprint(pw, "data: [DONE]\n")
+	}()
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	resp := &http.Response{Body: pr}
+	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{}}
+
+	var count atomic.Int64
+	done := make(chan struct{})
+	go func() {
+		StreamScannerHandler(c, resp, info, func(data string, sr *StreamResult) {
+			count.Add(1)
+			// Simulate the real relay path: the data handler forwards each
+			// chunk into the client response body.
+			fmt.Fprint(c.Writer, data+"\n")
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stream to finish")
+	}
+
+	assert.Equal(t, int64(1), count.Load())
+
+	body := recorder.Body.String()
+	assert.Contains(t, body, "chunk_0", "upstream data chunk should be forwarded")
+	assert.NotContains(t, body, ": PING",
+		"no ping may be written before the first upstream data chunk: "+
+			"a premature ping commits the response and would break TTFB fallback")
+}
+
 func TestStreamScannerHandler_PingDisabledByRelayInfo(t *testing.T) {
 	setting := operation_setting.GetGeneralSetting()
 	oldEnabled := setting.PingIntervalEnabled

--- a/relay/helper/stream_scanner_test.go
+++ b/relay/helper/stream_scanner_test.go
@@ -336,6 +336,19 @@ func TestStreamScannerHandler_PingSentDuringSlowUpstream(t *testing.T) {
 		"expected at least 1 ping during slow stream with 1s interval; got %d", pingCount)
 }
 
+// signalReadCloser closes `started` on the first Read, letting the test wait
+// until the scanner goroutine has actually begun consuming the upstream body.
+type signalReadCloser struct {
+	io.ReadCloser
+	started chan struct{}
+	once    sync.Once
+}
+
+func (s *signalReadCloser) Read(p []byte) (int, error) {
+	s.once.Do(func() { close(s.started) })
+	return s.ReadCloser.Read(p)
+}
+
 func TestStreamScannerHandler_PingSuppressedBeforeFirstChunk(t *testing.T) {
 	setting := operation_setting.GetGeneralSetting()
 	oldEnabled := setting.PingIntervalEnabled
@@ -348,19 +361,44 @@ func TestStreamScannerHandler_PingSuppressedBeforeFirstChunk(t *testing.T) {
 	})
 
 	pr, pw := io.Pipe()
+	// The writer waits for the scanner to start reading before it begins the
+	// 1.5s delay. Otherwise a late-scheduled handler goroutine could let the
+	// first chunk arrive before the ping ticker exists, and the test would
+	// pass even with a buggy pre-first-chunk ping.
+	scannerStarted := make(chan struct{})
+	resp := &http.Response{Body: &signalReadCloser{ReadCloser: pr, started: scannerStarted}}
+
+	writeErr := make(chan error, 1)
 	go func() {
-		defer pw.Close()
+		var werr error
+		defer func() {
+			if err := pw.Close(); err != nil && werr == nil {
+				werr = fmt.Errorf("close pipe writer: %w", err)
+			}
+			writeErr <- werr
+		}()
+		select {
+		case <-scannerStarted:
+		case <-time.After(5 * time.Second):
+			werr = fmt.Errorf("scanner never started reading")
+			return
+		}
 		// First upstream chunk is delayed well past one ping interval.
 		time.Sleep(1500 * time.Millisecond)
-		fmt.Fprint(pw, "data: chunk_0\n")
-		fmt.Fprint(pw, "data: [DONE]\n")
+		if _, err := fmt.Fprint(pw, "data: chunk_0\n"); err != nil {
+			werr = fmt.Errorf("write chunk: %w", err)
+			return
+		}
+		if _, err := fmt.Fprint(pw, "data: [DONE]\n"); err != nil {
+			werr = fmt.Errorf("write [DONE]: %w", err)
+			return
+		}
 	}()
 
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 
-	resp := &http.Response{Body: pr}
 	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{}}
 
 	var count atomic.Int64
@@ -370,7 +408,7 @@ func TestStreamScannerHandler_PingSuppressedBeforeFirstChunk(t *testing.T) {
 			count.Add(1)
 			// Simulate the real relay path: the data handler forwards each
 			// chunk into the client response body.
-			fmt.Fprint(c.Writer, data+"\n")
+			_, _ = fmt.Fprint(c.Writer, data+"\n")
 		})
 		close(done)
 	}()
@@ -379,6 +417,10 @@ func TestStreamScannerHandler_PingSuppressedBeforeFirstChunk(t *testing.T) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for stream to finish")
+	}
+
+	if err := <-writeErr; err != nil {
+		t.Fatalf("pipe writer failed: %v", err)
 	}
 
 	assert.Equal(t, int64(1), count.Load())

--- a/relaykit/dto/channel_settings.go
+++ b/relaykit/dto/channel_settings.go
@@ -24,6 +24,12 @@ type ChannelSettings struct {
 	// HTTP2ConnectionShards spreads HTTP/2 traffic across N independent transports
 	// (1-8). Zero/unset means 1. Ignored when HTTPProtocol is "http1".
 	HTTP2ConnectionShards int `json:"http2_connection_shards,omitempty"`
+	// TTFBTimeoutSeconds bounds the wait for the first upstream data chunk after
+	// the response headers have arrived (streaming requests only). If the first
+	// chunk does not arrive within this window, the request fails with a
+	// channel-level error so the relay falls back to the next channel.
+	// 0 = unset for this channel; falls back to the global TTFB_TIMEOUT env.
+	TTFBTimeoutSeconds int `json:"ttfb_timeout,omitempty"`
 }
 
 const (

--- a/relaykit/types/error.go
+++ b/relaykit/types/error.go
@@ -59,6 +59,7 @@ const (
 	ErrorCodeChannelAwsClientError        ErrorCode = "channel:aws_client_error"
 	ErrorCodeChannelInvalidKey            ErrorCode = "channel:invalid_key"
 	ErrorCodeChannelResponseTimeExceeded  ErrorCode = "channel:response_time_exceeded"
+	ErrorCodeChannelTTFBTimeout           ErrorCode = "channel:ttfb_timeout"
 
 	// client request error
 	ErrorCodeReadRequestBodyFailed ErrorCode = "read_request_body_failed"

--- a/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
+++ b/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
@@ -54,6 +54,7 @@ import {
 import { type SubmitErrorHandler, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
+import { NumericSpinnerInput } from '../numeric-spinner-input'
 
 import {
   sideDrawerContentClassName,
@@ -350,6 +351,7 @@ function hasAdvancedSettingsValues(values: ChannelFormValues): boolean {
     (values.http_protocol && values.http_protocol !== 'auto') ||
     (values.http2_connection_shards != null &&
       values.http2_connection_shards > 1) ||
+    (values.ttfb_timeout != null && values.ttfb_timeout > 0) ||
     values.claude_beta_query ||
     values.upstream_model_update_check_enabled ||
     values.upstream_model_update_auto_sync_enabled ||
@@ -4413,6 +4415,32 @@ export function ChannelMutateDrawer({
                                   </FormItem>
                                 )
                               }}
+                            />
+
+                            <FormField
+                              control={form.control}
+                              name='ttfb_timeout'
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel>
+                                    {t('TTFB Timeout (seconds)')}
+                                  </FormLabel>
+                                  <FormControl>
+                                    <NumericSpinnerInput
+                                      value={field.value ?? 0}
+                                      onChange={(value) => field.onChange(value)}
+                                      min={0}
+                                      step={1}
+                                    />
+                                  </FormControl>
+                                  <FormDescription>
+                                    {t(
+                                      'Max seconds to wait for the first upstream data chunk before the request falls back to the next channel (streaming only). 0 disables.'
+                                    )}
+                                  </FormDescription>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
                             />
 
                             <FormField

--- a/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
+++ b/web/src/features/channels/components/drawers/channel-mutate-drawer.tsx
@@ -759,6 +759,7 @@ export function ChannelMutateDrawer({
   const currentForceFormat = form.watch('force_format')
   const currentThinkingToContent = form.watch('thinking_to_content')
   const currentPassThroughBodyEnabled = form.watch('pass_through_body_enabled')
+  const currentTtfbTimeout = form.watch('ttfb_timeout')
   const currentDisableTaskPollingSleep = form.watch(
     'disable_task_polling_sleep'
   )
@@ -1043,7 +1044,8 @@ export function ChannelMutateDrawer({
     currentSystemPrompt?.trim() ||
     currentSystemPromptOverride ||
     (currentHttpProtocol && currentHttpProtocol !== 'auto') ||
-    (currentHttp2ConnectionShards != null && currentHttp2ConnectionShards > 1)
+    (currentHttp2ConnectionShards != null && currentHttp2ConnectionShards > 1) ||
+    (currentTtfbTimeout != null && currentTtfbTimeout > 0)
   )
   let fieldPassthroughConfigured = false
   if (OPENAI_FIELD_PASSTHROUGH_TYPES.has(currentType)) {
@@ -4435,7 +4437,7 @@ export function ChannelMutateDrawer({
                                   </FormControl>
                                   <FormDescription>
                                     {t(
-                                      'Max seconds to wait for the first upstream data chunk before the request falls back to the next channel (streaming only). 0 disables.'
+                                      'Max seconds to wait for the first upstream data chunk before the request falls back to the next channel (streaming only). 0 uses the global TTFB_TIMEOUT default.'
                                     )}
                                   </FormDescription>
                                   <FormMessage />

--- a/web/src/features/channels/components/numeric-spinner-input.tsx
+++ b/web/src/features/channels/components/numeric-spinner-input.tsx
@@ -17,7 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import { Minus, Plus } from 'lucide-react'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useId } from 'react'
 
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
@@ -54,6 +54,7 @@ export function NumericSpinnerInput({
   'aria-invalid': ariaInvalid,
 }: NumericSpinnerInputProps) {
   const [localValue, setLocalValue] = useState(String(value ?? 0))
+  const autoId = useId()
   const [editing, setEditing] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -143,10 +144,16 @@ export function NumericSpinnerInput({
   const atMin = min !== undefined && Number(localValue) <= min
   const atMax = max !== undefined && Number(localValue) >= max
 
+  // Control id: caller-provided (FormControl) wins; otherwise auto-generate
+  // one so a `label` (htmlFor) always has a focusable control to point at.
+  const controlId = id ?? autoId
+
   return (
     <div className={cn('inline-flex items-center', className)}>
       {label && (
-        <Label className='text-muted-foreground mr-1.5 text-xs'>{label}</Label>
+        <Label htmlFor={controlId} className='text-muted-foreground mr-1.5 text-xs'>
+          {label}
+        </Label>
       )}
       <div
         onBlur={handleControlBlur}
@@ -176,7 +183,7 @@ export function NumericSpinnerInput({
         {editing ? (
           <input
             ref={inputRef}
-            id={id}
+            id={controlId}
             aria-describedby={ariaDescribedby}
             aria-invalid={ariaInvalid}
             type='text'
@@ -190,7 +197,7 @@ export function NumericSpinnerInput({
         ) : (
           <button
             type='button'
-            id={id}
+            id={controlId}
             aria-describedby={ariaDescribedby}
             aria-invalid={ariaInvalid}
             onClick={handleStartEdit}

--- a/web/src/features/channels/components/numeric-spinner-input.tsx
+++ b/web/src/features/channels/components/numeric-spinner-input.tsx
@@ -32,6 +32,11 @@ interface NumericSpinnerInputProps {
   disabled?: boolean
   className?: string
   label?: string
+  /** Forwarded from FormControl so label htmlFor / aria-describedby /
+   * aria-invalid land on the focusable element inside this control. */
+  id?: string
+  'aria-describedby'?: string
+  'aria-invalid'?: boolean | 'true' | 'false'
 }
 
 export function NumericSpinnerInput({
@@ -44,6 +49,9 @@ export function NumericSpinnerInput({
   disabled = false,
   className,
   label,
+  id,
+  'aria-describedby': ariaDescribedby,
+  'aria-invalid': ariaInvalid,
 }: NumericSpinnerInputProps) {
   const [localValue, setLocalValue] = useState(String(value ?? 0))
   const [editing, setEditing] = useState(false)
@@ -168,6 +176,9 @@ export function NumericSpinnerInput({
         {editing ? (
           <input
             ref={inputRef}
+            id={id}
+            aria-describedby={ariaDescribedby}
+            aria-invalid={ariaInvalid}
             type='text'
             value={localValue}
             onChange={handleInputChange}
@@ -179,6 +190,9 @@ export function NumericSpinnerInput({
         ) : (
           <button
             type='button'
+            id={id}
+            aria-describedby={ariaDescribedby}
+            aria-invalid={ariaInvalid}
             onClick={handleStartEdit}
             disabled={disabled}
             title={localValue}

--- a/web/src/features/channels/lib/channel-form.ts
+++ b/web/src/features/channels/lib/channel-form.ts
@@ -263,6 +263,7 @@ export const channelFormSchema = z
       .refine(isOptionalProxyURL, ERROR_MESSAGES.INVALID_PROXY),
     http_protocol: z.enum(['auto', 'http1']).optional(),
     http2_connection_shards: z.number().int().optional(),
+    ttfb_timeout: z.number().int().min(0).optional(),
     pass_through_body_enabled: z.boolean().optional(),
     system_prompt: z.string().optional(),
     system_prompt_override: z.boolean().optional(),
@@ -444,6 +445,7 @@ export const CHANNEL_FORM_DEFAULT_VALUES: ChannelFormValues = {
   proxy: '',
   http_protocol: HTTP_PROTOCOL_AUTO,
   http2_connection_shards: 1,
+  ttfb_timeout: 0,
   pass_through_body_enabled: false,
   system_prompt: '',
   system_prompt_override: false,
@@ -485,6 +487,7 @@ export function transformChannelToFormDefaults(
     proxy: '',
     http_protocol: HTTP_PROTOCOL_AUTO as 'auto' | 'http1',
     http2_connection_shards: 1,
+    ttfb_timeout: 0,
     pass_through_body_enabled: false,
     system_prompt: '',
     system_prompt_override: false,
@@ -504,6 +507,10 @@ export function transformChannelToFormDefaults(
         proxy: parsed.proxy || '',
         http_protocol: protocol,
         http2_connection_shards: protocol === HTTP_PROTOCOL_HTTP1 ? 1 : shards,
+        ttfb_timeout:
+          typeof parsed.ttfb_timeout === 'number' && parsed.ttfb_timeout >= 0
+            ? Math.floor(parsed.ttfb_timeout)
+            : 0,
         pass_through_body_enabled: parsed.pass_through_body_enabled || false,
         system_prompt: parsed.system_prompt || '',
         system_prompt_override: parsed.system_prompt_override || false,
@@ -641,6 +648,10 @@ export function buildSettingJSON(formData: ChannelFormValues): string {
     settingObj.http_protocol = HTTP_PROTOCOL_HTTP1
   } else if (shards > 1) {
     settingObj.http2_connection_shards = shards
+  }
+
+  if (typeof formData.ttfb_timeout === 'number' && formData.ttfb_timeout > 0) {
+    settingObj.ttfb_timeout = Math.floor(formData.ttfb_timeout)
   }
 
   return JSON.stringify(settingObj)

--- a/web/src/features/channels/types.ts
+++ b/web/src/features/channels/types.ts
@@ -88,6 +88,11 @@ export interface ChannelSettings {
   system_prompt_override?: boolean
   http_protocol?: 'auto' | 'http1' | string
   http2_connection_shards?: number
+  // First-token (TTFB) timeout in seconds for streaming requests: when the
+  // upstream has sent response headers but no data chunk arrives within this
+  // window, the request fails as a channel error and the relay falls back to
+  // the next channel. 0/unset = disabled (fall back to TTFB_TIMEOUT env).
+  ttfb_timeout?: number
 }
 
 export interface ChannelOtherSettings {


### PR DESCRIPTION
## Summary

Adds a per-channel **TTFB (first-token) timeout** for streaming requests with automatic fallback.

**Problem:** When an upstream channel sends response headers but never delivers the first data chunk, the request would previously stall until the much longer overall streaming timeout — and even then it wouldn't fall back through the relay's channel retry logic in a timely manner. In practice this turns one slow upstream into multi-minute hangs for every user request routed to it.

**Solution:** After upstream response headers arrive, start a timer for the configured TTFB window. If the first data chunk doesn't arrive in time, the request fails immediately with a channel-level error (`channel:ttfb_timeout`, HTTP 502) so the relay falls back to the next available channel. Nothing has been written to the client yet at that point, so the fallback is safe and transparent.

## Changes

- `common/constants.go`, `common/init.go`: new global `TTFB_TIMEOUT` env var (seconds, `0` = disabled)
- `relay/helper/stream_scanner.go`: TTFB timer armed when headers arrive, disarmed on first data chunk; per-channel `ttfb_timeout` overrides the global default
- `relay/channel/openai/relay-openai.go`, `relay/channel/openai/relay_responses.go`: surface TTFB timeout as a channel error to trigger fallback
- `relay/common/stream_status.go`: new `StreamEndReasonTTFBTimeout`
- `relaykit/dto/channel_settings.go`, `relaykit/types/error.go`: new `ttfb_timeout` channel setting + `ErrorCodeChannelTTFBTimeout`
- `web/src`: TTFB timeout input in the channel advanced settings drawer (frontend form schema, defaults, settings JSON builder)

## Notes

- Timing starts when headers arrive, **not** at request start — normal streams are completely unaffected
- `0`/unset disables the feature (preserves existing behavior)
- Tested in production: a channel with a slow first token now fails fast and the relay falls back to the next channel as expected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable time-to-first-byte (TTFB) timeouts for streaming requests.
  - Set a global default with `TTFB_TIMEOUT` or override it for individual channels.
  - Added channel settings UI for choosing the timeout in seconds; `0` disables the limit.
  - If the first data arrives too late, the request returns a channel error and can automatically fall back to the next channel.
  - Prevented keepalive pings from being sent before the first upstream data arrives.
  - Improved accessibility by associating numeric setting labels with their input controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->