### PR TITLE
Prevent double-charging of image tokens when cache hits include images /claim #7229 Closes #7229

### DIFF
--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -282,7 +282,6 @@ func calculateTextQuotaSummary(ctx *gin.Context, relayInfo *relaycommon.RelayInf
 
 	dPromptTokens := decimal.NewFromInt(int64(summary.PromptTokens))
 	dCacheTokens := decimal.NewFromInt(int64(summary.CacheTokens))
-	dImageTokens := decimal.NewFromInt(int64(summary.ImageTokens))
 	dAudioTokens := decimal.NewFromInt(int64(summary.AudioTokens))
 	dCompletionTokens := decimal.NewFromInt(int64(summary.CompletionTokens))
 	dCachedCreationTokens := decimal.NewFromInt(int64(summary.CacheCreationTokens))
@@ -296,6 +295,17 @@ func calculateTextQuotaSummary(ctx *gin.Context, relayInfo *relaycommon.RelayInf
 	dCacheCreationRatio5m := decimal.NewFromFloat(summary.CacheCreationRatio5m)
 	dCacheCreationRatio1h := decimal.NewFromFloat(summary.CacheCreationRatio1h)
 	dQuotaPerUnit := decimal.NewFromFloat(common.QuotaPerUnit)
+
+	// Prevent double-charging when some image tokens are also reported as cache hits.
+	// cache tokens is a modality-agnostic count; if cached tokens include some image
+	// tokens, those image tokens should not be additionally charged as image input.
+	imageTokensNotCached := summary.ImageTokens
+	if summary.CacheTokens >= imageTokensNotCached {
+		imageTokensNotCached = 0
+	} else {
+		imageTokensNotCached = summary.ImageTokens - summary.CacheTokens
+	}
+	dImageTokensEffective := decimal.NewFromInt(int64(imageTokensNotCached))
 
 	ratio := dModelRatio.Mul(dGroupRatio)
 	summary.ToolCallSurchargeQuota = calculateTextToolCallSurcharge(ctx, relayInfo, &summary)
@@ -330,9 +340,9 @@ func calculateTextQuotaSummary(ctx *gin.Context, relayInfo *relaycommon.RelayInf
 		}
 
 		var imageTokensWithRatio decimal.Decimal
-		if !dImageTokens.IsZero() {
-			baseTokens = baseTokens.Sub(dImageTokens)
-			imageTokensWithRatio = dImageTokens.Mul(dImageRatio)
+		if !dImageTokensEffective.IsZero() {
+			baseTokens = baseTokens.Sub(dImageTokensEffective)
+			imageTokensWithRatio = dImageTokensEffective.Mul(dImageRatio)
 		}
 
 		if !dAudioTokens.IsZero() {


### PR DESCRIPTION
/claim #7229
Closes #7229

Summary
- Fix double billing when cached tokens include image tokens by deducting cached image tokens from the image-specific charge path.
- Implemented in calculateTextQuotaSummary (service/text_quota.go): compute imageTokensNotCached = max(0, imageTokens - cacheTokens) and use that value when subtracting image tokens from baseTokens and when applying image-specific ratio pricing.

Why
- Cache tokens are modality-agnostic in upstream usage snapshots. Previously image tokens were always charged in addition to the cache-related billing adjustments, which caused duplicated charges when those image tokens were part of cache hits (reported by Gemini/OpenAI conversions).

Verification (manual reasoning using the issue example)
- Input tokens: 24643, Output tokens: 3110, Cache read tokens: 24503, Image tokens: 22000.
- Old (incorrect) total cost (example in issue): 0.06487545
- New (correct) total cost (expected):
  - Input un-cached: (24643-24503)/1e6 * 1.5 = 0.00021
  - Output: 3110/1e6 * 9 = 0.02799
  - Cache read: 24503/1e6 * 0.15 = 0.00367545
  - Total = 0.03187545

How to validate locally
- Create a unit test that builds a dto.Usage with the numbers above and calls calculateTextQuotaSummary; assert summary.Quota matches expected quota computed from the project's Quota math.
- Or run the project's test suite: go test ./...

Notes
- Change is small and local to billing computation; it does not alter tiered billing logic or other modifiers.


Closes #7229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected text quota calculations to prevent image tokens that are reported as cache hits from being charged twice.
  - Improved handling when cached image tokens exceed total image tokens, ensuring quota calculations do not produce negative values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->