### PR TITLE
feat(relay): Add Huawei MaaS channel support

### DIFF
--- a/common/api_type.go
+++ b/common/api_type.go
@@ -81,6 +81,8 @@ func ChannelType2APIType(channelType int) (int, bool) {
 		apiType = constant.APITypeSub2API
 	case constant.ChannelTypeNewAPI:
 		apiType = constant.APITypeNewAPI
+	case constant.ChannelTypeHuaweiMaaS:
+		apiType = constant.APITypeHuaweiMaaS
 	}
 	if apiType == -1 {
 		// Task plugin channels are served by the task relay and must never

--- a/constant/api_type.go
+++ b/constant/api_type.go
@@ -39,5 +39,6 @@ const (
 	APITypeAdvancedCustom
 	APITypeSub2API
 	APITypeNewAPI
+	APITypeHuaweiMaaS
 	APITypeDummy // this one is only for count, do not add any channel after this
 )

--- a/constant/channel.go
+++ b/constant/channel.go
@@ -59,6 +59,7 @@ const (
 	ChannelTypeSub2API        = 59
 	ChannelTypeNewAPI         = 60
 	ChannelTypeTaskPlugin     = 61
+	ChannelTypeHuaweiMaaS     = 62
 	ChannelTypeDummy          // this one is only for count, do not add any channel after this
 
 )
@@ -126,6 +127,7 @@ var ChannelBaseURLs = []string{
 	"",                                          //59
 	"",                                          //60
 	"",                                          //61
+	"https://api.modelarts-maas.com",            //62
 }
 
 func GetChannelBaseURL(channelType int) string {
@@ -194,6 +196,7 @@ var ChannelTypeNames = map[int]string{
 	ChannelTypeSub2API:        "Sub2API",
 	ChannelTypeNewAPI:         "New API",
 	ChannelTypeTaskPlugin:     "Task Plugin",
+	ChannelTypeHuaweiMaaS:     "Huawei MaaS",
 }
 
 func GetChannelTypeName(channelType int) string {

--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -138,6 +138,12 @@ func testChannel(ctx context.Context, channel *model.Channel, testUserID int, te
 			requestPath = "/v1/images/generations"
 		}
 
+		// Huawei MaaS 图像生成/编辑模型
+		if channel.Type == constant.ChannelTypeHuaweiMaaS &&
+			(strings.Contains(strings.ToLower(testModel), "qwen-image") || strings.Contains(strings.ToLower(testModel), "qwen_image")) {
+			requestPath = "/v1/images/generations"
+		}
+
 		// responses-only models
 		if strings.Contains(strings.ToLower(testModel), "codex") {
 			requestPath = "/v1/responses"

--- a/controller/channel_upstream_update.go
+++ b/controller/channel_upstream_update.go
@@ -428,6 +428,9 @@ func fetchChannelUpstreamModelIDs(channel *model.Channel) ([]string, error) {
 		} else {
 			url = fmt.Sprintf("%s/v1/models", baseURL)
 		}
+	case constant.ChannelTypeHuaweiMaaS:
+		// Huawei MaaS lists models under /v2/models with an OpenAI-style body.
+		url = fmt.Sprintf("%s/v2/models", baseURL)
 	default:
 		url = fmt.Sprintf("%s/v1/models", baseURL)
 	}

--- a/relay/channel/huawei/adaptor.go
+++ b/relay/channel/huawei/adaptor.go
@@ -1,0 +1,125 @@
+package huawei
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/QuantumNous/new-api/relay/channel"
+	"github.com/QuantumNous/new-api/relay/channel/openai"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/types"
+
+	"github.com/gin-gonic/gin"
+)
+
+type Adaptor struct {
+}
+
+func (a *Adaptor) Init(info *relaycommon.RelayInfo) {
+}
+
+// GetRequestURL routes each relay mode to its Huawei MaaS endpoint. Chat goes
+// through the OpenAI-compatible interface (/openai/v1), while embeddings,
+// rerank and images use the MaaS native v1 paths.
+func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
+	var path string
+	switch info.RelayMode {
+	case relayconstant.RelayModeChatCompletions:
+		path = "/openai/v1/chat/completions"
+	case relayconstant.RelayModeCompletions:
+		path = "/openai/v1/completions"
+	case relayconstant.RelayModeEmbeddings:
+		path = "/v1/embeddings"
+	case relayconstant.RelayModeRerank:
+		path = "/v1/rerank"
+	case relayconstant.RelayModeImagesGenerations, relayconstant.RelayModeImagesEdits:
+		path = "/v1/images/generations"
+	default:
+		return "", fmt.Errorf("huawei MaaS does not support relay mode %d", info.RelayMode)
+	}
+	return relaycommon.GetFullRequestURL(info.ChannelBaseUrl, path, info.ChannelType), nil
+}
+
+func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *relaycommon.RelayInfo) error {
+	channel.SetupApiRequestHeader(info, c, req)
+	req.Set("Authorization", "Bearer "+info.ApiKey)
+	// Image edits arrive as multipart/form-data from the client but are
+	// converted to a JSON body before the upstream call.
+	req.Set("Content-Type", "application/json")
+	return nil
+}
+
+func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeneralOpenAIRequest) (any, error) {
+	if request == nil {
+		return nil, errors.New("request is nil")
+	}
+	return request, nil
+}
+
+func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {
+	return nil, errors.New("endpoint not supported")
+}
+
+func (a *Adaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.EmbeddingRequest) (any, error) {
+	return request, nil
+}
+
+func (a *Adaptor) ConvertRerankRequest(c *gin.Context, relayMode int, request dto.RerankRequest) (any, error) {
+	return &MaaSRerankRequest{
+		Model:     request.Model,
+		Query:     request.Query,
+		Documents: request.Documents,
+	}, nil
+}
+
+func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.ClaudeRequest) (any, error) {
+	adaptor := openai.Adaptor{}
+	return adaptor.ConvertClaudeRequest(c, info, request)
+}
+
+func (a *Adaptor) ConvertGeminiRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeminiChatRequest) (any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *Adaptor) ConvertAudioRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.AudioRequest) (io.Reader, error) {
+	return nil, errors.New("endpoint not supported")
+}
+
+func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.ImageRequest) (any, error) {
+	switch info.RelayMode {
+	case relayconstant.RelayModeImagesGenerations:
+		return convertGenerationRequest(request)
+	case relayconstant.RelayModeImagesEdits:
+		return convertEditRequest(c, request)
+	}
+	return nil, fmt.Errorf("unsupported image relay mode: %d", info.RelayMode)
+}
+
+func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBody io.Reader) (any, error) {
+	return channel.DoApiRequest(a, c, info, requestBody)
+}
+
+func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
+	switch info.RelayMode {
+	case relayconstant.RelayModeImagesGenerations, relayconstant.RelayModeImagesEdits:
+		usage, err = huaweiImageHandler(c, info, resp)
+	case relayconstant.RelayModeRerank:
+		usage, err = huaweiRerankHandler(c, info, resp)
+	default:
+		adaptor := openai.Adaptor{}
+		usage, err = adaptor.DoResponse(c, resp, info)
+	}
+	return
+}
+
+func (a *Adaptor) GetModelList() []string {
+	return ModelList
+}
+
+func (a *Adaptor) GetChannelName() string {
+	return ChannelName
+}

--- a/relay/channel/huawei/adaptor_test.go
+++ b/relay/channel/huawei/adaptor_test.go
@@ -1,0 +1,367 @@
+package huawei
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	relaytypes "github.com/QuantumNous/new-api/relaykit/types"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newHTTPResp(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+	}
+}
+
+func newTestContext(t *testing.T) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	return c, w
+}
+
+func TestGetRequestURL(t *testing.T) {
+	a := &Adaptor{}
+	tests := []struct {
+		mode int
+		want string
+	}{
+		{relayconstant.RelayModeChatCompletions, "https://api.modelarts-maas.com/openai/v1/chat/completions"},
+		{relayconstant.RelayModeCompletions, "https://api.modelarts-maas.com/openai/v1/completions"},
+		{relayconstant.RelayModeEmbeddings, "https://api.modelarts-maas.com/v1/embeddings"},
+		{relayconstant.RelayModeRerank, "https://api.modelarts-maas.com/v1/rerank"},
+		{relayconstant.RelayModeImagesGenerations, "https://api.modelarts-maas.com/v1/images/generations"},
+		{relayconstant.RelayModeImagesEdits, "https://api.modelarts-maas.com/v1/images/generations"},
+	}
+	for _, tt := range tests {
+		info := &relaycommon.RelayInfo{
+			ChannelMeta: &relaycommon.ChannelMeta{ChannelBaseUrl: "https://api.modelarts-maas.com"},
+			RelayMode:   tt.mode,
+		}
+		got, err := a.GetRequestURL(info)
+		require.NoError(t, err)
+		assert.Equal(t, tt.want, got)
+	}
+
+	unsupported := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{ChannelBaseUrl: "https://api.modelarts-maas.com"},
+		RelayMode:   relayconstant.RelayModeResponses,
+	}
+	_, err := a.GetRequestURL(unsupported)
+	require.Error(t, err)
+}
+
+func TestConvertGenerationRequest(t *testing.T) {
+	t.Run("maps openai fields and seed from extra", func(t *testing.T) {
+		var req dto.ImageRequest
+		require.NoError(t, common.Unmarshal([]byte(`{"model":"qwen-image","prompt":"a cat","size":"1024x1024","response_format":"b64_json","seed":44,"watermark":false}`), &req))
+
+		got, err := convertGenerationRequest(req)
+		require.NoError(t, err)
+		assert.Equal(t, "qwen-image", got.Model)
+		assert.Equal(t, "a cat", got.Prompt)
+		assert.Equal(t, "1024x1024", got.Size)
+		assert.Equal(t, "b64_json", got.ResponseFormat)
+		assert.NotNil(t, got.Seed)
+		assert.Equal(t, 44, *got.Seed)
+		assert.NotNil(t, got.Watermark)
+		assert.False(t, *got.Watermark)
+	})
+
+	t.Run("omits response_format unless b64_json", func(t *testing.T) {
+		var req dto.ImageRequest
+		require.NoError(t, common.Unmarshal([]byte(`{"model":"qwen-image","prompt":"a cat","response_format":"png"}`), &req))
+
+		got, err := convertGenerationRequest(req)
+		require.NoError(t, err)
+		assert.Empty(t, got.ResponseFormat)
+	})
+
+	t.Run("rejects n greater than 1", func(t *testing.T) {
+		var req dto.ImageRequest
+		require.NoError(t, common.Unmarshal([]byte(`{"model":"qwen-image","prompt":"a cat","n":2}`), &req))
+
+		_, err := convertGenerationRequest(req)
+		require.Error(t, err)
+		var apiErr *relaytypes.NewAPIError
+		require.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+	})
+
+	t.Run("rejects n above MaxImageN", func(t *testing.T) {
+		req := dto.ImageRequest{
+			Model:  "qwen-image",
+			Prompt: "a cat",
+			N:      common.GetPointer(uint(dto.MaxImageN + 1)),
+		}
+		_, err := convertGenerationRequest(req)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects response_format url", func(t *testing.T) {
+		var req dto.ImageRequest
+		require.NoError(t, common.Unmarshal([]byte(`{"model":"qwen-image","prompt":"a cat","response_format":"url"}`), &req))
+
+		_, err := convertGenerationRequest(req)
+		require.Error(t, err)
+		var apiErr *relaytypes.NewAPIError
+		require.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+	})
+
+	t.Run("rejects streaming", func(t *testing.T) {
+		req := dto.ImageRequest{
+			Model:  "qwen-image",
+			Prompt: "a cat",
+			Stream: common.GetPointer(true),
+		}
+		_, err := convertGenerationRequest(req)
+		require.Error(t, err)
+	})
+}
+
+func TestConvertEditRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	newJSONContext := func() *gin.Context {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/edits", nil)
+		c.Request.Header.Set("Content-Type", "application/json")
+		return c
+	}
+
+	t.Run("single image string", func(t *testing.T) {
+		c := newJSONContext()
+		var req dto.ImageRequest
+		require.NoError(t, common.Unmarshal([]byte(`{"model":"qwen-image-edit-2509","prompt":"make it blue","image":"data:image/jpg;base64,/9j/QVBJ"}`), &req))
+
+		got, err := convertEditRequest(c, req)
+		require.NoError(t, err)
+		assert.Equal(t, "data:image/jpg;base64,/9j/QVBJ", got.Image)
+	})
+
+	t.Run("image array is comma joined", func(t *testing.T) {
+		c := newJSONContext()
+		var req dto.ImageRequest
+		require.NoError(t, common.Unmarshal([]byte(`{"model":"qwen-image-edit-2509","prompt":"blend","image":["data:image/jpg;base64,QUFB","data:image/png;base64,QkJC"]}`), &req))
+
+		got, err := convertEditRequest(c, req)
+		require.NoError(t, err)
+		assert.Equal(t, "data:image/jpg;base64,QUFB,data:image/png;base64,QkJC", got.Image)
+	})
+
+	t.Run("rejects edit without an image", func(t *testing.T) {
+		c := newJSONContext()
+		var req dto.ImageRequest
+		require.NoError(t, common.Unmarshal([]byte(`{"model":"qwen-image-edit-2509","prompt":"make it blue"}`), &req))
+
+		_, err := convertEditRequest(c, req)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects response_format url", func(t *testing.T) {
+		c := newJSONContext()
+		var req dto.ImageRequest
+		require.NoError(t, common.Unmarshal([]byte(`{"model":"qwen-image-edit-2509","prompt":"make it blue","image":"data:image/jpg;base64,QUFB","response_format":"url"}`), &req))
+
+		_, err := convertEditRequest(c, req)
+		require.Error(t, err)
+		var apiErr *relaytypes.NewAPIError
+		require.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+	})
+
+	t.Run("rejects more than two images", func(t *testing.T) {
+		c := newJSONContext()
+		var req dto.ImageRequest
+		require.NoError(t, common.Unmarshal([]byte(`{"model":"qwen-image-edit-2509","prompt":"blend","image":["data:image/jpg;base64,QUFB","data:image/png;base64,QkJC","data:image/png;base64,Q0ND"]}`), &req))
+
+		_, err := convertEditRequest(c, req)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects raw base64 without data uri prefix", func(t *testing.T) {
+		c := newJSONContext()
+		var req dto.ImageRequest
+		require.NoError(t, common.Unmarshal([]byte(`{"model":"qwen-image-edit-2509","prompt":"make it blue","image":["QUFB"]}`), &req))
+
+		_, err := convertEditRequest(c, req)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects n greater than 1", func(t *testing.T) {
+		c := newJSONContext()
+		var req dto.ImageRequest
+		require.NoError(t, common.Unmarshal([]byte(`{"model":"qwen-image-edit-2509","prompt":"make it blue","image":"data:image/jpg;base64,QUFB","n":2}`), &req))
+
+		_, err := convertEditRequest(c, req)
+		require.Error(t, err)
+	})
+
+	t.Run("multipart image becomes a data url", func(t *testing.T) {
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		require.NoError(t, writer.WriteField("model", "qwen-image-edit-2509"))
+		require.NoError(t, writer.WriteField("prompt", "make it blue"))
+		part, err := writer.CreateFormFile("image", "input.png")
+		require.NoError(t, err)
+		_, err = part.Write([]byte("fake image"))
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+		c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+		require.NoError(t, c.Request.ParseMultipartForm(32<<20))
+
+		req := dto.ImageRequest{Model: "qwen-image-edit-2509", Prompt: "make it blue"}
+		got, err := convertEditRequest(c, req)
+		require.NoError(t, err)
+		want := fmt.Sprintf("data:%s;base64,%s", http.DetectContentType([]byte("fake image")), base64.StdEncoding.EncodeToString([]byte("fake image")))
+		assert.Equal(t, want, got.Image)
+	})
+}
+
+func TestHuaweiImageHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("strips data uri prefix and sets n ratio", func(t *testing.T) {
+		c, w := newTestContext(t)
+		info := &relaycommon.RelayInfo{StartTime: time.Now()}
+
+		usage, apiErr := huaweiImageHandler(c, info, newHTTPResp(`{"model":"qwen-image","created":123,"data":[{"url":null,"b64_json":"data:image/jpg;base64,/9j/QVBJ"}],"usage":{"prompt_tokens":10,"completion_tokens":100,"total_tokens":110}}`))
+		require.Nil(t, apiErr)
+
+		var out dto.ImageResponse
+		require.NoError(t, common.Unmarshal(w.Body.Bytes(), &out))
+		require.Len(t, out.Data, 1)
+		assert.Empty(t, out.Data[0].Url)
+		assert.Equal(t, "/9j/QVBJ", out.Data[0].B64Json)
+
+		ratios := info.PriceData.OtherRatios()
+		require.NotNil(t, ratios)
+		assert.Equal(t, 1.0, ratios["n"])
+
+		require.NotNil(t, usage)
+		assert.Equal(t, 10, usage.PromptTokens)
+		assert.Equal(t, 100, usage.CompletionTokens)
+		assert.Equal(t, 110, usage.TotalTokens)
+	})
+
+	t.Run("keeps raw b64_json without prefix", func(t *testing.T) {
+		c, w := newTestContext(t)
+		info := &relaycommon.RelayInfo{StartTime: time.Now()}
+
+		_, apiErr := huaweiImageHandler(c, info, newHTTPResp(`{"model":"qwen-image","data":[{"b64_json":"/9j/RAW"}]}`))
+		require.Nil(t, apiErr)
+
+		var out dto.ImageResponse
+		require.NoError(t, common.Unmarshal(w.Body.Bytes(), &out))
+		require.Len(t, out.Data, 1)
+		assert.Empty(t, out.Data[0].Url)
+		assert.Equal(t, "/9j/RAW", out.Data[0].B64Json)
+	})
+
+	t.Run("does not set n ratio above MaxImageN", func(t *testing.T) {
+		c, _ := newTestContext(t)
+		info := &relaycommon.RelayInfo{StartTime: time.Now()}
+
+		items := make([]string, dto.MaxImageN+1)
+		for i := range items {
+			items[i] = `{"b64_json":"/9j/RAW"}`
+		}
+		body := `{"data":[` + strings.Join(items, ",") + `]}`
+		_, apiErr := huaweiImageHandler(c, info, newHTTPResp(body))
+		require.Nil(t, apiErr)
+
+		ratios := info.PriceData.OtherRatios()
+		if ratios != nil {
+			assert.NotContains(t, ratios, "n")
+		}
+	})
+
+	t.Run("surfaces upstream error with upstream status", func(t *testing.T) {
+		c, _ := newTestContext(t)
+
+		resp := newHTTPResp(`{"error":{"message":"model not found"}}`)
+		resp.StatusCode = http.StatusTooManyRequests
+		_, apiErr := huaweiImageHandler(c, &relaycommon.RelayInfo{}, resp)
+		require.NotNil(t, apiErr)
+		assert.Equal(t, http.StatusTooManyRequests, apiErr.StatusCode)
+	})
+}
+
+func TestHuaweiRerankHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("flattens document.text and maps usage", func(t *testing.T) {
+		c, w := newTestContext(t)
+		info := &relaycommon.RelayInfo{
+			RerankerInfo: &relaycommon.RerankerInfo{
+				ReturnDocuments: true,
+				Documents:       []any{"doc one", "doc two"},
+			},
+		}
+
+		_, apiErr := huaweiRerankHandler(c, info, newHTTPResp(`{"id":"x","model":"bge-reranker-v2-m3","results":[{"index":0,"document":{"text":"doc one"},"relevance_score":0.9}],"usage":{"total_tokens":99}}`))
+		require.Nil(t, apiErr)
+
+		var out dto.RerankResponse
+		require.NoError(t, common.Unmarshal(w.Body.Bytes(), &out))
+		require.Len(t, out.Results, 1)
+		assert.Equal(t, 0, out.Results[0].Index)
+		assert.Equal(t, 0.9, out.Results[0].RelevanceScore)
+		assert.Equal(t, "doc one", out.Results[0].Document)
+		assert.Equal(t, 99, out.Usage.TotalTokens)
+		assert.Equal(t, 99, out.Usage.PromptTokens)
+	})
+
+	t.Run("omits document when return_documents is false", func(t *testing.T) {
+		c, w := newTestContext(t)
+		info := &relaycommon.RelayInfo{
+			RerankerInfo: &relaycommon.RerankerInfo{ReturnDocuments: false},
+		}
+
+		_, apiErr := huaweiRerankHandler(c, info, newHTTPResp(`{"results":[{"index":0,"document":{"text":"doc one"},"relevance_score":0.9}],"usage":{"total_tokens":1}}`))
+		require.Nil(t, apiErr)
+
+		var out dto.RerankResponse
+		require.NoError(t, common.Unmarshal(w.Body.Bytes(), &out))
+		require.Len(t, out.Results, 1)
+		assert.Nil(t, out.Results[0].Document)
+	})
+
+	t.Run("falls back to original document", func(t *testing.T) {
+		c, w := newTestContext(t)
+		info := &relaycommon.RelayInfo{
+			RerankerInfo: &relaycommon.RerankerInfo{
+				ReturnDocuments: true,
+				Documents:       []any{"original doc"},
+			},
+		}
+
+		_, apiErr := huaweiRerankHandler(c, info, newHTTPResp(`{"results":[{"index":0,"document":{},"relevance_score":0.5}],"usage":{"total_tokens":1}}`))
+		require.Nil(t, apiErr)
+
+		var out dto.RerankResponse
+		require.NoError(t, common.Unmarshal(w.Body.Bytes(), &out))
+		assert.Equal(t, "original doc", out.Results[0].Document)
+	})
+}

--- a/relay/channel/huawei/constant.go
+++ b/relay/channel/huawei/constant.go
@@ -1,0 +1,26 @@
+package huawei
+
+// ChannelName is the display name used when creating a Huawei MaaS channel.
+var ChannelName = "Huawei MaaS"
+
+// ModelList covers the models documented by Huawei Cloud MaaS
+// (https://support.huaweicloud.com/model-call-maas/): chat models served via
+// the OpenAI-compatible interface, plus embeddings, rerank, and image
+// generation/editing models.
+var ModelList = []string{
+	"openpangu-2.0-pro",
+	"openpangu-2.0-flash",
+	"glm-5.2",
+	"glm-5.1",
+	"kimi-k2.6",
+	"deepseek-v4-pro",
+	"deepseek-v4-flash",
+	"qwen3-32b",
+	"qwen3-30b-a3b",
+	"qwen2.5-vl-72b",
+	"bge-m3",
+	"bge-reranker-v2-m3",
+	"qwen-image",
+	"qwen-image-edit-2509",
+	"qwen_image_edit",
+}

--- a/relay/channel/huawei/dto.go
+++ b/relay/channel/huawei/dto.go
@@ -1,0 +1,60 @@
+package huawei
+
+// MaaSImageRequest is the Huawei Cloud MaaS image generation/editing request
+// shape. Editing sends the image as a base64 data URL (or public URL) in the
+// `image` field; multiple images are comma-joined. MaaS only accepts
+// response_format=b64_json and does not document the n parameter.
+type MaaSImageRequest struct {
+	Model          string `json:"model"`
+	Prompt         string `json:"prompt"`
+	Size           string `json:"size,omitempty"`
+	ResponseFormat string `json:"response_format,omitempty"`
+	Seed           *int   `json:"seed,omitempty"`
+	Watermark      *bool  `json:"watermark,omitempty"`
+	Image          string `json:"image,omitempty"`
+}
+
+type MaaSImageData struct {
+	Url     string `json:"url"`
+	B64Json string `json:"b64_json"`
+}
+
+type MaaSImageResponse struct {
+	Model   string          `json:"model"`
+	Created int64           `json:"created"`
+	Data    []MaaSImageData `json:"data"`
+	Usage   struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+		InputTokens      int `json:"input_tokens"`
+		OutputTokens     int `json:"output_tokens"`
+	} `json:"usage"`
+	Error any `json:"error"`
+}
+
+// MaaSRerankRequest is the Huawei MaaS rerank request. Only model/query/
+// documents are supported upstream; OpenAI rerank options are dropped.
+type MaaSRerankRequest struct {
+	Model     string `json:"model"`
+	Query     string `json:"query"`
+	Documents []any  `json:"documents"`
+}
+
+type MaaSRerankResult struct {
+	Index    int `json:"index"`
+	Document struct {
+		Text any `json:"text"`
+	} `json:"document"`
+	RelevanceScore float64 `json:"relevance_score"`
+}
+
+type MaaSRerankResponse struct {
+	ID      string             `json:"id"`
+	Model   string             `json:"model"`
+	Results []MaaSRerankResult `json:"results"`
+	Usage   struct {
+		TotalTokens int `json:"total_tokens"`
+	} `json:"usage"`
+	Error any `json:"error"`
+}

--- a/relay/channel/huawei/image.go
+++ b/relay/channel/huawei/image.go
@@ -1,0 +1,290 @@
+package huawei
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/types"
+	"github.com/QuantumNous/new-api/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+// maxEditImages is the per-request image limit for MaaS image editing
+// (https://support.huaweicloud.com/model-call-maas/model-call-023.html).
+const maxEditImages = 2
+
+// convertGenerationRequest maps an OpenAI-format image generation request to
+// the Huawei MaaS shape. MaaS does not document the n parameter and returns a
+// single image per call, so n > 1 is rejected before it can become a billing
+// multiplier; n is also bounded by dto.MaxImageN as everywhere else.
+func convertGenerationRequest(request dto.ImageRequest) (*MaaSImageRequest, error) {
+	if request.Stream != nil && *request.Stream {
+		return nil, types.NewErrorWithStatusCode(errors.New("huawei MaaS image generation does not support streaming"), types.ErrorCodeInvalidRequest, http.StatusBadRequest)
+	}
+	if err := validateImageN(request.N); err != nil {
+		return nil, err
+	}
+	if err := validateResponseFormat(request.ResponseFormat); err != nil {
+		return nil, err
+	}
+
+	imageRequest := MaaSImageRequest{
+		Model:     request.Model,
+		Prompt:    request.Prompt,
+		Size:      request.Size,
+		Watermark: request.Watermark,
+	}
+	// MaaS only accepts response_format=b64_json; omit the field otherwise so
+	// the upstream never sees an unsupported value.
+	if request.ResponseFormat == "b64_json" {
+		imageRequest.ResponseFormat = request.ResponseFormat
+	}
+	if err := applySeed(request, &imageRequest); err != nil {
+		return nil, err
+	}
+	return &imageRequest, nil
+}
+
+// convertEditRequest builds the MaaS edit request. Multipart clients provide
+// the image(s) as uploaded files; JSON clients pass an image data URL or URL
+// (or a comma-joined list) in the top-level image field. MaaS edits return a
+// single image and accept at most maxEditImages input images.
+func convertEditRequest(c *gin.Context, request dto.ImageRequest) (*MaaSImageRequest, error) {
+	if err := validateImageN(request.N); err != nil {
+		return nil, err
+	}
+	if err := validateResponseFormat(request.ResponseFormat); err != nil {
+		return nil, err
+	}
+
+	imageRequest := MaaSImageRequest{
+		Model:     request.Model,
+		Prompt:    request.Prompt,
+		Size:      request.Size,
+		Watermark: request.Watermark,
+	}
+	// MaaS only accepts response_format=b64_json; omit the field otherwise so
+	// the upstream never sees an unsupported value.
+	if request.ResponseFormat == "b64_json" {
+		imageRequest.ResponseFormat = request.ResponseFormat
+	}
+	if err := applySeed(request, &imageRequest); err != nil {
+		return nil, err
+	}
+
+	if strings.Contains(c.Request.Header.Get("Content-Type"), "multipart/form-data") {
+		imageBase64s, err := getImageBase64sFromForm(c)
+		if err != nil {
+			return nil, fmt.Errorf("get image base64s from form failed: %w", err)
+		}
+		imageRequest.Image = strings.Join(imageBase64s, ",")
+		return &imageRequest, nil
+	}
+
+	if len(request.Image) == 0 {
+		return nil, errors.New("image is required for huawei MaaS image editing")
+	}
+	var single string
+	if err := common.Unmarshal(request.Image, &single); err == nil {
+		if err := validateEditImages([]string{single}); err != nil {
+			return nil, err
+		}
+		imageRequest.Image = single
+		return &imageRequest, nil
+	}
+	var multiple []string
+	if err := common.Unmarshal(request.Image, &multiple); err == nil {
+		if err := validateEditImages(multiple); err != nil {
+			return nil, err
+		}
+		imageRequest.Image = strings.Join(multiple, ",")
+		return &imageRequest, nil
+	}
+	return nil, errors.New("invalid image field: expected a string or an array of strings")
+}
+
+// validateImageN bounds the OpenAI n parameter by dto.MaxImageN before it can
+// become a billing multiplier, then rejects n != 1 because MaaS returns a
+// single image per call for both generation and editing.
+func validateImageN(n *uint) error {
+	imageN := uint(1)
+	if n != nil && *n > 0 {
+		imageN = *n
+	}
+	if imageN > dto.MaxImageN {
+		return types.NewErrorWithStatusCode(fmt.Errorf("n must be between 1 and %d", dto.MaxImageN), types.ErrorCodeInvalidRequest, http.StatusBadRequest)
+	}
+	if imageN != 1 {
+		return types.NewErrorWithStatusCode(errors.New("huawei MaaS supports only one image per request (n must be 1)"), types.ErrorCodeInvalidRequest, http.StatusBadRequest)
+	}
+	return nil
+}
+
+// validateResponseFormat rejects response_format=url up front: MaaS only ever
+// returns base64 payloads, so a client asking for URLs would get unusable data.
+func validateResponseFormat(format string) error {
+	if format == "url" {
+		return types.NewErrorWithStatusCode(errors.New("huawei MaaS does not support response_format=url; only b64_json is available"), types.ErrorCodeInvalidRequest, http.StatusBadRequest)
+	}
+	return nil
+}
+
+// validateEditImages enforces the MaaS image-edit constraints: 1 to
+// maxEditImages images, each a public URL or a base64 data URI. Raw base64
+// without the "data:image/...;base64," prefix is rejected by the upstream.
+func validateEditImages(images []string) error {
+	if len(images) == 0 || len(images) > maxEditImages {
+		return fmt.Errorf("huawei MaaS image editing supports 1 to %d images per request", maxEditImages)
+	}
+	for _, image := range images {
+		if strings.HasPrefix(image, "http://") || strings.HasPrefix(image, "https://") {
+			continue
+		}
+		if strings.HasPrefix(image, "data:image/") && strings.Contains(image, ";base64,") {
+			continue
+		}
+		return errors.New(`image must be a public URL or a base64 data URI (e.g. "data:image/jpg;base64,...")`)
+	}
+	return nil
+}
+
+// applySeed reads the OpenAI-style seed from the request's extra fields; MaaS
+// has no top-level seed field in the dto.ImageRequest.
+func applySeed(request dto.ImageRequest, imageRequest *MaaSImageRequest) error {
+	if request.Extra == nil {
+		return nil
+	}
+	seedRaw, ok := request.Extra["seed"]
+	if !ok {
+		return nil
+	}
+	var seed int
+	if err := common.Unmarshal(seedRaw, &seed); err != nil {
+		return fmt.Errorf("invalid seed field: %w", err)
+	}
+	imageRequest.Seed = &seed
+	return nil
+}
+
+// getImageBase64sFromForm extracts uploaded image files (from the "image",
+// "image[]" or "image[...]" form fields) and encodes them as base64 data URLs
+// for the MaaS edit request.
+func getImageBase64sFromForm(c *gin.Context) ([]string, error) {
+	mf := c.Request.MultipartForm
+	if mf == nil {
+		if _, err := c.MultipartForm(); err != nil {
+			return nil, fmt.Errorf("failed to parse image edit form request: %w", err)
+		}
+		mf = c.Request.MultipartForm
+	}
+
+	var imageFiles []*multipart.FileHeader
+	var exists bool
+	if imageFiles, exists = mf.File["image"]; !exists || len(imageFiles) == 0 {
+		if imageFiles, exists = mf.File["image[]"]; !exists || len(imageFiles) == 0 {
+			foundArrayImages := false
+			for fieldName, files := range mf.File {
+				if strings.HasPrefix(fieldName, "image[") && len(files) > 0 {
+					foundArrayImages = true
+					imageFiles = append(imageFiles, files...)
+				}
+			}
+			if !foundArrayImages && len(imageFiles) == 0 {
+				return nil, errors.New("image is required")
+			}
+		}
+	}
+
+	if len(imageFiles) == 0 {
+		return nil, errors.New("image is required")
+	}
+	if len(imageFiles) > maxEditImages {
+		return nil, fmt.Errorf("huawei MaaS image editing supports 1 to %d images per request", maxEditImages)
+	}
+
+	imageBase64s := make([]string, 0, len(imageFiles))
+	for _, file := range imageFiles {
+		image, err := file.Open()
+		if err != nil {
+			return nil, errors.New("failed to open image file")
+		}
+		imageData, readErr := io.ReadAll(image)
+		image.Close()
+		if readErr != nil {
+			return nil, errors.New("failed to read image file")
+		}
+		mimeType := http.DetectContentType(imageData)
+		imageBase64s = append(imageBase64s, fmt.Sprintf("data:%s;base64,%s", mimeType, base64.StdEncoding.EncodeToString(imageData)))
+	}
+	return imageBase64s, nil
+}
+
+// huaweiImageHandler converts the MaaS image response (whose b64_json values
+// are data URIs) into the OpenAI image response shape and sets the "n" billing
+// ratio from the actual number of returned images.
+func huaweiImageHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeReadResponseBodyFailed, http.StatusInternalServerError)
+	}
+	service.CloseResponseBodyGracefully(resp)
+
+	var imageResp MaaSImageResponse
+	if err := common.Unmarshal(responseBody, &imageResp); err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+	if imageResp.Error != nil {
+		return nil, types.WithOpenAIError(types.OpenAIError{Message: fmt.Sprintf("huawei maas image error: %v", imageResp.Error)}, resp.StatusCode)
+	}
+
+	imageResponse := dto.ImageResponse{
+		Created:  info.StartTime.Unix(),
+		Metadata: responseBody,
+	}
+	for _, data := range imageResp.Data {
+		b64Json := data.B64Json
+		// Strip the "data:<mime>;base64," prefix so b64_json carries the raw
+		// payload expected by OpenAI-style clients; url is passed through
+		// unchanged (MaaS returns null for b64 responses).
+		if idx := strings.Index(b64Json, ";base64,"); idx >= 0 {
+			b64Json = b64Json[idx+len(";base64,"):]
+		}
+		imageResponse.Data = append(imageResponse.Data, dto.ImageData{
+			Url:     data.Url,
+			B64Json: b64Json,
+		})
+	}
+
+	// Same guard as openai's updateOpenAIImageCount: an out-of-range image
+	// count must never become a billing multiplier; the requested n from the
+	// pre-consume estimate stays in effect instead.
+	imageCount := len(imageResponse.Data)
+	if imageCount > 0 && imageCount <= dto.MaxImageN {
+		info.PriceData.AddOtherRatio("n", float64(imageCount))
+	}
+
+	jsonResponse, err := common.Marshal(imageResponse)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+	service.IOCopyBytesGracefully(c, resp, jsonResponse)
+
+	usage := &dto.Usage{
+		PromptTokens:     imageResp.Usage.PromptTokens,
+		CompletionTokens: imageResp.Usage.CompletionTokens,
+		TotalTokens:      imageResp.Usage.TotalTokens,
+	}
+	if usage.TotalTokens == 0 {
+		usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+	}
+	return usage, nil
+}

--- a/relay/channel/huawei/rerank.go
+++ b/relay/channel/huawei/rerank.go
@@ -1,0 +1,63 @@
+package huawei
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/QuantumNous/new-api/common"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/relaykit/types"
+	"github.com/QuantumNous/new-api/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+// huaweiRerankHandler converts the MaaS rerank response into the
+// OpenAI-compatible rerank shape. MaaS nests the document text under
+// document.text; it is flattened before the response is written back.
+func huaweiRerankHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeReadResponseBodyFailed, http.StatusInternalServerError)
+	}
+	service.CloseResponseBodyGracefully(resp)
+
+	var hwResp MaaSRerankResponse
+	if err := common.Unmarshal(responseBody, &hwResp); err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+	if hwResp.Error != nil {
+		return nil, types.WithOpenAIError(types.OpenAIError{Message: fmt.Sprintf("huawei maas rerank error: %v", hwResp.Error)}, resp.StatusCode)
+	}
+
+	rerankResp := dto.RerankResponse{
+		Results: make([]dto.RerankResponseResult, 0, len(hwResp.Results)),
+		Usage: dto.Usage{
+			PromptTokens: hwResp.Usage.TotalTokens,
+			TotalTokens:  hwResp.Usage.TotalTokens,
+		},
+	}
+	for _, result := range hwResp.Results {
+		item := dto.RerankResponseResult{
+			Index:          result.Index,
+			RelevanceScore: result.RelevanceScore,
+		}
+		if info.ReturnDocuments {
+			if result.Document.Text != nil {
+				item.Document = result.Document.Text
+			} else if result.Index >= 0 && result.Index < len(info.Documents) {
+				item.Document = info.Documents[result.Index]
+			}
+		}
+		rerankResp.Results = append(rerankResp.Results, item)
+	}
+
+	jsonResponse, err := common.Marshal(rerankResp)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+	service.IOCopyBytesGracefully(c, resp, jsonResponse)
+	return &rerankResp.Usage, nil
+}

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -378,6 +378,7 @@ var streamSupportedChannels = map[int]bool{
 	constant.ChannelTypeSub2API:        true,
 	constant.ChannelTypeNewAPI:         true,
 	constant.ChannelTypeTencent:        true,
+	constant.ChannelTypeHuaweiMaaS:     true,
 }
 
 func GenRelayInfoWs(c *gin.Context, ws *websocket.Conn) *RelayInfo {

--- a/relay/relay_adaptor.go
+++ b/relay/relay_adaptor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/QuantumNous/new-api/relay/channel/deepseek"
 	"github.com/QuantumNous/new-api/relay/channel/dify"
 	"github.com/QuantumNous/new-api/relay/channel/gemini"
+	"github.com/QuantumNous/new-api/relay/channel/huawei"
 	"github.com/QuantumNous/new-api/relay/channel/jimeng"
 	"github.com/QuantumNous/new-api/relay/channel/jina"
 	"github.com/QuantumNous/new-api/relay/channel/minimax"
@@ -123,6 +124,8 @@ func GetAdaptor(apiType int) channel.Adaptor {
 		return &sub2api.Adaptor{}
 	case constant.APITypeNewAPI:
 		return &newapi.Adaptor{}
+	case constant.APITypeHuaweiMaaS:
+		return &huawei.Adaptor{}
 	}
 	return nil
 }

--- a/web/src/features/channels/constants.ts
+++ b/web/src/features/channels/constants.ts
@@ -84,12 +84,13 @@ export const CHANNEL_TYPES = {
   59: 'Sub2API',
   60: 'New API',
   61: 'Task Plugin',
+  62: 'Huawei MaaS',
 } as const
 
 const CHANNEL_TYPE_DISPLAY_ORDER: number[] = [
   1, 14, 33, 24, 43, 3, 41, 48, 60, 58, 61, 42, 34, 20, 4, 40, 27, 25, 17, 26,
   15, 46, 23, 18, 45, 31, 35, 49, 19, 47, 37, 38, 39, 11, 8, 57, 59, 22, 21,
-  44, 2, 5, 36, 50, 51, 52, 53, 54, 55, 56,
+  44, 2, 5, 36, 50, 51, 52, 53, 54, 55, 56, 62,
 ]
 
 export const CHANNEL_TYPE_OPTIONS: { value: number; label: string }[] = (() => {

--- a/web/src/features/channels/lib/channel-type-config.ts
+++ b/web/src/features/channels/lib/channel-type-config.ts
@@ -164,6 +164,17 @@ export const CHANNEL_TYPE_CONFIGS: Record<number, ChannelTypeConfig> = {
       models: 'Models',
     },
   },
+  62: {
+    id: 62,
+    name: CHANNEL_TYPES[62],
+    icon: 'Huawei',
+    defaultBaseUrl: 'https://api.modelarts-maas.com',
+    hints: {
+      baseUrl: 'Default: https://api.modelarts-maas.com',
+      key: 'Huawei Cloud MaaS API Key',
+      models: 'Use model IDs from Huawei Modelarts Maas',
+    },
+  },
 }
 
 /**

--- a/web/src/features/channels/lib/channel-utils.ts
+++ b/web/src/features/channels/lib/channel-utils.ts
@@ -81,6 +81,7 @@ export function getChannelTypeIcon(type: number): string {
     31: 'Yi', // LingYiWanWu
     35: 'Minimax', // MiniMax
     45: 'Volcengine', // VolcEngine
+    62: 'Huawei', // Huawei MaaS
 
     // Other AI providers
     4: 'Ollama', // Ollama


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

English template: `.github/PULL_REQUEST_TEMPLATE/en.md`

> [!IMPORTANT]
>
> - 描述可用 AI 辅助。提交前请审阅全文，并**声明对其负责**，避免未经核对的直接粘贴。
> - 请按本模板填写后再提交。

## 🔗 关联任务 / Related Issue
- 新功能请填写下方 Issue 编号；若还没有对应 Issue，请先自行创建。功能讨论请放在 Issue 中进行。
- 改动较大或方向性变更，请先在关联 Issue 中与维护者达成一致，再提交 PR。
- Bug 修复请关联对应 Issue。设计取舍、理解偏差或预期不一致，更适合作为讨论或功能请求。

- Closes #7236 

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description

**新增 relay 渠道类型 华为Maas。**

添加embeddings、rerank、image-generation 功能接口转发实现。

其中华为 image-generation 实际同时也是图像编辑接口，因此图像编辑请求也通过此接口调用。

[华为云官方文档](https://support.huaweicloud.com/model-call-maas/model-call-012.html)

## 📸 运行证明 / Proof of Work
(请写明如何验证：实际步骤与观察结果。UI 变更请附截图或录屏；Bug 修复请说明复现过程与修复后结果。)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 无论描述是否由 AI 生成，我已审阅全部内容，并声明对其准确性与完整性负责。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **新功能关联 Issue:** 若此 PR 标记为 `New feature`，我已关联对应 Issue；若尚无 Issue，我已先自行创建。
- [x] **事前沟通:** 若改动较大或涉及方向性变更，已在关联 Issue 中与维护者沟通并达成一致。
- [x] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口，也不是对 Codex 渠道类型的改动。
- [x] **范围聚焦:** 本 PR 为一项聚焦改动，未包含无关代码。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Huawei MaaS as a configurable channel with its own icon, base URL, API key, and model settings.
  - Added support for Huawei MaaS chat, embeddings, reranking, image generation, and image editing.
  - Huawei MaaS image models now route automatically to the appropriate image-generation endpoint.
  - Added model discovery through the Huawei MaaS models endpoint.
  - Added streaming support for Huawei MaaS channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->