### PR TITLE
feat(ali): support wan3.0 all-in-one video models

### DIFF
--- a/plugins/tasks/alibaba/plugin.js
+++ b/plugins/tasks/alibaba/plugin.js
@@ -7,10 +7,12 @@ export const meta = {
     en: "Alibaba Cloud Bailian Wanxiang video generation (text-to-video and image-to-video)",
     zh: "阿里云百炼万相视频生成（文生视频、图生视频）",
   },
-  version: "1.0.1",
+  version: "1.1.0",
   author: { name: "QuantumNous" },
   channelTypes: [17],
   models: [
+    "wan3.0-video",
+    "wan3.0-video-prime",
     "wan2.7-i2v",
     "wan2.7-t2v",
     "wan2.5-t2v-preview",
@@ -79,13 +81,14 @@ function convert(ctx) {
     else parameters.resolution = normalizeResolution(req.size);
   } else if (String(req.model).includes("t2v")) {
     parameters.size = String(req.model).startsWith("wan2.5") || String(req.model).startsWith("wan2.2") ? "1920*1080" : "1280*720";
-  } else if (String(req.model).startsWith("wan2.6") || String(req.model).startsWith("wan2.5") || String(req.model).startsWith("wan2.2-i2v-plus")) {
+  } else if (String(req.model).startsWith("wan2.6") || String(req.model).startsWith("wan2.5") || String(req.model).startsWith("wan2.2-i2v-plus") || String(req.model).startsWith("wan3.0")) {
     parameters.resolution = "1080P";
   } else {
     parameters.resolution = "720P";
   }
 
   if (Number(req.duration) > 0) parameters.duration = Number(req.duration);
+  else if (Number(req.duration) === -1 && String(upstreamModel).startsWith("wan3.0")) parameters.duration = -1;
   else if (req.seconds) {
     const seconds = Number(req.seconds);
     if (!Number.isInteger(seconds)) throw new Error("convert seconds to int failed");
@@ -99,16 +102,42 @@ function convert(ctx) {
   if (model !== upstreamModel) throw new Error("can't change model with metadata");
   const body = { model: model, input: input, parameters: parameters };
 
-  if (String(model).startsWith("wan2.7-i2v")) {
+  if (String(model).startsWith("wan2.7-i2v") || String(model).startsWith("wan3.0-video")) {
     if (!Array.isArray(input.media) || input.media.length === 0) {
       input.media = [];
       const first = trimmed(input.first_frame_url) || trimmed(input.img_url) || firstImage(req);
       const last = trimmed(input.last_frame_url) || secondImage(req);
       if (first) input.media.push({ type: "first_frame", url: first });
       if (last) input.media.push({ type: "last_frame", url: last });
-      if (trimmed(input.audio_url)) input.media.push({ type: "driving_audio", url: input.audio_url });
+      if (String(model).startsWith("wan2.7-i2v") && trimmed(input.audio_url)) input.media.push({ type: "driving_audio", url: input.audio_url });
     }
-    if (input.media.length === 0) throw new Error("wan2.7-i2v requires image, images, input_reference, or input.media");
+    if (String(model).startsWith("wan2.7-i2v") && input.media.length === 0) throw new Error("wan2.7-i2v requires image, images, input_reference, or input.media");
+    if (String(model).startsWith("wan3.0-video")) {
+      if (input.media.length === 0) delete input.media;
+      if (!trimmed(input.prompt) && !(Array.isArray(input.media) && input.media.length)) throw new Error("wan3.0-video requires prompt or input.media");
+      if (parameters.size) {
+        parameters.resolution = {
+          "832*480": "480P",
+          "480*832": "480P",
+          "624*624": "480P",
+          "1280*720": "720P",
+          "720*1280": "720P",
+          "960*960": "720P",
+          "1088*832": "720P",
+          "832*1088": "720P",
+          "1920*1080": "1080P",
+          "1080*1920": "1080P",
+          "1440*1440": "1080P",
+          "1632*1248": "1080P",
+          "1248*1632": "1080P",
+        }[parameters.size] || parameters.resolution;
+        delete parameters.size;
+      }
+      if (!parameters.resolution) parameters.resolution = "1080P";
+      if (!parameters.ratio) parameters.ratio = "adaptive";
+      const duration = Number(parameters.duration);
+      if (duration !== -1 && (!Number.isInteger(duration) || duration < 2 || duration > 30)) throw new Error("wan3.0 duration must be -1 or an integer between 2 and 30");
+    }
     delete input.img_url;
     delete input.first_frame_url;
     delete input.last_frame_url;
@@ -117,7 +146,7 @@ function convert(ctx) {
   if (!parameters.prompt_extend) delete parameters.prompt_extend;
   if (!parameters.watermark) delete parameters.watermark;
   if (!parameters.seed) delete parameters.seed;
-  for (const key of ["resolution", "size"]) if (!parameters[key]) delete parameters[key];
+  for (const key of ["resolution", "size", "ratio"]) if (!parameters[key]) delete parameters[key];
   return body;
 }
 
@@ -140,6 +169,8 @@ function resolutionRatio(body) {
       }[body.parameters.size]
     : normalizeResolution(body.parameters.resolution);
   const ratios = {
+    "wan3.0-video": { "480P": 1, "720P": 2, "1080P": 4 },
+    "wan3.0-video-prime": { "480P": 1, "720P": 2, "1080P": 4 },
     "wan2.6-i2v": { "720P": 1, "1080P": 1 / 0.6 },
     "wan2.5-t2v-preview": { "480P": 1, "720P": 2, "1080P": 1 / 0.3 },
     "wan2.2-t2v-plus": { "480P": 1, "1080P": 5 },
@@ -205,7 +236,7 @@ export function buildSubmitRequest(ctx) {
     method: "POST",
     headers: { Authorization: "Bearer " + ctx.apiKey, "Content-Type": "application/json", "X-DashScope-Async": "enable" },
     body: body,
-    action: firstImage(ctx.requestBody) ? "image_to_video" : "text_to_video",
+    action: firstImage(ctx.requestBody) || (body.input && Array.isArray(body.input.media) && body.input.media.length) ? "image_to_video" : "text_to_video",
   };
 }
 
@@ -218,8 +249,10 @@ export function parseSubmitResponse(ctx, resp) {
 
 export function extractUsage(ctx) {
   const body = convert(ctx);
+  const duration = Number(body.parameters.duration);
+  const seconds = Math.min(duration === -1 ? 30 : duration, 3600);
   if (ctx.usagePurpose === "billing_ratios") {
-    const ratios = { seconds: Math.min(Number(body.parameters.duration), 3600) };
+    const ratios = { seconds: seconds };
     const resolution = resolutionRatio(body);
     if (resolution && resolution.value !== undefined) ratios[resolution.key] = resolution.value;
     return ratios;
@@ -241,8 +274,8 @@ export function extractUsage(ctx) {
         "1248*1632": "1080P",
       }[body.parameters.size]
     : normalizeResolution(body.parameters.resolution);
-  if (!["480P", "720P", "1080P"].includes(resolution)) resolution = "720P";
-  return { seconds: Math.min(Number(body.parameters.duration), 3600), resolution: resolution };
+  if (!["480P", "720P", "1080P"].includes(resolution)) resolution = String(body.model).startsWith("wan3.0") ? "1080P" : "720P";
+  return { seconds: seconds, resolution: resolution };
 }
 
 export function extractUsageOnComplete(task, taskResult, body) {
@@ -297,17 +330,19 @@ export const native = {
     const req = ctx.body.value,
       input = req.input || {},
       parameters = req.parameters || {};
+    const requestBody = {
+      model: req.model,
+      prompt: input.prompt || "",
+      image: input.img_url,
+      duration: parameters.duration,
+      size: parameters.size || parameters.resolution,
+    };
+    if (Array.isArray(input.media) && input.media.length) requestBody.metadata = { input: { media: input.media }, parameters: parameters };
     return {
       kind: "submit",
       model: req.model,
-      action: input.img_url ? "image_to_video" : "text_to_video",
-      requestBody: {
-        model: req.model,
-        prompt: input.prompt || "",
-        image: input.img_url,
-        duration: parameters.duration,
-        size: parameters.size || parameters.resolution,
-      },
+      action: input.img_url || (Array.isArray(input.media) && input.media.length) ? "image_to_video" : "text_to_video",
+      requestBody: requestBody,
     };
   },
   taskCreated: function (ctx, task) {
@@ -347,8 +382,9 @@ export const protocols = {
         if (Object.prototype.hasOwnProperty.call(req, key)) requestBody[key] = req[key];
       }
       if (Object.prototype.hasOwnProperty.call(req, "metadata")) requestBody.metadata = req.metadata;
-      if (!prompt && (!model.includes("i2v") || !firstImage(requestBody))) throw new Error("input is required");
-      return { kind: "submit", model: model, action: firstImage(requestBody) ? "image_to_video" : "text_to_video", requestBody: requestBody };
+      const hasMetaMedia = req.metadata && req.metadata.input && Array.isArray(req.metadata.input.media) && req.metadata.input.media.length > 0;
+      if (!prompt && !firstImage(requestBody) && !hasMetaMedia) throw new Error("input is required");
+      return { kind: "submit", model: model, action: firstImage(requestBody) || hasMetaMedia ? "image_to_video" : "text_to_video", requestBody: requestBody };
     },
     renderEvents: function (ctx, task, previousState) {
       const status = String(task.status || "UNKNOWN").toUpperCase();


### PR DESCRIPTION
<!--
Agent-only PR body. Humans use `.github/PULL_REQUEST_TEMPLATE.md`.
Filled for branch feat/alibaba-wan3-video → QuantumNous/new-api.
Paste this entire file as the PR body. Replace Closes # after filing the Issue.
-->

## Agent

- Tool: Cursor
- Tool version: unknown (Cursor IDE agent session)
- Model (full id): Composer (Cursor agent router)
- Host: IDE
- Date (UTC): 2026-09-07

## Links

- Closes #7238
- Related: 既有万相视频任务插件 `plugins/tasks/alibaba/plugin.js`；相关历史方向见 #4078（wan2.7）、changelog 中 Wan2.7 i2v media mapping（#4984）。本 PR **不是**它们的重复实现，而是补 wan3.0 全功能视频模型。

## User request

在阿里百炼任务插件中支持 `wan3.0-video` / `wan3.0-video-prime`（文生/图生、`media`、resolution/ratio、duration 含 `-1`、计费倍率）。

## Out of scope — refuse

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR):

## Kind

- [ ] Bug fix
- [x] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

（以下基于功能缺口与代码现状整理；**正式编号请以新建 Issue 为准。**）

- Actual behavior: 当前 `plugins/tasks/alibaba` 模型列表与 convert/native 路径未注册 `wan3.0-video` / `wan3.0-video-prime`，无法按百炼 wan3.0 规则提交/校验/计费。
- Impact: 渠道类型 17（阿里百炼）用户无法通过 new-api 任务协议/透传使用官方 wan3.0 全功能视频模型。
- Frequency: 凡请求 wan3.0 模型时必现（能力缺失，非偶发）。
- Evidence that the problem is in new-api rather than the client or upstream: upstream DashScope 已提供 wan3.0；main 上 `plugins/tasks/alibaba/plugin.js` 的 `models` / convert / native / usage 未覆盖该模型，属于适配层缺口。
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise):
  - relay/task：Alibaba 任务插件 submit/query、native `/ali/...`、openai_responses 路径对 `media`/prompt 的校验
  - billing：`extractUsage` / `resolutionRatio` 增加 wan3.0 分辨率倍率；`duration === -1` 预扣按最多 30s
  - frontend：not applicable
  - deployment：not applicable

## Change

仅改 `plugins/tasks/alibaba/plugin.js`（v1.0.1 → 1.1.0）：

1. 注册模型 `wan3.0-video`、`wan3.0-video-prime`。
2. `convert`：wan3.0 走与 wan2.7-i2v 类似的 `input.media` 归一；纯文生可无 media；`size` 映射为 `resolution`；默认 `ratio=adaptive`；时长允许 `-1` 或 2–30 整数。
3. `buildSubmitRequest` / native / openai_responses：有 `media` 时判为 image_to_video；native 把 `input.media`+parameters 放进 `metadata`。
4. 计费：wan3.0 分辨率倍率 480P:1 / 720P:2 / 1080P:4；`duration === -1` 时 seconds 按 30 封顶参与预扣。
5. 风格上与既有 wan2.x 分支合并（`startsWith("wan3.0")`），避免平行 helper。

**声明：** 本 PR 代码为 AI 辅助生成/修改（提交者 `qiuliw` 非仓库历史核心维护者名单中的 CaIon / Calcium-Ion / JustSong 等），提交人已审阅并对其负责。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `repo:QuantumNous/new-api wan3` / `wan3.0` / `alibaba video`；issues API 检索 wan3.0 OR wan3 alibaba video
- What already existed and why this is not a duplicate: 有 wan2.7 / HappyHorse 等相关 PR（如 #4078、#4507、#4810），**无**已合并的 wan3.0-video 支持；changelog 记载 Wan2.7 i2v media mapping（#4984），不覆盖 wan3.0 统一视频模型。

### Docs and code

- https://docs.newapi.ai/ : 视频任务通用接口（`/v1/video/generations` 等）有文档；未单列 wan3.0-video 模型说明。结论：属产品能力扩展，不是文档用法问答。
- https://deepwiki.com/QuantumNous/new-api : 架构上存在 Alibaba 渠道与 task 插件体系；wan3.0 需落在 Alibaba task plugin。
- README / repo docs: 任务插件目录 `plugins/tasks/alibaba/`；渠道类型 17。
- Code paths and what they imply for this change: `plugins/tasks/alibaba/plugin.js` 的 `meta.models`、`convert`、`native.createVideoTask`、`protocols.openai_responses`、`extractUsage`/`resolutionRatio` 是唯一必要改动面。

### Alternatives considered

- Option A: 新建独立插件只服务 wan3.0  
- Option B: 在现有 Alibaba 任务插件中扩展（本 PR）  
- Why this approach: wan3.0 与现有百炼异步 `video-synthesis` 同协议同渠道类型；扩展现有插件改动面最小、行为与 wan2.7 media 路径一致，便于维护。

## Files

| Path | Why |
| --- | --- |
| `plugins/tasks/alibaba/plugin.js` | 注册 wan3.0 模型、convert/native/responses/计费规则 |

## Behavior

- Before: 任务插件不声明 wan3.0；请求无法按 wan3.0 的 media/ratio/duration(-1) 规则正确转换与预扣。
- After: 可对 `wan3.0-video` / `wan3.0-video-prime` 走 OpenAI Videos / Responses / `/ali` 原生透传；校验与分辨率倍率按上表生效。
- Explicit non-goals / leftover work: 不改前端；控制台需为新模型配置价格后方可正常预扣。

## Verification

Only what was actually run.

- Commands and results:
  - 当前分支相对分叉点为单提交 `feat(ali): support wan3.0 all-in-one video models`；`git diff --stat` 仅 `plugins/tasks/alibaba/plugin.js`（+56/-20）。
  - 手动：`POST /ali/api/v1/services/aigc/video-generation/video-synthesis`（`wan3.0-video`，480P / 5s）→ 200 得 `task_id`；轮询 `GET /ali/api/v1/tasks/{task_id}` → SUCCEEDED 并取得 `video_url`。
- Manual steps and observed result: 同上。
- UI: screenshot or recording (or why none): 无 UI 变更。
- Tests added or updated, or why none: 未新增测试文件；依赖既有 Alibaba 协议相关覆盖。
- Databases / providers / platforms exercised: 无 schema 变更；渠道类型 17 + 百炼视频异步 API。
- Not verified: DB 三引擎矩阵（本改不动 DB）；`wan3.0-video-prime` 实机；`duration=-1` 结算差额自动化断言。

## Risks

- Failure modes: 未配模型价格时预扣失败；`duration=-1` 预扣按 30s，实际秒数依赖 complete 回填纠偏。
- Billing / quota / auth impact: 新增分辨率 OtherRatio；`extractUsageOnComplete` 可读上游 `output.duration`。
- Follow-ups: 已关联 #7238。

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Alibaba Wan 3.0 video models, including Wan 3.0 Video and Wan 3.0 Video Prime.
  - Added image-to-video generation support for multiple media inputs and media supplied through request metadata.
  - Added adaptive aspect-ratio and resolution handling for video generation.

- **Bug Fixes**
  - Improved validation for prompts, media inputs, video sizes, and durations.
  - Improved usage calculation for variable aspect ratios and open-ended durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->