### PR TITLE
fix(relay): bill Responses stream usage on incomplete/cancelled/failed terminal events

### DIFF
--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -113,6 +113,17 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 				imageCommitted = true
 			}
 		case "response.failed", "response.incomplete", "response.cancelled", "response.canceled":
+			// These terminal events also carry the response object with upstream usage: the
+			// tokens were already produced and charged by the provider, so record them here as
+			// well. OaiResponsesHandler reads usage unconditionally on the non-streaming path;
+			// without this the streaming path drops it silently. The output-text fallback below
+			// cannot cover the gap when no response.output_text.delta was emitted (reasoning
+			// models, or truncation before the first text token), leaving the request billed as
+			// zero even though the terminal event reported real token counts.
+			if streamResponse.Response != nil && streamResponse.Response.Usage != nil {
+				incomingUsage := relayconvert.NormalizeResponsesUsage(streamResponse.Response.Usage)
+				usage = dto.MergeUsageNonZero(usage, incomingUsage)
+			}
 			if !imageCommitted {
 				imageCounter.Reset()
 				imageCounter.Commit(info)

--- a/relay/channel/openai/relay_responses_billing_test.go
+++ b/relay/channel/openai/relay_responses_billing_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/QuantumNous/new-api/constant"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting/operation_setting"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -264,4 +265,106 @@ func TestOaiResponsesStreamHandlerDoesNotCountPartialImageEvent(t *testing.T) {
 	)
 
 	assert.Equal(t, 0, info.ResponsesUsageInfo.BuiltInTools[dto.BuildInToolImageGeneration].CallCount)
+}
+
+// runResponsesUsageStream drives OaiResponsesStreamHandler over the given SSE events and
+// returns the usage it reports. Unlike runResponsesImageBillingStream it makes no assertion
+// about image-generation tools, so it can be used for plain text/reasoning billing cases.
+func runResponsesUsageStream(t *testing.T, events ...string) *dto.Usage {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	// The handler falls back to counting the streamed output text when no usage was recorded.
+	// That path dereferences the default token encoder, so initialize it here; otherwise a
+	// regression in this area surfaces as a nil-pointer panic instead of a clear assertion.
+	service.InitTokenEncoders()
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() {
+		constant.StreamingTimeout = oldTimeout
+	})
+
+	var body strings.Builder
+	for _, event := range events {
+		body.WriteString("data: ")
+		body.WriteString(event)
+		body.WriteString("\n\n")
+	}
+	body.WriteString("data: [DONE]\n\n")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Set(common.RequestIdKey, "responses-usage-billing-test")
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "gpt-5.1",
+		DisablePing:     true,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "gpt-5.1",
+		},
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body.String())),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+
+	usage, apiErr := OaiResponsesStreamHandler(c, info, resp)
+	require.Nil(t, apiErr)
+	require.NotNil(t, usage)
+	return usage
+}
+
+// A reasoning model truncated by max_output_tokens emits no response.output_text.delta, so the
+// output-text fallback cannot estimate anything. The terminal event is the only source of token
+// counts; dropping it bills the request as zero.
+func TestOaiResponsesStreamHandlerBillsUsageOnIncompleteWithoutTextDelta(t *testing.T) {
+	usage := runResponsesUsageStream(
+		t,
+		`{"type":"response.created","response":{"status":"in_progress"}}`,
+		`{"type":"response.incomplete","response":{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":11,"output_tokens":64,"total_tokens":75}}}`,
+	)
+
+	assert.Equal(t, 11, usage.PromptTokens)
+	assert.Equal(t, 64, usage.CompletionTokens)
+	assert.Equal(t, 75, usage.TotalTokens)
+}
+
+// When text was streamed the handler could fall back to counting it, but the upstream numbers
+// are authoritative and must win over the local estimate.
+func TestOaiResponsesStreamHandlerPrefersUpstreamUsageOnIncomplete(t *testing.T) {
+	usage := runResponsesUsageStream(
+		t,
+		`{"type":"response.output_text.delta","delta":"partial answer"}`,
+		`{"type":"response.incomplete","response":{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":7,"output_tokens":123,"total_tokens":130}}}`,
+	)
+
+	assert.Equal(t, 7, usage.PromptTokens)
+	assert.Equal(t, 123, usage.CompletionTokens)
+	assert.Equal(t, 130, usage.TotalTokens)
+}
+
+// Cancellation stops generation but the tokens produced up to that point are still charged
+// upstream, and the cancelled terminal event reports them.
+func TestOaiResponsesStreamHandlerBillsUsageOnCancelled(t *testing.T) {
+	usage := runResponsesUsageStream(
+		t,
+		`{"type":"response.cancelled","response":{"status":"cancelled","usage":{"input_tokens":5,"output_tokens":9,"total_tokens":14}}}`,
+	)
+
+	assert.Equal(t, 5, usage.PromptTokens)
+	assert.Equal(t, 9, usage.CompletionTokens)
+	assert.Equal(t, 14, usage.TotalTokens)
+}
+
+// Guard against a terminal event that carries no usage at all: the handler must not panic and
+// must leave the existing zero-usage path untouched.
+func TestOaiResponsesStreamHandlerIncompleteWithoutUsageStaysZero(t *testing.T) {
+	usage := runResponsesUsageStream(
+		t,
+		`{"type":"response.incomplete","response":{"status":"incomplete"}}`,
+	)
+
+	assert.Equal(t, 0, usage.PromptTokens)
+	assert.Equal(t, 0, usage.CompletionTokens)
+	assert.Equal(t, 0, usage.TotalTokens)
 }


### PR DESCRIPTION
## Agent

- Tool: Claude Code
- Tool version: CLI (claude.ai/code)
- Model (full id): claude-opus-5
- Host (CLI / IDE / GitHub coding agent / other): CLI
- Date (UTC): 2026-09-07

## Links

- Closes #7241
- Related: #6904(同一 `switch`,改的是 `completed` 分支的 `sr.Done()`,与本 PR 不冲突)· #7059 · #7066(均为「终止事件缺失」类,与本 PR 互补)

## User request

用户原话:「rc.30 计费缺口:流式 `/v1/responses` 以 `response.incomplete` 结束时不读 usage,整条按 0 计」,并要求「向上游提交 issue 和 PR……PR 更是要遵从规范,让 PR 能够真正被接受」。

## Out of scope — refuse

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): 不适用。本 PR 是中继计费缺陷修复,不属于 Coding Plan、逆向渠道、第三方封装、Codex 渠道类型改动、透传转发或第三方托管。

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: 流式 `/v1/responses` 以 `response.incomplete` 结束(如 `incomplete_details.reason = max_output_tokens`)时,该请求 `quota = 0`,日志记「上游没有返回计费信息,无法扣费」,**而该终止事件体内带有 `usage`**。
- Impact: 静默单向漏计。token 已产生、上游已计费,网关侧记 0 且不报错、无告警。
- Frequency: 某自托管网关近 7 天(截至 2026-09-03)流式 responses 日志 47,347 行中,属本缺陷的 **75 行**(`glm-5.3` 38 · `glm-5.3-flash` 35 · `doubao-seed-evolving` 2,涉 6 个用户)。
- Evidence that the problem is in new-api rather than the client or upstream: ① 终止事件体内确有 `usage.output_tokens`(64 / 1500,与请求的 `max_output_tokens` 一致);② 同上游、同模型、同截断条件下**非流式请求计费正常**,差异只在 `stream`;③ 源码分支可直接解释该差异(见 Change)。
- Applicable types and their fields (relay / billing / frontend / deployment): **relay** 与 **billing** 适用,字段已在 #7241 对应小节逐项填写;frontend / deployment 不适用。

## Change

`OaiResponsesStreamHandler` 只在 `response.completed` / `response.done` 分支读取 `Response.Usage`;`response.failed` / `response.incomplete` / `response.cancelled` / `response.canceled` 这一分支**只复位图像计数器,不读 usage**。

本 PR 在该终止分支复用 `completed` 分支已在用的同一对函数读取 usage:

```go
if streamResponse.Response != nil && streamResponse.Response.Usage != nil {
    incomingUsage := relayconvert.NormalizeResponsesUsage(streamResponse.Response.Usage)
    usage = dto.MergeUsageNonZero(usage, incomingUsage)
}
```

为什么这样能生效,三点都落在实际改到的代码上:

1. **与非流式路径对齐。** 同文件的 `OaiResponsesHandler` 第 42 行 `usage := relayconvert.NormalizeResponsesUsage(responsesResponse.Usage)` 是**无条件**的,所以 `stream = false` 时同一截断请求计费正确。流式路径此前与它不一致,本 PR 消除这个分叉。
2. **既有兜底覆盖不到。** 函数结尾 142-150 行的输出文本兜底要求流中出现过 `response.output_text.delta`;推理型模型在产出首个文本 token 前被截断时 `responseTextBuilder` 为空,兜底不触发,prompt 与 completion 均归零。这解释了生产命中集中在推理模型。
3. **图像计数语义不变。** `IsNonBillableResponsesStatus` 只服务于图像生成调用计数,终止分支仍照旧 `Reset()` 后 `Commit()`;本 PR 不触碰这段。token 已经产生,与图像调用是否成立是两件事。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `response.incomplete`、`incomplete usage`、`responses 计费`、`stream usage 0`、`responses not billed`、`responses usage`、`incomplete billing`
- What already existed and why this is not a duplicate:
  - **#7059**(issue)/ **#7066**(PR):上游断连导致**没有**终止事件。本 PR 的前提相反 —— 终止事件正常到达。
  - **#6904**(PR):正常完成的流被误标 `client_gone`,改的是 `completed` / `done` 分支加 `sr.Done()`。与本 PR 同文件同 `switch` 但**不同分支、不同目的**,可并存。
  - 三者恰好对应报告方日志里三类不同的未计费行(75 / 319 / 48),互不重叠。

### Docs and code

- https://docs.newapi.ai/ :检索首页与 `zh/docs/guide/feature-guide/user/pricing`。未记载流式 Responses 的 usage 提取,也未记载终止事件的计费处理;无可配置开关。
- https://deepwiki.com/QuantumNous/new-api :检索 streaming billing / Responses usage。仅有「three-phase quota tracking, tiered pricing expressions」一句概括,未涉及本主题。
- README / repo docs:未见相关条目。
- Code paths and what they imply for this change:
  - `relay/channel/openai/relay_responses.go:91-96` — `completed` / `done` 分支读 usage 的现成写法,本 PR 直接复用。
  - `relay/channel/openai/relay_responses.go:115-120` — 终止分支,本 PR 唯一改动点。
  - `relay/channel/openai/relay_responses.go:42` — 非流式无条件读 usage,是「应有行为」的项目内参照。
  - `relay/channel/openai/relay_responses.go:142-150` — 文本兜底,说明为何缺陷未被现有机制掩盖。
  - `relay/common/tool_usage.go:180` — `IsNonBillableResponsesStatus` 的适用范围仅为图像计数,故不能拿它否定 token 计费。

### Alternatives considered

- **Option A:把终止事件也并入 `completed` 分支统一处理。** 会一并把图像计数的 `Observe` 逻辑套到终止事件上,改变现有图像计费语义,超出修复范围。
- **Option B:在函数结尾兜底处补一条「若 usage 为空则回看最后一个终止事件」。** 需要额外保存事件状态,且把「事件里已有的数」推迟到收尾再取,增加状态而非减少分叉。
- **Why this approach:** 只补一个分支缺失的读取,复用同文件已在用的 `NormalizeResponsesUsage` + `MergeUsageNonZero`,不新增状态、不改变图像计数、不引入新概念,并直接消除与非流式路径的不一致。

## Files

| Path | Why |
| --- | --- |
| `relay/channel/openai/relay_responses.go` | 终止事件分支补读 `Response.Usage`(+11 行,含注释) |
| `relay/channel/openai/relay_responses_billing_test.go` | 新增 4 个计费用例与一个共享驱动 helper(+103 行) |

## Behavior

- Before: 流式 `/v1/responses` 以 `incomplete` / `cancelled` / `canceled` / `failed` 结束时,终止事件里的 usage 被丢弃;若流中又没有过文本增量,该请求最终按 0 计费。
- After: 该终止事件里的 usage 被采用,结果与 `stream = false` 的同条件请求一致;若终止事件本身不带 usage,行为与此前完全相同。
- Explicit non-goals / leftover work: 不处理终止事件缺失的场景(#7059 / #7066);不处理 `client_gone` 误标(#6904);不改动图像生成调用计数;不改动计费口径与倍率。

## Verification

- Commands and results:
  - `gofmt -l relay/` → 无输出
  - `go vet ./...` → 通过
  - `make test` → **EXIT=0**,全部包通过(50 个包报 `ok`)
  - `go test ./relay/channel/openai/` → `ok`
- Manual steps and observed result: 缺陷本身在自托管网关上以真实上游复现(`stream = true`,`max_output_tokens = 64` 与 `1500`,推理型模型),两次均以 `response.incomplete` 结束、事件体带 `usage`、日志 `quota = 0`。详见 #7241。
- UI: screenshot or recording (or why none): 无 UI 改动。
- Tests added or updated: 新增 4 个用例。**每个用例都做了阳性对照**(临时移除修复后单独运行):

  | 用例 | 无修复 | 有修复 |
  | --- | --- | --- |
  | `...BillsUsageOnIncompleteWithoutTextDelta` | FAIL(0 vs 64) | PASS |
  | `...PrefersUpstreamUsageOnIncomplete` | FAIL | PASS |
  | `...BillsUsageOnCancelled` | FAIL | PASS |
  | `...IncompleteWithoutUsageStaysZero` | PASS(**阴性对照**,按设计两侧都应通过) | PASS |

  共享 helper 里调用了 `service.InitTokenEncoders()`:文本兜底路径会解引用默认编码器,不初始化时该路径以空指针 panic 收场而非给出断言失败。初始化后为纯内存操作(实测 0.01s,不联网)。
- Databases / providers / platforms exercised: 复现发生在 mysql + 原生 Responses 上游(`converter = none`);单元测试不触及数据库。
- Not verified: 未做「直连上游 vs 经 new-api」逐字对照;未在 sqlite / postgres 上复现(该路径不含数据库分支);未验证 `response.failed` 在真实上游下是否总带 usage(实测只覆盖 `incomplete`);经转换器的 Responses 路径未验证。

## Risks

- Failure modes: 若某上游在终止事件中返回**错误的** usage,现在会被采用而非忽略。考虑到同一份 usage 在 `completed` 分支早已被无条件采用、非流式路径也无条件采用,本 PR 不引入新的信任面。
- Billing / quota impact: **方向为增加计费**——此前记 0 的这类请求将按上游报告的 token 计费。这正是修复目标,但部署方应知晓:升级后这类请求会开始扣费。终止事件不带 usage 时行为不变。
- Follow-ups: 终止事件缺失(#7059 / #7066)与 `client_gone` 误标(#6904)是另外两类,不在本 PR 内。

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved usage tracking for incomplete, failed, and cancelled streaming responses.
  - Billing now reflects upstream usage even when no text output was streamed.
  - Preserved accurate usage precedence when upstream usage data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->