### PR TITLE
fix(relaykit): accept normalized Gemini thinking levels

### DIFF
--- a/relaykit/relayconvert/reasoning/gemini.go
+++ b/relaykit/relayconvert/reasoning/gemini.go
@@ -213,7 +213,7 @@ func ValidateGeminiThinkingConfig(model string, config *dto.GeminiThinkingConfig
 		if err != nil {
 			return "", err
 		}
-		if level != config.ThinkingLevel {
+		if Effort(level) != intent.Effort {
 			return "", fmt.Errorf("thinkingLevel %q is not supported by model %q", config.ThinkingLevel, model)
 		}
 		return Effort(level), nil

--- a/relaykit/relayconvert/request_registry_test.go
+++ b/relaykit/relayconvert/request_registry_test.go
@@ -1,6 +1,7 @@
 package relayconvert
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/QuantumNous/new-api/relaykit/dto"
@@ -11,6 +12,41 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGeminiToOpenAIThinkingLevelNormalization(t *testing.T) {
+	for _, fields := range []struct{ generation, thinking, level string }{
+		{"generationConfig", "thinkingConfig", "thinkingLevel"},
+		{"generationConfig", "thinking_config", "thinking_level"},
+	} {
+		for _, tt := range []struct {
+			model, level, want string
+		}{
+			{"gemini-3.7-flash", "medium", "medium"},
+			{"gemini-3.7-flash", "MEDIUM", "medium"},
+			{"gemini-3.7-flash", " Medium ", "medium"},
+			{"gemini-3-pro-preview", "LOW", "low"},
+			{"gemini-3-pro-preview", "MEDIUM", ""},
+			{"gemini-3.7-flash", "MAX", ""},
+			{"gemini-2.5-flash", "LOW", ""},
+		} {
+			t.Run(fields.thinking+"/"+tt.model+"/"+tt.level, func(t *testing.T) {
+				body := fmt.Sprintf(`{"%s":{"%s":{"%s":%q,"includeThoughts":true}}}`, fields.generation, fields.thinking, fields.level, tt.level)
+				var request dto.GeminiChatRequest
+				require.NoError(t, kitutil.UnmarshalJsonStr(body, &request))
+				info := &convmeta.Values{ChannelMetaAttached: true, OriginModelName: tt.model, UpstreamModelName: "gpt-5"}
+				converted, err := GeminiGenerateContentRequestToOpenAIChat(&request, info)
+				if tt.want == "" {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, info.GetReasoningEffort())
+				assert.Equal(t, tt.want, converted.ReasoningEffort)
+				assert.Equal(t, tt.level, request.GenerationConfig.ThinkingConfig.ThinkingLevel)
+			})
+		}
+	}
+}
 
 func TestRequestConverterRegistryListsSupportedTextConverters(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Agent

- Tool / Host: OpenAI Codex Desktop，应用版本未提供
- Model (full id): GPT-6，完整后端 ID 未提供
- Date (UTC): 2026-09-07
- 代码和测试由 AI 生成并验证。git 用户 Grada 与仓库近期主要作者 CaIon / Calcium-Ion 不同。

## Links

- Closes #7205

## User request

「进行 3 个高质量 pr」，尽量减少下载与编译；本 PR 处理已有 issue #7205。

## Out of scope — refuse

- Matched: no。标准 Gemini → OpenAI 请求转换中的本地校验错误，不涉及仓库排除的渠道、直通兼容、第三方服务或配置咨询。

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other

## Issue facts

- Actual behavior / impact: `MEDIUM` 被误判为模型不支持，`medium` 正常，合法请求被本地拒绝。
- Frequency: issue 报告原实例连续三次失败及稳定单元复现；本次转换器测试中 6 个大小写/空白用例在修复前失败。
- Evidence: `ParseEffort` 已规范化输入，但 `ValidateGeminiThinkingConfig` 将能力映射结果与原始字符串比较。
- Relay: 当前 main 的原生无修改路径已绕过该校验；本次在仍调用校验的 Gemini → OpenAI 转换入口复现。来源模型 `gemini-3.7-flash` / `gemini-3-pro-preview`，测试映射目标 `gpt-5`。
- Billing / frontend / deployment: 不适用，无相关变更。

## Change

改为比较 `Effort(level)` 与规范化后的 `intent.Effort`。保留模型能力约束、输入 DTO 原值和既有转换逻辑。

## Research

### Duplicate / prior art

PR 搜索 `7205`、`thinkingLevel`：未发现同一校验修复。#2274 处理参数别名，#6641 处理日志。原生路径的早返回保留。

### Docs and code

- [new-api API 文档](https://docs.newapi.ai/en/docs/api)：查看 API 入口，未找到控制该比较的设置。
- [DeepWiki Gemini](https://deepwiki.com/QuantumNous/new-api/4.3-google-gemini)：查看接入/转换背景；故障结论以当前源码及本地复现为依据。
- README.md：Gemini 原生格式与 Gemini/OpenAI 转换属于已有能力。
- [Google ThinkingLevel](https://ai.google.dev/api/generate-content#ThinkingLevel)：官方枚举包含大写 `MINIMAL/LOW/MEDIUM/HIGH`。
- `reasoning/intent.go` 规范化；`reasoning/gemini.go` 校验；`internal/gemini_chat/to_oai_chat_req.go` 校验后生成 OpenAI 请求。

### Alternatives considered

DTO 规范化会改变原生保留行为；删除能力检查会放宽模型限制。因此仅调整比较操作数。

## Files

| Path | Why |
| --- | --- |
| relaykit/relayconvert/reasoning/gemini.go | 比较规范化 effort |
| relaykit/relayconvert/request_registry_test.go | 覆盖实际转换入口 |

## Behavior

- Before: 转换拒绝合法 `MEDIUM`、` Medium `、`LOW`。
- After: 生成正确的 `reasoning_effort`；Pro 的 `MEDIUM`、Flash 的 `MAX`、Gemini 2.5 的 level 配置仍拒绝。
- Non-goals: 模型能力表、原生保留路径及顶层字段别名不变。

## Verification

在 `relaykit/` 执行：

- 修复前 `GOWORK=off go test ./relayconvert -run TestGeminiToOpenAIThinkingLevelNormalization -count=1`：6 个合法输入子用例失败。
- 修复后 `GOWORK=off go test ./...`、`GOWORK=off go build ./...`、`git diff --check`：通过。
- 新增 14 个表格子用例：camelCase/snake_case thinking 字段、大小写/空白、能力拒绝、输出 effort、输入保留。
- 平台：macOS；使用真实 DTO 和本地转换器。UI、数据库不适用；未调用付费上游或运行根模块应用测试。

## Risks

主要风险是放宽模型能力，已覆盖拒绝用例。无配额、价格或鉴权修改；无必需后续工作。

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no
