### PR TITLE
fix(openai): escape image edit multipart filenames

### DIFF
--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -579,7 +579,7 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 
 				// Create a form file with the appropriate content type
 				h := make(textproto.MIMEHeader)
-				h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, fieldName, fileHeader.Filename))
+				h.Set("Content-Disposition", multipart.FileContentDisposition(fieldName, fileHeader.Filename))
 				h.Set("Content-Type", mimeType)
 
 				part, err := writer.CreatePart(h)
@@ -608,7 +608,7 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 
 				// Create a form file with the appropriate content type
 				h := make(textproto.MIMEHeader)
-				h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="mask"; filename="%s"`, maskFiles[0].Filename))
+				h.Set("Content-Disposition", multipart.FileContentDisposition("mask", maskFiles[0].Filename))
 				h.Set("Content-Type", mimeType)
 
 				maskPart, err := writer.CreatePart(h)

--- a/relay/channel/openai/image_edit_test.go
+++ b/relay/channel/openai/image_edit_test.go
@@ -13,6 +13,7 @@ import (
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -95,4 +96,65 @@ func TestConvertImageEditRequestMultipart(t *testing.T) {
 
 		convertAndReplay(t, c, prompt)
 	})
+}
+
+// TestConvertImageEditRequestPreservesFilenames verifies that multipart conversion
+// preserves image and mask attachments with filenames that require escaping.
+func TestConvertImageEditRequestPreservesFilenames(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, filename := range []string{"input.png", `input"quoted.png`, `input\\backslash.png`, "图片.png"} {
+		for _, imageField := range []string{"image", "image[]"} {
+			t.Run(imageField+"/"+filename, func(t *testing.T) {
+				var body bytes.Buffer
+				writer := multipart.NewWriter(&body)
+				fields := []string{imageField, "mask"}
+				if imageField == "image[]" {
+					fields = append(fields, imageField)
+				}
+				for _, field := range fields {
+					part, err := writer.CreateFormFile(field, filename)
+					require.NoError(t, err)
+					_, err = io.WriteString(part, "contents of "+field)
+					require.NoError(t, err)
+				}
+				require.NoError(t, writer.Close())
+
+				c, _ := gin.CreateTestContext(httptest.NewRecorder())
+				c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+				c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+				require.NoError(t, c.Request.ParseMultipartForm(32<<20))
+				t.Cleanup(func() { require.NoError(t, c.Request.MultipartForm.RemoveAll()) })
+
+				converted, err := (&Adaptor{}).ConvertImageRequest(c, &relaycommon.RelayInfo{
+					RelayMode: relayconstant.RelayModeImagesEdits,
+				}, dto.ImageRequest{Model: "gpt-image-1"})
+				require.NoError(t, err)
+				convertedBody, ok := converted.(*bytes.Buffer)
+				require.True(t, ok)
+				replayed := httptest.NewRequest(http.MethodPost, "/v1/images/edits", convertedBody)
+				replayed.Header.Set("Content-Type", c.Request.Header.Get("Content-Type"))
+				require.NoError(t, replayed.ParseMultipartForm(32<<20))
+				t.Cleanup(func() { require.NoError(t, replayed.MultipartForm.RemoveAll()) })
+
+				for _, field := range []string{imageField, "mask"} {
+					wantCount := 1
+					if field == "image[]" {
+						wantCount = 2
+					}
+					files := replayed.MultipartForm.File[field]
+					require.Len(t, files, wantCount)
+					for _, header := range files {
+						assert.Equal(t, c.Request.MultipartForm.File[field][0].Filename, header.Filename)
+						assert.Equal(t, "image/png", header.Header.Get("Content-Type"))
+						file, err := header.Open()
+						require.NoError(t, err)
+						contents, err := io.ReadAll(file)
+						require.NoError(t, err)
+						require.NoError(t, file.Close())
+						assert.Equal(t, "contents of "+field, string(contents))
+					}
+				}
+			})
+		}
+	}
 }


### PR DESCRIPTION
## Agent

- Tool: OpenAI Codex；本 PR 为 AI 辅助编写，由贡献者账号提交。
- Tool version: 桌面应用未在会话中提供版本号。
- Model (full id): 会话未提供可核实的完整模型 ID。
- Host (CLI / IDE / GitHub coding agent / other): Codex desktop。
- Date (UTC): 2026-09-07。

## Links

- Closes #: 无；代码检查中发现并用本地回归测试复现。
- Related: [图片编辑接口文档](https://docs.newapi.ai/en/docs/api/ai-model/images/openai/post-v1-images-edits)。

## User request

> 我的目标是成为该项目的代码贡献者（提交PR并被项目管理者合并），不需要找复杂的bug或feature，只要明确的 改动小但仍然一看就值得合并的pr。最好是改动不大的，但是明确清晰的fix。 或者有bug的代码。

## Out of scope — refuse

- Matched: no。此修复属于官方 OpenAI 图片编辑适配器的 multipart 请求构造问题，不涉及 Coding Plan、逆向渠道、第三方包装或托管服务、Codex 协议或纯透传模式。
- If yes, what was told to the user (stop here; do not open a PR): 不适用。

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

无关联 issue；以下是本 PR 回归测试的直接观测，不代表用户线上故障报告。

- Actual behavior: 原代码上，input"quoted.png 对应的附件在重新解析后数量为 0；文件名中的两个连续反斜杠被缩减为一个。
- Impact: 图片编辑请求的上传附件可能丢失或文件名改变。
- Frequency: 指定文件名可确定性复现；未测量线上发生频率。
- Evidence that the problem is in new-api rather than the client or upstream: 测试用标准库生成合法 multipart 请求，交给 ConvertImageRequest 转换，再用标准库解析转换结果；无外部上游参与。
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): relay，POST /v1/images/edits 的 image、image[]、mask 文件名。billing / frontend / deployment 不适用。

## Change

将图片及遮罩的两处手工 Content-Disposition 拼接替换为 multipart.FileContentDisposition。该函数负责双引号和反斜杠转义，同时允许继续保留原有按扩展名设置的 Content-Type。Go 1.25 已提供此函数，符合 go.mod 的最低版本要求。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): 在 QuantumNous/new-api 搜索 PR：`multipart filename`、`image edits escape`、`FileContentDisposition`；issue：`image filename`、`filename quote`。
- What already existed and why this is not a duplicate: 上述检索均未返回匹配项；另检查开放 PR 中图片相关标题。#6962 修改 xAI 请求转换，本 PR 修复 OpenAI 适配器已有 multipart 文件头的转义。

### Docs and code

- https://docs.newapi.ai/ : 已读取首页及[图片编辑接口](https://docs.newapi.ai/en/docs/api/ai-model/images/openai/post-v1-images-edits)，接口接受 multipart/form-data 的 image 与 mask；此问题不能通过文档中的配置解决。
- https://deepwiki.com/QuantumNous/new-api : 已读取 Overview，确认多模态请求及提供商适配属于项目功能。
- README / repo docs: README.md 的项目定位及 README.zh_CN.md 的 Image 接口链接。
- Code paths and what they imply for this change: relay/channel/openai/adaptor.go 中 ConvertImageRequest 对 image 和 mask 使用 fmt.Sprintf 直接写入原始文件名；同文件音频上传使用标准库 CreateFormFile，已有正确转义。标准库 [Go 1.25.1 writer.go](https://github.com/golang/go/blob/go1.25.1/src/mime/multipart/writer.go) 的 FileContentDisposition 正是 CreateFormFile 使用的文件头构造方法。

### Alternatives considered

- Option A: 手写 strings.NewReplacer，增加需要维护的重复转义规则。
- Option B: 使用 multipart.FileContentDisposition。
- Why this approach: 复用标准库现有行为，仅两处替换，无需依赖或工具链升级。

## Files

| Path | Why |
| --- | --- |
| relay/channel/openai/adaptor.go | 正确转义图片和遮罩文件名。 |
| relay/channel/openai/image_edit_test.go | 在已有测试文件中覆盖文件名、附件内容、MIME 类型及单图/多图/遮罩。 |

## Behavior

- Before: 原代码上，input"quoted.png 对应的附件在重新解析后数量为 0；文件名中的两个连续反斜杠被缩减为一个。
- After: 含双引号或反斜杠的文件名能正确转发；普通和中文文件名、文件内容以及 image/png 类型得到保留。
- Explicit non-goals / leftover work: 不改变图片顺序、模型参数或其他提供商适配器。

## Verification

Only what was actually run.

- Commands and results: `GOPROXY=https://goproxy.cn,https://proxy.golang.org,direct go test ./relay/channel/openai -run TestConvertImageEditRequestPreservesFilenames -count=1`：修复前 4 个子用例因附件丢失或文件名变化而失败；`GOPROXY=https://goproxy.cn,https://proxy.golang.org,direct go test ./relay/channel/openai -count=1`：修复后整个适配器测试包通过（0.871s）；`git diff --check`：通过。Go 1.26.0，darwin/arm64。仅当前命令临时指定下载代理，未改仓库配置。
- Manual steps and observed result: 标准库构造和重放 multipart 请求，由自动化回归测试执行。
- UI: 不涉及 UI，无截图。
- Tests added or updated, or why none: 在现有 image_edit_test.go 新增表驱动测试，覆盖普通文件名、双引号、连续反斜杠、中文文件名，以及单图/多图和 mask。
- Databases / providers / platforms exercised: macOS arm64；测试在本地调用 OpenAI 适配器并重放请求，不调用真实提供商。不涉及数据库行为或依赖变更。
- Not verified: 真实 OpenAI 调用、线上发生频率及完整仓库 CI。

## Risks

- Failure modes: 文件名参数转义交由标准库，文件内容和原有 Content-Type 生成保持现有行为。
- Billing / quota / auth impact: 无对应代码变更。
- Follow-ups: 等待维护者审阅与 CI。

## Scope check

- Single focused change: yes。
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of filenames in image uploads, including special characters such as quotes, backslashes, and non-ASCII text.
  * Preserved image and mask file metadata and contents more reliably during image editing requests.
  * Improved compatibility for image and mask attachments with complex filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->