### PR TITLE
fix(relay): apply channel model_mapping to pass-through request bodies

### DIFF
--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -91,7 +91,16 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 		if err != nil {
 			return types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
 		}
-		requestBody = common.NewReplayableBodyReader(storage)
+		// 透传不等于「忽略模型映射」：渠道 model_mapping 命中时，顶层 model
+		// 字段必须跟着改写，否则上游收到的仍是对外模型名（404）。
+		passthroughBody, passthroughCloser, err := relaycommon.NewPassthroughBody(storage, info)
+		if err != nil {
+			return types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+		}
+		if passthroughCloser != nil {
+			defer passthroughCloser.Close()
+		}
+		requestBody = passthroughBody
 	} else {
 		convertedRequest, err := adaptor.ConvertClaudeRequest(c, info, request)
 		if err != nil {

--- a/relay/common/passthrough_body.go
+++ b/relay/common/passthrough_body.go
@@ -1,0 +1,162 @@
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+// NewPassthroughBody builds the upstream request body for channels that forward
+// the inbound payload verbatim (全局「请求体透传」或渠道 PassThroughBodyEnabled)。
+//
+// 透传的契约是「请求体原样转发」，所以这里只做一件事：当渠道的 model_mapping
+// 真的改写了模型名时，把顶层 `model` 字段替换成映射后的名字。其余字节
+// （字段顺序、未知字段、空白、数值精度）一律不动。
+//
+// 为什么必须替换：ModelMappedHelper 只改写内存里的 request 副本
+// （info.UpstreamModelName + request.SetModelName），透传分支直接取入站 body，
+// 那次改写从未落回请求体。于是 new-api 侧看起来映射生效了（日志、计费、
+// 渠道选择都用 UpstreamModelName），上游收到的却仍是客户端的对外模型名 ——
+// 上游不认识这个模型，直接 404。详见 issue #6002 / #6639。
+//
+// 返回值的 closer 非空时调用方必须 defer closer.Close()（与 NewOutboundJSONBody
+// 一致）；未发生改写时 closer 为 nil，直接复用入站 storage，零额外拷贝。
+func NewPassthroughBody(storage common.BodyStorage, info *RelayInfo) (common.ReplayableBody, io.Closer, error) {
+	if storage == nil {
+		return nil, nil, errors.New("missing request body storage")
+	}
+	if info == nil || !info.HasChannelMeta() || !info.IsModelMapped {
+		return common.NewReplayableBodyReader(storage), nil, nil
+	}
+	upstreamModel := info.GetUpstreamModelName()
+	if upstreamModel == "" {
+		return common.NewReplayableBodyReader(storage), nil, nil
+	}
+	raw, err := storage.Bytes()
+	if err != nil || len(raw) == 0 {
+		// 读不到内容（已关闭 / 落盘读失败）就退回原样转发，
+		// 绝不因为改写失败而丢掉请求体。
+		return common.NewReplayableBodyReader(storage), nil, nil
+	}
+	patched, changed := ReplaceTopLevelModel(raw, upstreamModel)
+	if !changed {
+		return common.NewReplayableBodyReader(storage), nil, nil
+	}
+	body, closer, err := NewOutboundJSONBody(patched)
+	if err != nil {
+		return nil, nil, err
+	}
+	return body, closer, nil
+}
+
+// ReplaceTopLevelModel 把 JSON 对象顶层名为 "model" 的字符串字段替换为 newModel，
+// 其余内容保持逐字节不变。
+//
+// 只处理顶层：嵌套结构里的同名字段（tools[].function.name 之类更不会叫 model）
+// 不属于请求模型名，保持原样。发生替换时返回 true。
+func ReplaceTopLevelModel(src []byte, newModel string) ([]byte, bool) {
+	dec := json.NewDecoder(bytes.NewReader(src))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, false
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		return nil, false
+	}
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, false
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return nil, false
+		}
+		// InputOffset 位于刚读完的 key token 之后，值还在后面。
+		beforeValue := dec.InputOffset()
+		valueTok, err := dec.Token()
+		if err != nil {
+			return nil, false
+		}
+		afterValue := dec.InputOffset()
+		if key == "model" {
+			current, ok := valueTok.(string)
+			if !ok {
+				// model 不是字符串（null / 对象 / 数组）：请求本身就不合规，
+				// 交给上游报错，不在这里替它做决定。
+				return nil, false
+			}
+			if current == newModel {
+				return nil, false
+			}
+			start := valueStartOffset(src, int(beforeValue))
+			if start < 0 || start >= len(src) || src[start] != '"' {
+				return nil, false
+			}
+			quoted, err := json.Marshal(newModel)
+			if err != nil {
+				return nil, false
+			}
+			out := make([]byte, 0, len(src)+len(quoted))
+			out = append(out, src[:start]...)
+			out = append(out, quoted...)
+			out = append(out, src[afterValue:]...)
+			return out, true
+		}
+		if delim, ok := valueTok.(json.Delim); ok && (delim == '{' || delim == '[') {
+			if !skipJSONValue(dec) {
+				return nil, false
+			}
+		}
+	}
+	return nil, false
+}
+
+// valueStartOffset 从 key token 结束处向后跳过空白与 ':'，返回值的起始下标。
+func valueStartOffset(src []byte, from int) int {
+	i := from
+	for i < len(src) && isJSONSpace(src[i]) {
+		i++
+	}
+	if i >= len(src) || src[i] != ':' {
+		return -1
+	}
+	i++
+	for i < len(src) && isJSONSpace(src[i]) {
+		i++
+	}
+	if i >= len(src) {
+		return -1
+	}
+	return i
+}
+
+func isJSONSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+// skipJSONValue 把一个已经读到起始定界符（'{' 或 '['）的复合值读完，
+// 让外层循环继续从下一个顶层 key 开始。
+func skipJSONValue(dec *json.Decoder) bool {
+	depth := 1
+	for depth > 0 {
+		tok, err := dec.Token()
+		if err != nil {
+			return false
+		}
+		if delim, ok := tok.(json.Delim); ok {
+			switch delim {
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+			default:
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/relay/common/passthrough_body_test.go
+++ b/relay/common/passthrough_body_test.go
@@ -1,0 +1,170 @@
+package common
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/require"
+)
+
+func newPassthroughStorage(t *testing.T, payload string) common.BodyStorage {
+	t.Helper()
+	storage, err := common.CreateBodyStorage([]byte(payload))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storage.Close() })
+	return storage
+}
+
+func readBody(t *testing.T, body io.Reader) string {
+	t.Helper()
+	raw, err := io.ReadAll(body)
+	require.NoError(t, err)
+	return string(raw)
+}
+
+func mappedRelayInfo(mapped bool, upstreamModel string) *RelayInfo {
+	return &RelayInfo{
+		ChannelMeta: &ChannelMeta{
+			UpstreamModelName: upstreamModel,
+			IsModelMapped:     mapped,
+		},
+	}
+}
+
+// 核心回归：透传 + 映射命中 → 上游收到映射后的模型名，其余字节一字不动。
+func TestNewPassthroughBodyRewritesModelWhenMapped(t *testing.T) {
+	payload := `{"model":"public-a","messages":[{"role":"user","content":"hi"}],"temperature":0.7,"unknown_field":123,"extra":{"model":"nested-keep"}}`
+	storage := newPassthroughStorage(t, payload)
+
+	body, closer, err := NewPassthroughBody(storage, mappedRelayInfo(true, "upstream-b"))
+	require.NoError(t, err)
+	require.NotNil(t, closer)
+	defer closer.Close()
+
+	got := readBody(t, body)
+	require.Contains(t, got, `"model":"upstream-b"`)
+	// 其余字段（含嵌套结构里的同名 key）逐字节保持
+	require.Contains(t, got, `"temperature":0.7,"unknown_field":123,"extra":{"model":"nested-keep"}`)
+	require.NotContains(t, got, "public-a")
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &decoded))
+	require.Equal(t, "upstream-b", decoded["model"])
+	require.Equal(t, float64(123), decoded["unknown_field"])
+	require.Equal(t, "nested-keep", decoded["extra"].(map[string]any)["model"])
+}
+
+// 未发生映射时绝不改写：closer 为 nil，内容与入站完全一致。
+func TestNewPassthroughBodyLeavesBodyUntouchedWhenNotMapped(t *testing.T) {
+	payload := `{"model":"public-a","messages":[{"role":"user","content":"hi"}]}`
+	storage := newPassthroughStorage(t, payload)
+
+	body, closer, err := NewPassthroughBody(storage, mappedRelayInfo(false, "public-a"))
+	require.NoError(t, err)
+	require.Nil(t, closer)
+	require.Equal(t, payload, readBody(t, body))
+}
+
+// ChannelMeta 缺失（老路径/任务轮询构造的裸 RelayInfo）不能 panic。
+func TestNewPassthroughBodyWithoutChannelMeta(t *testing.T) {
+	storage := newPassthroughStorage(t, `{"model":"public-a"}`)
+
+	body, closer, err := NewPassthroughBody(storage, &RelayInfo{})
+	require.NoError(t, err)
+	require.Nil(t, closer)
+	require.Equal(t, `{"model":"public-a"}`, readBody(t, body))
+}
+
+func TestReplaceTopLevelModel(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		model    string
+		want     string
+		changed  bool
+		contains string
+	}{
+		{
+			name:    "顶层改写/保留未知字段",
+			src:     `{"model":"a","top":1}`,
+			model:   "b",
+			want:    `{"model":"b","top":1}`,
+			changed: true,
+		},
+		{
+			name:    "键前后有空白与换行",
+			src:     "{\n  \"model\" : \"a\" ,\n  \"top\":1\n}",
+			model:   "b",
+			want:    "{\n  \"model\" : \"b\" ,\n  \"top\":1\n}",
+			changed: true,
+		},
+		{
+			name:    "模型名需要转义",
+			src:     `{"model":"a"}`,
+			model:   `we"ird`,
+			want:    `{"model":"we\"ird"}`,
+			changed: true,
+		},
+		{
+			name:    "值相同则不动",
+			src:     `{"model":"a"}`,
+			model:   "a",
+			changed: false,
+		},
+		{
+			name:    "model 在嵌套结构之后仍能被找到",
+			src:     `{"messages":[{"model":"keep"}],"model":"a"}`,
+			model:   "b",
+			want:    `{"messages":[{"model":"keep"}],"model":"b"}`,
+			changed: true,
+		},
+		{
+			name:    "model 非字符串不改",
+			src:     `{"model":null}`,
+			model:   "b",
+			changed: false,
+		},
+		{
+			name:    "没有 model 字段不改",
+			src:     `{"prompt":"hi"}`,
+			model:   "b",
+			changed: false,
+		},
+		{
+			name:    "非对象 body 不改",
+			src:     `["a","b"]`,
+			model:   "b",
+			changed: false,
+		},
+		{
+			name:    "非法 JSON 不改",
+			src:     `{"model":`,
+			model:   "b",
+			changed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed := ReplaceTopLevelModel([]byte(tt.src), tt.model)
+			require.Equal(t, tt.changed, changed)
+			if tt.changed {
+				require.Equal(t, tt.want, string(got))
+			} else {
+				require.Nil(t, got)
+			}
+		})
+	}
+}
+
+// 改写后的 body 必须仍是合法 JSON，且除 model 外与原文等价。
+func TestReplaceTopLevelModelKeepsEverythingElseByteIdentical(t *testing.T) {
+	src := []byte(`{"stream":true,"model":"public-a","messages":[{"role":"user","content":"\"quoted\""}], "max_tokens":  10}`)
+	got, changed := ReplaceTopLevelModel(src, "upstream-b")
+	require.True(t, changed)
+	require.Equal(t,
+		`{"stream":true,"model":"upstream-b","messages":[{"role":"user","content":"\"quoted\""}], "max_tokens":  10}`,
+		string(got))
+}

--- a/relay/compatible_handler.go
+++ b/relay/compatible_handler.go
@@ -107,7 +107,16 @@ func TextHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types
 				logger.LogDebug(c, "requestBody: %s", debugBytes)
 			}
 		}
-		requestBody = common.NewReplayableBodyReader(storage)
+		// 透传不等于「忽略模型映射」：渠道 model_mapping 命中时，顶层 model
+		// 字段必须跟着改写，否则上游收到的仍是对外模型名（404）。
+		passthroughBody, passthroughCloser, err := relaycommon.NewPassthroughBody(storage, info)
+		if err != nil {
+			return types.NewError(err, types.ErrorCodeReadRequestBodyFailed, types.ErrOptionWithSkipRetry())
+		}
+		if passthroughCloser != nil {
+			defer passthroughCloser.Close()
+		}
+		requestBody = passthroughBody
 	} else {
 		convertedRequest, err := adaptor.ConvertOpenAIRequest(c, info, request)
 		if err != nil {

--- a/relay/gemini_handler.go
+++ b/relay/gemini_handler.go
@@ -94,7 +94,16 @@ func GeminiHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 		if err != nil {
 			return types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
 		}
-		requestBody = common.NewReplayableBodyReader(storage)
+		// 透传不等于「忽略模型映射」：渠道 model_mapping 命中时，顶层 model
+		// 字段必须跟着改写，否则上游收到的仍是对外模型名（404）。
+		passthroughBody, passthroughCloser, err := relaycommon.NewPassthroughBody(storage, info)
+		if err != nil {
+			return types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+		}
+		if passthroughCloser != nil {
+			defer passthroughCloser.Close()
+		}
+		requestBody = passthroughBody
 	} else {
 		// 使用 ConvertGeminiRequest 转换请求格式
 		convertedRequest, err := adaptor.ConvertGeminiRequest(c, info, request)

--- a/relay/image_handler.go
+++ b/relay/image_handler.go
@@ -51,7 +51,16 @@ func ImageHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *type
 		if err != nil {
 			return types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
 		}
-		requestBody = common.NewReplayableBodyReader(storage)
+		// 透传不等于「忽略模型映射」：渠道 model_mapping 命中时，顶层 model
+		// 字段必须跟着改写，否则上游收到的仍是对外模型名（404）。
+		passthroughBody, passthroughCloser, err := relaycommon.NewPassthroughBody(storage, info)
+		if err != nil {
+			return types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+		}
+		if passthroughCloser != nil {
+			defer passthroughCloser.Close()
+		}
+		requestBody = passthroughBody
 	} else {
 		convertedRequest, err := adaptor.ConvertImageRequest(c, info, *request)
 		if err != nil {

--- a/relay/rerank_handler.go
+++ b/relay/rerank_handler.go
@@ -47,7 +47,16 @@ func RerankHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 		if err != nil {
 			return types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
 		}
-		requestBody = common.NewReplayableBodyReader(storage)
+		// 透传不等于「忽略模型映射」：渠道 model_mapping 命中时，顶层 model
+		// 字段必须跟着改写，否则上游收到的仍是对外模型名（404）。
+		passthroughBody, passthroughCloser, err := relaycommon.NewPassthroughBody(storage, info)
+		if err != nil {
+			return types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+		}
+		if passthroughCloser != nil {
+			defer passthroughCloser.Close()
+		}
+		requestBody = passthroughBody
 	} else {
 		convertedRequest, err := adaptor.ConvertRerankRequest(c, info.RelayMode, *request)
 		if err != nil {

--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -85,7 +85,16 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 		if err != nil {
 			return types.NewError(err, types.ErrorCodeReadRequestBodyFailed, types.ErrOptionWithSkipRetry())
 		}
-		requestBody = common.NewReplayableBodyReader(storage)
+		// 透传不等于「忽略模型映射」：渠道 model_mapping 命中时，顶层 model
+		// 字段必须跟着改写，否则上游收到的仍是对外模型名（404）。
+		passthroughBody, passthroughCloser, err := relaycommon.NewPassthroughBody(storage, info)
+		if err != nil {
+			return types.NewError(err, types.ErrorCodeReadRequestBodyFailed, types.ErrOptionWithSkipRetry())
+		}
+		if passthroughCloser != nil {
+			defer passthroughCloser.Close()
+		}
+		requestBody = passthroughBody
 	} else {
 		convertedRequest, err := adaptor.ConvertOpenAIResponsesRequest(c, info, *request)
 		if err != nil {


### PR DESCRIPTION
## 问题

渠道开启「请求体透传」后，**渠道的 model_mapping 不会落到请求体上**，上游收到的仍是客户端的对外模型名，于是不认识这个模型、直接 404。

相关 issue：#6002（透传时仍按 model 映射改写 model 字段）、#6639（高级自定义路由 + 模型映射 → `/v1/messages` 返回 404，同一个模型在 `/v1/chat/completions` 却正常）。

## 根因

`ModelMappedHelper` 只改写两处内存状态：`info.UpstreamModelName` 与传入的 `request` 副本（`request.SetModelName`）。透传分支根本不经过序列化，而是直接把入站 body 交给上游：

```go
// relay/compatible_handler.go
err = helper.ModelMappedHelper(c, info, request)   // :42  写进 request 副本
...
if passThroughGlobal || info.ChannelSetting.PassThroughBodyEnabled {
    storage, _ := common.GetBodyStorage(c)
    requestBody = common.NewReplayableBodyReader(storage)   // :110 直接用入站 body，改写被丢弃
}
```

`claude_handler.go:94`、`responses_handler.go:88`、`gemini_handler.go:97`、`image_handler.go:54`、`rerank_handler.go:50` 是同一形态。

这个失效是**静默**的：new-api 的日志、计费、渠道选择用的都是已映射的 `UpstreamModelName`，后台看上去映射完全生效，只有上游在报 404。所以表现为「偶发 404、改多少遍配置都没用」——只要流量走到透传分支就必现，而是否走到取决于渠道开关与入站端点。

## 修复

新增 `relay/common.NewPassthroughBody`：在透传分支里，当且仅当**确实发生了映射**（`info.IsModelMapped` 为真）时，把顶层 `model` 字段替换为映射后的名字，其余字节逐字节保持原样（字段顺序、未知字段、空白、数值精度、嵌套结构都不动）。

- 只改顶层 `model`，不重新 marshal 整个 body —— 保住透传「原样转发未知字段」的语义；
- 未映射 / body 非 JSON 对象 / `model` 不是字符串 / 名称未变 → 一律零改动，直接复用入站 storage，无额外拷贝；
- 读 body 失败（落盘读异常）时退回原样转发，绝不因为改写失败丢掉请求体。

六个透传分支统一接入该方法。

## 测试

`relay/common/passthrough_body_test.go`：

- 映射命中时 `model` 被改写，且 `unknown_field`、嵌套 `extra.model`、空白与标点逐字节保持；
- 未映射时 `closer == nil` 且内容与入站完全一致；
- `ChannelMeta` 缺失（任务轮询等裸 `RelayInfo`）不 panic；
- 表格用例覆盖：键名前后有空白与换行、模型名含需转义字符、值相同不动、`model` 在嵌套结构之后仍能被找到、`model` 非字符串、无 `model` 字段、非对象、非法 JSON。

已做变异检验：把 `NewPassthroughBody` 的改写分支短路掉后，`TestNewPassthroughBodyRewritesModelWhenMapped` 如实失败。

`go test ./relay/...` 全绿。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pass-through requests now correctly rewrite the top-level model name when channel model mapping is configured.
  * Other request fields and formatting remain unchanged during model rewriting.
  * Improved handling of pass-through request-body construction errors and resource cleanup.
* **Tests**
  * Added coverage for model mapping, formatting preservation, nested fields, invalid input, and unchanged pass-through requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->