### PR TITLE
fix(playground): show full model group names on hover

### DIFF
--- a/web/src/components/model-group-selector.tsx
+++ b/web/src/components/model-group-selector.tsx
@@ -676,7 +676,10 @@ export const ModelGroupSelector: React.FC<ModelGroupSelectorProps> = ({
       <span className='min-w-0 truncate text-xs'>
         {currentModel?.label || t('Model')}
       </span>
-      <span className='bg-muted text-muted-foreground hidden max-w-20 shrink-0 rounded px-1.5 py-0.5 text-[10px] sm:inline-flex'>
+      <span
+        className='bg-muted text-muted-foreground hidden max-w-20 shrink-0 rounded px-1.5 py-0.5 text-[10px] sm:inline-flex'
+        title={currentGroup?.label}
+      >
         {currentGroup?.label || t('Group')}
       </span>
       <ChevronsUpDown className='text-muted-foreground ml-auto size-3.5 shrink-0 opacity-60' />
@@ -715,6 +718,7 @@ export const ModelGroupSelector: React.FC<ModelGroupSelectorProps> = ({
               key={group.value}
               onClick={() => handleGroupChange(group.value)}
               ref={isSelected ? selectedGroupOptionRef : undefined}
+              title={group.label}
               type='button'
             >
               <span className='min-w-0 truncate font-medium'>

--- a/web/src/components/model-group-selector/__tests__/model-group-selector.test.tsx
+++ b/web/src/components/model-group-selector/__tests__/model-group-selector.test.tsx
@@ -1,0 +1,59 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, test, vi } from 'vitest'
+
+import { ModelGroupSelector } from '../../model-group-selector'
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}))
+
+const groups = [
+  { label: 'Claude-Code-Kiro-A', value: 'claude-kiro-a' },
+  {
+    label: 'Claude-Code-Kiro-Long-Context',
+    value: 'claude-kiro-long-context',
+  },
+]
+
+describe('ModelGroupSelector group labels', () => {
+  test('exposes the complete group name when a label is truncated', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ModelGroupSelector
+        groups={groups}
+        models={[]}
+        onGroupChange={() => undefined}
+        onModelChange={() => undefined}
+        selectedGroup={groups[0].value}
+        selectedModel=''
+      />
+    )
+
+    await user.click(screen.getByRole('combobox'))
+
+    expect(
+      screen.getByRole('button', { name: groups[0].label })
+    ).toHaveAttribute('title', groups[0].label)
+    expect(
+      screen.getByRole('button', { name: groups[1].label })
+    ).toHaveAttribute('title', groups[1].label)
+  })
+})


### PR DESCRIPTION
## 🔗 关联任务 / Related Issue

- Closes #

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description

修复游乐场页面模型分组名称显示不完整的问题。

当多个模型分组拥有相同前缀，且名称长度超过分组选择器可用宽度时，前端会通过 `truncate` 截断名称。例如：

- `Claude-Code-Kiro-A`
- `Claude-Code-Kiro-Long-Context`

在原有界面中，较长名称会被截断，用户无法仅凭可见文本准确区分不同模型分组。

本次修改：

1. 为模型分组下拉选项增加完整名称的悬浮提示。
2. 为当前已选模型分组徽标增加完整名称的悬浮提示。
3. 保持原有布局宽度和截断策略不变，避免长名称挤压模型列表。
4. 增加 React Testing Library 回归测试，覆盖同前缀模型分组名称场景。

本次修改使用了 AI 辅助，我已审阅并确认代码变更、测试内容和 PR 描述。

## 📸 运行证明 / Proof of Work

已在游乐场页面创建并测试以下模型分组：

- `Claude-Code-Kiro-A`
- `Claude-Code-Kiro-Long-Context`

修改前，两者在下拉列表中都显示为相同的截断前缀，无法区分。

修改后：

- 下拉列表仍保持原有紧凑布局；
- 鼠标悬浮在模型分组选项上时，可以看到完整的分组名称；
- 鼠标悬浮在当前选中的分组徽标上时，也可以看到完整名称。

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 本次修改使用 AI 辅助，但我已审阅全部代码和 PR 描述，并对其准确性与完整性负责。
- [x] **非重复提交:** 已检查当前代码和相关布局历史，确认该问题尚未被现有修复覆盖。
- [ ] **新功能关联 Issue:** 本次为 Bug 修复，不涉及新功能。
- [ ] **事前沟通:** 本次为小范围前端 Bug 修复，不涉及重大方向调整。
- [x] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口，也不是 Codex 渠道类型改动。
- [x] **范围聚焦:** 本 PR 仅包含模型分组名称显示修复及对应回归测试。
- [x] **本地验证:** 已运行相关测试并通过。
- [x] **安全合规:** 未包含敏感凭据，不涉及后端、数据库、鉴权或计费逻辑。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added tooltips to the selected model group and group options, making full labels visible when names are truncated.

* **Tests**
  * Added coverage verifying that truncated group labels display their complete text on hover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->