### PR TITLE
fix: harden SSE encoding, close Coze stream body, and remove dead default-password code

### DIFF
--- a/common/custom-event.go
+++ b/common/custom-event.go
@@ -62,8 +62,9 @@ func encode(writer io.Writer, event CustomEvent) error {
 }
 
 func writeData(w stringWriter, data interface{}) error {
-	dataReplacer.WriteString(w, fmt.Sprint(data))
-	if strings.HasPrefix(data.(string), "data") {
+	s := fmt.Sprint(data)
+	dataReplacer.WriteString(w, s)
+	if strings.HasPrefix(s, "data") {
 		w.writeString("\n\n")
 	}
 	return nil

--- a/common/custom_event_test.go
+++ b/common/custom_event_test.go
@@ -1,0 +1,40 @@
+package common
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteDataDoesNotPanicOnNonStringData(t *testing.T) {
+	tests := []struct {
+		name       string
+		data       interface{}
+		wantSuffix string
+	}{
+		{name: "string starting with data", data: "data: hello", wantSuffix: "\n\n"},
+		{name: "string not starting with data", data: "event: hello", wantSuffix: ""},
+		{name: "map data", data: map[string]string{"a": "b"}, wantSuffix: ""},
+		{name: "struct data", data: struct{ A int }{A: 1}, wantSuffix: ""},
+		{name: "int data", data: 42, wantSuffix: ""},
+		{name: "bytes data", data: []byte("data bytes"), wantSuffix: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := checkWriter(&buf)
+
+			require.NotPanics(t, func() {
+				_ = writeData(w, tt.data)
+			})
+
+			if tt.wantSuffix != "" {
+				assert.True(t, strings.HasSuffix(buf.String(), tt.wantSuffix), "output = %q", buf.String())
+			}
+		})
+	}
+}

--- a/model/main.go
+++ b/model/main.go
@@ -67,29 +67,6 @@ var DB *gorm.DB
 
 var LOG_DB *gorm.DB
 
-func createRootAccountIfNeed() error {
-	var user User
-	//if user.Status != common.UserStatusEnabled {
-	if err := DB.First(&user).Error; err != nil {
-		common.SysLog("no user exists, create a root user for you: username is root, password is 123456")
-		hashedPassword, err := common.Password2Hash("123456")
-		if err != nil {
-			return err
-		}
-		rootUser := User{
-			Username:    "root",
-			Password:    hashedPassword,
-			Role:        common.RoleRootUser,
-			Status:      common.UserStatusEnabled,
-			DisplayName: "Root User",
-			AccessToken: nil,
-			Quota:       100000000,
-		}
-		DB.Create(&rootUser)
-	}
-	return nil
-}
-
 func CheckSetup() {
 	setup := GetSetup()
 	if setup == nil {

--- a/relay/channel/coze/relay-coze.go
+++ b/relay/channel/coze/relay-coze.go
@@ -98,6 +98,7 @@ func cozeChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Res
 }
 
 func cozeChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
+	defer service.CloseResponseBodyGracefully(resp)
 	scanner := helper.NewStreamScanner(resp.Body)
 	scanner.Split(bufio.ScanLines)
 	helper.SetEventStreamHeaders(c)


### PR DESCRIPTION
## 📝 变更描述 / Description

本 PR 包含三个小而独立的健壮性/安全修复：

1. **修复 SSE 事件编码的潜在 panic**（`common/custom-event.go`）：`writeData` 接收 `interface{}`，却无保护地做 `data.(string)` 断言。只要传入非 string（例如未来某个渠道传入 struct/`[]byte`/map），整个流式响应就会 panic。改为先 `fmt.Sprint(data)` 再对字符串判断前缀，并补充回归测试。

2. **修复 Coze 流式响应体未关闭导致的连接泄漏**（`relay/channel/coze/relay-coze.go`）：`cozeChatStreamHandler` 现在通过 `defer service.CloseResponseBodyGracefully(resp)` 确保响应体关闭、归还连接池。

3. **删除死代码中硬编码的默认管理员口令**（`model/main.go`）：`createRootAccountIfNeed` 全仓库无任何调用点，却包含 `root/123456` 硬编码口令字面量，属安全负债，直接删除。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [x] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
无（本次为主动审计发现，未关联既有 Issue）。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 已亲自整理并撰写此描述。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs。
- [x] **变更理解:** 已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已本地运行并验证通过（见下方运行证明）。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- `go build ./common/... ./model/... ./relay/channel/coze/...` → 成功
- `go test ./common/ -run TestWriteData -v` → PASS（新增用例覆盖非 string 数据不再 panic）

---

> 说明：本 PR 由 AI 辅助完成代码审计与修改（提交者 Sunrise992023 非上游仓库历史核心开发者）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed event handling so non-string data types no longer cause errors during processing.
  - Improved streaming response cleanup to prevent resources from remaining open after a request ends.
  - Removed automatic creation of a default root account with preset credentials when no users exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->