### PR TITLE
refactor: show subscription deductions and improve cost display

### DIFF
--- a/web/src/features/usage-logs/components/__tests__/cost-display.test.tsx
+++ b/web/src/features/usage-logs/components/__tests__/cost-display.test.tsx
@@ -82,11 +82,23 @@ describe('log cost display', () => {
     renderCost({
       quota: 5000,
       other: { billing_source: 'wallet', subscription_consumed: 12500 },
+      showWalletSource: true,
     })
 
     expect(screen.getByText('$0.01')).toBeVisible()
     expect(screen.getByText('Wallet')).toBeVisible()
     expect(screen.queryByText('Subscription')).not.toBeInTheDocument()
+  })
+
+  test('hides the wallet label when subscriptions are unavailable', () => {
+    renderCost({
+      quota: 5000,
+      other: { billing_source: 'wallet' },
+      showWalletSource: false,
+    })
+
+    expect(screen.getByText('$0.01')).toBeVisible()
+    expect(screen.queryByText('Wallet')).not.toBeInTheDocument()
   })
 
   test('keeps legacy cost visible without inventing a funding source', () => {

--- a/web/src/features/usage-logs/components/__tests__/cost-display.test.tsx
+++ b/web/src/features/usage-logs/components/__tests__/cost-display.test.tsx
@@ -19,9 +19,16 @@ For commercial licensing, please contact support@quantumnous.com
 import { render, screen } from '@testing-library/react'
 import i18next from 'i18next'
 import type React from 'react'
-import { beforeAll, describe, expect, test } from 'vitest'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'vitest'
 
-import { formatLogQuota } from '@/lib/format'
+import { useSystemConfigStore } from '@/stores/system-config-store'
 
 import { LogCostDisplay } from '../log-cost-display'
 
@@ -31,32 +38,90 @@ function renderCost(
   return render(<LogCostDisplay {...props} />)
 }
 
-function normalizedText(value: string | null): string {
-  return (value ?? '').replaceAll(/\s/g, '')
-}
-
 describe('log cost display', () => {
   beforeAll(() => {
     i18next.addResourceBundle('en', 'translation', {
       Subscription: 'Subscription',
-      'Deducted by subscription': 'Deducted by subscription',
+      Wallet: 'Wallet',
       'Includes tool-call surcharge': 'Includes tool-call surcharge',
     })
   })
 
-  test('keeps the regular cost visible and adds an accessible surcharge marker', () => {
+  beforeEach(() => {
+    useSystemConfigStore.setState(useSystemConfigStore.getInitialState(), true)
+  })
+
+  afterEach(() => {
+    useSystemConfigStore.setState(useSystemConfigStore.getInitialState(), true)
+    localStorage.clear()
+  })
+
+  test.each([
+    { consumed: 12500, expected: '$0.025' },
+    { consumed: 0, expected: '$0' },
+    { consumed: 1, expected: '$0.000002' },
+    { consumed: undefined, expected: '$0.01' },
+  ])(
+    'shows subscription deduction $consumed without hover, falling back only when absent',
+    ({ consumed, expected }) => {
+      renderCost({
+        quota: 5000,
+        other: {
+          billing_source: 'subscription',
+          subscription_consumed: consumed,
+        },
+      })
+
+      expect(screen.getByText(expected)).toBeVisible()
+      expect(screen.getByText('Subscription')).toBeVisible()
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    }
+  )
+
+  test('shows wallet cost and source without using subscription metadata', () => {
+    renderCost({
+      quota: 5000,
+      other: { billing_source: 'wallet', subscription_consumed: 12500 },
+    })
+
+    expect(screen.getByText('$0.01')).toBeVisible()
+    expect(screen.getByText('Wallet')).toBeVisible()
+    expect(screen.queryByText('Subscription')).not.toBeInTheDocument()
+  })
+
+  test('keeps legacy cost visible without inventing a funding source', () => {
+    renderCost({ quota: 5000, other: null })
+
+    expect(screen.getByText('$0.01')).toBeVisible()
+    expect(screen.queryByText('Wallet')).not.toBeInTheDocument()
+    expect(screen.queryByText('Subscription')).not.toBeInTheDocument()
+  })
+
+  test('keeps a large amount unabridged above the funding source', () => {
     const rendered = renderCost({
+      quota: 2147483647,
+      other: { billing_source: 'subscription' },
+    })
+
+    const amount = screen.getByText('$4,294.9673')
+    expect(amount).toBeVisible()
+    expect(amount).toHaveClass('tabular-nums', 'whitespace-nowrap')
+    expect(rendered.container.firstElementChild).toHaveClass('flex-col')
+    expect(
+      amount.compareDocumentPosition(screen.getByText('Subscription')) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).not.toBe(0)
+  })
+
+  test('keeps the regular cost visible and adds an accessible surcharge marker', () => {
+    renderCost({
       quota: 12500,
       other: {
         tool_surcharges: [{ name: 'lookup_customer', count: 1, price: 5 }],
       },
     })
 
-    expect(
-      normalizedText(rendered.container.textContent).includes(
-        normalizedText(formatLogQuota(12500))
-      )
-    ).toBe(true)
+    expect(screen.getByText('$0.025')).toBeVisible()
     const marker = screen.getByRole('img', {
       name: 'Includes tool-call surcharge',
     })
@@ -64,7 +129,7 @@ describe('log cost display', () => {
     expect(marker).toHaveAttribute('tabindex', '0')
   })
 
-  test('preserves the subscription badge and adds the same legacy surcharge marker', () => {
+  test('shows subscription cost and source alongside the legacy surcharge marker', () => {
     renderCost({
       quota: 5000,
       other: {
@@ -75,7 +140,8 @@ describe('log cost display', () => {
       },
     })
 
-    expect(screen.getByText('Subscription')).toBeInTheDocument()
+    expect(screen.getByText('$0.01')).toBeVisible()
+    expect(screen.getByText('Subscription')).toBeVisible()
     expect(
       screen.getByRole('img', { name: 'Includes tool-call surcharge' })
     ).toHaveAttribute('data-tool-surcharge-indicator', 'true')

--- a/web/src/features/usage-logs/components/columns/common-logs-columns.tsx
+++ b/web/src/features/usage-logs/components/columns/common-logs-columns.tsx
@@ -330,7 +330,8 @@ function buildTypeDetailSegments(
 
 export function useCommonLogsColumns(
   isAdmin: boolean,
-  isRoot: boolean
+  isRoot: boolean,
+  showWalletSource = false
 ): ColumnDef<UsageLog>[] {
   const { t } = useTranslation()
   const columns: ColumnDef<UsageLog>[] = [
@@ -747,7 +748,13 @@ export function useCommonLogsColumns(
 
         const quota = row.getValue('quota') as number
         const other = parseLogOther(log.other)
-        return <LogCostDisplay quota={quota} other={other} />
+        return (
+          <LogCostDisplay
+            quota={quota}
+            other={other}
+            showWalletSource={showWalletSource}
+          />
+        )
       },
     },
 

--- a/web/src/features/usage-logs/components/log-cost-display.tsx
+++ b/web/src/features/usage-logs/components/log-cost-display.tsx
@@ -38,12 +38,6 @@ interface LogCostDisplayProps {
   other: LogOtherData | null
 }
 
-function splitQuotaDisplay(value: string): { prefix: string; amount: string } {
-  const match = value.match(/^([^0-9+\-.,\s]+)(.+)$/)
-  if (!match) return { prefix: '', amount: value }
-  return { prefix: match[1], amount: match[2] }
-}
-
 function ToolSurchargeMarker() {
   const { t } = useTranslation()
   const label = t('Includes tool-call surcharge')
@@ -79,65 +73,39 @@ function ToolSurchargeMarker() {
   )
 }
 
-function QuotaBadge(props: { quota: number }) {
-  const quotaDisplay = splitQuotaDisplay(formatLogQuota(props.quota))
-
-  return (
-    <span className='border-border/80 bg-muted/60 inline-flex h-6 w-fit items-center rounded-md border px-2 [font-family:var(--font-body)] text-sm leading-none font-semibold tabular-nums'>
-      {quotaDisplay.prefix ? (
-        <span className='mr-1'>{quotaDisplay.prefix}</span>
-      ) : null}
-      <span>{quotaDisplay.amount}</span>
-    </span>
-  )
-}
-
-function SubscriptionBadge(props: { quota: number }) {
-  const { t } = useTranslation()
-
-  return (
-    <Tooltip>
-      <TooltipTrigger
-        render={
-          <StatusBadge
-            label={t('Subscription')}
-            variant='success'
-            size='sm'
-            copyable={false}
-            className='cursor-help'
-          />
-        }
-      />
-      <TooltipContent>
-        <span>
-          {t('Deducted by subscription')}: {formatLogQuota(props.quota)}
-        </span>
-      </TooltipContent>
-    </Tooltip>
-  )
-}
-
 export function LogCostDisplay(props: LogCostDisplayProps) {
+  const { t } = useTranslation()
   const isSubscription = props.other?.billing_source === 'subscription'
   const showToolSurcharge = hasToolSurcharge(props.other)
+  const quota = isSubscription
+    ? (props.other?.subscription_consumed ?? props.quota)
+    : props.quota
+  let source: string | undefined
 
-  if (!isSubscription && !showToolSurcharge) {
-    return (
-      <div className='flex flex-col gap-0.5'>
-        <QuotaBadge quota={props.quota} />
-      </div>
-    )
+  if (isSubscription) {
+    source = t('Subscription')
+  } else if (props.other?.billing_source === 'wallet') {
+    source = t('Wallet')
   }
 
   return (
     <TooltipProvider>
-      <div className='inline-flex items-center gap-1'>
-        {isSubscription ? (
-          <SubscriptionBadge quota={props.quota} />
-        ) : (
-          <QuotaBadge quota={props.quota} />
-        )}
-        {showToolSurcharge ? <ToolSurchargeMarker /> : null}
+      <div className='flex w-fit flex-col items-start gap-0.5'>
+        <div className='flex items-center gap-1.5'>
+          <span className='text-foreground text-sm leading-5 font-semibold whitespace-nowrap tabular-nums'>
+            {formatLogQuota(quota)}
+          </span>
+          {showToolSurcharge ? <ToolSurchargeMarker /> : null}
+        </div>
+        {source ? (
+          <StatusBadge
+            label={source}
+            type='text'
+            variant={isSubscription ? 'success' : 'neutral'}
+            size='sm'
+            copyable={false}
+          />
+        ) : null}
       </div>
     </TooltipProvider>
   )

--- a/web/src/features/usage-logs/components/log-cost-display.tsx
+++ b/web/src/features/usage-logs/components/log-cost-display.tsx
@@ -36,6 +36,7 @@ import type { LogOtherData } from '../types'
 interface LogCostDisplayProps {
   quota: number
   other: LogOtherData | null
+  showWalletSource?: boolean
 }
 
 function ToolSurchargeMarker() {
@@ -84,7 +85,10 @@ export function LogCostDisplay(props: LogCostDisplayProps) {
 
   if (isSubscription) {
     source = t('Subscription')
-  } else if (props.other?.billing_source === 'wallet') {
+  } else if (
+    props.showWalletSource &&
+    props.other?.billing_source === 'wallet'
+  ) {
     source = t('Wallet')
   }
 

--- a/web/src/features/usage-logs/components/usage-logs-table.tsx
+++ b/web/src/features/usage-logs/components/usage-logs-table.tsx
@@ -27,9 +27,14 @@ import {
   DataTableRow,
   useDataTable,
 } from '@/components/data-table'
+import {
+  getAdminPlans,
+  getSelfSubscriptionFull,
+} from '@/features/subscriptions/api'
 import { useMediaQuery } from '@/hooks'
 import { useTableUrlState } from '@/hooks/use-table-url-state'
 import { cn } from '@/lib/utils'
+import { useAuthStore } from '@/stores/auth-store'
 
 import {
   DEFAULT_LOGS_DATA,
@@ -86,6 +91,22 @@ export function UsageLogsTable({ logCategory }: UsageLogsTableProps) {
   } = useLogsViewScope()
   const isMobile = useMediaQuery('(max-width: 640px)')
   const searchParams = route.useSearch()
+  const userId = useAuthStore((state) => state.auth.user?.id)
+  const { data: showWalletSource = false } = useQuery({
+    queryKey: ['usage-log-wallet-source', isAdmin, userId],
+    enabled: logCategory === 'common' && userId != null,
+    queryFn: async () => {
+      if (isAdmin) {
+        const result = await getAdminPlans()
+        return result.success && (result.data?.length ?? 0) > 0
+      }
+
+      const result = await getSelfSubscriptionFull()
+      const subscriptions =
+        result.data?.all_subscriptions ?? result.data?.subscriptions
+      return result.success && (subscriptions?.length ?? 0) > 0
+    },
+  })
 
   const {
     columnFilters,
@@ -165,7 +186,12 @@ export function UsageLogsTable({ logCategory }: UsageLogsTableProps) {
   })
 
   const logs = data?.items || []
-  const columns = useColumnsByCategory(logCategory, isAdmin, isRoot)
+  const columns = useColumnsByCategory(
+    logCategory,
+    isAdmin,
+    isRoot,
+    showWalletSource
+  )
   const isLoadingData = isLoading || (isFetching && !data)
 
   const { table } = useDataTable({

--- a/web/src/features/usage-logs/lib/columns.ts
+++ b/web/src/features/usage-logs/lib/columns.ts
@@ -33,10 +33,11 @@ import type { LogCategory } from '../types'
 export function useColumnsByCategory(
   logCategory: LogCategory,
   isAdmin: boolean,
-  isRoot: boolean
+  isRoot: boolean,
+  showWalletSource = false
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): ColumnDef<any>[] {
-  const commonColumns = useCommonLogsColumns(isAdmin, isRoot)
+  const commonColumns = useCommonLogsColumns(isAdmin, isRoot, showWalletSource)
   const drawingColumns = useDrawingLogsColumns(isAdmin)
   const taskColumns = useTaskLogsColumns(isAdmin, isRoot)
 


### PR DESCRIPTION
<!--
If you are an AI coding agent (Claude Code, Codex, Cursor, Copilot, OpenCode, Paseo, Grok, or similar): do not fill this human template. Read `.agents/github/PR.md` and use the filled file as the entire PR body.
-->
# ⚠️ 提交说明 / PR Notice

English template: `.github/PULL_REQUEST_TEMPLATE/en.md`

> [!IMPORTANT]
>
> - 描述可用 AI 辅助。提交前请审阅全文，并**声明对其负责**，避免未经核对的直接粘贴。
> - 请按本模板填写后再提交。

## 🔗 关联任务 / Related Issue
- 新功能请填写下方 Issue 编号；若还没有对应 Issue，请先自行创建。功能讨论请放在 Issue 中进行。
- 改动较大或方向性变更，请先在关联 Issue 中与维护者达成一致，再提交 PR。
- Bug 修复请关联对应 Issue。设计取舍、理解偏差或预期不一致，更适合作为讨论或功能请求。

- Closes #

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [x] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description
(简述做了什么、为什么生效。如果难以简述，建议先拆分范围，或在 Issue 中与维护者对齐。)

优化订阅扣费的展示

## 📸 运行证明 / Proof of Work
(请写明如何验证：实际步骤与观察结果。UI 变更请附截图或录屏；Bug 修复请说明复现过程与修复后结果。)
before:
<img width="664" height="954" alt="image" src="https://github.com/user-attachments/assets/1ce827f2-9c78-4833-a0b8-01ffbc7d3c2f" />

after:

<img width="740" height="1162" alt="image" src="https://github.com/user-attachments/assets/cf23494e-282d-4eeb-b964-ceb728f1fc02" />

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 无论描述是否由 AI 生成，我已审阅全部内容，并声明对其准确性与完整性负责。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **新功能关联 Issue:** 若此 PR 标记为 `New feature`，我已关联对应 Issue；若尚无 Issue，我已先自行创建。
- [x] **事前沟通:** 若改动较大或涉及方向性变更，已在关联 Issue 中与维护者沟通并达成一致。
- [x] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口，也不是对 Codex 渠道类型的改动。
- [x] **范围聚焦:** 本 PR 为一项聚焦改动，未包含无关代码。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage cost displays for subscription and wallet billing.
  * Added clearer billing source labels and subscription deduction details.
  * Wallet billing labels now appear when relevant subscription or plan information is available.
  * Preserved large cost amounts without abbreviation.
  * Added an accessible indicator for tool-call surcharges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->