### PR TITLE
fix: realtime (wss) 会话双重扣费——结算只补未扣差额

### DIFF
--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -132,6 +132,10 @@ type RelayInfo struct {
 	ChatToGeminiStreamState any
 	ReceivedResponseCount   int
 	FinalPreConsumedQuota   int // 最终预消耗的配额
+	// RealtimeIncrementalQuota 累计 realtime（wss）会话中已按增量实时扣除的额度。
+	// 每个 response.done 段落经 PostConsumeQuota 实扣一次并累加到这里；
+	// 会话结束时的总结算以该值为基数只补差额，避免与增量扣费重复计费。
+	RealtimeIncrementalQuota int64
 	// ForcePreConsume 为 true 时禁用 BillingSession 的信任额度旁路，
 	// 强制预扣全额。用于异步任务（视频/音乐生成等），因为请求返回后任务仍在运行，
 	// 必须在提交前锁定全额。

--- a/service/quota.go
+++ b/service/quota.go
@@ -150,6 +150,7 @@ func PreWssConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, usag
 	if err != nil {
 		return err
 	}
+	relayInfo.RealtimeIncrementalQuota += int64(quota)
 	logger.LogInfo(ctx, "realtime streaming consume quota success, quota: "+fmt.Sprintf("%d", quota))
 	return nil
 }
@@ -227,7 +228,12 @@ func PostWssConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, mod
 		model.UpdateChannelUsedQuota(relayInfo.ChannelId, quota)
 	}
 
-	if err := SettleBilling(ctx, relayInfo, quota); err != nil {
+	// 结算只补差额：realtime 会话中每个 response.done 段落已经通过
+	// PreWssConsumeQuota 实时扣过费（RealtimeIncrementalQuota 累计），
+	// 总额里只结算尚未扣除的部分；增量扣除已超过总额时净额为负，
+	// SettleBilling 会走返还路径退回多扣部分，保证净扣费恰好等于总额。
+	netQuota := quota - int(relayInfo.RealtimeIncrementalQuota)
+	if err := SettleBilling(ctx, relayInfo, netQuota); err != nil {
 		logger.LogError(ctx, "error settling billing: "+err.Error())
 	}
 

--- a/service/wss_quota_test.go
+++ b/service/wss_quota_test.go
@@ -1,0 +1,197 @@
+package service
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/QuantumNous/new-api/model"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/QuantumNous/new-api/setting/ratio_setting"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// initWssTestDB initializes the dialect-specific column mappings through the
+// real InitLogDB entry (LOG_SQL_DSN unset ⇒ LOG_DB = DB), which the shared
+// TestMain does not run. PreWssConsumeQuota resolves tokens via the mapped
+// key column, so the mapping must exist before the billing paths run.
+func initWssTestDB(t *testing.T) {
+	t.Helper()
+	if err := model.InitLogDB(); err != nil {
+		t.Fatalf("init log db: %s", err)
+	}
+}
+
+// TestPostWssConsumeQuotaSettlesOnlyTheUnbilledRemainder pins the realtime
+// billing contract: every response.done segment is charged in real time by
+// PreWssConsumeQuota, so the end-of-session settlement may only collect the
+// remainder (and refund via the negative-delta path when the increments have
+// already covered the total). The net wallet/token movement over the whole
+// session must equal the total quota of the summed usage — nothing more.
+func TestPostWssConsumeQuotaSettlesOnlyTheUnbilledRemainder(t *testing.T) {
+	truncate(t)
+	initWssTestDB(t)
+	gin.SetMode(gin.TestMode)
+
+	previousRatios := ratio_setting.ModelRatio2JSONString()
+	require.NoError(t, ratio_setting.UpdateModelRatioByJSONString(`{"realtime-test-model":1}`))
+	t.Cleanup(func() {
+		require.NoError(t, ratio_setting.UpdateModelRatioByJSONString(previousRatios))
+	})
+
+	const (
+		userID    = 60
+		tokenID   = 60
+		channelID = 60
+	)
+	const initialQuota, tokenRemain, preConsumed = 100_000, 50_000, 2_000
+
+	seedUser(t, userID, initialQuota)
+	seedToken(t, tokenID, userID, "realtime-wss-key", tokenRemain)
+	seedChannel(t, channelID)
+
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/realtime", nil)
+	ctx.Set("token_name", "test_token")
+
+	relayInfo := &relaycommon.RelayInfo{
+		UserId:          userID,
+		TokenId:         tokenID,
+		TokenKey:        "sk-realtime-wss-key",
+		OriginModelName: "realtime-test-model",
+		UsingGroup:      "default",
+		StartTime:       time.Now(),
+		IsStream:        true,
+		// 绕过信任额度旁路，预扣一个可预期的 P（与生产 wss 计费路径一致）
+		ForcePreConsume: true,
+		ChannelMeta:     &relaycommon.ChannelMeta{ChannelId: channelID},
+		PriceData: types.PriceData{
+			ModelRatio:     1,
+			GroupRatioInfo: types.GroupRatioInfo{GroupRatio: 1},
+		},
+	}
+
+	if apiErr := PreConsumeBilling(ctx, preConsumed, relayInfo); apiErr != nil {
+		t.Fatalf("pre-consume billing failed: %s", apiErr.Error())
+	}
+	require.NotNil(t, relayInfo.Billing)
+
+	// 一个 response.done 段落：10 输入 + 10 输出文本 token（纯文本，便于对账）
+	segmentUsage := func() *dto.RealtimeUsage {
+		return &dto.RealtimeUsage{
+			TotalTokens:        20,
+			InputTokens:        10,
+			OutputTokens:       10,
+			InputTokenDetails:  dto.InputTokenDetails{TextTokens: 10},
+			OutputTokenDetails: dto.OutputTokenDetails{TextTokens: 10},
+		}
+	}
+
+	segQuota, clamp := calculateAudioQuota(QuotaInfo{
+		InputDetails:  TokenDetails{TextTokens: 10},
+		OutputDetails: TokenDetails{TextTokens: 10},
+		ModelName:     "realtime-test-model",
+		ModelRatio:    1,
+		GroupRatio:    1,
+	})
+	require.Nil(t, clamp)
+	require.Positive(t, segQuota)
+
+	// 两个段落逐段实扣（模拟 relay_realtime.go 的 preConsumeUsage 循环）
+	require.NoError(t, PreWssConsumeQuota(ctx, relayInfo, segmentUsage()))
+	require.NoError(t, PreWssConsumeQuota(ctx, relayInfo, segmentUsage()))
+	require.EqualValues(t, 2*segQuota, relayInfo.RealtimeIncrementalQuota)
+	require.Equal(t, initialQuota-preConsumed-2*segQuota, getUserQuota(t, userID))
+
+	// 会话结束：按累计总量结算
+	totalUsage := &dto.RealtimeUsage{
+		TotalTokens:        40,
+		InputTokens:        20,
+		OutputTokens:       20,
+		InputTokenDetails:  dto.InputTokenDetails{TextTokens: 20},
+		OutputTokenDetails: dto.OutputTokenDetails{TextTokens: 20},
+	}
+	totalQuota, clamp := calculateAudioQuota(QuotaInfo{
+		InputDetails:  TokenDetails{TextTokens: 20},
+		OutputDetails: TokenDetails{TextTokens: 20},
+		ModelName:     "realtime-test-model",
+		ModelRatio:    1,
+		GroupRatio:    1,
+	})
+	require.Nil(t, clamp)
+	require.Positive(t, totalQuota)
+
+	PostWssConsumeQuota(ctx, relayInfo, "realtime-test-model", totalUsage, "")
+
+	// 净扣费必须恰好等于总量：增量已扣过的部分不得重复扣
+	assert.Equal(t, initialQuota-totalQuota, getUserQuota(t, userID))
+	assert.Equal(t, tokenRemain-totalQuota, getTokenRemainQuota(t, tokenID))
+
+	// 统计口径记录总量，与净扣费一致（日志与余额可对账）
+	usedQuota, requestCount := getUserUsageAccounting(t, userID)
+	assert.Equal(t, totalQuota, usedQuota)
+	assert.Equal(t, 1, requestCount)
+	assert.EqualValues(t, totalQuota, getChannelUsedQuota(t, channelID))
+}
+
+// TestPreWssConsumeQuotaRejectsWhenBalanceRunsDry keeps the live-balance
+// enforcement of the incremental charge: once the wallet cannot cover a
+// segment, PreWssConsumeQuota must fail so the relay disconnects the session.
+func TestPreWssConsumeQuotaRejectsWhenBalanceRunsDry(t *testing.T) {
+	truncate(t)
+	initWssTestDB(t)
+	gin.SetMode(gin.TestMode)
+
+	previousRatios := ratio_setting.ModelRatio2JSONString()
+	require.NoError(t, ratio_setting.UpdateModelRatioByJSONString(`{"realtime-test-model":1}`))
+	t.Cleanup(func() {
+		require.NoError(t, ratio_setting.UpdateModelRatioByJSONString(previousRatios))
+	})
+
+	const (
+		userID    = 61
+		tokenID   = 61
+		channelID = 61
+	)
+	// 钱包/令牌额度只够扣第一段（20），第二段必须被拒
+	const initialQuota, tokenRemain = 30, 30
+
+	seedUser(t, userID, initialQuota)
+	seedToken(t, tokenID, userID, "realtime-dry-key", tokenRemain)
+	seedChannel(t, channelID)
+
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/realtime", nil)
+	ctx.Set("token_name", "test_token")
+
+	relayInfo := &relaycommon.RelayInfo{
+		UserId:          userID,
+		TokenId:         tokenID,
+		TokenKey:        "sk-realtime-dry-key",
+		OriginModelName: "realtime-test-model",
+		UsingGroup:      "default",
+		StartTime:       time.Now(),
+		ChannelMeta:     &relaycommon.ChannelMeta{ChannelId: channelID},
+		PriceData: types.PriceData{
+			ModelRatio:     1,
+			GroupRatioInfo: types.GroupRatioInfo{GroupRatio: 1},
+		},
+	}
+
+	usage := &dto.RealtimeUsage{
+		TotalTokens:        20,
+		InputTokens:        10,
+		OutputTokens:       10,
+		InputTokenDetails:  dto.InputTokenDetails{TextTokens: 10},
+		OutputTokenDetails: dto.OutputTokenDetails{TextTokens: 10},
+	}
+
+	// 无预扣会话（Billing == nil）时也允许逐段扣费；钱包见底必须报错断流
+	require.NoError(t, PreWssConsumeQuota(ctx, relayInfo, usage))
+	require.Error(t, PreWssConsumeQuota(ctx, relayInfo, usage))
+}


### PR DESCRIPTION
## Agent

- Tool: Claude Code
- Tool version: 2.1.234
- Model (full id): glm-5.3-flash
- Host (CLI / IDE / GitHub coding agent / other): CLI
- Date (UTC): 2026-09-09

## Links

- Closes #7273
- Related: #5690、#6598

## User request

（verbatim）"继续找国内的高star含金量项目去做pr吧" —— 计费链路审计发现的资金级 bug，随 issue 附修复。

## Out of scope — refuse

If the request matches any item below, tell the user this repository does not
accept it, point them to the right place when there is one, and **do not open a PR**.

- Coding Plan
- Reverse-engineered channels
- Third-party API wrappers
- Compatibility issues from exposing a Codex endpoint as a general-purpose API through a reverse proxy
- Codex API-specific protocol or behavior treated as standard OpenAI API behavior (confirm with the channel or API provider)
- Pass-through mode forwarding (pass-through forwards as-is; verify upstream yourself)
- Relay reports that only paste an upstream error, with no direct-upstream vs new-api comparison
- Third-party hosting sites, relay services, or API services (contact their operator)
- Usage, configuration, or integration questions (answer from docs and code instead)

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): 不适用

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

（取自 #7273）

- Actual behavior: realtime 会话净扣费 = 总额 + Σ增量（复现：应扣 40 实扣 80）
- Impact: 所有 realtime 会话约 2 倍扣费，钱包/订阅双资金源受影响
- Frequency: 每会话 100%
- Evidence that the problem is in new-api rather than the client or upstream: 纯本地记账路径，内存 sqlite 测试修复前稳定复现差值
- Applicable types and their fields: Billing（详见 issue）；relay/frontend/deployment 不适用

## Change

- `relay/common/relay_info.go`：`RelayInfo` 新增 `RealtimeIncrementalQuota int64`，累计本会话已逐段实扣的配额
- `service/quota.go` PreWssConsumeQuota：每段 `PostConsumeQuota` 成功后累加该字段
- `service/quota.go` PostWssConsumeQuota：结算改为只补差额 `netQuota := quota - int(relayInfo.RealtimeIncrementalQuota)`；差额为负（增量已超总额）时，`SettleBilling`→`BillingSession.Settle` 既有负差额路径自然退回多扣部分
- 音频路径 `PostAudioConsumeQuota` 不动（无逐段实扣，字段恒 0）
- 统计与消费日志保持记录会话总额——修复后该口径第一次与净扣费一致

## Research

### Duplicate / prior art

- Search queries (issues, PRs): "realtime double charge" / "双重扣费" / "realtime billing" / "wss 扣费" / "realtime 扣费"
- What already existed and why this is not a duplicate: #5690 预扣 TOCTOU、#6598 byte 计费，均与本结算基数问题无关

### Docs and code

- https://docs.newapi.ai/ : 首页无 realtime 计费文档
- https://deepwiki.com/QuantumNous/new-api : 未检索（以源码为准）
- README / repo docs: 无
- Code paths and what they imply for this change: `preConsumeUsage` 先折账后计费的顺序决定了累计总额≡已实扣 usage 之和 → 差额法天然正确；`BillingSession.Settle` 负差额原生支持返还（WalletFunding.IncreaseUserQuota / Subscription PostDelta），无需新增返还机制

### Alternatives considered

- Option A: 会话内不做逐段实扣，全部留到会话末结算 —— 丢弃实时余额校验，余额不足的会话会拖到结束才停，攻击面变大，放弃
- Option B: 结算时逐段回放重算 —— 复杂度高、易错，放弃
- Why this approach: 差额法一行记账 + 既有负差额返还路径，改动最小、语义精确

## Files

| Path | Why |
| --- | --- |
| relay/common/relay_info.go | 新增增量记账字段 |
| service/quota.go | 增量累加 + 差额结算 |
| service/wss_quota_test.go | 两条回归测试（内存 sqlite 计费环境） |

## Behavior

- Before: 净扣费 = 总额 + Σ增量（约 2 倍）
- After: 净扣费 = 总额；增量超扣自动退回；统计口径=总额（与净扣一致）
- Explicit non-goals / leftover work: 免费 realtime 模型逐段扣费、中途断流增量不结算——已在 #7273 中挂账为后续独立问题

## Verification

Only what was actually run.

- Commands and results（均在 rebase 到 main 4fc9d1f1 之后重跑）:
  - `go build ./...` → OK
  - `go test ./service/ -run 'TestPostWssConsumeQuotaSettlesOnlyTheUnbilledRemainder|TestPreWssConsumeQuotaRejectsWhenBalanceRunsDry' -count=1` → 2/2 PASS
- Manual steps and observed result: 修复前对照（同一测试、掐掉新字段断言）：钱包 expected 99960 / actual 99920，令牌 expected 49960 / actual 49920 —— 差值恰为两段增量 40；修复后全部相等
- UI: screenshot or recording (or why none): 无 UI 改动
- Tests added or updated, or why none: 新增 `service/wss_quota_test.go`：①两段实扣+会话结算后钱包/令牌/统计恰等于总额（旗舰不变量）；②无预扣会话下余额见底仍逐段报错断流（实时校验不回退）
- Databases / providers / platforms exercised: sqlite 内存库（测试环境）
- Not verified: 生产 mysql/postgres、真实上游 realtime 联调
- Upstream note: ebe4c368（`interface{}`→`any` 重构）与本改动同文件不同语义区域，本分支已 rebase 其上并全量重验；`go test ./service/ -count=1` 中 `TestObserveChannelAffinityUsageCacheByRelayFormat_UnsupportedModeKeepsEmpty` 为上游现存测试间状态污染（在未改动的主流基线干净树上同样 FAIL，stash 验证过），与本 PR 无关

## Risks

- Failure modes: 记账字段依赖 `RelayInfo` 生命周期与会话一一对应（现状即如此，每个 wss 会话一个 RelayInfo）
- Billing / quota / auth impact: 正向——用户侧从超收取回等额；统计/日志口径不变
- Follow-ups: issue 中挂账的两项后续观察

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved realtime session billing to prevent duplicate charges when usage is billed incrementally.
  - Final session settlement now charges only outstanding usage or refunds any overpayment.
  - Realtime usage is rejected when the available balance cannot cover a segment.

- **Tests**
  - Added coverage for incremental charging, final settlement, and insufficient-balance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->