### PR TITLE
fix: 多 key 轮询保存不再回滚并发的 per-key 状态更新（丢失更新）

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -252,20 +252,20 @@ func (channel *Channel) GetNextEnabledKey() (string, int, *types.NewAPIError) {
 	case constant.MultiKeyModePolling:
 		// Use channel-specific lock to ensure thread-safe polling
 
+		// CacheGetChannelInfo re-reads the current ChannelInfo from the DB (or
+		// the shared cache) while we hold the same per-channel polling lock that
+		// UpdateChannelStatus holds across its own read-modify-write. The
+		// request's `channel` snapshot, by contrast, was read before this lock,
+		// so its ChannelInfo may be stale.
 		channelInfo, err := CacheGetChannelInfo(channel.Id)
 		if err != nil {
 			return "", 0, types.NewError(err, types.ErrorCodeGetChannelFailed, types.ErrOptionWithSkipRetry())
 		}
-		defer func() {
-			if common.DebugEnabled {
-				logger.LogDebug(nil, "channel %d polling index: %d", channel.Id, channel.ChannelInfo.MultiKeyPollingIndex)
-			}
-			if !common.MemoryCacheEnabled {
-				_ = channel.SaveChannelInfo()
-			} else {
-				// CacheUpdateChannel(channel)
-			}
-		}()
+		if common.DebugEnabled {
+			defer func() {
+				logger.LogDebug(nil, "channel %d polling index: %d", channel.Id, channelInfo.MultiKeyPollingIndex)
+			}()
+		}
 		// Start from the saved polling index and look for the next enabled key
 		start := channelInfo.MultiKeyPollingIndex
 		if start < 0 || start >= len(keys) {
@@ -275,7 +275,17 @@ func (channel *Channel) GetNextEnabledKey() (string, int, *types.NewAPIError) {
 			idx := (start + i) % len(keys)
 			if getStatus(idx) == common.ChannelStatusEnabled {
 				// update polling index for next call (point to the next position)
-				channel.ChannelInfo.MultiKeyPollingIndex = (idx + 1) % len(keys)
+				channelInfo.MultiKeyPollingIndex = (idx + 1) % len(keys)
+				if !common.MemoryCacheEnabled {
+					// channel_info is a single JSON column holding both the
+					// polling cursor and the per-key status list. Persist the
+					// freshly read ChannelInfo — never the request's stale
+					// snapshot, which would silently revert a concurrent key
+					// disable/enable that UpdateChannelStatus just persisted.
+					if err := DB.Model(&Channel{}).Where("id = ?", channel.Id).Update("channel_info", *channelInfo).Error; err != nil {
+						common.SysLog(fmt.Sprintf("failed to save multi-key polling index: channel_id=%d, error=%v", channel.Id, err))
+					}
+				}
 				return keys[idx], idx, nil
 			}
 		}

--- a/model/channel_status_test.go
+++ b/model/channel_status_test.go
@@ -100,3 +100,82 @@ func TestSaveStatusStateFromSingleKeySnapshotPreservesUnownedColumns(t *testing.
 	assert.Equal(t, "manual operation", otherInfo["status_reason"])
 	assert.Equal(t, float64(1234), otherInfo["status_time"])
 }
+
+func seedPollingChannel(t *testing.T, name string) Channel {
+	t.Helper()
+	channel := Channel{
+		Name:   name,
+		Key:    "key-a\nkey-b",
+		Status: common.ChannelStatusEnabled,
+		ChannelInfo: ChannelInfo{
+			IsMultiKey:   true,
+			MultiKeySize: 2,
+			MultiKeyMode: constant.MultiKeyModePolling,
+		},
+	}
+	require.NoError(t, DB.Create(&channel).Error)
+	return channel
+}
+
+// TestGetNextEnabledKeyDoesNotRevertConcurrentKeyDisable pins the write side
+// of the polling path: the per-key status list updated by a concurrent
+// UpdateChannelStatus must survive a request whose channel snapshot was read
+// before that update. channel_info is a single JSON column, so persisting the
+// request's stale snapshot here used to re-enable keys that had just been
+// disabled.
+func TestGetNextEnabledKeyDoesNotRevertConcurrentKeyDisable(t *testing.T) {
+	setupChannelStatusTest(t)
+	channel := seedPollingChannel(t, "polling-lost-update")
+
+	// The request path reads its channel snapshot up front...
+	stale, err := GetChannelById(channel.Id, true)
+	require.NoError(t, err)
+
+	// ...and an async status update lands mid-request.
+	require.True(t, UpdateChannelStatus(channel.Id, "key-a", common.ChannelStatusAutoDisabled, "provider rejected key"))
+
+	// The request finishes selecting a key. The scan still uses the snapshot
+	// (the key was already handed out by the time it was disabled), but the
+	// persisted state must come from the fresh read, not the snapshot.
+	key, idx, apiErr := stale.GetNextEnabledKey()
+	require.Nil(t, apiErr)
+	assert.Equal(t, "key-a", key)
+	assert.Equal(t, 0, idx)
+
+	var stored Channel
+	require.NoError(t, DB.First(&stored, channel.Id).Error)
+	assert.Equal(t, common.ChannelStatusAutoDisabled, stored.ChannelInfo.MultiKeyStatusList[0],
+		"concurrent key disable was reverted by the polling save")
+	assert.Equal(t, 1, stored.ChannelInfo.MultiKeyPollingIndex,
+		"polling cursor was not persisted")
+	assert.Equal(t, "provider rejected key", stored.ChannelInfo.MultiKeyDisabledReason[0])
+}
+
+// TestGetNextEnabledKeyPersistsPollingCursorInDBMode keeps round-robin working
+// across independent reads when the memory cache is off: each call must pick up
+// the cursor persisted by the previous one.
+func TestGetNextEnabledKeyPersistsPollingCursorInDBMode(t *testing.T) {
+	setupChannelStatusTest(t)
+	channel := seedPollingChannel(t, "polling-cursor-persistence")
+
+	first, err := GetChannelById(channel.Id, true)
+	require.NoError(t, err)
+	key, idx, apiErr := first.GetNextEnabledKey()
+	require.Nil(t, apiErr)
+	assert.Equal(t, "key-a", key)
+	assert.Equal(t, 0, idx)
+
+	second, err := GetChannelById(channel.Id, true)
+	require.NoError(t, err)
+	key, idx, apiErr = second.GetNextEnabledKey()
+	require.Nil(t, apiErr)
+	assert.Equal(t, "key-b", key)
+	assert.Equal(t, 1, idx)
+
+	third, err := GetChannelById(channel.Id, true)
+	require.NoError(t, err)
+	key, idx, apiErr = third.GetNextEnabledKey()
+	require.Nil(t, apiErr)
+	assert.Equal(t, "key-a", key)
+	assert.Equal(t, 0, idx)
+}


### PR DESCRIPTION
## Agent

- Tool: Claude Code
- Tool version: 2.1.234
- Model (full id): glm-5.3-flash
- Host (CLI / IDE / GitHub coding agent / other): CLI
- Date (UTC): 2026-09-09

## Links

- Closes #7275
- Related: #1744、#7071、#6015、#4983

## User request

（verbatim）"继续找国内的高star含金量项目去做pr吧" —— 渠道容错链路审计发现的并发 bug，随 issue 附修复。

## Out of scope — refuse

If the request matches any item below, tell the user this repository does not
accept it, point them to the right place when there is one, and **do not open a PR**.

- Coding Plan
- Reverse-engineered channels
- Third-party API wrappers
- Compatibility issues from exposing a Codex endpoint as a general-purpose API through a reverse proxy
- Codex API-specific protocol or behavior treated as standard OpenAI API behavior (confirm with the channel or API provider)
- Pass-through mode forwarding (pass-through forwards as-is; verify upstream yourself)
- Relay reports that only paste an upstream error, with no direct-upstream vs new-api comparison
- Third-party hosting sites, relay services, or API services (contact their operator)
- Usage, configuration, or integration questions (answer from docs and code instead)

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): 不适用

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

（取自 #7275）

- Actual behavior: DB 模式下请求路径轮询保存用过期快照整列覆盖 `channel_info`，并发禁用的 key 被复活
- Impact: 坏 key 复活继续承接流量；禁用原因/时间被抹
- Frequency: DB 模式多 key 轮询渠道的高频并发窗口
- Evidence that the problem is in new-api rather than the client or upstream: 本地并发写问题，回归测试修复前红修复后绿
- Applicable types and their fields: deployment 相关（`MEMORY_CACHE_ENABLED` 关闭）；relay/billing/frontend 不适用

## Change

- `model/channel.go` GetNextEnabledKey 轮询分支：
  - 游标推进写在 `CacheGetChannelInfo` 返回的**锁内现读最新 ChannelInfo** 上（缓存模式=共享缓存对象，与现状等价；DB 模式=新读的私有对象）
  - DB 模式下立即持久化该最新对象（仅推进游标），删除原来对请求过期快照的整列延迟保存
  - 由此 `UpdateChannelStatus` 注释中的不变量"同一渠道锁内从首次读到持久化"在请求侧也成立——两侧写者不可能再用过期状态覆盖对方
  - debug 日志改为在持锁路径上报持久化后的游标
- 选 key 扫描仍用请求快照（key 已发出的固有竞态，重试兜底，良性，不在本 PR 范围）

## Research

### Duplicate / prior art

- Search queries (issues, PRs): "MultiKeyStatusList" / "polling index" / "轮询 key 状态"
- What already existed and why this is not a duplicate: #1744 缓存游标继承、#7071 自动恢复策略、#6015 key 测试恢复、#4983 缓存剔除——均非本丢失更新问题；`saveStatusState` 的列白名单（防止过期快照覆盖其他列）说明仓库已有此类防线意识，本 PR 补上被绕过的请求侧

### Docs and code

- https://docs.newapi.ai/ : 首页无相关文档
- https://deepwiki.com/QuantumNous/new-api : 未检索（以源码为准）
- README / repo docs: 无
- Code paths and what they imply for this change: `CacheGetChannelInfo` 在 DB 模式本就锁内现读（`GetChannelById`）——修复只需把写与持久化对齐到这个最新对象上，不引入新读放大；`UpdateChannelStatus` 持锁跨读改写，两侧共用 `GetChannelPollingLock`

### Alternatives considered

- Option A: 延迟保存改为只写游标子字段 —— `channel_info` 是单 JSON 列，无法原子更新子字段，仍需读改写，等于本方案
- Option B: 请求侧完全不落库、游标仅内存 —— DB 模式下轮询退化（每次都从头选），行为回退，放弃
- Why this approach: 复用既有锁内现读，写-持久化对齐到同一最新对象，改动局部、不变量完整

## Files

| Path | Why |
| --- | --- |
| model/channel.go | 轮询分支写-持久化对齐到锁内现读对象，删过期快照延迟保存 |
| model/channel_status_test.go | 两条回归测试（复用既有 sqlite 测试基建） |

## Behavior

- Before: 并发禁用可被请求路径延迟保存静默回滚；禁用原因/时间被抹
- After: 并发状态更新不可回滚；游标照常持久化，round-robin 不变；缓存模式行为不变
- Explicit non-goals / leftover work: 选 key 扫描的快照竞态（良性）；缓存模式语义重构

## Verification

Only what was actually run.

- Commands and results（均在 rebase 到 main 4fc9d1f1 之后重跑）:
  - `go build ./...` → OK
  - `go test ./model/ -run 'TestGetNextEnabledKey' -count=1` → PASS（含新增两条回归测试与既有轮询测试）
- Manual steps and observed result: mutant 演示——保留新测试、还原旧 `model/channel.go`：`TestGetNextEnabledKeyDoesNotRevertConcurrentKeyDisable` FAIL（禁用状态被回滚），恢复修复后 PASS
- UI: screenshot or recording (or why none): 无 UI 改动
- Tests added or updated, or why none: ①并发禁用存活 + 游标持久化（核心回归）；②DB 模式下跨独立读取的 round-robin 轮转
- Databases / providers / platforms exercised: sqlite 内存库
- Not verified: mysql/postgres 实测；缓存模式共享对象写竞争的更细粒度审计（语义保持现状）
- Upstream note: ebe4c368 把轮询循环改为 `for i := range keys` 并重排了 debug defer，与本改动同区域；本分支已 rebase 其上（合并结果保留本修复语义、采纳上游新循环语法，stale 延迟保存无残留），并在新基线上重跑全部测试

## Risks

- Failure modes: DB 模式每次轮询选 key 多一次已存在的现读（`CacheGetChannelInfo` 原本就在调），持久化时机从 defer 前移到选 key 成功时，写次数持平
- Billing / quota / auth impact: 无
- Follow-ups: 无

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multi-key polling to use the latest channel state when selecting and persisting keys.
  - Prevented concurrent key status updates from being unintentionally overwritten.
  - Ensured round-robin key selection remains consistent across independent channel reads.

- **Tests**
  - Added coverage for concurrent key disabling and polling cursor persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->