### PR TITLE
fix(pricing): keep model status bar spacing uniform

### DIFF
--- a/web/src/features/pricing/__tests__/model-cards.test.tsx
+++ b/web/src/features/pricing/__tests__/model-cards.test.tsx
@@ -154,6 +154,15 @@ describe('model cards', () => {
     expect(screen.getByRole('button', { name: 'Details' })).toBeEnabled()
   })
 
+  it('uses fixed spacing between hourly status bars', () => {
+    render(<ModelCard model={pricingModel()} onClick={vi.fn()} />)
+    const statusStrip = screen.getByRole('img', {
+      name: 'Recent success-rate samples; gray bars indicate missing data.',
+    })
+    expect(statusStrip).toHaveClass('gap-px')
+    expect(statusStrip).not.toHaveClass('justify-between')
+  })
+
   it('keeps group, endpoint and tag overflow counts with their own metadata', () => {
     const groups = ['default-with-a-long-group-name', 'premium', 'internal']
     const endpoints = ['openai-response', 'openai', 'claude', 'gemini', 'jina']

--- a/web/src/features/pricing/components/model-perf-badge.tsx
+++ b/web/src/features/pricing/components/model-perf-badge.tsx
@@ -96,7 +96,7 @@ export const ModelPerfBadge = memo(function ModelPerfBadge(
             title={t(
               'Recent success-rate samples; gray bars indicate missing data.'
             )}
-            className='mt-1 flex h-3 w-24 items-center justify-between'
+            className='mt-1 flex h-3 w-24 items-center gap-px'
           >
             {STATUS_SLOTS.map((slot) => {
               const rate = statusRates[slot]


### PR DESCRIPTION
## Agent

- Tool: OpenAI Codex CLI
- Tool version: 0.153.4
- Model (full id): gpt-5.6-sol
- Host (CLI / IDE / GitHub coding agent / other): CLI
- Date (UTC): 2026-09-09
- AI assistance disclosure: This change was implemented and verified with assistance from OpenAI Codex.

## Links

- Closes #7282
- Related: #4635, #7073

## User request

Fix the uneven spacing between the recent 24-hour success-rate bars shown on model cards in the model marketplace.

## Out of scope — refuse

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): not applicable

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: Some adjacent bars in the recent 24-hour success-rate strip have a visibly wider gap. The position of the wider gap can differ between cards in different grid columns.
- Impact: The inconsistent spacing reduces the visual accuracy of the status strip and can appear to represent a missing or separated sample.
- Frequency: Reproducible in the three-column model marketplace layout reported in #7282.
- Evidence that the problem is in new-api rather than the client or upstream: The issue is produced by the layout of the status strip rendered by new-api's `/pricing` frontend. The bars have equal widths, while only their rendered spacing varies. It does not depend on relay requests or upstream model responses.
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise):
  - Frontend:
    - Page: `/pricing`
    - Browser: Google Chrome `126.0.6478.26`
    - Theme: default
    - Console / Network errors: none
  - Relay / API: not applicable
  - Billing: not applicable
  - Deployment: not applicable

## Change

Replace distributed free-space alignment on the 24-hour status strip with a fixed one-pixel gap.

The strip contains 24 fixed-width bars inside a fixed-width container. With `justify-between`, the remaining width cannot be divided into 23 whole-pixel gaps, so browser subpixel rounding places an extra pixel in one gap. The exact position can change with the card's layout position.

Using `gap-px` makes every inter-bar gap exactly one pixel while preserving the existing container and bar dimensions.

A focused regression test verifies that the status strip uses fixed spacing and no longer uses distributed spacing.

## Research

### Duplicate / prior art

- Search queries (issues, PRs):
  - `模型广场 成功率`
  - `模型广场 柱状`
  - `模型广场 间隔`
  - `成功采样率`
  - `success rate model square`
  - `success-rate samples`
  - `status bar spacing`
  - `justify-between`
- What already existed and why this is not a duplicate:
  - #7282 reports this specific visual defect.
  - #4635 introduced model performance metrics but does not address status-bar spacing.
  - #7073 changes performance-metric recording behavior rather than frontend spacing.
  - No existing PR was found that fixes the uneven gap between the 24 hourly bars.

### Docs and code

- https://docs.newapi.ai/ : No configuration or documented behavior controls the spacing of the model status strip.
- https://deepwiki.com/QuantumNous/new-api : No existing configuration-based solution or matching fix was found.
- README / repo docs: No relevant configuration or documented exception was found.
- Code paths and what they imply for this change:
  - `web/src/features/pricing/components/model-perf-badge.tsx` renders the 24 hourly status bars and controls their spacing.
  - `web/src/features/pricing/components/model-card.tsx` embeds the performance badge in each model card.
  - `web/src/features/pricing/components/model-card-grid.tsx` places cards into the responsive grid.
  - The spacing can therefore be fixed once in `ModelPerfBadge` without changing the card or grid layouts.

### Alternatives considered

- Option A: Keep `justify-between` and change the container width so the remaining width divides evenly across 23 gaps.
- Option B: Use an explicit one-pixel flex gap while preserving the existing container width.
- Why this approach: Option B directly expresses the intended fixed spacing, avoids reliance on distributed fractional space, and requires only a one-class change.

## Files

| Path | Why |
| --- | --- |
| `web/src/features/pricing/components/model-perf-badge.tsx` | Use a fixed one-pixel gap between hourly status bars. |
| `web/src/features/pricing/__tests__/model-cards.test.tsx` | Add a focused regression test for the status-strip spacing contract. |

## Behavior

- Before: The status strip used `justify-between`. Browser subpixel rounding could make one gap visibly wider, with its position varying between grid columns.
- After: Every adjacent pair of hourly status bars uses the same fixed one-pixel gap.
- Explicit non-goals / leftover work:
  - No changes to success-rate collection or aggregation.
  - No changes to API responses, billing, channels, or databases.
  - No changes to model-card width or responsive grid breakpoints.

## Verification

- Commands and results:
  - Before implementation, `bun run test -- src/features/pricing/__tests__/model-cards.test.tsx` failed on the new spacing regression as expected.
  - After implementation, `bun run test -- src/features/pricing/__tests__/model-cards.test.tsx` passed: 1 test file, 24 tests.
  - `bun run typecheck` passed.
  - `bun x oxlint -c .oxlintrc.json src/features/pricing/components/model-perf-badge.tsx src/features/pricing/__tests__/model-cards.test.tsx` passed.
  - `bun x oxfmt --check src/features/pricing/components/model-perf-badge.tsx src/features/pricing/__tests__/model-cards.test.tsx` passed.
  - `bun run build` passed.
  - GitNexus impact and change analysis reported LOW risk, one changed production symbol, and no affected execution flows.
- Manual steps and observed result: Pixel inspection of the original screenshots confirmed that all bars were the same width while one inter-bar gap was wider. The updated layout now uses an explicit integer-pixel gap.
- UI: screenshot or recording (or why none): The pre-fix screenshots are documented in #7282. A post-fix browser screenshot was not captured because browser automation was unavailable in the implementation environment.
- Tests added or updated, or why none: Added a dedicated test asserting fixed status-bar spacing.
- Databases / providers / platforms exercised: Frontend Vitest/jsdom, TypeScript compiler, oxlint, oxfmt, and Rsbuild production build. No database or provider behavior is affected.
- Not verified:
  - Firefox and Safari rendering.
  - Non-default themes.
  - Different browser zoom levels and device pixel ratios.
  - Manual post-fix browser screenshot.

## Risks

- Failure modes: The fixed gaps occupy 95px inside the existing 96px container, leaving one unused pixel at the trailing edge. This does not affect spacing between bars.
- Billing / quota / auth impact: None.
- Follow-ups: Attach a post-fix screenshot or recording if requested during review.

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the model performance success-rate strip to display hourly status bars with consistent 1-pixel spacing, improving visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->