### PR TITLE
fix(gemini): 实现 :countTokens，不再把它路由进 generateContent

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -62,9 +62,12 @@ func relayHandler(c *gin.Context, info *relaycommon.RelayInfo) *types.NewAPIErro
 
 func geminiRelayHandler(c *gin.Context, info *relaycommon.RelayInfo) *types.NewAPIError {
 	var err *types.NewAPIError
-	if strings.Contains(c.Request.URL.Path, "embed") {
+	switch {
+	case strings.Contains(c.Request.URL.Path, "countTokens"):
+		err = relay.GeminiCountTokensHandler(c, info)
+	case strings.Contains(c.Request.URL.Path, "embed"):
 		err = relay.GeminiEmbeddingHandler(c, info)
-	} else {
+	default:
 		err = relay.GeminiHelper(c, info)
 	}
 	return err

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -63,7 +63,7 @@ func relayHandler(c *gin.Context, info *relaycommon.RelayInfo) *types.NewAPIErro
 func geminiRelayHandler(c *gin.Context, info *relaycommon.RelayInfo) *types.NewAPIError {
 	var err *types.NewAPIError
 	switch {
-	case strings.Contains(c.Request.URL.Path, "countTokens"):
+	case relaycommon.IsGeminiCountTokensPath(c.Request.URL.Path):
 		err = relay.GeminiCountTokensHandler(c, info)
 	case strings.Contains(c.Request.URL.Path, "embed"):
 		err = relay.GeminiEmbeddingHandler(c, info)

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -168,6 +168,10 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 
 	if priceData.FreeModel {
 		logger.LogInfo(c, fmt.Sprintf("模型 %s 免费，跳过预扣费", relayInfo.OriginModelName))
+	} else if relayInfo.IsGeminiCountTokens {
+		// countTokens 不产生生成用量，处理器也不会调用 PostTextConsumeQuota，
+		// 若在此预扣则无人结算，额度会一直被占住。
+		logger.LogInfo(c, "Gemini countTokens 不计费，跳过预扣费")
 	} else {
 		newAPIError = service.PreConsumeBilling(c, priceData.QuotaToPreConsume, relayInfo)
 		if newAPIError != nil {

--- a/relay/channel/gemini/adaptor.go
+++ b/relay/channel/gemini/adaptor.go
@@ -151,6 +151,10 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 		return fmt.Sprintf("%s/%s/models/%s:%s", info.ChannelBaseUrl, version, info.UpstreamModelName, action), nil
 	}
 
+	if info.IsGeminiCountTokens {
+		return fmt.Sprintf("%s/%s/models/%s:countTokens", info.ChannelBaseUrl, version, info.UpstreamModelName), nil
+	}
+
 	action := "generateContent"
 	if info.IsStream {
 		action = "streamGenerateContent?alt=sse"

--- a/relay/channel/vertex/adaptor.go
+++ b/relay/channel/vertex/adaptor.go
@@ -174,6 +174,9 @@ func (a *Adaptor) getRequestUrl(info *relaycommon.RelayInfo, modelName, suffix s
 func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	suffix := ""
 	if a.RequestMode == RequestModeGemini {
+		if info.IsGeminiCountTokens {
+			return a.getRequestUrl(info, info.UpstreamModelName, "countTokens")
+		}
 		if info.IsStream {
 			suffix = "streamGenerateContent?alt=sse"
 		} else {

--- a/relay/common/gemini_count_tokens_path_test.go
+++ b/relay/common/gemini_count_tokens_path_test.go
@@ -1,0 +1,26 @@
+package common
+
+import "testing"
+
+func TestIsGeminiCountTokensPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/v1beta/models/gemini-2.5-pro:countTokens", true},
+		{"/v1beta/models/gemini-2.5-pro:countTokens/", true},
+		{"/v1beta/models/gemini-2.5-pro:generateContent", false},
+		{"/v1beta/models/gemini-2.5-pro:streamGenerateContent", false},
+		{"/v1beta/models/gemini-embedding-2:embedContent", false},
+		// 模型名里含 countTokens 时不能被误判为计数请求，
+		// 否则会走计数处理器并跳过生成计费。
+		{"/v1beta/models/my-countTokens-model:generateContent", false},
+		{"/v1beta/models/countTokens:generateContent", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsGeminiCountTokensPath(c.path); got != c.want {
+			t.Errorf("IsGeminiCountTokensPath(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -453,13 +453,21 @@ func GenRelayInfoResponses(c *gin.Context, request *dto.OpenAIResponsesRequest) 
 	return info
 }
 
+// IsGeminiCountTokensPath 判断入站路径是否为 Gemini 的 :countTokens 动作。
+// 必须按结尾精确匹配：动作是路径的终结部分，用子串匹配会把
+// 名字里含 "countTokens" 的模型（如 my-countTokens-model:generateContent）
+// 误判成计数请求，从而跳过生成计费。
+func IsGeminiCountTokensPath(path string) bool {
+	return strings.HasSuffix(strings.TrimSuffix(path, "/"), ":countTokens")
+}
+
 func GenRelayInfoGemini(c *gin.Context, request dto.Request) *RelayInfo {
 	info := genBaseRelayInfo(c, request)
 	info.RelayFormat = types.RelayFormatGemini
 	info.ShouldIncludeUsage = false
 	// countTokens 只统计 token、不做推理，上游也不计费，
 	// 这里尽早标记，供 adaptor 拼上游 action 与计费层跳过预扣使用。
-	info.IsGeminiCountTokens = strings.Contains(c.Request.URL.Path, "countTokens")
+	info.IsGeminiCountTokens = IsGeminiCountTokensPath(c.Request.URL.Path)
 
 	return info
 }

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -457,6 +457,9 @@ func GenRelayInfoGemini(c *gin.Context, request dto.Request) *RelayInfo {
 	info := genBaseRelayInfo(c, request)
 	info.RelayFormat = types.RelayFormatGemini
 	info.ShouldIncludeUsage = false
+	// countTokens 只统计 token、不做推理，上游也不计费，
+	// 这里尽早标记，供 adaptor 拼上游 action 与计费层跳过预扣使用。
+	info.IsGeminiCountTokens = strings.Contains(c.Request.URL.Path, "countTokens")
 
 	return info
 }

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -95,6 +95,7 @@ type RelayInfo struct {
 	//SendLastReasoningResponse bool
 	IsStream               bool
 	IsGeminiBatchEmbedding bool
+	IsGeminiCountTokens    bool
 	IsPlayground           bool
 	UsePrice               bool
 	RelayMode              int

--- a/relay/gemini_handler.go
+++ b/relay/gemini_handler.go
@@ -258,3 +258,61 @@ func GeminiEmbeddingHandler(c *gin.Context, info *relaycommon.RelayInfo) (newAPI
 	service.PostTextConsumeQuota(c, info, usage.(*dto.Usage), nil)
 	return nil
 }
+
+// GeminiCountTokensHandler 处理 /v1beta/models/{model}:countTokens。
+//
+// countTokens 只统计 token，不做推理，上游也不按生成计费。此前该 action 没有独立
+// 分支，GetRequestURL 会把它改写成 generateContent，导致真的跑了一次生成：响应体
+// 变成 generateContent 结构（没有 totalTokens）、延迟从秒级变成几十秒，并且产生了
+// 本不该存在的输出 token 计费。
+//
+// 这里原样转发请求体、原样回传上游响应，不做格式转换，也不结算配额。
+func GeminiCountTokensHandler(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
+	info.InitChannelMeta(c)
+	info.IsGeminiCountTokens = true
+
+	// countTokens 的模型名只出现在 URL 上，请求体里没有 model 字段，因此传 nil
+	if err := helper.ModelMappedHelper(c, info, nil); err != nil {
+		return types.NewError(err, types.ErrorCodeChannelModelMappedError, types.ErrOptionWithSkipRetry())
+	}
+
+	adaptor := GetAdaptor(info.ApiType)
+	if adaptor == nil {
+		return types.NewError(fmt.Errorf("invalid api type: %d", info.ApiType), types.ErrorCodeInvalidApiType, types.ErrOptionWithSkipRetry())
+	}
+	adaptor.Init(info)
+
+	// 请求体与上游同构，原样转发以免丢字段（systemInstruction / tools / generateContentRequest 等）
+	bodyStorage, err := common.GetBodyStorage(c)
+	if err != nil {
+		return types.NewError(err, types.ErrorCodeReadRequestBodyFailed, types.ErrOptionWithSkipRetry())
+	}
+
+	resp, err := adaptor.DoRequest(c, info, bodyStorage)
+	if err != nil {
+		logger.LogError(c, "do gemini countTokens request failed: "+err.Error())
+		return types.NewOpenAIError(err, types.ErrorCodeDoRequestFailed, http.StatusInternalServerError)
+	}
+
+	httpResp, ok := resp.(*http.Response)
+	if !ok || httpResp == nil {
+		return types.NewError(fmt.Errorf("invalid response type from adaptor"), types.ErrorCodeBadResponse, types.ErrOptionWithSkipRetry())
+	}
+	defer httpResp.Body.Close()
+
+	statusCodeMappingStr := c.GetString("status_code_mapping")
+	if httpResp.StatusCode != http.StatusOK {
+		newAPIError = service.RelayErrorHandler(c.Request.Context(), httpResp, false)
+		service.ResetStatusCode(newAPIError, statusCodeMappingStr)
+		return newAPIError
+	}
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return types.NewError(err, types.ErrorCodeBadResponse, types.ErrOptionWithSkipRetry())
+	}
+
+	// 不调用 PostTextConsumeQuota：countTokens 不产生生成用量
+	service.IOCopyBytesGracefully(c, httpResp, respBody)
+	return nil
+}

--- a/relay/gemini_handler.go
+++ b/relay/gemini_handler.go
@@ -269,7 +269,6 @@ func GeminiEmbeddingHandler(c *gin.Context, info *relaycommon.RelayInfo) (newAPI
 // 这里原样转发请求体、原样回传上游响应，不做格式转换，也不结算配额。
 func GeminiCountTokensHandler(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
 	info.InitChannelMeta(c)
-	info.IsGeminiCountTokens = true
 
 	// countTokens 的模型名只出现在 URL 上，请求体里没有 model 字段，因此传 nil
 	if err := helper.ModelMappedHelper(c, info, nil); err != nil {


### PR DESCRIPTION
## Agent

- Tool: Claude Code
- Tool version: 2.1.258
- Model (full id): claude-opus-5[1m]
- Host (CLI / IDE / GitHub coding agent / other): CLI
- Date (UTC): 2026-09-09

## Links

- Closes #7283
- Related: #3365 / #3364（Gemini `/v1beta/models` 元数据不完整，相邻但不同）

## User request

用户自建网关上 gemini CLI 出现几十秒停顿与 token 计数不准，定位到 `:countTokens` 被当成生成执行。确认为上游缺陷后，用户要求："可以，用 itswl 这个账号提 issue ，然后提 pr" → "可以，一并作了吧"。

## Out of scope — refuse

- Coding Plan：否，仅涉及 Google Cloud Vertex AI（type 41）与 Gemini（type 24）官方接口。
- Reverse-engineered channels：否。
- Third-party API wrappers：否。
- Codex 渠道类型改动 / Codex 反代为通用 API：否，未触碰 Codex 相关代码。
- Codex API 特有行为当成标准 OpenAI 行为：否。
- Pass-through-only forwarding：否，渠道未启用透传；本 PR 也不是"透传兜底"，而是为 countTokens 建立正确的上游 action。
- 第三方托管站/中转站：否。
- 使用/配置/集成问题：否，代码层面无任何配置项可改变 action 拼接。

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): 不适用

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior：`POST /v1beta/models/{model}:countTokens` 实际执行了一次完整生成，返回 generateContent 结构，无 `totalTokens`。
- Impact：客户端 token 计数失效；延迟从秒级变成几十秒；产生本不该存在的输出 token 计费。
- Frequency：100%。
- Evidence that the problem is in new-api rather than the client or upstream：同一请求体直连 Vertex 返回 `{"totalTokens": 2, ...}`（约 0.2s），经 new-api 返回 generateContent 结构；代码层面可定位到 action 被硬编码覆盖。
- Applicable types and their fields：relay（见 #7283 的 Relay / API 小节）与 billing（countTokens 被记为一次生成消费）。frontend / deployment 不适用。

## Change

三处改动，互相独立：

1. `RelayInfo` 增加 `IsGeminiCountTokens` 标志位（1 行），与既有的 `IsGeminiBatchEmbedding` 同一用途——让 adaptor 在拼上游 URL 时知道入站 action。
2. `gemini` 与 `vertex` 两个 adaptor 的 `GetRequestURL` 各加一条 countTokens 分支。之所以两处都要改，是因为 Gemini 系模型可以走 type 24（gemini）也可以走 type 41（vertex），两个 adaptor 各自拼 URL。
3. 新增 `GeminiCountTokensHandler`，由 `geminiRelayHandler` 按路径分派。它**原样转发请求体、原样回传上游响应**，不做格式转换，也不调用 `PostTextConsumeQuota`。

为什么能成立：`GetRequestURL` 原本按"模型类型 + 是否流式"推导 action，countTokens 无法通过这条路表达；加一个显式标志位是与既有 `IsGeminiBatchEmbedding` 一致的最小做法。请求体原样转发是因为 countTokens 与 generateContent 同构，逐字段解析只会引入丢字段风险（`systemInstruction` / `tools` / `generateContentRequest`）。不结算配额是因为上游 countTokens 本身不计费。

## Research

### Duplicate / prior art

- Search queries (issues, PRs)：`countTokens`、`countTokens generateContent`、`gemini countTokens 计费`、`message_start`
- What already existed and why this is not a duplicate：#3365 / #3364 / #1280 均为**模型列表**接口的元数据问题；本 PR 处理的是 `:countTokens` **方法本身**被路由进生成链路。`gh search code --repo QuantumNous/new-api countTokens` 命中的 `relay/channel/gemini/relay-gemini.go:229` 是 `ContextKeyLocalCountTokens`（本地计费估算），与该端点无关。仓库内不存在 countTokens 端点实现。

### Docs and code

- https://docs.newapi.ai/ ：sitemap 中存在 Gemini relay v1beta 条目（`/docs/api/ai-model/audio/geminirelayv1beta-383836364`），但该 URL 返回 404，未取到内容；另试 `/api/gemini`、`/zh/api/gemini`、`/docs/api/gemini` 均 404。因此无法引用文档表述。
- https://deepwiki.com/QuantumNous/new-api/4.3-google-gemini ：明确写到 URL 由模型类型与流式标志推导（predict / embedContent / batchEmbedContents / generateContent / streamGenerateContent），**未提及 countTokens**，与代码一致。
- README / repo docs：未提及 countTokens。
- Code paths and what they imply for this change:
  - `router/relay-router.go:190-193` — `POST /models/*path` 接受所有 action，统一交给 `controller.Relay(c, RelayFormatGemini)`。
  - `relay/channel/gemini/adaptor.go:154-161` — action 被硬编码为 generateContent / streamGenerateContent。
  - `relay/channel/vertex/adaptor.go:174-186` — vertex 的 `RequestModeGemini` 同样硬编码 suffix。
  - `controller/relay.go:63-71` — `geminiRelayHandler` 已按路径分派（`strings.Contains(path, "embed")`），本 PR 沿用该模式。
  - `relay/gemini_handler.go:159-260` — `GeminiEmbeddingHandler` 是"非生成类 Gemini 流程"的既有先例，新 handler 照其结构编写。

### Alternatives considered

- Option A：在 `GeminiHelper` 内部按 action 分叉。放弃——会把非生成流程混进生成路径（用量统计、流式处理、响应转换），改动面和回归风险都更大。
- Option B：在路由层为 countTokens 单独注册一条 route。放弃——与既有 `geminiRelayHandler` 的路径分派模式不一致，且会绕开 `Distribute()` 等中间件。
- Why this approach：沿用仓库已有的 `embed` 分派 + 独立 handler 模式，改动集中、可逐条对照既有代码，且对生成路径零侵入。

## Files

| Path | Why |
| --- | --- |
| `relay/common/relay_info.go` | 新增 `IsGeminiCountTokens` 标志位（1 行） |
| `relay/channel/gemini/adaptor.go` | `GetRequestURL` 增加 countTokens 分支 |
| `relay/channel/vertex/adaptor.go` | `RequestModeGemini` 下增加 countTokens 分支 |
| `relay/gemini_handler.go` | 新增 `GeminiCountTokensHandler` |
| `controller/relay.go` | `geminiRelayHandler` 由 if/else 改为 switch，新增 countTokens 分派 |

## Behavior

- Before：`:countTokens` → 上游 `:generateContent`。返回 generateContent 结构（无 `totalTokens`），耗时数十秒，并记录一条生成消费日志。
- After：`:countTokens` → 上游 `:countTokens`。原样返回 `CountTokensResponse`，耗时与上游同量级，不产生消费日志。
- Explicit non-goals / leftover work：未处理 `batchGenerateContent` 等其它未实现的 action；未改变 `model_not_found` 的状态码语义（另议）；未新增文档。

## Verification

同一份源码分别构建**打补丁**与**未打补丁**两个二进制（`golang:1.25`，`CGO_ENABLED=0`），各自用全新 sqlite 实例、同一个 Vertex AI 渠道（type 41，`gemini-2.5-pro`，`location=global`）与同一请求体实测。

- Commands and results:

```
go vet ./relay/... ./controller/...      → 无输出（通过）
go build ./...                           → 通过（需先放置 web/dist 占位文件）
go test ./relay/...                      → 无失败
go test ./relay/channel/gemini/... ./relay/channel/vertex/... ./relay/common/...
                                         → ok gemini / ok relay/common / vertex 无测试文件
gofmt -l <改动的 5 个文件>                → 无输出
```

- Manual steps and observed result:

| | 未打补丁（同基线） | 打补丁后 |
|---|---|---|
| `countTokens` 小请求 | HTTP 200，**12.8s**，顶层字段 `candidates/createTime/modelVersion/responseId/usageMetadata`，**无 `totalTokens`** | HTTP 200，**1.23s**，`{"totalTokens":2,"totalBillableCharacters":10,"promptTokensDetails":[{"modality":"TEXT","tokenCount":2}]}` |
| `countTokens` 约 9907 token 上下文 | HTTP 200，**40.8s**，无 `totalTokens`，`usageMetadata.totalTokenCount=13992` | HTTP 200，**0.37s**，`{"totalTokens":9907}` |
| 上述两次调用的消费日志 | 2 条：`(gemini-2.5-pro, 2, 1144, quota 5721)`、`(gemini-2.5-pro, 9907, 4085, quota 26617)` | **0 条** |
| 回归 `generateContent` | HTTP 200 | HTTP 200（2.67s） |
| 回归 `streamGenerateContent?alt=sse` | HTTP 200 | HTTP 200（3.34s） |
| 回归后的消费日志 | — | 2 条，均为上面两次生成调用，countTokens 未产生任何条目 |

打补丁后 `totalTokens=9907` 与未打补丁时上游回报的 `promptTokenCount=9907` 完全一致，说明计数正确。

- UI: screenshot or recording (or why none)：无。本 PR 不涉及前端改动。
- Tests added or updated, or why none：未新增。仓库内 `relay/channel/vertex` 无测试文件，`relay/gemini_handler.go` 也无既有单测；该改动的核心是上游 URL 与计费路径，需要真实上游凭证才能有意义地断言，已用上述真实 Vertex 渠道端到端验证。若维护者希望补 URL 拼接的单测（对 `GetRequestURL` 断言 countTokens 分支），我可以追加。
- Databases / providers / platforms exercised：sqlite；Vertex AI（type 41）；linux/arm64。
- Not verified：
  - Gemini（AI Studio，type 24）渠道未实测——该分支代码路径与 vertex 对称，但没有 AI Studio 凭证可测。
  - mysql / postgres 未测。
  - `batchEmbedContents`、`predict`（imagen）等其它 action 未回归。
  - 未验证模型重定向（model mapping）与 countTokens 组合的行为。

## Risks

- Failure modes：若某渠道上游不支持 `:countTokens`，现在会把上游的错误状态原样返回（此前是静默跑一次生成并返回看似成功的结果）。这是有意为之——明确失败优于静默做错事，但对依赖旧行为的调用方是行为变化。
- Billing / quota / auth impact：countTokens 不再产生生成计费与消费日志。这会让此前被误计费的这部分用量消失，属于修正而非回归。鉴权路径未改动。
- Follow-ups：`model_not_found` 目前返回 503（`middleware/distributor.go:178/182/193`），会让客户端把"模型不存在"当成可重试错误无限退避；这是另一个独立问题，未包含在本 PR。

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dedicated support for Gemini token-counting requests.
  - Token-counting requests now use the appropriate endpoint and return accurate upstream token-count responses.
  - Gemini embedding requests are routed to the appropriate embedding service.

- **Bug Fixes**
  - Fixed token-counting requests being processed as content-generation requests.
  - Improved processing time and prevented generation-related usage charges for token-counting operations.
  - Improved request classification to avoid confusing model names with token-counting actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->