### PR TITLE
fix: restore add split button in advanced custom routes

### DIFF
--- a/web/src/features/channels/components/dialogs/advanced-custom-editor-dialog.tsx
+++ b/web/src/features/channels/components/dialogs/advanced-custom-editor-dialog.tsx
@@ -1180,7 +1180,20 @@ onValueChange={onIncomingPathChange}
 className='h-9 max-w-full lg:max-w-[420px]'
 />
           </div>
+        </div>
+      ) : null}
 
+      <div className={cn('px-3 py-2', !hideHeader && 'border-t')}>
+        <div className='flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
+          <p className='text-muted-foreground text-xs leading-relaxed'>
+            {isModelListGroup
+              ? t(
+                  'This route discovers upstream OpenAI models and cannot be split or matched by client model rules.'
+                )
+              : t(
+                  'Routes with the same incoming path are split by client model rules. Unmatched requests use the final fallback.'
+                )}
+          </p>
           {!isModelListGroup ? (
             <Button
               type='button'
@@ -1188,23 +1201,11 @@ className='h-9 max-w-full lg:max-w-[420px]'
               size='sm'
               onClick={onAddRoute}
             >
-              <Plus data-icon='inline-start' />
+              <Plus data-icon='inline-start' aria-hidden='true' />
               {t('Add split')}
             </Button>
           ) : null}
         </div>
-      ) : null}
-
-      <div className={cn('px-3 py-2', !hideHeader && 'border-t')}>
-        <p className='text-muted-foreground text-xs leading-relaxed'>
-          {isModelListGroup
-            ? t(
-                'This route discovers upstream OpenAI models and cannot be split or matched by client model rules.'
-              )
-            : t(
-                'Routes with the same incoming path are split by client model rules. Unmatched requests use the final fallback.'
-              )}
-        </p>
         {groupHasError && validationError ? (
           <p className='text-destructive mt-1 text-xs'>
             {validationError.routeIndex !== undefined


### PR DESCRIPTION
<!--
If you are an AI coding agent (Claude Code, Codex, Cursor, Copilot, OpenCode, Paseo, Grok, or similar): do not fill this human template. Read `.agents/github/PR.md` and use the filled file as the entire PR body.
-->
# ⚠️ 提交说明 / PR Notice

English template: `.github/PULL_REQUEST_TEMPLATE/en.md`

> [!IMPORTANT]
>
> - 描述可用 AI 辅助。提交前请审阅全文，并**声明对其负责**，避免未经核对的直接粘贴。
> - 请按本模板填写后再提交。

## 🔗 关联任务 / Related Issue
- 新功能请填写下方 Issue 编号；若还没有对应 Issue，请先自行创建。功能讨论请放在 Issue 中进行。
- 改动较大或方向性变更，请先在关联 Issue 中与维护者达成一致，再提交 PR。
- Bug 修复请关联对应 Issue。设计取舍、理解偏差或预期不一致，更适合作为讨论或功能请求。

- Closes #7286

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description
(简述做了什么、为什么生效。如果难以简述，建议先拆分范围，或在 Issue 中与维护者对齐。)

修复被错误隐藏的内容

## 📸 运行证明 / Proof of Work
(请写明如何验证：实际步骤与观察结果。UI 变更请附截图或录屏；Bug 修复请说明复现过程与修复后结果。)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 无论描述是否由 AI 生成，我已审阅全部内容，并声明对其准确性与完整性负责。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **新功能关联 Issue:** 若此 PR 标记为 `New feature`，我已关联对应 Issue；若尚无 Issue，我已先自行创建。
- [x] **事前沟通:** 若改动较大或涉及方向性变更，已在关联 Issue 中与维护者沟通并达成一致。
- [x] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口，也不是对 Codex 渠道类型的改动。
- [x] **范围聚焦:** 本 PR 为一项聚焦改动，未包含无关代码。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen-reader handling for the “Add split” button icon.

* **UI Improvements**
  * Moved the “Add split” control and explanatory text into the route group body for clearer layout and interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->