### PR TITLE
fix(billing): count cache tokens in Anthropic consume log input totals

### DIFF
--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -67,6 +67,11 @@ type textQuotaSummary struct {
 	ToolSurchargeItems     []ToolSurchargeItem
 	ToolCallSurchargeQuota decimal.Decimal
 	FixedPriceBilling      bool
+	// PromptTokensExcludeCache marks usage whose PromptTokens counts only the
+	// fresh (non-cached) input, with cache reads and cache writes reported
+	// separately. Anthropic-style usage works this way, while OpenAI-style
+	// PromptTokens already includes both.
+	PromptTokensExcludeCache bool
 }
 
 // hasBillableUsage reports whether this request should incur any charge.
@@ -86,6 +91,19 @@ func cacheWriteTokensTotal(summary textQuotaSummary) int {
 		return splitCacheWriteTokens
 	}
 	return summary.CacheCreationTokens
+}
+
+// logInputTokens is the total input token count recorded on the consume log.
+// It must mean the same thing for every provider, because the usage log UI, the
+// RPM/TPM and token-sum statistics and the data export all read it as the whole
+// input and show the cache counts as a breakdown of it. Anthropic-style usage
+// reports input_tokens without the cached and cache-written tokens, so the
+// input that was billed separately is added back here.
+func logInputTokens(summary textQuotaSummary) int {
+	if !summary.PromptTokensExcludeCache {
+		return summary.PromptTokens
+	}
+	return summary.PromptTokens + summary.CacheTokens + cacheWriteTokensTotal(summary)
 }
 
 func isLegacyClaudeDerivedOpenAIUsage(relayInfo *relaycommon.RelayInfo, usage *dto.Usage) bool {
@@ -265,6 +283,7 @@ func calculateTextQuotaSummary(ctx *gin.Context, relayInfo *relaycommon.RelayInf
 	summary.ImageTokens = usage.PromptTokensDetails.ImageTokens
 	summary.AudioTokens = usage.PromptTokensDetails.AudioTokens
 	legacyClaudeDerived := isLegacyClaudeDerivedOpenAIUsage(relayInfo, usage)
+	summary.PromptTokensExcludeCache = summary.IsClaudeUsageSemantic || legacyClaudeDerived
 	isOpenRouterClaudeBilling := relayInfo.ChannelMeta != nil &&
 		relayInfo.ChannelType == constant.ChannelTypeOpenRouter &&
 		summary.IsClaudeUsageSemantic
@@ -534,7 +553,7 @@ func PostTextConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, us
 
 	model.RecordConsumeLog(ctx, relayInfo.UserId, model.RecordConsumeLogParams{
 		ChannelId:        relayInfo.ChannelId,
-		PromptTokens:     summary.PromptTokens,
+		PromptTokens:     logInputTokens(summary),
 		CompletionTokens: summary.CompletionTokens,
 		ModelName:        logModel,
 		TokenName:        summary.TokenName,

--- a/service/text_quota_test.go
+++ b/service/text_quota_test.go
@@ -255,6 +255,9 @@ func TestCalculateTextQuotaSummaryUnifiedForClaudeSemantic(t *testing.T) {
 	require.Equal(t, messageSummary.CacheCreationTokens1h, chatSummary.CacheCreationTokens1h)
 	require.True(t, chatSummary.IsClaudeUsageSemantic)
 	require.Equal(t, 1488, chatSummary.Quota)
+	// 日志记录的总输入 = fresh 1000 + 缓存命中 100 + 缓存写入 50。
+	require.True(t, chatSummary.PromptTokensExcludeCache)
+	require.Equal(t, 1150, logInputTokens(chatSummary))
 }
 
 func TestCalculateTextQuotaSummaryUsesSplitClaudeCacheCreationRatios(t *testing.T) {
@@ -667,6 +670,52 @@ func TestCacheWriteTokensTotal(t *testing.T) {
 	})
 }
 
+// 日志里的 prompt_tokens 必须对所有供应商表示同一含义（总输入 token），
+// 因为使用日志、RPM/TPM 与 token 统计、数据看板导出都按“总输入”读取它，
+// 并把缓存数量当作它的明细展示。
+func TestLogInputTokensNormalizesCacheAcrossSemantics(t *testing.T) {
+	t.Run("openai semantic keeps prompt tokens", func(t *testing.T) {
+		// OpenAI 语义下 PromptTokens 已包含缓存，再加一次会重复计算。
+		assert.Equal(t, 1000, logInputTokens(textQuotaSummary{
+			PromptTokens:        1000,
+			CompletionTokens:    200,
+			CacheTokens:         800,
+			CacheCreationTokens: 100,
+		}))
+	})
+
+	t.Run("anthropic semantic adds cache read and write back", func(t *testing.T) {
+		// Anthropic 语义下 input_tokens 只是未命中缓存的 fresh token，
+		// 不加回缓存会让一次 59 万 token 的请求在日志里只显示 2。
+		assert.Equal(t, 590823, logInputTokens(textQuotaSummary{
+			PromptTokens:             2,
+			CompletionTokens:         1117,
+			CacheTokens:              589733,
+			CacheCreationTokens:      1088,
+			PromptTokensExcludeCache: true,
+		}))
+	})
+
+	t.Run("anthropic semantic uses billed cache write total", func(t *testing.T) {
+		// 只有 5m/1h 拆分值时，按实际计费的缓存写入总量加回。
+		assert.Equal(t, 1300, logInputTokens(textQuotaSummary{
+			PromptTokens:             100,
+			CacheTokens:              1000,
+			CacheCreationTokens5m:    150,
+			CacheCreationTokens1h:    50,
+			PromptTokensExcludeCache: true,
+		}))
+	})
+
+	t.Run("anthropic semantic without cache", func(t *testing.T) {
+		assert.Equal(t, 100, logInputTokens(textQuotaSummary{
+			PromptTokens:             100,
+			CompletionTokens:         50,
+			PromptTokensExcludeCache: true,
+		}))
+	})
+}
+
 func TestCalculateTextQuotaSummaryHandlesLegacyClaudeDerivedOpenAIUsage(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
@@ -700,6 +749,8 @@ func TestCalculateTextQuotaSummaryHandlesLegacyClaudeDerivedOpenAIUsage(t *testi
 
 	// 62 + 3544*0.1 + 586*1.25 + 95*5 = 1624.9 => 1624
 	require.Equal(t, 1624, summary.Quota)
+	// 这条旧路径的 PromptTokens 同样不含缓存，日志总输入 = 62 + 3544 + 586。
+	require.Equal(t, 4192, logInputTokens(summary))
 }
 
 func TestCalculateTextQuotaSummaryBillsOpenAICacheWriteTokens(t *testing.T) {


### PR DESCRIPTION
## Agent

- Tool: Claude Code
- Tool version: 未知（运行环境未向 agent 暴露版本号）
- Model (full id): claude-opus-5[1m]
- Host (CLI / IDE / GitHub coding agent / other): IDE（VS Code 扩展）
- Date (UTC): 2026-09-09

> **声明：本 PR 的代码由 AI 生成／AI 辅助完成。** 提交者 `TomJKS` 不是本仓库的历史核心开发者（在 `upstream/main` 上提交数为 0），按项目约定在此显式说明。变更已经过人工复核与真实环境验证，详见 Verification。

## Links

- Closes #`7290`
- Related: #5069（数据看板 token 统计不含缓存 token，方案取向不同，见 Research）、#3309、#6011、#4395、#6212

## User request

用户原话：「Claude模型的tokens统计还是不准确，参考其他模型是正常的，修复统计错误的bug」，并附使用日志截图：同一页面 qwen3.8-max 显示 `70,397 / 2,228`（缓存↓ 67,584），claude-opus-5 却显示 `2 / 1,117`（缓存↓ 589,733 ↑ 1,088）。

## Out of scope — refuse

- Coding Plan
- Reverse-engineered channels
- Third-party API wrappers
- Codex channel-type changes, or compatibility from exposing Codex as a general-purpose API
- Codex API-specific protocol or behavior treated as standard OpenAI API behavior
- Pass-through-only forwarding
- Third-party hosting sites, relay services, or API services
- Usage, configuration, or integration

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): 不适用。本变更修复 new-api 自身写入消耗日志时缺失的 token 归一化，不涉及上述任何一类。

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: Anthropic 语义的消耗日志把 `prompt_tokens` 写成 Claude 原始 `input_tokens`，即仅未命中缓存的 fresh token。一次命中 589,733 缓存读取、1,088 缓存写入的请求，`prompt_tokens` 只有 2。
- Impact: ①展示——使用日志 Tokens 列、详情弹窗 "Input Tokens"、移动端卡片均按「总输入」读取该字段并把缓存作为其明细，Claude 行严重偏小且无法与其他模型横向比较；②统计——`model/log.go:625` 的 RPM/TPM 与 `model/log.go:684` 的 `SumUsedToken` 都按 `sum(prompt_tokens) + sum(completion_tokens)` 聚合，Claude 请求静默漏掉全部缓存输入，缓存密集场景下 TPM 可低估两个数量级；③看板——`LogQuotaData` 的 `TokenUsed` 取同一表达式，导出同样偏小。**计费金额不受影响。**
- Frequency: 确定性发生，100%。任何走 Anthropic 语义且使用 prompt caching 的请求皆然。
- Evidence that the problem is in new-api rather than the client or upstream: 上游 usage 符合 Anthropic 规范且被 new-api 完整接收——同一条日志的 `other.cache_tokens=589733`、`other.cache_write_tokens=1088` 均正确落库。更直接的内部证据：new-api 自身在别处已实现正确归一化，`service/tiered_settle.go:45-48` 用同一个 `isClaudeUsageSemantic` 标记计算 `len = p + cr + cc5m + cc1h`，`pkg/billingexpr/expr.md:354` 将该公式写成规范。仓库既知道公式也拿到了数据，只是写日志时未套用。属纯内部不一致。
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): 详见所链 issue 的 Type-specific details 段（Relay/API、Billing、Frontend 已填；Deployment 不适用）。

## Change

在写消耗日志的边界补齐 Anthropic 语义的 token 归一化，使 `logs.prompt_tokens` 对所有供应商统一表示「总输入 token」。

1. `textQuotaSummary` 新增 `PromptTokensExcludeCache` 字段，取值为计费逻辑已在使用的同一判定 `summary.IsClaudeUsageSemantic || legacyClaudeDerived`（`text_quota.go:284`）。复用同源条件，而非另写一份判断，避免日志与计费口径日后分叉。
2. 新增 `logInputTokens(summary)`：该标记为真时返回 `PromptTokens + CacheTokens + cacheWriteTokensTotal(summary)`，否则原样返回 `PromptTokens`。
3. `RecordConsumeLog` 的 `PromptTokens` 改为传 `logInputTokens(summary)`。

为什么成立：

- **计费金额不变。** `summary.PromptTokens` 本身未被修改，配额在 `calculateTextQuotaSummary` 内部早已算完并结算，本变更只改变此后传给 `RecordConsumeLog` 的值。原有配额断言 1488 / 1624 未做任何调整即通过。
- **不重复累加。** OpenAI 语义下 `PromptTokens` 已含缓存，`PromptTokensExcludeCache` 为假，直接返回原值。
- **缓存写入取的是实际计费量。** 选用 `cacheWriteTokensTotal` 而非 `summary.CacheCreationTokens`：Claude 语义的计费分支实际按 `max(总量, 5m+1h)` 计价（`text_quota.go:322-325` 中 `remaining = max(总量-5m-1h, 0)` 再加 5m、1h），`cacheWriteTokensTotal` 正是该量；且当上游只给 5m/1h 拆分而缺总量字段时仍然准确。
- **既有特殊路径能正确还原。** OpenRouter 的 Claude 计费路径先从 prompt 中减去缓存（`text_quota.go:273-281`），加回后即为上游原始的含缓存总输入；`legacyClaudeDerived` 旧路径的 `PromptTokens` 同样不含缓存，故沿用同一条件一并归一化。
- **与既有规范一致。** 该公式与 `expr.md:354` 记载的 `len = input_tokens + cache_read_tokens + cache_creation_tokens` 相同，不引入新概念，只是把既有归一化补齐到缺失的那条路径。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `new-api QuantumNous Claude cache_read_input_tokens prompt_tokens 日志 统计 issue`；`QuantumNous/new-api pull request text_quota.go prompt_tokens anthropic cache tokens log statistics`
- What already existed and why this is not a duplicate: #3309 是缓存字段反序列化不到（本变更中缓存字段已正确落库）；#6011 是前端缓存**价格**展示被 `other.claude === true` 门控（本变更是后端写入的 token **数值**口径）；#4395 是 Claude←OpenAI 的反向转换且不影响计费；#6212 是流式与非流式的 token 计数差异。**#5069 关系最近但取向不同**：它把「看板统计不含缓存」当作功能缺失，提议在 `quota_data` 侧新增 `cache_tokens` 等拆分字段；本 PR 主张同一列语义随供应商而变本身是 bug。两者可并存——本 PR 修正列语义，#5069 仍可提供明细拆分。**若维护者倾向统一到 #5069 的拆分字段方案，请直接说明，我按该方向重做。**
  ⚠️ `github.com` 在本工作环境无法访问，上述 issue 内容来自站外搜索摘要，未逐一打开原页核对。

### Docs and code

- https://docs.newapi.ai/ : 无法访问（网络策略拦截，`Unable to verify if domain ... is safe to fetch`），未取得结论。
- https://deepwiki.com/QuantumNous/new-api : 无法访问（同上），未取得结论。
- README / repo docs: `pkg/billingexpr/expr.md` 是直接相关的仓库内规范。第 17 行说明表达式无需知道上游是 OpenAI 格式（`prompt_tokens` 含缓存）还是 Claude 格式（`input_tokens` 不含缓存），「系统会在求值前按上游响应格式归一化」；第 34 行定义 `len`「非 Claude：等于原始 `prompt_tokens`；Claude：等于文本输入 + 缓存读取 + 缓存创建」；第 338–340 行列出两种语义差异；第 354 行给出 `len = input_tokens + cache_read_tokens + cache_creation_tokens`。
- Code paths and what they imply for this change:
  - `relaykit/dto/billing_usage.go:298-327` — `canonicalClaudeUsage()` 令 `PromptTokens = InputTokens`（fresh），同时另算含缓存的 `InputTokens`，并把缓存放入 `PromptTokensDetails`。含缓存总输入在这一层就已存在。
  - `service/text_quota.go:258-262` — `summary.PromptTokens` 取 fresh 值。
  - `service/text_quota.go:309-327` — 计费分支对 Anthropic 语义不减缓存、按各自倍率单独计价，证明计费侧对语义差异知情且正确。
  - `service/tiered_settle.go:45-48` — 同一标记已在计费 `len` 上做正确归一化，与 `expr.md:354` 一致。
  - `model/log.go:625`、`model/log.go:684`、`model/log.go:393` — 三处按「总输入」消费 `prompt_tokens`。
  - `web/.../common-logs-columns.tsx:703-735`、`web/.../details-dialog.tsx:373-403` — 前端按「总输入」渲染并把缓存作为明细，前提对 OpenAI 语义成立、对 Anthropic 不成立。
  - 结论：写入方与所有消费方对该列的解释相互矛盾，修正点应在写入边界。

### Alternatives considered

- Option A（本 PR）：在写日志边界归一化，使该列对所有供应商统一表示总输入。
- Option B：保留列为 fresh 语义，改为在消费侧补偿——前端三处展示与 `model/log.go` 两处 SQL 聚合都读取并累加缓存字段。
- Option C：不动该列，另加 `input_tokens_total` 之类的新列供 UI 与统计使用。
- Why this approach: B 需要改动五个消费点（含两处 SQL 聚合，且 `quota_data` 侧还需再算一次），面更大且此后每新增一个消费方都要记得补偿；C 会让两个含义相近的列长期并存，而 `other.input_tokens_total` 已存在却恰好对 Claude 格式不写入（`text_quota.go:541-546`）且前端从未读取，说明该方向此前已尝试并搁置。A 只改一处写入、与 `expr.md` 既有规范同源、且让所有现有消费方自动正确，是最小且最不易再次分叉的做法。**不过 A 会改变 `token_used` 的口径，这一点与 #5069 存在取向分歧，需维护者确认。**

## Files

| Path | Why |
| --- | --- |
| `service/text_quota.go` | 新增 `PromptTokensExcludeCache` 标记与 `logInputTokens()`，并把 `RecordConsumeLog` 的 `PromptTokens` 改为归一化后的总输入 |
| `service/text_quota_test.go` | 新增 `TestLogInputTokensNormalizesCacheAcrossSemantics`；在既有的 Claude 语义与 `legacyClaudeDerived` 测试中补充归一化断言 |

## Behavior

- Before: Anthropic 语义记录写入 `prompt_tokens = input_tokens`（fresh）。示例记录写入 `2`，而同条记录的 `other.cache_tokens=589733`、`other.cache_write_tokens=1088`。TPM／`SumUsedToken`／看板 `TokenUsed` 均漏掉缓存输入。
- After: 同类记录写入 `prompt_tokens = 590823`（`2 + 589733 + 1088`），与缓存明细自洽，并与 OpenAI 语义模型口径一致；TPM 与 token 统计包含缓存输入。OpenAI 语义记录数值不变。计费金额、`quota` 字段、预扣费与结算逻辑不变。
- Explicit non-goals / leftover work:
  - **不追溯修正历史日志**，仅影响变更后新产生的记录。存量数据需独立的回填迁移，本 PR 不含。
  - 不改动前端与 SQL 聚合（采用本方案后它们本已正确）。
  - 观察到一处**相邻的潜在缺陷，本次刻意不修**以保持单一聚焦：`service/tiered_settle.go:47` 的 `len` 用 `cc5m + cc1h` 加回缓存写入，而 Anthropic 语义下这两个值仅取自 `ClaudeCacheCreation5m/1hTokens`；若上游只给了 `cache_creation_input_tokens` 总量而未给 `cache_creation` 子对象，`len` 会漏掉该部分。建议另开条目。

## Verification

- Commands and results:
  - `gofmt -l service/text_quota.go service/text_quota_test.go` — 无输出。
  - `go vet ./service/... ./model/...` — 无告警。
  - `go test ./service/ -run 'TestLogInputTokens|TestCacheWriteTokensTotal|TestCalculateTextQuotaSummary' -v` — 全部 PASS，含新增 4 个子用例。
  - `go test ./service/... ./model/...` — `model` 全绿；`service` 包内 `TestObserveChannelAffinityUsageCacheByRelayFormat_MixedMode` 与 `_UnsupportedModeKeepsEmpty` 失败（`expected: int(2), actual: int64(3)`）。已用 `git stash` 在未修改的 `064ed943e` 上复现同样失败，确认为**既有问题，与本 PR 无关**。
  - `go build ./...` — 仅因未构建前端而报 `pattern web/dist: no matching files found`，与本变更无关。
- Manual steps and observed result: 以本变更构建 Docker 镜像部署到实际服务器，通过 Claude Code 客户端向 `POST /v1/messages` 发起会命中缓存的连续对话（`claude-opus-5`、`claude-sonnet-5`），在 `/usage-logs` 观察。六条记录逐条精确自洽：`261,283 = 2 + 260,411 + 870`、`678,781 = 2 + 677,478 + 1,301`、`677,480 = 2 + 676,858 + 620`、`72,230 = 2 + 29,717 + 42,511`、`260,413 = 2 + 257,765 + 2,646`、`72,037 = 2 + 29,261 + 42,774`。TPM 从修复前的 0 变为 941,332，恰等于最近 60 秒两条记录之和 `(678,781 + 178) + (261,283 + 1,090) = 941,332`，分毫不差——这直接证明修复贯通到了 `SumUsedQuota` 的聚合。同一页面中切换容器前写入的最后一条仍为 `2 / 2,568`，构成同图前后对照。
- UI: screenshot or recording (or why none): 有修复前后各一张 `/usage-logs` 截图（由报告者提供）。如需附在 PR 中请告知。
- Tests added or updated, or why none: 新增 `TestLogInputTokensNormalizesCacheAcrossSemantics`（OpenAI 语义不累加、Anthropic 语义加回缓存读写含真实数据 `2 → 590,823`、仅有 5m/1h 拆分时按实际计费量加回、Anthropic 无缓存时不变）；并在既有 `TestCalculateTextQuotaSummaryUnifiedForClaudeSemantic` 与 `TestCalculateTextQuotaSummaryHandlesLegacyClaudeDerivedOpenAIUsage` 中补充断言（分别为 1150 与 4192），未新建测试文件。
- Databases / providers / platforms exercised: postgres 15（Docker）；Anthropic 原生渠道，`claude-opus-5` 与 `claude-sonnet-5`；linux/amd64。
- Not verified: MySQL、SQLite 未实测——本变更不含 schema、GORM tag、迁移或 SQL 变更，仅改变写入既有 `prompt_tokens` 列的数值，故三库行为应一致，但未逐一验证。OpenRouter Claude 计费路径、`legacyClaudeDerived` 旧路径、Claude←OpenAI 跨格式转换路径仅有单元测试覆盖，无真实上游实测。Bedrock、Vertex 等其他承载 Claude 的渠道类型未实测。历史日志回填未验证（本 PR 不涉及）。`docs.newapi.ai`、`deepwiki.com`、`github.com` 在本工作环境无法访问，文档与重复排查依赖站外搜索摘要。

## Risks

- Failure modes: 若某条路径的 `PromptTokens` 实际**已经**含缓存却被判定为 Anthropic 语义，会导致重复累加、`prompt_tokens` 偏大。该判定沿用计费侧同源条件 `IsClaudeUsageSemantic || legacyClaudeDerived`，若它误判，现有计费也会同时算错，因此不引入新的误判面。OpenRouter 路径已在单元测试中覆盖往返一致性。
- Billing / quota / auth impact: **计费与配额无影响。** `summary.PromptTokens` 未被改动，配额在写日志之前已计算并结算完毕；原有配额断言未做调整即通过。不涉及认证。唯一的口径变化是 `logs.prompt_tokens` 及由其派生的 RPM/TPM、`SumUsedToken`、看板 `TokenUsed` 对 Claude 请求开始包含缓存输入——这正是本 PR 的目的，但会造成修复前后同一模型的统计数字出现台阶，且与 #5069 的方案取向需要协调。
- Follow-ups: ①历史日志回填迁移（可选，独立 PR）；②`tiered_settle.go:47` 的 `len` 在缺少 5m/1h 拆分时漏算缓存写入（见 Behavior 段）；③与 #5069 的方案协调。

## Scope check

- Single focused change: yes — 仅修正写入消耗日志时的 token 归一化，两个文件，不含无关重构。
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no
## Agent

- Tool: Claude Code
- Tool version: 未知（运行环境未向 agent 暴露版本号）
- Model (full id): claude-opus-5[1m]
- Host (CLI / IDE / GitHub coding agent / other): IDE（VS Code 扩展）
- Date (UTC): 2026-09-09

> **声明：本 PR 的代码由 AI 生成／AI 辅助完成。** 提交者 `TomJKS` 不是本仓库的历史核心开发者（在 `upstream/main` 上提交数为 0），按项目约定在此显式说明。变更已经过人工复核与真实环境验证，详见 Verification。

## Links

- Closes #`7290`
- Related: #5069（数据看板 token 统计不含缓存 token，方案取向不同，见 Research）、#3309、#6011、#4395、#6212

## User request

用户原话：「Claude模型的tokens统计还是不准确，参考其他模型是正常的，修复统计错误的bug」，并附使用日志截图：同一页面 qwen3.8-max 显示 `70,397 / 2,228`（缓存↓ 67,584），claude-opus-5 却显示 `2 / 1,117`（缓存↓ 589,733 ↑ 1,088）。

## Out of scope — refuse

- Coding Plan
- Reverse-engineered channels
- Third-party API wrappers
- Codex channel-type changes, or compatibility from exposing Codex as a general-purpose API
- Codex API-specific protocol or behavior treated as standard OpenAI API behavior
- Pass-through-only forwarding
- Third-party hosting sites, relay services, or API services
- Usage, configuration, or integration

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): 不适用。本变更修复 new-api 自身写入消耗日志时缺失的 token 归一化，不涉及上述任何一类。

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: Anthropic 语义的消耗日志把 `prompt_tokens` 写成 Claude 原始 `input_tokens`，即仅未命中缓存的 fresh token。一次命中 589,733 缓存读取、1,088 缓存写入的请求，`prompt_tokens` 只有 2。
- Impact: ①展示——使用日志 Tokens 列、详情弹窗 "Input Tokens"、移动端卡片均按「总输入」读取该字段并把缓存作为其明细，Claude 行严重偏小且无法与其他模型横向比较；②统计——`model/log.go:625` 的 RPM/TPM 与 `model/log.go:684` 的 `SumUsedToken` 都按 `sum(prompt_tokens) + sum(completion_tokens)` 聚合，Claude 请求静默漏掉全部缓存输入，缓存密集场景下 TPM 可低估两个数量级；③看板——`LogQuotaData` 的 `TokenUsed` 取同一表达式，导出同样偏小。**计费金额不受影响。**
- Frequency: 确定性发生，100%。任何走 Anthropic 语义且使用 prompt caching 的请求皆然。
- Evidence that the problem is in new-api rather than the client or upstream: 上游 usage 符合 Anthropic 规范且被 new-api 完整接收——同一条日志的 `other.cache_tokens=589733`、`other.cache_write_tokens=1088` 均正确落库。更直接的内部证据：new-api 自身在别处已实现正确归一化，`service/tiered_settle.go:45-48` 用同一个 `isClaudeUsageSemantic` 标记计算 `len = p + cr + cc5m + cc1h`，`pkg/billingexpr/expr.md:354` 将该公式写成规范。仓库既知道公式也拿到了数据，只是写日志时未套用。属纯内部不一致。
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): 详见所链 issue 的 Type-specific details 段（Relay/API、Billing、Frontend 已填；Deployment 不适用）。

## Change

在写消耗日志的边界补齐 Anthropic 语义的 token 归一化，使 `logs.prompt_tokens` 对所有供应商统一表示「总输入 token」。

1. `textQuotaSummary` 新增 `PromptTokensExcludeCache` 字段，取值为计费逻辑已在使用的同一判定 `summary.IsClaudeUsageSemantic || legacyClaudeDerived`（`text_quota.go:284`）。复用同源条件，而非另写一份判断，避免日志与计费口径日后分叉。
2. 新增 `logInputTokens(summary)`：该标记为真时返回 `PromptTokens + CacheTokens + cacheWriteTokensTotal(summary)`，否则原样返回 `PromptTokens`。
3. `RecordConsumeLog` 的 `PromptTokens` 改为传 `logInputTokens(summary)`。

为什么成立：

- **计费金额不变。** `summary.PromptTokens` 本身未被修改，配额在 `calculateTextQuotaSummary` 内部早已算完并结算，本变更只改变此后传给 `RecordConsumeLog` 的值。原有配额断言 1488 / 1624 未做任何调整即通过。
- **不重复累加。** OpenAI 语义下 `PromptTokens` 已含缓存，`PromptTokensExcludeCache` 为假，直接返回原值。
- **缓存写入取的是实际计费量。** 选用 `cacheWriteTokensTotal` 而非 `summary.CacheCreationTokens`：Claude 语义的计费分支实际按 `max(总量, 5m+1h)` 计价（`text_quota.go:322-325` 中 `remaining = max(总量-5m-1h, 0)` 再加 5m、1h），`cacheWriteTokensTotal` 正是该量；且当上游只给 5m/1h 拆分而缺总量字段时仍然准确。
- **既有特殊路径能正确还原。** OpenRouter 的 Claude 计费路径先从 prompt 中减去缓存（`text_quota.go:273-281`），加回后即为上游原始的含缓存总输入；`legacyClaudeDerived` 旧路径的 `PromptTokens` 同样不含缓存，故沿用同一条件一并归一化。
- **与既有规范一致。** 该公式与 `expr.md:354` 记载的 `len = input_tokens + cache_read_tokens + cache_creation_tokens` 相同，不引入新概念，只是把既有归一化补齐到缺失的那条路径。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `new-api QuantumNous Claude cache_read_input_tokens prompt_tokens 日志 统计 issue`；`QuantumNous/new-api pull request text_quota.go prompt_tokens anthropic cache tokens log statistics`
- What already existed and why this is not a duplicate: #3309 是缓存字段反序列化不到（本变更中缓存字段已正确落库）；#6011 是前端缓存**价格**展示被 `other.claude === true` 门控（本变更是后端写入的 token **数值**口径）；#4395 是 Claude←OpenAI 的反向转换且不影响计费；#6212 是流式与非流式的 token 计数差异。**#5069 关系最近但取向不同**：它把「看板统计不含缓存」当作功能缺失，提议在 `quota_data` 侧新增 `cache_tokens` 等拆分字段；本 PR 主张同一列语义随供应商而变本身是 bug。两者可并存——本 PR 修正列语义，#5069 仍可提供明细拆分。**若维护者倾向统一到 #5069 的拆分字段方案，请直接说明，我按该方向重做。**
  ⚠️ `github.com` 在本工作环境无法访问，上述 issue 内容来自站外搜索摘要，未逐一打开原页核对。

### Docs and code

- https://docs.newapi.ai/ : 无法访问（网络策略拦截，`Unable to verify if domain ... is safe to fetch`），未取得结论。
- https://deepwiki.com/QuantumNous/new-api : 无法访问（同上），未取得结论。
- README / repo docs: `pkg/billingexpr/expr.md` 是直接相关的仓库内规范。第 17 行说明表达式无需知道上游是 OpenAI 格式（`prompt_tokens` 含缓存）还是 Claude 格式（`input_tokens` 不含缓存），「系统会在求值前按上游响应格式归一化」；第 34 行定义 `len`「非 Claude：等于原始 `prompt_tokens`；Claude：等于文本输入 + 缓存读取 + 缓存创建」；第 338–340 行列出两种语义差异；第 354 行给出 `len = input_tokens + cache_read_tokens + cache_creation_tokens`。
- Code paths and what they imply for this change:
  - `relaykit/dto/billing_usage.go:298-327` — `canonicalClaudeUsage()` 令 `PromptTokens = InputTokens`（fresh），同时另算含缓存的 `InputTokens`，并把缓存放入 `PromptTokensDetails`。含缓存总输入在这一层就已存在。
  - `service/text_quota.go:258-262` — `summary.PromptTokens` 取 fresh 值。
  - `service/text_quota.go:309-327` — 计费分支对 Anthropic 语义不减缓存、按各自倍率单独计价，证明计费侧对语义差异知情且正确。
  - `service/tiered_settle.go:45-48` — 同一标记已在计费 `len` 上做正确归一化，与 `expr.md:354` 一致。
  - `model/log.go:625`、`model/log.go:684`、`model/log.go:393` — 三处按「总输入」消费 `prompt_tokens`。
  - `web/.../common-logs-columns.tsx:703-735`、`web/.../details-dialog.tsx:373-403` — 前端按「总输入」渲染并把缓存作为明细，前提对 OpenAI 语义成立、对 Anthropic 不成立。
  - 结论：写入方与所有消费方对该列的解释相互矛盾，修正点应在写入边界。

### Alternatives considered

- Option A（本 PR）：在写日志边界归一化，使该列对所有供应商统一表示总输入。
- Option B：保留列为 fresh 语义，改为在消费侧补偿——前端三处展示与 `model/log.go` 两处 SQL 聚合都读取并累加缓存字段。
- Option C：不动该列，另加 `input_tokens_total` 之类的新列供 UI 与统计使用。
- Why this approach: B 需要改动五个消费点（含两处 SQL 聚合，且 `quota_data` 侧还需再算一次），面更大且此后每新增一个消费方都要记得补偿；C 会让两个含义相近的列长期并存，而 `other.input_tokens_total` 已存在却恰好对 Claude 格式不写入（`text_quota.go:541-546`）且前端从未读取，说明该方向此前已尝试并搁置。A 只改一处写入、与 `expr.md` 既有规范同源、且让所有现有消费方自动正确，是最小且最不易再次分叉的做法。**不过 A 会改变 `token_used` 的口径，这一点与 #5069 存在取向分歧，需维护者确认。**

## Files

| Path | Why |
| --- | --- |
| `service/text_quota.go` | 新增 `PromptTokensExcludeCache` 标记与 `logInputTokens()`，并把 `RecordConsumeLog` 的 `PromptTokens` 改为归一化后的总输入 |
| `service/text_quota_test.go` | 新增 `TestLogInputTokensNormalizesCacheAcrossSemantics`；在既有的 Claude 语义与 `legacyClaudeDerived` 测试中补充归一化断言 |

## Behavior

- Before: Anthropic 语义记录写入 `prompt_tokens = input_tokens`（fresh）。示例记录写入 `2`，而同条记录的 `other.cache_tokens=589733`、`other.cache_write_tokens=1088`。TPM／`SumUsedToken`／看板 `TokenUsed` 均漏掉缓存输入。
- After: 同类记录写入 `prompt_tokens = 590823`（`2 + 589733 + 1088`），与缓存明细自洽，并与 OpenAI 语义模型口径一致；TPM 与 token 统计包含缓存输入。OpenAI 语义记录数值不变。计费金额、`quota` 字段、预扣费与结算逻辑不变。
- Explicit non-goals / leftover work:
  - **不追溯修正历史日志**，仅影响变更后新产生的记录。存量数据需独立的回填迁移，本 PR 不含。
  - 不改动前端与 SQL 聚合（采用本方案后它们本已正确）。
  - 观察到一处**相邻的潜在缺陷，本次刻意不修**以保持单一聚焦：`service/tiered_settle.go:47` 的 `len` 用 `cc5m + cc1h` 加回缓存写入，而 Anthropic 语义下这两个值仅取自 `ClaudeCacheCreation5m/1hTokens`；若上游只给了 `cache_creation_input_tokens` 总量而未给 `cache_creation` 子对象，`len` 会漏掉该部分。建议另开条目。

## Verification

- Commands and results:
  - `gofmt -l service/text_quota.go service/text_quota_test.go` — 无输出。
  - `go vet ./service/... ./model/...` — 无告警。
  - `go test ./service/ -run 'TestLogInputTokens|TestCacheWriteTokensTotal|TestCalculateTextQuotaSummary' -v` — 全部 PASS，含新增 4 个子用例。
  - `go test ./service/... ./model/...` — `model` 全绿；`service` 包内 `TestObserveChannelAffinityUsageCacheByRelayFormat_MixedMode` 与 `_UnsupportedModeKeepsEmpty` 失败（`expected: int(2), actual: int64(3)`）。已用 `git stash` 在未修改的 `064ed943e` 上复现同样失败，确认为**既有问题，与本 PR 无关**。
  - `go build ./...` — 仅因未构建前端而报 `pattern web/dist: no matching files found`，与本变更无关。
- Manual steps and observed result: 以本变更构建 Docker 镜像部署到实际服务器，通过 Claude Code 客户端向 `POST /v1/messages` 发起会命中缓存的连续对话（`claude-opus-5`、`claude-sonnet-5`），在 `/usage-logs` 观察。六条记录逐条精确自洽：`261,283 = 2 + 260,411 + 870`、`678,781 = 2 + 677,478 + 1,301`、`677,480 = 2 + 676,858 + 620`、`72,230 = 2 + 29,717 + 42,511`、`260,413 = 2 + 257,765 + 2,646`、`72,037 = 2 + 29,261 + 42,774`。TPM 从修复前的 0 变为 941,332，恰等于最近 60 秒两条记录之和 `(678,781 + 178) + (261,283 + 1,090) = 941,332`，分毫不差——这直接证明修复贯通到了 `SumUsedQuota` 的聚合。同一页面中切换容器前写入的最后一条仍为 `2 / 2,568`，构成同图前后对照。
- UI: screenshot or recording (or why none): 有修复前后各一张 `/usage-logs` 截图（由报告者提供）。如需附在 PR 中请告知。
- Tests added or updated, or why none: 新增 `TestLogInputTokensNormalizesCacheAcrossSemantics`（OpenAI 语义不累加、Anthropic 语义加回缓存读写含真实数据 `2 → 590,823`、仅有 5m/1h 拆分时按实际计费量加回、Anthropic 无缓存时不变）；并在既有 `TestCalculateTextQuotaSummaryUnifiedForClaudeSemantic` 与 `TestCalculateTextQuotaSummaryHandlesLegacyClaudeDerivedOpenAIUsage` 中补充断言（分别为 1150 与 4192），未新建测试文件。
- Databases / providers / platforms exercised: postgres 15（Docker）；Anthropic 原生渠道，`claude-opus-5` 与 `claude-sonnet-5`；linux/amd64。
- Not verified: MySQL、SQLite 未实测——本变更不含 schema、GORM tag、迁移或 SQL 变更，仅改变写入既有 `prompt_tokens` 列的数值，故三库行为应一致，但未逐一验证。OpenRouter Claude 计费路径、`legacyClaudeDerived` 旧路径、Claude←OpenAI 跨格式转换路径仅有单元测试覆盖，无真实上游实测。Bedrock、Vertex 等其他承载 Claude 的渠道类型未实测。历史日志回填未验证（本 PR 不涉及）。`docs.newapi.ai`、`deepwiki.com`、`github.com` 在本工作环境无法访问，文档与重复排查依赖站外搜索摘要。

## Risks

- Failure modes: 若某条路径的 `PromptTokens` 实际**已经**含缓存却被判定为 Anthropic 语义，会导致重复累加、`prompt_tokens` 偏大。该判定沿用计费侧同源条件 `IsClaudeUsageSemantic || legacyClaudeDerived`，若它误判，现有计费也会同时算错，因此不引入新的误判面。OpenRouter 路径已在单元测试中覆盖往返一致性。
- Billing / quota / auth impact: **计费与配额无影响。** `summary.PromptTokens` 未被改动，配额在写日志之前已计算并结算完毕；原有配额断言未做调整即通过。不涉及认证。唯一的口径变化是 `logs.prompt_tokens` 及由其派生的 RPM/TPM、`SumUsedToken`、看板 `TokenUsed` 对 Claude 请求开始包含缓存输入——这正是本 PR 的目的，但会造成修复前后同一模型的统计数字出现台阶，且与 #5069 的方案取向需要协调。
- Follow-ups: ①历史日志回填迁移（可选，独立 PR）；②`tiered_settle.go:47` 的 `len` 在缺少 5m/1h 拆分时漏算缓存写入（见 Behavior 段）；③与 #5069 的方案协调。

## Scope check

- Single focused change: yes — 仅修正写入消耗日志时的 token 归一化，两个文件，不含无关重构。
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no
<img width="564" height="345" alt="image" src="https://github.com/user-attachments/assets/b9e58d95-d091-4a5f-b7ee-abdbc8676ec7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved usage and quota accounting for requests with cached input.
  - Input token totals now consistently include fresh, cache-read, and cache-write usage where applicable.
  - Corrected handling across Anthropic-style, Claude-derived, and standard OpenAI usage formats.
  - Cache-excluded prompt counts are preserved while recorded consumption reflects the total billable input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->