### PR TITLE
fix(plugin): send sampleCount instead of numberOfVideos in google veo requests

### DIFF
--- a/plugins/tasks/google/plugin.js
+++ b/plugins/tasks/google/plugin.js
@@ -148,7 +148,7 @@ function converted(ctx) {
   if (!params.resolution && req.size) params.resolution = resolutionForSize(req.size);
   if (!params.aspectRatio && req.size) params.aspectRatio = aspectForSize(req.size);
   if (params.resolution) params.resolution = String(params.resolution).toLowerCase();
-  params.numberOfVideos = 1;
+  params.sampleCount = 1;
   const instance = { prompt: req.prompt };
   const image = imageInput((req.images || [])[0], ctx.files);
   if (image) instance.image = image;


### PR DESCRIPTION
gemini veo默认带`numberOfVideos`生视频会报错参数不支持, 必现

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description
google 插件组装 `predictLongRunning` 请求体时固定带了 `parameters.numberOfVideos = 1`。这是 Python SDK 里的配置名,Gemini REST 接口对应字段是 `sampleCount`,Google 现在直接拒绝未知参数,导致 veo 任务提交失败。

改成 `sampleCount`,和 vertex-ai 插件以及原 Go 适配器保持一致。

## 📸 运行证明 / Proof of Work
复现:通过 `/v1/videos` 提交 `veo-3.1-fast-generate-preview`,只传 model/prompt/seconds/size,Google 返回 400:

```
`numberOfVideos` isn't supported by this model. Please remove it or ...
```

修复后 `go test ./plugins/ ./controller/` 通过。

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 无论描述是否由 AI 生成，我已审阅全部内容，并声明对其准确性与完整性负责。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **新功能关联 Issue:** 若此 PR 标记为 `New feature`，我已关联对应 Issue；若尚无 Issue，我已先自行创建。
- [ ] **事前沟通:** 若改动较大或涉及方向性变更，已在关联 Issue 中与维护者沟通并达成一致。
- [x] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口，也不是对 Codex 渠道类型的改动。
- [x] **范围聚焦:** 本 PR 为一项聚焦改动，未包含无关代码。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected video generation requests to use the expected sampling parameter, improving compatibility with the Veo API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->