### PR TITLE
feat: add optional Langfuse gateway observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,3 +137,15 @@ LINUX_DO_USER_ENDPOINT=https://connect.linux.do/api/user
 # 用于验证支付成功/取消回调URL的域名安全性
 # 示例: example.com,myapp.io 将允许 example.com, sub.example.com, myapp.io 等
 # TRUSTED_REDIRECT_DOMAINS=example.com,myapp.io
+# Langfuse 网关请求观测（默认关闭；只上传请求级指标，不上传 prompt/completion）
+# LANGFUSE_ENABLED=false
+# LANGFUSE_HOST=https://cloud.langfuse.com
+# LANGFUSE_PUBLIC_KEY=
+# LANGFUSE_SECRET_KEY=
+# LANGFUSE_SAMPLE_RATE=1
+# LANGFUSE_TIMEOUT_MS=3000
+# LANGFUSE_QUEUE_SIZE=256
+# LANGFUSE_BATCH_SIZE=20
+# LANGFUSE_FLUSH_INTERVAL_MS=1000
+# LANGFUSE_CAPTURE_CONTENT=false
+# LANGFUSE_CONTENT_MAX_BYTES=16384

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -98,6 +98,10 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 			safeError := newAPIError.MaskSensitiveErrorWithStatusCode()
 			logger.LogError(c, fmt.Sprintf("relay error: %s", common.LocalLogPreview(safeError)))
 			metadata := map[string]any{"retry_count": c.GetInt("retry_count"), "use_channel": c.GetStringSlice("use_channel"), "status_code": newAPIError.StatusCode}
+			durationMS := 0
+			if startTime := common.GetContextKeyTime(c, constant.ContextKeyRequestStartTime); !startTime.IsZero() {
+				durationMS = int(time.Since(startTime).Milliseconds())
+			}
 			traceID := c.GetString("trace_id")
 			if traceID == "" {
 				traceID = c.GetHeader("X-Trace-ID")
@@ -115,7 +119,7 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 					return relayInfo.OriginModelName
 				}
 				return ""
-			}(), Status: "error", Error: common.LocalLogPreview(safeError), Metadata: metadata})
+			}(), DurationMS: durationMS, Status: "error", Error: common.LocalLogPreview(safeError), Metadata: metadata})
 			newAPIError.SetMessage(common.MessageWithRequestId(newAPIError.Error(), requestId))
 			switch relayFormat {
 			case types.RelayFormatOpenAIRealtime:

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -16,6 +16,7 @@ import (
 	"github.com/QuantumNous/new-api/middleware"
 	"github.com/QuantumNous/new-api/model"
 	pluginruntime "github.com/QuantumNous/new-api/pkg/jsplugin"
+	"github.com/QuantumNous/new-api/pkg/langfuse"
 	perfmetrics "github.com/QuantumNous/new-api/pkg/perf_metrics"
 	"github.com/QuantumNous/new-api/relay"
 	"github.com/QuantumNous/new-api/relay/channel/task/taskcommon"
@@ -79,6 +80,7 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 	var (
 		newAPIError *types.NewAPIError
 		ws          *websocket.Conn
+		relayInfo   *relaycommon.RelayInfo
 	)
 
 	if relayFormat == types.RelayFormatOpenAIRealtime {
@@ -93,7 +95,27 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 
 	defer func() {
 		if newAPIError != nil {
-			logger.LogError(c, fmt.Sprintf("relay error: %s", common.LocalLogPreview(newAPIError.Error())))
+			safeError := newAPIError.MaskSensitiveErrorWithStatusCode()
+			logger.LogError(c, fmt.Sprintf("relay error: %s", common.LocalLogPreview(safeError)))
+			metadata := map[string]any{"retry_count": c.GetInt("retry_count"), "use_channel": c.GetStringSlice("use_channel"), "status_code": newAPIError.StatusCode}
+			traceID := c.GetString("trace_id")
+			if traceID == "" {
+				traceID = c.GetHeader("X-Trace-ID")
+			}
+			sessionID := c.GetString("session_id")
+			if sessionID == "" {
+				sessionID = c.GetHeader("X-Session-ID")
+			}
+			projectID := c.GetString("project_id")
+			if projectID == "" {
+				projectID = c.GetHeader("X-Project-ID")
+			}
+			langfuse.Publish(langfuse.Event{RequestID: requestId, TraceID: traceID, SessionID: sessionID, ProjectID: projectID, Model: func() string {
+				if relayInfo != nil {
+					return relayInfo.OriginModelName
+				}
+				return ""
+			}(), Status: "error", Error: common.LocalLogPreview(safeError), Metadata: metadata})
 			newAPIError.SetMessage(common.MessageWithRequestId(newAPIError.Error(), requestId))
 			switch relayFormat {
 			case types.RelayFormatOpenAIRealtime:
@@ -122,7 +144,7 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 		return
 	}
 
-	relayInfo, err := relaycommon.GenRelayInfo(c, relayFormat, request, ws)
+	relayInfo, err = relaycommon.GenRelayInfo(c, relayFormat, request, ws)
 	if err != nil {
 		newAPIError = types.NewError(err, types.ErrorCodeGenRelayInfoFailed)
 		return
@@ -195,6 +217,7 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 
 	for ; retryParam.GetRetry() <= common.RetryTimes; retryParam.IncreaseRetry() {
 		relayInfo.RetryIndex = retryParam.GetRetry()
+		c.Set("retry_count", relayInfo.RetryIndex)
 		channel, channelErr := getChannel(c, relayInfo, retryParam)
 		if channelErr != nil {
 			logger.LogError(c, channelErr.Error())

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/oauth"
 	"github.com/QuantumNous/new-api/pkg/jsplugin"
+	"github.com/QuantumNous/new-api/pkg/langfuse"
 	perfmetrics "github.com/QuantumNous/new-api/pkg/perf_metrics"
 	"github.com/QuantumNous/new-api/relay"
 	kitutil "github.com/QuantumNous/new-api/relaykit/relayconvert/kitutil"
@@ -73,6 +74,9 @@ func main() {
 	kitutil.Debug.Store(common.DebugEnabled)
 
 	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = langfuse.CloseDefault(shutdownCtx)
 		err := model.CloseDB()
 		if err != nil {
 			common.FatalLog("failed to close database: " + err.Error())
@@ -305,6 +309,7 @@ func InitResources() error {
 	ratio_setting.InitRatioSettings()
 
 	service.InitHttpClient()
+	langfuse.SetDefaultReporter(langfuse.NewReporter(langfuse.LoadConfig()))
 
 	service.InitTokenEncoders()
 

--- a/model/log.go
+++ b/model/log.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/logger"
+	"github.com/QuantumNous/new-api/pkg/langfuse"
 	"github.com/QuantumNous/new-api/types"
 
 	"github.com/gin-gonic/gin"
@@ -211,7 +213,7 @@ func RecordLogWithAdminInfo(userId int, logType int, content string, adminInfo *
 // username 由调用方传入（登录流程已持有用户对象），避免额外的数据库查询。
 // content 为英文兜底文本（用于导出）；action+params 供前端本地化渲染。
 // other 包含 login_method、user_agent 等结构化信息。
-func RecordLoginLog(userId, actorRole int, username string, content string, ip string, action string, params map[string]any, other AuditOther, request ...*gin.Context) {
+func RecordLoginLog(userId, actorRole int, username string, content string, ip string, action string, params map[string]interface{}, other AuditOther, request ...*gin.Context) {
 	other.Op = &AuditOperation{Action: action, Params: params}
 	var c *gin.Context
 	if len(request) > 0 {
@@ -226,7 +228,7 @@ func RecordLoginLog(userId, actorRole int, username string, content string, ip s
 // action+params 写入 Other.op，供前端本地化渲染（普通用户可见，不含敏感信息）。
 // adminInfo 存放操作者身份（写入 Other.admin_info，普通用户查询时剥离）；
 // auditInfo 存放路由/方法/结果等中间件兜底信息（写入 Other.audit_info，普通用户查询时剥离）。
-func RecordOperationAuditLog(logUserId, actorRole int, content string, ip string, action string, params map[string]any, adminInfo *AuditAdminInfo, auditInfo *AuditRequestInfo, request ...*gin.Context) {
+func RecordOperationAuditLog(logUserId, actorRole int, content string, ip string, action string, params map[string]interface{}, adminInfo *AuditAdminInfo, auditInfo *AuditRequestInfo, request ...*gin.Context) {
 	username, _ := GetUsernameById(logUserId, false)
 	other := AuditOther{
 		Op:        &AuditOperation{Action: action, Params: params},
@@ -252,7 +254,7 @@ func RecordOperationAuditLog(logUserId, actorRole int, content string, ip string
 func RecordTopupLog(userId int, content string, callerIp string, paymentMethod string, callbackPaymentMethod string) {
 	username, _ := GetUsernameById(userId, false)
 	other := NewLogOther()
-	other.MergeAdmin(map[string]any{
+	other.MergeAdmin(map[string]interface{}{
 		"server_ip":               common.GetIp(),
 		"node_name":               common.NodeName,
 		"caller_ip":               callerIp,
@@ -336,6 +338,33 @@ type RecordConsumeLogParams struct {
 	Other            *LogOther `json:"other"`
 }
 
+func langfuseEventFromConsumeLog(c *gin.Context, log *Log) langfuse.Event {
+	event := langfuse.Event{
+		RequestID: log.RequestId, UserID: strconv.Itoa(log.UserId), Model: log.ModelName,
+		InputTokens: log.PromptTokens, OutputTokens: log.CompletionTokens,
+		TotalTokens: log.PromptTokens + log.CompletionTokens, Quota: log.Quota,
+		DurationMS: log.UseTime * 1000, IsStream: log.IsStream, Status: "success",
+		Metadata: map[string]any{"username": log.Username, "token_name": log.TokenName, "token_id": log.TokenId, "channel_id": log.ChannelId, "channel_name": log.ChannelName, "group": log.Group, "upstream_request_id": log.UpstreamRequestId},
+	}
+	if c != nil {
+		event.TraceID = c.GetString("trace_id")
+		if event.TraceID == "" {
+			event.TraceID = c.GetHeader("X-Trace-ID")
+		}
+		event.SessionID = c.GetString("session_id")
+		if event.SessionID == "" {
+			event.SessionID = c.GetHeader("X-Session-ID")
+		}
+		event.ProjectID = c.GetString("project_id")
+		if event.ProjectID == "" {
+			event.ProjectID = c.GetHeader("X-Project-ID")
+		}
+		event.Metadata["retry_count"] = c.GetInt("retry_count")
+		event.Metadata["use_channel"] = c.GetStringSlice("use_channel")
+	}
+	return event
+}
+
 func RecordConsumeLog(c *gin.Context, userId int, params RecordConsumeLogParams) {
 	if !common.LogConsumeEnabled {
 		return
@@ -382,6 +411,8 @@ func RecordConsumeLog(c *gin.Context, userId int, params RecordConsumeLogParams)
 	err := createLog(log)
 	if err != nil {
 		logger.LogError(c, "failed to record log: "+err.Error())
+	} else {
+		langfuse.Publish(langfuseEventFromConsumeLog(c, log))
 	}
 	if common.DataExportEnabled {
 		LogQuotaData(QuotaDataLogParams{

--- a/pkg/langfuse/langfuse.go
+++ b/pkg/langfuse/langfuse.go
@@ -1,0 +1,488 @@
+package langfuse
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+const defaultHost = "https://cloud.langfuse.com"
+
+var defaultReporter atomic.Pointer[Reporter]
+
+// Config controls Langfuse reporting and content capture behavior.
+type Config struct {
+	Enabled         bool
+	Host            string
+	PublicKey       string
+	SecretKey       string
+	SampleRate      float64
+	Timeout         time.Duration
+	QueueSize       int
+	BatchSize       int
+	CaptureContent  bool
+	ContentMaxBytes int
+	FlushInterval   time.Duration
+	HTTPClient      *http.Client
+}
+
+// Event is the normalized gateway event sent to Langfuse.
+type Event struct {
+	RequestID    string
+	TraceID      string
+	SessionID    string
+	ProjectID    string
+	UserID       string
+	Model        string
+	InputTokens  int
+	OutputTokens int
+	TotalTokens  int
+	Quota        int
+	DurationMS   int
+	IsStream     bool
+	Status       string
+	Error        string
+	Metadata     map[string]any
+	Input        any
+	Output       any
+}
+
+// Reporter asynchronously batches and sends gateway events to Langfuse.
+type Reporter struct {
+	config    Config
+	client    *http.Client
+	queue     chan Event
+	flush     chan chan struct{}
+	done      chan struct{}
+	stop      chan struct{}
+	wg        sync.WaitGroup
+	once      sync.Once
+	workerCtx context.Context
+	cancel    context.CancelFunc
+	closed    atomic.Bool
+	dropped   atomic.Uint64
+	sent      atomic.Uint64
+	failed    atomic.Uint64
+}
+
+// SetDefaultReporter sets the process-wide reporter used by Publish.
+func SetDefaultReporter(reporter *Reporter) { defaultReporter.Store(reporter) }
+
+// DefaultReporter returns the process-wide Langfuse reporter.
+func DefaultReporter() *Reporter { return defaultReporter.Load() }
+
+// Publish publishes an event to the process-wide reporter when enabled.
+func Publish(event Event) {
+	if reporter := DefaultReporter(); reporter != nil {
+		reporter.Publish(event)
+	}
+}
+
+// CloseDefault flushes and closes the process-wide reporter.
+func CloseDefault(ctx context.Context) error {
+	reporter := DefaultReporter()
+	if reporter == nil {
+		return nil
+	}
+	err := reporter.Close(ctx)
+	defaultReporter.Store(nil)
+	return err
+}
+
+type batchPayload struct {
+	Batch []batchEvent `json:"batch"`
+}
+
+type batchEvent struct {
+	ID   string         `json:"id"`
+	Type string         `json:"type"`
+	Body generationBody `json:"body"`
+}
+
+type generationBody struct {
+	ID            string         `json:"id"`
+	Name          string         `json:"name,omitempty"`
+	Model         string         `json:"model,omitempty"`
+	TraceID       string         `json:"traceId,omitempty"`
+	SessionID     string         `json:"sessionId,omitempty"`
+	ProjectID     string         `json:"projectId,omitempty"`
+	UserID        string         `json:"userId,omitempty"`
+	StartTime     time.Time      `json:"startTime"`
+	EndTime       time.Time      `json:"endTime"`
+	Usage         usage          `json:"usage"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
+	Level         string         `json:"level,omitempty"`
+	StatusMessage string         `json:"statusMessage,omitempty"`
+	Input         any            `json:"input,omitempty"`
+	Output        any            `json:"output,omitempty"`
+}
+
+type usage struct {
+	Input  int `json:"input"`
+	Output int `json:"output"`
+	Total  int `json:"total"`
+}
+
+// LoadConfig reads Langfuse settings from environment variables.
+func LoadConfig() Config {
+	cfg := Config{
+		Enabled:         envBool("LANGFUSE_ENABLED", false),
+		Host:            strings.TrimRight(envString("LANGFUSE_HOST", defaultHost), "/"),
+		PublicKey:       strings.TrimSpace(os.Getenv("LANGFUSE_PUBLIC_KEY")),
+		SecretKey:       strings.TrimSpace(os.Getenv("LANGFUSE_SECRET_KEY")),
+		SampleRate:      envFloat("LANGFUSE_SAMPLE_RATE", 1),
+		Timeout:         time.Duration(envInt("LANGFUSE_TIMEOUT_MS", 3000)) * time.Millisecond,
+		QueueSize:       envInt("LANGFUSE_QUEUE_SIZE", 256),
+		BatchSize:       envInt("LANGFUSE_BATCH_SIZE", 20),
+		CaptureContent:  envBool("LANGFUSE_CAPTURE_CONTENT", false),
+		ContentMaxBytes: envInt("LANGFUSE_CONTENT_MAX_BYTES", 16384),
+		FlushInterval:   time.Duration(envInt("LANGFUSE_FLUSH_INTERVAL_MS", 1000)) * time.Millisecond,
+	}
+	if cfg.SampleRate < 0 || cfg.SampleRate > 1 {
+		cfg.SampleRate = 0
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 3 * time.Second
+	}
+	if cfg.QueueSize <= 0 {
+		cfg.QueueSize = 256
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = 20
+	}
+	if cfg.FlushInterval <= 0 {
+		cfg.FlushInterval = time.Second
+	}
+	if cfg.ContentMaxBytes <= 0 {
+		cfg.ContentMaxBytes = 16384
+	}
+	return cfg
+}
+
+// NewReporter creates a Langfuse reporter. It starts a worker only when the
+// feature is enabled and all required credentials are present.
+func NewReporter(config Config) *Reporter {
+	if config.Host == "" {
+		config.Host = defaultHost
+	}
+	config.Host = strings.TrimRight(config.Host, "/")
+	if config.SampleRate < 0 || config.SampleRate > 1 {
+		config.SampleRate = 0
+	}
+	if config.QueueSize <= 0 {
+		config.QueueSize = 256
+	}
+	if config.BatchSize <= 0 {
+		config.BatchSize = 20
+	}
+	if config.Timeout <= 0 {
+		config.Timeout = 3 * time.Second
+	}
+	if config.FlushInterval <= 0 {
+		config.FlushInterval = time.Second
+	}
+	if config.ContentMaxBytes <= 0 {
+		config.ContentMaxBytes = 16384
+	}
+	workerCtx, cancel := context.WithCancel(context.Background())
+	r := &Reporter{config: config, client: config.HTTPClient, queue: make(chan Event, config.QueueSize), flush: make(chan chan struct{}), done: make(chan struct{}), stop: make(chan struct{}), workerCtx: workerCtx, cancel: cancel}
+	if r.client == nil {
+		r.client = &http.Client{Timeout: config.Timeout}
+	}
+	if config.Enabled && config.PublicKey != "" && config.SecretKey != "" && config.SampleRate > 0 {
+		r.wg.Add(1)
+		go r.run()
+	}
+	return r
+}
+
+// Publish queues an event without blocking the caller when the queue is full.
+func (r *Reporter) Publish(event Event) {
+	if r == nil || !r.configured() || r.closed.Load() || !sample(r.config.SampleRate) {
+		return
+	}
+	select {
+	case r.queue <- event:
+	default:
+		dropped := r.dropped.Add(1)
+		if dropped == 1 || dropped%100 == 0 {
+			log.Printf("langfuse events dropped: queue is full, total=%d", dropped)
+		}
+	}
+}
+
+// Stats contains cumulative reporter delivery counters.
+type Stats struct {
+	Dropped uint64
+	Sent    uint64
+	Failed  uint64
+}
+
+// Stats returns the reporter's cumulative queue and delivery counters.
+func (r *Reporter) Stats() Stats {
+	if r == nil {
+		return Stats{}
+	}
+	return Stats{Dropped: r.dropped.Load(), Sent: r.sent.Load(), Failed: r.failed.Load()}
+}
+
+// Flush synchronously drains the reporter queue within the caller's deadline.
+func (r *Reporter) Flush(ctx context.Context) error {
+	if r == nil || !r.configured() {
+		return nil
+	}
+	ack := make(chan struct{})
+	select {
+	case r.flush <- ack:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case <-ack:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Close flushes pending events and stops the reporter within the caller's deadline.
+func (r *Reporter) Close(ctx context.Context) error {
+	if r == nil || !r.configured() {
+		return nil
+	}
+	if !r.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	flushDone := make(chan struct{})
+	go func() {
+		_ = r.Flush(ctx)
+		close(flushDone)
+	}()
+	select {
+	case <-flushDone:
+	case <-ctx.Done():
+		if r.cancel != nil {
+			r.cancel()
+		}
+	}
+	r.once.Do(func() { close(r.stop) })
+	select {
+	case <-r.done:
+		return nil
+	case <-ctx.Done():
+		if r.cancel != nil {
+			r.cancel()
+		}
+		return ctx.Err()
+	}
+}
+
+func (r *Reporter) configured() bool {
+	return r.config.Enabled && r.config.PublicKey != "" && r.config.SecretKey != "" && r.config.SampleRate > 0
+}
+
+func (r *Reporter) run() {
+	defer r.wg.Done()
+	defer close(r.done)
+	ticker := time.NewTicker(r.config.FlushInterval)
+	defer ticker.Stop()
+	batch := make([]Event, 0, r.config.BatchSize)
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		if err := r.send(r.workerCtx, batch); err != nil {
+			r.failed.Add(uint64(len(batch)))
+			log.Printf("langfuse batch send failed: %v", err)
+		} else {
+			r.sent.Add(uint64(len(batch)))
+		}
+		batch = batch[:0]
+	}
+	for {
+		select {
+		case event := <-r.queue:
+			batch = append(batch, event)
+			if len(batch) >= r.config.BatchSize {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		case ack := <-r.flush:
+			for {
+			fill:
+				for len(batch) < r.config.BatchSize {
+					select {
+					case event := <-r.queue:
+						batch = append(batch, event)
+					default:
+						break fill
+					}
+				}
+				if len(batch) == 0 {
+					break
+				}
+				flush()
+			}
+			close(ack)
+		case <-r.stop:
+			flush()
+			return
+		}
+	}
+}
+
+func (r *Reporter) take(limit int) []Event {
+	batch := make([]Event, 0, limit)
+	for len(batch) < limit {
+		select {
+		case event := <-r.queue:
+			batch = append(batch, event)
+		default:
+			return batch
+		}
+	}
+	return batch
+}
+
+func (r *Reporter) send(ctx context.Context, events []Event) error {
+	parsedHost, err := url.Parse(r.config.Host)
+	if err != nil {
+		return fmt.Errorf("invalid Langfuse host: %w", err)
+	}
+	if parsedHost.Scheme != "https" || parsedHost.Host == "" {
+		return fmt.Errorf("Langfuse host must use HTTPS")
+	}
+	payload := batchPayload{Batch: make([]batchEvent, 0, len(events))}
+	now := time.Now().UTC()
+	for _, event := range events {
+		traceID := event.TraceID
+		if traceID == "" {
+			traceID = event.RequestID
+		}
+		metadata := make(map[string]any, len(event.Metadata)+5)
+		for key, value := range event.Metadata {
+			metadata[key] = value
+		}
+		metadata["request_id"] = event.RequestID
+		metadata["quota"] = event.Quota
+		metadata["duration_ms"] = event.DurationMS
+		metadata["is_stream"] = event.IsStream
+		body := generationBody{ID: newID(), Name: event.Model, Model: event.Model, TraceID: traceID, SessionID: event.SessionID, ProjectID: event.ProjectID, UserID: event.UserID, StartTime: now.Add(-time.Duration(event.DurationMS) * time.Millisecond), EndTime: now, Usage: usage{Input: event.InputTokens, Output: event.OutputTokens, Total: event.TotalTokens}, Metadata: metadata, Level: "DEFAULT", StatusMessage: event.Error}
+		if event.Status == "error" {
+			body.Level = "ERROR"
+		}
+		if r.config.CaptureContent {
+			body.Input = sanitizeContent(event.Input, r.config.ContentMaxBytes)
+			body.Output = sanitizeContent(event.Output, r.config.ContentMaxBytes)
+		}
+		payload.Batch = append(payload.Batch, batchEvent{ID: newID(), Type: "generation-create", Body: body})
+	}
+	data, err := common.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.config.Host+"/api/public/ingestion", strings.NewReader(string(data)))
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(r.config.PublicKey, r.config.SecretKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &httpError{status: resp.StatusCode}
+	}
+	return nil
+}
+
+func sanitizeContent(value any, maxBytes int) any {
+	if value == nil {
+		return nil
+	}
+	data, err := common.Marshal(value)
+	if err != nil {
+		return "[content omitted: not serializable]"
+	}
+	if len(data) <= maxBytes {
+		return value
+	}
+	return map[string]any{"truncated": true, "original_bytes": len(data), "preview": strings.ToValidUTF8(string(data[:maxBytes]), "�")}
+}
+
+type httpError struct{ status int }
+
+func (e *httpError) Error() string {
+	return "langfuse ingestion returned HTTP " + strconv.Itoa(e.status)
+}
+
+func sample(rate float64) bool {
+	if rate >= 1 {
+		return true
+	}
+	if rate <= 0 {
+		return false
+	}
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return false
+	}
+	return float64(uint64FromBytes(b[:]))/float64(^uint64(0)) < rate
+}
+
+func uint64FromBytes(b []byte) uint64 {
+	var n uint64
+	for _, v := range b {
+		n = n<<8 | uint64(v)
+	}
+	return n
+}
+func newID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return strconv.FormatInt(time.Now().UnixNano(), 10)
+	}
+	return hex.EncodeToString(b[:])
+}
+func envString(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+func envBool(key string, fallback bool) bool {
+	value, err := strconv.ParseBool(os.Getenv(key))
+	if err != nil {
+		return fallback
+	}
+	return value
+}
+func envInt(key string, fallback int) int {
+	value, err := strconv.Atoi(os.Getenv(key))
+	if err != nil {
+		return fallback
+	}
+	return value
+}
+func envFloat(key string, fallback float64) float64 {
+	value, err := strconv.ParseFloat(os.Getenv(key), 64)
+	if err != nil {
+		return fallback
+	}
+	return value
+}

--- a/pkg/langfuse/langfuse.go
+++ b/pkg/langfuse/langfuse.go
@@ -69,6 +69,7 @@ type Reporter struct {
 	stop      chan struct{}
 	wg        sync.WaitGroup
 	once      sync.Once
+	stateMu   sync.Mutex
 	workerCtx context.Context
 	cancel    context.CancelFunc
 	closed    atomic.Bool
@@ -201,6 +202,18 @@ func NewReporter(config Config) *Reporter {
 	if r.client == nil {
 		r.client = &http.Client{Timeout: config.Timeout}
 	}
+	clientCopy := *r.client
+	previousRedirectHandler := clientCopy.CheckRedirect
+	clientCopy.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if req.URL == nil || req.URL.Scheme != "https" {
+			return fmt.Errorf("refusing non-HTTPS Langfuse redirect")
+		}
+		if previousRedirectHandler != nil {
+			return previousRedirectHandler(req, via)
+		}
+		return nil
+	}
+	r.client = &clientCopy
 	if config.Enabled && config.PublicKey != "" && config.SecretKey != "" && config.SampleRate > 0 {
 		r.wg.Add(1)
 		go r.run()
@@ -210,7 +223,12 @@ func NewReporter(config Config) *Reporter {
 
 // Publish queues an event without blocking the caller when the queue is full.
 func (r *Reporter) Publish(event Event) {
-	if r == nil || !r.configured() || r.closed.Load() || !sample(r.config.SampleRate) {
+	if r == nil {
+		return
+	}
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+	if !r.configured() || r.closed.Load() || !sample(r.config.SampleRate) {
 		return
 	}
 	select {
@@ -262,9 +280,12 @@ func (r *Reporter) Close(ctx context.Context) error {
 	if r == nil || !r.configured() {
 		return nil
 	}
+	r.stateMu.Lock()
 	if !r.closed.CompareAndSwap(false, true) {
+		r.stateMu.Unlock()
 		return nil
 	}
+	r.stateMu.Unlock()
 	flushDone := make(chan struct{})
 	go func() {
 		_ = r.Flush(ctx)
@@ -404,7 +425,7 @@ func (r *Reporter) send(ctx context.Context, events []Event) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return &httpError{status: resp.StatusCode}
 	}

--- a/pkg/langfuse/langfuse_test.go
+++ b/pkg/langfuse/langfuse_test.go
@@ -1,0 +1,106 @@
+package langfuse
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReporterSendsGenerationBatch(t *testing.T) {
+	var got batchPayload
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/public/ingestion", r.URL.Path)
+		user, password, ok := r.BasicAuth()
+		assert.True(t, ok)
+		assert.Equal(t, "public", user)
+		assert.Equal(t, "secret", password)
+		require.NoError(t, common.DecodeJson(r.Body, &got))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	reporter := NewReporter(Config{Enabled: true, Host: server.URL, PublicKey: "public", SecretKey: "secret", SampleRate: 1, QueueSize: 2, BatchSize: 1, HTTPClient: server.Client()})
+	reporter.Publish(Event{RequestID: "req-1", TraceID: "trace-1", Model: "gpt-test", InputTokens: 10, OutputTokens: 5, TotalTokens: 15, Quota: 20, DurationMS: 125, Status: "success"})
+	require.NoError(t, reporter.Flush(context.Background()))
+	assert.Len(t, got.Batch, 1)
+	assert.Equal(t, "generation-create", got.Batch[0].Type)
+	assert.Equal(t, "gpt-test", got.Batch[0].Body.Name)
+	assert.Equal(t, 10, got.Batch[0].Body.Usage.Input)
+	assert.Equal(t, 5, got.Batch[0].Body.Usage.Output)
+}
+
+func TestLoadConfigDefaultsToDisabled(t *testing.T) {
+	for _, key := range []string{"LANGFUSE_ENABLED", "LANGFUSE_HOST", "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_SAMPLE_RATE"} {
+		t.Setenv(key, "")
+	}
+	assert.False(t, LoadConfig().Enabled)
+}
+
+func TestPublishDoesNotBlockWhenQueueIsFull(t *testing.T) {
+	reporter := newQueueOnlyReporter(1)
+	reporter.Publish(Event{RequestID: "first"})
+	started := time.Now()
+	reporter.Publish(Event{RequestID: "second"})
+	assert.Less(t, time.Since(started), 100*time.Millisecond)
+}
+
+func TestHTTPFailureDoesNotReturnApplicationError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "failed", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	reporter := NewReporter(Config{Enabled: true, Host: server.URL, PublicKey: "p", SecretKey: "s", SampleRate: 1, QueueSize: 1, BatchSize: 1, HTTPClient: server.Client()})
+	reporter.Publish(Event{RequestID: "failed-request"})
+	assert.NoError(t, reporter.Flush(context.Background()))
+}
+
+func TestCapturedContentIsTruncated(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload batchPayload
+		require.NoError(t, common.DecodeJson(r.Body, &payload))
+		content, ok := payload.Batch[0].Body.Input.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, true, content["truncated"])
+		assert.Equal(t, float64(22), content["original_bytes"])
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	reporter := NewReporter(Config{Enabled: true, Host: server.URL, PublicKey: "p", SecretKey: "s", SampleRate: 1, QueueSize: 1, BatchSize: 1, CaptureContent: true, ContentMaxBytes: 8, HTTPClient: server.Client()})
+	reporter.Publish(Event{RequestID: "content", Input: "01234567890123456789"})
+	require.NoError(t, reporter.Flush(context.Background()))
+}
+
+func TestReporterTracksDroppedAndSentEvents(t *testing.T) {
+	reporter := newQueueOnlyReporter(1)
+	reporter.Publish(Event{RequestID: "one"})
+	reporter.Publish(Event{RequestID: "two"})
+	assert.Equal(t, uint64(1), reporter.Stats().Dropped)
+}
+
+func TestReporterRejectsInsecureHost(t *testing.T) {
+	reporter := NewReporter(Config{Enabled: true, Host: "http://127.0.0.1:1", PublicKey: "p", SecretKey: "s", SampleRate: 1})
+	err := reporter.send(context.Background(), []Event{{RequestID: "insecure"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTPS")
+}
+
+func TestReporterCloseIsIdempotent(t *testing.T) {
+	reporter := NewReporter(Config{Enabled: true, Host: "https://127.0.0.1:1", PublicKey: "p", SecretKey: "s", SampleRate: 1, QueueSize: 1, BatchSize: 1})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	assert.NoError(t, reporter.Close(ctx))
+	assert.NoError(t, reporter.Close(ctx))
+}
+
+func newQueueOnlyReporter(queueSize int) *Reporter {
+	return &Reporter{
+		config: Config{Enabled: true, PublicKey: "p", SecretKey: "s", SampleRate: 1},
+		queue:  make(chan Event, queueSize),
+	}
+}

--- a/pkg/langfuse/langfuse_test.go
+++ b/pkg/langfuse/langfuse_test.go
@@ -90,6 +90,27 @@ func TestReporterRejectsInsecureHost(t *testing.T) {
 	assert.Contains(t, err.Error(), "HTTPS")
 }
 
+func TestReporterRejectsHTTPRedirectBeforeSendingCredentials(t *testing.T) {
+	var targetCalled bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetCalled = true
+		assert.Empty(t, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	source := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer source.Close()
+
+	reporter := NewReporter(Config{Enabled: true, Host: source.URL, PublicKey: "p", SecretKey: "s", SampleRate: 1, HTTPClient: source.Client()})
+	err := reporter.send(context.Background(), []Event{{RequestID: "redirect"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-HTTPS Langfuse redirect")
+	assert.False(t, targetCalled)
+}
+
 func TestReporterCloseIsIdempotent(t *testing.T) {
 	reporter := NewReporter(Config{Enabled: true, Host: "https://127.0.0.1:1", PublicKey: "p", SecretKey: "s", SampleRate: 1, QueueSize: 1, BatchSize: 1})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)


### PR DESCRIPTION
## Summary

Add optional Langfuse gateway observability to New API. The integration records request outcomes and retry metadata, then sends observations asynchronously in batches so telemetry does not block or alter the primary request path.

## Changes

- Add `pkg/langfuse` reporter with configuration loading, sampling, bounded asynchronous queuing, batch ingestion, runtime statistics, and graceful shutdown flushing.
- Record successful and failed relay requests and correlate events with request, trace, session, and project identifiers.
- Record model, token usage, duration, status, streaming state, quota, and channel metadata from completed consumption logs.
- Capture error and retry metadata without changing the original request response.
- Keep prompt and completion capture disabled by default.
- Apply a configurable maximum byte limit when content capture is explicitly enabled.
- Add dropped, sent, and failed event counters with production-safe logging.
- Isolate Langfuse network failures, timeouts, HTTP errors, and full queues from the main request flow.
- Require HTTPS before sending credentials to Langfuse.
- Make worker shutdown cancellation-aware so in-flight requests cannot block application shutdown past its deadline.
- Add `.env.example` configuration entries.
- Add unit tests for configuration, sampling, content truncation, queue behavior, HTTPS enforcement, HTTP ingestion, failures, and shutdown.

## Configuration

The integration is disabled by default:

```env
LANGFUSE_ENABLED=false
```

Example enabled configuration:

```env
LANGFUSE_ENABLED=true
LANGFUSE_HOST=https://cloud.langfuse.com
LANGFUSE_PUBLIC_KEY=
LANGFUSE_SECRET_KEY=
LANGFUSE_SAMPLE_RATE=1
LANGFUSE_CAPTURE_CONTENT=false
```

When disabled, when credentials are missing, or when the sampling rate is zero, the reporter does not start its background worker and does not send network requests.

## Compatibility and Safety

- Runtime-configurable and fully optional.
- Asynchronous, non-blocking reporting preserves existing request behavior.
- Telemetry failures cannot fail the primary gateway request.
- Prompt and completion data are not exported unless explicitly enabled.
- Captured content is truncated to a configurable maximum byte length.
- Failure events use the same context-first identifier lookup as success events.
- Error details are masked before being written to logs or exported to Langfuse.

## Verification

- `go test ./pkg/langfuse ./model`
- `go test ./controller -run ^`
- `go test ./...` was attempted; the repository's existing integration test suite exceeded the local execution window and was interrupted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Langfuse observability integration for capturing request, consumption, and relay error telemetry.
  - Added configurable event batching, sampling, timeouts, content capture, and secure delivery settings.
  - Added graceful telemetry flushing during application shutdown.

- **Bug Fixes**
  - Relay failure events now include request duration when available.

- **Documentation**
  - Added a commented configuration example for enabling and tuning Langfuse integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Related issue

Related to #7371

This issue is the structured English Feature Request for the current PR. The earlier submission #7370 was closed by the format reviewer before functional review.