### PR TITLE
fix(plugin): read veo video uri from generatedSamples in google plugin

### DIFF
--- a/plugins/google_generated_samples_test.go
+++ b/plugins/google_generated_samples_test.go
@@ -1,0 +1,38 @@
+package plugins_test
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/pkg/jsplugin"
+	builtinplugins "github.com/QuantumNous/new-api/plugins"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Gemini REST 成功体用 generatedSamples,取不到 uri 会让产物为空、内容接口 410
+func TestGoogleVideoURIFromGeneratedSamples(t *testing.T) {
+	source, err := builtinplugins.Source("google")
+	require.NoError(t, err)
+	plugin, err := jsplugin.NewRegistry().RegisterFactory(source, jsplugin.Options{Key: "google"})
+	require.NoError(t, err)
+	const uri = "https://generativelanguage.googleapis.com/v1beta/files/abc:download?alt=media"
+	body := map[string]any{"name": "models/veo-3.1-fast-generate-preview/operations/abc", "done": true,
+		"response": map[string]any{"generateVideoResponse": map[string]any{
+			"generatedSamples": []any{map[string]any{"video": map[string]any{"uri": uri}}},
+		}}}
+
+	value, err := plugin.Engine.Call(t.Context(), "parseTaskResult", map[string]any{}, body)
+	require.NoError(t, err)
+	encoded, err := common.Marshal(value)
+	require.NoError(t, err)
+	var result map[string]any
+	require.NoError(t, common.Unmarshal(encoded, &result))
+	assert.Equal(t, uri, result["remoteUrl"])
+
+	value, err = plugin.Engine.Call(t.Context(), "listArtifacts", map[string]any{"taskId": "task_x", "status": "SUCCESS", "data": body})
+	require.NoError(t, err)
+	encoded, err = common.Marshal(value)
+	require.NoError(t, err)
+	assert.JSONEq(t, `[{"key":"video","type":"video"}]`, string(encoded))
+}

--- a/plugins/tasks/google/plugin.js
+++ b/plugins/tasks/google/plugin.js
@@ -176,9 +176,7 @@ export function parseSubmitResponse(ctx, resp) {
   if (!String(body.name || "").trim()) throw new Error("missing operation name");
   const result = { taskId: utils.base64URL(body.name), taskData: body };
   if (body.done && !(body.error && body.error.message)) {
-    const videos = ((body.response || {}).generateVideoResponse || {}).generatedVideos || [];
-    const uri = videos.length && videos[0].video ? videos[0].video.uri || "" : "";
-    result.immediate = { taskId: result.taskId, status: "SUCCESS", progress: "100%", remoteUrl: uri };
+    result.immediate = { taskId: result.taskId, status: "SUCCESS", progress: "100%", remoteUrl: generatedVideoURI(body) };
   }
   return result;
 }
@@ -211,9 +209,7 @@ export function parseTaskResult(ctx, body) {
   // unrecognized.
   if (!body || typeof body !== "object" || !String(body.name || "").trim()) return { status: "UNKNOWN", reason: "unrecognized operation state" };
   if (body.done !== true) return { status: "IN_PROGRESS", progress: "50%" };
-  const videos = ((body.response || {}).generateVideoResponse || {}).generatedVideos || [];
-  const uri = videos.length && videos[0].video ? videos[0].video.uri || "" : "";
-  return { taskId: utils.base64URL(body.name || ""), status: "SUCCESS", progress: "100%", remoteUrl: uri };
+  return { taskId: utils.base64URL(body.name || ""), status: "SUCCESS", progress: "100%", remoteUrl: generatedVideoURI(body) };
 }
 
 function artifactData(ctx) {
@@ -222,9 +218,15 @@ function artifactData(ctx) {
   return data;
 }
 
-function artifactVideoURL(ctx) {
-  const videos = ((artifactData(ctx).response || {}).generateVideoResponse || {}).generatedVideos || [];
+// REST returns generatedSamples; generatedVideos is the SDK field name.
+function generatedVideoURI(body) {
+  const gvr = ((body || {}).response || {}).generateVideoResponse || {};
+  const videos = gvr.generatedSamples || gvr.generatedVideos || [];
   return videos.length && videos[0].video ? String(videos[0].video.uri || "").trim() : "";
+}
+
+function artifactVideoURL(ctx) {
+  return generatedVideoURI(artifactData(ctx));
 }
 
 export function listArtifacts(task) {


### PR DESCRIPTION
gemini生视频, 取视频url字段错误,必现

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 📝 变更描述 / Description
google 插件读 Veo 结果时取的是 `response.generateVideoResponse.generatedVideos[0].video.uri`,但 Gemini REST 接口(`generativelanguage.googleapis.com`)实际返回的字段名是 `generatedSamples`。`generatedVideos` 是 genai SDK 里的属性名,REST 原始 JSON 里没有这个键。

结果是任务能提交、能轮询到 done,状态也标成 SUCCESS,但 remoteUrl 是空串,`listArtifacts` 返回空数组,`/v1/tasks/{id}/artifacts/video/content` 直接 410 artifact_gone,后台任务日志里制品也是空的。

修法:抽一个 `generatedVideoURI(body)`,优先读 `generatedSamples`,没有再读 `generatedVideos`,提交立即完成、轮询、列制品、取内容四处统一走它。加了一个单测锁住 REST 字段形态。

## 📸 运行证明 / Proof of Work
复现:Gemini 渠道 + `veo-3.1-fast-generate-preview`,走 `/v1/videos` 文生视频。修复前任务 SUCCESS 但制品为空,取内容 410;修复后 `/api/task/{id}/artifacts` 返回 `[{"key":"video","type":"video"}]`,`/content` 能拿到 mp4,后台预览正常。

```
$ go test ./plugins/ -run GeneratedSamples -count=1 -v
=== RUN   TestGoogleVideoURIFromGeneratedSamples
--- PASS: TestGoogleVideoURIFromGeneratedSamples (0.00s)
PASS
ok  	github.com/QuantumNous/new-api/plugins	1.664s
```

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 无论描述是否由 AI 生成，我已审阅全部内容，并声明对其准确性与完整性负责。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **新功能关联 Issue:** 若此 PR 标记为 `New feature`，我已关联对应 Issue；若尚无 Issue，我已先自行创建。
- [ ] **事前沟通:** 若改动较大或涉及方向性变更，已在关联 Issue 中与维护者沟通并达成一致。
- [x] **功能范围:** 本 PR 不是 Coding Plan、逆向渠道、第三方封装接口，也不是对 Codex 渠道类型的改动。
- [x] **范围聚焦:** 本 PR 为一项聚焦改动，未包含无关代码。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Google video generation result handling.
  - Video URIs are now consistently recognized from generated samples across supported response formats.
  - Video artifacts now include the correct video metadata and URLs when returned by Google tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->