### PR TITLE
fix(middleware): 过载哨兵改用容器口径并加入连续性与新鲜度判定

### DIFF
--- a/common/container_usage.go
+++ b/common/container_usage.go
@@ -1,0 +1,192 @@
+package common
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// 容器自身资源采样。
+//
+// 历史实现直接读取宿主机口径（/proc/stat 与 /proc/meminfo），把同节点其它
+// 工作负载的占用也算成本进程过载，导致正常的 relay 流量被 503 熔断。这里
+// 改为优先读取当前容器的 cgroup 配额与用量，只有在拿不到 cgroup 数据时才由
+// 调用方回退到宿主机口径。
+
+// 路径变量而不是常量，便于测试注入临时目录。
+var (
+	cgroupV2CPUMaxPath    = "/sys/fs/cgroup/cpu.max"
+	cgroupV2CPUStatPath   = "/sys/fs/cgroup/cpu.stat"
+	cgroupV2MemoryMaxPath = "/sys/fs/cgroup/memory.max"
+	cgroupV2MemoryCurPath = "/sys/fs/cgroup/memory.current"
+
+	cgroupV1CPUQuotaPath  = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+	cgroupV1CPUPeriodPath = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+	cgroupV1CPUUsagePath  = "/sys/fs/cgroup/cpuacct/cpuacct.usage"
+	cgroupV1MemoryMaxPath = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	cgroupV1MemoryCurPath = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
+
+	// cgroup v1 用接近 int64 上限的值表示"未限制"。
+	unlimitedMemoryBytes = uint64(1) << 60
+)
+
+// ContainerUsage 记录上一次采样点，用来计算区间内的 CPU 占用。
+type ContainerUsage struct {
+	cpuLastUsec    uint64
+	cpuLastSampled time.Time
+}
+
+func NewContainerUsage() *ContainerUsage {
+	return &ContainerUsage{}
+}
+
+// CPUSaturation 返回相对容器 CPU 配额的使用率（百分比）。
+// ok=false 表示当前环境没有可用的 cgroup CPU 数据，调用方应回退到宿主机口径。
+func (u *ContainerUsage) CPUSaturation(now time.Time) (float64, bool) {
+	quotaCores, ok := readCgroupCPULimitCores()
+	if !ok || quotaCores <= 0 {
+		return 0, false
+	}
+	usageUsec, ok := readCgroupCPUUsageUsec()
+	if !ok {
+		return 0, false
+	}
+	if u.cpuLastSampled.IsZero() || usageUsec < u.cpuLastUsec || !now.After(u.cpuLastSampled) {
+		u.cpuLastUsec = usageUsec
+		u.cpuLastSampled = now
+		return 0, false
+	}
+	elapsed := now.Sub(u.cpuLastSampled)
+	if elapsed < time.Second {
+		return 0, false
+	}
+	deltaUsec := usageUsec - u.cpuLastUsec
+	u.cpuLastUsec = usageUsec
+	u.cpuLastSampled = now
+
+	usedCores := float64(deltaUsec) / 1e6 / elapsed.Seconds()
+	return usedCores / quotaCores * 100, true
+}
+
+// MemoryUsage 返回相对容器内存上限的使用率（百分比）。
+// ok=false 表示没有可用的 cgroup 内存上限，调用方应回退到宿主机口径。
+func (u *ContainerUsage) MemoryUsage() (float64, bool) {
+	used, limit, ok := readCgroupMemory()
+	if !ok || limit == 0 {
+		return 0, false
+	}
+	return float64(used) / float64(limit) * 100, true
+}
+
+// CPULimitCores 返回当前容器的 CPU 配额（核）。ok=false 表示未限制或不可读。
+func (u *ContainerUsage) CPULimitCores() (float64, bool) {
+	return readCgroupCPULimitCores()
+}
+
+func readCgroupCPULimitCores() (float64, bool) {
+	if raw, err := os.ReadFile(cgroupV2CPUMaxPath); err == nil {
+		fields := strings.Fields(string(raw))
+		if len(fields) < 2 {
+			return 0, false
+		}
+		if strings.EqualFold(fields[0], "max") {
+			return 0, false
+		}
+		quota, err := strconv.ParseFloat(fields[0], 64)
+		if err != nil || quota <= 0 {
+			return 0, false
+		}
+		period, err := strconv.ParseFloat(fields[1], 64)
+		if err != nil || period <= 0 {
+			return 0, false
+		}
+		return quota / period, true
+	}
+
+	quotaRaw, err := os.ReadFile(cgroupV1CPUQuotaPath)
+	if err != nil {
+		return 0, false
+	}
+	periodRaw, err := os.ReadFile(cgroupV1CPUPeriodPath)
+	if err != nil {
+		return 0, false
+	}
+	quota, err := strconv.ParseFloat(strings.TrimSpace(string(quotaRaw)), 64)
+	if err != nil || quota <= 0 {
+		return 0, false
+	}
+	period, err := strconv.ParseFloat(strings.TrimSpace(string(periodRaw)), 64)
+	if err != nil || period <= 0 {
+		return 0, false
+	}
+	return quota / period, true
+}
+
+func readCgroupCPUUsageUsec() (uint64, bool) {
+	if raw, err := os.ReadFile(cgroupV2CPUStatPath); err == nil {
+		for _, line := range strings.Split(string(raw), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) != 2 || fields[0] != "usage_usec" {
+				continue
+			}
+			value, err := strconv.ParseUint(fields[1], 10, 64)
+			if err != nil {
+				return 0, false
+			}
+			return value, true
+		}
+		return 0, false
+	}
+
+	// cgroup v1 的 cpuacct.usage 单位是纳秒。
+	raw, err := os.ReadFile(cgroupV1CPUUsagePath)
+	if err != nil {
+		return 0, false
+	}
+	nanos, err := strconv.ParseUint(strings.TrimSpace(string(raw)), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return nanos / 1000, true
+}
+
+func readCgroupMemory() (used uint64, limit uint64, ok bool) {
+	if curRaw, err := os.ReadFile(cgroupV2MemoryCurPath); err == nil {
+		maxRaw, err := os.ReadFile(cgroupV2MemoryMaxPath)
+		if err != nil {
+			return 0, 0, false
+		}
+		limitText := strings.TrimSpace(string(maxRaw))
+		if strings.EqualFold(limitText, "max") {
+			return 0, 0, false
+		}
+		limitValue, err := strconv.ParseUint(limitText, 10, 64)
+		if err != nil || limitValue == 0 {
+			return 0, 0, false
+		}
+		usedValue, err := strconv.ParseUint(strings.TrimSpace(string(curRaw)), 10, 64)
+		if err != nil {
+			return 0, 0, false
+		}
+		return usedValue, limitValue, true
+	}
+
+	curRaw, err := os.ReadFile(cgroupV1MemoryCurPath)
+	if err != nil {
+		return 0, 0, false
+	}
+	maxRaw, err := os.ReadFile(cgroupV1MemoryMaxPath)
+	if err != nil {
+		return 0, 0, false
+	}
+	limitValue, err := strconv.ParseUint(strings.TrimSpace(string(maxRaw)), 10, 64)
+	if err != nil || limitValue == 0 || limitValue >= unlimitedMemoryBytes {
+		return 0, 0, false
+	}
+	usedValue, err := strconv.ParseUint(strings.TrimSpace(string(curRaw)), 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	return usedValue, limitValue, true
+}

--- a/common/container_usage_test.go
+++ b/common/container_usage_test.go
@@ -1,0 +1,128 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeCgroupFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+// isolateCgroupPaths 把 cgroup 路径指向临时目录，避免依赖运行环境。
+func isolateCgroupPaths(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	origin := struct {
+		v2CPUMax, v2CPUStat, v2MemMax, v2MemCur        string
+		v1Quota, v1Period, v1Usage, v1MemMax, v1MemCur string
+	}{
+		cgroupV2CPUMaxPath, cgroupV2CPUStatPath, cgroupV2MemoryMaxPath, cgroupV2MemoryCurPath,
+		cgroupV1CPUQuotaPath, cgroupV1CPUPeriodPath, cgroupV1CPUUsagePath, cgroupV1MemoryMaxPath, cgroupV1MemoryCurPath,
+	}
+	t.Cleanup(func() {
+		cgroupV2CPUMaxPath, cgroupV2CPUStatPath = origin.v2CPUMax, origin.v2CPUStat
+		cgroupV2MemoryMaxPath, cgroupV2MemoryCurPath = origin.v2MemMax, origin.v2MemCur
+		cgroupV1CPUQuotaPath, cgroupV1CPUPeriodPath = origin.v1Quota, origin.v1Period
+		cgroupV1CPUUsagePath = origin.v1Usage
+		cgroupV1MemoryMaxPath, cgroupV1MemoryCurPath = origin.v1MemMax, origin.v1MemCur
+	})
+
+	cgroupV2CPUMaxPath = filepath.Join(dir, "cpu.max")
+	cgroupV2CPUStatPath = filepath.Join(dir, "cpu.stat")
+	cgroupV2MemoryMaxPath = filepath.Join(dir, "memory.max")
+	cgroupV2MemoryCurPath = filepath.Join(dir, "memory.current")
+	cgroupV1CPUQuotaPath = filepath.Join(dir, "cpu.cfs_quota_us")
+	cgroupV1CPUPeriodPath = filepath.Join(dir, "cpu.cfs_period_us")
+	cgroupV1CPUUsagePath = filepath.Join(dir, "cpuacct.usage")
+	cgroupV1MemoryMaxPath = filepath.Join(dir, "memory.limit_in_bytes")
+	cgroupV1MemoryCurPath = filepath.Join(dir, "memory.usage_in_bytes")
+	return dir
+}
+
+func TestCPUSaturationUsesContainerQuota(t *testing.T) {
+	dir := isolateCgroupPaths(t)
+	writeCgroupFile(t, filepath.Join(dir, "cpu.max"), "200000 100000\n")
+	writeCgroupFile(t, filepath.Join(dir, "cpu.stat"), "usage_usec 1000000\nuser_usec 900000\n")
+
+	usage := NewContainerUsage()
+	base := time.Date(2026, 9, 11, 3, 0, 0, 0, time.UTC)
+	_, ok := usage.CPUSaturation(base)
+	assert.False(t, ok, "首次采样只建立基线，不产出使用率")
+
+	// 5 秒内消耗 10 秒 CPU，配额 2 核 => 自身使用 2 核 => 100%。
+	writeCgroupFile(t, filepath.Join(dir, "cpu.stat"), "usage_usec 11000000\n")
+	got, ok := usage.CPUSaturation(base.Add(5 * time.Second))
+	require.True(t, ok, "容器 cgroup 可用时必须返回自身占用")
+	assert.InDelta(t, 100, got, 1)
+}
+
+func TestCPUSaturationFallsBackWhenQuotaMissing(t *testing.T) {
+	dir := isolateCgroupPaths(t)
+	writeCgroupFile(t, filepath.Join(dir, "cpu.max"), "max 100000\n")
+	writeCgroupFile(t, filepath.Join(dir, "cpu.stat"), "usage_usec 1000000\n")
+
+	usage := NewContainerUsage()
+	_, ok := usage.CPUSaturation(time.Now())
+	assert.False(t, ok, "未设置配额时不给出容器口径，交由调用方回退")
+}
+
+func TestCPUSaturationSupportsCgroupV1(t *testing.T) {
+	dir := isolateCgroupPaths(t)
+	// 不创建 cgroup v2 文件，读取失败后应回退到 cgroup v1 路径。
+	writeCgroupFile(t, filepath.Join(dir, "cpu.cfs_quota_us"), "200000\n")
+	writeCgroupFile(t, filepath.Join(dir, "cpu.cfs_period_us"), "100000\n")
+	// cpuacct.usage 为纳秒口径：起始 1s CPU。
+	writeCgroupFile(t, filepath.Join(dir, "cpuacct.usage"), "1000000000\n")
+
+	usage := NewContainerUsage()
+	base := time.Date(2026, 9, 11, 3, 0, 0, 0, time.UTC)
+	_, ok := usage.CPUSaturation(base)
+	assert.False(t, ok)
+
+	writeCgroupFile(t, filepath.Join(dir, "cpuacct.usage"), "11000000000\n")
+	got, ok := usage.CPUSaturation(base.Add(5 * time.Second))
+	require.True(t, ok, "cgroup v1 也应支持容器口径")
+	assert.InDelta(t, 100, got, 1)
+}
+
+func TestMemoryUsageUsesContainerLimit(t *testing.T) {
+	dir := isolateCgroupPaths(t)
+	writeCgroupFile(t, filepath.Join(dir, "memory.current"), "805306368\n") // 768MiB
+	writeCgroupFile(t, filepath.Join(dir, "memory.max"), "1610612736\n")    // 1.5GiB
+
+	usage := NewContainerUsage()
+	got, ok := usage.MemoryUsage()
+	require.True(t, ok, "容器内存上限可读时必须返回自身占用")
+	assert.InDelta(t, 50, got, 0.1)
+}
+
+func TestMemoryUsageFallsBackWhenUnlimited(t *testing.T) {
+	dir := isolateCgroupPaths(t)
+	writeCgroupFile(t, filepath.Join(dir, "memory.usage_in_bytes"), "1000\n")
+	writeCgroupFile(t, filepath.Join(dir, "memory.limit_in_bytes"), "9223372036854771712\n")
+
+	usage := NewContainerUsage()
+	_, ok := usage.MemoryUsage()
+	assert.False(t, ok, "内存未限制时不给出容器口径")
+}
+
+func TestOverloadStreakResetsOnHealthySample(t *testing.T) {
+	streak := 0
+	streak = nextOverloadStreak(streak, true)
+	streak = nextOverloadStreak(streak, true)
+	assert.Equal(t, 2, streak)
+	assert.Equal(t, 0, nextOverloadStreak(streak, false), "健康采样必须清零连续计数")
+}
+
+func TestSystemStatusFreshness(t *testing.T) {
+	assert.False(t, IsSystemStatusFresh(SystemStatus{}), "零值状态不算新鲜")
+	assert.False(t, IsSystemStatusFresh(SystemStatus{SampledAt: time.Now().Add(-time.Minute)}), "过期采样不算新鲜")
+	assert.True(t, IsSystemStatusFresh(SystemStatus{SampledAt: time.Now()}), "刚采样的状态应可用")
+}

--- a/common/system_monitor.go
+++ b/common/system_monitor.go
@@ -22,12 +22,27 @@ type DiskSpaceInfo struct {
 
 // SystemStatus 系统状态信息
 type SystemStatus struct {
-	CPUUsage    float64
-	MemoryUsage float64
-	DiskUsage   float64
+	CPUUsage      float64
+	MemoryUsage   float64
+	DiskUsage     float64
+	CPUQuotaCores float64
+	SampledAt     time.Time
+	// 过载判定带连续性要求：单一采样尖峰不再直接熔断，需连续多次超阈值。
+	CPUOverloaded    bool
+	MemoryOverloaded bool
+	DiskOverloaded   bool
 }
 
 var latestSystemStatus atomic.Value
+
+const (
+	systemMonitorInterval = 5 * time.Second
+	// 连续 3 次采样（约 15 秒）仍高于阈值才判定过载，
+	// 任一采样回落到阈值以下即恢复，避免瞬时尖峰打满重试。
+	overloadConsecutiveSamples = 3
+	// 采样超过该时长未刷新（监控未运行或被阻塞）时，哨兵不据此熔断。
+	SystemStatusMaxAge = 30 * time.Second
+)
 
 func init() {
 	latestSystemStatus.Store(SystemStatus{})
@@ -36,46 +51,85 @@ func init() {
 // StartSystemMonitor 启动系统监控
 func StartSystemMonitor() {
 	go func() {
+		usage := NewContainerUsage()
+		cpuStreak, memoryStreak, diskStreak := 0, 0, 0
 		for {
 			config := GetPerformanceMonitorConfig()
 			if !config.Enabled {
-				time.Sleep(30 * time.Second)
+				cpuStreak, memoryStreak, diskStreak = 0, 0, 0
+				latestSystemStatus.Store(SystemStatus{SampledAt: time.Now()})
+				time.Sleep(systemMonitorInterval)
 				continue
 			}
 
-			updateSystemStatus()
-			time.Sleep(5 * time.Second)
+			status, cpuOver, memoryOver, diskOver := collectSystemStatus(usage, config)
+			cpuStreak = nextOverloadStreak(cpuStreak, cpuOver)
+			memoryStreak = nextOverloadStreak(memoryStreak, memoryOver)
+			diskStreak = nextOverloadStreak(diskStreak, diskOver)
+			status.CPUOverloaded = cpuStreak >= overloadConsecutiveSamples
+			status.MemoryOverloaded = memoryStreak >= overloadConsecutiveSamples
+			status.DiskOverloaded = diskStreak >= overloadConsecutiveSamples
+			latestSystemStatus.Store(status)
+
+			time.Sleep(systemMonitorInterval)
 		}
 	}()
 }
 
-func updateSystemStatus() {
-	var status SystemStatus
+func nextOverloadStreak(streak int, over bool) int {
+	if !over {
+		return 0
+	}
+	return streak + 1
+}
 
-	// CPU
-	// 注意：cpu.Percent(0, false) 返回自上次调用以来的 CPU 使用率
-	// 如果是第一次调用，可能会返回错误或不准确的值，但在循环中会逐渐正常
-	percents, err := cpu.Percent(0, false)
-	if err == nil && len(percents) > 0 {
+func collectSystemStatus(usage *ContainerUsage, config PerformanceMonitorConfig) (
+	status SystemStatus, cpuOver bool, memoryOver bool, diskOver bool,
+) {
+	now := time.Now()
+	status.SampledAt = now
+
+	// CPU / 内存优先按容器 cgroup 配额计算；容器口径不可用时回退宿主机口径，
+	// 保持对未限制资源或被挂载为宿主 cgroup 的环境的兼容。
+	if quota, ok := usage.CPULimitCores(); ok {
+		status.CPUQuotaCores = quota
+	}
+	if saturation, ok := usage.CPUSaturation(now); ok {
+		status.CPUUsage = saturation
+	} else if percents, err := cpu.Percent(0, false); err == nil && len(percents) > 0 {
 		status.CPUUsage = percents[0]
 	}
-
-	// Memory
-	memInfo, err := mem.VirtualMemory()
-	if err == nil {
+	if containerMemory, ok := usage.MemoryUsage(); ok {
+		status.MemoryUsage = containerMemory
+	} else if memInfo, err := mem.VirtualMemory(); err == nil {
 		status.MemoryUsage = memInfo.UsedPercent
 	}
 
-	// Disk
 	diskInfo := GetDiskSpaceInfo()
 	if diskInfo.Total > 0 {
 		status.DiskUsage = diskInfo.UsedPercent
 	}
 
-	latestSystemStatus.Store(status)
+	cpuOver = config.CPUThreshold > 0 && int(status.CPUUsage) > config.CPUThreshold
+	memoryOver = config.MemoryThreshold > 0 && int(status.MemoryUsage) > config.MemoryThreshold
+	diskOver = config.DiskThreshold > 0 && int(status.DiskUsage) > config.DiskThreshold
+	return status, cpuOver, memoryOver, diskOver
 }
 
 // GetSystemStatus 获取当前系统状态
 func GetSystemStatus() SystemStatus {
 	return latestSystemStatus.Load().(SystemStatus)
+}
+
+// SetSystemStatus 覆盖当前系统状态；系统监控与测试使用。
+func SetSystemStatus(status SystemStatus) {
+	latestSystemStatus.Store(status)
+}
+
+// IsSystemStatusFresh 判断采样是否足够新，过期状态不参与过载熔断。
+func IsSystemStatusFresh(status SystemStatus) bool {
+	if status.SampledAt.IsZero() {
+		return false
+	}
+	return time.Since(status.SampledAt) <= SystemStatusMaxAge
 }

--- a/middleware/performance.go
+++ b/middleware/performance.go
@@ -45,23 +45,28 @@ func checkSystemPerformance() *types.NewAPIError {
 	}
 
 	status := common.GetSystemStatus()
+	// 采样过期（监控未运行或被阻塞）时不熔断，避免状态陈旧误伤流量。
+	if !common.IsSystemStatusFresh(status) {
+		return nil
+	}
 
-	// 检查 CPU
-	if config.CPUThreshold > 0 && int(status.CPUUsage) > config.CPUThreshold {
+	// 过载标记在采样侧完成：CPU / 内存按容器 cgroup 配额计算，并要求连续多次
+	// 超阈值；这样同节点其它工作负载或瞬时尖峰不会把正常 relay 流量打成 503。
+	if status.CPUOverloaded {
 		return types.NewErrorWithStatusCode(
 			fmt.Errorf("system cpu overloaded (current: %.1f%%, threshold: %d%%)", status.CPUUsage, config.CPUThreshold),
 			"system_cpu_overloaded", http.StatusServiceUnavailable)
 	}
 
 	// 检查内存
-	if config.MemoryThreshold > 0 && int(status.MemoryUsage) > config.MemoryThreshold {
+	if status.MemoryOverloaded {
 		return types.NewErrorWithStatusCode(
 			fmt.Errorf("system memory overloaded (current: %.1f%%, threshold: %d%%)", status.MemoryUsage, config.MemoryThreshold),
 			"system_memory_overloaded", http.StatusServiceUnavailable)
 	}
 
 	// 检查磁盘
-	if config.DiskThreshold > 0 && int(status.DiskUsage) > config.DiskThreshold {
+	if status.DiskOverloaded {
 		return types.NewErrorWithStatusCode(
 			fmt.Errorf("system disk overloaded (current: %.1f%%, threshold: %d%%)", status.DiskUsage, config.DiskThreshold),
 			"system_disk_overloaded", http.StatusServiceUnavailable)

--- a/middleware/performance_test.go
+++ b/middleware/performance_test.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemPerformanceCheckRequiresFreshOverloadStatus(t *testing.T) {
+	thresholds := common.PerformanceMonitorConfig{
+		Enabled:         true,
+		CPUThreshold:    90,
+		MemoryThreshold: 90,
+		DiskThreshold:   90,
+	}
+
+	// 采样过期（监控未运行或被阻塞）时不应熔断，避免状态陈旧误伤流量。
+	common.SetPerformanceMonitorConfig(thresholds)
+	common.SetSystemStatus(common.SystemStatus{
+		CPUOverloaded: true,
+		SampledAt:     time.Now().Add(-time.Minute),
+	})
+	assert.Nil(t, checkSystemPerformance(), "过期采样不得触发哨兵")
+
+	// 监控关闭时不熔断。
+	common.SetPerformanceMonitorConfig(common.PerformanceMonitorConfig{Enabled: false, CPUThreshold: 90})
+	common.SetSystemStatus(common.SystemStatus{CPUOverloaded: true, SampledAt: time.Now()})
+	assert.Nil(t, checkSystemPerformance(), "关闭监控时不得触发哨兵")
+
+	// 新采样判定过载时必须熔断，并保留可分类的错误码。
+	common.SetPerformanceMonitorConfig(thresholds)
+	common.SetSystemStatus(common.SystemStatus{CPUUsage: 99.5, CPUOverloaded: true, SampledAt: time.Now()})
+	err := checkSystemPerformance()
+	require.Error(t, err, "新鲜采样判定过载时必须熔断")
+	assert.Equal(t, http.StatusServiceUnavailable, err.StatusCode)
+	assert.Equal(t, "system_cpu_overloaded", string(err.GetErrorCode()))
+
+	// 采样正常时放行。
+	common.SetSystemStatus(common.SystemStatus{CPUUsage: 10, SampledAt: time.Now()})
+	assert.Nil(t, checkSystemPerformance(), "健康状态必须放行")
+}


### PR DESCRIPTION
## Agent

- Tool: Codex (OpenAI coding agent)
- Tool version: local Codex harness build
- Model (full id): gpt-5.6-sol
- Host (CLI / IDE / GitHub coding agent / other): CLI (local)
- Date (UTC): 2026-09-11

## Links

- Closes #7316
- Related: 无（本 PR 只修采样口径与判定方式）

## User request

「优化 system_cpu_overloaded 的哨兵处理方式」，并明确「不要直接改我们 fork 的仓库，而是尝试直接给官方提 issue 和 pr」。

## Out of scope — refuse

- Matched: no
- 说明：不涉及 Coding Plan、逆向渠道、第三方封装、Codex 反代兼容、pass-through 转发、第三方托管站；也不是使用/配置/接入类问题。

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior：容器 CPU 配额 2 核、容器自身 CPU 峰值不足 0.12 核时，仍以「宿主机 CPU > 90%」判定过载，对 `/v1/*` 返回 503 `system_cpu_overloaded`。
- Impact：同节点其它负载把宿主机 CPU 顶高时，正常 relay 请求被拒绝，客户端收到语义为「服务端过载」的 503。
- Frequency：近 7 天中 4 天出现，集中在个别分钟窗口：09-04 2 次、09-07 11 次、09-09 5 次、09-10 182 次（15:00–15:36 密集）、09-11 46 次（10:47–10:49）。
- Evidence that the problem is in new-api rather than the client or upstream：503 由 `middleware/performance.go` 产生、尚未进入渠道选择；同窗口容器自身 CPU 峰值：new-api master 0.12 核 / worker 0.08 核，同节点 search-engine 副本 1.24–1.34 核；容器内 `/sys/fs/cgroup/cpu.max=200000 100000`（2 核）而 `/proc/stat` 暴露宿主机 4 核。
- Applicable types and their fields：
  - Relay / API：`POST /v1/chat/completions`，channel type 43，模型 `deepseek-v4-flash`，非 pass-through，直连上游 200 / 经 new-api 503。
  - Billing：not applicable（准入阶段即失败，未产生扣费）。
  - Frontend：not applicable。
  - Deployment / upgrade：Kubernetes，Linux amd64，PostgreSQL 16，master/worker 均 `cpu limit=2`；与版本升级无关。

## Change

根因在采样侧：`common/system_monitor.go` 的 `updateSystemStatus()` 用 `cpu.Percent(0, false)`（gopsutil，读宿主机 `/proc/stat`）和 `mem.VirtualMemory()`（`/proc/meminfo`）写入 `SystemStatus`，中间件再拿这些宿主机指标与阈值比较。容器里度量的是宿主机，而不是本进程。

本 PR：

1. 新增 `common/container_usage.go`：优先用容器 cgroup 配额计算自身占用——v2 读 `cpu.max` / `cpu.stat` / `memory.max` / `memory.current`，v1 读 `cpu.cfs_quota_us` / `cpu.cfs_period_us` / `cpuacct.usage` / `memory.limit_in_bytes` / `memory.usage_in_bytes`；容器口径不可用（未限制或路径不可读）时回退原有宿主机口径，保持兼容。
2. 过载判定加入连续性要求：连续 3 次采样（约 15 秒）超阈值才判定过载，任一采样回落立即恢复，避免瞬时尖峰熔断。
3. 采样超过 30 秒未刷新（监控未运行或被阻塞）时不再熔断，避免状态陈旧误伤流量。
4. `middleware/performance.go` 改为消费采样结果中的过载标记；`system_cpu_overloaded` / `system_memory_overloaded` / `system_disk_overloaded` 错误码与 503 语义保持不变，`Error` 文本仍带当前值与阈值。

## Research

### Duplicate / prior art

- Search queries (issues, PRs)：`system_cpu_overloaded`、`performance monitor`、`性能监控`、`CPU 阈值`
- What already existed and why this is not a duplicate：#2835 只是引入性能监控功能，未讨论采样口径；#3472 与本问题无关。代码中没有任何 cgroup 感知的采样。

### Docs and code

- https://docs.newapi.ai/ ：307 跳转，未检索到性能监控/阈值口径的说明
- https://deepwiki.com/QuantumNous/new-api ：未使用（直接以代码与线上观测为证据）
- README / repo docs：未找到该哨兵口径说明
- Code paths and what they imply for this change：
  - `common/system_monitor.go` — 5 秒采样一次，宿主机口径，是根因所在；
  - `middleware/performance.go` — 单次采样即时判定，只消费 `SystemStatus`；
  - `setting/performance_setting/config.go` — 阈值运行时可配（默认 90），没有任何口径定义；
  - `router/relay-router.go` — 中间件挂在 `/v1/*` relay 路由上，影响全部转发流量。

### Alternatives considered

- Option A：仅在中间件里提高阈值或默认关闭监控 —— 只是把误报推迟，宿主机负载依旧会触发，且会削弱真实的过载保护。
- Option B：在采样侧改用容器 cgroup 口径，并加入连续性与新鲜度判定（本 PR 采用）。改动集中在采样与判定，不触及路由、渠道、计费与数据库。
- Why this approach：过载保护应该保护「本进程自己的资源」，容器配额才是它的真实上限；容器口径不可用时回退旧行为，避免破坏非容器部署。

## Files

| Path | Why |
| --- | --- |
| `common/container_usage.go` | 新增容器 cgroup 口径的 CPU/内存采样（v2 优先，v1 兼容） |
| `common/container_usage_test.go` | 覆盖配额换算、v1 回退、内存上限、未限制回退 |
| `common/system_monitor.go` | 改用容器口径、加入连续性与新鲜度判定，新增状态导出与新鲜度判断 |
| `middleware/performance.go` | 改为消费过载标记，保留错误码与 503 语义 |
| `middleware/performance_test.go` | 覆盖过期采样不熔断、监控关闭不熔断、过载熔断、正常放行 |

## Behavior

- Before：CPU/内存取宿主机口径；单次采样超阈值即对 `/v1/*` 返回 503。
- After：CPU/内存优先取容器自身相对配额的占用；连续 3 次采样超阈值才熔断，回落即恢复；采样过期不熔断；容器口径不可用时回退宿主机口径。
- Explicit non-goals / leftover work：不修改阈值默认值、不改错误码、不新增配置项、不改前端；未额外引入指标或日志（可按需另开）。

## Verification

- Commands and results：
  - `go build ./...` — 通过
  - `go test ./common/... ./middleware/...` — `ok github.com/QuantumNous/new-api/common`、`ok github.com/QuantumNous/new-api/middleware`
  - `gofmt -l common middleware` — 无输出
- Manual steps and observed result：在线上 Pod 内确认容器口径可用：`/sys/fs/cgroup/cpu.max=200000 100000`（2 核）、`memory.max=1610612736`、`cpu.stat` 与 `memory.current` 可读；同容器 `/proc/stat` 暴露宿主机 4 核，佐证原采样为宿主机口径。
- UI: screenshot or recording：无 UI 变化
- Tests added or updated：新增 `common/container_usage_test.go`、`middleware/performance_test.go`
- Databases / providers / platforms exercised：PostgreSQL 16 + Linux amd64 容器（Kubernetes）；未改动数据库相关代码
- Not verified：未在 Windows/macOS 上验证 cgroup 路径缺失时的回退（会走宿主机口径，与旧行为一致）

## Risks

- Failure modes：cgroup 文件不可读（宿主 cgroup 命名空间、Windows 等）时回退宿主机口径，等同旧行为；阈值语义从「宿主机占用率」变为「相对容器 limit 的占用率」，若用户按旧语义调低阈值，会比以前更早触发。
- Billing / quota / auth impact：无（发生在计费与鉴权之后、转发之前，仅影响是否放行）
- Follow-ups：可考虑把采样值以指标/日志形式暴露，便于观测真实过载

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added container-aware resource monitoring for CPU and memory usage, including support for container limits.
  - System status now includes resource overload indicators, CPU quota, and sample freshness information.
  - Added the ability to provide and validate system status data programmatically.

- **Bug Fixes**
  - Prevented performance protection from reacting to outdated monitoring data.
  - Improved overload detection across CPU, memory, and disk resources.
  - Added safer handling when monitoring is disabled or resource limits are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->