### PR TITLE
fix(audio): case-insensitive file extension in GetAudioDuration

### DIFF
--- a/common/audio.go
+++ b/common/audio.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/abema/go-mp4"
 	"github.com/go-audio/aiff"
@@ -20,6 +21,7 @@ import (
 // 它不再依赖外部的 ffmpeg 或 ffprobe 程序。
 func GetAudioDuration(ctx context.Context, f io.ReadSeeker, ext string) (duration float64, err error) {
 	SysLog(fmt.Sprintf("GetAudioDuration: ext=%s", ext))
+	ext = strings.ToLower(ext)
 	// 根据文件扩展名选择解析器
 	switch ext {
 	case ".mp3":

--- a/common/audio_case_test.go
+++ b/common/audio_case_test.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// minimalWAV builds a valid 16-bit PCM mono WAV with the given number of sample frames.
+func minimalWAV(sampleRate uint32, frames int) []byte {
+	const numChannels = 1
+	const bitsPerSample = 16
+	dataSize := frames * numChannels * (bitsPerSample / 8)
+	buf := &bytes.Buffer{}
+	buf.WriteString("RIFF")
+	binary.Write(buf, binary.LittleEndian, uint32(36+dataSize))
+	buf.WriteString("WAVE")
+	buf.WriteString("fmt ")
+	binary.Write(buf, binary.LittleEndian, uint32(16))
+	binary.Write(buf, binary.LittleEndian, uint16(1)) // PCM
+	binary.Write(buf, binary.LittleEndian, uint16(numChannels))
+	binary.Write(buf, binary.LittleEndian, sampleRate)
+	byteRate := sampleRate * numChannels * (bitsPerSample / 8)
+	binary.Write(buf, binary.LittleEndian, byteRate)
+	binary.Write(buf, binary.LittleEndian, uint16(numChannels*(bitsPerSample/8)))
+	binary.Write(buf, binary.LittleEndian, uint16(bitsPerSample))
+	buf.WriteString("data")
+	binary.Write(buf, binary.LittleEndian, uint32(dataSize))
+	buf.Write(make([]byte, dataSize))
+	return buf.Bytes()
+}
+
+func TestGetAudioDurationCaseInsensitiveExt(t *testing.T) {
+	wav := minimalWAV(8000, 8000) // 1 second
+
+	for _, ext := range []string{".wav", ".WAV", ".Wav"} {
+		d, err := GetAudioDuration(context.Background(), bytes.NewReader(wav), ext)
+		if err != nil {
+			t.Fatalf("ext %q: unexpected error: %v", ext, err)
+		}
+		if d < 0.99 || d > 1.01 {
+			t.Fatalf("ext %q: expected ~1s duration, got %v", ext, d)
+		}
+	}
+}
+
+func TestGetAudioDurationUppercaseNotUnsupported(t *testing.T) {
+	_, err := GetAudioDuration(context.Background(), bytes.NewReader([]byte("not audio")), ".MP3")
+	if err != nil && strings.Contains(err.Error(), "unsupported audio format") {
+		t.Fatalf("uppercase extension rejected as unsupported: %v", err)
+	}
+}


### PR DESCRIPTION
## Agent

- Tool: Hermes Agent (Nous Research)
- Tool version: n/a
- Model (full id): claude-opus-4-8
- Host (CLI / IDE / GitHub coding agent / other): CLI
- Date (UTC): Sep 11 2026

## Links

- Closes #7319
- Related: PR #1243 (prior audio-duration bug fix)

## User request

`common/audio.GetAudioDuration` does not handle case-insensitive file
extensions; `ext = strings.ToLower(ext)` was suggested. Expected: `MP3`/`mp3`
treated the same.

## Out of scope — refuse

- Matched: no
- This is a plain bug fix in existing pure-Go audio-duration code, none of the
  refused categories apply.

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: `GetAudioDuration` selects a parser via `switch ext` with
  lowercase-only cases (`.mp3`, `.wav`, ...). An extension that arrives with any
  uppercase letter (`.MP3`, `.WAV`) misses every case and hits `default`,
  returning `unsupported audio format: <ext>`.
- Impact: for such inputs the duration cannot be parsed, so audio completion
  token usage falls back to the rough size-based estimate instead of the real
  duration-based count.
- Frequency: any request whose audio format string is not already lowercase.
- Evidence that the problem is in new-api rather than the client or upstream:
  the `switch` is entirely inside new-api (`common/audio.go`) and is
  case-sensitive; the value is built locally as `ext := "." + audioFormat` in
  `relay/channel/openai/audio.go`.
- Applicable types and their fields: billing (audio completion token counting).

## Change

Lowercase `ext` with `strings.ToLower` immediately before the format `switch`
in `GetAudioDuration`, so mixed/upper-case extensions resolve to the correct
parser. One-line behavioral change plus the import.

## Research

### Duplicate / prior art

- Search queries (issues, PRs): PRs searched for `GetAudioDuration`, `7319 audio
  case`; issues searched for existing audio-case reports.
- What already existed and why this is not a duplicate: PR #1243 fixed a webm
  `ParseFloat "N/A"` parse issue, unrelated to extension casing. No open PR
  references #7319.

### Docs and code

- README / repo docs: audio duration is computed by the pure-Go
  `common/audio.go` path (no external ffmpeg).
- Code paths and what they imply for this change:
  `relay/channel/openai/audio.go` builds `ext := "." + audioFormat` and calls
  `common.GetAudioDuration`; the switch there is the single place format
  selection happens, so normalizing case at its entry covers all callers.

### Alternatives considered

- Option A: lowercase every `case` label — noisier, easy to miss one.
- Option B: lowercase the caller's `audioFormat` — only fixes one call site.
- Why this approach: normalizing once at the function entry fixes all current
  and future callers with a single line.

## Files

| Path | Why |
| --- | --- |
| common/audio.go | Lowercase `ext` before the parser switch; add `strings` import |
| common/audio_case_test.go | Regression tests for case-insensitive extension handling |

## Behavior

- Before: `GetAudioDuration(..., ".WAV")` returns `unsupported audio format: .WAV`.
- After: `.WAV`/`.Wav`/`.wav` all resolve to the WAV parser and return the same duration.
- Explicit non-goals / leftover work: none.

## Verification

Toolchain: Go 1.25.1 fetched locally, `GOFLAGS=-mod=mod`.

- Commands and results:
  - `go test ./common/ -run 'TestGetAudioDurationCaseInsensitiveExt|TestGetAudioDurationUppercaseNotUnsupported' -v` → PASS (both tests).
  - `go vet ./common/` → clean.
  - `gofmt -l common/audio.go common/audio_case_test.go` → no output.
- RED→GREEN: with the `strings.ToLower(ext)` line removed, both tests FAIL
  (`unsupported audio format: .WAV` / `.MP3`); restoring the line → PASS.
- Tests added: `TestGetAudioDurationCaseInsensitiveExt` (builds a valid 1s
  16-bit PCM mono WAV in memory, asserts `.wav`/`.WAV`/`.Wav` all yield ~1.0s)
  and `TestGetAudioDurationUppercaseNotUnsupported` (asserts `.MP3` is not
  rejected as an unsupported format).
- UI: none (backend-only).
- Not verified: full end-to-end relay flow with a live upstream (no API creds);
  the extracted duration logic is exercised directly by the unit tests.

## Risks

- Failure modes: none new — lowercasing an already-lowercase string is a no-op,
  so existing lowercase inputs are unchanged.
- Billing / quota / auth impact: fixes under-counting of audio completion tokens
  for mixed/upper-case formats; no change for lowercase inputs.
- Follow-ups: none.

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio files are now recognized regardless of whether their file extensions use uppercase, lowercase, or mixed-case letters.

* **Tests**
  * Added coverage for mixed-case WAV extensions and uppercase MP3 extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->