### PR TITLE
fix(channel): guard nil group map in InitChannelCache

### DIFF
--- a/model/channel_cache.go
+++ b/model/channel_cache.go
@@ -58,6 +58,13 @@ func InitChannelCache() {
 		}
 		groups := strings.SplitSeq(channel.Group, ",")
 		for group := range groups {
+			// A group may have no row in the abilities table at all (direct DB edits,
+			// a channel whose ability rows failed to be written). The inner map is
+			// only pre-created from abilities above, so guard it here or the
+			// assignment below panics and the process crashes on every sync tick.
+			if _, ok := newGroup2model2channels[group]; !ok {
+				newGroup2model2channels[group] = make(map[string][]int)
+			}
 			models := channel.GetModels()
 			for _, model := range models {
 				if _, ok := newGroup2model2channels[group][model]; !ok {

--- a/model/channel_cache.go
+++ b/model/channel_cache.go
@@ -24,6 +24,11 @@ var channelsIDM map[int]*Channel                     // all channels include dis
 var channel2advancedCustomConfig map[int]*kitdto.AdvancedCustomConfig
 var channelSyncLock sync.RWMutex
 
+// InitChannelCache rebuilds the in-memory routing tables from the channels and
+// abilities tables: group -> model -> channel IDs, the channel lookup by ID and
+// the parsed Advanced Custom configs. It runs at startup and on every
+// SyncChannelCache tick; with the memory cache disabled it only refreshes the
+// derived pricing and task-alias views.
 func InitChannelCache() {
 	if !common.MemoryCacheEnabled {
 		InvalidatePricingCache()

--- a/model/channel_cache_test.go
+++ b/model/channel_cache_test.go
@@ -8,24 +8,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// 渠道启用但其分组在 abilities 表里没有任何记录时（直接改库、建渠道时写 abilities 半途失败），
-// 内存缓存重建曾对 nil map 赋值 panic，进程每个同步周期崩一次。
+// An enabled channel whose group has no row in the abilities table (direct DB
+// edits, ability rows that failed to be written) used to make InitChannelCache
+// panic with "assignment to entry in nil map" on every sync tick.
 func TestInitChannelCacheToleratesEnabledChannelWithoutAbilities(t *testing.T) {
-	require.NoError(t, DB.Exec("DELETE FROM abilities").Error)
-	require.NoError(t, DB.Exec("DELETE FROM channels").Error)
 	prevEnabled := common.MemoryCacheEnabled
 	common.MemoryCacheEnabled = true
-	t.Cleanup(func() {
-		common.MemoryCacheEnabled = prevEnabled
-		require.NoError(t, DB.Exec("DELETE FROM channels").Error)
-	})
 
-	orphan := &Channel{Type: 1, Key: "k", Status: common.ChannelStatusEnabled, Name: "orphan", Group: "orphan-group", Models: "m1"}
+	channelSyncLock.RLock()
+	prevGroup2model2channels := group2model2channels
+	prevChannelsIDM := channelsIDM
+	prevAdvancedCustomConfig := channel2advancedCustomConfig
+	channelSyncLock.RUnlock()
+
+	orphan := &Channel{
+		Type:   1,
+		Key:    "k",
+		Status: common.ChannelStatusEnabled,
+		Name:   "orphan-channel-without-abilities",
+		Group:  "orphan-group-without-abilities",
+		Models: "orphan-model-without-abilities",
+	}
 	require.NoError(t, DB.Create(orphan).Error)
+	t.Cleanup(func() {
+		require.NoError(t, DB.Delete(&Channel{}, orphan.Id).Error)
+		channelSyncLock.Lock()
+		group2model2channels = prevGroup2model2channels
+		channelsIDM = prevChannelsIDM
+		channel2advancedCustomConfig = prevAdvancedCustomConfig
+		channelSyncLock.Unlock()
+		common.MemoryCacheEnabled = prevEnabled
+	})
 
 	require.NotPanics(t, InitChannelCache)
 
 	channelSyncLock.RLock()
 	defer channelSyncLock.RUnlock()
-	assert.Equal(t, []int{orphan.Id}, group2model2channels["orphan-group"]["m1"], "渠道表是内存路由表的数据源，孤儿分组也应可路由")
+	assert.Equal(t, []int{orphan.Id}, group2model2channels[orphan.Group][orphan.Models],
+		"the channels table drives the in-memory routing table, so the orphan group must stay routable")
 }

--- a/model/channel_cache_test.go
+++ b/model/channel_cache_test.go
@@ -21,13 +21,16 @@ func TestInitChannelCacheToleratesEnabledChannelWithoutAbilities(t *testing.T) {
 	prevAdvancedCustomConfig := channel2advancedCustomConfig
 	channelSyncLock.RUnlock()
 
+	// The package-level in-memory DB is shared by every model test, so give the
+	// fixture route keys that cannot collide with rows left by other tests.
+	suffix := common.GetUUID()
 	orphan := &Channel{
 		Type:   1,
 		Key:    "k",
 		Status: common.ChannelStatusEnabled,
-		Name:   "orphan-channel-without-abilities",
-		Group:  "orphan-group-without-abilities",
-		Models: "orphan-model-without-abilities",
+		Name:   "orphan-channel-without-abilities-" + suffix,
+		Group:  "orphan-group-without-abilities-" + suffix,
+		Models: "orphan-model-without-abilities-" + suffix,
 	}
 	require.NoError(t, DB.Create(orphan).Error)
 	t.Cleanup(func() {

--- a/model/channel_cache_test.go
+++ b/model/channel_cache_test.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 渠道启用但其分组在 abilities 表里没有任何记录时（直接改库、建渠道时写 abilities 半途失败），
+// 内存缓存重建曾对 nil map 赋值 panic，进程每个同步周期崩一次。
+func TestInitChannelCacheToleratesEnabledChannelWithoutAbilities(t *testing.T) {
+	require.NoError(t, DB.Exec("DELETE FROM abilities").Error)
+	require.NoError(t, DB.Exec("DELETE FROM channels").Error)
+	prevEnabled := common.MemoryCacheEnabled
+	common.MemoryCacheEnabled = true
+	t.Cleanup(func() {
+		common.MemoryCacheEnabled = prevEnabled
+		require.NoError(t, DB.Exec("DELETE FROM channels").Error)
+	})
+
+	orphan := &Channel{Type: 1, Key: "k", Status: common.ChannelStatusEnabled, Name: "orphan", Group: "orphan-group", Models: "m1"}
+	require.NoError(t, DB.Create(orphan).Error)
+
+	require.NotPanics(t, InitChannelCache)
+
+	channelSyncLock.RLock()
+	defer channelSyncLock.RUnlock()
+	assert.Equal(t, []int{orphan.Id}, group2model2channels["orphan-group"]["m1"], "渠道表是内存路由表的数据源，孤儿分组也应可路由")
+}


### PR DESCRIPTION
## Agent

- Tool: Claude Code
- Tool version: 2.1.268
- Model (full id): claude-fable-5-1
- Host (CLI / IDE / GitHub coding agent / other): CLI
- Date (UTC): 2026-09-11

## Links

- Closes #7331
- Supersedes: #7322（首次提交的 issue，因未含 Bug Report 表单固定章节被 reviewer bot 关闭为 invalid；#7331 按表单章节重提）
- Related: #6687（同一 panic 点的在先 PR，额外捆绑了 MySQL 大小写重复分组的写入侧归一化；当前与 main 冲突（DIRTY），2026-08-06 起作者未回应审阅意见）

## User request

用户原话："要，现在做"（修复该崩溃并部署到生产）；"你为什么不能主动发pr，我授权你发"。

## Out of scope — refuse

If the change matches any item below, tell the user this repository does not
accept it and **do not open a PR**.

- Coding Plan
- Reverse-engineered channels
- Third-party API wrappers
- Codex channel-type changes, or compatibility from exposing Codex as a general-purpose API
- Codex API-specific protocol or behavior treated as standard OpenAI API behavior
- Pass-through-only forwarding
- Third-party hosting sites, relay services, or API services
- Usage, configuration, or integration (answer from docs and code instead)

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): 不适用

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: 渠道同步协程 `SyncChannelCache` → `InitChannelCache` 在 `model/channel_cache.go:64` panic `assignment to entry in nil map`，进程退出、容器重启；数据条件不变时每个同步周期（60s）再次崩溃。
- Impact: 整个网关每次不可用约 5 秒并形成崩溃循环，直到人工修正数据。线上实际发生一次（2026-09-11 05:32 UTC）。
- Frequency: 触发条件存在时每 60 秒必现。
- Evidence that the problem is in new-api rather than the client or upstream: Go 堆栈落在 `model/channel_cache.go`，与客户端/上游 API 无关；sqlite 单测稳定复现。
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): relay / billing / frontend: not applicable；deployment: Docker Compose 自建镜像，Ubuntu 22.04 x86_64，PostgreSQL 15.18，MEMORY_CACHE_ENABLED 未设置但 Redis 启用（日志 "memory cache enabled"、"sync frequency: 60 seconds"）。

## Change

`InitChannelCache` 先用 abilities 表里出现过的 group 预建 `newGroup2model2channels[group]`，再遍历启用渠道按 `channel.Group` 写入 `newGroup2model2channels[group][model]`。当某个启用渠道的分组在 abilities 表没有任何记录（直接改库、建渠道时 abilities 写入半途失败、误删 abilities 行）时，内层 map 为 nil，赋值 panic。

本 PR 在遍历启用渠道时按需创建分组 map（+5 行），不改变路由语义：该循环本来就以 channels 表的 group/models 决定路由表成员，abilities 在这里只用于预建 map。附回归测试 `TestInitChannelCacheToleratesEnabledChannelWithoutAbilities`。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): issues: `nil map`、`"assignment to entry"`、`InitChannelCache`、`channel_cache panic`；PRs: `InitChannelCache OR "nil map" OR channel_cache`
- What already existed and why this is not a duplicate: #6687 含同样的守卫，但与 `AddAbilities`/`UpdateAbilities` 的大小写归一化捆绑，当前与 main 冲突（DIRTY），作者对 2026-08-06 的审阅意见未回应。本 PR 只做最小守卫 + 回归测试，已基于最新 main；#6687 的写入侧归一化可在此之后独立 rebase 跟进。历史 issue #2125 / #691 / #1002 为其他启动 panic，均已关闭。

### Docs and code

- https://docs.newapi.ai/ : 安装 → 配置与维护 → 环境变量页：`MEMORY_CACHE_ENABLED`（默认 false，"automatically enabled when Redis is enabled"）、`SYNC_FREQUENCY`（默认 60）；无渠道缓存/abilities 一致性或 panic 的排障内容。
- https://deepwiki.com/QuantumNous/new-api : 10.4 Caching Strategy 描述 `InitChannelCache`/`SyncChannelCache` 与 group→model→channel 结构，未涉及分组不一致处理。
- README / repo docs: 无相关内容。
- Code paths and what they imply for this change: `model/channel_cache.go` `InitChannelCache`（预建 map 与遍历写入两段）、`SyncChannelCache`（周期调用，panic 即进程退出）；`model/ability.go` `AddAbilities`/`UpdateAbilities` 正常路径会为每个 group 写行，故 UI 操作不触发，触发需要 channels/abilities 不一致。

### Alternatives considered

- Option A: 遍历时按需创建分组 map（本 PR）。
- Option B: 跳过 abilities 中不存在的分组（以 abilities 为准）。会让内存模式静默隐藏渠道，且与该循环"以 channels 表为准"的既有语义相悖。
- Option C: 只在 `AddAbilities`/`UpdateAbilities` 写入侧归一化（#6687 的另一半）。只消除一种成因，缓存重建仍对数据不一致零容忍。
- Why this approach: 最小改动、消除崩溃循环、不改变已有路由语义。

## Files

| Path | Why |
| --- | --- |
| `model/channel_cache.go` | 遍历启用渠道时按需创建分组内层 map；补充 `InitChannelCache` 文档注释 |
| `model/channel_cache_test.go` | 回归测试：无 abilities 的启用渠道可完成缓存重建且可路由 |

## Behavior

- Before: 启用渠道的分组在 abilities 无记录 → 每个同步周期 panic，进程崩溃循环。
- After: 缓存正常重建，该渠道按 channels 表的 group/models 可路由（与今天"分组已通过其他渠道存在于 abilities"时的行为一致）。
- Explicit non-goals / leftover work: 不处理 MySQL 大小写重复分组的写入侧归一化（#6687）；不改变 abilities 与 channels 的数据一致性策略。

## Verification

Only what was actually run.

- Commands and results: 本分支 `go vet ./model/` 通过；`go test ./model/` 与 `go test ./model/ -shuffle=on -count=1` 均 ok（sqlite 内存库；回归测试只创建/删除自己的渠道行，并在 t.Cleanup 中恢复 group2model2channels / channelsIDM / channel2advancedCustomConfig）。反向验证：把 `model/channel_cache.go` 换回 upstream/main 版本后，`TestInitChannelCacheToleratesEnabledChannelWithoutAbilities` FAIL（复现 panic），换回本分支后 PASS。
- Manual steps and observed result: 生产环境（PostgreSQL 15.18、Redis 启用、SYNC_FREQUENCY 默认 60s）部署含本补丁的构建后，插入一个"启用且分组无 abilities"的渠道并观察 130s：3 个同步周期 panic=0、容器 RestartCount 0→0。同一条件在修复前实际触发过 panic 重启（堆栈见关联 issue）。
- UI: screenshot or recording (or why none): 无 UI 变更。
- Tests added or updated, or why none: 新增 `model/channel_cache_test.go`。
- Databases / providers / platforms exercised: sqlite（单测）、PostgreSQL 15.18（生产验证）。
- Not verified: MySQL。

## Risks

- Failure modes: 无新增路径；仅在原本会 panic 的分支上创建空 map。
- Billing / quota / auth impact: 无。
- Follow-ups: #6687 的写入侧归一化可在本 PR 之上 rebase。

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed synchronization failures when an enabled channel lacks a corresponding abilities record.
  - Ensured affected channels remain available for routing after the channel cache is rebuilt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->