### PR TITLE
fix(pricing): display complex time-rule multipliers in billing logs

### DIFF
--- a/web/src/features/pricing/__tests__/request-rule-display.test.tsx
+++ b/web/src/features/pricing/__tests__/request-rule-display.test.tsx
@@ -1,0 +1,156 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+
+import { getTieredBillingSummary } from '@/features/usage-logs/lib/format'
+
+import { DynamicPricingBreakdown } from '../components/dynamic-pricing-breakdown'
+import {
+  combineBillingExpr,
+  splitBillingExprAndRequestRules,
+  tryParseRequestRuleExpr,
+} from '../lib/billing-expr'
+import { hasDynamicRequestRules } from '../lib/dynamic-price'
+
+const base = 'tier("base", p * 0.0231270000 + c * 0.4400000000)'
+const condition =
+  'hour("UTC") < 12 || hour("UTC") >= 18 || weekday("UTC") == 0 || weekday("UTC") == 6'
+const rules = `((${condition}) ? 0.5 : 1)`
+const expression = `${base} * ${rules}`
+
+describe('time request rule display', () => {
+  test('extracts base prices from the overnight-or-weekend rule in #7296', () => {
+    expect(splitBillingExprAndRequestRules(expression)).toEqual({
+      billingExpr: base,
+      requestRuleExpr: rules,
+    })
+    expect(
+      getTieredBillingSummary({
+        billing_mode: 'tiered_expr',
+        expr_b64: btoa(expression),
+        matched_tier: 'base',
+      })?.tier
+    ).toMatchObject({
+      label: 'base',
+      inputPrice: 0.023127,
+      outputPrice: 0.44,
+    })
+  })
+
+  test('keeps complex rules in raw editing mode and preserves their source', () => {
+    const split = splitBillingExprAndRequestRules(expression)
+    expect(tryParseRequestRuleExpr(rules)).toBeNull()
+    expect(split.requestRuleExpr).toBe(rules)
+    expect(combineBillingExpr(split.billingExpr, split.requestRuleExpr)).toBe(
+      combineBillingExpr(base, rules)
+    )
+  })
+
+  test.each([
+    '(weekday("UTC")==0||weekday("UTC")==6?5e-1:1)',
+    '(!((hour("UTC") >= 12 && hour("UTC") < 18) && weekday("UTC") != 0) ? 0 : 1)',
+  ])(
+    'recognizes a complete time rule with nested logic or compact syntax: %s',
+    (rule) => {
+      expect(splitBillingExprAndRequestRules(`${base} * ${rule}`)).toEqual({
+        billingExpr: base,
+        requestRuleExpr: rule,
+      })
+    }
+  )
+
+  test('retains all factors when time and existing header rules are combined', () => {
+    const headerRule = '(header("x-mode") == "a * b" ? 2 : 1)'
+    expect(
+      splitBillingExprAndRequestRules(`${rules} * (${base}) * ${headerRule}`)
+    ).toEqual({
+      billingExpr: base,
+      requestRuleExpr: `${rules} * ${headerRule}`,
+    })
+  })
+
+  test('keeps the request-rule indicator on models with complex time conditions', () => {
+    expect(
+      hasDynamicRequestRules({
+        id: 1,
+        model_name: 'time-priced-model',
+        quota_type: 0,
+        model_ratio: 1,
+        completion_ratio: 1,
+        enable_groups: ['default'],
+        billing_mode: 'tiered_expr',
+        billing_expr: expression,
+      })
+    ).toBe(true)
+  })
+
+  test.each([
+    `(${condition} ? 0.5 : 2)`,
+    `(${condition} ? p : 1)`,
+    `(${condition} ? 0.5 : 1) + 3`,
+    '(hour("UTC") < 12 || unknown("UTC") == 6 ? 0.5 : 1)',
+    '(hour("UTC") < 12 || ? 0.5 : 1)',
+    `${rules} *`,
+  ])(
+    'keeps unsupported or malformed factors in the base expression: %s',
+    (factor) => {
+      const source = `${base} * ${factor}`
+      expect(splitBillingExprAndRequestRules(source)).toEqual({
+        billingExpr: source,
+        requestRuleExpr: '',
+      })
+      expect(
+        getTieredBillingSummary({
+          billing_mode: 'tiered_expr',
+          expr_b64: btoa(source),
+          matched_tier: 'base',
+        })
+      ).toBeNull()
+    }
+  )
+
+  test('shows base prices and the multiplier without log traces', () => {
+    render(<DynamicPricingBreakdown billingExpr={expression} />)
+    expect(screen.getByText('Conditional multipliers')).toBeInTheDocument()
+    expect(
+      screen.getByText('00:00–12:00 or 18:00–24:00 or Sun or Sat (UTC)')
+    ).toBeInTheDocument()
+    expect(screen.getByText('0.5x')).toBeInTheDocument()
+    expect(screen.getAllByText('$0.0231').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('$0.4400').length).toBeGreaterThan(0)
+  })
+
+  test.each([true, false])(
+    'uses the recorded matched=%s state rather than evaluating the clock',
+    (matched) => {
+      render(
+        <DynamicPricingBreakdown
+          billingExpr={expression}
+          matchedTierLabel='base'
+          requestRules={[{ cond: condition, multiplier: 0.5, matched }]}
+        />
+      )
+      expect(screen.getAllByText('$0.0231').length).toBeGreaterThan(0)
+      expect(
+        screen.getByText(matched ? '0.5x · Matched' : '0.5x')
+      ).toBeInTheDocument()
+    }
+  )
+})

--- a/web/src/features/pricing/components/dynamic-pricing-breakdown.tsx
+++ b/web/src/features/pricing/components/dynamic-pricing-breakdown.tsx
@@ -34,10 +34,10 @@ import {
   MATCH_LT,
   MATCH_RANGE,
   SOURCE_TIME,
+  parseRequestRuleExprForDisplay,
   parseTiersFromExpr,
   requestRuleGroupsFromTrace,
   splitBillingExprAndRequestRules,
-  tryParseRequestRuleExpr,
   type ParsedTaskTier,
   type ParsedTier,
   type RequestCondition,
@@ -306,7 +306,7 @@ export function DynamicPricingBreakdown({
     const parsedRules =
       requestRules != null
         ? requestRuleGroupsFromTrace(requestRules)
-        : tryParseRequestRuleExpr(split.requestRuleExpr || '')
+        : parseRequestRuleExprForDisplay(split.requestRuleExpr || '')
     return {
       tiers: parsedTiers,
       ruleGroups: parsedRules || [],

--- a/web/src/features/pricing/lib/billing-expr.ts
+++ b/web/src/features/pricing/lib/billing-expr.ts
@@ -29,6 +29,7 @@ For commercial licensing, please contact support@quantumnous.com
 
 import type { BillingUsageSchema } from '../types'
 import {
+  isTimeCondition,
   readTokenTierChain,
   readTaskTierChain,
   readTimeTokenPricing,
@@ -577,6 +578,36 @@ export function tryParseRequestRuleExpr(
   return groups
 }
 
+/** Display-only time rules may retain raw conditions that the rule editor cannot rebuild. */
+export function parseRequestRuleExprForDisplay(
+  expr: string
+): RequestRuleGroup[] | null {
+  const editable = tryParseRequestRuleExpr(expr)
+  if (editable) return editable
+  if (compileBillingExpression(expr).status !== 'ready') return null
+
+  const groups: RequestRuleGroup[] = []
+  for (const part of splitTopLevelMultiply(expr)) {
+    const group = tryParseRuleGroupFactor(part)
+    if (group) {
+      groups.push(group)
+      continue
+    }
+    const compiled = compileBillingExpression(part)
+    if (compiled.status !== 'ready') return null
+    const rule = compiled.requestRules.find(
+      (entry) => entry.node === compiled.ast
+    )
+    if (!rule || !isTimeCondition(rule.condition)) return null
+    groups.push({
+      conditions: [],
+      conditionText: rule.cond,
+      multiplier: String(rule.multiplier),
+    })
+  }
+  return groups
+}
+
 // ---------------------------------------------------------------------------
 // Combine / split billing expr and request rules
 // ---------------------------------------------------------------------------
@@ -597,9 +628,12 @@ export function splitBillingExprAndRequestRules(expr: string): {
 
   const ruleParts: string[] = []
   const baseParts: string[] = []
+  const allowTimeRules = compileBillingExpression(trimmed).status === 'ready'
 
   parts.forEach((part) => {
-    const parsed = tryParseRequestRuleExpr(part)
+    const parsed = allowTimeRules
+      ? parseRequestRuleExprForDisplay(part)
+      : tryParseRequestRuleExpr(part)
     if (parsed && parsed.length > 0) {
       ruleParts.push(part)
     } else {

--- a/web/src/features/pricing/lib/dynamic-price.ts
+++ b/web/src/features/pricing/lib/dynamic-price.ts
@@ -28,10 +28,10 @@ import type {
 import {
   BILLING_PRICING_VARS,
   getCurrentTimePricingTiers,
+  parseRequestRuleExprForDisplay,
   parseTaskTiersFromExpr,
   parseTiersFromExpr,
   splitBillingExprAndRequestRules,
-  tryParseRequestRuleExpr,
   type BillingVar,
   type ParsedTaskTier,
   type ParsedTier,
@@ -242,7 +242,7 @@ export function hasDynamicRequestRules(model: PricingModel): boolean {
   const { requestRuleExpr } = splitBillingExprAndRequestRules(
     model.billing_expr || ''
   )
-  return Boolean(tryParseRequestRuleExpr(requestRuleExpr || '')?.length)
+  return Boolean(parseRequestRuleExprForDisplay(requestRuleExpr || '')?.length)
 }
 
 export function getDynamicPriceEntries(


### PR DESCRIPTION
## Agent

- Tool: OpenAI Codex；本 PR 的实现、测试和说明由 AI 辅助完成。
- Tool version: 可读取的本机 CLI 版本为 `codex-cli 0.153.4`。
- Model (full id): GPT-6；完整运行时 model id 未向此任务暴露，不推断具体快照。
- Host (CLI / IDE / GitHub coding agent / other): Codex desktop，本地 macOS arm64。
- Date (UTC): 2026-09-11。

## Links

- Closes #7296
- Related: #7268 / #7269（时间条件作为定价分支的展示；本次处理乘在基础价格后的请求规则）。

## User request

用户要求从 New API、热门 AI 基础设施或高质量 Unix/macOS 仓库中，选择中等难度、可轻量验证、合并机会较好的 issue，完成实现、验证并提交 PR，尽量减少下载、编译、实验和磁盘占用。

## Out of scope — refuse

- Matched: no。
- If yes, what was told to the user (stop here; do not open a PR): 不适用。此变更修复本仓库前端计费表达式展示，不涉及 Coding Plan、逆向渠道、第三方封装、Codex 渠道或协议、纯透传、第三方托管服务，也不是使用或配置问题。

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: #7296 报告 `tiered_expr` 请求日志显示“动态计费 · 无匹配结果”，尽管实际命中 `base` 档且扣费正确。
- Impact: 无法从摘要查看基础单价、请求规则倍率与命中状态，容易误判对账结果。
- Frequency: issue 报告对包含多段 OR 时间条件的模型日志必现。
- Evidence that the problem is in new-api rather than the client or upstream: 在未修改的上游 `bdef117505247769268b209665fb3ad7554c3da7` 上，用 issue 的表达式调用真实前端解析器及日志摘要函数，可稳定复现；无需上游 API、数据库或模型。
- Applicable types and their fields: 前端展示；issue 版本为 `v1.0.0-rc.36`，页面为“使用日志”，含完整表达式、复现步骤和截图。本地验证为源码单元/组件测试，未另行部署该版本。扣费正确是 issue 报告的事实，本地未执行结算或真实 API 请求。

## Change

复用现有编译器识别完整的 `time-condition ? numeric-literal : 1` 请求倍率因子，并在展示适配器中保留复杂条件的原始文本。基础档位可以正常提取，倍率使用已有条件格式化与组件展示。

原有 `tryParseRequestRuleExpr` 的编辑契约保持不变：不能无损重建的 OR 条件仍返回 `null`，保留原始规则表达式。日志继续以服务端 `request_rules` 的倍率及 `matched` 字段为准。没有日志 trace 时，详情与模型规则标识使用同一展示适配器。

新增识别仅覆盖可完整编译的时间条件，且 AST 根节点必须是编译器识别出的倍率规则；其他形状继续降级展示。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `repo:QuantumNous/new-api is:pr is:open 7296`、`repo:QuantumNous/new-api is:pr is:open "OR" "billing"`，以及 #7296 timeline。
- What already existed and why this is not a duplicate: 提交前未发现直接修复 #7296 的 PR。已检查 #7269 的说明和文件范围，它处理定价条件分支，不处理基础价格后的多段 OR 请求倍率。本次复用主分支已有 AST 编译器，不另写表达式语法解析器。

### Docs and code

- https://docs.newapi.ai/ : 已阅读入口及[倍率设置](https://docs.newapi.ai/zh/docs/guide/console/settings/rate-settings)，区分配额结算和本次展示问题。
- https://deepwiki.com/QuantumNous/new-api : 已阅读概览及 [Pricing & Ratio System](https://deepwiki.com/QuantumNous/new-api/5.2-pricing-and-ratio-system)，仅作导航，具体行为以当前源码为准。
- README / repo docs: `README.md` 的计费功能说明；`pkg/billingexpr/expr.md` 的“一份表达式”、Request Rule Tracing、Log Display 约定。
- Code paths and what they imply for this change: `billing-expression/parser.ts` 已记录精确的倍率条件 AST；`display.ts` 已有 `isTimeCondition`；`usage-logs/lib/format.ts` 通过拆分表达式提取档位；`tiered-pricing-editor.tsx` 使用严格解析结果控制可视化规则编辑。已有 `DynamicPricingBreakdown`、条件格式化、Badge 和表格足以展示，无需新增 UI 组件。

### Alternatives considered

- Option A: 扩展可视化编辑器的条件模型，支持任意 OR 树。
- Option B: 为展示新增受限适配器，保留原始复杂条件，复用已有 AST 校验。
- Why this approach: B 能修复价格和日志展示，同时保留编辑往返语义；不必为本 issue 扩展规则编辑器或结算逻辑。

## Files

| Path | Why |
| --- | --- |
| `web/src/features/pricing/lib/billing-expr.ts` | 增加展示适配器，并在完整表达式校验通过后识别复杂时间倍率因子。 |
| `web/src/features/pricing/lib/dynamic-price.ts` | 保持模型请求规则标识与展示识别结果一致。 |
| `web/src/features/pricing/components/dynamic-pricing-breakdown.tsx` | 没有日志 trace 时使用展示适配器；有 trace 时沿用原路径。 |
| `web/src/features/pricing/__tests__/request-rule-display.test.tsx` | 复现日志摘要问题，覆盖原始规则保留、混合因子、嵌套逻辑、非法表达式降级和实际组件展示。 |

## Behavior

- Before: issue 表达式无法拆出 `base` 档位，日志摘要返回 `null`，详情显示无法解析结构化价格。
- After: 提取输入 `$0.023127/1M`、输出 `$0.44/1M` 的基础单价；保留 `0.5x` 规则及日志命中状态。组件沿用四位小数显示单价，时间条件显示为 `00:00–12:00 or 18:00–24:00 or Sun or Sat (UTC)`。
- Explicit non-goals / leftover work: 不实现通用原始条件的可视化编辑，不更改扣费、额度、后端、数据库、认证、i18n 文案或页面布局。

## Verification

Only what was actually run.

- Commands and results（在 `web/` 中运行）:
  - `bun run test --maxWorkers=4`: **119 files / 1154 tests passed**，含新增的 15 项回归。
  - `bun run test src/features/pricing src/features/usage-logs src/features/system-settings/models`: **32 files / 407 tests passed**。
  - `bun run typecheck`: 通过。
  - `bun run build`: 通过，8.68 秒完成构建；未引入新依赖。
  - `oxlint -c .oxlintrc.json <四个改动文件>`、`oxfmt --check <四个改动文件>` 和 `git diff --check`: 通过。
  - 第一次无并发限制的完整测试遇到未改动的 `setup-guide.test.tsx` 中一项可见性断言失败；该文件单独运行 6/6 通过，随后限制 4 workers 的完整测试全部通过。未修改该无关测试。
  - 额外的全仓库 `copyright:check` 报告 11 个未改动文件的既有版权头问题；本次四个文件均不在报告中。
- Manual steps and observed result: 将三个生产文件临时恢复为上游原始内容，保留最终回归测试运行，得到 9 failed / 6 passed；随后恢复修复内容。此操作未修改基线提交或提交历史。
- UI: screenshot or recording (or why none): 未改布局、样式或交互，使用 React Testing Library 挂载真实组件，检查基础价格、完整时间条件、倍率和 trace 的 true/false 命中状态；没有浏览器截图，不声称完成真实部署验证。
- Tests added or updated: 新增 15 项聚焦的回归用例，使用小型内存表达式和日志 fixture。
- Databases / providers / platforms exercised: 本地 macOS arm64，Node.js 22.19.0，Bun 1.4.2；未连接数据库和提供商。
- Not verified: 后端 Go 编译、数据库矩阵、真实模型请求与端到端结算不属于本次改动，未在本地执行。

## Risks

- Failure modes: 新增识别要求完整编译成功、精确的倍率因子形状及纯时间条件。非法表达式、非数值倍率、非 1 fallback 和未知函数仍保留降级路径；严格编辑解析器不接受新增展示形状。
- Billing / quota / auth impact: 不改后端结算、额度或认证；仍展示基础单价和独立规则倍率，不把当前时间计算结果当作历史请求事实。
- Follow-ups: 若维护者希望进一步支持其他原始条件，可在单独 issue 中讨论；本 PR 不扩展该范围。

## Scope check

- Single focused change: yes。
- Secrets included: no。
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pricing displays for complex or unsupported time-based request rules.
  * Preserved request-rule details, pricing factors, and multipliers when showing dynamic pricing breakdowns.
  * Added safer fallback behavior for malformed or unsupported pricing factors.
  * Improved detection and display of dynamic request rules without relying on the current clock state.

* **Tests**
  * Added coverage for request-rule parsing, tiered pricing summaries, dynamic pricing indicators, and recorded match states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->