### PR TITLE
fix(perf-metrics): hide groups unavailable to the viewer

### DIFF
--- a/controller/perf_metrics.go
+++ b/controller/perf_metrics.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	perfmetrics "github.com/QuantumNous/new-api/pkg/perf_metrics"
+	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting/ratio_setting"
 
 	"github.com/gin-gonic/gin"
@@ -65,7 +66,7 @@ func GetPerfMetrics(c *gin.Context) {
 		return
 	}
 
-	result.Groups = filterActiveGroups(result.Groups)
+	result.Groups = filterActiveGroups(result.Groups, c.GetString("group"))
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
@@ -73,10 +74,12 @@ func GetPerfMetrics(c *gin.Context) {
 	})
 }
 
-func filterActiveGroups(groups []perfmetrics.GroupResult) []perfmetrics.GroupResult {
+func filterActiveGroups(groups []perfmetrics.GroupResult, userGroup string) []perfmetrics.GroupResult {
 	activeRatios := ratio_setting.GetGroupRatioCopy()
+	usableGroups := service.GetUserUsableGroups(userGroup)
 	return lo.Filter(groups, func(g perfmetrics.GroupResult, _ int) bool {
-		_, ok := activeRatios[g.Group]
-		return ok || g.Group == "auto"
+		_, active := activeRatios[g.Group]
+		_, usable := usableGroups[g.Group]
+		return usable && (active || g.Group == "auto")
 	})
 }

--- a/controller/perf_metrics_test.go
+++ b/controller/perf_metrics_test.go
@@ -1,0 +1,116 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/model"
+	perfmetrics "github.com/QuantumNous/new-api/pkg/perf_metrics"
+	"github.com/QuantumNous/new-api/setting"
+	"github.com/QuantumNous/new-api/setting/ratio_setting"
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestGetPerfMetricsRespectsUsableGroups(t *testing.T) {
+	originalDB, originalLogDB := model.DB, model.LOG_DB
+	originalRatios := ratio_setting.GroupRatio2JSONString()
+	originalUsable := setting.UserUsableGroups2JSONString()
+	special := ratio_setting.GetGroupRatioSetting().GroupSpecialUsableGroup
+	originalSpecial := special.ReadAll()
+	originalGinMode := gin.Mode()
+	t.Cleanup(func() {
+		model.DB, model.LOG_DB = originalDB, originalLogDB
+		require.NoError(t, ratio_setting.UpdateGroupRatioByJSONString(originalRatios))
+		require.NoError(t, setting.UpdateUserUsableGroupsByJSONString(originalUsable))
+		special.Clear()
+		special.AddAll(originalSpecial)
+		gin.SetMode(originalGinMode)
+	})
+	initModelListColumnNames(t)
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sqlDB.Close()) })
+	model.DB = db
+	require.NoError(t, db.AutoMigrate(&model.PerfMetric{}))
+	require.NoError(t, ratio_setting.UpdateGroupRatioByJSONString(`{"default":1,"staff":1,"vip":1,"internal":1}`))
+	for _, group := range []string{"default", "auto", "staff", "vip", "internal", "deleted"} {
+		require.NoError(t, db.Create(&model.PerfMetric{
+			ModelName: "zz-group-visibility-regression", Group: group,
+			BucketTs: time.Now().Unix() - 60, RequestCount: 1,
+			SuccessCount: 1, TotalLatencyMs: 123,
+		}).Error)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		userGroup string
+		query     string
+		usable    string
+		special   map[string]string
+		want      []string
+	}{
+		{
+			name:   "anonymous sees only public active groups",
+			usable: `{"default":"Default","auto":"Auto","deleted":"Deleted"}`,
+			want:   []string{"auto", "default"},
+		},
+		{
+			name: "query cannot reveal a hidden group", query: "&group=internal",
+			usable: `{"default":"Default"}`, want: []string{},
+		},
+		{
+			name: "member retains own group and special grants", userGroup: "staff",
+			usable:  `{"default":"Default","auto":"Auto"}`,
+			special: map[string]string{"+:vip": "VIP", "-:default": ""},
+			want:    []string{"auto", "staff", "vip"},
+		},
+		{
+			name: "special removal also hides auto", userGroup: "staff",
+			usable: `{"auto":"Auto"}`, special: map[string]string{"-:auto": ""},
+			want: []string{"staff"},
+		},
+		{
+			name: "empty public groups deny all", usable: `{}`, want: []string{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, setting.UpdateUserUsableGroupsByJSONString(tc.usable))
+			special.Clear()
+			if tc.special != nil {
+				special.Set(tc.userGroup, tc.special)
+			}
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet,
+				"/api/perf-metrics?model=zz-group-visibility-regression"+tc.query, nil)
+			if tc.userGroup != "" {
+				c.Set("group", tc.userGroup)
+			}
+			GetPerfMetrics(c)
+			require.Equal(t, http.StatusOK, w.Code)
+			var response struct {
+				Success bool                    `json:"success"`
+				Data    perfmetrics.QueryResult `json:"data"`
+			}
+			require.NoError(t, common.Unmarshal(w.Body.Bytes(), &response))
+			require.True(t, response.Success)
+			got := make([]string, 0, len(response.Data.Groups))
+			for _, group := range response.Data.Groups {
+				got = append(got, group.Group)
+				assert.EqualValues(t, 123, group.AvgLatencyMs)
+			}
+			assert.ElementsMatch(t, tc.want, got)
+			assert.NotNil(t, response.Data.Groups)
+		})
+	}
+}


### PR DESCRIPTION
## Agent

- Tool: OpenAI Codex；本 PR 的实现、测试与说明由 AI 辅助完成。
- Tool version: 本机 `codex-cli 0.153.4`。
- Model (full id): GPT-6；完整运行时 model id 未向此任务暴露，不推断具体快照。
- Host (CLI / IDE / GitHub coding agent / other): Codex desktop，macOS arm64。
- Date (UTC): 2026-09-11。

## Links

- Closes #7309
- Related: #7310（已关闭的重复报告）。

## User request

用户要求选择 New API、热门 AI 基础设施或高质量 Unix/macOS 仓库中的中等难度 issue，完成修复、验证并提交 PR，同时减少下载、编译、实验和磁盘占用。

## Out of scope — refuse

- Matched: no。
- If yes, what was told to the user (stop here; do not open a PR): 不适用；这是模型广场管理 API 的分组展示缺陷，不涉及第三方服务、Codex、Coding Plan 或透传协议。

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: 模型广场 → 模型详情 → 性能的「各分组性能」显示隐藏分组。
- Impact: 访问者能看到未向其开放的分组名称及性能数据。
- Frequency: 报告没有给出频率统计；本地在当前 main 的 5 个权限场景中可确定性复现。
- Evidence that the problem is in new-api rather than the client or upstream: `GetPerfMetrics` 仅按 `GroupRatio` 过滤已删除分组，未使用 `GetUserUsableGroups`；本地直接调用真实 HTTP handler 和 SQLite 中的合成性能记录即复现，无上游请求。
- Applicable types and their fields: 前端路径如上；报告部署为官方仓库版本、自行托管，版本填写 `v1.0`。本地额外验证基于 `bdef117505247769268b209665fb3ad7554c3da7`。Relay、计费和上游 provider 不适用。

## Change

性能详情的服务端响应同时要求分组处于启用状态、且当前访问者可以使用它。沿用已有 `service.GetUserUsableGroups`，保留用户自身分组、特殊 `+:` 授权与 `-:` 撤销规则；`auto` 同样需要可用分组授权。用户组来自现有认证中间件设置的 Gin context，不使用查询参数作为身份。性能路由同时使用现有 `DisableCache` 中间件，禁止浏览器或共享缓存复用按用户组过滤的响应。

## Research

### Duplicate / prior art

- Search queries (issues, PRs): `7309`、`隐藏 分组`、`performance group`、`hidden groups`，并读取 issue comments/timeline。
- What already existed and why this is not a duplicate: #7310 已按重复报告关闭；提交前未找到直接修复的 open PR。`GetPricing` 和 `GetUserGroups` 已复用可用分组规则，本修复将同一规则用于性能详情。

### Docs and code

- https://docs.newapi.ai/ : 已打开官方文档入口；文档没有给出应公开隐藏分组性能名称的约定。
- https://deepwiki.com/QuantumNous/new-api/9.1-application-layout-and-navigation : 已读取，索引存在旧版前端结构，仅作导航；结论以当前源码为准。
- README / repo docs: 已读 README 的项目与分组能力说明、AGENTS.md、agent PR 模板和 CI 配置。
- Code paths and what they imply for this change: `controller/pricing.go`、`controller/group.go`、`service/group.go` 定义可用分组规则；`middleware/auth.go:setDashboardAuthContext` 提供可信用户组；`model-details-performance.tsx` 直接展示 API 返回的 groups，故过滤应在服务器完成。参考 [OWASP Authorization Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html) 的每次请求校验、最小权限和默认拒绝原则；没有改动认证流程，也不宣称全系统 ASVS 合规。

### Alternatives considered

- Option A: 仅在 React 表格隐藏分组，API 仍泄露数据。
- Option B: 在已有响应过滤器中复用用户可用分组规则。
- Why this approach: B 对直接 API 请求也生效，且不新增查询、修改 SQL、数据库结构或缓存键。

## Files

| Path | Why |
| --- | --- |
| `controller/perf_metrics.go` | 按请求用户的可用分组过滤性能详情 |
| `controller/perf_metrics_test.go` | 真实 handler + 内存 SQLite 的分组可见性回归 |
| `router/api-router.go` | 性能路由使用现有禁缓存中间件 |
| `router/perf_metrics_test.go` | 相同 URL 切换用户组与匿名 context，验证响应头及各自可见分组 |

## Behavior

- Before: 匿名用户可看到所有启用分组；显式 `?group=internal` 也能取得隐藏分组数据。
- After: 仅返回当前用户可使用的启用分组；无可见分组返回空数组；保留可见分组指标。
- Explicit non-goals / leftover work: 此 PR 聚焦 `/api/perf-metrics` 的逐分组详情。汇总接口不返回分组名，其跨分组汇总策略未在本次修改；未改 UI、认证、数据库查询、统计采集或计费。

## Verification

Only what was actually run.

- Commands and results: `go test ./controller -run '^TestGetPerfMetricsRespectsUsableGroups$' -count=1 -v`：原版 5 个子场景全部失败，修复后全部通过；相关 model listing / group resolution 测试通过；`go test ./router -count=1` 共 56 项通过；`go vet ./router ./controller`、gofmt、`git diff --check` 通过。
- Manual steps and observed result: 回归通过 httptest 调用真实 handler，使用独立内存 SQLite 记录；路由回归调用实际 `SetApiRouter`，注入认证后 group context，先以 staff 再以匿名访问相同 URL，断言各自分组及 `no-store` / `private`。补丁前只有 4 条缓存头断言失败，补丁后通过；未模拟真实浏览器缓存或完整登录。没有访问部署实例或上游 API。
- UI: screenshot or recording (or why none): 无 UI 代码变更；直接断言前端消费的 JSON groups。
- Tests added or updated: 匿名可见组、显式隐藏组查询、用户自身组及特殊授权、撤销 auto、空权限默认拒绝，同时验证删除组被过滤、可见指标不变。
- Databases / providers / platforms exercised: macOS arm64、Go 1.27.1、SQLite 3.50.4；未运行 MySQL/PostgreSQL，未修改数据库行为。
- Not verified: 完整 controller 测试结果为 845 passed / 22 skipped / 1 failed（含子测试）。唯一失败 `TestSecurityAccountDeletionConcurrentRequestsHaveOneWinner` 为 SQLite 并发删除时 `SQLITE_BUSY`；未修改的 Go 基线代码上单独运行 5 次也出现 1 次相同失败、4 次通过。未运行完整全仓 `make test` 或前端构建，不把局部通过表述为全仓 CI 通过。

## Risks

- Failure modes: 过去能看到隐藏分组数据的访问者会收到更少的 groups，这是预期行为。
- Billing / quota / auth impact: 不改变扣费、统计记录或认证；仅读取已有请求用户组并应用已有权限设置。未增加身份信息日志。
- Follow-ups: 等待维护者 CI 放行；并发账户删除基线失败不在此修复范围。

## Scope check

- Single focused change: yes。
- Secrets included: no。
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no。
