### PR TITLE
fix: report container memory usage from cgroup

### DIFF
--- a/common/cgroup_memory.go
+++ b/common/cgroup_memory.go
@@ -1,0 +1,97 @@
+package common
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	cgroupV2MemoryCurrentPath = "/sys/fs/cgroup/memory.current"
+	cgroupV2MemoryMaxPath     = "/sys/fs/cgroup/memory.max"
+	cgroupV1MemoryUsagePath   = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
+	cgroupV1MemoryLimitPath   = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+)
+
+// readContainerMemoryUsage returns the memory usage relative to the container
+// limit. The second return value is false when no finite cgroup limit can be
+// read, so callers can fall back to a host-level metric.
+func readContainerMemoryUsage() (float64, bool) {
+	return readCgroupMemoryUsage(os.ReadFile)
+}
+
+func readCgroupMemoryUsage(readFile func(string) ([]byte, error)) (float64, bool) {
+	if usage, limit, ok := readCgroupMemoryFiles(
+		readFile,
+		cgroupV2MemoryCurrentPath,
+		cgroupV2MemoryMaxPath,
+	); ok {
+		return memoryUsagePercent(usage, limit)
+	}
+
+	if usage, limit, ok := readCgroupMemoryFiles(
+		readFile,
+		cgroupV1MemoryUsagePath,
+		cgroupV1MemoryLimitPath,
+	); ok {
+		return memoryUsagePercent(usage, limit)
+	}
+
+	return 0, false
+}
+
+func readCgroupMemoryFiles(
+	readFile func(string) ([]byte, error),
+	usagePath string,
+	limitPath string,
+) (uint64, uint64, bool) {
+	usageData, err := readFile(usagePath)
+	if err != nil {
+		return 0, 0, false
+	}
+	limitData, err := readFile(limitPath)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	usage, ok := parseCgroupUint(usageData)
+	if !ok {
+		return 0, 0, false
+	}
+	limitText := strings.TrimSpace(string(limitData))
+	if isUnlimitedCgroupLimit(limitText) {
+		return 0, 0, false
+	}
+	limit, ok := parseCgroupUint([]byte(limitText))
+	if !ok || limit == 0 {
+		return 0, 0, false
+	}
+
+	return usage, limit, true
+}
+
+func parseCgroupUint(data []byte) (uint64, bool) {
+	value, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	return value, err == nil
+}
+
+func isUnlimitedCgroupLimit(value string) bool {
+	if value == "max" {
+		return true
+	}
+
+	// cgroup v1 uses a very large value as its unlimited sentinel. Treat the
+	// upper range as unlimited instead of allowing a meaningless tiny percent.
+	limit, err := strconv.ParseUint(value, 10, 64)
+	return err == nil && limit >= 1<<60
+}
+
+func memoryUsagePercent(usage, limit uint64) (float64, bool) {
+	if limit == 0 {
+		return 0, false
+	}
+	if usage > limit {
+		usage = limit
+	}
+	return float64(usage) / float64(limit) * 100, true
+}

--- a/common/cgroup_memory_test.go
+++ b/common/cgroup_memory_test.go
@@ -1,0 +1,78 @@
+package common
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadCgroupMemoryUsagePrefersV2(t *testing.T) {
+	files := map[string]string{
+		cgroupV2MemoryCurrentPath: "256",
+		cgroupV2MemoryMaxPath:     "1024",
+		cgroupV1MemoryUsagePath:   "900",
+		cgroupV1MemoryLimitPath:   "1000",
+	}
+
+	usage, ok := readCgroupMemoryUsage(fakeCgroupReader(files))
+
+	require.True(t, ok)
+	assert.InDelta(t, 25.0, usage, 0.0001)
+}
+
+func TestReadCgroupMemoryUsageFallsBackToV1(t *testing.T) {
+	files := map[string]string{
+		cgroupV1MemoryUsagePath: "300",
+		cgroupV1MemoryLimitPath: "1200",
+	}
+
+	usage, ok := readCgroupMemoryUsage(fakeCgroupReader(files))
+
+	require.True(t, ok)
+	assert.InDelta(t, 25.0, usage, 0.0001)
+}
+
+func TestReadCgroupMemoryUsageFallsBackWhenLimitIsUnlimited(t *testing.T) {
+	files := map[string]string{
+		cgroupV2MemoryCurrentPath: "256",
+		cgroupV2MemoryMaxPath:     "max",
+		cgroupV1MemoryUsagePath:   "512",
+		cgroupV1MemoryLimitPath:   "9223372036854771712",
+	}
+
+	usage, ok := readCgroupMemoryUsage(fakeCgroupReader(files))
+
+	assert.False(t, ok)
+	assert.Zero(t, usage)
+}
+
+func TestReadCgroupMemoryUsageRejectsInvalidInput(t *testing.T) {
+	files := map[string]string{
+		cgroupV2MemoryCurrentPath: "not-a-number",
+		cgroupV2MemoryMaxPath:     "1024",
+	}
+
+	usage, ok := readCgroupMemoryUsage(fakeCgroupReader(files))
+
+	assert.False(t, ok)
+	assert.Zero(t, usage)
+}
+
+func TestMemoryUsagePercentClampsUsageToLimit(t *testing.T) {
+	usage, ok := memoryUsagePercent(1200, 1000)
+
+	require.True(t, ok)
+	assert.Equal(t, 100.0, usage)
+}
+
+func fakeCgroupReader(files map[string]string) func(string) ([]byte, error) {
+	return func(path string) ([]byte, error) {
+		value, ok := files[path]
+		if !ok {
+			return nil, errors.New("file not found")
+		}
+		return []byte(value), nil
+	}
+}

--- a/common/system_monitor.go
+++ b/common/system_monitor.go
@@ -61,8 +61,11 @@ func updateSystemStatus() {
 	}
 
 	// Memory
-	memInfo, err := mem.VirtualMemory()
-	if err == nil {
+	if containerMemoryUsage, ok := readContainerMemoryUsage(); ok {
+		status.MemoryUsage = containerMemoryUsage
+	} else if memInfo, err := mem.VirtualMemory(); err == nil {
+		// Fall back to the host metric for non-container deployments and
+		// environments where no finite cgroup memory limit is available.
 		status.MemoryUsage = memInfo.UsedPercent
 	}
 


### PR DESCRIPTION
## Agent

- Tool: OpenCode
- Tool version: not exposed by the harness
- Model (full id): not exposed by the harness
- Host (CLI / IDE / GitHub coding agent / other): CLI
- Date (UTC): 2026-09-12

## Links

- Closes #6744
- Related: #6768

## User request

修复 NewAPI 在 Docker/Kubernetes 容器中把宿主机内存使用率显示为实例/容器内存使用率的问题。要求采用 surgical change，补充合适的测试，并提交一个可合并的 PR。

## Out of scope — refuse

- Matched: no
- If yes, what was told to the user (stop here; do not open a PR): not applicable

## Kind

- [x] Bug fix
- [ ] New feature
- [ ] Performance / refactor
- [ ] Docs
- [ ] Other:

## Issue facts

- Actual behavior: `common/system_monitor.go` assigns `mem.VirtualMemory().UsedPercent` to `SystemStatus.MemoryUsage`. On Linux containers this reads host `/proc/meminfo`, so the System Info instance table reports host/Node memory as if it were the NewAPI instance memory.
- Impact: Operators can see a worker at 96% memory while its Pod is using only a few percent of its cgroup limit. Any memory threshold protection using the same value can also evaluate the wrong scope.
- Frequency: Deterministic for the affected container environments; the reported percentage follows the host/Node `/proc/meminfo` values rather than the Pod cgroup values.
- Evidence that the problem is in new-api rather than the client or upstream: In a production GKE Autopilot cluster, the System Info page showed a worker at 96%, while `kubectl top pod --containers` showed 54Mi and the Pod cgroup showed `memory.current=87,412,736` with `memory.max=2,147,483,648` (about 4%). The same Pod's `/proc/meminfo` was `MemTotal=65848272 kB`, `MemAvailable=1763488 kB`, yielding about 97.3%, matching the NewAPI value. The Pod had zero restarts and no OOMKilled termination.
- Applicable types and their fields (relay / billing / frontend / deployment; write "not applicable" otherwise): Deployment/container resource monitoring and the System Info instance resource fields; relay, billing, and authentication are not applicable.

## Change

- Add a small cgroup memory reader that first reads cgroup v2 `memory.current`/`memory.max`, then cgroup v1 `memory.usage_in_bytes`/`memory.limit_in_bytes`.
- Calculate `current / limit * 100`, clamp an over-limit reading to 100%, and treat `max`, v1 unlimited sentinels, missing files, malformed values, and zero limits as unavailable.
- Make `updateSystemStatus` use the finite cgroup value when available and preserve the existing `gopsutil` host metric as a fallback for non-container or unlimited environments.
- Keep the public `SystemStatus` shape and API behavior unchanged; this is intentionally limited to correcting the memory value's scope.

## Research

### Duplicate / prior art

- Search queries (issues, PRs): searched NewAPI issues for container memory, cgroup, `/proc/meminfo`, `system_monitor`, and `monitor_memory_threshold`; reviewed #6744 and #6768.
- What already existed and why this is not a duplicate: #6744 identifies the same bug and proposes cgroup-aware reading; this PR implements that focused fix with v1/v2 fallback behavior and deterministic tests. #6768 is related operational mitigation, while this change corrects the reported metric at its source.

### Docs and code

- https://docs.newapi.ai/ : reviewed the performance monitoring and container deployment behavior; the documented system monitoring feature should report the resource scope relevant to the running instance.
- https://deepwiki.com/QuantumNous/new-api : reviewed the system monitoring and container deployment references.
- README / repo docs: reviewed the repository deployment and monitoring context; no database or provider behavior is changed.
- Code paths and what they imply for this change: `common/system_monitor.go` samples CPU/memory/disk and stores `SystemStatus`; `service/system_instance.go` serializes `SystemStatus.MemoryUsage` into instance reports; `controller/system_info.go` returns those reports; `web/src/features/system-info/components/system-instances-panel.tsx` renders the value. The minimal correct seam is the memory sampling branch in `common/system_monitor.go`.

### Alternatives considered

- Option A: Upgrade gopsutil or add a container-aware third-party cgroup library. This adds dependency scope and still requires explicit handling for unlimited limits and fallback semantics.
- Option B: Read the small set of cgroup files directly, inject the file reader for tests, and fall back to the existing host metric. This covers cgroup v1/v2 without changing dependencies or public types.
- Why this approach: Option B is the smallest dependency-free change, preserves existing behavior outside finite cgroup-limited environments, and is directly testable with deterministic fixtures.

## Files

| Path | Why |
| --- | --- |
| `common/cgroup_memory.go` | Reads cgroup v2/v1 memory usage and computes a bounded percentage, with host-metric fallback signaled to the caller. |
| `common/cgroup_memory_test.go` | Covers v2 preference, v1 fallback, unlimited limits, invalid input, and clamping. |
| `common/system_monitor.go` | Uses the cgroup percentage before the existing host-level fallback. |

## Behavior

- Before: `MemoryUsage` always used `gopsutil/mem.VirtualMemory().UsedPercent`, which reads host-level `/proc/meminfo` in the affected Linux container setup.
- After: `MemoryUsage` uses the current cgroup usage divided by its finite cgroup limit when available; it falls back to the existing host metric when the environment has no finite cgroup limit or cannot expose the cgroup files.
- Explicit non-goals / leftover work: CPU remains on the existing host-level `gopsutil` metric in this PR. Disk scope is unchanged. `GOMEMLIMIT` and application-level memory protection are separate follow-ups.

## Verification

- Commands and results:
  - `gofmt -w common/cgroup_memory.go common/cgroup_memory_test.go common/system_monitor.go` — passed.
  - `go test ./common -count=1` — passed.
  - `go test -run '^$' ./...` — passed; all packages compiled without executing tests.
  - `go test ./...` — the focused `common` package passed; the full run was not green because unrelated existing `controller` and `service` tests failed in the cloned upstream baseline (`TestSecurityEnrollmentTelegramAndWeChatFirstFactor` SQLite setup and `TestObserveChannelAffinityUsageCacheByRelayFormat_UnsupportedModeKeepsEmpty`). No files in those packages were changed.
  - `git diff --check` — passed.
- Manual steps and observed result: In the production GKE cluster, compared the NewAPI instance value with `kubectl top pod --containers` and `/sys/fs/cgroup/memory.current`/`memory.max`; the reported 96% matched host `/proc/meminfo`, while actual Pod usage was about 4% of the 2Gi limit.
- UI: no screenshot or recording; this PR changes the backend value source and does not change UI structure.
- Tests added or updated, or why none: Added `common/cgroup_memory_test.go` with deterministic table-equivalent cases for cgroup v2/v1 selection, unlimited/malformed input, and percentage clamping.
- Databases / providers / platforms exercised: No database or provider behavior is involved. Focused tests ran on Windows; the cgroup parser is platform-neutral and covers Linux cgroup file formats through injected readers. Full package compilation passed.
- Not verified: A live Linux build/runtime of the modified branch was not run in this environment; the production Linux cgroup values were inspected on the deployed NewAPI Pod before implementation.

## Risks

- Failure modes: If cgroup files are unavailable, malformed, or represent an unlimited limit, the code falls back to the previous host-level metric. If current usage temporarily exceeds the limit due to accounting timing, the displayed percentage is capped at 100%.
- Billing / quota / auth impact: none.
- Follow-ups: A separate change could make CPU quota metrics cgroup-aware and could add an explicit metric-scope label to the API/UI. Neither is necessary for this memory correction.

## Scope check

- Single focused change: yes
- Secrets included: no
- Out of scope (Coding Plan / reverse-engineered channel / third-party wrapper / Codex): no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory usage reporting in containerized environments by using the container’s assigned memory limit when available.
  * Preserved fallback to host-level memory metrics when container limits are unavailable or unlimited.
  * Ensured reported usage does not exceed the applicable memory limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->