### PR TITLE
fix(relay): preserve Gemini 3.x compute-tier suffixes after model mapping

### DIFF
--- a/relay/helper/reasoning_suffix_test.go
+++ b/relay/helper/reasoning_suffix_test.go
@@ -120,6 +120,25 @@ func TestApplyReasoningModelSuffixBlacklistDoesNotTrim(t *testing.T) {
 	assert.Nil(t, info.ReasoningConversion)
 }
 
+func TestApplyReasoningModelSuffixKeepsGemini3ComputeTierAfterMapping(t *testing.T) {
+	// Regression: gemini-3.8-flash-high is an official Google model name
+	// whose -high suffix collides with legacy thinking aliases. After model
+	// mapping sets UpstreamModelName to it, ApplyReasoningModelSuffix must
+	// NOT strip the suffix and revert to gemini-3.8-flash.
+	info := &relaycommon.RelayInfo{
+		OriginModelName: "gemini-3.8-flash",
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "gemini-3.8-flash-high",
+			IsModelMapped:     true,
+		},
+	}
+
+	mustApplyReasoningModelSuffix(t, info)
+	assert.Equal(t, "gemini-3.8-flash-high", info.UpstreamModelName,
+		"compute-tier suffix must not be stripped from official Gemini 3.x model names")
+	assert.Nil(t, info.ReasoningConversion)
+}
+
 func TestApplyReasoningModelSuffixModifierOverridesExplicitConflict(t *testing.T) {
 	info := &relaycommon.RelayInfo{
 		OriginModelName: "claude-3-7-sonnet-thinking",

--- a/setting/model_setting/global.go
+++ b/setting/model_setting/global.go
@@ -51,6 +51,10 @@ var defaultOpenaiSettings = GlobalSettings{
 	ThinkingModelBlacklist: []string{
 		"moonshotai/kimi-k2-thinking",
 		"kimi-k2-thinking",
+		// Gemini 3.x official model names end in compute-tier suffixes
+		// (-high/-medium/-low/...) that collide with legacy thinking aliases.
+		// Preserve them so model mapping and upstream routing stay intact.
+		"re:^gemini-3\\.\\d+-(flash|pro)-(high|medium|low|minimal|max|xhigh)$",
 	},
 	EffortTailModelIDs: []string{
 		"gpt-5.1-codex-max",

--- a/setting/model_setting/global_test.go
+++ b/setting/model_setting/global_test.go
@@ -42,3 +42,22 @@ func TestShouldPreserveThinkingSuffixExactAndRegex(t *testing.T) {
 	assert.True(t, ShouldPreserveThinkingSuffix("beta@sha256:abc"))
 	assert.False(t, ShouldPreserveThinkingSuffix("alpha@sha256:abc"))
 }
+
+func TestShouldPreserveThinkingSuffixGemini3ComputeTier(t *testing.T) {
+	// Gemini 3.x official model names end in compute-tier suffixes that
+	// collide with legacy thinking aliases. The default blacklist must
+	// preserve them so model mapping and upstream routing stay intact.
+	assert.True(t, ShouldPreserveThinkingSuffix("gemini-3.8-flash-high"),
+		"gemini-3.8-flash-high is an official model name, not a thinking alias")
+	assert.True(t, ShouldPreserveThinkingSuffix("gemini-3.8-pro-high"))
+	assert.True(t, ShouldPreserveThinkingSuffix("gemini-3.5-flash-medium"))
+	assert.True(t, ShouldPreserveThinkingSuffix("gemini-3.8-flash-low"))
+
+	// Gemini 2.x legacy thinking aliases must NOT be preserved.
+	assert.False(t, ShouldPreserveThinkingSuffix("gemini-2.5-pro-high"),
+		"gemini-2.5-pro-high is a legacy thinking alias, not an official model name")
+
+	// Models without a compute-tier suffix are unaffected.
+	assert.False(t, ShouldPreserveThinkingSuffix("gemini-3.8-flash"))
+	assert.False(t, ShouldPreserveThinkingSuffix("gemini-3.8-pro"))
+}


### PR DESCRIPTION
## 问题（中文）

用户通过客户端请求标准模型名 `gemini-3.8-flash`，渠道配置了模型映射将其转为上游（如 CPA）实际支持的模型名 `gemini-3.8-flash-high`。但 `ApplyReasoningModelSuffix` 中的旧版后缀解析器会错误地把 `gemini-3.8-flash-high` 末尾的 `-high` 当成思考强度别名剥离，导致映射后的上游模型名被还原：

1. 客户端请求：`gemini-3.8-flash`
2. 模型映射正确执行：`gemini-3.8-flash` -> `gemini-3.8-flash-high`
3. `ApplyReasoningModelSuffix` 错误剥离 `-high`，还原为 `gemini-3.8-flash`
4. 上游收到 `gemini-3.8-flash`，返回 `unknown provider for model gemini-3.8-flash`（上游只认 `gemini-3.8-flash-high`）

这是一个回归 bug：映射目标名不含思考后缀时正常（如 `gemini-3.1-pro-preview` -> `gemini-pro-agent`），但只要映射目标以 effort 词（`-high/-medium/-low/-minimal/-max/-xhigh`）结尾就会失败。

## 严重性

- **影响范围**：所有使用 Gemini 原生格式且配置了模型映射到 `*-high/medium/low` 等后缀模型的渠道（如对接 CPA 等上游）
- **实际表现**：请求直接失败（400 model_not_found），用户完全无法使用映射后的模型
- **触发条件**：渠道类型为 Gemini，模型映射目标名以 `-high/-medium/-low/-minimal/-max/-xhigh` 结尾
- **不受影响**：OpenAI 兼容格式请求、映射目标不含这些后缀的情况、Gemini 2.x 旧版思考别名

## 修复

在默认 `ThinkingModelBlacklist` 中加入正则，使 Gemini 3.x flash/pro 模型带计算档位后缀时跳过后缀解析：

```
re:^gemini-3\.\d+-(flash|pro)-(high|medium|low|minimal|max|xhigh)$
```

这与现有保留真实模型 ID 的模式一致（如 `kimi-k2-thinking`、`gpt-5.1-codex-max`）。

## 测试

- `TestShouldPreserveThinkingSuffixGemini3ComputeTier`：验证 Gemini 3.x 计算档位模型的黑名单匹配，同时确认 Gemini 2.x 旧版别名不受影响
- `TestApplyReasoningModelSuffixKeepsGemini3ComputeTierAfterMapping`：完整回归测试，覆盖 ModelMappedHelper -> ApplyReasoningModelSuffix 流程

`setting/model_setting` 和 `relay/helper` 全部已有测试通过。

---

## Problem (English)

Clients request the standard model name `gemini-3.8-flash`, and the channel is configured with a model mapping to convert it to the upstream's (e.g. CPA) actual model name `gemini-3.8-flash-high`. However, the legacy suffix parser in `ApplyReasoningModelSuffix` incorrectly strips the `-high` suffix (treating it as a thinking-effort alias), reverting the mapped upstream model name:

1. Client requests: `gemini-3.8-flash`
2. Model mapping works: `gemini-3.8-flash` -> `gemini-3.8-flash-high`
3. `ApplyReasoningModelSuffix` strips `-high`, reverting to `gemini-3.8-flash`
4. Upstream receives `gemini-3.8-flash`, returns `unknown provider for model gemini-3.8-flash` (upstream only recognizes `gemini-3.8-flash-high`)

This is a regression: model mapping works when the target has no effort suffix (e.g. `gemini-3.1-pro-preview` -> `gemini-pro-agent`) but fails whenever the mapped target ends in an effort word (`-high/-medium/-low/-minimal/-max/-xhigh`).

## Severity

- **Scope**: All channels using Gemini native format with model mapping to `*-high/medium/low` suffixed models (e.g. when integrating with CPA-like upstreams)
- **Impact**: Requests fail directly (400 model_not_found), users cannot use mapped models at all
- **Trigger**: Channel type Gemini, model mapping target ends in `-high/-medium/-low/-minimal/-max/-xhigh`
- **Not affected**: OpenAI-compatible format requests, mappings without these suffixes, Gemini 2.x legacy thinking aliases

## Fix

Add a regex to the default `ThinkingModelBlacklist` so Gemini 3.x `flash`/`pro` models with compute-tier suffixes skip suffix parsing entirely. This matches the existing pattern of preserving real model IDs that end in effort words (e.g. `kimi-k2-thinking`, `gpt-5.1-codex-max`).