### PR TITLE
fix(relaykit/dto): keep aspect_ratio/resolution when an image request is re-marshaled

### DIFF
--- a/relaykit/dto/openai_image.go
+++ b/relaykit/dto/openai_image.go
@@ -21,12 +21,23 @@ type ImageBillingParameters struct {
 	PromptExtend *bool `json:"prompt_extend,omitempty"`
 }
 
+// ImageRequest keeps the provider scalars it declares separate from the fields
+// it only forwards. Image generation APIs such as xAI's grok-imagine accept
+// geometry hints (aspect_ratio/resolution) that no other provider shares, so
+// they stay optional pointers: an absent field is omitted instead of being sent
+// as an empty string.
+//
+// Anything not declared here lands in Extra, and MarshalJSON deliberately does
+// not re-marshal Extra (see the note in that method), so a parameter that must
+// reach the upstream provider has to be declared on this struct.
 type ImageRequest struct {
 	Model             string          `json:"model"`
 	Prompt            string          `json:"prompt" binding:"required"`
 	N                 *uint           `json:"n,omitempty"`
 	Size              string          `json:"size,omitempty"`
 	Quality           string          `json:"quality,omitempty"`
+	AspectRatio       *string         `json:"aspect_ratio,omitempty"`
+	Resolution        *string         `json:"resolution,omitempty"`
 	ResponseFormat    string          `json:"response_format,omitempty"`
 	Style             json.RawMessage `json:"style,omitempty"`
 	User              json.RawMessage `json:"user,omitempty"`

--- a/relaykit/dto/openai_image_geometry_test.go
+++ b/relaykit/dto/openai_image_geometry_test.go
@@ -1,0 +1,60 @@
+package dto
+
+import (
+	"testing"
+
+	kitutil "github.com/QuantumNous/new-api/relaykit/relayconvert/kitutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// Image generation providers such as xAI's grok-imagine take geometry hints
+// (aspect_ratio/resolution) that no other provider shares. They only reach the
+// upstream provider when declared on ImageRequest, because MarshalJSON
+// deliberately does not re-marshal Extra.
+func TestImageRequestKeepsGeometryFields(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{
+			name: "geometry alongside a field only Extra knows",
+			body: `{"model":"grok-imagine-image-2.0","prompt":"a lake","n":1,"aspect_ratio":"16:9","resolution":"2K","unknown_param":"x"}`,
+		},
+		{
+			name: "geometry alone",
+			body: `{"model":"grok-imagine-image-2.0","prompt":"a lake","aspect_ratio":"9:16","resolution":"1K"}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var request ImageRequest
+			require.NoError(t, kitutil.Unmarshal([]byte(tc.body), &request))
+
+			encoded, err := kitutil.Marshal(request)
+			require.NoError(t, err)
+
+			require.NotNil(t, request.AspectRatio)
+			require.NotNil(t, request.Resolution)
+			assert.Equal(t, *request.AspectRatio, gjson.GetBytes(encoded, "aspect_ratio").String())
+			assert.Equal(t, *request.Resolution, gjson.GetBytes(encoded, "resolution").String())
+			assert.False(t, gjson.GetBytes(encoded, "unknown_param").Exists(),
+				"undeclared fields stay in Extra and are not re-marshaled")
+		})
+	}
+}
+
+// An absent hint must stay absent: an empty string would be sent upstream and
+// rejected by providers that treat the parameter as a closed enum.
+func TestImageRequestOmitsAbsentGeometryFields(t *testing.T) {
+	var request ImageRequest
+	require.NoError(t, kitutil.Unmarshal([]byte(`{"model":"gpt-image-1","prompt":"a lake"}`), &request))
+
+	encoded, err := kitutil.Marshal(request)
+	require.NoError(t, err)
+
+	assert.Nil(t, request.AspectRatio)
+	assert.Nil(t, request.Resolution)
+	assert.False(t, gjson.GetBytes(encoded, "aspect_ratio").Exists())
+	assert.False(t, gjson.GetBytes(encoded, "resolution").Exists())
+}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

> **AI 辅助声明 / AI-assisted disclosure**：提交者（leochena）不在本仓库历史核心开发者名单中。本 PR 的代码、测试与描述由 AI 辅助生成，提交者已复核 diff、理解变更原理，并在本地按下方"运行证明"复现了验证结果。

## 📝 变更描述 / Description

`relaykit/dto.ImageRequest` 的 `UnmarshalJSON` 会把未声明的字段收进 `Extra`，而 `MarshalJSON` 有意不把 `Extra` 合并回去（文件内注释：`不能合并ExtraFields！！！！！！！！`）。结果是：**没有在结构体上声明的参数，永远无法随请求发往上游**。`aspect_ratio`、`resolution` 都不在声明里，于是对支持它们的图片模型（xAI grok-imagine / `-2.0` 等）被静默丢弃；而 `size` 有声明，所以一直能转发——这正是"只有 size 可控"的原因。

改动：在 `ImageRequest` 上声明两个可选字段，并为这个不直观的约束补一段说明注释，避免以后再有人往 `Extra` 里加参数而不知道它不会生效。

```go
AspectRatio       *string         `json:"aspect_ratio,omitempty"`
Resolution        *string         `json:"resolution,omitempty"`
```

为什么用指针：这两个参数是**可选标量**，仓库规范要求 *optional relay scalar fields MUST use pointer types with `omitempty`*。缺失时必须整个省略——上游把该参数当封闭枚举，发空串会被拒；因此不能用 `string` + `omitempty`。

为什么放在 `relaykit/dto`：这是客户端 JSON 被解析、并重新序列化给上游的边界，字段声明就在这里生效；`relaykit` 是独立模块，本次改动不引入任何新依赖，模块仍可独立构建。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *已提交对应 Issue：#7340*
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #7340

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 已按模板逐节整理描述，未直接粘贴未经处理的模型输出；代码与测试由 AI 辅助生成并在上文声明。
- [x] **非重复提交:** 已搜索现有 Issues 与 PRs，未见针对 `aspect_ratio` / `resolution` 被 `Extra` 吞噬的同类改动（最接近的 #4546 / #6962 是 xAI 图生图的 multipart 问题，另一回事）。
- [x] **Bug fix 说明:** 已提交 Issue #7340；这不是设计取舍或预期不一致——客户端参数被静默丢弃且两侧都没有提示，属可复现的行为缺陷。
- [x] **变更理解:** 变更只影响"是否把这两个可选参数转发给上游"；不传该参数的请求、以及本来就不支持该参数的上游，行为完全不变；不涉及计费路径（`GetTokenCountMeta` / `ImageCount` 未改动）。
- [x] **范围聚焦:** 只改了 `relaykit/dto/openai_image.go` 与新增的测试文件，未夹带任何无关改动（见下方 diffstat）。
- [x] **本地验证:** `gofmt` 通过、新增测试通过、`relaykit/dto` 整包测试通过（见下方运行证明）。
- [x] **安全合规:** 无凭据、无敏感信息；改动符合仓库的指针/`omitempty` 规范。

## 📸 运行证明 / Proof of Work

**1) 变更范围**（基于 `main` = `043ff99a`）：

```
 relaykit/dto/openai_image.go               | 11 ++++++
 relaykit/dto/openai_image_geometry_test.go | 60 ++++++++++++++++++++++++++++++
 2 files changed, 71 insertions(+)
```

**2) 新增测试**（`go test ./dto/ -run TestImageRequest -count=1 -v`，在独立 checkout 的 `relaykit` 模块内运行）：

```
=== RUN   TestImageRequestKeepsGeometryFields
=== RUN   TestImageRequestKeepsGeometryFields/geometry_alongside_a_field_only_Extra_knows
=== RUN   TestImageRequestKeepsGeometryFields/geometry_alone
--- PASS: TestImageRequestKeepsGeometryFields (0.00s)
    --- PASS: TestImageRequestKeepsGeometryFields/geometry_alongside_a_field_only_Extra_knows
    --- PASS: TestImageRequestKeepsGeometryFields/geometry_alone
=== RUN   TestImageRequestOmitsAbsentGeometryFields
--- PASS: TestImageRequestOmitsAbsentGeometryFields (0.00s)
PASS
ok  	github.com/QuantumNous/new-api/relaykit/dto	0.004s
```

测试覆盖三件事：① 声明的字段能在 `Unmarshal → Marshal` 往返后存活；② 未声明的字段仍然只进 `Extra`、不会被重新序列化（顺手把这个有意行为固定下来，避免以后误改）；③ 缺失的几何参数不会以空串发往上游。

**3) 整包无回归**：

```
$ go test ./dto/ -count=1
ok  	github.com/QuantumNous/new-api/relaykit/dto	0.008s
```

**4) 真实链路对照**（同一模型、同一参数；"经网关"一列是在**下游 fork 的部署**上实测的——该 fork 的应用方式与本 PR 完全相同，均为"把字段声明到 `ImageRequest` 上"。上游 `main` 的文件布局不同，本 PR 的上游路径由上面的单元测试覆盖）：

| 请求 | 改前经网关 | 改后经网关（下游部署实测） | 直连上游 |
|---|---|---|---|
| `aspect_ratio=16:9` | 上游收不到该字段，出默认比例 768×1152 | 实际出 **1280×720** | 1280×720 |
| `aspect_ratio=9:16` | 同上 | 实际出 **720×1280** | 720×1280 |
| `aspect_ratio=19.5:9` | 同上 | 实际出 **1456×672** | 1456×672 |
| 不传 `aspect_ratio` | 默认比例 | 默认比例（未变） | 默认比例 |

补充：`resolution`（1K/2K）在部分上游只是被接受、并不改变输出像素（该上游的像素由比例决定）。本 PR 的职责是**不再把它丢掉**，是否生效取决于上游；这一点已在 Issue 里注明，避免把上游行为误当成本网关的问题。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Image generation requests now support optional aspect ratio and resolution settings.
  - These settings are preserved when requests are processed and omitted when not provided.

- **Bug Fixes**
  - Prevents unspecified geometry settings from being sent as empty values.
  - Ensures unsupported extra fields are not unintentionally included in serialized requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->